### PR TITLE
Update author link.

### DIFF
--- a/types/levenshtein-edit-distance/index.d.ts
+++ b/types/levenshtein-edit-distance/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for levenshtein-edit-distance 2.0
 // Project: https://words.github.io/levenshtein-edit-distance/
-// Definitions by: Ryan Blackman <https://github.com/me>
+// Definitions by: Ryan Blackman <https://github.com/rblackman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare function levenshtein(value: string, other: string, insensitive?: boolean): number;


### PR DESCRIPTION
I forgot to change the template author link when I submitted the definition. I am adding my profile here. No definitions are changed with this PR. Only the _Definitions by_ comment.
