### PR TITLE
chore: Add `typescript@next` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "danger": "^10.1.1",
         "dtslint": "latest",
         "prettier": "^2.0.2",
+        "typescript": "next",
         "@definitelytyped/dtslint-runner": "latest"
     },
     "husky": {
@@ -33,6 +34,5 @@
             "_comment": "This will remove husky from when we started migrating to use prettier",
             "pre-commit": "npm uninstall husky"
         }
-    },
-    "dependencies": {}
+    }
 }


### PR DESCRIPTION
This is a workaround for <https://github.com/microsoft/dtslint/issues/281>.

**npm** would end up deduping **typescript@latest**, since it encounters it first as a dependency of `@definitelytyped/definitions‑parser` and `dts‑critic`, then it would dedupe `tslint`, and lastly `dtslint` would get **typescript@next**:
```
node_modules/
	@definitelytyped/dtslint-runner/ 0.0.35
	@definitelytyped/definitions-parser/ 0.0.35
	dts-critic/ 3.2.3
	dtslint/ 3.6.6
		node_modules/
			typescript/ 4.0.0-dev
	tslint/ 5.14
	typescript/ 3.9.3
```

This results in <https://github.com/microsoft/dtslint/issues/281>.

---

Adding `typescript@next` forces the `node_modules` structure to:
```
node_modules/
	@definitelytyped/dtslint-runner/ 0.0.35
	@definitelytyped/definitions-parser/ 0.0.35
		node_modules/
			typescript/ 3.9.3
	dts-critic/ 3.2.3
		node_modules/
			typescript/ 3.9.3
	dtslint/ 3.6.6
	tslint/ 5.14
	typescript/ 4.0.0-dev
```

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

---

review?(@sandersn)