### PR TITLE
Add typescript dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "dtslint": "latest",
         "prettier": "^2.0.2",
         "@definitelytyped/dtslint-runner": "latest",
-        "typescript": "^3.8.3"
+        "typescript": "next"
     },
     "husky": {
         "hooks": {

--- a/package.json
+++ b/package.json
@@ -34,5 +34,7 @@
             "pre-commit": "npm uninstall husky"
         }
     },
-    "dependencies": {}
+    "dependencies": {
+        "typescript": "next"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -26,15 +26,13 @@
         "danger": "^10.1.1",
         "dtslint": "latest",
         "prettier": "^2.0.2",
-        "@definitelytyped/dtslint-runner": "latest"
+        "@definitelytyped/dtslint-runner": "latest",
+        "typescript": "next"
     },
     "husky": {
         "hooks": {
             "_comment": "This will remove husky from when we started migrating to use prettier",
             "pre-commit": "npm uninstall husky"
         }
-    },
-    "dependencies": {
-        "typescript": "next"
     }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "dtslint": "latest",
         "prettier": "^2.0.2",
         "@definitelytyped/dtslint-runner": "latest",
-        "typescript": "next"
+        "typescript": "^3.8.3"
     },
     "husky": {
         "hooks": {

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
         "prettier": "prettier"
     },
     "devDependencies": {
+        "@definitelytyped/dtslint-runner": "latest",
         "danger": "^10.1.1",
         "dtslint": "latest",
         "prettier": "^2.0.2",
-        "@definitelytyped/dtslint-runner": "latest",
         "typescript": "next"
     },
     "husky": {


### PR DESCRIPTION
In preparation for merging https://github.com/microsoft/dtslint/pull/295 and shipping a new version of dtslint that has typescript as a peer dependency.