### PR TITLE
update(compression-webpack-plugin): v4 bump and other changes

### DIFF
--- a/types/compression-webpack-plugin/index.d.ts
+++ b/types/compression-webpack-plugin/index.d.ts
@@ -1,16 +1,20 @@
-// Type definitions for compression-webpack-plugin 2.0
+// Type definitions for compression-webpack-plugin 4.0
 // Project: https://github.com/webpack-contrib/compression-webpack-plugin
 // Definitions by: Anton Kandybo <https://github.com/dublicator>
 //                 Rhys van der Waerden <https://github.com/rhys-vdw>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
 
 import { Plugin } from 'webpack';
 import { ZlibOptions as ZlibCompressionOptions } from 'zlib';
 
 export = CompressionPlugin;
 
+/**
+ * Prepare compressed versions of assets to serve them with Content-Encoding.
+ */
 declare class CompressionPlugin<O = any> extends Plugin {
+    static isWebpack4(): boolean;
     constructor(options?: CompressionPlugin.Options<O>);
 }
 
@@ -20,21 +24,74 @@ declare namespace CompressionPlugin {
 
     // NOTE: These are the async compression algorithms on the zlib object.
     type ZlibAlgorithm = 'deflate' | 'deflateRaw' | 'gzip' | 'brotliCompress';
-    type Pattern = string | RegExp | ReadonlyArray<RegExp> | ReadonlyArray<string>;
+
+    /** Filtering rule as regex or string */
+    type Rule = string | RegExp;
+
+    /** Filtering rules. */
+    type Rules = Rule | ReadonlyArray<Rule>;
+
+    interface FileInfo {
+        /** original asset filename */
+        file: string;
+        /** path of the original asset */
+        path: string;
+        /** query */
+        query: string;
+    }
+
+    type FilenameFunction = (info: FileInfo) => string;
 
     interface BaseOptions {
+        /**
+         * Enable file caching
+         * ⚠ Ignored in webpack 5! Please use webpack.js.org/configuration/other-options/#cache.
+         * @default true
+         */
         cache?: boolean | string;
+        /**
+         * @default false
+         */
         deleteOriginalAssets?: boolean;
-        exclude?: Pattern;
-        filename?: string;
-        include?: Pattern;
+        /**
+         * Exclude all assets matching any of these conditions
+         */
+        exclude?: Rules;
+        /**
+         * The target asset filename.
+         * @default '[path].gz[query]'
+         */
+        filename?: string | FilenameFunction;
+        /**
+         * Include all assets matching any of these conditions
+         */
+        include?: Rules;
+        /**
+         * Only assets that compress better than this ratio are processed (minRatio = Compressed Size / Original Size)
+         * @default 0.8
+         */
         minRatio?: number;
-        test?: Pattern;
+        /**
+         * Include all assets that pass test assertion
+         */
+        test?: Rules;
+        /**
+         * Only assets bigger than this size are processed (in bytes)
+         * @default 0
+         */
         threshold?: number;
     }
 
     interface ZlibOptions extends BaseOptions {
+        /**
+         * The compression algorithm/function
+         * @default 'gzip'
+         */
         algorithm?: ZlibAlgorithm;
+        /**
+         * Compression options for algorithm
+         * @default { level: 9 }
+         */
         compressionOptions?: ZlibCompressionOptions;
     }
 

--- a/types/compression-webpack-plugin/v2/compression-webpack-plugin-tests.ts
+++ b/types/compression-webpack-plugin/v2/compression-webpack-plugin-tests.ts
@@ -4,8 +4,8 @@ import CompressionPlugin = require('compression-webpack-plugin');
 new CompressionPlugin();
 
 new CompressionPlugin({
-    include: ["a"],
-    exclude: [/a/g],
+    include: ["a"] as ReadonlyArray<string>,
+    exclude: [/a/g] as ReadonlyArray<RegExp>,
     test: "a",
 });
 
@@ -19,14 +19,6 @@ const config: Configuration = {
             test: /\.js$|\.html$/,
             threshold: 10240,
             deleteOriginalAssets: true
-        }),
-        new CompressionPlugin({
-            filename: (info) => {
-                info.file; // $ExpectType string
-                info.path; // $ExpectType string
-                info.query; // $ExpectType string
-                return `${info.path}.gz${info.query}`;
-            },
         })
     ]
 };

--- a/types/compression-webpack-plugin/v2/index.d.ts
+++ b/types/compression-webpack-plugin/v2/index.d.ts
@@ -1,0 +1,47 @@
+// Type definitions for compression-webpack-plugin 2.0
+// Project: https://github.com/webpack-contrib/compression-webpack-plugin
+// Definitions by: Anton Kandybo <https://github.com/dublicator>
+//                 Rhys van der Waerden <https://github.com/rhys-vdw>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+import { Plugin } from 'webpack';
+import { ZlibOptions as ZlibCompressionOptions } from 'zlib';
+
+export = CompressionPlugin;
+
+declare class CompressionPlugin<O = any> extends Plugin {
+    constructor(options?: CompressionPlugin.Options<O>);
+}
+
+declare namespace CompressionPlugin {
+    type AlgorithmCallback = (error: Error | null, result: Buffer) => void;
+    type Algorithm<O> = (source: string, options: O, callback: AlgorithmCallback) => void;
+
+    // NOTE: These are the async compression algorithms on the zlib object.
+    type ZlibAlgorithm = 'deflate' | 'deflateRaw' | 'gzip' | 'brotliCompress';
+    type Pattern = string | RegExp | ReadonlyArray<RegExp> | ReadonlyArray<string>;
+
+    interface BaseOptions {
+        cache?: boolean | string;
+        deleteOriginalAssets?: boolean;
+        exclude?: Pattern;
+        filename?: string;
+        include?: Pattern;
+        minRatio?: number;
+        test?: Pattern;
+        threshold?: number;
+    }
+
+    interface ZlibOptions extends BaseOptions {
+        algorithm?: ZlibAlgorithm;
+        compressionOptions?: ZlibCompressionOptions;
+    }
+
+    interface CustomOptions<O> extends BaseOptions {
+        algorithm: Algorithm<O>;
+        compressionOptions?: O;
+    }
+
+    type Options<O> = ZlibOptions | CustomOptions<O>;
+}

--- a/types/compression-webpack-plugin/v2/tsconfig.json
+++ b/types/compression-webpack-plugin/v2/tsconfig.json
@@ -1,0 +1,29 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "paths": {
+            "compression-webpack-plugin": [
+                "compression-webpack-plugin/v2"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "compression-webpack-plugin-tests.ts"
+    ]
+}

--- a/types/compression-webpack-plugin/v2/tslint.json
+++ b/types/compression-webpack-plugin/v2/tslint.json
@@ -1,0 +1,4 @@
+{ 
+    "extends": "dtslint/dt.json"
+}
+ 


### PR DESCRIPTION
- v2 created (though the api change is minimal). The release notes lists
v4 as breaking version due to behaviour changes
- `filename` definition correct to support function
- names of types aligned with plugin schema names (otherwise this change
is backward compatible)
- test amended

https://github.com/webpack-contrib/compression-webpack-plugin/releases/tag/v4.0.0
schema:
https://github.com/webpack-contrib/compression-webpack-plugin/blob/master/src/options.json

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)