### PR TITLE
feat(es‑abstract): Make `ESAbstract.PropertyDescriptor` generic

### DIFF
--- a/types/es-abstract/es2015.d.ts
+++ b/types/es-abstract/es2015.d.ts
@@ -208,13 +208,13 @@ interface ES2015 extends Omit<typeof ES5, 'CheckObjectCoercible' | 'ToPrimitive'
             '[[Configurable]]': boolean;
             '[[Enumerable]]': boolean;
             '[[Writable]]': boolean;
-            '[[Value]]': P extends keyof O ? O[P] : any;
+            '[[Value]]': P extends keyof O ? O[P] : unknown;
         }
         | {
             '[[Configurable]]': boolean;
             '[[Enumerable]]': boolean;
-            '[[Get]]': (() => P extends keyof O ? O[P] : any) | undefined;
-            '[[Set]]': (value: P extends keyof O ? O[P] : any) => void;
+            '[[Get]]': (() => P extends keyof O ? O[P] : unknown) | undefined;
+            '[[Set]]': ((value: P extends keyof O ? O[P] : unknown) => void) | undefined;
         }
         | undefined;
 
@@ -250,9 +250,9 @@ declare namespace ES2015 {
     // Re-export types from previous versions
     // - ES5:
     type GenericDescriptor = ES5.GenericDescriptor;
-    type AccessorDescriptor<T = any> = ES5.AccessorDescriptor<T>;
-    type DataDescriptor<T = any> = ES5.DataDescriptor<T>;
-    type PropertyDescriptor<T = any> = ES5.PropertyDescriptor<T>;
+    type AccessorDescriptor<T = unknown> = ES5.AccessorDescriptor<T>;
+    type DataDescriptor<T = unknown> = ES5.DataDescriptor<T>;
+    type PropertyDescriptor<T = unknown> = ES5.PropertyDescriptor<T>;
 }
 
 declare const ES2015: ES2015;

--- a/types/es-abstract/es2015.d.ts
+++ b/types/es-abstract/es2015.d.ts
@@ -200,8 +200,23 @@ interface ES2015 extends Omit<typeof ES5, 'CheckObjectCoercible' | 'ToPrimitive'
         current?: ES5.PropertyDescriptor & ThisType<any>,
     ): boolean;
     OrdinaryDefineOwnProperty(O: object, P: ESPropertyKey, Desc: ES5.PropertyDescriptor & ThisType<any>): boolean;
-    OrdinaryGetOwnProperty<O extends object, P extends ESPropertyKey>(O: O, P: P): ES5.PropertyDescriptor<P extends keyof O ? O[P] : any> | undefined;
-    OrdinaryGetOwnProperty(O: object, P: ESPropertyKey): ES5.PropertyDescriptor | undefined;
+    OrdinaryGetOwnProperty<O extends object, P extends ESPropertyKey>(
+        O: O,
+        P: P,
+    ):
+        | {
+            '[[Configurable]]': boolean;
+            '[[Enumerable]]': boolean;
+            '[[Writable]]': boolean;
+            '[[Value]]': P extends keyof O ? O[P] : any;
+        }
+        | {
+            '[[Configurable]]': boolean;
+            '[[Enumerable]]': boolean;
+            '[[Get]]': (() => P extends keyof O ? O[P] : any) | undefined;
+            '[[Set]]': (value: P extends keyof O ? O[P] : any) => void;
+        }
+        | undefined;
 
     ArrayCreate(length: number, proto?: object | null): unknown[];
     ArraySetLength(A: unknown[], Desc: ES5.PropertyDescriptor & ThisType<any>): boolean;

--- a/types/es-abstract/es2015.d.ts
+++ b/types/es-abstract/es2015.d.ts
@@ -4,8 +4,6 @@ import ES5 = require('./es5');
 import { Intrinsics } from './GetIntrinsic';
 import { PropertyKey as ESPropertyKey } from './index';
 
