### PR TITLE
update(gh-pages): v3 bump

### DIFF
--- a/types/gh-pages/gh-pages-tests.ts
+++ b/types/gh-pages/gh-pages-tests.ts
@@ -23,3 +23,5 @@ ghpages.publish(
     },
     callback,
 );
+
+ghpages.defaults.remote; // $ExpectType string

--- a/types/gh-pages/index.d.ts
+++ b/types/gh-pages/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for gh-pages 2.2
+// Type definitions for gh-pages 3.0
 // Project: https://github.com/tschaub/gh-pages
 // Definitions by: Daniel Rosenwasser <https://github.com/DanielRosenwasser>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>

--- a/types/gh-pages/index.d.ts
+++ b/types/gh-pages/index.d.ts
@@ -39,3 +39,21 @@ export function publish(basePath: string, callback: (err: any) => void): void;
 export function publish(basePath: string, config: PublishOptions, callback?: (err: any) => void): void;
 
 export function clean(): void;
+
+export interface Defaults {
+    dest: '.';
+    add: false;
+    git: 'git';
+    depth: 1;
+    dotfiles: false;
+    branch: 'gh-pages';
+    remote: string;
+    src: '**/*';
+    remove: '.';
+    push: true;
+    history: true;
+    message: 'Updates';
+    silent: false;
+}
+
+export const defaults: Readonly<Defaults>;


### PR DESCRIPTION
This version (as per release notes) does not change API. So this just
aligns with source code package version:

https://github.com/tschaub/gh-pages/releases/tag/v3.0.0

Thanks!

**Edit:**
Added export for `defaults` to meet new CI checks for exported API

- [x] Use a meaningful title for the pull request. Include the name of the package modified.