### PR TITLE
[@types/react-dates] Fix incorrect phrase arg type and add missing phrase properties

### DIFF
--- a/types/react-dates/index.d.ts
+++ b/types/react-dates/index.d.ts
@@ -236,7 +236,10 @@ declare namespace ReactDates {
     }
 
     // PHRASES
-    //
+    type PhraseArg = {
+        date: string;
+    }
+
     // defaultPhrases.js
     type DateRangePickerPhrases = {
         calendarLabel?: string;
@@ -263,10 +266,12 @@ declare namespace ReactDates {
         moveFocustoStartAndEndOfWeek?: string;
         returnFocusToInput?: string;
         keyboardNavigationInstructions?: string;
-        chooseAvailableStartDate?: (date: string) => string;
-        chooseAvailableEndDate?: (date: string) => string;
-        dateIsUnavailable?: (date: string) => string;
-        dateIsSelected?: (date: string) => string;
+        chooseAvailableStartDate?: (phraseArg: PhraseArg) => string;
+        chooseAvailableEndDate?: (phraseArg: PhraseArg) => string;
+        dateIsUnavailable?: (phraseArg: PhraseArg)  => string;
+        dateIsSelected?: (phraseArg: PhraseArg) => string;
+        dateIsSelectedAsStartDate?: (phraseArg: PhraseArg) => string;
+        dateIsSelectedAsEndDate?: (phraseArg: PhraseArg) => string;
     };
 
     // defaultPhrases.js
@@ -301,9 +306,9 @@ declare namespace ReactDates {
         moveFocustoStartAndEndOfWeek?: string;
         returnFocusToInput?: string;
         keyboardNavigationInstructions?: string;
-        chooseAvailableDate?: (date: string) => string;
-        dateIsUnavailable?: (date: string) => string;
-        dateIsSelected?: (date: string) => string;
+        chooseAvailableDate?: (phraseArg: PhraseArg) => string;
+        dateIsUnavailable?: (phraseArg: PhraseArg) => string;
+        dateIsSelected?: (phraseArg: PhraseArg) => string;
     };
 
     // defaultPhrases.js
@@ -334,11 +339,11 @@ declare namespace ReactDates {
         moveFocusByOneMonth?: string;
         moveFocustoStartAndEndOfWeek?: string;
         returnFocusToInput?: string;
-        chooseAvailableStartDate?: (date: string) => string;
-        chooseAvailableEndDate?: (date: string) => string;
-        chooseAvailableDate?: (date: string) => string;
-        dateIsUnavailable?: (date: string) => string;
-        dateIsSelected?: (date: string) => string;
+        chooseAvailableStartDate?: (phraseArg: PhraseArg) => string;
+        chooseAvailableEndDate?: (phraseArg: PhraseArg) => string;
+        chooseAvailableDate?: (phraseArg: PhraseArg) => string;
+        dateIsUnavailable?: (phraseArg: PhraseArg) => string;
+        dateIsSelected?: (phraseArg: PhraseArg) => string;
     };
 
     // defaultPhrases.js
@@ -370,9 +375,11 @@ declare namespace ReactDates {
 
     // defaultPhrases.js
     type CalendarDayPhrases = {
-        chooseAvailableDate: (date: string) => string;
-        dateIsUnavailable: (date: string) => string;
-        dateIsSelected: (date: string) => string;
+        chooseAvailableDate?: (phraseArg: PhraseArg) => string;
+        dateIsUnavailable?: (phraseArg: PhraseArg) => string;
+        dateIsSelected?: (phraseArg: PhraseArg) => string;
+        dateIsSelectedAsStartDate?: (phraseArg: PhraseArg) => string;
+        dateIsSelectedAsEndDate?: (phraseArg: PhraseArg) => string;
     };
 
     // COMPONENTS

--- a/types/react-dates/index.d.ts
+++ b/types/react-dates/index.d.ts
@@ -9,13 +9,15 @@
 import * as React from 'react';
 import * as moment from 'moment';
 
+export = ReactDates;
+
 declare namespace momentPropTypes {
     type momentObj = moment.Moment;
     type momentString = any;
     type momentDurationObj = any;
 }
 
-export namespace ReactDates {
+declare namespace ReactDates {
     // SHAPES
     //
     // shapes/AnchorDirectionShape.js

--- a/types/react-dates/index.d.ts
+++ b/types/react-dates/index.d.ts
@@ -9,15 +9,13 @@
 import * as React from 'react';
 import * as moment from 'moment';
 
-export = ReactDates;
-
 declare namespace momentPropTypes {
     type momentObj = moment.Moment;
     type momentString = any;
     type momentDurationObj = any;
 }
 
-declare namespace ReactDates {
+export namespace ReactDates {
     // SHAPES
     //
     // shapes/AnchorDirectionShape.js

--- a/types/react-dates/tslint.json
+++ b/types/react-dates/tslint.json
@@ -17,6 +17,7 @@
         "semicolon": false,
         "trim-file": false,
         "typedef-whitespace": false,
-        "whitespace": false
+        "whitespace": false,
+        "strict-export-declare-modifiers": false
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/39929

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/airbnb/react-dates/blob/master/src/defaultPhrases.js#L29
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
