### PR TITLE
[draft-js] Use index signature for raw block data object

### DIFF
--- a/types/draft-js/draft-js-tests.tsx
+++ b/types/draft-js/draft-js-tests.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+import * as Immutable from "immutable";
 
 import {
   ContentBlock,
@@ -124,6 +125,16 @@ class RichEditorExample extends React.Component<{}, { editorState: EditorState }
         this.onChange(RichUtils.toggleInlineStyle(this.state.editorState, inlineStyle));
     };
 
+    toggleCodeBlockLanguage: (language: string) => void = (language: string) => {
+      const { editorState } = this.state;
+      const contentState = editorState.getCurrentContent();
+      const selection = editorState.getSelection();
+
+      const blockData = Immutable.Map<string, string>([['language', language]]);
+      const contentWithData = Modifier.setBlockData(contentState, selection, blockData);
+      this.onChange(EditorState.push(editorState, contentWithData, 'change-block-data'));
+    }
+
     splitHeaderToNewBlock(): EditorState {
         const { editorState } = this.state;
         const selection = editorState.getSelection();
@@ -168,6 +179,7 @@ class RichEditorExample extends React.Component<{}, { editorState: EditorState }
             <div className="RichEditor-root">
                 <BlockStyleControls editorState={this.state.editorState} onToggle={this.toggleBlockType} />
                 <InlineStyleControls editorState={this.state.editorState} onToggle={this.toggleInlineStyle} />
+                <CodeBlockTypeControl editorState={this.state.editorState} onToggle={this.toggleCodeBlockLanguage} />
                 <div className={className}>
                     <Editor
                         blockStyleFn={getBlockStyle}
@@ -311,6 +323,39 @@ const InlineStyleControls = (props: {editorState: EditorState, onToggle: (blockT
   );
 };
 
+const SUPPORTED_LANGUAGES = [
+  { label: 'JavaScript', value: 'javascript' },
+  { label: 'Java', value: 'java' },
+  { label: 'Python', value: 'python' },
+  { label: 'C++', value: 'c++' },
+]
+
+const CodeBlockTypeControl = (props: {editorState: EditorState, onToggle: (blockType: string) => void}) => {
+  const {editorState} = props;
+  const selection = editorState.getSelection();
+  const block = editorState
+    .getCurrentContent()
+    .getBlockForKey(selection.getStartKey())
+
+  if (block.getType() === 'code-block') {
+    return (
+      <div className="RichEditor-controls">
+        {SUPPORTED_LANGUAGES.map((language) =>
+          <StyleButton
+            key={language.label}
+            active={block.getData().get('language') === language}
+            label={language.label}
+            onToggle={props.onToggle}
+            style={language.value}
+          />
+        ) }
+      </div>
+    );
+  } else {
+    return null
+  }
+};
+
 ReactDOM.render(
   <RichEditorExample />,
   document.getElementById('target')
@@ -335,4 +380,8 @@ rawContentState.blocks.forEach((block: RawDraftContentBlock) => {
     const inlineStyle: DraftInlineStyleType = inlineStyleRange.style;
     console.log(inlineStyle, offset, length);
   });
+
+  if (block.type === 'code-block' && block.data.language) {
+    console.log(block.data.language)
+  }
 });

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -575,7 +575,7 @@ declare namespace Draft {
                 depth: number;
                 inlineStyleRanges: Array<RawDraftInlineStyleRange>;
                 entityRanges: Array<RawDraftEntityRange>;
-                data?: Object;
+                data?: { [key: string]: any };
             }
 
             /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://draftjs.org/docs/api-reference-modifier/#setblockdata https://github.com/facebook/draft-js/blob/96e7f25503c9f0422573ab33be6c1f8986c6c818/src/model/encoding/convertFromDraftStateToRaw.js#L35
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
