### PR TITLE
update(jsdoc-to-markdown): version 6 bump

### DIFF
--- a/types/jsdoc-to-markdown/index.d.ts
+++ b/types/jsdoc-to-markdown/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jsdoc-to-markdown 5.0
+// Type definitions for jsdoc-to-markdown 6.0
 // Project: https://github.com/jsdoc2md/jsdoc-to-markdown
 // Definitions by:  Adam Zerella <https://github.com/adamzerella>
 //                  Piotr Błażejewicz <https://github.com/peterblazejewicz>


### PR DESCRIPTION
This just updates the major version number as adviced by release notes,
though there is no changes to external api shape:
https://github.com/jsdoc2md/jsdoc-to-markdown/releases/tag/v6.0.0

Thanks!


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)