-type TSPropertyKey = PropertyKey;
-
 interface ES2015 extends Omit<typeof ES5, 'CheckObjectCoercible' | 'ToPrimitive' | 'Type'> {
     Call<R, T = unknown>(F: (this: T) => R, thisArg: T): R;
     Call<R, A extends unknown[] | [unknown], T = unknown>(
@@ -71,10 +69,21 @@ interface ES2015 extends Omit<typeof ES5, 'CheckObjectCoercible' | 'ToPrimitive'
     CompletePropertyDescriptor<D extends ES5.PropertyDescriptor>(
         Desc: D & ThisType<any>,
     ): Required<
-        D extends { '[[Value]]': unknown } | { '[[Writable]]': boolean }
-            ? D & ES5.DataDescriptor
-            : D extends { '[[Get]]': () => unknown } | { '[[Set]]': (value: unknown) => void }
-            ? D & ES5.AccessorDescriptor
+        D extends { '[[Value]]': infer T }
+            ? ES5.GenericDescriptor & {
+                '[[Value]]': T;
+                '[[Writable]]': boolean;
+            }
+            : D extends { '[[Value]]'?: infer T } | { '[[Writable]]'?: boolean }
+            ? ES5.GenericDescriptor & {
+                '[[Value]]': T | undefined;
+                '[[Writable]]': boolean;
+            }
+            : D extends { '[[Get]]'?: () => infer T } | { '[[Set]]'?: (value: infer T) => void }
+            ? ES5.GenericDescriptor & {
+                '[[Get]]': (() => T) | undefined;
+                '[[Set]]': ((value: T) => void) | undefined;
+            }
             : D & ES5.PropertyDescriptor
     >;
     CompletePropertyDescriptor(Desc: ES5.PropertyDescriptor & ThisType<any>): Required<ES5.PropertyDescriptor>;
@@ -191,6 +200,7 @@ interface ES2015 extends Omit<typeof ES5, 'CheckObjectCoercible' | 'ToPrimitive'
         current?: ES5.PropertyDescriptor & ThisType<any>,
     ): boolean;
     OrdinaryDefineOwnProperty(O: object, P: ESPropertyKey, Desc: ES5.PropertyDescriptor & ThisType<any>): boolean;
+    OrdinaryGetOwnProperty<O extends object, P extends ESPropertyKey>(O: O, P: P): ES5.PropertyDescriptor<P extends keyof O ? O[P] : any> | undefined;
     OrdinaryGetOwnProperty(O: object, P: ESPropertyKey): ES5.PropertyDescriptor | undefined;
 
     ArrayCreate(length: number, proto?: object | null): unknown[];
@@ -225,9 +235,9 @@ declare namespace ES2015 {
     // Re-export types from previous versions
     // - ES5:
     type GenericDescriptor = ES5.GenericDescriptor;
-    type AccessorDescriptor = ES5.AccessorDescriptor;
-    type DataDescriptor = ES5.DataDescriptor;
-    type PropertyDescriptor = ES5.PropertyDescriptor;
+    type AccessorDescriptor<T = any> = ES5.AccessorDescriptor<T>;
+    type DataDescriptor<T = any> = ES5.DataDescriptor<T>;
+    type PropertyDescriptor<T = any> = ES5.PropertyDescriptor<T>;
 }
 
 declare const ES2015: ES2015;

--- a/types/es-abstract/es2016.d.ts
+++ b/types/es-abstract/es2016.d.ts
@@ -27,9 +27,9 @@ declare namespace ES2016 {
 
     // - ES5:
     type GenericDescriptor = ES2015.GenericDescriptor;
-    type AccessorDescriptor = ES2015.AccessorDescriptor;
-    type DataDescriptor = ES2015.DataDescriptor;
-    type PropertyDescriptor = ES2015.PropertyDescriptor;
+    type AccessorDescriptor<T = any> = ES2015.AccessorDescriptor<T>;
+    type DataDescriptor<T = any> = ES2015.DataDescriptor<T>;
+    type PropertyDescriptor<T = any> = ES2015.PropertyDescriptor<T>;
 }
 
 declare const ES2016: ES2016;

--- a/types/es-abstract/es2016.d.ts
+++ b/types/es-abstract/es2016.d.ts
@@ -27,9 +27,9 @@ declare namespace ES2016 {
 
     // - ES5:
     type GenericDescriptor = ES2015.GenericDescriptor;
-    type AccessorDescriptor<T = any> = ES2015.AccessorDescriptor<T>;
-    type DataDescriptor<T = any> = ES2015.DataDescriptor<T>;
-    type PropertyDescriptor<T = any> = ES2015.PropertyDescriptor<T>;
+    type AccessorDescriptor<T = unknown> = ES2015.AccessorDescriptor<T>;
+    type DataDescriptor<T = unknown> = ES2015.DataDescriptor<T>;
+    type PropertyDescriptor<T = unknown> = ES2015.PropertyDescriptor<T>;
 }
 
 declare const ES2016: ES2016;

--- a/types/es-abstract/es2017.d.ts
+++ b/types/es-abstract/es2017.d.ts
@@ -33,9 +33,9 @@ declare namespace ES2017 {
 
     // - ES5:
     type GenericDescriptor = ES2016.GenericDescriptor;
-    type AccessorDescriptor<T = any> = ES2016.AccessorDescriptor<T>;
-    type DataDescriptor<T = any> = ES2016.DataDescriptor<T>;
-    type PropertyDescriptor<T = any> = ES2016.PropertyDescriptor<T>;
+    type AccessorDescriptor<T = unknown> = ES2016.AccessorDescriptor<T>;
+    type DataDescriptor<T = unknown> = ES2016.DataDescriptor<T>;
+    type PropertyDescriptor<T = unknown> = ES2016.PropertyDescriptor<T>;
 }
 
 declare const ES2017: ES2017;

--- a/types/es-abstract/es2017.d.ts
+++ b/types/es-abstract/es2017.d.ts
@@ -33,9 +33,9 @@ declare namespace ES2017 {
 
     // - ES5:
     type GenericDescriptor = ES2016.GenericDescriptor;
-    type AccessorDescriptor = ES2016.AccessorDescriptor;
-    type DataDescriptor = ES2016.DataDescriptor;
-    type PropertyDescriptor = ES2016.PropertyDescriptor;
+    type AccessorDescriptor<T = any> = ES2016.AccessorDescriptor<T>;
+    type DataDescriptor<T = any> = ES2016.DataDescriptor<T>;
+    type PropertyDescriptor<T = any> = ES2016.PropertyDescriptor<T>;
 }
 
 declare const ES2017: ES2017;

--- a/types/es-abstract/es2018.d.ts
+++ b/types/es-abstract/es2018.d.ts
@@ -38,9 +38,9 @@ declare namespace ES2018 {
 
     // - ES5:
     type GenericDescriptor = ES2017.GenericDescriptor;
-    type AccessorDescriptor<T = any> = ES2017.AccessorDescriptor<T>;
-    type DataDescriptor<T = any> = ES2017.DataDescriptor<T>;
-    type PropertyDescriptor<T = any> = ES2017.PropertyDescriptor<T>;
+    type AccessorDescriptor<T = unknown> = ES2017.AccessorDescriptor<T>;
+    type DataDescriptor<T = unknown> = ES2017.DataDescriptor<T>;
+    type PropertyDescriptor<T = unknown> = ES2017.PropertyDescriptor<T>;
 }
 
 declare const ES2018: ES2018;

--- a/types/es-abstract/es2018.d.ts
+++ b/types/es-abstract/es2018.d.ts
@@ -38,9 +38,9 @@ declare namespace ES2018 {
 
     // - ES5:
     type GenericDescriptor = ES2017.GenericDescriptor;
-    type AccessorDescriptor = ES2017.AccessorDescriptor;
-    type DataDescriptor = ES2017.DataDescriptor;
-    type PropertyDescriptor = ES2017.PropertyDescriptor;
+    type AccessorDescriptor<T = any> = ES2017.AccessorDescriptor<T>;
+    type DataDescriptor<T = any> = ES2017.DataDescriptor<T>;
+    type PropertyDescriptor<T = any> = ES2017.PropertyDescriptor<T>;
 }
 
 declare const ES2018: ES2018;

--- a/types/es-abstract/es2019.d.ts
+++ b/types/es-abstract/es2019.d.ts
@@ -54,9 +54,9 @@ declare namespace ES2019 {
 
     // - ES5:
     type GenericDescriptor = ES2018.GenericDescriptor;
-    type AccessorDescriptor<T = any> = ES2018.AccessorDescriptor<T>;
-    type DataDescriptor<T = any> = ES2018.DataDescriptor<T>;
-    type PropertyDescriptor<T = any> = ES2018.PropertyDescriptor<T>;
+    type AccessorDescriptor<T = unknown> = ES2018.AccessorDescriptor<T>;
+    type DataDescriptor<T = unknown> = ES2018.DataDescriptor<T>;
+    type PropertyDescriptor<T = unknown> = ES2018.PropertyDescriptor<T>;
 }
 
 declare const ES2019: ES2019;

--- a/types/es-abstract/es2019.d.ts
+++ b/types/es-abstract/es2019.d.ts
@@ -54,9 +54,9 @@ declare namespace ES2019 {
 
     // - ES5:
     type GenericDescriptor = ES2018.GenericDescriptor;
-    type AccessorDescriptor = ES2018.AccessorDescriptor;
-    type DataDescriptor = ES2018.DataDescriptor;
-    type PropertyDescriptor = ES2018.PropertyDescriptor;
+    type AccessorDescriptor<T = any> = ES2018.AccessorDescriptor<T>;
+    type DataDescriptor<T = any> = ES2018.DataDescriptor<T>;
+    type PropertyDescriptor<T = any> = ES2018.PropertyDescriptor<T>;
 }
 
 declare const ES2019: ES2019;

--- a/types/es-abstract/es5.d.ts
+++ b/types/es-abstract/es5.d.ts
@@ -8,8 +8,6 @@ import {
     PropertyDescriptor as ESPropertyDescriptor,
 } from './index';
 
-type TSPropertyDescriptor = PropertyDescriptor;
-
 interface ES5 {
     readonly ToPrimitive: typeof toPrimitive;
     ToBoolean(value: unknown): boolean;
@@ -43,12 +41,14 @@ interface ES5 {
         : 'String' | 'Number' | 'Boolean' | 'Null' | 'Undefined' | 'Object' | undefined;
 
     IsPropertyDescriptor(Desc: unknown): Desc is ESPropertyDescriptor;
+    IsAccessorDescriptor<T = any>(Desc: ESPropertyDescriptor<T>): Desc is ESAccessorDescriptor<T>;
     IsAccessorDescriptor(Desc: unknown): Desc is ESAccessorDescriptor;
+    IsDataDescriptor<T = any>(Desc: ESPropertyDescriptor<T>): Desc is ESDataDescriptor<T>;
     IsDataDescriptor(Desc: unknown): Desc is ESDataDescriptor;
     IsGenericDescriptor(Desc: unknown): Desc is ESGenericDescriptor;
 
-    FromPropertyDescriptor(Desc: ESPropertyDescriptor): TSPropertyDescriptor;
-    ToPropertyDescriptor(Desc: TSPropertyDescriptor): ESPropertyDescriptor;
+    FromPropertyDescriptor<T = any>(Desc: ESPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+    ToPropertyDescriptor<T = any>(Desc: TypedPropertyDescriptor<T>): ESPropertyDescriptor<T>;
 
     'Abstract Equality Comparison'(x: unknown, y: unknown): boolean;
     'Strict Equality Comparison'(x: unknown, y: unknown): boolean;
@@ -79,9 +79,9 @@ interface ES5 {
 
 declare namespace ES5 {
     type GenericDescriptor = ESGenericDescriptor;
-    type AccessorDescriptor = ESAccessorDescriptor;
-    type DataDescriptor = ESDataDescriptor;
-    type PropertyDescriptor = ESPropertyDescriptor;
+    type AccessorDescriptor<T = any> = ESAccessorDescriptor<T>;
+    type DataDescriptor<T = any> = ESDataDescriptor<T>;
+    type PropertyDescriptor<T = any> = ESPropertyDescriptor<T>;
 }
 
 declare const ES5: ES5;

--- a/types/es-abstract/es5.d.ts
+++ b/types/es-abstract/es5.d.ts
@@ -41,14 +41,14 @@ interface ES5 {
         : 'String' | 'Number' | 'Boolean' | 'Null' | 'Undefined' | 'Object' | undefined;
 
     IsPropertyDescriptor(Desc: unknown): Desc is ESPropertyDescriptor;
-    IsAccessorDescriptor<T = any>(Desc: ESPropertyDescriptor<T>): Desc is ESAccessorDescriptor<T>;
+    IsAccessorDescriptor<T = unknown>(Desc: ESPropertyDescriptor<T>): Desc is ESAccessorDescriptor<T>;
     IsAccessorDescriptor(Desc: unknown): Desc is ESAccessorDescriptor;
-    IsDataDescriptor<T = any>(Desc: ESPropertyDescriptor<T>): Desc is ESDataDescriptor<T>;
+    IsDataDescriptor<T = unknown>(Desc: ESPropertyDescriptor<T>): Desc is ESDataDescriptor<T>;
     IsDataDescriptor(Desc: unknown): Desc is ESDataDescriptor;
     IsGenericDescriptor(Desc: unknown): Desc is ESGenericDescriptor;
 
-    FromPropertyDescriptor<T = any>(Desc: ESPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
-    ToPropertyDescriptor<T = any>(Desc: TypedPropertyDescriptor<T>): ESPropertyDescriptor<T>;
+    FromPropertyDescriptor<T = unknown>(Desc: ESPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+    ToPropertyDescriptor<T = unknown>(Desc: TypedPropertyDescriptor<T>): ESPropertyDescriptor<T>;
 
     'Abstract Equality Comparison'(x: unknown, y: unknown): boolean;
     'Strict Equality Comparison'(x: unknown, y: unknown): boolean;

--- a/types/es-abstract/es5.d.ts
+++ b/types/es-abstract/es5.d.ts
@@ -79,9 +79,9 @@ interface ES5 {
 
 declare namespace ES5 {
     type GenericDescriptor = ESGenericDescriptor;
-    type AccessorDescriptor<T = any> = ESAccessorDescriptor<T>;
-    type DataDescriptor<T = any> = ESDataDescriptor<T>;
-    type PropertyDescriptor<T = any> = ESPropertyDescriptor<T>;
+    type AccessorDescriptor<T = unknown> = ESAccessorDescriptor<T>;
+    type DataDescriptor<T = unknown> = ESDataDescriptor<T>;
+    type PropertyDescriptor<T = unknown> = ESPropertyDescriptor<T>;
 }
 
 declare const ES5: ES5;

--- a/types/es-abstract/helpers/isPropertyDescriptor.d.ts
+++ b/types/es-abstract/helpers/isPropertyDescriptor.d.ts
@@ -11,6 +11,6 @@ declare function IsPropertyDescriptor(
         IsDataDescriptor(Desc: unknown): Desc is ESDataDescriptor;
     },
     Desc: unknown,
-): Desc is ESPropertyDescriptor;
+): Desc is ESPropertyDescriptor<unknown>;
 
 export = IsPropertyDescriptor;

--- a/types/es-abstract/helpers/isPropertyDescriptor.d.ts
+++ b/types/es-abstract/helpers/isPropertyDescriptor.d.ts
@@ -11,6 +11,6 @@ declare function IsPropertyDescriptor(
         IsDataDescriptor(Desc: unknown): Desc is ESDataDescriptor;
     },
     Desc: unknown,
-): Desc is ESPropertyDescriptor<unknown>;
+): Desc is ESPropertyDescriptor;
 
 export = IsPropertyDescriptor;

--- a/types/es-abstract/index.d.ts
+++ b/types/es-abstract/index.d.ts
@@ -25,17 +25,17 @@ declare namespace ESAbstract {
         '[[Enumerable]]'?: boolean;
     }
 
-    interface AccessorDescriptor<T = any> extends GenericDescriptor {
+    interface AccessorDescriptor<T = unknown> extends GenericDescriptor {
         '[[Get]]'?(): T;
         '[[Set]]'?(value: T): void;
     }
 
-    interface DataDescriptor<T = any> extends GenericDescriptor {
+    interface DataDescriptor<T = unknown> extends GenericDescriptor {
         '[[Writable]]'?: boolean;
         '[[Value]]'?: T;
     }
 
-    type PropertyDescriptor<T = any> = AccessorDescriptor<T> | DataDescriptor<T>;
+    type PropertyDescriptor<T = unknown> = AccessorDescriptor<T> | DataDescriptor<T>;
 }
 
 interface ESAbstract extends ES6 {

--- a/types/es-abstract/index.d.ts
+++ b/types/es-abstract/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for es-abstract 1.16
 // Project: https://github.com/ljharb/es-abstract#readme
-// Definitions by: ExE Boss <https://github.com/ExE-Boss>
-//                 Jordan Harband <https://github.com/ljharb>
+// Definitions by: Jordan Harband <https://github.com/ljharb>
+//                 ExE Boss <https://github.com/ExE-Boss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 
@@ -25,17 +25,17 @@ declare namespace ESAbstract {
         '[[Configurable]]'?: boolean;
     }
 
-    interface AccessorDescriptor extends GenericDescriptor {
-        '[[Get]]'?(): any;
-        '[[Set]]'?(value: any): void;
+    interface AccessorDescriptor<T = any> extends GenericDescriptor {
+        '[[Get]]'?(): T;
+        '[[Set]]'?(value: T): void;
     }
 
-    interface DataDescriptor extends GenericDescriptor {
-        '[[Value]]'?: any;
+    interface DataDescriptor<T = any> extends GenericDescriptor {
+        '[[Value]]'?: T;
         '[[Writable]]'?: boolean;
     }
 
-    type PropertyDescriptor = AccessorDescriptor | DataDescriptor;
+    type PropertyDescriptor<T = any> = AccessorDescriptor<T> | DataDescriptor<T>;
 }
 
 interface ESAbstract extends ES6 {

--- a/types/es-abstract/index.d.ts
+++ b/types/es-abstract/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for es-abstract 1.16
-// Project: https://github.com/ljharb/es-abstract#readme
+// Project: https://github.com/ljharb/es-abstract
 // Definitions by: Jordan Harband <https://github.com/ljharb>
 //                 ExE Boss <https://github.com/ExE-Boss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/es-abstract/index.d.ts
+++ b/types/es-abstract/index.d.ts
@@ -21,8 +21,8 @@ declare namespace ESAbstract {
 
     // ES5 types:
     interface GenericDescriptor {
-        '[[Enumerable]]'?: boolean;
         '[[Configurable]]'?: boolean;
+        '[[Enumerable]]'?: boolean;
     }
 
     interface AccessorDescriptor<T = any> extends GenericDescriptor {
@@ -31,8 +31,8 @@ declare namespace ESAbstract {
     }
 
     interface DataDescriptor<T = any> extends GenericDescriptor {
-        '[[Value]]'?: T;
         '[[Writable]]'?: boolean;
+        '[[Value]]'?: T;
     }
 
     type PropertyDescriptor<T = any> = AccessorDescriptor<T> | DataDescriptor<T>;

--- a/types/es-abstract/test/es2015.test.ts
+++ b/types/es-abstract/test/es2015.test.ts
@@ -1,5 +1,5 @@
 import ES2015 = require('es-abstract/es2015');
-import { expectType } from './index.test';
+import { expectType, newType } from './index.test';
 
 declare const any: unknown;
 
@@ -103,6 +103,40 @@ const anyIterator = any as Iterator<unknown, unknown, unknown>;
 ES2015.GetMethod(anyIterator, 'next'); // $ExpectType (...args: [] | [unknown]) => IteratorResult<unknown, unknown>
 ES2015.GetMethod(anyIterator, 'throw'); // $ExpectType ((e?: any) => IteratorResult<unknown, unknown>) | undefined
 ES2015.GetMethod(anyIterator, 'return'); // $ExpectType ((value?: unknown) => IteratorResult<unknown, unknown>) | undefined
+
+expectType<ES2015.PropertyDescriptor<typeof Reflect.getPrototypeOf> | undefined>(
+    ES2015.OrdinaryGetOwnProperty(Reflect, 'getPrototypeOf'),
+);
+expectType<ES2015.PropertyDescriptor<typeof Reflect.setPrototypeOf> | undefined>(
+    ES2015.OrdinaryGetOwnProperty(Reflect, 'setPrototypeOf'),
+);
+
+const completeNullishUnionDescriptor = ES2015.CompletePropertyDescriptor(
+    // tslint:disable-next-line: no-null-undefined-union
+    newType<{ '[[Value]]': object | null | undefined }>(),
+);
+completeNullishUnionDescriptor['[[Configurable]]']; // $ExpectType boolean
+completeNullishUnionDescriptor['[[Enumerable]]']; // $ExpectType boolean
+completeNullishUnionDescriptor['[[Writable]]']; // $ExpectType boolean
+completeNullishUnionDescriptor['[[Value]]']; // $ExpectType object | null | undefined
+
+const completeRequiredValueDescriptor = ES2015.CompletePropertyDescriptor(newType<{ '[[Value]]': string }>());
+completeRequiredValueDescriptor['[[Configurable]]']; // $ExpectType boolean
+completeRequiredValueDescriptor['[[Enumerable]]']; // $ExpectType boolean
+completeRequiredValueDescriptor['[[Writable]]']; // $ExpectType boolean
+completeRequiredValueDescriptor['[[Value]]']; // $ExpectType string
+
+const completeDataDescriptor = ES2015.CompletePropertyDescriptor(newType<{ '[[Value]]'?: number }>());
+completeDataDescriptor['[[Configurable]]']; // $ExpectType boolean
+completeDataDescriptor['[[Enumerable]]']; // $ExpectType boolean
+completeDataDescriptor['[[Writable]]']; // $ExpectType boolean
+completeDataDescriptor['[[Value]]']; // $ExpectType number | undefined
+
+const completeAccessorDescriptor = ES2015.CompletePropertyDescriptor(newType<{ '[[Get]]'?: () => symbol }>());
+completeAccessorDescriptor['[[Configurable]]']; // $ExpectType boolean
+completeAccessorDescriptor['[[Enumerable]]']; // $ExpectType boolean
+completeAccessorDescriptor['[[Get]]']; // $ExpectType (() => symbol) | undefined
+completeAccessorDescriptor['[[Set]]']; // $ExpectType ((value: symbol) => void) | undefined
 
 // Removed in ES2015:
 ES2015.CheckObjectCoercible; // $ExpectError

--- a/types/es-abstract/test/es5.test.ts
+++ b/types/es-abstract/test/es5.test.ts
@@ -51,3 +51,6 @@ ES5.ToObject(nullableMaybePromise); // $ExpectType String | Promise<string>
 
 ES5.CheckObjectCoercible(nullableObject); // $ExpectType string | object
 ES5.CheckObjectCoercible(any); // $ExpectType unknown
+
+ES5.ToPropertyDescriptor({ value: 123 }); // $ExpectType PropertyDescriptor<number>
+ES5.FromPropertyDescriptor({ "[[Value]]": '456' }); // $ExpectType TypedPropertyDescriptor<string>

--- a/types/es-abstract/test/helpers/isPropertyDescriptor.test.ts
+++ b/types/es-abstract/test/helpers/isPropertyDescriptor.test.ts
@@ -2,7 +2,12 @@ import ES5 = require('es-abstract/es5');
 import isPropertyDescriptor = require('es-abstract/helpers/isPropertyDescriptor');
 
 declare const any: unknown;
+declare const optPropDesc: ES5.PropertyDescriptor<string> | null;
 
 if (isPropertyDescriptor(ES5, any)) {
-    any; // $ExpectType PropertyDescriptor
+    any; // $ExpectType PropertyDescriptor<unknown>
+}
+
+if (isPropertyDescriptor(ES5, optPropDesc)) {
+    optPropDesc; // $ExpectType PropertyDescriptor<string>
 }

--- a/types/es-abstract/test/index.test.ts
+++ b/types/es-abstract/test/index.test.ts
@@ -16,6 +16,9 @@ import ES2019 = require('es-abstract/es2019');
  */
 export declare function expectType<T>(value: T): T;
 
+// tslint:disable-next-line: no-unnecessary-generics
+export declare function newType<T>(): T;
+
 expectType<typeof ES5>(ESAbstract.ES5); // $ExpectType ES5
 
 expectType<typeof ES6>(ESAbstract.ES6); // $ExpectType ES2015


### PR DESCRIPTION
This makes the `ESAbstract.PropertyDescriptor` definition generic to improve type safety and match `TypedPropertyDescriptor`.

## Blocks:
- <https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44805>

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes:
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
