### PR TITLE
react-table: fix type of nested headers

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -272,7 +272,7 @@ export interface UseTableInstanceProps<D extends object> {
 }
 
 export interface UseTableHeaderGroupProps<D extends object> {
-    headers: Array<ColumnInstance<D>>;
+    headers: Array<HeaderGroup<D>>;
     getHeaderGroupProps: (propGetter?: HeaderGroupPropGetter<D>) => TableHeaderProps;
     getFooterGroupProps: (propGetter?: FooterGroupPropGetter<D>) => TableFooterProps;
     totalHeaderCount: number; // not documented


### PR DESCRIPTION
headers should be defined as a HeaderGroup rather than a ColumnInstance,
this looks like an oversight rather than any particular change in
behavior.

Addresses
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/45113
