### PR TITLE
update(stylelint-webpack-plugin): v2 update

### DIFF
--- a/types/stylelint-webpack-plugin/index.d.ts
+++ b/types/stylelint-webpack-plugin/index.d.ts
@@ -1,13 +1,17 @@
-// Type definitions for https://github.com/JaKXz/stylelint-webpack-plugin 0.1
-// Project: https://github.com/JaKXz/stylelint-webpack-plugin
+// Type definitions for https://github.com/webpack-contrib/stylelint-webpack-plugin 2.0
+// Project: https://github.com/webpack-contrib/stylelint-webpack-plugin#readme
 // Definitions by: Arne Bahlo <https://github.com/bahlo>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 import { Plugin } from 'webpack';
+import { LinterOptions as StylelintOptions, FormatterType } from 'stylelint';
 
 export = StylelintWebpackPlugin;
 
+/**
+ * A Stylelint plugin for webpack
+ */
 declare class StylelintWebpackPlugin extends Plugin {
     constructor(options?: StylelintWebpackPlugin.Options);
 }
@@ -21,28 +25,70 @@ declare namespace StylelintWebpackPlugin {
         rule: string;
     }
 
-    type Formatter = (messages: Message[], source: string) => string;
-
     interface Config {
         rules?: object;
         extends?: string | string[];
         plugins?: string[];
         processors?: string[];
         ignoreFiles?: string | string[];
-        defaultSeverity?: "warning" | "error";
+        defaultSeverity?: 'warning' | 'error';
     }
 
-    interface Options {
-        config?: Config;
+    /**
+     * See stylelint's options for the complete list of options available.
+     * These options are passed through to the 'stylelint' directly.
+     */
+    interface Options extends Partial<StylelintOptions> {
+        /**
+         * Specify the config file location to be used by stylelint.
+         */
         configFile?: string;
+        /**
+         * @default compiler.context
+         */
         context?: string;
+        /**
+         * Will always return errors, if set to true.
+         * @default false
+         */
         emitErrors?: boolean;
+        /**
+         * Will cause the module build to fail if there are any errors, if set to true.
+         * @default false
+         */
         failOnError?: boolean;
-        files?: string|string[];
-        formatter?: Formatter;
+        /**
+         * Will process and report errors only and ignore warnings, if set to true.
+         * @default false
+         */
+        failOnWarning?: boolean;
+        /**
+         * Specify the glob pattern for finding files. Must be relative to options.context.
+         */
+        files?: string | string[];
+        /**
+         * Specify the formatter that you would like to use to format your results. See formatter option.
+         */
+        formatter?: FormatterType;
+        /**
+         * Lint only changed files, skip lint on start.
+         * @default false
+         */
         lintDirtyModulesOnly?: boolean;
-        syntax?: string;
+        /**
+         * Path to `stylelint` instance that will be used for linting.
+         * @default 'stylelint'
+         */
+        stylelintPath?: string;
+        /**
+         * Will process and report errors only and ignore warnings, if set to true.
+         * @default false
+         */
         quiet?: boolean;
+        /**
+         * If true, stylelint will fix as many errors as possible. The fixes are made to the actual source files.
+         * All unfixed errors will be reported. See Autofixing errors docs.
+         */
         fix?: boolean;
     }
 }

--- a/types/stylelint-webpack-plugin/stylelint-webpack-plugin-tests.ts
+++ b/types/stylelint-webpack-plugin/stylelint-webpack-plugin-tests.ts
@@ -1,8 +1,22 @@
-import webpack = require("webpack");
-import StylelintWebpackPlugin = require("stylelint-webpack-plugin");
+import webpack = require('webpack');
+import StylelintWebpackPlugin = require('stylelint-webpack-plugin');
 
-const compiler = webpack({
+const _ = webpack({
     plugins: [
         new StylelintWebpackPlugin(),
+        new StylelintWebpackPlugin({}),
+        new StylelintWebpackPlugin({
+            configFile: './conf.json',
+            context: './dir',
+            files: ['/a/b/c/', '/e/f/g'],
+            fix: true,
+            formatter: 'string',
+            lintDirtyModulesOnly: true,
+            stylelintPath: 'stylelint',
+            emitErrors: true,
+            failOnError: true,
+            failOnWarning: true,
+            quiet: false,
+        }),
     ],
 });

--- a/types/stylelint-webpack-plugin/v0/index.d.ts
+++ b/types/stylelint-webpack-plugin/v0/index.d.ts
@@ -1,0 +1,48 @@
+// Type definitions for https://github.com/JaKXz/stylelint-webpack-plugin 0.1
+// Project: https://github.com/JaKXz/stylelint-webpack-plugin
+// Definitions by: Arne Bahlo <https://github.com/bahlo>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import { Plugin } from 'webpack';
+
+export = StylelintWebpackPlugin;
+
+declare class StylelintWebpackPlugin extends Plugin {
+    constructor(options?: StylelintWebpackPlugin.Options);
+}
+
+declare namespace StylelintWebpackPlugin {
+    interface Message {
+        line: number;
+        column: number;
+        severity: string;
+        text: string;
+        rule: string;
+    }
+
+    type Formatter = (messages: Message[], source: string) => string;
+
+    interface Config {
+        rules?: object;
+        extends?: string | string[];
+        plugins?: string[];
+        processors?: string[];
+        ignoreFiles?: string | string[];
+        defaultSeverity?: "warning" | "error";
+    }
+
+    interface Options {
+        config?: Config;
+        configFile?: string;
+        context?: string;
+        emitErrors?: boolean;
+        failOnError?: boolean;
+        files?: string|string[];
+        formatter?: Formatter;
+        lintDirtyModulesOnly?: boolean;
+        syntax?: string;
+        quiet?: boolean;
+        fix?: boolean;
+    }
+}

--- a/types/stylelint-webpack-plugin/v0/stylelint-webpack-plugin-tests.ts
+++ b/types/stylelint-webpack-plugin/v0/stylelint-webpack-plugin-tests.ts
@@ -1,0 +1,8 @@
+import webpack = require("webpack");
+import StylelintWebpackPlugin = require("stylelint-webpack-plugin");
+
+const compiler = webpack({
+    plugins: [
+        new StylelintWebpackPlugin(),
+    ],
+});

--- a/types/stylelint-webpack-plugin/v0/tsconfig.json
+++ b/types/stylelint-webpack-plugin/v0/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "paths": {
+            "stylelint-webpack-plugin": [
+                "stylelint-webpack-plugin/v0"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "stylelint-webpack-plugin-tests.ts"
+    ]
+}

--- a/types/stylelint-webpack-plugin/v0/tslint.json
+++ b/types/stylelint-webpack-plugin/v0/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- project URL updated
- pre-1 version created
- use `stylelint` to redeclare constructor options
- documented types are left on the API interface for the options
- `failOnWarning` option added
- other minor changes

https://github.com/webpack-contrib/stylelint-webpack-plugin/releases/tag/v2.0.0
https://github.com/webpack-contrib/stylelint-webpack-plugin/compare/v1.2.3...v2.0.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.