### PR TITLE
[aws-lambda] Add support for payload format v2 of API Gateway proxy

### DIFF
--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -34,6 +34,7 @@
 //                 Marian Zange <https://github.com/marianzange>
 //                 Alexander Pepper <https://github.com/apepper>
 //                 Alessandro Palumbo <https://github.com/apalumbo>
+//                 Sachin Shekhar <https://github.com/SachinShekhar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -227,8 +227,8 @@ function createProxyResult(): APIGatewayProxyResult {
     return result;
 }
 
-function createProxyResultV2(): APIGatewayProxyResult {
-    let result: APIGatewayProxyResult = {
+function createProxyResultV2(): APIGatewayProxyResultV2 {
+    let result: APIGatewayProxyResultV2 = {
         statusCode: num,
         body: str,
     };

--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -12,6 +12,9 @@ import {
     APIGatewayProxyEvent,
     APIGatewayProxyHandler,
     APIGatewayProxyResult,
+    APIGatewayProxyEventV2,
+    APIGatewayProxyHandlerV2,
+    APIGatewayProxyResultV2,
     APIGatewayProxyWithLambdaAuthorizerEventRequestContext,
     APIGatewayProxyWithLambdaAuthorizerHandler,
     APIGatewayRequestAuthorizerHandler,
@@ -132,6 +135,36 @@ let proxyHandler: APIGatewayProxyHandler = async (event, context, callback) => {
     return result;
 };
 
+const proxyHandlerV2: APIGatewayProxyHandlerV2 = async (event, context, callback) => {
+    strOrNull = event.body;
+    str = event.headers['example'];
+    str = event.routeKey;
+    bool = event.isBase64Encoded;
+    str = event.rawPath;
+    str = event.rawQueryString;
+    strOrUndefinedOrNull = event.cookies[0];
+    str = event.stageVariables['example'];
+
+    str = event.requestContext.http.protocol;
+    str = event.requestContext.http.sourceIp;
+    str = event.requestContext.http.method;
+    str = event.requestContext.http.userAgent;
+    str = event.requestContext.accountId;
+    str = event.requestContext.apiId;
+    str = event.requestContext.domainName;
+    str = event.requestContext.domainPrefix;
+    str = event.requestContext.stage;
+    str = event.requestContext.requestId;
+    str = event.requestContext.time;
+    num = event.requestContext.timeEpoch;
+
+    const result = createProxyResultV2();
+
+    callback(new Error());
+    callback(null, result);
+    return result;
+};
+
 const proxyHandlerWithCustomAuthorizer: APIGatewayProxyWithLambdaAuthorizerHandler<CustomAuthorizerContext> = async (event, context, callback) => {
     // standard fields...
     strOrNull = event.body;
@@ -187,6 +220,24 @@ function createProxyResult(): APIGatewayProxyResult {
         },
         multiValueHeaders: {
             [str]: [str, bool, num],
+        },
+        isBase64Encoded: true,
+        body: str,
+    };
+    return result;
+}
+
+function createProxyResultV2(): APIGatewayProxyResult {
+    let result: APIGatewayProxyResult = {
+        statusCode: num,
+        body: str,
+    };
+    result = {
+        statusCode: num,
+        headers: {
+            [str]: str,
+            [str]: bool,
+            [str]: num,
         },
         isBase64Encoded: true,
         body: str,

--- a/types/aws-lambda/trigger/api-gateway-proxy.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-proxy.d.ts
@@ -142,7 +142,7 @@ export interface APIGatewayProxyResultV2 {
     headers?: {
         [header: string]: boolean | number | string;
     };
-    body: string;
+    body?: string | object;
     isBase64Encoded?: boolean;
     cookies?: string[];
 }

--- a/types/aws-lambda/trigger/api-gateway-proxy.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-proxy.d.ts
@@ -105,33 +105,34 @@ export interface APIGatewayProxyEventV2 {
     headers: { [name: string]: string };
     queryStringParameters: { [name: string]: string };
     requestContext: {
-      accountId: string;
-      apiId: string;
-      authorizer: { jwt: {
-          claims: { [name: string]: string };
-          scopes: string[]
-          }
-      };
-      domainName: string;
-      domainPrefix: string;
-      http: {
-        method: string;
-        path: string;
-        protocol: string;
-        sourceIp: string;
-        userAgent: string;
-      };
-      requestId: string;
-      routeKey: string;
-      stage: string;
-      time: string;
-      timeEpoch: number;
+        accountId: string;
+        apiId: string;
+        authorizer: {
+            jwt: {
+                claims: { [name: string]: string };
+                scopes: string[];
+            };
+        };
+        domainName: string;
+        domainPrefix: string;
+        http: {
+            method: string;
+            path: string;
+            protocol: string;
+            sourceIp: string;
+            userAgent: string;
+        };
+        requestId: string;
+        routeKey: string;
+        stage: string;
+        time: string;
+        timeEpoch: number;
     };
     body: string;
     pathParameters: { [name: string]: string };
     isBase64Encoded: boolean;
     stageVariables: { [name: string]: string };
-    }
+}
 
 /**
  * Works with HTTP API integration Payload Format version 2.0

--- a/types/aws-lambda/trigger/api-gateway-proxy.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-proxy.d.ts
@@ -4,9 +4,32 @@ import {
 } from "../common/api-gateway";
 import { Callback, Handler } from "../handler";
 
+/**
+ * Works with Lambda Proxy Integration for Rest API or HTTP API integration Payload Format version 1.0
+ * @see - https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
+ */
 export type APIGatewayProxyHandler = Handler<APIGatewayProxyEvent, APIGatewayProxyResult>;
+/**
+ * Works with Lambda Proxy Integration for Rest API or HTTP API integration Payload Format version 1.0
+ * @see - https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
+ */
 export type APIGatewayProxyCallback = Callback<APIGatewayProxyResult>;
 
+/**
+ * Works with HTTP API integration Payload Format version 2.0
+ * @see - https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
+ */
+export type APIGatewayProxyHandlerV2 = Handler<APIGatewayProxyEventV2, APIGatewayProxyResultV2>;
+/**
+ * Works with HTTP API integration Payload Format version 2.0
+ * @see - https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
+ */
+export type APIGatewayProxyCallbackV2 = Callback<APIGatewayProxyResultV2>;
+
+/**
+ * Works with Lambda Proxy Integration for Rest API or HTTP API integration Payload Format version 1.0
+ * @see - https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
+ */
 export type APIGatewayProxyEvent = APIGatewayProxyEventBase<APIGatewayEventDefaultAuthorizerContext>;
 
 export type APIGatewayProxyWithLambdaAuthorizerHandler<TAuthorizerContext> =
@@ -54,6 +77,10 @@ export interface APIGatewayProxyEventBase<TAuthorizerContext> {
     resource: string;
 }
 
+/**
+ * Works with Lambda Proxy Integration for Rest API or HTTP API integration Payload Format version 1.0
+ * @see - https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
+ */
 export interface APIGatewayProxyResult {
     statusCode: number;
     headers?: {
@@ -64,6 +91,60 @@ export interface APIGatewayProxyResult {
     };
     body: string;
     isBase64Encoded?: boolean;
+}
+
+/**
+ * Works with HTTP API integration Payload Format version 2.0
+ * @see - https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
+ */
+export interface APIGatewayProxyEventV2 {
+    routeKey: string;
+    rawPath: string;
+    rawQueryString: string;
+    cookies: string[];
+    headers: { [name: string]: string };
+    queryStringParameters: { [name: string]: string };
+    requestContext: {
+      accountId: string;
+      apiId: string;
+      authorizer: { jwt: {
+          claims: { [name: string]: string };
+          scopes: string[]
+          }
+      };
+      domainName: string;
+      domainPrefix: string;
+      http: {
+        method: string;
+        path: string;
+        protocol: string;
+        sourceIp: string;
+        userAgent: string;
+      };
+      requestId: string;
+      routeKey: string;
+      stage: string;
+      time: string;
+      timeEpoch: number;
+    };
+    body: string;
+    pathParameters: { [name: string]: string };
+    isBase64Encoded: boolean;
+    stageVariables: { [name: string]: string };
+    }
+
+/**
+ * Works with HTTP API integration Payload Format version 2.0
+ * @see - https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
+ */
+export interface APIGatewayProxyResultV2 {
+    statusCode?: number;
+    headers?: {
+        [header: string]: boolean | number | string;
+    };
+    body: string;
+    isBase64Encoded?: boolean;
+    cookies?: string[];
 }
 
 // Legacy names


### PR DESCRIPTION
This PR adds support for Payload Format version 2.0 of AWS API Gateway proxy event.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html