### PR TITLE
[workerpool] Fix the return type of workerpool.Promise.catch.

### DIFF
--- a/types/workerpool/index.d.ts
+++ b/types/workerpool/index.d.ts
@@ -67,7 +67,7 @@ export class Promise<T, E = Error> {
 
     always<TT>(handler: () => Promise<TT>): Promise<TT>;
     then<TT, EE = Error>(result: (r: T) => TT, err?: (r: E) => EE): Promise<TT, EE>;
-    catch<TT>(err: (error: E) => TT): Promise<TT>;
+    catch<TT>(err: (error: E) => TT): Promise<T | TT>;
     cancel(): this;
     timeout(delay: number): this;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/josdejong/workerpool/blob/bac2fe1d87a0794c5dbb3c7773773fd97b4283d7/src/Promise.js#L178-L186

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

 Fix the return type of `workerpool.Promise.catch`. It should include the type of `fulfillment value`.
