### PR TITLE
created typings for react-portal-tooltip

### DIFF
--- a/types/react-portal-tooltip/index.d.ts
+++ b/types/react-portal-tooltip/index.d.ts
@@ -3,37 +3,10 @@
 // Definitions by: naortor <https://github.com/me>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/*~ If this module is a UMD module that exposes a global variable 'myLib' when
- *~ loaded outside a module loader environment, declare that global here.
- *~ Otherwise, delete this declaration.
- */
-export as namespace myLib;
+import * as React from 'react';
 
-/*~ If this module has methods, declare them as functions like so.
- */
-export function myMethod(a: string): string;
-export function myOtherMethod(a: number): number;
+import ToolTip from './lib/ToolTip';
+import StatefulToolTip from './lib/StatefulToolTip';
 
-/*~ You can declare types that are available via importing the module */
-export interface someType {
-    name: string;
-    length: number;
-    extras?: string[];
-}
-
-/*~ You can declare properties of the module using const, let, or var */
-export const myField: number;
-
-/*~ If there are types, properties, or methods inside dotted names
- *~ of the module, declare them inside a 'namespace'.
- */
-export namespace subProp {
-    /*~ For example, given this definition, someone could write:
-     *~   import { subProp } from 'yourModule';
-     *~   subProp.foo();
-     *~ or
-     *~   import * as yourMod from 'yourModule';
-     *~   yourMod.subProp.foo();
-     */
-    function foo(): void;
-}
+export default ToolTip;
+export { StatefulToolTip };

--- a/types/react-portal-tooltip/index.d.ts
+++ b/types/react-portal-tooltip/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for react-portal-tooltip 2.4
+// Project: https://github.com/romainberger/react-portal-tooltip
+// Definitions by: naortor <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/*~ If this module is a UMD module that exposes a global variable 'myLib' when
+ *~ loaded outside a module loader environment, declare that global here.
+ *~ Otherwise, delete this declaration.
+ */
+export as namespace myLib;
+
+/*~ If this module has methods, declare them as functions like so.
+ */
+export function myMethod(a: string): string;
+export function myOtherMethod(a: number): number;
+
+/*~ You can declare types that are available via importing the module */
+export interface someType {
+    name: string;
+    length: number;
+    extras?: string[];
+}
+
+/*~ You can declare properties of the module using const, let, or var */
+export const myField: number;
+
+/*~ If there are types, properties, or methods inside dotted names
+ *~ of the module, declare them inside a 'namespace'.
+ */
+export namespace subProp {
+    /*~ For example, given this definition, someone could write:
+     *~   import { subProp } from 'yourModule';
+     *~   subProp.foo();
+     *~ or
+     *~   import * as yourMod from 'yourModule';
+     *~   yourMod.subProp.foo();
+     */
+    function foo(): void;
+}

--- a/types/react-portal-tooltip/index.d.ts
+++ b/types/react-portal-tooltip/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-portal-tooltip 2.4
 // Project: https://github.com/romainberger/react-portal-tooltip
-// Definitions by: naortor <https://github.com/me>
+// Definitions by: naortor <https://github.com/naortor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as React from 'react';

--- a/types/react-portal-tooltip/lib/Card.d.ts
+++ b/types/react-portal-tooltip/lib/Card.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-declare class Card extends React.Component<{}> {}
+declare class Card extends React.Component<Card.CardProps> {}
 
 export default Card;
 

--- a/types/react-portal-tooltip/lib/Card.d.ts
+++ b/types/react-portal-tooltip/lib/Card.d.ts
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+declare class Card extends React.Component<{}> {}
+
+export default Card;
+
+declare namespace Card {
+    type Position = 'top' | 'right' | 'bottom' | 'left';
+    type Arrow = null | 'center' | 'top' | 'right' | 'bottom' | 'left';
+    type Align = null | 'center' | 'right' | 'left';
+
+    interface CardProps {
+        position?: Position;
+        arrow?: Arrow;
+        align?: Align;
+        useHover?: boolean;
+        style?: {
+            style?: React.CSSProperties;
+            arrowStyle?: React.CSSProperties;
+        };
+    }
+}

--- a/types/react-portal-tooltip/lib/StatefulToolTip.d.ts
+++ b/types/react-portal-tooltip/lib/StatefulToolTip.d.ts
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import ToolTip, { TooltipProps } from './ToolTip';
+
+declare class StatefulToolTip extends React.Component<StatefulToolTipProps> {}
+
+export default StatefulToolTip;
+
+interface StatefulToolTipProps extends TooltipProps {
+    className?: string;
+}

