### PR TITLE
[rethinkdb] Add missing promise types for cursor.next()

### DIFF
--- a/types/rethinkdb/index.d.ts
+++ b/types/rethinkdb/index.d.ts
@@ -82,6 +82,8 @@ declare module "rethinkdb" {
         each<T>(cb: (err: Error, row: T) => boolean, done?: () => void): void; // returning false stops iteration
         next(cb: (err: Error, row: any) => void): void;
         next<T>(cb: (err: Error, row: T) => void): void;
+        next(): Promise<any>;
+        next<T>(): Promise<T>;
         toArray(cb: (err: Error, rows: any[]) => void): void;
         toArray<T>(cb: (err: Error, rows: T[]) => void): void;
         toArray(): Promise<any[]>;

--- a/types/rethinkdb/rethinkdb-tests.ts
+++ b/types/rethinkdb/rethinkdb-tests.ts
@@ -98,9 +98,14 @@ r.connect({ host: "localhost", port: 28015 }).then(function(conn: r.Connection) 
         .limit(4)
         .run(conn)
         .then((cursor: r.Cursor) => {
-          cursor.toArray().then((rows: any[]) => {
-            console.log(rows);
-          });
+          return cursor.next().then((row) => {
+            console.log('first row', row);
+            return cursor.toArray();
+          }).then((rows) => {
+            console.log('all rows', rows);
+          }).then(() => {
+            return cursor.close();
+          })
         });
     });
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://rethinkdb.com/api/javascript/next
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
