### PR TITLE
[scriptable-ios] Updated typings for iOS app version 1.4.11

### DIFF
--- a/types/scriptable-ios/index.d.ts
+++ b/types/scriptable-ios/index.d.ts
@@ -1998,6 +1998,16 @@ declare var DocumentPicker: {
      * @see https://docs.scriptable.app/documentpicker/#exportimage
      */
     exportImage(image: Image, name?: string): Promise<string[]>;
+
+    /**
+     * _Exports data._
+     *
+     * Exports data to a new file. The name of the file can optionally be specified. A picker prompting for a destination to export the document to is presented.
+     * @param data - Data to export.
+     * @param name - Optional name of the image to export.
+     * @see https://docs.scriptable.app/documentpicker/#exportdata
+     */
+    exportData(data: Data, name?: string): Promise<string[]>;
 };
 
 /**
@@ -2357,7 +2367,7 @@ declare class FileManager {
     /**
      * _Copies a file._
      *
-     * Copies the file from the source path to the destination path. Caution: This operation will replace any existing file at the the destination.
+     * Copies the file from the source path to the destination path. If a file already exists at the destination file path, the operation will fail and the file will not be copied.
      * @param sourceFilePath - Path of the file to copy.
      * @param destinationFilePath - Path to copy the file to.
      * @see https://docs.scriptable.app/filemanager/#-copy
@@ -2405,8 +2415,7 @@ declare class FileManager {
      *
      * Used to retrieve the path to the documents directory. Your scripts are stored in this directory. If you have iCloud enabled, your scripts will be stored in the documents directory
      * in iCloud otherwise they will be stored in the local documents directory. The directory can be used for long time storage. Documents stored in this directory can be accessed using
-     * the Files app. Note that files stored in the local documents directory will not appear in the Files app unless you enable the "Scriptable Local" file provider. Visit the Files app
-     * to enable the file provider.
+     * the Files app. Files stored in the local documents directory will not appear in the Files app.
      * @see https://docs.scriptable.app/filemanager/#-documentsdirectory
      */
     documentsDirectory(): string;

--- a/types/scriptable-ios/scriptable-ios-tests.ts
+++ b/types/scriptable-ios/scriptable-ios-tests.ts
@@ -14,3 +14,27 @@
     a.presentSheet();
     const textFieldValue = a.textFieldValue(0);
 }
+
+{
+    // $ExpectType Promise<string[]>
+    DocumentPicker.open(['public.plain-text']);
+    // $ExpectType Promise<string>
+    DocumentPicker.openFile();
+    // $ExpectType Promise<string>
+    DocumentPicker.openFolder();
+
+    // $ExpectType Promise<string[]>
+    DocumentPicker.export('some/file.txt');
+    // $ExpectType Promise<string[]>
+    DocumentPicker.exportString('foo-bar');
+    // $ExpectType Promise<string[]>
+    DocumentPicker.exportString('foo-bar', 'file.txt');
+    // $ExpectType Promise<string[]>
+    DocumentPicker.exportImage(Image.fromFile('some/image.png'));
+    // $ExpectType Promise<string[]>
+    DocumentPicker.exportImage(Image.fromFile('some/image.png'), 'super interesting image.png');
+    // $ExpectType Promise<string[]>
+    DocumentPicker.exportData(Data.fromFile('test.bin'));
+    // $ExpectType Promise<string[]>
+    DocumentPicker.exportData(Data.fromFile('test.bin'), 'super interesting data.bin');
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.scriptable.app/documentpicker/#exportdata
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

