### PR TITLE
Add chrome.input.ime.AssistiveWindow* types

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -4000,6 +4000,18 @@ declare namespace chrome.input.ime {
         engineId: string;
     }
 
+    /** Type of the assistive window. */
+    export type AssistiveWindowType = 'undo';
+
+    /** ID of a button in an assistive window. */
+    export type AssistiveWindowButton = 'undo'|'addToDictionary';
+
+    /** Properties of an assistive window. */
+    export interface AssistiveWindowProperties {
+      type: AssistiveWindowType;
+      visible: boolean;
+    }
+
     export interface CandidateWindowParameterProperties {
         /**
          * Optional.
@@ -4084,7 +4096,16 @@ declare namespace chrome.input.ime {
         anchor: number;
     }
 
+    export interface AssistiveWindowButtonClickedDetails {
+        /** The ID of the button clicked. */
+        buttonID: AssistiveWindowButton;
+        /** The type of the assistive window. */
+        windowType: AssistiveWindowType;
+    }
+
     export interface BlurEvent extends chrome.events.Event<(contextID: number) => void> { }
+
+    export interface AssistiveWindowButtonClickedEvent extends chrome.events.Event<(details: AssistiveWindowButtonClickedDetails) => void> { }
 
     export interface CandidateClickedEvent extends chrome.events.Event<(engineID: string, candidateID: number, button: string) => void> { }
 
@@ -4139,6 +4160,17 @@ declare namespace chrome.input.ime {
      */
     export function updateMenuItems(parameters: MenuItemParameters, callback?: () => void): void;
     /**
+     * Shows/Hides an assistive window with the given properties.
+     * @param {{
+     *   contextID: number,
+     *   properties: !chrome.input.ime.AssistiveWindowProperties
+     * }} parameters
+     * @param callback Called when the operation completes.
+     * If you specify the callback parameter, it should be a function that looks like this:
+     * function(boolean success) {...};
+     */
+    export function setAssistiveWindowProperties(parameters: object, callback?: (success: boolean) => void): void;
+    /**
      * Sets the properties of the candidate window. This fails if the extension doesn't own the active IME
      * @param callback Called when the operation completes.
      * If you specify the callback parameter, it should be a function that looks like this:
@@ -4187,6 +4219,8 @@ declare namespace chrome.input.ime {
 
     /** This event is sent when focus leaves a text box. It is sent to all extensions that are listening to this event, and enabled by the user. */
     export var onBlur: BlurEvent;
+    /** This event is sent when a button in an assistive window is clicked. */
+    export var onAssistiveWindowButtonClicked: AssistiveWindowButtonClickedEvent;
     /** This event is sent if this extension owns the active IME. */
     export var onCandidateClicked: CandidateClickedEvent;
     /** This event is sent if this extension owns the active IME. */

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -480,3 +480,18 @@ chrome.devtools.network.getHAR((harLog: chrome.devtools.network.HARLog) => {
     harLog; // $ExpectType HARLog
     console.log('harLog: ', harLog)
 });
+
+function testAssistiveWindow() {
+    chrome.input.ime.setAssistiveWindowProperties({
+      contextId: 0,
+      properties: {
+          type: 'undo',
+          visible: true
+        }
+    });
+    chrome.input.ime.onAssistiveWindowButtonClicked.addListener((details: chrome.input.ime.AssistiveWindowButtonClickedDetails) => {
+          details;
+          console.log(
+            `${details.buttonID} button in ${details.windowType} window clicked`);
+        });
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). => Couldn't run this.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://developer.chrome.com/extensions/input_ime#type-AssistiveWindowType
https://developer.chrome.com/extensions/input_ime#method-setAssistiveWindowProperties
https://developer.chrome.com/extensions/input_ime#event-onAssistiveWindowButtonClicked
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.