### PR TITLE
react-calendar: value prop can be null too

### DIFF
--- a/types/react-calendar/index.d.ts
+++ b/types/react-calendar/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-calendar 3.0
+// Type definitions for react-calendar 3.1
 // Project: https://github.com/wojtekmaj/react-calendar
 // Definitions by: Stéphane Saquet <https://github.com/Guymestef>, Katie Soldau <https://github.com/ksoldau>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/react-calendar/index.d.ts
+++ b/types/react-calendar/index.d.ts
@@ -62,7 +62,7 @@ export interface CalendarProps {
   tileClassName?: string | string[] | ((props: CalendarTileProperties) => string | string[] | null);
   tileContent?: JSX.Element | ((props: CalendarTileProperties) => JSX.Element | null);
   tileDisabled?: (props: CalendarTileProperties & { activeStartDate: Date }) => boolean;
-  value?: Date | Date[];
+  value?: Date | Date[] | null;
   view?: Detail;
 }
 

--- a/types/react-calendar/react-calendar-tests.tsx
+++ b/types/react-calendar/react-calendar-tests.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import Calendar from 'react-calendar';
 
 interface State {
-  value: Date | Date[];
+  value: Date | Date[] | null;
 }
 
 export default class Sample extends React.Component<{}, State> {
   state = {
-    value: new Date(),
+    value: null,
   };
 
   onChange = (value: Date | Date[]) => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Couldn't run the last one. On OSX I've got this issue: `Cannot find module 'csstype' or its corresponding type declarations`

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wojtekmaj/react-calendar/issues/380
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

No substantial changes

In that issue the source code is visible!
Basically the "value" prop must be allowed to have a null type because it's intentionally coded that when it's null, it resets a particular UI effect.