### PR TITLE
[react-select] Remove cssKey param from CommonProps.cx

### DIFF
--- a/types/react-select/src/types.d.ts
+++ b/types/react-select/src/types.d.ts
@@ -41,7 +41,7 @@ export type ClassNamesState = { [key: string]: boolean } | undefined;
 export interface CommonProps<OptionType extends OptionTypeBase> {
   clearValue: () => void;
   className?: string;
-  cx: (a: string | null, b: ClassNamesState | undefined, c: string | undefined) => string | void;
+  cx: (state: ClassNamesState | undefined, className: string | undefined) => string;
   /*
     Get the styles of a particular part of the select. Pass in the name of the
     property as the first argument, and the current props as the second argument.


### PR DESCRIPTION
cx is a classNames with the first parameter bound.

cssKey param was removed from classNames here: https://github.com/JedWatson/react-select/commit/a860de4f9904473886cb66e7bfeea8539ca6a50f#diff-b194f39baaee25481bb4ebca83fd3850L44

`cx` now only takes 2 params as seen in usages through react-select
https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/components/Group.js#L40

It's also not possible for classNames to return void.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JedWatson/react-select/commit/a860de4f9904473886cb66e7bfeea8539ca6a50f#diff-b194f39baaee25481bb4ebca83fd3850L44 cssKey param was removed.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
TODO - There's no existing test for this. Where should this go?