### PR TITLE
[mongoose] Solve TypeError when setting different currentTime

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -1129,7 +1129,7 @@ declare module "mongoose" {
   interface SchemaTimestampsConfig {
     createdAt?: boolean | string;
     updatedAt?: boolean | string;
-    currentTime?: () => Date;
+    currentTime?: () => Date | () => number;
   }
 
   /*

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -1129,6 +1129,7 @@ declare module "mongoose" {
   interface SchemaTimestampsConfig {
     createdAt?: boolean | string;
     updatedAt?: boolean | string;
+    currentTime?: () => Date;
   }
 
   /*

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -1129,7 +1129,7 @@ declare module "mongoose" {
   interface SchemaTimestampsConfig {
     createdAt?: boolean | string;
     updatedAt?: boolean | string;
-    currentTime?: () => Date | () => number;
+    currentTime?: () => (Date | number);
   }
 
   /*

--- a/types/mongoose/test/mongoose.ts
+++ b/types/mongoose/test/mongoose.ts
@@ -1567,3 +1567,19 @@ var foobarSchema = new mongoose.Schema({
 });
 var Foobar = mongoose.model<Foobar, mongoose.Model<Foobar>>('AnimFoobarl', foobarSchema);
 Foobar.find({ _id: 123 });
+                                                     
+new mongoose.Schema({
+  createdAt: Number,
+  updatedAt: Number,
+  name: String
+}, {
+  timestamps: { currentTime: () => Math.floor(Date.now() / 1000) }
+});
+
+new mongoose.Schema({
+  createdAt: Number,
+  updatedAt: Number,
+  name: String
+}, {
+  timestamps: { currentTime: () => new Date() }
+});


### PR DESCRIPTION
We can set `timestamps.currentTime` as seen on [mongoose docs](https://mongoosejs.com/docs/guide.html#timestamps), however that type definition isn't available

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [https://mongoosejs.com/docs/guide.html#timestamps](https://mongoosejs.com/docs/guide.html#timestamps)

