### PR TITLE
Add typings for cache-manager-ioredis

### DIFF
--- a/types/cache-manager-ioredis/cache-manager-ioredis-tests.ts
+++ b/types/cache-manager-ioredis/cache-manager-ioredis-tests.ts
@@ -1,7 +1,7 @@
 import cacheManager = require("cache-manager");
 import redisStore = require("cache-manager-ioredis");
 
-var redisCache = cacheManager.caching({
+const redisCache = cacheManager.caching({
     store: redisStore,
     host: 'localhost', // default value
     port: 6379, // default value
@@ -10,7 +10,7 @@ var redisCache = cacheManager.caching({
     ttl: 600,
 });
 
-var clusterCache = cacheManager.caching({
+const clusterCache = cacheManager.caching({
     store: redisStore,
     clusterConfig: {
         nodes: [
@@ -33,6 +33,6 @@ var clusterCache = cacheManager.caching({
 redisCache.store.getClient();
 clusterCache.store.getClient();
 
-var memoryCache = cacheManager.caching({ store: 'memory', max: 100, ttl: 60 });
+const memoryCache = cacheManager.caching({ store: 'memory', max: 100, ttl: 60 });
 
 cacheManager.multiCaching([redisCache, memoryCache]);

--- a/types/cache-manager-ioredis/cache-manager-ioredis-tests.ts
+++ b/types/cache-manager-ioredis/cache-manager-ioredis-tests.ts
@@ -1,0 +1,38 @@
+import cacheManager = require("cache-manager");
+import redisStore = require("cache-manager-ioredis");
+
+var redisCache = cacheManager.caching({
+    store: redisStore,
+    host: 'localhost', // default value
+    port: 6379, // default value
+    password: 'XXXXX',
+    db: 0,
+    ttl: 600,
+});
+
+var clusterCache = cacheManager.caching({
+    store: redisStore,
+    clusterConfig: {
+        nodes: [
+            {
+                port: 6380,
+                host: '127.0.0.1'
+            },
+            {
+              port: 6381,
+              host: '127.0.0.1'
+            },
+        ],
+        options: {
+            maxRedirections: 16,
+        },
+    },
+    ttl: 600,
+});
+
+redisCache.store.getClient();
+clusterCache.store.getClient();
+
+var memoryCache = cacheManager.caching({ store: 'memory', max: 100, ttl: 60 });
+
+cacheManager.multiCaching([redisCache, memoryCache]);

--- a/types/cache-manager-ioredis/index.d.ts
+++ b/types/cache-manager-ioredis/index.d.ts
@@ -25,7 +25,7 @@ declare namespace CacheManagerIORedis {
     }
 
     interface RedisStoreConstructor {
-        create: (...options: Array<RedisStoreSingleNodeConfig>) => RedisSingleNodeStore | ((...options: Array<RedisStoreClusterConfig>) => RedisClusterStore);
+        create: (...options: RedisStoreSingleNodeConfig[]) => RedisSingleNodeStore | ((...options: RedisStoreClusterConfig[]) => RedisClusterStore);
     }
 
     type RedisStoreSingleNodeConfig = (CachingConfig & IORedis.RedisOptions & {

--- a/types/cache-manager-ioredis/index.d.ts
+++ b/types/cache-manager-ioredis/index.d.ts
@@ -1,0 +1,67 @@
+// Type definitions for cache-manager-ioredis 2.0
+// Project: https://github.com/dabroek/node-cache-manager-ioredis
+// Definitions by: Yi Hong <https://github.com/hongyiweiwu>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="cache-manager" />
+/// <reference types="ioredis" />
+
+import * as IORedis from "ioredis";
+import { Store, CachingConfig, CacheOptions, Cache } from 'cache-manager';
+
+declare const methods: CacheManagerIORedis.RedisStoreConstructor;
+export = methods;
+
+declare module 'cache-manager' {
+    function caching(IConfig: CacheManagerIORedis.RedisStoreClusterConfig): CacheManagerIORedis.ClusterCache;
+    function caching(IConfig: CacheManagerIORedis.RedisStoreSingleNodeConfig): CacheManagerIORedis.SingleNodeCache;
+    function caching(IConfig: StoreConfig & CacheOptions): Cache;
+}
+
+declare namespace CacheManagerIORedis {
+    interface SingleNodeCache extends Cache {
+        store: RedisSingleNodeStore;
+    }
+
+    interface ClusterCache extends Cache {
+        store: RedisClusterStore;
+    }
+
+    interface RedisStoreConstructor {
+        create: (...options: ((RedisStoreSingleNodeConfig | any)[]) | ((RedisStoreClusterConfig | any)[])) => RedisSingleNodeStore;
+    }
+
+    type RedisStoreSingleNodeConfig = (CachingConfig & IORedis.RedisOptions & {
+        store: RedisStoreConstructor;
+        max?: number;
+    } & CacheOptions);
+
+    type RedisStoreClusterConfig = (CachingConfig & {
+        store: RedisStoreConstructor;
+        max?: number;
+        clusterConfig: ClusterOptions;
+    } & CacheOptions);
+
+    interface RedisStore extends Store {
+        getClient(): IORedis.Redis | IORedis.Cluster;
+        name: 'redis';
+        isCacheableValue(value: any): boolean;
+        del<T>(...args: any[]): Promise<any>;
+        reset<T>(...args: any[]): Promise<any>;
+        keys<T>(...args: any[]): Promise<any>;
+        ttl<T>(...args: any[]): Promise<any>;
+    }
+
+    interface RedisSingleNodeStore extends Store {
+        getClient(): IORedis.Redis;
+    }
+
+    interface RedisClusterStore extends Store {
+        getClient(): IORedis.Cluster;
+    }
+
+    interface ClusterOptions {
+        nodes: IORedis.ClusterNode[];
+        options: IORedis.ClusterOptions;
+    }
+}

--- a/types/cache-manager-ioredis/index.d.ts
+++ b/types/cache-manager-ioredis/index.d.ts
@@ -8,6 +8,7 @@ import { Store, CachingConfig, CacheOptions, Cache } from 'cache-manager';
 
 declare const methods: CacheManagerIORedis.RedisStoreConstructor;
 export = methods;
+export { };
 
 declare module 'cache-manager' {
     function caching(IConfig: CacheManagerIORedis.RedisStoreClusterConfig): CacheManagerIORedis.ClusterCache;

--- a/types/cache-manager-ioredis/index.d.ts
+++ b/types/cache-manager-ioredis/index.d.ts
@@ -3,9 +3,6 @@
 // Definitions by: Yi Hong <https://github.com/hongyiweiwu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="cache-manager" />
-/// <reference types="ioredis" />
-
 import * as IORedis from "ioredis";
 import { Store, CachingConfig, CacheOptions, Cache } from 'cache-manager';
 
@@ -28,7 +25,7 @@ declare namespace CacheManagerIORedis {
     }
 
     interface RedisStoreConstructor {
-        create: (...options: ((RedisStoreSingleNodeConfig | any)[]) | ((RedisStoreClusterConfig | any)[])) => RedisSingleNodeStore;
+        create: (...options: Array<RedisStoreSingleNodeConfig>) => RedisSingleNodeStore | ((...options: Array<RedisStoreClusterConfig>) => RedisClusterStore);
     }
 
     type RedisStoreSingleNodeConfig = (CachingConfig & IORedis.RedisOptions & {
@@ -46,10 +43,10 @@ declare namespace CacheManagerIORedis {
         getClient(): IORedis.Redis | IORedis.Cluster;
         name: 'redis';
         isCacheableValue(value: any): boolean;
-        del<T>(...args: any[]): Promise<any>;
-        reset<T>(...args: any[]): Promise<any>;
-        keys<T>(...args: any[]): Promise<any>;
-        ttl<T>(...args: any[]): Promise<any>;
+        del(...args: any[]): Promise<any>;
+        reset(...args: any[]): Promise<any>;
+        keys(...args: any[]): Promise<any>;
+        ttl(...args: any[]): Promise<any>;
     }
 
     interface RedisSingleNodeStore extends Store {

--- a/types/cache-manager-ioredis/tsconfig.json
+++ b/types/cache-manager-ioredis/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "cache-manager-ioredis-tests.ts"
+    ]
+}

--- a/types/cache-manager-ioredis/tslint.json
+++ b/types/cache-manager-ioredis/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
