### PR TITLE
fix(react-tracking): Fix return type of trackEvent

### DIFF
--- a/types/react-tracking/index.d.ts
+++ b/types/react-tracking/index.d.ts
@@ -8,7 +8,7 @@
 import * as React from 'react';
 
 export interface TrackingProp<P = {}> {
-    trackEvent(data: Partial<P>): any;
+    trackEvent(data: Partial<P>): void;
 
     /**
      * This method returns all of the contextual tracking data up until this point in the component hierarchy.

--- a/types/react-tracking/test/react-tracking-with-types-tests.tsx
+++ b/types/react-tracking/test/react-tracking-with-types-tests.tsx
@@ -115,6 +115,12 @@ interface Trackables {
 
 const App = track()((props: { foo: string }) => {
     const tracking = useTracking<Trackables>();
+
+    React.useEffect(() =>
+        tracking.trackEvent({
+            page: 'Home - useEffect callback'
+        })
+    )
     return (
         <div
             onClick={() => {

--- a/types/react-tracking/test/react-tracking-with-types-tests.tsx
+++ b/types/react-tracking/test/react-tracking-with-types-tests.tsx
@@ -120,7 +120,7 @@ const App = track()((props: { foo: string }) => {
         tracking.trackEvent({
             page: 'Home - useEffect callback'
         })
-    )
+    );
     return (
         <div
             onClick={() => {

--- a/types/react-tracking/test/react-tracking-without-types-tests.tsx
+++ b/types/react-tracking/test/react-tracking-without-types-tests.tsx
@@ -71,7 +71,7 @@ const App = track()(({ foo }: { foo: string }) => {
         tracking.trackEvent({
             page: 'Home - useEffect callback'
         })
-    )
+    );
     return (
         <div
             onClick={() => {

--- a/types/react-tracking/test/react-tracking-without-types-tests.tsx
+++ b/types/react-tracking/test/react-tracking-without-types-tests.tsx
@@ -66,6 +66,12 @@ class Test extends React.Component<any, null> {
 
 const App = track()(({ foo }: { foo: string }) => {
     const tracking = useTracking();
+
+    React.useEffect(() =>
+        tracking.trackEvent({
+            page: 'Home - useEffect callback'
+        })
+    )
     return (
         <div
             onClick={() => {


### PR DESCRIPTION
Please fill in this template.

Using `useTracking().trackEvent()` as a return causes a linting warning from our project. 
As the type is explicitly set to `any`, we're seeing `@typescript-eslint` throw ['no-unsafe-return'](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unsafe-return.md)
As this method does not return anything, it's expected that it should be typed as a void return.

Looking for suggestions on how to add tests for `void` vs `any` in the scope of this change. I wasn't sure how to approach this, I went with using it in the return of a useEffect callback. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/nytimes/react-tracking/blob/master/src/useTracking.js#L18>>
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
