### PR TITLE
stripe-v3: add type for method stripe.retrieveSetupIntent

### DIFF
--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -15,6 +15,7 @@
 //                 Austin Turner <https://github.com/paustint>
 //                 Kevin Soltysiak <https://github.com/ksol>
 //                 Kohei Matsubara <https://github.com/matsuby>
+//                 Marko Kaznovac <https://github.com/kaznovac>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var Stripe: stripe.StripeStatic;
@@ -93,6 +94,9 @@ declare namespace stripe {
             clientSecret: string,
             data?: ConfirmCardSetupData,
             options?: ConfirmCardSetupOptions,
+        ): Promise<SetupIntentResponse>;
+        retrieveSetupIntent(
+            clientSecret: string,
         ): Promise<SetupIntentResponse>;
         confirmSepaDebitSetup(
             clientSecret: string,

--- a/types/stripe-v3/stripe-v3-tests.ts
+++ b/types/stripe-v3/stripe-v3-tests.ts
@@ -499,6 +499,18 @@ describe("Stripe elements", () => {
         });
     });
 
+    it("should retrieve setup intent", () => {
+        stripe.retrieveSetupIntent(
+            'pi_18eYalAHEMiOZZp1l9ZTjSU0_secret_NibvRz4PMmJqjfb0sqmT7aq2',
+        ).then(result => {
+            if (result.error) {
+                console.error(result.error.message);
+            } else if (result.setupIntent) {
+                console.log(result.setupIntent.id);
+            }
+        });
+    });
+
     it("should confirm SEPA debit setup", () => {
         const ibanElement = elements.create('iban');
 


### PR DESCRIPTION
https://stripe.com/docs/js/setup_intents/retrieve_setup_intent

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/js/setup_intents/retrieve_setup_intent
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
