### PR TITLE
fix(amazon-connect-streams) Sync types with official repo

### DIFF
--- a/types/amazon-connect-streams/amazon-connect-streams-tests.ts
+++ b/types/amazon-connect-streams/amazon-connect-streams-tests.ts
@@ -1,88 +1,312 @@
-let elem: HTMLElement = new HTMLElement();
-connect.core.initCCP(elem, { ccpUrl: "" }); // $ExpectType void
+const container: HTMLElement = new HTMLElement();
 
-// Types for below tests
-let agentCallback: connect.AgentCallback = () => {};
-let muteCallback: connect.MuteCallback = () => {};
-let agentConfiguration: connect.AgentConfiguration;
-let successFailOptions: connect.SuccessFailOptions;
-let agentState: connect.AgentState;
-let endpoint: connect.Endpoint;
-let contactCallback: connect.ContactCallback;
-let sendDigitOptions: connect.SendDigitOptions;
+//
+// connect.core
 
-connect.Endpoint.byPhoneNumber(""); // $ExpectType: connect.Endpoint
-
-connect.agent(agent => {
-    agent.onContactPending(agentCallback); // $ExpectType: void
-    agent.onRefresh(agentCallback); // $ExpectType: void
-    agent.onRoutable(agentCallback); // $ExpectType: void
-    agent.onNotRoutable(agentCallback); // $ExpectType: void
-    agent.onOffline(agentCallback); // $ExpectType: void
-    agent.onError(agentCallback); // $ExpectType: void
-    agent.onAfterCallWork(agentCallback); // $ExpectType: void
-    agent.onMuteToggle(muteCallback); // $ExpectType: void
-    agent.getState(); // $ExpectType: AgentState
-    agent.getStateDuration(); // $ExpectType: number
-    agent.getContacts(""); // $ExpectType: connect.Contact[]
-    agent.getConfiguration(); // $ExpectType: connect.AgentConfiguration
-    agent.getAgentStates(); // $ExpectType: connect.AgentState[]
-    agent.getRoutingProfile(); // $ExpectType: connect.AgentRoutingProfile
-    agent.getName(); // $ExpectType: string
-    agent.getExtension(); // $ExpectType: string
-    agent.isSoftphoneEnabled(); // $ExpectType: boolean
-    agent.setConfiguration(agentConfiguration, successFailOptions); // $ExpectType: void
-    agent.setState(agentState, successFailOptions); // $ExpectType: void
-    agent.connect(endpoint, successFailOptions); // $ExpectType: void
-    agent.toSnapshot(); // $ExpectType: connect.Agent
-    agent.mute(); // $ExpectType: void
-    agent.unmute(); // $ExpectType: void
-    agent.getAgentStates(); // $ExpectType: connect.AgentState[]
+connect.core.initCCP(container, { ccpUrl: "" }); // $ExpectType void
+// $ExpectType void
+connect.core.initCCP(container, {
+  ccpUrl: "",
+  region: "",
+  loginPopup: true,
+  loginPopupAutoClose: true,
+  loginUrl: "",
+  softphone: {
+    allowFramedSoftphone: true,
+    disableRingtone: true,
+    ringtoneUrl: ""
+  }
 });
+
+connect.core.terminate(); // $ExpectType void
+
+connect.core.viewContact(""); // $ExpectType void
+
+const onViewContactCallback: connect.ViewContactCallback = c => {
+  c; // $ExpectType ViewContactEvent
+  c.contactId; // $ExpectType string
+};
+connect.core.onViewContact(onViewContactCallback); // $ExpectType void
+
+const authFailCallback: connect.SuccessFailCallback = () => {};
+connect.core.onAuthFail(authFailCallback); // $ExpectType void
+
+const accessDeniedCallback: connect.SuccessFailCallback = () => {};
+connect.core.onAccessDenied(accessDeniedCallback); // $ExpectType void
+
+//
+// connect.Endpoint
+
+const endpoint = connect.Endpoint.byPhoneNumber(""); // $ExpectType Endpoint
+endpoint.endpointARN; // $ExpectType string
+endpoint.endpointId; // $ExpectType string
+endpoint.type; // $ExpectType EndpointType
+endpoint.name; // $ExpectType string
+endpoint.phoneNumber; // $ExpectType string
+endpoint.agentLogin; // $ExpectType string
+endpoint.queue; // $ExpectType string
+
+//
+// connect.getLog()
+
+const log = connect.getLog(); // $ExpectType Logger
+log.debug(""); // $ExpectType LogEntry
+log.debug("", "random", 1, "values").withException(new Error()).withObject({}); // $ExpectType LogEntry
+log.info(""); // $ExpectType LogEntry
+log.info("", "random", 1, "values").withException(new Error()).withObject({}); // $ExpectType LogEntry
+log.warn(""); // $ExpectType LogEntry
+log.warn("", "random", 1, "values").withException(new Error()).withObject({}); // $ExpectType LogEntry
+log.error(""); // $ExpectType LogEntry
+log.error("", "random", 1, "values").withException(new Error()).withObject({}); // $ExpectType LogEntry
+log.download(); // $ExpectType void
+
+//
+// connect.hitch()
+
+connect.hitch({}, (param: string) => 123); // $ExpectType (param: string) => number
+
+//
+// connect.agent()
+
+const agentCallback: connect.AgentCallback = a => {
+  a; // $ExpectType Agent
+};
+const stateChangeCallback: connect.AgentStateChangeCallback = state => {
+  state; // $ExpectType AgentStateChange
+  state.agent; // $ExpectType Agent
+  state.newState; // $ExpectType string
+  state.oldState; // $ExpectType string
+};
+const softphoneErrorCallback: connect.SoftphoneErrorCallback = error => {
+  error; // $ExpectType SoftphoneError
+  error.endPointUrl; // $ExpectType string
+  error.errorMessage; // $ExpectType string
+  error.errorType; // $ExpectType string
+};
+const muteToggleCallback: connect.AgentMutedStatusCallback = state => {
+  state; // $ExpectType AgentMutedStatus
+  state.muted; // $ExpectType boolean
+};
+const successFailOptions: connect.SuccessFailOptions = {
+  success: () => {},
+  failure: e => {
+    e; // $ExpectType string
+  }
+};
+const getEndpointsCallbacks: connect.GetEndpointsCallbacks = {
+  success: r => {
+    r; // $ExpectType GetEndpointsResult
+    r.addresses; // $ExpectType Endpoint[]
+    r.endpoints; // $ExpectType Endpoint[]
+  },
+  failure: e => {
+    e; // $ExpectType string
+  }
+};
+
+// $ExpectType void
+connect.agent(agent => {
+  agent; // $ExpectType Agent
+
+  // events
+  agent.onContactPending(agentCallback); // $ExpectType void
+  agent.onRefresh(agentCallback); // $ExpectType void
+  agent.onStateChange(stateChangeCallback); // $ExpectType void
+  agent.onRoutable(agentCallback); // $ExpectType void
+  agent.onNotRoutable(agentCallback); // $ExpectType void
+  agent.onOffline(agentCallback); // $ExpectType void
+  agent.onError(agentCallback); // $ExpectType void
+  agent.onAfterCallWork(agentCallback); // $ExpectType void
+  agent.onMuteToggle(muteToggleCallback); // $ExpectType void
+
+  // getters
+  const state = agent.getState(); // $ExpectType AgentState
+  state.agentStateARN; // $ExpectType string | null
+  state.name; // $ExpectType string
+  state.startTimestamp; // $ExpectType Date
+  state.type; // $ExpectType AgentStateType
+  agent.getStatus(); // $ExpectType AgentState
+  agent.getStateDuration(); // $ExpectType number
+  agent.getPermissions(); // $ExpectType string[]
+  agent.getContacts(); // $ExpectType Contact[]
+  agent.getContacts(connect.ContactType.CHAT); // $ExpectType Contact[]
+  const config = agent.getConfiguration(); // $ExpectType AgentConfiguration
+  config.agentStates; // $ExpectType AgentStateDefinition[]
+  config.dialableCountries; // $ExpectType string[]
+  config.extension; // $ExpectType string
+  config.extension = "";
+  config.name; // $ExpectType string
+  config.permissions; // $ExpectType string[]
+  config.routingProfile; // $ExpectType AgentRoutingProfile
+  config.softphoneAutoAccept; // $ExpectType boolean
+  config.softphoneEnabled; // $ExpectType boolean
+  config.softphoneEnabled = true;
+  config.username; // $ExpectType string
+  const states = agent.getAgentStates(); // $ExpectType AgentStateDefinition[]
+  states[0].agentStateARN; // $ExpectType string
+  states[0].name; // $ExpectType string
+  states[0].type; // $ExpectType AgentStateType
+  const profile = agent.getRoutingProfile(); // $ExpectType AgentRoutingProfile
+  profile.channelConcurrencyMap; // $ExpectType AgentChannelConcurrencyMap
+  profile.defaultOutboundQueue; // $ExpectType Queue
+  profile.name; // $ExpectType string
+  profile.queues; // $ExpectType Queue[]
+  profile.routingProfileARN; // $ExpectType string
+  profile.routingProfileId; // $ExpectType string
+  const concurrency = agent.getChannelConcurrency(); // $ExpectType AgentChannelConcurrencyMap
+  concurrency.CHAT; // $ExpectType number
+  agent.getChannelConcurrency(connect.ChannelType.CHAT); // $ExpectType number
+  agent.getName(); // $ExpectType string
+  agent.getExtension(); // $ExpectType string
+  agent.getDialableCountries(); // $ExpectType string[]
+  agent.isSoftphoneEnabled(); // $ExpectType boolean
+  agent.getAllQueueARNs(); // $ExpectType string[]
+  agent.getEndpoints("", getEndpointsCallbacks); // $ExpectType void
+  agent.getEndpoints(["", ""], getEndpointsCallbacks); // $ExpectType void
+  agent.toSnapshot(); // $ExpectType Agent
+
+  // setters
+  agent.setConfiguration(config); // $ExpectType void
+  agent.setConfiguration(config, successFailOptions); // $ExpectType void
+  agent.setState(states[0]); // $ExpectType void
+  agent.setState(states[0], successFailOptions); // $ExpectType void
+
+  // actions
+  agent.connect(endpoint);
+  // $ExpectType void
+  agent.connect(endpoint, {
+    ...successFailOptions,
+    queueARN: ""
+  });
+  agent.mute(); // $ExpectType void
+  agent.unmute(); // $ExpectType void
+});
+
+//
+// connect.contact()
+
+const contactCallback: connect.ContactCallback = c => {
+  c; // $ExpectType Contact
+};
 
 connect.contact(contact => {
-    contact.onRefresh(contactCallback); // $ExpectType: void
-    contact.onIncoming(contactCallback); // $ExpectType: void
-    contact.onAccepted(contactCallback); // $ExpectType: void
-    contact.onEnded(contactCallback); // $ExpectType: void
-    contact.onConnected(contactCallback); // $ExpectType: void
-    contact.getContactId(); // $ExpectType: string
-    contact.getOriginalContactId(); // $ExpectType: string
-    contact.getType(); // $ExpectType: string
-    contact.getStatus(); // $ExpectType: connect.ContactState
-    contact.getStatusDuration(); // $ExpectType: number
-    contact.getQueue(); // $ExpectType: connect.Queue
-    contact.getConnections(); // $ExpectType: connect.Connection[]
-    contact.getInitialConnection(); // $ExpectType: connect.Connection
-    contact.getActiveInitialConnection(); // $ExpectType: connect.Connection
-    contact.getThirdPartyConnections(); // $ExpectType: connect.Connection
-    contact.getSingleActiveThirdPartyConnection(); // $ExpectType: connect.Connection
-    contact.getAgentConnection(); // $ExpectType: Connection
-    contact.getAttributes(); // $ExpectType: connect.AttributeDictionary
-    contact.isSoftphoneCall(); // $ExpectType: boolean
-    contact.isInbound(); // $ExpectType: boolean
-    contact.isConnected(); // $ExpectType: boolean
-    contact.accept(successFailOptions); // $ExpectType: void
-    contact.destroy(successFailOptions); // $ExpectType: void
-    contact.notifyIssue(successFailOptions); // $ExpectType: void
-    contact.addConnection(endpoint, successFailOptions); // $ExpectType: void
-    contact.toggleActiveConnections(successFailOptions); // $ExpectType: void
-    contact.conferenceConnections(successFailOptions); // $ExpectType: void
+  contact; // $ExpectType Contact
+  contact.contactId; // $ExpectType string
 
-    const connection = contact.getAgentConnection();
-    connection.getContactId(); // $ExpectType string
-    connection.getConnectionId(); // $ExpectType string
-    connection.getEndpoint(); // $ExpectType Endpoint
-    connection.getState(); // $ExpectType ConnectionState
-    connection.getStateDuration(); // $ExpectType number
-    connection.getType(); // $ExpectType "inbound" | "outbound" | "monitoring"
-    connection.isInitialConnection(); // $ExpectType boolean
-    connection.isActive(); // $ExpectType boolean
-    connection.isConnected(); // $ExpectType boolean
-    connection.isConnecting(); // $ExpectType boolean
-    connection.isOnHold(); // $ExpectType boolean
-    connection.destroy(successFailOptions); // $ExpectType void
-    connection.sendDigits(sendDigitOptions); // $ExpectType void
-    connection.hold(successFailOptions); // $ExpectType: void
-    connection.resume(successFailOptions); // $ExpectType: void
+  // events
+  contact.onRefresh(contactCallback); // $ExpectType void
+  contact.onIncoming(contactCallback); // $ExpectType void
+  contact.onPending(contactCallback); // $ExpectType void
+  contact.onConnecting(contactCallback); // $ExpectType void
+  contact.onAccepted(contactCallback); // $ExpectType void
+  contact.onMissed(contactCallback); // $ExpectType void
+  contact.onEnded(contactCallback); // $ExpectType void
+  contact.onDestroy(contactCallback); // $ExpectType void
+  contact.onACW(contactCallback); // $ExpectType void
+  contact.onConnected(contactCallback); // $ExpectType void
+
+  // getters
+  contact.getContactId(); // $ExpectType string
+  contact.getOriginalContactId(); // $ExpectType string
+  contact.getInitialContactId(); // $ExpectType string
+  contact.getType(); // $ExpectType ContactType
+  const contactStatus = contact.getStatus(); // $ExpectType ContactState
+  contactStatus.timestamp; // $ExpectType Date
+  contactStatus.type; // $ExpectType ContactStateType
+  contact.getStatusDuration(); // $ExpectType number
+  const queue = contact.getQueue(); // $ExpectType Queue
+  queue.name; // $ExpectType string
+  queue.queueARN; // $ExpectType string
+  queue.queueId; // $ExpectType string
+  contact.getQueueTimestamp(); // $ExpectType Date
+  contact.getConnections(); // $ExpectType BaseConnection[]
+  contact.getInitialConnection(); // $ExpectType BaseConnection
+  contact.getActiveInitialConnection(); // $ExpectType BaseConnection | null
+  contact.getThirdPartyConnections(); // $ExpectType BaseConnection[]
+  contact.getSingleActiveThirdPartyConnection(); // $ExpectType BaseConnection | null
+  contact.getAgentConnection(); // $ExpectType BaseConnection
+  const attr = contact.getAttributes(); // $ExpectType AttributeDictionary
+  attr.key.name; // $ExpectType string
+  attr.key.value; // $ExpectType string
+  contact.isSoftphoneCall(); // $ExpectType boolean
+  contact.isInbound(); // $ExpectType boolean
+  contact.isConnected(); // $ExpectType boolean
+  contact.toSnapshot(); // $ExpectType Contact
+
+  // actions
+  contact.accept(); // $ExpectType void
+  contact.accept(successFailOptions); // $ExpectType void
+  contact.destroy(); // $ExpectType void
+  contact.destroy(successFailOptions); // $ExpectType void
+  contact.complete(); // $ExpectType void
+  contact.complete(successFailOptions); // $ExpectType void
+  contact.notifyIssue("", ""); // $ExpectType void
+  contact.notifyIssue("", "", successFailOptions); // $ExpectType void
+  contact.addConnection(endpoint); // $ExpectType void
+  contact.addConnection(endpoint, successFailOptions); // $ExpectType void
+  contact.toggleActiveConnections(); // $ExpectType void
+  contact.toggleActiveConnections(successFailOptions); // $ExpectType void
+  contact.conferenceConnections(); // $ExpectType void
+  contact.conferenceConnections(successFailOptions); // $ExpectType void
 });
+
+//
+// connect.BaseConnection
+
+const cnn = new connect.BaseConnection();
+cnn.connectionId; // $ExpectType string
+cnn.contactId; // $ExpectType string
+
+// getters
+cnn.getContactId(); // $ExpectType string
+cnn.getConnectionId(); // $ExpectType string
+cnn.getEndpoint(); // $ExpectType Endpoint
+cnn.getAddress(); // $ExpectType Endpoint
+const cnnStatus = cnn.getStatus(); // $ExpectType ConnectionState
+cnnStatus.timestamp; // $ExpectType Date
+cnnStatus.type; // $ExpectType ConnectionStateType
+cnn.getStatusDuration(); // $ExpectType number
+cnn.getType(); // $ExpectType ConnectionType
+const monitor = cnn.getMonitorInfo(); // $ExpectType MonitorInfo | null
+if (monitor) {
+  monitor.agentName; // $ExpectType string
+  monitor.customerName; // $ExpectType string
+  monitor.joinTime; // $ExpectType Date
+}
+cnn.isInitialConnection(); // $ExpectType boolean
+cnn.isActive(); // $ExpectType boolean
+cnn.isConnected(); // $ExpectType boolean
+cnn.isOnHold(); // $ExpectType boolean
+
+// actions
+cnn.destroy(); // $ExpectType void
+cnn.destroy(successFailOptions); // $ExpectType void
+cnn.sendDigits(""); // $ExpectType void
+cnn.sendDigits("", successFailOptions); // $ExpectType void
+cnn.hold(); // $ExpectType void
+cnn.hold(successFailOptions); // $ExpectType void
+cnn.resume(); // $ExpectType void
+cnn.resume(successFailOptions); // $ExpectType void
+
+if (cnn instanceof connect.ChatConnection) {
+  const info = cnn.getMediaInfo(); // $ExpectType ChatMediaInfo
+  info.contactId; // $ExpectType string
+  const token = info.getConnectionToken(); // $ExpectType Promise<ConnectionToken>
+  token.then(r => {
+    r.chatTokenTransport.expiry; // $ExpectType string
+    r.chatTokenTransport.participantToken; // $ExpectType string
+  });
+  cnn.getMediaType(); // $ExpectType MediaType.CHAT
+  cnn.getMediaController(); // $ExpectType Promise<any>
+}
+
+if (cnn instanceof connect.VoiceConnection) {
+  const info = cnn.getMediaInfo(); // $ExpectType VoiceMediaInfo
+  info.autoAccept; // $ExpectType boolean
+  info.callConfigJson; // $ExpectType string
+  info.callContextToken; // $ExpectType string
+  info.callType; // $ExpectType SoftphoneCallType
+  info.mediaLegContextToken; // $ExpectType string
+  cnn.getMediaType(); // $ExpectType MediaType.SOFTPHONE
+  cnn.getMediaController(); // $ExpectType Promise<any>
+}

--- a/types/amazon-connect-streams/index.d.ts
+++ b/types/amazon-connect-streams/index.d.ts
@@ -1,753 +1,1238 @@
 // Type definitions for Amazon Connect Streams API 1.4
 // Project: https://github.com/aws/amazon-connect-streams
-// Definitions by: Andy Hopper <https://github.com/andyhopp>
-//                 Ivan Bliskavka <https://github.com/ibliskavka>
+// Definitions by: Andy Hopper <https://github.com/andyhopp>, Ivan Bliskavka <https://github.com/ibliskavka>, Marco Gonzalez <https://github.com/marcogrcr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 3.0
 declare namespace connect {
+  /**
+   * A callback to receive `Agent` API object instances.
+   *
+   * @param agent The `Agent` API object instance.
+   */
+  type AgentCallback = (agent: Agent) => void;
+
+  /**
+   * A callback to receive `AgentMutedStatus` API object instances.
+   *
+   * @param agentMutedStatus The `AgentMutedStatus` API object instance.
+   */
+  type AgentMutedStatusCallback = (agentMutedStatus: AgentMutedStatus) => void;
+
+  /**
+   * A callback to receive an agent state change event.
+   *
+   * @param agentStateChange The agent state change event.
+   */
+  type AgentStateChangeCallback = (agentStateChange: AgentStateChange) => void;
+
+  /**
+   * A callback to receive `SoftphoneError` errors.
+   *
+   * @param error A `SoftphoneError` error.
+   */
+  type SoftphoneErrorCallback = (error: SoftphoneError) => void;
+
+  /**
+   * Subscribe a method to be called when the agent is initialized.
+   * If the agent has already been initalized, the call is synchronous and the callback is invoked immediately.
+   * Otherwise, the callback is invoked once the first agent data is received from upstream.
+   * This callback is provided with an `Agent` API object, which can also be created at any time after initialization is complete via `new connect.Agent()`.
+   *
+   * @param callback A callback that will receive an `Agent` API object instance.
+   */
+  function agent(callback: AgentCallback): void;
+
+  /**
+   * A callback to receive `Contact` API object instances.
+   *
+   * @param contact A `Contact` API object instance.
+   */
+  type ContactCallback = (contact: Contact) => void;
+
+  /**
+   * A callback to receive `ViewContactEvent` objects.
+   *
+   * @param contact A `ViewContactEvent` object.
+   */
+  type ViewContactCallback = (contact: ViewContactEvent) => void;
+
+  /**
+   * Subscribe a method to be called for each newly detected agent contact.
+   * Note that this function is not only for incoming contacts, but for contacts which already existed when Streams was initialized, such as from a previous agent session.
+   * This callback is provided with a `Contact` API object for this contact. `Contact` API objects can also be listed from the `Agent` API by calling `agent.getContacts()`.
+   *
+   * @param callback A callback that will receive an `Contact` API object instance.
+   */
+  function contact(callback: ContactCallback): void;
+
+  /**
+   * A useful utility function for creating callback closures that bind a function to an object instance.
+   *
+   * @param scope The instance object to be set as the scope of the function.
+   * @param method The method to be encapsulated.
+   */
+  function hitch<T extends (...args: any[]) => any>(scope: object, method: T): T;
+
+  interface Core {
     /**
+     * Integrates with Amazon Connect by loading the pre-built CCP located at `ccpUrl` into an iframe and placing it into the `container` provided.
+     * API requests are funneled through this CCP and agent and contact updates are published through it and made available to your JS client code.
      *
-     * A callback to receive agent details
-     *
-     * @param agent An Agent object containing information about the currently
-     * signed-in agent.
+     * @param container The DOM element to place the CCP.
+     * @param options The CCP init options.
      */
-    type AgentCallback = (agent: Agent) => void;
-
-    /**
-     *
-     * A callback to receive agent details
-     *
-     * @param agent An Agent object containing information about the currently
-     * signed-in agent.
-     */
-    type MuteCallback = (muteState: MuteState) => void;
-
-    /**
-     * Register a callback to receive agent details
-     *
-     * @param callback A callback that will receive an {Agent} instance
-     *                 when agent information becomes available.
-     */
-    function agent(callback: AgentCallback): void;
-
-    /**
-     *
-     * A callback to receive contact details
-     *
-     * @param agent A Contact object containing information about the current contact.
-     */
-    type ContactCallback = (contact: Contact) => void;
-
-    /**
-     * Register a callback to receive contact details
-     *
-     * @param callback A callback that will receive a Contact instance
-     *                 when contact information is updated.
-     */
-    function contact(callback: ContactCallback): void;
-
-    /**
-     * Binds the given instance object as the context for
-     * the method provided.
-     *
-     * @param scope The instance object to be set as the scope
-     *              of the function.
-     * @param method The method to be encapsulated.
-     *
-     * All other arguments, if any, are bound to the method
-     * invocation inside the closure.
-     *
-     * @return A closure encapsulating the invocation of the
-     *    method provided in context of the given instance.
-     */
-    function hitch(scope: object, method: () => any): void;
-
-    interface Core {
-        initCCP(containerDiv: HTMLElement, options: InitCCPOptions): void;
-        terminate(): void;
-        initialized: boolean;
-    }
-    let core: Core;
-
-    interface SoftPhoneOptions {
-        /*
-         * Whether to disable the ringtone.
-         */
-        disableRingtone?: boolean;
-        /*
-         * Whether to display the softphone in a frame.
-         */
-        allowFramedSoftphone?: boolean;
-        /*
-         * A URL for a custom ringtone.
-         */
-        ringtoneUrl?: string;
-    }
-
-    interface InitCCPOptions {
-        /*
-         * The URL for the Connect CCP.
-         */
-        ccpUrl: string;
-        /**
-         * Amazon connect instance region
-         * Only required for chat channel
-         */
-        region?: string;
-        /*
-         * Whether to display the login view.
-         */
-        loginPopup?: boolean;
-        /**
-         * Defaults to false.
-         * Set to true to automatically close the loginPopup window after authentication.
-         */
-        loginPopupAutoClose?: boolean;
-        /**
-         * Allows custom URL to be used to initiate the ccp, as in the case of SAML authentication.
-         */
-        loginUrl?: string;
-        /*
-         * Options specifying softphone configuration.
-         */
-        softphone?: SoftPhoneOptions;
-    }
-
-    enum AgentStateType {
-        INIT = 'init',
-        ROUTABLE = 'routable',
-        NOT_ROUTABLE = 'not_routable',
-        OFFLINE = 'offline'
-    }
-
-    enum AgentAvailStates {
-        INIT = 'Init',
-        BUSY = 'Busy',
-        AFTER_CALL_WORK = 'AfterCallWork',
-        CALLING_CUSTOMER = 'CallingCustomer',
-        DIALING = 'Dialing',
-        JOINING = 'Joining',
-        PENDING_AVAILABLE = 'PendingAvailable',
-        PENDING_BUSY = 'PendingBusy'
-    }
-
-    enum AgentErrorStates {
-        ERROR = 'Error',
-        AGENT_HUNG_UP = 'AgentHungUp',
-        BAD_ADDRESS_AGENT = 'BadAddressAgent',
-        BAD_ADDRESS_CUSTOMER = 'BadAddressCustomer',
-        DEFAULT = 'Default',
-        FAILED_CONNECT_AGENT = 'FailedConnectAgent',
-        FAILED_CONNECT_CUSTOMER = 'FailedConnectCustomer',
-        LINE_ENGAGED_AGENT = 'LineEngagedAgent',
-        LINE_ENGAGED_CUSTOMER = 'LineEngagedCustomer',
-        MISSED_CALL_AGENT = 'MissedCallAgent',
-        MISSED_CALL_CUSTOMER = 'MissedCallCustomer',
-        MULTIPLE_CCP_WINDOWS = 'MultipleCcpWindows',
-        REALTIME_COMMUNICATION_ERROR = 'RealtimeCommunicationError'
-    }
-
-    enum EndpointType {
-        PHONE_NUMBER = 'phone_number',
-        AGENT = 'agent',
-        QUEUE = 'queue'
-    }
-
-    enum ConnectionType {
-        AGENT = 'agent',
-        INBOUND = 'inbound',
-        OUTBOUND = 'outbound',
-        MONITORING = 'monitoring'
-    }
-
-    enum ConnectionStateType {
-        INIT = 'init',
-        CONNECTING = 'connecting',
-        CONNECTED = 'connected',
-        HOLD = 'hold',
-        DISCONNECTED = 'disconnected'
-    }
-
-    interface CONNECTION_ACTIVE_STATES {
-        [key: string]: number;
-    }
-
-    enum ContactStateType {
-        INIT = 'init',
-        INCOMING = 'incoming',
-        PENDING = 'pending',
-        CONNECTING = 'connecting',
-        CONNECTED = 'connected',
-        MISSED = 'missed',
-        ERROR = 'error',
-        ENDED = 'ended'
-    }
-
-    enum CONTACT_ACTIVE_STATES {
-        INCOMING = 'incoming',
-        CONNECTING = 'connecting',
-        CONNECTED = 'connected'
-    }
-
-    enum ContactType {
-        VOICE = 'voice',
-        QUEUE_CALLBACK = 'queue_callback'
-    }
-
-    enum SoftphoneCallType {
-        AUDIO_VIDEO = 'audio_video',
-        VIDEO_ONLY = 'video_only',
-        AUDIO_ONLY = 'audio_only',
-        NONE = 'none'
-    }
-
-    enum SoftphoneErrorTypes {
-        UNSUPPORTED_BROWSER = 'unsupported_browser',
-        MICROPHONE_NOT_SHARED = 'microphone_not_shared',
-        SIGNALLING_HANDSHAKE_FAILURE = 'signalling_handshake_failure',
-        SIGNALLING_CONNECTION_FAILURE = 'signalling_connection_failure',
-        ICE_COLLECTION_TIMEOUT = 'ice_collection_timeout',
-        USER_BUSY_ERROR = 'user_busy_error',
-        WEBRTC_ERROR = 'webrtc_error',
-        REALTIME_COMMUNICATION_ERROR = 'realtime_communication_error',
-        OTHER = 'other'
-    }
-
-    enum CTIExceptions {
-        ACCESS_DENIED_EXCEPTION = 'AccessDeniedException',
-        INVALID_STATE_EXCEPTION = 'InvalidStateException',
-        BAD_ENDPOINT_EXCEPTION = 'BadEndpointException',
-        INVALID_AGENT_ARNEXCEPTION = 'InvalidAgentARNException',
-        INVALID_CONFIGURATION_EXCEPTION = 'InvalidConfigurationException',
-        INVALID_CONTACT_TYPE_EXCEPTION = 'InvalidContactTypeException',
-        PAGINATION_EXCEPTION = 'PaginationException',
-        REFRESH_TOKEN_EXPIRED_EXCEPTION = 'RefreshTokenExpiredException',
-        SEND_DATA_FAILED_EXCEPTION = 'SendDataFailedException',
-        UNAUTHORIZED_EXCEPTION = 'UnauthorizedException'
-    }
-
-    /*
-     * A callback to receive notifications of success or failure.
-     */
-    type SuccessFailCallback = () => void;
-
-    interface SuccessFailOptions {
-        /*
-         * A {SuccessFailCallback} to receive a notification of success.
-         */
-        success?: SuccessFailCallback;
-        /*
-         * A {SuccessFailCallback} to receive a notification of failure.
-         */
-        failure?: SuccessFailCallback;
-    }
-    interface ConnectOptions extends SuccessFailOptions {
-        /*
-         * A string containing a Connect Queue ARN.
-         */
-        queueARN?: string;
-    }
-
-    interface MuteState {
-        muted: boolean;
-    }
-
-    interface Agent {
-        /**
-         * Subscribe a method to be called whenever Contact information is about to be updated.
-         *
-         * @param callback A callback to receive updated Agent information.
-         */
-        onContactPending(callback: AgentCallback): void;
-        /**
-         * Subscribe a method to be called whenever new agent data is available.
-         *
-         * @param callback A callback to receive updated Agent information.
-         */
-        onRefresh(callback: AgentCallback): void;
-        /**
-         * Subscribe a method to be called when the agent becomes routable, meaning that they can be routed incoming contacts.
-         *
-         * @param callback A callback to receive updated Agent information.
-         */
-        onRoutable(callback: AgentCallback): void;
-        /**
-         * Subscribe a method to be called when the agent becomes not-routable, meaning that they are online but cannot be routed incoming contacts.
-         *
-         * @param callback A callback to receive updated Agent information.
-         */
-        onNotRoutable(callback: AgentCallback): void;
-        /**
-         * Subscribe a method to be called when the agent goes offline.
-         *
-         * @param callback A callback to receive updated Agent information.
-         */
-        onOffline(callback: AgentCallback): void;
-        /**
-         * Subscribe a method to be called when the agent is put into an error state.
-         *
-         * @param callback A callback to receive updated Agent information.
-         */
-        onError(callback: AgentCallback): void;
-        /**
-         * Subscribe a method to be called when the agent enters the "After Call Work" (ACW) state.
-         *
-         * @param callback A callback to receive updated Agent information.
-         */
-        onAfterCallWork(callback: AgentCallback): void;
-        /**
-         * Subscribe a method to be called when the agent updates the mute status,
-         * meaning that agents mute/unmute APIs are called and the local media stream
-         * is succesfully updated with the new status.
-         *
-         * @param callback A callback to receive updates on agent mute state
-         */
-        onMuteToggle(callback: MuteCallback): void;
-
-        /**
-         * Subscribe a method to be called when the agent is put into an error state specific to softphone functionality.
-         * @param callback
-         */
-        onSoftphoneError(callback: AgentCallback): void;
-        /**
-         * Subscribe a method to be called whenever new agent data is available.
-         * @param callback
-         */
-        onStateChange(callback: (agentStateChange: AgentStateChange) => void): void;
-
-        /**
-         * Get the agent's current AgentState object indicating their availability state type.
-         */
-        getState(): AgentState;
-        /**
-         * Get the duration of the agent's state in milliseconds relative to local time.
-         */
-        getStateDuration(): number;
-        // /**
-        //  * For internal purposes only.
-        //  */
-        // getPermissions(): string[];
-        /**
-         * Gets a list of Contact API objects for each of the agent's current contacts.
-         */
-        getContacts(contactTypeFilter: string): Contact[];
-        /**
-         * Gets the full AgentConfiguration object for the agent.
-         */
-        getConfiguration(): AgentConfiguration;
-        /**
-         * Gets the list of selectable AgentState API objects.
-         */
-        getAgentStates(): AgentState[];
-        /**
-         * Gets the agent's routing profile.
-         */
-        getRoutingProfile(): AgentRoutingProfile;
-        /**
-         * Gets the agent's user friendly display name from the AgentConfiguration object for the agent.
-         */
-        getName(): string;
-        /**
-         * Gets the agent's phone number from the AgentConfiguration object for the agent.
-         */
-        getExtension(): string;
-        /**
-         * Determine if softphone is enabled for the agent.
-         */
-        isSoftphoneEnabled(): boolean;
-        /**
-         * Updates the agent's configuration with the given AgentConfiguration object.
-         *
-         * @param configuration The desired configuration
-         * @param successFailOptions Optional success and failure callbacks can be provided to determine whether the operation was successful.
-         */
-        setConfiguration(configuration: AgentConfiguration, successFailOptions: SuccessFailOptions): void;
-        /**
-         * Set the agent's current availability state.
-         *
-         * @param state The new agent state.
-         * @param successFailOptions Optional success and failure callbacks can be provided to determine whether the operation was successful.
-         */
-        setState(state: AgentState, successFailOptions: SuccessFailOptions): void;
-        /**
-         * Creates an outbound contact to the given endpoint.
-         *
-         * @param endpoint An object describing the endpoint to which to connect.
-         * @param successFailOptions Optional success and failure callbacks can be provided to determine whether the operation was successful.
-         */
-        connect(endpoint: Endpoint, successFailOptions: ConnectOptions): void;
-        /**
-         * Create a snapshot version of the current Agent state and save it for future use, such as adding to a log file or posting elsewhere.
-         */
-        toSnapshot(): Agent;
-
-        /*
-         * Sets the agent local media to mute mode.
-         */
-        mute(): void;
-
-        /*
-         * Sets the agent localmedia to unmute mode.
-         */
-        unmute(): void;
-    }
+    initCCP(container: HTMLElement, options: InitCCPOptions): void;
 
     /**
-     * An object containing the current Agent state
+     * Terminates Amazon Connect Streams. Removing any subscription methods that have been called.
+     * The CCP iframe will not be removed though, so you'll have to manually remove it.
      */
-    interface AgentState {
-        /**
-         * The name of the agent's current availability state.
-         */
-        name: string;
-
-        /**
-         * The agent's current availability state type, as per the AgentStateType enumeration.
-         */
-        type: AgentStateType;
-
-        /**
-         * A relative local state duration. To get the actual duration of the state relative
-         * to the current time, use agent.getStateDuration().
-         */
-        duration?: number;
-
-        /**
-         * Indicates whether the agent is currently muted.
-         */
-        muted?: boolean;
-    }
+    terminate(): void;
 
     /**
-     * An object containing the Agent old state and new state
+     * Changes the currently selected contact in the CCP user interface.
+     * Useful when an agent handles more than one concurrent chat.
+     *
+     * @param contactId The contact ID.
      */
-    interface AgentStateChange {
-        /**
-         * The Agent object
-         */
-        agent: Agent;
-        /**
-         * The name of the agent's previous state.
-         */
-        oldState: string;
-        /**
-         * The name of the agent's new state.
-         */
-        newState: string;
-    }
+    viewContact(contactId: string): void;
 
-    interface AgentConfiguration {
-        /**
-         * The agent's user friendly display name.
-         */
-        name: string;
+    /**
+     * Subscribes a callback that executes whenever the currently selected contact on the CCP changes.
+     * The callback is called when the contact changes in the UI (i.e. via `click` events) or via `connect.core.viewContact()`.
+     *
+     * @param callback A callback that will receive a `ViewContactEvent` object.
+     */
+    onViewContact(callback: ViewContactCallback): void;
 
-        /**
-         * Indicates whether the agent's phone calls should route to the agent's browser-based softphone or the telephone number configured as the agent's extension.
-         */
-        softphoneEnabled: boolean;
+    /**
+     * Subscribes a callback that executes whenever authentication fails (e.g. SAML authentication).
+     *
+     * @param callback A callback that will execute whenever authentication fails.
+     */
+    onAuthFail(callback: SuccessFailCallback): void;
 
-        /**
-         * Indicates the phone number that should be dialed to connect the agent to their inbound or outbound calls when softphone is not enabled.
-         */
-        extension: string;
+    /**
+     * Subscribes a callback that executes whenever authorization fails (i.e. access denied).
+     *
+     * @param callback A callback that will execute whenever access is denied.
+     */
+    onAccessDenied(callback: SuccessFailCallback): void;
+  }
 
-        /**
-         * Describes the agent's current routing profile and list of queues therein. See agent.getRoutingProfile() for more info.
-         */
-        routingProfile: AgentRoutingProfile;
+  const core: Core;
 
-        /**
-         * The username for the agent as entered in their Amazon Connect user account.
-         */
-        username: string;
-    }
+  interface ViewContactEvent {
+    /** The ID of the viewed contact. */
+    contactId: string;
+  }
 
-    interface AgentRoutingProfile {
-        /**
-         * The name of the routing profile.
-         */
-        name: string;
+  interface SoftPhoneOptions {
+    /**
+     * Normally, the softphone microphone and speaker components are not allowed to be hosted in an iframe.
+     * This is because the softphone must be hosted in a single window or tab.
+     * The window hosting the softphone session must not be closed during the course of a softphone call or the call will be disconnected.
+     * If `allowFramedSoftphone` is `true`, the softphone components will be allowed to be hosted in this window or tab.
+     */
+    readonly allowFramedSoftphone?: boolean;
 
-        /**
-         * The queues contained in the routing profile.
-         */
-        queues: string;
+    /** This option allows you to completely disable the built-in ringtone audio that is played when a call is incoming. */
+    readonly disableRingtone?: boolean;
 
-        /**
-         * The default queue which should be associated with outbound contacts.
-         */
-        defaultOutboundQueue: string;
-    }
+    /** If the ringtone is not disabled, this allows for overriding the ringtone with any browser-supported audio file accessible by the user. */
+    readonly ringtoneUrl?: string;
+  }
 
-    interface AttributeDictionary {
-        [key: string]: string;
-    }
+  interface InitCCPOptions {
+    /**
+     * The URL of the CCP.
+     * This is the page you would normally navigate to in order to use the CCP in a standalone page, it is different for each instance.
+     */
+    readonly ccpUrl: string;
 
-    interface Contact {
-        /**
-         * Subscribe a method to be invoked whenever the contact is updated.
-         */
-        onRefresh(callback: ContactCallback): void;
-        /**
-         * Subscribe a method to be invoked when the contact is incoming.
-         */
-        onIncoming(callback: ContactCallback): void;
-        /**
-         * Subscribe a method to be invoked whenever the contact is accepted.
-         */
-        onAccepted(callback: ContactCallback): void;
-        /**
-         * Subscribe a method to be invoked whenever the contact is ended or destroyed.
-         */
-        onEnded(callback: ContactCallback): void;
+    /**
+     * Amazon connect instance region. Only required for chat channel.
+     * @example "us-west-2"
+     */
+    readonly region?: string;
 
-        /**
-         * Subscribe a method to be invoked when the contact is connecting.
-         */
-        onConnecting(callback: ContactCallback): void;
+    /**
+     * Set to `false` to disable the login popup which is shown when the user's authentication expires.
+     * @default true
+     */
+    readonly loginPopup?: boolean;
 
-        /**
-         * Subscribe a method to be invoked when the contact is connected.
-         */
-        onConnected(callback: ContactCallback): void;
+    /**
+     * Set to `true` in conjunction with the `loginPopup` parameter to automatically close the login Popup window once the authentication step has completed.
+     * If the login page opened in a new tab, this parameter will also auto-close that tab.
+     * @default false
+     */
+    readonly loginPopupAutoClose?: boolean;
 
-        /**
-         * Get the unique contactId of this contact.
-         */
-        getContactId(): string;
-        /**
-         * Get the original contact id from which this contact was transferred,
-         * or none if this is not an internal Connect transfer.
-         */
-        getOriginalContactId(): string;
-        /**
-         * Get the type of the contact. This indicates what type of media is
-         * carried over the connections of the contact.
-         */
-        getType(): string;
-        /**
-         * Get a ContactState object representing the state of the contact.
-         */
-        getStatus(): ContactState;
-        /**
-         * Get the duration of the contact state in milliseconds relative to local time.
-         */
-        getStatusDuration(): number;
-        /**
-         * Get the queue associated with the contact.
-         */
-        getQueue(): Queue;
-        /**
-         * Get a list containing Connection API objects for each connection in the contact.
-         */
-        getConnections(): Connection[];
-        /**
-         * Get the initial connection of the contact.
-         */
-        getInitialConnection(): Connection;
-        /**
-         * Get the inital connection of the contact, or null if the initial connection
-         * is no longer active.
-         */
-        getActiveInitialConnection(): Connection;
-        /**
-         * Get a list of all of the third-party connections, i.e. the list of all
-         * connections except for the initial connection, or an empty list if there
-         * are no third-party connections.
-         */
-        getThirdPartyConnections(): Connection;
-        /**
-         * In Voice contacts, there can only be one active third-party connection.
-         * This method returns the single active third-party connection, or null if
-         * there are no currently active third-party connections.
-         */
-        getSingleActiveThirdPartyConnection(): Connection;
-        /**
-         * Gets the agent connection. This is the connection that represents the agent's
-         * participation in the contact.
-         */
-        getAgentConnection(): Connection;
-        /**
-         * Get a map from attribute name to value for each attribute associated with the contact.
-         */
-        getAttributes(): { [key: string]: { label: string; value: string } };
-        /*
-         * Determine whether this contact is a softphone call.
-         */
-        isSoftphoneCall(): boolean;
-        /**
-         * Determine whether this is an inbound or outbound contact.
-         */
-        isInbound(): boolean;
-        /**
-         * Determine whether the contact is in a connected state.
-         */
-        isConnected(): boolean;
-        /**
-         * Accept an incoming contact.
-         *
-         * @param successFailOptions Optional success and failure callbacks can be provided to determine whether the operation was successful.
-         */
-        accept(successFailOptions: SuccessFailOptions): void;
-        /**
-         * Close the contact and all of its associated connections.
-         *
-         * @param successFailOptions Optional success and failure callbacks can be provided to determine whether the operation was successful.
-         */
-        destroy(successFailOptions: SuccessFailOptions): void;
-        /**
-         * Provide diagnostic information for the contact in the case
-         * something exceptional happens on the front end.
-         *
-         * @param successFailOptions Optional success and failure callbacks can be provided to determine whether the operation was successful.
-         */
-        notifyIssue(successFailOptions: SuccessFailOptions): void;
-        /**
-         * Add a new outbound third-party connection to this contact and connect
-         * it to the specified endpoint.
-         *
-         * @param endpoint The endpoint to add.
-         * @param successFailOptions Optional success and failure callbacks can be provided to determine whether the operation was successful.
-         */
-        addConnection(endpoint: Endpoint, successFailOptions: SuccessFailOptions): void;
-        /**
-         * Rotate through the connected and on hold connections of the contact.
-         * @param successFailOptions Optional success and failure callbacks can be provided to determine whether the operation was successful.
-         */
-        toggleActiveConnections(successFailOptions: SuccessFailOptions): void;
-        /**
-         * Conference together the active connections of the conversation.
-         *
-         * @param successFailOptions Optional success and failure callbacks can be provided to determine whether the operation was successful.
-         */
-        conferenceConnections(successFailOptions: SuccessFailOptions): void;
-    }
+    /** Allows custom URL to be used to initiate the ccp, as in the case of SAML authentication. */
+    readonly loginUrl?: string;
 
-    interface ContactState {
-        /**
-         * The contact state type, as per the ContactStateType enumeration.
-         */
-        type: string;
+    /** Allows you to specify some settings surrounding the softphone feature of Connect. */
+    readonly softphone?: SoftPhoneOptions;
+  }
 
-        /**
-         * A relative local state duration. To get the actual duration of the state
-         * relative to the current time, use contact.getStateDuration().
-         */
-        duration: number;
-    }
+  /** This enumeration lists the different types of agent states. */
+  enum AgentStateType {
+    /** The agent state hasn't been initialized yet. */
+    INIT = "init",
 
-    interface Queue {
-        /**
-         * The queueARN of the queue.
-         */
-        queueARN: string;
+    /** The agent is in a state where they can be routed contacts. */
+    ROUTABLE = "routable",
 
-        /**
-         * The name of the queue.
-         */
-        name: string;
-    }
+    /** The agent is in a state where they cannot be routed contacts. */
+    NOT_ROUTABLE = "not_routable",
 
-    class Endpoint {
-        endpointARN: string;
-        endpointId: string;
-        type: EndpointType;
-        name: string;
-        phoneNumber: string;
-        agentLogin: string;
-        queue: string;
-        static byPhoneNumber(phoneNumber: string): Endpoint;
-    }
+    /** The agent is offline. */
+    OFFLINE = "offline",
+  }
 
-    interface SendDigitOptions extends SuccessFailOptions {
-        /*
-         * A string containing digits to send.
-         */
-        digits: string;
-    }
+  enum AgentAvailStates {
+    INIT = "Init",
+    BUSY = "Busy",
+    AFTER_CALL_WORK = "AfterCallWork",
+    CALLING_CUSTOMER = "CallingCustomer",
+    DIALING = "Dialing",
+    JOINING = "Joining",
+    PENDING_AVAILABLE = "PendingAvailable",
+    PENDING_BUSY = "PendingBusy",
+  }
 
-    interface Connection {
-        /**
-         * Gets the unique contactId of the contact to which this connection belongs.
-         */
-        getContactId(): string;
-        /**
-         * Gets the unique connectionId for this connection.
-         */
-        getConnectionId(): string;
-        /**
-         * Gets the endpoint to which this connection is connected.
-         */
-        getEndpoint(): Endpoint;
-        /**
-         * Gets the ConnectionState object for this connection.
-         */
-        getState(): ConnectionState;
-        /**
-         * Get the duration of the connection state, in milliseconds, relative to local time.
-         */
-        getStateDuration(): number;
-        /**
-         * Get the type of connection.
-         */
-        getType(): 'inbound' | 'outbound' | 'monitoring';
-        /**
-         * Determine if the connection is the contact's initial connection.
-         */
-        isInitialConnection(): boolean;
-        /**
-         * Determine if the contact is active.
-         */
-        isActive(): boolean;
-        /**
-         * Determine if the connection is connected, meaning that the agent is live in a
-         * conversation through this connection.
-         */
-        isConnected(): boolean;
-        /**
-         * Determine whether the connection is in the process of connecting.
-         */
-        isConnecting(): boolean;
-        /**
-         * Determine whether the connection is on hold.
-         */
-        isOnHold(): boolean;
-        /**
-         * Ends the connection.
-         * @param successFailOptions Optional success and failure callbacks can be provided to determine whether the operation was successful.
-         */
-        destroy(successFailOptions: SuccessFailOptions): void;
-        /**
-         * Send a digit or string of digits through this connection.
-         * @param successFailOptions Optional success and failure callbacks can be provided to determine whether the operation was successful.
-         */
-        sendDigits(options: SendDigitOptions): void;
+  enum AgentErrorStates {
+    ERROR = "Error",
+    AGENT_HUNG_UP = "AgentHungUp",
+    BAD_ADDRESS_AGENT = "BadAddressAgent",
+    BAD_ADDRESS_CUSTOMER = "BadAddressCustomer",
+    DEFAULT = "Default",
+    FAILED_CONNECT_AGENT = "FailedConnectAgent",
+    FAILED_CONNECT_CUSTOMER = "FailedConnectCustomer",
+    LINE_ENGAGED_AGENT = "LineEngagedAgent",
+    LINE_ENGAGED_CUSTOMER = "LineEngagedCustomer",
+    MISSED_CALL_AGENT = "MissedCallAgent",
+    MISSED_CALL_CUSTOMER = "MissedCallCustomer",
+    MULTIPLE_CCP_WINDOWS = "MultipleCcpWindows",
+    REALTIME_COMMUNICATION_ERROR = "RealtimeCommunicationError",
+  }
 
-        /**
-         * Put this connection on hold.
-         * @param successFailOptions Optional success and failure callbacks can be provided to determine whether the operation was successful.
-         */
-        hold(successFailOptions: SuccessFailOptions): void;
+  /** This enumeration lists the different types of endpoints. */
+  enum EndpointType {
+    /** An endpoint pointing to a phone number. */
+    PHONE_NUMBER = "phone_number",
 
-        /**
-         * Resume this connection if it was on hold.
-         * @param successFailOptions Optional success and failure callbacks can be provided to determine whether the operation was successful.
-         */
-        resume(successFailOptions: SuccessFailOptions): void;
-    }
+    /** An endpoint pointing to an agent in the same instance. */
+    AGENT = "agent",
 
-    interface ConnectionState {
-        /**
-         * The connection state type, as per the ConnectionStateType enumeration.
-         */
-        type: string;
+    /** An endpoint pointing to a queue call flow in the same instance. */
+    QUEUE = "queue",
+  }
 
-        /**
-         * A relative local state duration. To get the actual duration of the state
-         * relative to the current time, use connection.getStateDuration().
-         */
-        duration: number;
-    }
+  /** Lists the different types of connections. */
+  enum ConnectionType {
+    /** The agent connection. */
+    AGENT = "agent",
+
+    /** An inbound connection, usually representing an inbound call. */
+    INBOUND = "inbound",
+
+    /** An outbound connection, representing either an outbound call or additional connection added to the contact. */
+    OUTBOUND = "outbound",
+
+    /** A special connection type representing a manager listen-in session. */
+    MONITORING = "monitoring",
+  }
+
+  /** An enumeration listing the different states that a connection can have. */
+  enum ConnectionStateType {
+    /** The connection has not yet been initialized. */
+    INIT = "init",
+
+    /** The connection is being initialized. */
+    CONNECTING = "connecting",
+
+    /** The connection is connected to the contact. */
+    CONNECTED = "connected",
+
+    /** The connection is connected but on hold. */
+    HOLD = "hold",
+
+    /** The connection is no longer connected to the contact. */
+    DISCONNECTED = "disconnected",
+  }
+
+  enum ContactEvents {
+    INIT = "init",
+    REFRESH = "refresh",
+    DESTROYED = "destroyed",
+    INCOMING = "incoming",
+    PENDING = "pending",
+    CONNECTING = "connecting",
+    CONNECTED = "connected",
+    MISSED = "missed",
+    ACW = "acw",
+    VIEW = "view",
+    ENDED = "ended",
+    ERROR = "error",
+    ACCEPTED = "accepted",
+  }
+
+  /** An enumeration listing the different high-level states that a contact can have. */
+  enum ContactStateType {
+    /** Indicates the contact is being initialized. */
+    INIT = "init",
+
+    /**
+     * Indicates that the contact is incoming and is waiting for acceptance.
+     * This state is skipped for `ContactType.VOICE` contacts but is essential for `ContactType.QUEUE_CALLBACK` contacts.
+     */
+    INCOMING = "incoming",
+
+    /** Indicates the contact is pending. */
+    PENDING = "pending",
+
+    /**
+     * Indicates that the contact is currently connecting.
+     * For `ContactType.VOICE` contacts, this is when the user will accept the incoming call.
+     * For all other types, the contact will be accepted during the `ContactStateType.INCOMING` state.
+     */
+    CONNECTING = "connecting",
+
+    /** Indicates the contact is connected. */
+    CONNECTED = "connected",
+
+    /** Indicates the contact timed out before the agent could accept it. */
+    MISSED = "missed",
+
+    /** Indicates the contact is in an error state. */
+    ERROR = "error",
+
+    /** Indicates the contact has ended. */
+    ENDED = "ended",
+  }
+
+  enum CONTACT_ACTIVE_STATES {
+    INCOMING = "incoming",
+    PENDING = "pending",
+    CONNECTING = "connecting",
+    CONNECTED = "connected",
+  }
+
+  /** This enumeration lists all of the contact types supported by Connect Streams. */
+  enum ContactType {
+    /** Normal incoming and outgoing voice calls. */
+    VOICE = "voice",
+
+    /**
+     * Special outbound voice calls which are routed to agents before being placed.
+     * For more information about how to setup and use queued callbacks, see the Amazon Connect user documentation.
+     */
+    QUEUE_CALLBACK = "queue_callback",
+
+    /** Chat contact. */
+    CHAT = "chat",
+  }
+
+  /** This enumeration lists the different types of contact channels. */
+  enum ChannelType {
+    /** A voice contact. */
+    VOICE = "VOICE",
+
+    /** A chat contact. */
+    CHAT = "CHAT",
+  }
+
+  enum MediaType {
+    SOFTPHONE = "softphone",
+    CHAT = "chat",
+  }
+
+  enum SoftphoneCallType {
+    AUDIO_VIDEO = "audio_video",
+    VIDEO_ONLY = "video_only",
+    AUDIO_ONLY = "audio_only",
+    NONE = "none",
+  }
+
+  enum SoftphoneErrorTypes {
+    UNSUPPORTED_BROWSER = "unsupported_browser",
+    MICROPHONE_NOT_SHARED = "microphone_not_shared",
+    SIGNALLING_HANDSHAKE_FAILURE = "signalling_handshake_failure",
+    SIGNALLING_CONNECTION_FAILURE = "signalling_connection_failure",
+    ICE_COLLECTION_TIMEOUT = "ice_collection_timeout",
+    USER_BUSY_ERROR = "user_busy_error",
+    WEBRTC_ERROR = "webrtc_error",
+    REALTIME_COMMUNICATION_ERROR = "realtime_communication_error",
+    OTHER = "other",
+  }
+
+  enum CTIExceptions {
+    ACCESS_DENIED_EXCEPTION = "AccessDeniedException",
+    INVALID_STATE_EXCEPTION = "InvalidStateException",
+    BAD_ENDPOINT_EXCEPTION = "BadEndpointException",
+    INVALID_AGENT_ARNEXCEPTION = "InvalidAgentARNException",
+    INVALID_CONFIGURATION_EXCEPTION = "InvalidConfigurationException",
+    INVALID_CONTACT_TYPE_EXCEPTION = "InvalidContactTypeException",
+    PAGINATION_EXCEPTION = "PaginationException",
+    REFRESH_TOKEN_EXPIRED_EXCEPTION = "RefreshTokenExpiredException",
+    SEND_DATA_FAILED_EXCEPTION = "SendDataFailedException",
+    UNAUTHORIZED_EXCEPTION = "UnauthorizedException",
+  }
+
+  /*
+   * A callback to receive notifications of success or failure.
+   */
+  type SuccessFailCallback<T extends any[] = []> = (...args: T) => void;
+
+  interface SuccessFailOptions {
+    /** A callback that executes when the operation completes successfully. */
+    readonly success?: SuccessFailCallback;
+
+    /** A callback that executes when the operation has an error. */
+    readonly failure?: SuccessFailCallback<[string]>;
+  }
+
+  interface ConnectOptions extends SuccessFailOptions {
+    /** The queue ARN to associate the contact with. */
+    readonly queueARN?: string;
+  }
+
+  /**
+   * The Agent API provides event subscription methods and action methods which can be called on behalf of the agent.
+   * There is only ever one agent per Streams instantiation and all contacts and actions are assumed to be taken on behalf of this one agent.
+   */
+  class Agent {
+    /**
+     * Subscribe a method to be called whenever a contact enters the pending state for this particular agent.
+     *
+     * @param callback A callback to receive the `Agent` API object instance.
+     */
+    onContactPending(callback: AgentCallback): void;
+
+    /**
+     * Subscribe a method to be called whenever new agent data is available.
+     *
+     * @param callback A callback to receive the `Agent` API object instance.
+     */
+    onRefresh(callback: AgentCallback): void;
+
+    /**
+     * Subscribe a method to be called when the agent's state changes.
+     *
+     * @param callback A callback to receive the `AgentStateChange` API object instance.
+     */
+    onStateChange(callback: AgentStateChangeCallback): void;
+
+    /**
+     * Subscribe a method to be called when the agent becomes routable, meaning that they can be routed incoming contacts.
+     *
+     * @param callback A callback to receive the `Agent` API object instance.
+     */
+    onRoutable(callback: AgentCallback): void;
+
+    /**
+     * Subscribe a method to be called when the agent becomes not-routable, meaning that they are online but cannot be routed incoming contacts.
+     *
+     * @param callback A callback to receive the `Agent` API object instance.
+     */
+    onNotRoutable(callback: AgentCallback): void;
+
+    /**
+     * Subscribe a method to be called when the agent goes offline.
+     *
+     * @param callback A callback to receive the `Agent` API object instance.
+     */
+    onOffline(callback: AgentCallback): void;
+
+    /**
+     * Subscribe a method to be called when the agent is put into an error state.
+     * This can occur if Streams is unable to get new agent data, or if the agent fails to accept an incoming contact, or in other error cases.
+     * It means that the agent is not routable, and may require that the agent switch to a routable state before being able to be routed contacts again.
+     *
+     * @param callback A callback to receive the `Agent` API object instance.
+     */
+    onError(callback: AgentCallback): void;
+
+    /**
+     * Subscribe a method to be called when the agent is put into an error state specific to softphone funcionality.
+     *
+     * @param callback A callback to receive the `SoftphoneError` error.
+     */
+    onSoftphoneError(callback: SoftphoneErrorCallback): void;
+
+    /**
+     * Subscribe a method to be called when the agent enters the "After Call Work" (ACW) state.
+     * This is a non-routable state which exists to allow agents some time to wrap up after handling a contact before they are routed additional contacts.
+     *
+     * @param callback A callback to receive the `Agent` API object instance.
+     */
+    onAfterCallWork(callback: AgentCallback): void;
+
+    /** Get the agent's current `AgentState` object indicating their availability state type. */
+    getState(): AgentState;
+
+    /** Alias for `getState()`. */
+    getStatus(): AgentState;
+
+    /**
+     * Get the duration of the agent's state in milliseconds relative to local time.
+     * This takes into account time skew between the JS client and the Amazon Connect service.
+     */
+    getStateDuration(): number;
+
+    /**
+     * Mostly for internal purposes only.
+     * Contains strings which indicates actions that the agent can take in the CCP.
+     */
+    getPermissions(): string[];
+
+    /**
+     * Gets a list of `Contact` API objects for each of the agent's current contacts.
+     *
+     * @param contactTypeFilter If provided, only contacts of the given `ContactType` enum are returned.
+     */
+    getContacts(contactTypeFilter?: ContactType): Contact[];
+
+    /** Gets the full `AgentConfiguration` object for the agent. */
+    getConfiguration(): AgentConfiguration;
+
+    /**
+     * Gets the list of selectable `AgentState` API objects.
+     * These are the agent states that can be selected when the agent is not handling a live contact.
+     */
+    getAgentStates(): AgentStateDefinition[];
+
+    /** Gets the agent's routing profile. */
+    getRoutingProfile(): AgentRoutingProfile;
+
+    /**
+     * Gets a map of channel type to 1 or 0.
+     * 1 represents an enabled channel.
+     * 0 represents a disabled channel.
+     */
+    getChannelConcurrency(): AgentChannelConcurrencyMap;
+
+    /**
+     * Gets a number indicating how many concurrent contacts can an agent have on a given channel.
+     * 0 represents a disabled channel.
+     *
+     * @param channel The channel to get the configured concurrency.
+     */
+    getChannelConcurrency(channel: ChannelType): number;
+
+    /** Gets the agent's user friendly display name. */
+    getName(): string;
+
+    /**
+     * Gets the agent's phone number.
+     * This is the phone number that is dialed by Amazon Connect to connect calls to the agent for incoming and outgoing calls if softphone is not enabled.
+     */
+    getExtension(): string;
+
+    /** Returns a list of eligible countries to be dialed / deskphone redirected. */
+    getDialableCountries(): string[];
+
+    /** Indicates whether the agent's phone calls should route to the agent's browser-based softphone or the telephone number configured as the agent's extension. */
+    isSoftphoneEnabled(): boolean;
+
+    /**
+     * Updates the agent's configuration with the given `AgentConfiguration` object.
+     * The phone number specified must be in E.164 format or the update fails.
+     *
+     * @param config The desired configuration.
+     * @param callbacks Success and failure callbacks to determine whether the operation was successful.
+     */
+    setConfiguration(
+      config: AgentConfiguration,
+      callbacks?: SuccessFailOptions
+    ): void;
+
+    /**
+     * Set the agent's current availability state.
+     * Can only be performed if the agent is not handling a live contact.
+     *
+     * @param state The new agent state.
+     * @param callbacks Success and failure callbacks to determine whether the operation was successful.
+     */
+    setState(state: AgentStateDefinition, callbacks?: SuccessFailOptions): void;
+
+    /** Alias for `setState()`. */
+    setStatus(
+      state: AgentStateDefinition,
+      callbacks?: SuccessFailOptions
+    ): void;
+
+    /**
+     * Creates an outbound contact to the given endpoint.
+     *
+     * @param endpoint An `Endpoint` API object to connect to.
+     * @param connectOptions The connection options.
+     */
+    connect(endpoint: Endpoint, connectOptions?: ConnectOptions): void;
+
+    /** Returns a list of the ARNs associated with this agent's routing profile's queues. */
+    getAllQueueARNs(): string[];
+
+    /**
+     * Returns the endpoints associated with the queueARNs specified in `queueARNs`.
+     *
+     * @param queueARNs A single Queue ARN or a list of Queue ARNs associated with the desired queues.
+     * @param callbacks Success and failure callbacks to determine whether the operation was successful.
+     */
+    getEndpoints(
+      queueARNs: string | string[],
+      callbacks: GetEndpointsCallbacks
+    ): void;
+
+    /**
+     * The data behind the `Agent` API object is ephemeral and changes whenever new data is provided.
+     * This method provides an opportunity to create a snapshot version of the `Agent` API object and save it for future use, such as adding to a log file or posting elsewhere.
+     */
+    toSnapshot(): Agent;
+
+    /** Sets the agent local media to mute mode. */
+    mute(): void;
+
+    /** Sets the agent localmedia to unmute mode. */
+    unmute(): void;
+
+    /**
+     * Subscribe a method to be called when the agent updates the mute status, meaning that agents mute/unmute APIs are called and the local media stream is succesfully updated with the new status.
+     *
+     * @param callback A callback to receive updates on agent mute state
+     */
+    onMuteToggle(callback: AgentMutedStatusCallback): void;
+  }
+
+  interface AgentMutedStatus {
+    /** A value indicating whether the agent local media is muted. */
+    readonly muted: boolean;
+  }
+
+  interface AgentStateChange {
+    /** The `Agent` API object. */
+    readonly agent: Agent;
+
+    /** The name of the agent's previous state. */
+    readonly oldState: string;
+
+    /** The name of the agent's new state. */
+    readonly newState: string;
+  }
+
+  interface AgentStateDefinition {
+    /** The agent state ARN. */
+    readonly agentStateARN: string;
+
+    /** The agent state type. */
+    readonly type: AgentStateType;
+
+    /** The name of the agent state to be displayed in the UI. */
+    readonly name: string;
+  }
+
+  /** An object containing the current Agent state. */
+  interface AgentState {
+    /** The agent's current state ARN. */
+    readonly agentStateARN: string | null;
+
+    /** The name of the agent's current availability state. */
+    readonly name: string;
+
+    /** Indicates when the state was set. */
+    readonly startTimestamp: Date;
+
+    /** The agent's current availability state type, as per the `AgentStateType` enumeration. */
+    readonly type: AgentStateType;
+  }
+
+  interface AgentConfiguration {
+    /** See `agent.getAgentStates()` for more info. */
+    readonly agentStates: AgentStateDefinition[];
+
+    /** See `agent.getDialableCountries()` for more info. */
+    readonly dialableCountries: string[];
+
+    /** See `agent.getExtension()` for more info. */
+    extension: string;
+
+    /** See `agent.getName()` for more info. */
+    readonly name: string;
+
+    /** See `agent.getPermissions()` for more info. */
+    readonly permissions: string[];
+
+    /** See `agent.getRoutingProfile()` for more info. */
+    readonly routingProfile: AgentRoutingProfile;
+
+    /** Indicates whether auto accept soft phone calls is enabled. */
+    readonly softphoneAutoAccept: boolean;
+
+    /** See `agent.isSoftphoneEnabled()` for more info. */
+    softphoneEnabled: boolean;
+
+    /** The username for the agent as entered in their Amazon Connect user account. */
+    readonly username: string;
+  }
+
+  interface AgentRoutingProfile {
+    /** See `agent.getChannelConcurrency()` for more info. */
+    readonly channelConcurrencyMap: AgentChannelConcurrencyMap;
+
+    /** The default queue which should be associated with outbound contacts. */
+    readonly defaultOutboundQueue: Queue;
+
+    /** The name of the routing profile. */
+    readonly name: string;
+
+    /** The queues contained in the routing profile. */
+    readonly queues: Queue[];
+
+    /** The routing profile ARN. */
+    readonly routingProfileARN: string;
+
+    /** Alias for `routingProfileARN`. */
+    readonly routingProfileId: string;
+  }
+
+  type AgentChannelConcurrencyMap = {
+    readonly [channel in ChannelType]: number;
+  };
+
+  interface GetEndpointsResult {
+    endpoints: Endpoint[];
+    addresses: Endpoint[];
+  }
+
+  interface GetEndpointsCallbacks {
+    readonly success: SuccessFailCallback<[GetEndpointsResult]>;
+    readonly failure?: SuccessFailCallback<[string]>;
+  }
+
+  interface AttributeDictionary {
+    readonly [key: string]: {
+      name: string;
+      value: string;
+    };
+  }
+
+  /**
+   * The Contact API provides event subscription methods and action methods which can be called on behalf of a specific contact.
+   * Contacts come and go and so should these API objects.
+   * It is good practice not to persist these objects or keep them as internal state.
+   * If you need to, store the `contactId` of the contact and make sure that the contact still exists by fetching it from the `Agent` API object before calling methods on it.
+   */
+  class Contact {
+    /** The unique contactId of this contact. */
+    readonly contactId: string;
+
+    /**
+     * Subscribe a method to be invoked whenever the contact is updated.
+     *
+     * @param callback A callback to receive the `Contact` API object instance.
+     */
+    onRefresh(callback: ContactCallback): void;
+
+    /**
+     * Subscribe a method to be invoked when a queue callback contact is incoming.
+     * In this state, the contact is waiting to be accepted if it is a softphone call or is waiting for the agent to answer if it is not a softphone call.
+     *
+     * @param callback A callback to receive the `Contact` API object instance.
+     */
+    onIncoming(callback: ContactCallback): void;
+
+    /**
+     * Subscribe a method to be invoked when the contact is pending.
+     * This event is expected to occur before the connecting event.
+     *
+     * @param callback A callback to receive the `Contact` API object instance.
+     */
+    onPending(callback: ContactCallback): void;
+
+    /**
+     * Subscribe a method to be invoked when the contact is connecting.
+     * This works with chat and softphone contacts.
+     * This event happens when a call or chat comes in, before accepting (there is an exception for queue callbacks, in which onConnecting's handler is executed after the callback is accepted).
+     * Note that once the contact has been accepted, the `onAccepted` handler will be triggered.
+     *
+     * @param callback A callback to receive the `Contact` API object instance.
+     */
+    onConnecting(callback: ContactCallback): void;
+
+    /**
+     * Subscribe a method to be invoked whenever the contact is accepted.
+     *
+     * @param callback A callback to receive the `Contact` API object instance.
+     */
+    onAccepted(callback: ContactCallback): void;
+
+    /**
+     * Subscribe a method to be invoked whenever the contact is missed.
+     * This is an event which is fired when a contact is put in state "missed" by the backend, which happens when the agent does not answer for a certain amount of time, when the agent rejects the call, or when the other participant hangs up before the agent can accept.
+     *
+     * @param callback A callback to receive the `Contact` API object instance.
+     */
+    onMissed(callback: ContactCallback): void;
+
+    /**
+     * Subscribe a method to be invoked whenever the contact is ended or destroyed.
+     * This could be due to the conversation being ended by the agent, or due to the contact being missed.
+     * Call `contact.getState()` to determine the state of the contact and take appropriate action.
+     *
+     * @param callback A callback to receive the `Contact` API object instance.
+     */
+    onEnded(callback: ContactCallback): void;
+
+    /**
+     * Subscribe a method to be invoked whenever the contact is destroyed.
+     *
+     * @param callback A callback to receive the `Contact` API object instance.
+     */
+    onDestroy(callback: ContactCallback): void;
+
+    /**
+     * Subscribe a method to be invoked whenever the contact enters the ACW state.
+     * This is after the connection has been closed, but before the contact is destroyed.
+     *
+     * @param callback A callback to receive the `Contact` API object instance.
+     */
+    onACW(callback: ContactCallback): void;
+
+    /**
+     * Subscribe a method to be invoked when the contact is connected.
+     *
+     * @param callback A callback to receive the `Contact` API object instance.
+     */
+    onConnected(callback: ContactCallback): void;
+
+    /**
+     * Returns a formatted string with the contact event and ID.
+     *
+     * @param event The event to format.
+     */
+    getEventName(event: ContactEvents): string;
+
+    /** Get the unique contactId of this contact. */
+    getContactId(): string;
+
+    /**
+     * Get the original (initial) contact id from which this contact was transferred, or none if this is not an internal Connect transfer.
+     * This is typically a contact owned by another agent, thus this agent will not be able to manipulate it.
+     * It is for reference and association purposes only, and can be used to share data between transferred contacts externally if it is linked by originalContactId.
+     */
+    getOriginalContactId(): string;
+
+    /** Alias for `getOriginalContactId()`. */
+    getInitialContactId(): string;
+
+    /**
+     * Get the type of the contact.
+     * This indicates what type of media is carried over the connections of the contact.
+     */
+    getType(): ContactType;
+
+    /** Get a ContactState object representing the state of the contact. */
+    getStatus(): ContactState;
+
+    /**
+     * Get the duration of the contact state in milliseconds relative to local time.
+     * This takes into account time skew between the JS client and the Amazon Connect backend servers.
+     */
+    getStatusDuration(): number;
+
+    /** Get the queue associated with the contact. */
+    getQueue(): Queue;
+
+    /** Gets the timestamp associated with when the contact was placed in the queue. */
+    getQueueTimestamp(): Date;
+
+    /** Get a list containing `Connection` API objects for each connection in the contact. */
+    getConnections(): BaseConnection[];
+
+    /** Get the initial connection of the contact. */
+    getInitialConnection(): BaseConnection;
+
+    /** Get the inital connection of the contact, or null if the initial connection is no longer active. */
+    getActiveInitialConnection(): BaseConnection | null;
+
+    /** Get a list of all of the third-party connections, i.e. the list of all connections except for the initial connection, or an empty list if there are no third-party connections. */
+    getThirdPartyConnections(): BaseConnection[];
+
+    /**
+     * In Voice contacts, there can only be one active third-party connection.
+     * This method returns the single active third-party connection, or null if there are no currently active third-party connections.
+     */
+    getSingleActiveThirdPartyConnection(): BaseConnection | null;
+
+    /**
+     * Gets the agent connection.
+     * This is the connection that represents the agent's participation in the contact.
+     */
+    getAgentConnection(): BaseConnection;
+
+    /** Gets a map of the attributes associated with the contact. */
+    getAttributes(): AttributeDictionary;
+
+    /** Determine whether this contact is a softphone call.  */
+    isSoftphoneCall(): boolean;
+
+    /** Determine whether this is an inbound or outbound contact. */
+    isInbound(): boolean;
+
+    /**
+     * Determine whether the contact is in a connected state.
+     * Note that contacts no longer exist once they have been removed.
+     * To detect these instances, subscribe to the `contact.onEnded()` event for the contact.
+     */
+    isConnected(): boolean;
+
+    /**
+     * Accept an incoming contact.
+     *
+     * @param callbacks Success and failure callbacks to determine whether the operation was successful.
+     */
+    accept(callbacks?: SuccessFailOptions): void;
+
+    /**
+     * Close the contact and all of its associated connections.
+     * If the contact is a voice contact, and there is a third-party, the customer remains bridged with the third party and will not be disconnected from the call.
+     * Otherwise, the agent and customer are disconnected.
+     *
+     * @param callbacks Success and failure callbacks to determine whether the operation was successful.
+     */
+    destroy(callbacks?: SuccessFailOptions): void;
+
+    /**
+     * This is an API that completes this contact entirely.
+     * That means that this should only be used for non-monitoring agent connections.
+     *
+     * @param callbacks Success and failure callbacks to determine whether the operation was successful.
+     */
+    complete(callbacks?: SuccessFailOptions): void;
+
+    /**
+     * Provide diagnostic information for the contact in the case something exceptional happens on the front end.
+     * The Streams logs will be published along with the issue code and description provided here.
+     *
+     * @param issueCode An arbitrary issue code to associate with the diagnostic report.
+     * @param description A description to associate with the diagnostic report.
+     * @param callbacks Success and failure callbacks to determine whether the operation was successful.
+     */
+    notifyIssue(
+      issueCode: string,
+      description: string,
+      callbacks?: SuccessFailOptions
+    ): void;
+
+    /**
+     * Add a new outbound third-party connection to this contact and connect it to the specified endpoint.
+     *
+     * @param endpoint The endpoint to add.
+     * @param callbacks Success and failure callbacks to determine whether the operation was successful.
+     */
+    addConnection(endpoint: Endpoint, callbacks?: SuccessFailOptions): void;
+
+    /**
+     * Rotate through the connected and on hold connections of the contact.
+     * This operation is only valid if there is at least one third-party connection and the initial connection is still connected.
+     *
+     * @param callbacks Success and failure callbacks to determine whether the operation was successful.
+     */
+    toggleActiveConnections(callbacks?: SuccessFailOptions): void;
+
+    /**
+     * Conference together the active connections of the conversation.
+     * This operation is only valid if there is at least one third-party connection and the initial connection is still connected.
+     *
+     * @param callbacks Success and failure callbacks to determine whether the operation was successful.
+     */
+    conferenceConnections(callbacks?: SuccessFailOptions): void;
+
+    /**
+     * The data behind the `Contact` API object is ephemeral and changes whenever new data is provided.
+     * This method provides an opportunity to create a snapshot version of the `Contact` API object and save it for future use, such as adding to a log file or posting elsewhere.
+     */
+    toSnapshot(): Contact;
+  }
+
+  interface ContactState {
+    /** The contact state type, as per the ContactStateType enumeration. */
+    readonly type: ContactStateType;
+
+    /** Indicates when the the contact was put in that state. */
+    readonly timestamp: Date;
+  }
+
+  interface Queue {
+    /** The name of the queue. */
+    readonly name: string;
+
+    /** The ARN of the queue. */
+    readonly queueARN: string;
+
+    /** Alias for `queueARN`. */
+    readonly queueId: string;
+  }
+
+  class Endpoint {
+    readonly endpointARN: string;
+    readonly endpointId: string;
+    readonly type: EndpointType;
+    readonly name: string;
+    readonly phoneNumber: string;
+    readonly agentLogin: string;
+    readonly queue: string;
+
+    /**
+     * Creates an endpoint from a E.164 phone number.
+     *
+     * @param phoneNumber The E.164 endpoint phone number.
+     */
+    static byPhoneNumber(phoneNumber: string): Endpoint;
+  }
+
+  class SoftphoneError {
+    readonly errorType: string;
+    readonly errorMessage: string;
+    readonly endPointUrl: string;
+
+    constructor(errorType: string, errorMessage: string, endPointUrl: string);
+
+    getErrorType(): string;
+
+    getErrorMessage(): string;
+
+    getEndPointUrl(): string;
+  }
+
+  /**
+   * The Connection API provides action methods (no event subscriptions) which can be called to manipulate the state of a particular connection within a contact.
+   * Like contacts, connections come and go.
+   * It is good practice not to persist these object or keep them as internal state.
+   * If you need to, store the contactId and connectionId of the connection and make sure that the contact and connection still exist by fetching them in order from the Agent API object before calling methods on them.
+   */
+  class BaseConnection {
+    /** The unique contactId of the contact to which this connection belongs. */
+    readonly contactId: string;
+
+    /** The unique connectionId for this connection. */
+    readonly connectionId: string;
+
+    /** Gets the unique contactId of the contact to which this connection belongs. */
+    getContactId(): string;
+
+    /** Gets the unique connectionId for this connection. */
+    getConnectionId(): string;
+
+    /** Gets the endpoint to which this connection is connected. */
+    getEndpoint(): Endpoint;
+
+    /** Alias for `getEndpoint()`. */
+    getAddress(): Endpoint;
+
+    /** Gets the `ConnectionState` object for this connection. */
+    getStatus(): ConnectionState;
+
+    /**
+     * Get the duration of the connection state, in milliseconds, relative to local time.
+     * This takes into account time skew between the JS client and the Amazon Connect service.
+     */
+    getStatusDuration(): number;
+
+    /** Get the type of connection. */
+    getType(): ConnectionType;
+
+    /** Get the currently monitored contact info, or null if that does not exist. */
+    getMonitorInfo(): MonitorInfo | null;
+
+    /** Determine if the connection is the contact's initial connection. */
+    isInitialConnection(): boolean;
+
+    /**
+     * Determine if the contact is active.
+     * The connection is active it is incoming, connecting, connected, or on hold.
+     */
+    isActive(): boolean;
+
+    /** Determine if the connection is connected, meaning that the agent is live in a conversation through this connection. */
+    isConnected(): boolean;
+
+    /** Determine whether the connection is in the process of connecting. */
+    isConnecting(): boolean;
+
+    /** Determine whether the connection is on hold. */
+    isOnHold(): boolean;
+
+    /**
+     * Ends the connection.
+     *
+     * @param callbacks Success and failure callbacks to determine whether the operation was successful.
+     */
+    destroy(callbacks?: SuccessFailOptions): void;
+
+    /**
+     * Send a digit or string of digits through this connection.
+     * This is only valid for contact types that can accept digits, currently this is limited to softphone-enabled voice contacts.
+     *
+     * @param digits The digits to dial.
+     * @param callbacks Success and failure callbacks to determine whether the operation was successful.
+     */
+    sendDigits(digits: string, callbacks?: SuccessFailOptions): void;
+
+    /**
+     * Put this connection on hold.
+     *
+     * @param callbacks Success and failure callbacks to determine whether the operation was successful.
+     */
+    hold(callbacks?: SuccessFailOptions): void;
+
+    /**
+     * Resume this connection if it was on hold.
+     *
+     * @param callbacks Success and failure callbacks to determine whether the operation was successful.
+     */
+    resume(callbacks?: SuccessFailOptions): void;
+  }
+
+  /**
+   * The VoiceConnection API provides action methods (no event subscriptions) which can be called to manipulate the state of a particular voice connection within a contact.
+   * Like contacts, connections come and go.
+   * It is good practice not to persist these object or keep them as internal state.
+   * If you need to, store the `contactId` and `connectionId` of the connection and make sure that the contact and connection still exist by fetching them in order from the `Agent` API object before calling methods on them.
+   */
+  class VoiceConnection extends BaseConnection {
+    /** Returns the media info object associated with this connection. */
+    getMediaInfo(): VoiceMediaInfo;
+
+    /** Returns the `MediaType` enum value: `"softphone"`. */
+    getMediaType(): MediaType.SOFTPHONE;
+
+    /** Gets a `Promise` with the media controller associated with this connection. */
+    getMediaController(): Promise<any>;
+  }
+
+  /**
+   * The ChatConnection API provides action methods (no event subscriptions) which can be called to manipulate the state of a particular chat connection within a contact.
+   * Like contacts, connections come and go.
+   * It is good practice not to persist these object or keep them as internal state.
+   * If you need to, store the `contactId` and `connectionId` of the connection and make sure that the contact and connection still exist by fetching them in order from the `Agent` API object before calling methods on them.
+   */
+  class ChatConnection extends BaseConnection {
+    /** Get the media info object associated with this connection. */
+    getMediaInfo(): ChatMediaInfo;
+
+    /** Provides a promise which resolves with the API response from createTransport transportType chat_token for this connection. */
+    getConnectionToken(): Promise<ConnectionToken>;
+
+    /** Returns the `MediaType` enum value: `"chat"`.  */
+    getMediaType(): MediaType.CHAT;
+
+    /**
+     * Gets a `Promise` with the media controller associated with this connection.
+     * The promise resolves to a `ChatSession` object from `amazon-connect-chatjs` library.
+     */
+    getMediaController(): Promise<any>;
+  }
+
+  interface ConnectionState {
+    /** A `Date` object that indicates when the the connection was put in that state. */
+    readonly timestamp: Date;
+
+    /** The connection state type, as per the `ConnectionStateType` enumeration. */
+    readonly type: ConnectionStateType;
+  }
+
+  interface ConnectionToken {
+    readonly chatTokenTransport: {
+      readonly expiry: string;
+      readonly participantToken: string;
+    };
+  }
+
+  interface VoiceMediaInfo {
+    readonly autoAccept: boolean;
+    readonly callConfigJson: string;
+    readonly callContextToken: string;
+    readonly callType: SoftphoneCallType;
+    readonly mediaLegContextToken: string;
+  }
+
+  interface ChatMediaInfo {
+    readonly contactId: string;
+    getConnectionToken: ChatConnection["getConnectionToken"];
+    readonly initialContactId: string;
+    readonly originalInfo: {
+      readonly chatAutoAccept: boolean;
+      readonly connectionData: string;
+      readonly customerName: string | null;
+    };
+    readonly participantId: string;
+    readonly participantToken: string;
+  }
+
+  interface MonitorInfo {
+    readonly agentName: string;
+    readonly customerName: string;
+    readonly joinTime: Date;
+  }
+
+  /**
+   * The Streams library comes with a logging utility that can be used to easily gather logs and provide them for diagnostic purposes.
+   * You can even add your own logs to this logger if you prefer.
+   * Logs are written to the console log per normal and also kept in memory.
+   */
+  interface Logger {
+    /**
+     * Adds a log entry with debug level.
+     * @param template The `printf`-style template.
+     * @param args The arguments to the template.
+     */
+    debug(template: string, ...args: unknown[]): LogEntry;
+
+    /**
+     * Adds a log entry with info level.
+     * @param template The `printf`-style template.
+     * @param args The arguments to the template.
+     */
+    info(template: string, ...args: unknown[]): LogEntry;
+
+    /**
+     * Adds a log entry with warn level.
+     * @param template The `printf`-style template.
+     * @param args The arguments to the template.
+     */
+    warn(template: string, ...args: unknown[]): LogEntry;
+
+    /**
+     * Adds a log entry with error level.
+     * @param template The `printf`-style template.
+     * @param args The arguments to the template.
+     */
+    error(template: string, ...args: unknown[]): LogEntry;
+
+    /** Downloads the logs on the agent's machine in JSON form. */
+    download(): void;
+  }
+
+  /** Allows to add additional information to a log entry. */
+  interface LogEntry {
+    /**
+     * Adds an error stack trace and additional info.
+     *
+     * @param err The error to add.
+     */
+    withException(err: Error): LogEntry;
+
+    /**
+     * Adds an arbitrary object.
+     *
+     * @param obj The object to add.
+     */
+    withObject(obj: object): LogEntry;
+  }
+
+  /** Gets the global logger instance. */
+  function getLog(): Logger;
 }

--- a/types/amazon-connect-streams/tslint.json
+++ b/types/amazon-connect-streams/tslint.json
@@ -1,3 +1,7 @@
 {
-    "extends": "dtslint/dt.json"
+  "extends": "dtslint/dt.json",
+  "rules": {
+    "max-line-length": false,
+    "void-return": false
+  }
 }


### PR DESCRIPTION
Sync the typings here with the official types for version `1.4.7`.
Starting with version `1.4.8`+, `@types/amazon-connect-streams` should
be deprecated in favor of using the official typings.

A note on the removal of `connect.core.initialized`:
See https://github.com/amazon-connect/amazon-connect-streams/pull/256

BREAKING CHANGE: In order to match the typings with the official repo,
some types may change names, resulting in compilation errors for users
of previous versions.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/amazon-connect/amazon-connect-streams/blob/master/src/index.d.ts
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.