### PR TITLE
Created types for json-schema-faker npm library

### DIFF
--- a/types/json-schema-faker/index.d.ts
+++ b/types/json-schema-faker/index.d.ts
@@ -1,0 +1,71 @@
+// Type definitions for json-schema-faker 3.7
+// Project: https://github.com/json-schema-faker
+// Definitions by: Charles Desbiens <https://github.com/baremaximum>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.8
+
+/// <reference types="node" />
+
+import { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
+
+export as namespace jsf;
+
+export const version: string;
+export function format(nameOrFormatMap?: NameOrFormatMap, callback?: (schema?: Schema) => void): any;
+export function extend(name: string, cb: () => void): any;
+export function define(name: string, cb: () => void): any;
+export function reset(name: string): any;
+export function locate(name: string): any;
+export function generate<T>(schema: Schema, refs?: string | Schema[]): T[];
+export function resolve<T>(schema: Schema, refs?: string | Schema[], cwd?: string): Promise<T[]>;
+export function option(option: string | OptionInputObject, value?: any): any;
+
+// jsf.random
+export namespace random {
+    export function randexp(value: string): string | number;
+    export function pick<T>(collection: T[]): T;
+    export function date(step: string): Date;
+    export function shuffle<T>(collection: T[]): T[];
+    export function number(
+        min?: number,
+        max?: number,
+        defMin?: number,
+        defMax?: number,
+        hasPrecision?: boolean,
+    ): number;
+}
+
+// Type must be cast on parameters.
+export type Schema = JSONSchema4 | JSONSchema6 | JSONSchema7;
+export type OptionInputObject = Partial<
+    {
+        [option in jsfOptions]: any;
+    }
+>;
+declare type NameOrFormatMap = string | { name: string; callback: (schema?: Schema) => void };
+
+// List of all valid registerable options.
+declare type jsfOptions =
+    | 'defaultInvalidTypeProduct'
+    | 'defaultRandExpMax'
+    | 'ignoreProperties'
+    | 'ignoreMissingRefs'
+    | 'failOnInvalidTypes'
+    | 'failOnInvalidFormat'
+    | 'alwaysFakeOptionals'
+    | 'optionalsProbability'
+    | 'fixedProbabilities'
+    | 'useExamplesValue'
+    | 'useDefaultValue'
+    | 'requiredOnly'
+    | 'minItems'
+    | 'maxItems'
+    | 'minLength'
+    | 'maxLength'
+    | 'refDepthMin'
+    | 'refDepthMax'
+    | 'resolveJsonPath'
+    | 'reuseProperties'
+    | 'fillProperties'
+    | 'random'
+    | 'replaceEmptyByRandomValue';

--- a/types/json-schema-faker/index.d.ts
+++ b/types/json-schema-faker/index.d.ts
@@ -61,5 +61,6 @@ declare namespace jsf {
         | 'replaceEmptyByRandomValue';
 }
 
-declare function jsf(schema: jsf.Schema, refs?: string | jsf.Schema[]): any; // Deprecated.
+/** @deprecated calling JsonSchemaFaker() is deprecated, call either .generate() or .resolve()' */
+declare function jsf(schema: jsf.Schema, refs?: string | jsf.Schema[]): any;
 export = jsf;

--- a/types/json-schema-faker/index.d.ts
+++ b/types/json-schema-faker/index.d.ts
@@ -4,8 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.8
 
-/// <reference types="node" />
-
 import { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
 
 declare namespace jsf {

--- a/types/json-schema-faker/index.d.ts
+++ b/types/json-schema-faker/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for json-schema-faker 0.5
-// Project: https://github.com/json-schema-faker
+// Project: https://github.com/json-schema-faker/json-schema-faker
 // Definitions by: Charles Desbiens <https://github.com/baremaximum>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.8

--- a/types/json-schema-faker/index.d.ts
+++ b/types/json-schema-faker/index.d.ts
@@ -8,58 +8,60 @@
 
 import { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
 
-export as namespace jsf;
+export = jsf;
 
-declare const version: string;
-declare function format(nameOrFormatMap?: NameOrFormatMap, callback?: (schema?: Schema) => void): any;
-declare function extend(name: string, cb: () => void): any;
-declare function define(name: string, cb: () => void): any;
-declare function reset(name: string): any;
-declare function locate(name: string): any;
-declare function generate(schema: Schema, refs?: string | Schema[]): any[];
-declare function resolve(schema: Schema, refs?: string | Schema[], cwd?: string): Promise<any[]>;
-declare function option(option: string | OptionInputObject, value?: any): any;
+declare namespace jsf {
+    const version: string;
+    function format(nameOrFormatMap?: NameOrFormatMap, callback?: (schema?: Schema) => void): any;
+    function extend(name: string, cb: () => void): any;
+    function define(name: string, cb: () => void): any;
+    function reset(name: string): any;
+    function locate(name: string): any;
+    function generate(schema: Schema, refs?: string | Schema[]): any[];
+    function resolve(schema: Schema, refs?: string | Schema[], cwd?: string): Promise<any[]>;
+    function option(option: string | OptionInputObject, value?: any): any;
 
-// jsf.random
-export namespace random {
-    function randexp(value: string): string | number;
-    function pick<T>(collection: T[]): T;
-    function date(step: string): Date;
-    function shuffle<T>(collection: T[]): T[];
-    function number(min?: number, max?: number, defMin?: number, defMax?: number, hasPrecision?: boolean): number;
-}
-
-// Type must be cast on parameters.
-declare type Schema = JSONSchema4 | JSONSchema6 | JSONSchema7;
-declare type OptionInputObject = Partial<
-    {
-        [option in jsfOptions]: any;
+    // jsf.random
+    namespace random {
+        function randexp(value: string): string | number;
+        function pick<T>(collection: T[]): T;
+        function date(step: string): Date;
+        function shuffle<T>(collection: T[]): T[];
+        function number(min?: number, max?: number, defMin?: number, defMax?: number, hasPrecision?: boolean): number;
     }
->;
-declare type NameOrFormatMap = string | { name: string; callback: (schema?: Schema) => void };
 
-// List of all valid registerable options.
-declare type jsfOptions =
-    | 'defaultInvalidTypeProduct'
-    | 'defaultRandExpMax'
-    | 'ignoreProperties'
-    | 'ignoreMissingRefs'
-    | 'failOnInvalidTypes'
-    | 'failOnInvalidFormat'
-    | 'alwaysFakeOptionals'
-    | 'optionalsProbability'
-    | 'fixedProbabilities'
-    | 'useExamplesValue'
-    | 'useDefaultValue'
-    | 'requiredOnly'
-    | 'minItems'
-    | 'maxItems'
-    | 'minLength'
-    | 'maxLength'
-    | 'refDepthMin'
-    | 'refDepthMax'
-    | 'resolveJsonPath'
-    | 'reuseProperties'
-    | 'fillProperties'
-    | 'random'
-    | 'replaceEmptyByRandomValue';
+    type Schema = JSONSchema4 | JSONSchema6 | JSONSchema7;
+    // Type must be cast on parameters.
+    type OptionInputObject = Partial<
+        {
+            [option in jsfOptions]: any;
+        }
+    >;
+    type NameOrFormatMap = string | { name: string; callback: (schema?: Schema) => void };
+
+    // List of all valid registerable options.
+    type jsfOptions =
+        | 'defaultInvalidTypeProduct'
+        | 'defaultRandExpMax'
+        | 'ignoreProperties'
+        | 'ignoreMissingRefs'
+        | 'failOnInvalidTypes'
+        | 'failOnInvalidFormat'
+        | 'alwaysFakeOptionals'
+        | 'optionalsProbability'
+        | 'fixedProbabilities'
+        | 'useExamplesValue'
+        | 'useDefaultValue'
+        | 'requiredOnly'
+        | 'minItems'
+        | 'maxItems'
+        | 'minLength'
+        | 'maxLength'
+        | 'refDepthMin'
+        | 'refDepthMax'
+        | 'resolveJsonPath'
+        | 'reuseProperties'
+        | 'fillProperties'
+        | 'random'
+        | 'replaceEmptyByRandomValue';
+}

--- a/types/json-schema-faker/index.d.ts
+++ b/types/json-schema-faker/index.d.ts
@@ -63,5 +63,5 @@ declare namespace jsf {
         | 'replaceEmptyByRandomValue';
 }
 
-declare function jsf(): any;
+declare function jsf(schema: jsf.Schema, refs?: string | jsf.Schema[]): any; // Deprecated.
 export = jsf;

--- a/types/json-schema-faker/index.d.ts
+++ b/types/json-schema-faker/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for json-schema-faker 3.7
+// Type definitions for json-schema-faker 0.5
 // Project: https://github.com/json-schema-faker
 // Definitions by: Charles Desbiens <https://github.com/baremaximum>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -10,34 +10,28 @@ import { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
 
 export as namespace jsf;
 
-export const version: string;
-export function format(nameOrFormatMap?: NameOrFormatMap, callback?: (schema?: Schema) => void): any;
-export function extend(name: string, cb: () => void): any;
-export function define(name: string, cb: () => void): any;
-export function reset(name: string): any;
-export function locate(name: string): any;
-export function generate<T>(schema: Schema, refs?: string | Schema[]): T[];
-export function resolve<T>(schema: Schema, refs?: string | Schema[], cwd?: string): Promise<T[]>;
-export function option(option: string | OptionInputObject, value?: any): any;
+declare const version: string;
+declare function format(nameOrFormatMap?: NameOrFormatMap, callback?: (schema?: Schema) => void): any;
+declare function extend(name: string, cb: () => void): any;
+declare function define(name: string, cb: () => void): any;
+declare function reset(name: string): any;
+declare function locate(name: string): any;
+declare function generate(schema: Schema, refs?: string | Schema[]): any[];
+declare function resolve(schema: Schema, refs?: string | Schema[], cwd?: string): Promise<any[]>;
+declare function option(option: string | OptionInputObject, value?: any): any;
 
 // jsf.random
 export namespace random {
-    export function randexp(value: string): string | number;
-    export function pick<T>(collection: T[]): T;
-    export function date(step: string): Date;
-    export function shuffle<T>(collection: T[]): T[];
-    export function number(
-        min?: number,
-        max?: number,
-        defMin?: number,
-        defMax?: number,
-        hasPrecision?: boolean,
-    ): number;
+    function randexp(value: string): string | number;
+    function pick<T>(collection: T[]): T;
+    function date(step: string): Date;
+    function shuffle<T>(collection: T[]): T[];
+    function number(min?: number, max?: number, defMin?: number, defMax?: number, hasPrecision?: boolean): number;
 }
 
 // Type must be cast on parameters.
-export type Schema = JSONSchema4 | JSONSchema6 | JSONSchema7;
-export type OptionInputObject = Partial<
+declare type Schema = JSONSchema4 | JSONSchema6 | JSONSchema7;
+declare type OptionInputObject = Partial<
     {
         [option in jsfOptions]: any;
     }

--- a/types/json-schema-faker/index.d.ts
+++ b/types/json-schema-faker/index.d.ts
@@ -63,4 +63,5 @@ declare namespace jsf {
 
 /** @deprecated calling JsonSchemaFaker() is deprecated, call either .generate() or .resolve()' */
 declare function jsf(schema: jsf.Schema, refs?: string | jsf.Schema[]): any;
+export as namespace jsf;
 export = jsf;

--- a/types/json-schema-faker/index.d.ts
+++ b/types/json-schema-faker/index.d.ts
@@ -8,8 +8,6 @@
 
 import { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
 
-export = jsf;
-
 declare namespace jsf {
     const version: string;
     function format(nameOrFormatMap?: NameOrFormatMap, callback?: (schema?: Schema) => void): any;
@@ -31,7 +29,6 @@ declare namespace jsf {
     }
 
     type Schema = JSONSchema4 | JSONSchema6 | JSONSchema7;
-    // Type must be cast on parameters.
     type OptionInputObject = Partial<
         {
             [option in jsfOptions]: any;
@@ -65,3 +62,6 @@ declare namespace jsf {
         | 'random'
         | 'replaceEmptyByRandomValue';
 }
+
+declare function jsf(): any;
+export = jsf;

--- a/types/json-schema-faker/json-schema-faker-tests.ts
+++ b/types/json-schema-faker/json-schema-faker-tests.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import jsf, { Schema } from 'json-schema-faker';
 import Chance from 'chance';
 

--- a/types/json-schema-faker/json-schema-faker-tests.ts
+++ b/types/json-schema-faker/json-schema-faker-tests.ts
@@ -1,6 +1,7 @@
 /// <reference types="node" />
-import jsf, { Schema } from 'json-schema-faker';
-import Chance from 'chance';
+import jsf = require('json-schema-faker');
+import { Chance } from 'chance';
+import { Schema } from 'json-schema-faker';
 
 // custom chance extension
 jsf.extend('chance', () => {

--- a/types/json-schema-faker/json-schema-faker-tests.ts
+++ b/types/json-schema-faker/json-schema-faker-tests.ts
@@ -104,17 +104,6 @@ const testRef: jsf.Schema[] = [
     },
 ];
 
-interface Item {
-    user: {
-        id: number;
-        reffed: string;
-        randomname: string;
-        version: string;
-        email: string;
-        name: string;
-    };
-}
-
 // generate
 const generated = jsf.generate(testSchema);
 generated.forEach(testItem);

--- a/types/json-schema-faker/json-schema-faker-tests.ts
+++ b/types/json-schema-faker/json-schema-faker-tests.ts
@@ -1,4 +1,4 @@
-import jsf = require('json-schema-faker');
+import jsf, { Schema } from 'json-schema-faker';
 import Chance from 'chance';
 
 // custom chance extension
@@ -48,7 +48,7 @@ jsf.option('failOnInvalidTypes', false);
 
 // register an option using object input format
 jsf.option({ alwaysFakeOptionals: true });
-const testSchema: jsf.Schema = {
+const testSchema: Schema = {
     type: 'object',
     properties: {
         user: {
@@ -114,11 +114,11 @@ interface Item {
 }
 
 // generate
-const generated = jsf.generate<Item>(testSchema);
+const generated = jsf.generate(testSchema);
 generated.forEach(testItem);
 
 // resolve
-jsf.resolve<Item>(testSchema, testRef).then(res => {
+jsf.resolve(testSchema, testRef).then(res => {
     res.forEach(testItem);
 });
 

--- a/types/json-schema-faker/json-schema-faker-tests.ts
+++ b/types/json-schema-faker/json-schema-faker-tests.ts
@@ -1,0 +1,136 @@
+import jsf = require('json-schema-faker');
+import Chance from 'chance';
+
+// custom chance extension
+jsf.extend('chance', () => {
+    const chance = new Chance();
+    chance.mixin({
+        user: () => {
+            return {
+                first: chance.first(),
+                last: chance.last(),
+                email: chance.email(),
+            };
+        },
+    });
+
+    return chance;
+});
+
+// extend with faker
+jsf.extend('faker', () => require('faker'));
+
+// custom faker extension
+jsf.extend('faker', () => {
+    const faker = require('faker/locale/de');
+
+    faker.mixin = (namespace: string, fnObject: any) => {
+        faker[namespace] = fnObject;
+    };
+
+    faker.mixin('custom', {
+        statement(length: number) {
+            return `${faker.name.firstName()} has ${faker.finance.amount()} on ${faker.finance.account(length)}.`;
+        },
+    });
+
+    return faker;
+});
+
+// add custom format using arg input format
+jsf.format('semver', () => jsf.random.randexp('\\d\\.\\d\\.[1-9]\\d?'));
+
+// add custom format using object input format
+jsf.format({ name: 'semver2', callback: () => jsf.random.randexp('\\d\\.\\d\\.[1-9]\\d?') });
+
+// register an option using arg input format
+jsf.option('failOnInvalidTypes', false);
+
+// register an option using object input format
+jsf.option({ alwaysFakeOptionals: true });
+const testSchema: jsf.Schema = {
+    type: 'object',
+    properties: {
+        user: {
+            type: 'object',
+            properties: {
+                id: {
+                    $ref: '#/definitions/positiveInt',
+                },
+                name: {
+                    type: 'string',
+                    faker: 'name.findName',
+                },
+                email: {
+                    type: 'string',
+                    format: 'email',
+                    faker: 'internet.email',
+                },
+                version: {
+                    type: 'string',
+                    format: 'semver',
+                },
+                version2: {
+                    type: 'string',
+                    format: 'semver2',
+                },
+                reffed: {
+                    $ref: '#/otherSchema',
+                },
+                subuser: {
+                    type: 'object',
+                    chance: 'user',
+                },
+            },
+            required: ['id', 'name', 'email', 'version', 'version2', 'reffed', 'randomname'],
+        },
+    },
+    required: ['user'],
+    definitions: {
+        positiveInt: {
+            type: 'integer',
+            minimum: 0,
+            exclusiveMinimum: true,
+        },
+    },
+};
+
+const testRef: jsf.Schema[] = [
+    {
+        id: 'otherSchema',
+        type: 'string',
+    },
+];
+
+interface Item {
+    user: {
+        id: number;
+        reffed: string;
+        randomname: string;
+        version: string;
+        email: string;
+        name: string;
+    };
+}
+
+// generate
+const generated = jsf.generate<Item>(testSchema);
+generated.forEach(testItem);
+
+// resolve
+jsf.resolve<Item>(testSchema, testRef).then(res => {
+    res.forEach(testItem);
+});
+
+// test that item has all expected properties. If not, throw error.
+function testItem(item: any): void {
+    const user = item.user;
+    if (!item.hasOwnProperty('user')) throw new Error();
+    if (!user.hasOwnProperty('reffed')) throw new Error();
+    if (!user.hasOwnProperty('version')) throw new Error();
+    if (!user.hasOwnProperty('version2')) throw new Error();
+    if (!user.hasOwnProperty('name')) throw new Error();
+    if (!user.hasOwnProperty('email')) throw new Error();
+    if (!user.hasOwnProperty('subuser')) throw new Error();
+    if (!user.hasOwnProperty('id')) throw new Error();
+}

--- a/types/json-schema-faker/tsconfig.json
+++ b/types/json-schema-faker/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "esModuleInterop": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "json-schema-faker-tests.ts"]
+}

--- a/types/json-schema-faker/tsconfig.json
+++ b/types/json-schema-faker/tsconfig.json
@@ -4,7 +4,6 @@
         "lib": ["es6"],
         "noImplicitAny": true,
         "strictNullChecks": true,
-        "esModuleInterop": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/json-schema-faker/tslint.json
+++ b/types/json-schema-faker/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

