### PR TITLE
feat(svg-spritemap-webpack-plugin): new type definition

### DIFF
--- a/types/svg-spritemap-webpack-plugin/index.d.ts
+++ b/types/svg-spritemap-webpack-plugin/index.d.ts
@@ -1,0 +1,115 @@
+// Type definitions for svg-spritemap-webpack-plugin 3.5
+// Project: https://github.com/cascornelissen/svg-spritemap-webpack-plugin
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Plugin, compilation } from 'webpack';
+
+export = SVGSpritemapPlugin;
+
+declare namespace SVGSpritemapPlugin {
+    /**
+     * @see {@link https://github.com/cascornelissen/svg-spritemap-webpack-plugin/blob/master/docs/options.md#options}
+     */
+    interface Options {
+        /**
+         * The input object contains the configuration for the input of the plugin.
+         */
+        input?: {
+            options?: object;
+        };
+        /**
+         * The output object contains the configuration for the main output (SVG) of the plugin.
+         */
+        output?: {
+            /**
+             * Filename of the generated file (located at the webpack output.path), [hash] and [contenthash] are supported.
+             */
+            filename?: string;
+            svg?: {
+                /**
+                 * Whether to include the width and height attributes on the root SVG element.
+                 * The default value for this option is based on the value of the sprite.generate.use option but when specified will always overwrite it.
+                 */
+                sizes?: boolean;
+            };
+            chunk?: {
+                /**
+                 * Name of the chunk that will be generated.
+                 */
+                name?: string;
+                /**
+                 * Whether to keep the chunk after it's been emitted by webpack.
+                 */
+                keep?: boolean;
+            };
+            /**
+             * Whether to include the SVG4Everybody helper in your entries.
+             */
+            svg4everybody?: boolean | object;
+            /**
+             * Options object to pass to SVG Optimizer.
+             */
+            svgo?: boolean | object;
+        };
+        /**
+         * The sprite object contains the configuration for the generated sprites in the output spritemap.
+         */
+        sprite?: {
+            prefix?: string | ((file: string) => string) | false;
+            /**
+             * Function that will be used to transform the filename of each sprite into a valid HTML id
+             */
+            idify?: (file: string | false) => string;
+            /**
+             * Amount of pixels added between each sprite to prevent overlap.
+             * @default 0
+             */
+            gutter?: number | false;
+            generate?: {
+                /**
+                 * Whether to generate a <title> element containing the filename if no title is provided in the SVG.
+                 */
+                title?: boolean;
+                symbol?: boolean | string;
+                use?: boolean;
+                view?: boolean | string;
+            };
+        };
+        styles?:
+            | boolean
+            | string
+            | {
+                  filename?: string;
+                  format?: 'data' | 'fragment';
+                  variables?: {
+                      sprites?: string;
+                      sizes?: string;
+                      variables?: string;
+                      mixin?: string;
+                  };
+              };
+    }
+}
+declare class SVGSpritemapPlugin extends Plugin {
+    readonly files: string[];
+    readonly directories: string[];
+
+    constructor(pattern?: string | string[], options?: SVGSpritemapPlugin.Options);
+
+    private updateDependencies(): void;
+    private getStylesType(styles: object, filename?: string): 'asset' | 'dir' | 'module' | undefined;
+    private writeStylesToDisk(styles: object, type: string): void;
+    private rewriteAssetsHashes(
+        filename: string,
+        assets?: object,
+        hashes?: string[],
+    ): {
+        readonly filename: string;
+        readonly assets: object;
+    };
+    private hashFilename(fileaname: string, hashes?: string[]): string;
+    private getSpritemapHashes(compilation: compilation.Compilation): string[];
+    private getStylesHashes(compilation: compilation.Compilation): string[];
+    private getContentHash(source: string): string;
+}

--- a/types/svg-spritemap-webpack-plugin/svg-spritemap-webpack-plugin-tests.ts
+++ b/types/svg-spritemap-webpack-plugin/svg-spritemap-webpack-plugin-tests.ts
@@ -1,0 +1,34 @@
+/// <reference types="node" />
+import SVGSpritemapPlugin = require('svg-spritemap-webpack-plugin');
+import { Configuration } from 'webpack';
+import path = require('path');
+
+(config: Configuration) => {
+    // tests
+    config.plugins = [
+        new SVGSpritemapPlugin(),
+        new SVGSpritemapPlugin('images/sprites/**/*.svg'),
+        new SVGSpritemapPlugin(['images/logos/**/*.svg', 'images/icons/**/*.svg']),
+        new SVGSpritemapPlugin('src/**/*.svg', {
+            styles: path.join(__dirname, 'src/scss/_sprites.scss'),
+        }),
+        new SVGSpritemapPlugin('src/**/*.svg', {
+            output: {
+                svg: {
+                    sizes: false,
+                },
+            },
+            sprite: {
+                generate: {
+                    use: true,
+                    view: '-fragment',
+                    symbol: true,
+                },
+            },
+            styles: {
+                format: 'fragment',
+                filename: path.join(__dirname, 'src/scss/_sprites.scss'),
+            },
+        }),
+    ];
+};

--- a/types/svg-spritemap-webpack-plugin/tsconfig.json
+++ b/types/svg-spritemap-webpack-plugin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "svg-spritemap-webpack-plugin-tests.ts"
+    ]
+}

--- a/types/svg-spritemap-webpack-plugin/tslint.json
+++ b/types/svg-spritemap-webpack-plugin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- definition file
- tests

https://github.com/cascornelissen/svg-spritemap-webpack-plugin

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.