### PR TITLE
[@types/mkdirp] Fixed type of `opts` argument to sync methods.

### DIFF
--- a/types/mkdirp/index.d.ts
+++ b/types/mkdirp/index.d.ts
@@ -65,7 +65,7 @@ declare namespace mkdirp {
      * or providing an fs option that only overrides one of these.
      * @returns Returns the first directory that had to be created, or undefined if everything already exists.
      */
-    function sync(dir: string, opts?: Mode | Options): string|undefined;
+    function sync(dir: string, opts?: Mode | OptionsSync): string|undefined;
 
     /**
      * Use the manual implementation (not the native one). This is the default
@@ -79,7 +79,7 @@ declare namespace mkdirp {
      * when the native implementation is not available or the stat/mkdir
      * implementation is overridden.
      */
-    function manualSync(dir: string, opts?: Mode | Options): string|undefined;
+    function manualSync(dir: string, opts?: Mode | OptionsSync): string|undefined;
 
     /**
      * Use the native implementation (not the manual one). This is the default
@@ -93,6 +93,6 @@ declare namespace mkdirp {
      * when the native implementation is available and stat/mkdir are not
      * overridden.
      */
-    function nativeSync(dir: string, opts?: Mode | Options): string|undefined;
+    function nativeSync(dir: string, opts?: Mode | OptionsSync): string|undefined;
 }
 export = mkdirp;


### PR DESCRIPTION
I don't quite know how to test it, but it seems like a very small fix.
The original author made provisions for `OptionsSync` but did not use it in the corresponding function signatures.