### PR TITLE
[@types/hapi__hapi] add generic to ServerAuthScheme so an options typ…

### DIFF
--- a/types/hapi__hapi/index.d.ts
+++ b/types/hapi__hapi/index.d.ts
@@ -199,6 +199,8 @@ export interface AuthCredentials {
      * If set, will only work with routes that set `access.entity` to `app`.
      */
     app?: AppCredentials;
+
+    [key: string]: unknown;
 }
 
 export type AuthMode = 'required' | 'optional' | 'try';
@@ -2024,7 +2026,7 @@ export type ServerAuthSchemeOptions = object;
  * @param server - a reference to the server object the scheme is added to.
  * @param options - (optional) the scheme options argument passed to server.auth.strategy() when instantiation a strategy.
  */
-export type ServerAuthScheme = (server: Server, options?: ServerAuthSchemeOptions) => ServerAuthSchemeObject;
+export type ServerAuthScheme<T extends ServerAuthSchemeOptions = ServerAuthSchemeOptions> = (server: Server, options?: T) => ServerAuthSchemeObject;
 
 /* tslint:disable-next-line:no-empty-interface */
 export interface ServerAuthSchemeObjectApi {
@@ -2144,7 +2146,7 @@ export interface ServerAuth {
      * @return void.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-serverauthschemename-scheme)
      */
-    scheme(name: string, scheme: ServerAuthScheme): void;
+    scheme(name: string, scheme: ServerAuthScheme<any>): void;
 
     /**
      * Registers an authentication strategy where:
@@ -2154,6 +2156,10 @@ export interface ServerAuth {
      * @return Return value: none.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-serverauthstrategyname-scheme-options)
      */
+    /* tslint:disable-next-line:no-unnecessary-generics */
+    strategy<T extends ServerAuthScheme<any>>(name: string, scheme: string, options?: T extends ServerAuthScheme<infer U> ? U : never): void;
+    /* tslint:disable-next-line:no-unnecessary-generics */
+    strategy<T extends ServerAuthSchemeOptions>(name: string, scheme: string, options?: T): void;
     strategy(name: string, scheme: string, options?: object): void;
 
     /**

--- a/types/hapi__hapi/index.d.ts
+++ b/types/hapi__hapi/index.d.ts
@@ -2026,7 +2026,7 @@ export type ServerAuthSchemeOptions = object;
  * @param server - a reference to the server object the scheme is added to.
  * @param options - (optional) the scheme options argument passed to server.auth.strategy() when instantiation a strategy.
  */
-export type ServerAuthScheme<T extends ServerAuthSchemeOptions = ServerAuthSchemeOptions> = (server: Server, options?: T) => ServerAuthSchemeObject;
+export type ServerAuthScheme = (server: Server, options?: ServerAuthSchemeOptions) => ServerAuthSchemeObject;
 
 /* tslint:disable-next-line:no-empty-interface */
 export interface ServerAuthSchemeObjectApi {
@@ -2146,7 +2146,7 @@ export interface ServerAuth {
      * @return void.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-serverauthschemename-scheme)
      */
-    scheme(name: string, scheme: ServerAuthScheme<any>): void;
+    scheme(name: string, scheme: ServerAuthScheme): void;
 
     /**
      * Registers an authentication strategy where:
@@ -2156,10 +2156,6 @@ export interface ServerAuth {
      * @return Return value: none.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-serverauthstrategyname-scheme-options)
      */
-    /* tslint:disable-next-line:no-unnecessary-generics */
-    strategy<T extends ServerAuthScheme<any>>(name: string, scheme: string, options?: T extends ServerAuthScheme<infer U> ? U : never): void;
-    /* tslint:disable-next-line:no-unnecessary-generics */
-    strategy<T extends ServerAuthSchemeOptions>(name: string, scheme: string, options?: T): void;
     strategy(name: string, scheme: string, options?: object): void;
 
     /**

--- a/types/hapi__hapi/test/server/server-auth-api.ts
+++ b/types/hapi__hapi/test/server/server-auth-api.ts
@@ -25,7 +25,7 @@ const scheme: ServerAuthScheme = (server, options) => {
             if (!authorization) {
                 throw Boom.unauthorized(null, 'Custom');
             }
-            return h.authenticated({ credentials: { user: { a: 1 } } });
+            return h.authenticated({ credentials: { user: { a: 1 }, custom: {} } });
         }
     };
 };

--- a/types/hapi__hapi/test/server/server-auth-api.ts
+++ b/types/hapi__hapi/test/server/server-auth-api.ts
@@ -13,7 +13,12 @@ declare module '@hapi/hapi' {
     }
 }
 
-const scheme: ServerAuthScheme = (server, options) => {
+interface SchemeOptions {
+    option1: string;
+    option2: number;
+}
+
+const scheme: ServerAuthScheme<SchemeOptions> = (server, options) => {
     return {
         api: {
             settings: {
@@ -34,7 +39,10 @@ const server = new Server({
     port: 8000,
 });
 server.auth.scheme('custom', scheme);
-server.auth.strategy('default', 'custom');
+server.auth.strategy<typeof scheme>('default', 'custom', {
+    option1: 'option',
+    option2: 1,
+});
 server.start();
 
 console.log(server.auth.api.default.settings.x);    // 5

--- a/types/hapi__hapi/test/server/server-auth-api.ts
+++ b/types/hapi__hapi/test/server/server-auth-api.ts
@@ -13,12 +13,7 @@ declare module '@hapi/hapi' {
     }
 }
 
-interface SchemeOptions {
-    option1: string;
-    option2: number;
-}
-
-const scheme: ServerAuthScheme<SchemeOptions> = (server, options) => {
+const scheme: ServerAuthScheme = (server, options) => {
     return {
         api: {
             settings: {
@@ -39,10 +34,7 @@ const server = new Server({
     port: 8000,
 });
 server.auth.scheme('custom', scheme);
-server.auth.strategy<typeof scheme>('default', 'custom', {
-    option1: 'option',
-    option2: 1,
-});
+server.auth.strategy('default', 'custom');
 server.start();
 
 console.log(server.auth.api.default.settings.x);    // 5


### PR DESCRIPTION
…e can be provided

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/hapi/blob/master/API.md#-serverauthapi
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This allows users to specify the type of the options the scheme expects, allowing the options to be typed in the scheme implementation. It also allows users to provide either the options type or the scheme type to `server.auth.strategy` so options provided will be typed.

Lastly, fixes an issue with `AuthCredentials` trigger weak type detection due to all properties being optional. 