### PR TITLE
fix(nodemailer): improve types by defining SentMessageInfo

### DIFF
--- a/types/nodemailer/index.d.ts
+++ b/types/nodemailer/index.d.ts
@@ -19,7 +19,7 @@ import StreamTransport = require('./lib/stream-transport');
 
 export type SendMailOptions = Mail.Options;
 
-export type SentMessageInfo = any;
+export type SentMessageInfo = Mail.MessageInfo;
 
 export type Transporter = Mail;
 

--- a/types/nodemailer/index.d.ts
+++ b/types/nodemailer/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Rogier Schouten <https://github.com/rogierschouten>
 //                 Piotr Roszatycki <https://github.com/dex4er>
 //                 Daniel Chao <https://github.com/bioball>
+//                 Zheng Arnaud <https://github.com/arnaud-zg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.3
 

--- a/types/nodemailer/lib/mailer/index.d.ts
+++ b/types/nodemailer/lib/mailer/index.d.ts
@@ -93,6 +93,17 @@ declare namespace Mail {
         bcc?: string;
     }
 
+    interface MessageInfo {
+        accepted: string | Address | Array<string | Address>;
+        envelope: Envelope;
+        envelopeTime: number;
+        messageId: string;
+        messageSize: number;
+        messageTime: number;
+        rejected: string | Address | Array<string | Address>;
+        response: string;
+    }
+
     interface Options {
         /** The e-mail address of the sender. All e-mail addresses can be plain 'sender@server.com' or formatted 'Sender Name <sender@server.com>' */
         from?: string | Address;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
