### PR TITLE
Add types for react-relative-portal

### DIFF
--- a/types/react-relative-portal/index.d.ts
+++ b/types/react-relative-portal/index.d.ts
@@ -3,37 +3,21 @@
 // Definitions by: Andy Katz <https://github.com/katz12>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/*~ If this module is a UMD module that exposes a global variable 'myLib' when
- *~ loaded outside a module loader environment, declare that global here.
- *~ Otherwise, delete this declaration.
- */
-export as namespace myLib;
+import * as React from 'react';
 
-/*~ If this module has methods, declare them as functions like so.
- */
-export function myMethod(a: string): string;
-export function myOtherMethod(a: number): number;
+declare class RelativePortal extends React.Component<RelativePortal.Props> {}
 
-/*~ You can declare types that are available via importing the module */
-export interface someType {
-    name: string;
-    length: number;
-    extras?: string[];
+declare namespace RelativePortal {
+    interface Props {
+        children: React.ReactNode;
+        className?: string;
+        component: string;
+        fullWidth?: boolean;
+        left?: number;
+        onOutClick?: () => void;
+        right?: number;
+        top?: number;
+    }
 }
 
-/*~ You can declare properties of the module using const, let, or var */
-export const myField: number;
-
-/*~ If there are types, properties, or methods inside dotted names
- *~ of the module, declare them inside a 'namespace'.
- */
-export namespace subProp {
-    /*~ For example, given this definition, someone could write:
-     *~   import { subProp } from 'yourModule';
-     *~   subProp.foo();
-     *~ or
-     *~   import * as yourMod from 'yourModule';
-     *~   yourMod.subProp.foo();
-     */
-    function foo(): void;
-}
+export = RelativePortal;

--- a/types/react-relative-portal/index.d.ts
+++ b/types/react-relative-portal/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for react-relative-portal 1.8
+// Project: https://github.com/smartprogress/react-relative-portal#readme
+// Definitions by: Andy Katz <https://github.com/katz12>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/*~ If this module is a UMD module that exposes a global variable 'myLib' when
+ *~ loaded outside a module loader environment, declare that global here.
+ *~ Otherwise, delete this declaration.
+ */
+export as namespace myLib;
+
+/*~ If this module has methods, declare them as functions like so.
+ */
+export function myMethod(a: string): string;
+export function myOtherMethod(a: number): number;
+
+/*~ You can declare types that are available via importing the module */
+export interface someType {
+    name: string;
+    length: number;
+    extras?: string[];
+}
+
+/*~ You can declare properties of the module using const, let, or var */
+export const myField: number;
+
+/*~ If there are types, properties, or methods inside dotted names
+ *~ of the module, declare them inside a 'namespace'.
+ */
+export namespace subProp {
+    /*~ For example, given this definition, someone could write:
+     *~   import { subProp } from 'yourModule';
+     *~   subProp.foo();
+     *~ or
+     *~   import * as yourMod from 'yourModule';
+     *~   yourMod.subProp.foo();
+     */
+    function foo(): void;
+}

--- a/types/react-relative-portal/react-relative-portal-tests.tsx
+++ b/types/react-relative-portal/react-relative-portal-tests.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import RelativePortal = require('react-relative-portal');
+
+<React.Fragment>
+    <RelativePortal component="div">
+        <div>portalled content</div>
+    </RelativePortal>
+
+    <RelativePortal component="div" className="portal" fullWidth left={1} onOutClick={() => {}} right={2} top={3}>
+        <div>portalled content</div>
+    </RelativePortal>
+</React.Fragment>;

--- a/types/react-relative-portal/tsconfig.json
+++ b/types/react-relative-portal/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": [
             "es6"
         ],
+        "jsx": "react",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,
@@ -18,6 +19,6 @@
     },
     "files": [
         "index.d.ts",
-        "react-relative-portal-tests.ts"
+        "react-relative-portal-tests.tsx"
     ]
 }

--- a/types/react-relative-portal/tsconfig.json
+++ b/types/react-relative-portal/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-relative-portal-tests.ts"
+    ]
+}

--- a/types/react-relative-portal/tslint.json
+++ b/types/react-relative-portal/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.


