### PR TITLE
feat(glob): export glob api alias

### DIFF
--- a/types/glob/glob-tests.ts
+++ b/types/glob/glob-tests.ts
@@ -1,5 +1,7 @@
 import glob = require("glob");
 const Glob = glob.Glob;
+// ExpectType glob
+const globAlias = glob.glob;
 
 (() => {
     const pattern = "test/a/**/[cg]/../[cg]";

--- a/types/glob/index.d.ts
+++ b/types/glob/index.d.ts
@@ -21,6 +21,7 @@ declare namespace G {
 
     function hasMagic(pattern: string, options?: IOptions): boolean;
 
+    let glob: typeof G;
     let Glob: IGlobStatic;
     let GlobSync: IGlobSyncStatic;
 


### PR DESCRIPTION
This is beign reported by Danger CI tests now as missing export surface
for the module. No existing api was changed.
Reference:
https://git.io/Jf6lU

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)