### PR TITLE
add type definitions for @giusto/ink-router

### DIFF
--- a/types/giusto__ink-router/giusto__ink-router-tests.tsx
+++ b/types/giusto__ink-router/giusto__ink-router-tests.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import {
+    Router,
+    CommandLineRouter,
+    Route,
+    Switch,
+    withRouter
+} from "@giusto/ink-router";
+
+const HomeView = () => {
+    return <></>;
+};
+
+const test1 = () => {
+    return (
+        <Router>
+            <Route exact path="/" component={HomeView} />
+            <Route path="/settings" component={HomeView} />
+        </Router>
+    );
+};
+
+const test2 = () => {
+    return (
+        <CommandLineRouter>
+            <Switch>
+                <Route exact path="/" component={HomeView} />
+                <Route path="/settings" component={HomeView} />
+            </Switch>
+        </CommandLineRouter>
+    );
+};
+
+const test3 = () => {
+    return (
+        <CommandLineRouter>
+            <Switch>
+                <Route exact path="/" component={HomeView} />
+                <Route path="/settings" component={HomeView} />
+                <Route path="/" component={HomeView} />
+            </Switch>
+        </CommandLineRouter>
+    );
+};
+
+withRouter(HomeView);

--- a/types/giusto__ink-router/index.d.ts
+++ b/types/giusto__ink-router/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for @giusto/ink-router 2.4
-// Project: https://github.com/jimmed/ink-router
+// Project: https://github.com/lujiajing1126/ink-router
 // Definitions by: omjadas <https://github.com/omjadas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/giusto__ink-router/index.d.ts
+++ b/types/giusto__ink-router/index.d.ts
@@ -1,0 +1,57 @@
+// Type definitions for @giusto/ink-router 2.4
+// Project: https://github.com/jimmed/ink-router
+// Definitions by: omjadas <https://github.com/omjadas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { History, Location } from "history";
+import { Component, ComponentType } from "react";
+
+export interface RouterProps {
+    initialEntries?: Array<(string | {
+        pathname: string;
+        search?: string;
+        hash?: string;
+        state?: any;
+        key?: string;
+    })>;
+    initialIndex?: number;
+    keyLength?: number;
+    getUserConfirmation?: () => void;
+}
+export class Router extends Component<RouterProps> { }
+
+export interface CommandLineRouterProps {
+    args?: string[];
+    options?: Record<string, any>;
+    initialEntries?: string[];
+    initialIndex?: number;
+}
+export class CommandLineRouter extends Component<CommandLineRouterProps> { }
+
+export interface RouteComponentProps<T extends Record<string, any> = {}> {
+    match: {
+        path: string;
+        params: T;
+    };
+    location: Location<{}>;
+    history: History<{}>;
+}
+
+export interface RouteProps {
+    path: string;
+    exact?: boolean;
+    location?: {
+        key?: string,
+        pathname?: string,
+    };
+    component: React.ComponentType<any>;
+}
+export class Route extends Component<RouteProps> { }
+
+export interface SwitchProps {
+    children?: React.ReactElement<RouteProps> | Array<React.ReactElement<RouteProps>>;
+    notFound?: (() => any) | React.ComponentType<any>;
+}
+export class Switch extends Component<SwitchProps> { }
+
+export function withRouter(component: ComponentType<any>): (props: any) => JSX.Element;

--- a/types/giusto__ink-router/tsconfig.json
+++ b/types/giusto__ink-router/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react",
+        "paths": {
+            "@giusto/ink-router": ["giusto__ink-router"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "giusto__ink-router-tests.tsx"
+    ]
+}

--- a/types/giusto__ink-router/tslint.json
+++ b/types/giusto__ink-router/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
