### PR TITLE
fix(glob): correct return type to match Glob interface

### DIFF
--- a/types/glob/glob-tests.ts
+++ b/types/glob/glob-tests.ts
@@ -32,3 +32,15 @@ const Glob = glob.Glob;
 declare const ignore: ReadonlyArray<string>;
 glob.sync('/foo/*', {realpath: true, realpathCache: {'/foo/bar': '/bar'}, ignore: '/foo/baz'});
 glob.sync('/*', {ignore, nodir: true, cache: {'/': ['bar', 'baz']}, statCache: {'/foo/bar': false, '/foo/baz': {isDirectory() { return true; }}}});
+
+// $ExpectType IGlob
+const globInstance = glob('**/*.js', { mark: true }, (er, matches) => {
+    if (er) {
+        return;
+    }
+    er; // $ExpectType null
+    matches; // $ExpectType string[]
+});
+globInstance.pause();
+globInstance.resume();
+globInstance.abort();

--- a/types/glob/index.d.ts
+++ b/types/glob/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: vvakame <https://github.com/vvakame>
 //                 voy <https://github.com/voy>
 //                 Klaus Meinhardt <https://github.com/ajafff>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -10,8 +11,8 @@
 import events = require("events");
 import minimatch = require("minimatch");
 
-declare function G(pattern: string, cb: (err: Error | null, matches: string[]) => void): void;
-declare function G(pattern: string, options: G.IOptions, cb: (err: Error | null, matches: string[]) => void): void;
+declare function G(pattern: string, cb: (err: Error | null, matches: string[]) => void): G.IGlob;
+declare function G(pattern: string, options: G.IOptions, cb: (err: Error | null, matches: string[]) => void): G.IGlob;
 
 declare namespace G {
     function __promisify__(pattern: string, options?: IOptions): Promise<string[]>;


### PR DESCRIPTION
This changes detail of lesser known usage of the module.
As pointed in #45192 the function usage should return fully initialized
instance of the glob:
https://git.io/Jf6WM

/cc @Shinigami92

Thanks!

Fixes #45192

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)