### PR TITLE
fix(faker): add missing random arrayElements

### DIFF
--- a/types/faker/faker-tests.ts
+++ b/types/faker/faker-tests.ts
@@ -184,7 +184,9 @@ resultNum = faker.random.number({
 });
 resultStr = faker.random.arrayElement();
 resultStr = faker.random.arrayElement(['foo', 'bar', 'quux']);
-resultStr = faker.random.arrayElement(['foo', 'bar', 'quux'] as ReadonlyArray<string>);
+resultStrArr = faker.random.arrayElements(['foo', 'bar', 'quux'], 2);
+resultStrArr = faker.random.arrayElements(['foo', 'bar', 'quux'] as ReadonlyArray<string>, 2);
+
 resultStr = faker.random.objectElement();
 resultStr = faker.random.objectElement({foo: 'bar', field: 'foo'});
 resultStr = faker.random.uuid();

--- a/types/faker/index.d.ts
+++ b/types/faker/index.d.ts
@@ -189,6 +189,9 @@ declare namespace Faker {
             arrayElement(): string;
             arrayElement<T>(array: T[]): T;
             arrayElement<T>(array: ReadonlyArray<T>): T;
+            arrayElements(): [];
+            arrayElements<T>(array: T[], count: number): T[];
+            arrayElements<T>(array: ReadonlyArray<T>, count: number): T[];
             objectElement(object?: { [key: string]: any }, field?: "key"): string;
             objectElement<T>(object?: { [key: string]: T }, field?: any): T;
             uuid(): string;


### PR DESCRIPTION
I have noticed that types are missing one extra method: `arrayElements`.

There is `arrayElement` (singular) but the `arrayElements` (plural) was missing.

Link to method implementation: https://github.com/Marak/faker.js/blob/3b2fa4aebccee52ae1bafc15d575061fb30c3cf1/lib/random.js#L97

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
`
