### PR TITLE
react-boostrap-table-next: 2 additions, some corrections

### DIFF
--- a/types/react-bootstrap-table-next/index.d.ts
+++ b/types/react-bootstrap-table-next/index.d.ts
@@ -108,6 +108,10 @@ export interface ColumnDescription<T extends object = any, E = any> {
      * Column header field
      */
     text: string;
+    classes?: string | ((cell: T[keyof T], row: T, rowIndex: number, colIndex: number) => string);
+    style?:
+        | React.CSSProperties
+        | ((cell: T[keyof T], row: T, rowIndex: number, colIndex: number) => React.CSSProperties);
     sort?: boolean;
     sortFunc?: ColumnSortFunc<T>;
     searchable?: boolean;
@@ -510,17 +514,17 @@ export interface ExpandHeaderColumnRenderer {
 
 export interface ExpandRowProps<T> {
     renderer: (row: T, rowIndex: number) => JSX.Element;
-    expanded?: number[];
+    expanded?: any[];
     onExpand?: (row: T, isExpand: boolean, rowIndex: number, e: SyntheticEvent) => void;
-    onExpandAll: (isExpandAll: boolean, results: number[], e: SyntheticEvent) => void;
-    nonExpandable: number[];
+    onExpandAll?: (isExpandAll: boolean, results: number[], e: SyntheticEvent) => void;
+    nonExpandable?: number[];
     showExpandColumn?: boolean;
     onlyOneExpanding?: boolean;
     expandByColumnOnly?: boolean;
-    expandColumnRenderer: ReactElement<ExpandColumnRendererProps>;
-    expandHeaderColumnRenderer: ReactElement<ExpandHeaderColumnRenderer>;
-    expandColumnPosition: 'left' | 'right';
-    className: string | ((isExpand: boolean, row: T, rowIndex: number) => string);
+    expandColumnRenderer?: ReactElement<ExpandColumnRendererProps>;
+    expandHeaderColumnRenderer?: ReactElement<ExpandHeaderColumnRenderer>;
+    expandColumnPosition?: 'left' | 'right';
+    className?: string | ((isExpand: boolean, row: T, rowIndex: number) => string);
 }
 
 export type TableColumnFilterProps<FT = any, T extends object = any> = Partial<{


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [classes](https://react-bootstrap-table.github.io/react-bootstrap-table2/docs/column-props.html#columnclasses-string-function) and [style](https://react-bootstrap-table.github.io/react-bootstrap-table2/docs/column-props.html#columnstyle-object-function)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.