### PR TITLE
@testing-library/jest-dom: typo in toBeEmptyDOMElement

### DIFF
--- a/types/testing-library__jest-dom/index.d.ts
+++ b/types/testing-library__jest-dom/index.d.ts
@@ -86,12 +86,12 @@ declare namespace jest {
          *   <span data-testid="empty"></span>
          * </span>
          *
-         * expect(getByTestId('empty')).toBeEmptyDomElement()
-         * expect(getByTestId('not-empty')).not.toBeEmptyDomElement()
+         * expect(getByTestId('empty')).toBeEmptyDOMElement()
+         * expect(getByTestId('not-empty')).not.toBeEmptyDOMElement()
          * @see
          * [testing-library/jest-dom#tobeemptydomelement](https:github.com/testing-library/jest-dom#tobeemptydomelement)
          */
-        toBeEmptyDomElement(): R;
+        toBeEmptyDOMElement(): R;
         /**
          * @description
          * Allows you to check whether an element is disabled from the user's perspective.

--- a/types/testing-library__jest-dom/test/testing-library__jest-dom-global-tests.ts
+++ b/types/testing-library__jest-dom/test/testing-library__jest-dom-global-tests.ts
@@ -47,7 +47,7 @@ expect(element).not.toBeInTheDOM(document.body);
 expect(element).not.toBeInTheDocument();
 expect(element).not.toBeVisible();
 expect(element).not.toBeEmpty();
-expect(element).not.toBeEmptyDomElement();
+expect(element).not.toBeEmptyDOMElement();
 expect(element).not.toBeDisabled();
 expect(element).not.toBeEnabled();
 expect(element).not.toBeInvalid();


### PR DESCRIPTION
Sadly I copied the name that was used in the release notes (https://github.com/testing-library/jest-dom/releases/tag/v5.9.0) `toBeEmptyDomNode`
Correct is uppercased `DOM` though. (https://github.com/testing-library/jest-dom/blob/master/src/to-be-empty-dom-element.js#L4)
This is a follow up to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45145

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/testing-library/jest-dom/blob/master/src/to-be-empty-dom-element.js#L4
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
