### PR TITLE
concurrently: Add env option

### DIFF
--- a/types/concurrently/concurrently-tests.ts
+++ b/types/concurrently/concurrently-tests.ts
@@ -1,5 +1,13 @@
 import concurrently = require('concurrently');
 
+import { CommandObj, Options } from 'concurrently';
+
+const _COMMAND_OBJ: CommandObj = {
+    command: 'foo',
+};
+
+const _OPTIONS: Options = {};
+
 concurrently(['echo foo']); // $ExpectType Promise<null>
 // $ExpectType Promise<null>
 concurrently(

--- a/types/concurrently/concurrently-tests.ts
+++ b/types/concurrently/concurrently-tests.ts
@@ -7,6 +7,10 @@ concurrently(
         'echo foo',
         {
             command: 'echo bar',
+            env: {
+                a: 'bar',
+                b: undefined,
+            },
             name: 'bar',
             prefixColor: 'yellow',
         },

--- a/types/concurrently/index.d.ts
+++ b/types/concurrently/index.d.ts
@@ -2,22 +2,19 @@
 // Project: https://github.com/kimmobrunfeldt/concurrently#readme
 // Definitions by: Michael B. <https://github.com/Blasz>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+//                 Ryan Ling <https://github.com/72636c>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
 
-declare function concurrently(
-    commands: Array<concurrently.CommandObj | string>,
-    options?: concurrently.Options,
-): Promise<null>;
-
-declare namespace concurrently {
+declare module 'concurrently' {
     interface CommandObj {
         command: string;
         env?: NodeJS.ProcessEnv;
         name?: string;
         prefixColor?: string;
     }
+
     interface Options {
         /** the default input target when reading from `inputStream`. Default: `0`. */
         defaultInputTarget?: number;
@@ -49,6 +46,8 @@ declare namespace concurrently {
         /** a date-fns format to use when prefixing with time. Default: `yyyy-MM-dd HH:mm:ss.ZZZ` */
         timestampFormat?: string;
     }
-}
 
-export = concurrently;
+    function concurrently(commands: Array<CommandObj | string>, options?: Options): Promise<null>;
+
+    export = concurrently;
+}

--- a/types/concurrently/index.d.ts
+++ b/types/concurrently/index.d.ts
@@ -7,6 +7,11 @@
 
 /// <reference types="node" />
 
+declare function concurrently(
+    commands: Array<concurrently.CommandObj | string>,
+    options?: concurrently.Options,
+): Promise<null>;
+
 declare namespace concurrently {
     interface CommandObj {
         command: string;
@@ -46,10 +51,5 @@ declare namespace concurrently {
         timestampFormat?: string;
     }
 }
-
-declare function concurrently(
-    commands: Array<concurrently.CommandObj | string>,
-    options?: concurrently.Options,
-): Promise<null>;
 
 export = concurrently;

--- a/types/concurrently/index.d.ts
+++ b/types/concurrently/index.d.ts
@@ -7,52 +7,49 @@
 
 /// <reference types="node" />
 
-declare module 'concurrently' {
-    namespace concurrently {
-        interface CommandObj {
-            command: string;
-            env?: NodeJS.ProcessEnv;
-            name?: string;
-            prefixColor?: string;
-        }
-
-        interface Options {
-            /** the default input target when reading from `inputStream`. Default: `0`. */
-            defaultInputTarget?: number;
-            /** a Readable stream to read the input from, eg `process.stdin` */
-            inputStream?: NodeJS.ReadableStream;
-            /** an array of exiting conditions that will cause a process to kill others. Can contain any of success or failure. */
-            killOthers?: Array<'success' | 'failure'>;
-            /**
-             * how many processes should run at once
-             * @default 0
-             */
-            maxProcesses?: number;
-            /**  a Writable stream to write logs to. Default: `process.stdout` */
-            outputStream?: NodeJS.WritableStream;
-            /**
-             * the prefix type to use when logging processes output.
-             */
-            prefix?: 'index' | 'pid' | 'time' | 'command' | 'name' | 'none' | string;
-            /** how many characters to show when prefixing with `command`. Default: `10` */
-            prefixLength?: number;
-            /** whether raw mode should be used, meaning strictly process output will be logged, without any prefixes, colouring or extra stuff. */
-            raw?: boolean;
-            /** the condition to consider the run was successful. */
-            successCondition?: 'first' | 'last';
-            /** how many attempts to restart a process that dies will be made. Default: `0` */
-            restartTries?: number;
-            /** how many milliseconds to wait between process restarts. Default: 0 */
-            restartDelay?: number;
-            /** a date-fns format to use when prefixing with time. Default: `yyyy-MM-dd HH:mm:ss.ZZZ` */
-            timestampFormat?: string;
-        }
+declare namespace concurrently {
+    interface CommandObj {
+        command: string;
+        env?: NodeJS.ProcessEnv;
+        name?: string;
+        prefixColor?: string;
     }
-
-    function concurrently(
-        commands: Array<concurrently.CommandObj | string>,
-        options?: concurrently.Options,
-    ): Promise<null>;
-
-    export = concurrently;
+    interface Options {
+        /** the default input target when reading from `inputStream`. Default: `0`. */
+        defaultInputTarget?: number;
+        /** a Readable stream to read the input from, eg `process.stdin` */
+        inputStream?: NodeJS.ReadableStream;
+        /** an array of exiting conditions that will cause a process to kill others. Can contain any of success or failure. */
+        killOthers?: Array<'success' | 'failure'>;
+        /**
+         * how many processes should run at once
+         * @default 0
+         */
+        maxProcesses?: number;
+        /**  a Writable stream to write logs to. Default: `process.stdout` */
+        outputStream?: NodeJS.WritableStream;
+        /**
+         * the prefix type to use when logging processes output.
+         */
+        prefix?: 'index' | 'pid' | 'time' | 'command' | 'name' | 'none' | string;
+        /** how many characters to show when prefixing with `command`. Default: `10` */
+        prefixLength?: number;
+        /** whether raw mode should be used, meaning strictly process output will be logged, without any prefixes, colouring or extra stuff. */
+        raw?: boolean;
+        /** the condition to consider the run was successful. */
+        successCondition?: 'first' | 'last';
+        /** how many attempts to restart a process that dies will be made. Default: `0` */
+        restartTries?: number;
+        /** how many milliseconds to wait between process restarts. Default: 0 */
+        restartDelay?: number;
+        /** a date-fns format to use when prefixing with time. Default: `yyyy-MM-dd HH:mm:ss.ZZZ` */
+        timestampFormat?: string;
+    }
 }
+
+declare function concurrently(
+    commands: Array<concurrently.CommandObj | string>,
+    options?: concurrently.Options,
+): Promise<null>;
+
+export = concurrently;

--- a/types/concurrently/index.d.ts
+++ b/types/concurrently/index.d.ts
@@ -8,46 +8,51 @@
 /// <reference types="node" />
 
 declare module 'concurrently' {
-    interface CommandObj {
-        command: string;
-        env?: NodeJS.ProcessEnv;
-        name?: string;
-        prefixColor?: string;
+    namespace concurrently {
+        interface CommandObj {
+            command: string;
+            env?: NodeJS.ProcessEnv;
+            name?: string;
+            prefixColor?: string;
+        }
+
+        interface Options {
+            /** the default input target when reading from `inputStream`. Default: `0`. */
+            defaultInputTarget?: number;
+            /** a Readable stream to read the input from, eg `process.stdin` */
+            inputStream?: NodeJS.ReadableStream;
+            /** an array of exiting conditions that will cause a process to kill others. Can contain any of success or failure. */
+            killOthers?: Array<'success' | 'failure'>;
+            /**
+             * how many processes should run at once
+             * @default 0
+             */
+            maxProcesses?: number;
+            /**  a Writable stream to write logs to. Default: `process.stdout` */
+            outputStream?: NodeJS.WritableStream;
+            /**
+             * the prefix type to use when logging processes output.
+             */
+            prefix?: 'index' | 'pid' | 'time' | 'command' | 'name' | 'none' | string;
+            /** how many characters to show when prefixing with `command`. Default: `10` */
+            prefixLength?: number;
+            /** whether raw mode should be used, meaning strictly process output will be logged, without any prefixes, colouring or extra stuff. */
+            raw?: boolean;
+            /** the condition to consider the run was successful. */
+            successCondition?: 'first' | 'last';
+            /** how many attempts to restart a process that dies will be made. Default: `0` */
+            restartTries?: number;
+            /** how many milliseconds to wait between process restarts. Default: 0 */
+            restartDelay?: number;
+            /** a date-fns format to use when prefixing with time. Default: `yyyy-MM-dd HH:mm:ss.ZZZ` */
+            timestampFormat?: string;
+        }
     }
 
-    interface Options {
-        /** the default input target when reading from `inputStream`. Default: `0`. */
-        defaultInputTarget?: number;
-        /** a Readable stream to read the input from, eg `process.stdin` */
-        inputStream?: NodeJS.ReadableStream;
-        /** an array of exiting conditions that will cause a process to kill others. Can contain any of success or failure. */
-        killOthers?: Array<'success' | 'failure'>;
-        /**
-         * how many processes should run at once
-         * @default 0
-         */
-        maxProcesses?: number;
-        /**  a Writable stream to write logs to. Default: `process.stdout` */
-        outputStream?: NodeJS.WritableStream;
-        /**
-         * the prefix type to use when logging processes output.
-         */
-        prefix?: 'index' | 'pid' | 'time' | 'command' | 'name' | 'none' | string;
-        /** how many characters to show when prefixing with `command`. Default: `10` */
-        prefixLength?: number;
-        /** whether raw mode should be used, meaning strictly process output will be logged, without any prefixes, colouring or extra stuff. */
-        raw?: boolean;
-        /** the condition to consider the run was successful. */
-        successCondition?: 'first' | 'last';
-        /** how many attempts to restart a process that dies will be made. Default: `0` */
-        restartTries?: number;
-        /** how many milliseconds to wait between process restarts. Default: 0 */
-        restartDelay?: number;
-        /** a date-fns format to use when prefixing with time. Default: `yyyy-MM-dd HH:mm:ss.ZZZ` */
-        timestampFormat?: string;
-    }
-
-    function concurrently(commands: Array<CommandObj | string>, options?: Options): Promise<null>;
+    function concurrently(
+        commands: Array<concurrently.CommandObj | string>,
+        options?: concurrently.Options,
+    ): Promise<null>;
 
     export = concurrently;
 }

--- a/types/concurrently/index.d.ts
+++ b/types/concurrently/index.d.ts
@@ -14,6 +14,7 @@ declare function concurrently(
 declare namespace concurrently {
     interface CommandObj {
         command: string;
+        env?: NodeJS.ProcessEnv;
         name?: string;
         prefixColor?: string;
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [/src/concurrently.js#L62-L67](https://github.com/kimmobrunfeldt/concurrently/blob/54b6456eb5054ec32de9d81717b143d2ca8f8f6d/src/concurrently.js#L62-L67)
  - [/src/concurrently.spec.js#L101-L118](https://github.com/kimmobrunfeldt/concurrently/blob/54b6456eb5054ec32de9d81717b143d2ca8f8f6d/src/concurrently.spec.js#L101-L118)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
