### PR TITLE
Nodegit: Add `DiffStats` and `Diff.getStats`

### DIFF
--- a/types/nodegit/diff-stats.d.ts
+++ b/types/nodegit/diff-stats.d.ts
@@ -1,0 +1,25 @@
+import { Buf } from './buf';
+
+export class DiffStats {
+    /**
+     * @returns - total number of deletions in the diff
+     */
+    deletions(): Number;
+
+    /**
+     * @returns - total number of files changed in the diff
+     */
+    filesChanged(): Number;
+
+    /**
+     * @returns - total number of insertions in the diff
+     */
+    insertions(): Number;
+
+    /**
+     * @param format - Formatting option.
+     * @param width - Target width for output (only affects GIT_DIFF_STATS_FULL)
+     * @returns - buffer to store the formatted diff statistics in.
+     */
+    toBuf(format: Number, width: Number): Promise<Buf>;
+}

--- a/types/nodegit/diff.d.ts
+++ b/types/nodegit/diff.d.ts
@@ -8,6 +8,7 @@ import { DiffPerfdata } from './diff-perf-data';
 import { DiffOptions } from './diff-options';
 import { Buf } from './buf';
 import { ConvenientPatch } from './convenient-patch';
+import { DiffStats } from './diff-stats';
 
 export interface DiffFindOptions {
     version?: number;
@@ -31,7 +32,7 @@ export namespace Diff {
         UNTRACKED = 7,
         TYPECHANGE = 8,
         UNREADABLE = 9,
-        CONFLICTED = 10
+        CONFLICTED = 10,
     }
 
     const enum FIND {
@@ -50,14 +51,14 @@ export namespace Diff {
         DONT_IGNORE_WHITESPACE = 8192,
         EXACT_MATCH_ONLY = 16384,
         BREAK_REWRITES_FOR_RENAMES_ONLY = 32768,
-        REMOVE_UNMODIFIED = 65536
+        REMOVE_UNMODIFIED = 65536,
     }
 
     const enum FLAG {
         BINARY = 1,
         NOT_BINARY = 2,
         VALID_ID = 4,
-        EXISTS = 8
+        EXISTS = 8,
     }
 
     const enum FORMAT {
@@ -65,12 +66,12 @@ export namespace Diff {
         PATCH_HEADER = 2,
         RAW = 3,
         NAME_ONLY = 4,
-        NAME_STATUS = 5
+        NAME_STATUS = 5,
     }
 
     const enum FORMAT_EMAIL_FLAGS {
         FORMAT_EMAIL_NONE = 0,
-        FORMAT_EMAIL_EXCLUDE_SUBJECT_PATCH_MARKER = 1
+        FORMAT_EMAIL_EXCLUDE_SUBJECT_PATCH_MARKER = 1,
     }
 
     const enum LINE {
@@ -82,7 +83,7 @@ export namespace Diff {
         DEL_EOFNL = 60,
         FILE_HDR = 70,
         HUNK_HDR = 72,
-        BINARY = 66
+        BINARY = 66,
     }
 
     const enum OPTION {
@@ -114,7 +115,7 @@ export namespace Diff {
         SHOW_UNMODIFIED = 67108864,
         PATIENCE = 268435456,
         MINIMAL = 536870912,
-        SHOW_BINARY = 1073741824
+        SHOW_BINARY = 1073741824,
     }
 
     const enum STATS_FORMAT {
@@ -122,7 +123,7 @@ export namespace Diff {
         STATS_FULL = 1,
         STATS_SHORT = 2,
         STATS_NUMBER = 4,
-        STATS_INCLUDE_SUMMARY = 8
+        STATS_INCLUDE_SUMMARY = 8,
     }
 }
 
@@ -132,9 +133,17 @@ export class Diff {
      *
      *
      */
-    static blobToBuffer(oldBlob?: Blob, oldAsPath?: string,
-                        buffer?: string, bufferAsPath?: string, opts?: DiffOptions, fileCb?: Function,
-                        binaryCb?: Function, hunkCb?: Function, lineCb?: Function): Promise<any>;
+    static blobToBuffer(
+        oldBlob?: Blob,
+        oldAsPath?: string,
+        buffer?: string,
+        bufferAsPath?: string,
+        opts?: DiffOptions,
+        fileCb?: Function,
+        binaryCb?: Function,
+        hunkCb?: Function,
+        lineCb?: Function,
+    ): Promise<any>;
     static fromBuffer(content: string, contentLen: number): Promise<Diff>;
     static indexToWorkdir(repo: Repository, index?: Index, opts?: DiffOptions): Promise<Diff>;
     static indexToIndex(repo: Repository, oldIndex: Index, newIndex: Index, opts?: DiffOptions): Promise<Diff>;
@@ -155,4 +164,9 @@ export class Diff {
     patches(): Promise<ConvenientPatch[]>;
     merge(from: Diff): Promise<number>;
     toBuf(format: Diff.FORMAT): Promise<Buf>;
+
+    /**
+     * @returns - Structure containg the diff statistics.
+     */
+    getStats(): Promise<DiffStats>;
 }

--- a/types/nodegit/index.d.ts
+++ b/types/nodegit/index.d.ts
@@ -41,6 +41,7 @@ export { DiffFile } from './diff-file';
 export { DiffLine } from './diff-line';
 export { DiffOptions } from './diff-options';
 export { DiffPerfdata } from './diff-perf-data';
+export { DiffStats } from './diff-stats';
 export { Diff, DiffFindOptions } from './diff';
 export { Enums } from './enums';
 export { Error } from './error';

--- a/types/nodegit/nodegit-tests.ts
+++ b/types/nodegit/nodegit-tests.ts
@@ -1,10 +1,10 @@
 import * as Git from 'nodegit';
 
-Git.Repository.discover("startPath", 1, "ceilingDirs").then((string) => {
+Git.Repository.discover('startPath', 1, 'ceilingDirs').then(string => {
     // Use string
 });
 
-Git.Repository.init("path", 0).then((repository) => {
+Git.Repository.init('path', 0).then(repository => {
     // Use repository
 });
 
@@ -14,25 +14,25 @@ const ref = new Git.Reference();
 const tree = new Git.Tree();
 
 tree.walk().start();
-tree.getEntry("/").then(entry => {
+tree.getEntry('/').then(entry => {
     // Use entry
 });
 
 // AnnotatedCommit Tests
 
-Git.AnnotatedCommit.fromFetchhead(repo, "branch_name", "remote_url", id).then((annotatedCommit) => {
+Git.AnnotatedCommit.fromFetchhead(repo, 'branch_name', 'remote_url', id).then(annotatedCommit => {
     // Use annotatedCommit
 });
 
-Git.AnnotatedCommit.fromRef(repo, ref).then((annotatedCommit) => {
+Git.AnnotatedCommit.fromRef(repo, ref).then(annotatedCommit => {
     // Use annotatedCommit
 });
 
-Git.AnnotatedCommit.fromRevspec(repo, "revspec").then((annotatedCommit) => {
+Git.AnnotatedCommit.fromRevspec(repo, 'revspec').then(annotatedCommit => {
     // Use annotatedCommit
 });
 
-Git.AnnotatedCommit.lookup(repo, id).then((annotatedCommit) => {
+Git.AnnotatedCommit.lookup(repo, id).then(annotatedCommit => {
     // Use annotatedCommit
     annotatedCommit.free();
     annotatedCommit.id();
@@ -40,33 +40,44 @@ Git.AnnotatedCommit.lookup(repo, id).then((annotatedCommit) => {
 
 // Attr tests
 
-let result = Git.Attr.addMacro(repo, "name", "values");
+let result = Git.Attr.addMacro(repo, 'name', 'values');
 
 Git.Attr.cacheFlush(repo);
 
-Git.Attr.get(repo, 1, "path", "name").then((string) => {
+Git.Attr.get(repo, 1, 'path', 'name').then(string => {
     // Use string
 });
 
-const array = Git.Attr.getMany(repo, 1, "path", 1, "names");
+const array = Git.Attr.getMany(repo, 1, 'path', 1, 'names');
 
-result = Git.Attr.value("attr");
+result = Git.Attr.value('attr');
 
 const blameOptions = new Git.BlameOptions();
 
-Git.Branch.lookup(repo, "branch_name", Git.Branch.BRANCH.LOCAL).then((reference) => {
+Git.Branch.lookup(repo, 'branch_name', Git.Branch.BRANCH.LOCAL).then(reference => {
     // Use reference
 });
 
-repo.getCommit("0123456789abcdef0123456789abcdef").then((commit) => {
-  const sig = Git.Signature.now('John Doe', 'jd@example.com');
-  const newCommit: Promise<Git.Oid> = commit.amend('ref', sig, sig, 'utf8', 'message', tree);
+repo.getCommit('0123456789abcdef0123456789abcdef').then(commit => {
+    const sig = Git.Signature.now('John Doe', 'jd@example.com');
+    const newCommit: Promise<Git.Oid> = commit.amend('ref', sig, sig, 'utf8', 'message', tree);
 });
 
-const signature = Git.Signature.now("name", "email");
+const signature = Git.Signature.now('name', 'email');
 signature.name();
 signature.email();
 signature.when();
 
-repo.createBlobFromBuffer(Buffer.from("test")).then((oid: Git.Oid) => oid.cpy());
+repo.createBlobFromBuffer(Buffer.from('test')).then((oid: Git.Oid) => oid.cpy());
 repo.commondir();
+
+repo.getHeadCommit().then(async commit => {
+    const diffs = await commit.getDiff();
+    if (diffs.length > 0) {
+        const firstDiff = diffs[0];
+        const stats: Git.DiffStats = await firstDiff.getStats();
+        const insertions: Number = stats.insertions();
+        const deletions: Number = stats.deletions();
+        const filesChanged: Number = stats.filesChanged();
+    }
+});


### PR DESCRIPTION
Added methods to nodegit types corresponding to documentation
https://www.nodegit.org/api/diff/#getStats and
https://www.nodegit.org/api/diff_stats/

Please fill in this template.

- [✔️] Use a meaningful title for the pull request. Include the name of the package modified.
- [✔️] Test the change in your own code. (Compile and run.)
- [✔️] Add or edit tests to reflect the change. (Run with `npm test`.)
- [✔️] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [✔️] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [✔️] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [✔️] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [✔️] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [✔️] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [✔️] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [✔️] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [✔️] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.