### PR TITLE
add types for ink-divider

### DIFF
--- a/types/ink-divider/index.d.ts
+++ b/types/ink-divider/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for ink-divider 2.0
+// Project: https://github.com/juresotosek/ink-divider#readme
+// Definitions by: omjadas <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as React from "react";
+
+interface DividerProps {
+    title?: string;
+    width?: number;
+    padding?: number;
+    titlePadding?: number;
+    titleColor?: string;
+    dividerChar?: string;
+    dividerColor?: string;
+}
+declare const Divider: React.FC<DividerProps>;
+export = Divider;

--- a/types/ink-divider/ink-divider-tests.tsx
+++ b/types/ink-divider/ink-divider-tests.tsx
@@ -1,4 +1,4 @@
-import Divider from "ink-divider";
+import * as Divider from "ink-divider";
 import * as React from "react";
 
 const test1 = () => {

--- a/types/ink-divider/ink-divider-tests.tsx
+++ b/types/ink-divider/ink-divider-tests.tsx
@@ -1,0 +1,15 @@
+import Divider from "ink-divider";
+import * as React from "react";
+
+const test1 = () => {
+    return (
+        <Divider
+            title="Title"
+            width={10}
+            padding={10}
+            titlePadding={10}
+            titleColor="white"
+            dividerChar="-"
+            dividerColor="white" />
+    );
+};

--- a/types/ink-divider/tsconfig.json
+++ b/types/ink-divider/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "jsx": "react",
+        "esModuleInterop": true,
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ink-divider-tests.tsx"
+    ]
+}

--- a/types/ink-divider/tsconfig.json
+++ b/types/ink-divider/tsconfig.json
@@ -2,7 +2,6 @@
     "compilerOptions": {
         "module": "commonjs",
         "jsx": "react",
-        "esModuleInterop": true,
         "lib": [
             "es6"
         ],

--- a/types/ink-divider/tslint.json
+++ b/types/ink-divider/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
