### PR TITLE
[cache-manager-ioredis] Fixed type resolution for default export

### DIFF
--- a/types/cache-manager-ioredis/index.d.ts
+++ b/types/cache-manager-ioredis/index.d.ts
@@ -26,7 +26,7 @@ declare namespace CacheManagerIORedis {
     }
 
     interface RedisStoreConstructor {
-        create: (...options: RedisStoreSingleNodeConfig[]) => RedisSingleNodeStore | ((...options: RedisStoreClusterConfig[]) => RedisClusterStore);
+        create: ((...options: RedisStoreSingleNodeConfig[]) => RedisSingleNodeStore) | ((...options: RedisStoreClusterConfig[]) => RedisClusterStore);
     }
 
     type RedisStoreSingleNodeConfig = (CachingConfig & IORedis.RedisOptions & {
@@ -50,11 +50,11 @@ declare namespace CacheManagerIORedis {
         ttl(...args: any[]): Promise<any>;
     }
 
-    interface RedisSingleNodeStore extends Store {
+    interface RedisSingleNodeStore extends RedisStore {
         getClient(): IORedis.Redis;
     }
 
-    interface RedisClusterStore extends Store {
+    interface RedisClusterStore extends RedisStore {
         getClient(): IORedis.Cluster;
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: No reference URL. The failure in type resolution comes from a) a missing pair of parentheses that confuses Typescript compiler and b) `RedisSingleNodeStore` and `RedisClusterStore` mistakenly extending `Store` when they should extend `RedisStore` (which itself extends `Store`). This update fixes these issues.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

