### PR TITLE
react-native-calendars: Add missing props

### DIFF
--- a/types/react-native-calendars/index.d.ts
+++ b/types/react-native-calendars/index.d.ts
@@ -195,6 +195,16 @@ export interface CalendarBaseProps {
     disabledByDefault?: boolean;
 
     /**
+     *  Disable left arrow. Default = false
+     */
+    disableArrowLeft?: boolean;
+
+    /**
+     *  Disable right arrow. Default = false
+     */
+    disableArrowRight?: boolean;
+
+    /**
      *  If hideArrows=false and hideExtraDays=false do not switch month when tapping on greyed out
      *  day from another month that is visible in calendar page. Default = false
      */
@@ -209,6 +219,11 @@ export interface CalendarBaseProps {
      *  If firstDay=1 week starts from Monday. Note that dayNames and dayNamesShort should still start from Sunday.
      */
     firstDay?: number;
+
+    /**
+     *  Style passed to the header
+     */
+    headerStyle?: StyleProp<ViewStyle>;
 
     /**
      *  Hide month navigation arrows. Default = false
@@ -289,6 +304,11 @@ export interface CalendarBaseProps {
      *  Specify theme properties to override specific styles for calendar parts. Default = {}
      */
     theme?: CalendarTheme;
+
+    /**
+     *  Provide aria-level for calendar heading for proper accessibility when used with web (react-native-web)
+     */
+    webAriaLevel?: number;
 }
 
 export class Calendar extends React.Component<CalendarMarkingProps & CalendarBaseProps> { }

--- a/types/react-native-calendars/react-native-calendars-tests.tsx
+++ b/types/react-native-calendars/react-native-calendars-tests.tsx
@@ -2,31 +2,30 @@ import * as React from "react";
 import { Text, View } from "react-native";
 import { Calendar, CalendarList, Agenda } from "react-native-calendars";
 
+declare const Arrow: React.SFC<unknown>;
+
+// this is copied directly from the documentation at https://github.com/wix/react-native-calendars#basic-parameters
+// which is why formatting is slightly inconsistent
+// tslint:disable semicolon
 <Calendar
     // Initially visible month. Default = Date()
-    current={"2012-03-01"}
+    current={'2012-03-01'}
     // Minimum date that can be selected, dates before minDate will be grayed out. Default = undefined
-    minDate={"2012-05-10"}
+    minDate={'2012-05-10'}
     // Maximum date that can be selected, dates after maxDate will be grayed out. Default = undefined
-    maxDate={"2012-05-30"}
+    maxDate={'2012-05-30'}
     // Handler which gets executed on day press. Default = undefined
-    onDayPress={date => {
-        console.log("selected day", date.day);
-    }}
+    onDayPress={(day) => {console.log('selected day', day)}}
     // Handler which gets executed on day long press. Default = undefined
-    onDayLongPress={date => {
-        console.log("selected day", date.day);
-    }}
+    onDayLongPress={(day) => {console.log('selected day', day)}}
     // Month format in calendar title. Formatting values: http://arshaw.com/xdate/#Formatting
-    monthFormat={"yyyy MM"}
+    monthFormat={'yyyy MM'}
     // Handler which gets executed when visible month changes in calendar. Default = undefined
-    onMonthChange={date => {
-        console.log("month changed", date.month);
-    }}
+    onMonthChange={(month) => {console.log('month changed', month)}}
     // Hide month navigation arrows. Default = false
     hideArrows={true}
     // Replace default arrows with custom ones (direction can be 'left' or 'right')
-    renderArrow={direction => <View />}
+    renderArrow={(direction) => (<Arrow/>)}
     // Do not show days of other months in month page. Default = false
     hideExtraDays={true}
     // If hideArrows=false and hideExtraDays=false do not switch month when tapping on greyed out
@@ -39,11 +38,15 @@ import { Calendar, CalendarList, Agenda } from "react-native-calendars";
     // Show week numbers to the left. Default = false
     showWeekNumbers={true}
     // Handler which gets executed when press arrow icon left. It receive a callback can go back month
-    onPressArrowLeft={substractMonth => console.log(substractMonth)}
-    // Handler which gets executed when press arrow icon left. It receive a callback can go next month
-    onPressArrowRight={addMonth => console.log(addMonth)}
-    disabledByDefault={true}
+    onPressArrowLeft={substractMonth => substractMonth()}
+    // Handler which gets executed when press arrow icon right. It receive a callback can go next month
+    onPressArrowRight={addMonth => addMonth()}
+    // Disable left arrow. Default = false
+    disableArrowLeft={true}
+    // Disable right arrow. Default = false
+    disableArrowRight={true}
 />;
+// tslint:enable semicolon
 
 <Calendar
     // Initially visible month. Default = Date()

--- a/types/react-native-calendars/react-native-calendars-tests.tsx
+++ b/types/react-native-calendars/react-native-calendars-tests.tsx
@@ -5,8 +5,7 @@ import { Calendar, CalendarList, Agenda } from "react-native-calendars";
 declare const Arrow: React.SFC<unknown>;
 
 // this is copied directly from the documentation at https://github.com/wix/react-native-calendars#basic-parameters
-// which is why formatting is slightly inconsistent
-// tslint:disable semicolon
+// and then linting errors are addressed which is why formatting is slightly inconsistent
 <Calendar
     // Initially visible month. Default = Date()
     current={'2012-03-01'}
@@ -15,13 +14,13 @@ declare const Arrow: React.SFC<unknown>;
     // Maximum date that can be selected, dates after maxDate will be grayed out. Default = undefined
     maxDate={'2012-05-30'}
     // Handler which gets executed on day press. Default = undefined
-    onDayPress={(day) => {console.log('selected day', day)}}
+    onDayPress={(day) => { console.log('selected day', day); }}
     // Handler which gets executed on day long press. Default = undefined
-    onDayLongPress={(day) => {console.log('selected day', day)}}
+    onDayLongPress={(day) => { console.log('selected day', day); }}
     // Month format in calendar title. Formatting values: http://arshaw.com/xdate/#Formatting
     monthFormat={'yyyy MM'}
     // Handler which gets executed when visible month changes in calendar. Default = undefined
-    onMonthChange={(month) => {console.log('month changed', month)}}
+    onMonthChange={(month) => { console.log('month changed', month); }}
     // Hide month navigation arrows. Default = false
     hideArrows={true}
     // Replace default arrows with custom ones (direction can be 'left' or 'right')
@@ -46,7 +45,6 @@ declare const Arrow: React.SFC<unknown>;
     // Disable right arrow. Default = false
     disableArrowRight={true}
 />;
-// tslint:enable semicolon
 
 <Calendar
     // Initially visible month. Default = Date()


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - https://github.com/wix/react-native-calendars/blob/60559241248d8ee7b68a0421297bf36945c8a86a/src/calendar/index.js#L80-L87
- ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~

I'm seeing a linting crash (both on master, on the branch, and in CI). Possibly related to https://github.com/microsoft/dtslint/issues/231

```
The 'no-unnecessary-generics' rule threw an error in '/Users/cameronlittle/Dev/DefinitelyTyped/types/react-native-calendars/index.d.ts':
TypeError: sig.parameters is not iterable
```
