### PR TITLE
Webpack: Add ExternalsPlugin type

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1862,6 +1862,10 @@ declare namespace webpack {
         constructor();
     }
 
+    class ExternalsPlugin extends Plugin {
+        constructor(type: string, externals: ExternalsElement);
+    }
+
     class HashedModuleIdsPlugin extends Plugin {
         constructor(options?: {
             hashFunction?: string,

--- a/types/webpack/test/index.ts
+++ b/types/webpack/test/index.ts
@@ -430,6 +430,14 @@ plugin = new webpack.DllReferencePlugin({
     scope: 'dll prefix',
     sourceType: 'var'
 });
+plugin = new webpack.ExternalsPlugin('this', 'react');
+plugin = new webpack.ExternalsPlugin('this', {jquery: 'jQuery'});
+plugin = new webpack.ExternalsPlugin('this', (context, request, callback) => {
+    if (request === 'jquery') {
+        callback(null, 'jQuery');
+    }
+    callback();
+});
 plugin = new webpack.IgnorePlugin(requestRegExp);
 plugin = new webpack.IgnorePlugin(requestRegExp, contextRegExp);
 


### PR DESCRIPTION
Add type for the [`ExternalsPlugin`](https://github.com/webpack/webpack/blob/c9d4ff7b054fc581c96ce0e53432d44f9dd8ca72/lib/ExternalsPlugin.js#L9-L21) exposed by [`webpack`](https://github.com/webpack/webpack/blob/c9d4ff7b054fc581c96ce0e53432d44f9dd8ca72/lib/webpack.js#L116).

Its interface is similar to the `externals` configuration option, but the plugin may be useful to compose with other plugins. For example, the [`@wordpress/dependencies-extraction-webpack-plugin`](https://github.com/WordPress/gutenberg/blob/78587c9ae30be88cf3414ae66d2f5883f3b18623/packages/dependency-extraction-webpack-plugin/index.js#L38-L42) I'm in the process of typing.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/webpack/blob/c9d4ff7b054fc581c96ce0e53432d44f9dd8ca72/lib/ExternalsPlugin.js#L9-L21
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