--- a/types/react-portal-tooltip/lib/ToolTip.d.ts
+++ b/types/react-portal-tooltip/lib/ToolTip.d.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import Card from './Card';
+
+declare class Tooltip extends React.Component<TooltipProps> {}
+
+export default Tooltip;
+
+export interface TooltipProps extends Card.CardProps {
+    parent: string | JSX.Element | React.RefObject<unknown>;
+    active?: boolean;
+    group?: string;
+    tooltipTimeout?: number;
+}

--- a/types/react-portal-tooltip/react-portal-tooltip-tests.tsx
+++ b/types/react-portal-tooltip/react-portal-tooltip-tests.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import ToolTip, { StatefulToolTip } from 'react-portal-tooltip';
+
+// Tooltip test
+
+class ToolTipTest extends React.Component {
+    state = {
+        isTooltipActive: false,
+    };
+    showTooltip() {
+        this.setState({ isTooltipActive: true });
+    }
+    hideTooltip() {
+        this.setState({ isTooltipActive: false });
+    }
+    render() {
+        return (
+            <div>
+                <p id="text" onMouseEnter={this.showTooltip.bind(this)} onMouseLeave={this.hideTooltip.bind(this)}>
+                    This is a cool component
+                </p>
+                <ToolTip active={this.state.isTooltipActive} position="top" arrow="center" parent="#text">
+                    <div>
+                        <p>This is the content of the tooltip</p>
+                        <img src="image.png" />
+                    </div>
+                </ToolTip>
+            </div>
+        );
+    }
+}
+
+// Parent props
+
+class ToolTipTestParentProp1 extends React.Component {
+    state = {
+        isTooltipActive: false,
+    };
+    showTooltip() {
+        this.setState({ isTooltipActive: true });
+    }
+    hideTooltip() {
+        this.setState({ isTooltipActive: false });
+    }
+    render() {
+        return (
+            <div>
+                <div id="hoverMe" onMouseEnter={this.showTooltip} onMouseLeave={this.hideTooltip}>
+                    Hover me!!!
+                </div>
+                <ToolTip active={this.state.isTooltipActive} position="top" arrow="center" parent="#hoverMe">
+                    <div>
+                        <p>This is the content of the tooltip</p>
+                    </div>
+                </ToolTip>
+            </div>
+        );
+    }
+}
+
+class ToolTipTestParentProp2 extends React.Component<{}> {
+    private element = React.createRef<HTMLDivElement>();
+
+    constructor(props: {}) {
+        super(props);
+    }
+    state = {
+        isTooltipActive: false,
+    };
+    showTooltip() {
+        this.setState({ isTooltipActive: true });
+    }
+    hideTooltip() {
+        this.setState({ isTooltipActive: false });
+    }
+    render() {
+        return (
+            <div>
+                <div ref={this.element} onMouseEnter={this.showTooltip} onMouseLeave={this.hideTooltip}>
+                    Hover me!!!
+                </div>
+                <ToolTip active={this.state.isTooltipActive} position="top" arrow="center" parent={this.element}>
+                    <div>
+                        <p>This is the content of the tooltip</p>
+                    </div>
+                </ToolTip>
+            </div>
+        );
+    }
+}
+
+// StatefulToolTip test
+
+const StatefulToolTipTest = () => {
+    const button = <span>Hover me to display the tooltip</span>;
+
+    return <StatefulToolTip parent={button}>Stateful Tooltip content here!</StatefulToolTip>;
+};

--- a/types/react-portal-tooltip/react-portal-tooltip-tests.tsx
+++ b/types/react-portal-tooltip/react-portal-tooltip-tests.tsx
@@ -58,8 +58,8 @@ class ToolTipTestParentProp1 extends React.Component {
     }
 }
 
-class ToolTipTestParentProp2 extends React.Component<{}> {
-    private element = React.createRef<HTMLDivElement>();
+class ToolTipTestParentProp2 extends React.Component {
+    readonly element = React.createRef<HTMLDivElement>();
 
     constructor(props: {}) {
         super(props);

--- a/types/react-portal-tooltip/tsconfig.json
+++ b/types/react-portal-tooltip/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-portal-tooltip-tests.ts"
+    ]
+}

--- a/types/react-portal-tooltip/tsconfig.json
+++ b/types/react-portal-tooltip/tsconfig.json
@@ -1,23 +1,17 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": [
-            "es6"
-        ],
+        "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
+        "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
+        "jsx": "react",
         "forceConsistentCasingInFileNames": true
     },
-    "files": [
-        "index.d.ts",
-        "react-portal-tooltip-tests.ts"
-    ]
+    "files": ["index.d.ts", "react-portal-tooltip-tests.tsx"]
 }

--- a/types/react-portal-tooltip/tslint.json
+++ b/types/react-portal-tooltip/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [ v] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ v] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ v] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ v] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [v ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [v ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.