### PR TITLE
[jest] Add useFakeTimers implementation argument

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jest 26.0
+// Type definitions for Jest 25.2
 // Project: https://jestjs.io/
 // Definitions by: Asana (https://asana.com)
 //                 Ivo Stratev <https://github.com/NoHomey>
@@ -48,38 +48,30 @@ declare var xtest: jest.It;
 declare const expect: jest.Expect;
 
 type ExtractEachCallbackArgs<T extends ReadonlyArray<any>> = {
-    1: [T[0]];
-    2: [T[0], T[1]];
-    3: [T[0], T[1], T[2]];
-    4: [T[0], T[1], T[2], T[3]];
-    5: [T[0], T[1], T[2], T[3], T[4]];
-    6: [T[0], T[1], T[2], T[3], T[4], T[5]];
-    7: [T[0], T[1], T[2], T[3], T[4], T[5], T[6]];
-    8: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7]];
-    9: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8]];
-    10: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8], T[9]];
-    fallback: Array<T extends ReadonlyArray<infer U> ? U : any>;
-}[T extends Readonly<[any]>
-    ? 1
-    : T extends Readonly<[any, any]>
-    ? 2
-    : T extends Readonly<[any, any, any]>
-    ? 3
-    : T extends Readonly<[any, any, any, any]>
-    ? 4
-    : T extends Readonly<[any, any, any, any, any]>
-    ? 5
-    : T extends Readonly<[any, any, any, any, any, any]>
-    ? 6
-    : T extends Readonly<[any, any, any, any, any, any, any]>
-    ? 7
-    : T extends Readonly<[any, any, any, any, any, any, any, any]>
-    ? 8
-    : T extends Readonly<[any, any, any, any, any, any, any, any, any]>
-    ? 9
-    : T extends Readonly<[any, any, any, any, any, any, any, any, any, any]>
-    ? 10
-    : 'fallback'];
+    1: [T[0]],
+    2: [T[0], T[1]],
+    3: [T[0], T[1], T[2]],
+    4: [T[0], T[1], T[2], T[3]],
+    5: [T[0], T[1], T[2], T[3], T[4]],
+    6: [T[0], T[1], T[2], T[3], T[4], T[5]],
+    7: [T[0], T[1], T[2], T[3], T[4], T[5], T[6]],
+    8: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7]],
+    9: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8]],
+    10: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8], T[9]],
+    'fallback': Array<(T extends ReadonlyArray<infer U>? U: any)>
+}[
+    T extends Readonly<[any]> ? 1
+        : T extends Readonly<[any, any]> ? 2
+        : T extends Readonly<[any, any, any]> ? 3
+        : T extends Readonly<[any, any, any, any]> ? 4
+        : T extends Readonly<[any, any, any, any, any]> ? 5
+        : T extends Readonly<[any, any, any, any, any, any]> ? 6
+        : T extends Readonly<[any, any, any, any, any, any, any]> ? 7
+        : T extends Readonly<[any, any, any, any, any, any, any, any]> ? 8
+        : T extends Readonly<[any, any, any, any, any, any, any, any, any]> ? 9
+        : T extends Readonly<[any, any, any, any, any, any, any, any, any, any]> ? 10
+        : 'fallback'
+];
 
 interface NodeRequire {
     /**
@@ -281,22 +273,22 @@ declare namespace jest {
     function spyOn<T extends {}, M extends NonFunctionPropertyNames<Required<T>>>(
         object: T,
         method: M,
-        accessType: 'get',
+        accessType: 'get'
     ): SpyInstance<Required<T>[M], []>;
     function spyOn<T extends {}, M extends NonFunctionPropertyNames<Required<T>>>(
         object: T,
         method: M,
-        accessType: 'set',
+        accessType: 'set'
     ): SpyInstance<void, [Required<T>[M]]>;
     function spyOn<T extends {}, M extends FunctionPropertyNames<Required<T>>>(
         object: T,
-        method: M,
+        method: M
     ): Required<T>[M] extends (...args: any[]) => any
         ? SpyInstance<ReturnType<Required<T>[M]>, ArgsType<Required<T>[M]>>
         : never;
     function spyOn<T extends {}, M extends ConstructorPropertyNames<Required<T>>>(
         object: T,
-        method: M,
+        method: M
     ): Required<T>[M] extends new (...args: any[]) => any
         ? SpyInstance<InstanceType<Required<T>[M]>, ConstructorArgsType<Required<T>[M]>>
         : never;
@@ -328,9 +320,7 @@ declare namespace jest {
         string;
     type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends (...args: any[]) => any ? K : never }[keyof T] &
         string;
-    type ConstructorPropertyNames<T> = {
-        [K in keyof T]: T[K] extends new (...args: any[]) => any ? K : never;
-    }[keyof T] &
+    type ConstructorPropertyNames<T> = { [K in keyof T]: T[K] extends new (...args: any[]) => any ? K : never }[keyof T] &
         string;
 
     interface DoneCallback {
@@ -348,27 +338,19 @@ declare namespace jest {
 
     interface Each {
         // Exclusively arrays.
-        <T extends any[] | [any]>(cases: ReadonlyArray<T>): (
-            name: string,
-            fn: (...args: T) => any,
-            timeout?: number,
-        ) => void;
-        <T extends ReadonlyArray<any>>(cases: ReadonlyArray<T>): (
-            name: string,
-            fn: (...args: ExtractEachCallbackArgs<T>) => any,
-            timeout?: number,
-        ) => void;
+        <T extends any[] | [any]>(cases: ReadonlyArray<T>): (name: string, fn: (...args: T) => any, timeout?: number) => void;
+        <T extends ReadonlyArray<any>>(cases: ReadonlyArray<T>): (name: string, fn: (...args: ExtractEachCallbackArgs<T>) => any, timeout?: number) => void;
         // Not arrays.
         <T>(cases: ReadonlyArray<T>): (name: string, fn: (...args: T[]) => any, timeout?: number) => void;
         (cases: ReadonlyArray<ReadonlyArray<any>>): (
             name: string,
             fn: (...args: any[]) => any,
-            timeout?: number,
+            timeout?: number
         ) => void;
         (strings: TemplateStringsArray, ...placeholders: any[]): (
             name: string,
             fn: (arg: any) => any,
-            timeout?: number,
+            timeout?: number
         ) => void;
     }
 
@@ -502,7 +484,7 @@ declare namespace jest {
             readonly BOLD_WEIGHT: MatcherColorFn;
             readonly DIM_COLOR: MatcherColorFn;
             readonly SUGGEST_TO_CONTAIN_EQUAL: string;
-            diff(a: any, b: any, options?: import('jest-diff').DiffOptions): string | null;
+            diff(a: any, b: any, options?: import("jest-diff").DiffOptions): string | null;
             ensureActualIsNumber(actual: any, matcherName: string, options?: MatcherHintOptions): void;
             ensureExpectedIsNumber(actual: any, matcherName: string, options?: MatcherHintOptions): void;
             ensureNoExpected(actual: any, matcherName: string, options?: MatcherHintOptions): void;
@@ -512,9 +494,13 @@ declare namespace jest {
                 matcherName: string,
                 received?: string,
                 expected?: string,
-                options?: MatcherHintOptions,
+                options?: MatcherHintOptions
             ): string;
-            matcherErrorMessage(hint: string, generic: string, specific: string): string;
+            matcherErrorMessage(
+              hint: string,
+              generic: string,
+              specific: string
+            ): string;
             pluralize(word: string, count: number): string;
             printReceived(object: any): string;
             printExpected(value: any): string;
@@ -522,13 +508,7 @@ declare namespace jest {
             stringify(object: {}, maxDepth?: number): string;
             highlightTrailingWhitespace(text: string): string;
 
-            printDiffOrStringify(
-                expected: any,
-                received: any,
-                expectedLabel: string,
-                receivedLabel: string,
-                expand: boolean,
-            ): string;
+            printDiffOrStringify(expected: any, received: any, expectedLabel: string, receivedLabel: string, expand: boolean): string;
 
             getLabelPrinter(...strings: string[]): PrintLabel;
 
@@ -704,15 +684,15 @@ declare namespace jest {
          * Use resolves to unwrap the value of a fulfilled promise so any other
          * matcher can be chained. If the promise is rejected the assertion fails.
          */
-        resolves: AndNot<TPromise>;
+        resolves: AndNot<TPromise>,
         /**
          * Unwraps the reason of a rejected promise so any other matcher can be chained.
          * If the promise is fulfilled the assertion fails.
          */
-        rejects: AndNot<TPromise>;
+        rejects: AndNot<TPromise>
     } & AndNot<TNonPromise>;
     type AndNot<T> = T & {
-        not: T;
+        not: T
     };
     // should be R extends void|Promise<void> but getting dtslint error
     interface Matchers<R, T = {}> {
@@ -1022,11 +1002,9 @@ declare namespace jest {
         toThrowErrorMatchingInlineSnapshot(snapshot?: string): R;
     }
 
-    type RemoveFirstFromTuple<T extends any[]> = T['length'] extends 0
-        ? []
-        : ((...b: T) => void) extends (a: any, ...b: infer I) => void
-        ? I
-        : [];
+    type RemoveFirstFromTuple<T extends any[]> =
+    T['length'] extends 0 ? [] :
+        (((...b: T) => void) extends (a: any, ...b: infer I) => void ? I : []);
 
     type Parameters<T extends (...args: any[]) => any> = T extends (...args: infer P) => any ? P : never;
 
@@ -1034,44 +1012,30 @@ declare namespace jest {
         asymmetricMatch(other: unknown): boolean;
     }
     type NonAsyncMatchers<TMatchers extends ExpectExtendMap> = {
-        [K in keyof TMatchers]: ReturnType<TMatchers[K]> extends Promise<CustomMatcherResult> ? never : K;
+        [K in keyof TMatchers]: ReturnType<TMatchers[K]> extends Promise<CustomMatcherResult>? never: K
     }[keyof TMatchers];
-    type CustomAsyncMatchers<TMatchers extends ExpectExtendMap> = {
-        [K in NonAsyncMatchers<TMatchers>]: CustomAsymmetricMatcher<TMatchers[K]>;
-    };
-    type CustomAsymmetricMatcher<TMatcher extends (...args: any[]) => any> = (
-        ...args: RemoveFirstFromTuple<Parameters<TMatcher>>
-    ) => AsymmetricMatcher;
+    type CustomAsyncMatchers<TMatchers extends ExpectExtendMap> = {[K in NonAsyncMatchers<TMatchers>]: CustomAsymmetricMatcher<TMatchers[K]>};
+    type CustomAsymmetricMatcher<TMatcher extends (...args: any[]) => any> = (...args: RemoveFirstFromTuple<Parameters<TMatcher>>) => AsymmetricMatcher;
 
     // should be TMatcherReturn extends void|Promise<void> but getting dtslint error
-    type CustomJestMatcher<TMatcher extends (...args: any[]) => any, TMatcherReturn> = (
-        ...args: RemoveFirstFromTuple<Parameters<TMatcher>>
-    ) => TMatcherReturn;
+    type CustomJestMatcher<TMatcher extends (...args: any[]) => any, TMatcherReturn> = (...args: RemoveFirstFromTuple<Parameters<TMatcher>>) => TMatcherReturn;
 
-    type ExpectProperties = {
-        [K in keyof Expect]: Expect[K];
+    type ExpectProperties= {
+        [K in keyof Expect]: Expect[K]
     };
     // should be TMatcherReturn extends void|Promise<void> but getting dtslint error
     // Use the `void` type for return types only. Otherwise, use `undefined`. See: https://github.com/Microsoft/dtslint/blob/master/docs/void-return.md
     // have added issue https://github.com/microsoft/dtslint/issues/256 - Cannot have type union containing void ( to be used as return type only
-    type ExtendedMatchers<TMatchers extends ExpectExtendMap, TMatcherReturn, TActual> = Matchers<
-        TMatcherReturn,
-        TActual
-    > &
-        { [K in keyof TMatchers]: CustomJestMatcher<TMatchers[K], TMatcherReturn> };
-    type JestExtendedMatchers<TMatchers extends ExpectExtendMap, TActual> = JestMatchersShape<
-        ExtendedMatchers<TMatchers, void, TActual>,
-        ExtendedMatchers<TMatchers, Promise<void>, TActual>
-    >;
+    type ExtendedMatchers<TMatchers extends ExpectExtendMap, TMatcherReturn, TActual> = Matchers<TMatcherReturn, TActual> & {[K in keyof TMatchers]: CustomJestMatcher<TMatchers[K], TMatcherReturn>};
+    type JestExtendedMatchers<TMatchers extends ExpectExtendMap, TActual> = JestMatchersShape<ExtendedMatchers<TMatchers, void, TActual>, ExtendedMatchers<TMatchers, Promise<void>, TActual>>;
 
     // when have called expect.extend
-    type ExtendedExpectFunction<TMatchers extends ExpectExtendMap> = <TActual>(
-        actual: TActual,
-    ) => JestExtendedMatchers<TMatchers, TActual>;
+    type ExtendedExpectFunction<TMatchers extends ExpectExtendMap> = <TActual>(actual: TActual) => JestExtendedMatchers<TMatchers, TActual>;
 
-    type ExtendedExpect<TMatchers extends ExpectExtendMap> = ExpectProperties &
-        AndNot<CustomAsyncMatchers<TMatchers>> &
-        ExtendedExpectFunction<TMatchers>;
+    type ExtendedExpect<TMatchers extends ExpectExtendMap>=
+    ExpectProperties &
+    AndNot<CustomAsyncMatchers<TMatchers>> &
+    ExtendedExpectFunction<TMatchers>;
     /**
      * Construct a type with the properties of T except for those in type K.
      */
@@ -1145,7 +1109,7 @@ declare namespace jest {
             ? MockInstance<ReturnType<T[P]>, ArgsType<T[P]>>
             : T[P] extends Constructable
             ? MockedClass<T[P]>
-            : T[P];
+            : T[P]
     } &
         T;
 

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jest 25.2
+// Type definitions for Jest 26.0
 // Project: https://jestjs.io/
 // Definitions by: Asana (https://asana.com)
 //                 Ivo Stratev <https://github.com/NoHomey>

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jest 25.2
+// Type definitions for Jest 26.0
 // Project: https://jestjs.io/
 // Definitions by: Asana (https://asana.com)
 //                 Ivo Stratev <https://github.com/NoHomey>
@@ -48,30 +48,38 @@ declare var xtest: jest.It;
 declare const expect: jest.Expect;
 
 type ExtractEachCallbackArgs<T extends ReadonlyArray<any>> = {
-    1: [T[0]],
-    2: [T[0], T[1]],
-    3: [T[0], T[1], T[2]],
-    4: [T[0], T[1], T[2], T[3]],
-    5: [T[0], T[1], T[2], T[3], T[4]],
-    6: [T[0], T[1], T[2], T[3], T[4], T[5]],
-    7: [T[0], T[1], T[2], T[3], T[4], T[5], T[6]],
-    8: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7]],
-    9: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8]],
-    10: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8], T[9]],
-    'fallback': Array<(T extends ReadonlyArray<infer U>? U: any)>
-}[
-    T extends Readonly<[any]> ? 1
-        : T extends Readonly<[any, any]> ? 2
-        : T extends Readonly<[any, any, any]> ? 3
-        : T extends Readonly<[any, any, any, any]> ? 4
-        : T extends Readonly<[any, any, any, any, any]> ? 5
-        : T extends Readonly<[any, any, any, any, any, any]> ? 6
-        : T extends Readonly<[any, any, any, any, any, any, any]> ? 7
-        : T extends Readonly<[any, any, any, any, any, any, any, any]> ? 8
-        : T extends Readonly<[any, any, any, any, any, any, any, any, any]> ? 9
-        : T extends Readonly<[any, any, any, any, any, any, any, any, any, any]> ? 10
-        : 'fallback'
-];
+    1: [T[0]];
+    2: [T[0], T[1]];
+    3: [T[0], T[1], T[2]];
+    4: [T[0], T[1], T[2], T[3]];
+    5: [T[0], T[1], T[2], T[3], T[4]];
+    6: [T[0], T[1], T[2], T[3], T[4], T[5]];
+    7: [T[0], T[1], T[2], T[3], T[4], T[5], T[6]];
+    8: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7]];
+    9: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8]];
+    10: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8], T[9]];
+    fallback: Array<T extends ReadonlyArray<infer U> ? U : any>;
+}[T extends Readonly<[any]>
+    ? 1
+    : T extends Readonly<[any, any]>
+    ? 2
+    : T extends Readonly<[any, any, any]>
+    ? 3
+    : T extends Readonly<[any, any, any, any]>
+    ? 4
+    : T extends Readonly<[any, any, any, any, any]>
+    ? 5
+    : T extends Readonly<[any, any, any, any, any, any]>
+    ? 6
+    : T extends Readonly<[any, any, any, any, any, any, any]>
+    ? 7
+    : T extends Readonly<[any, any, any, any, any, any, any, any]>
+    ? 8
+    : T extends Readonly<[any, any, any, any, any, any, any, any, any]>
+    ? 9
+    : T extends Readonly<[any, any, any, any, any, any, any, any, any, any]>
+    ? 10
+    : 'fallback'];
 
 interface NodeRequire {
     /**
@@ -273,22 +281,22 @@ declare namespace jest {
     function spyOn<T extends {}, M extends NonFunctionPropertyNames<Required<T>>>(
         object: T,
         method: M,
-        accessType: 'get'
+        accessType: 'get',
     ): SpyInstance<Required<T>[M], []>;
     function spyOn<T extends {}, M extends NonFunctionPropertyNames<Required<T>>>(
         object: T,
         method: M,
-        accessType: 'set'
+        accessType: 'set',
     ): SpyInstance<void, [Required<T>[M]]>;
     function spyOn<T extends {}, M extends FunctionPropertyNames<Required<T>>>(
         object: T,
-        method: M
+        method: M,
     ): Required<T>[M] extends (...args: any[]) => any
         ? SpyInstance<ReturnType<Required<T>[M]>, ArgsType<Required<T>[M]>>
         : never;
     function spyOn<T extends {}, M extends ConstructorPropertyNames<Required<T>>>(
         object: T,
-        method: M
+        method: M,
     ): Required<T>[M] extends new (...args: any[]) => any
         ? SpyInstance<InstanceType<Required<T>[M]>, ConstructorArgsType<Required<T>[M]>>
         : never;
@@ -320,7 +328,9 @@ declare namespace jest {
         string;
     type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends (...args: any[]) => any ? K : never }[keyof T] &
         string;
-    type ConstructorPropertyNames<T> = { [K in keyof T]: T[K] extends new (...args: any[]) => any ? K : never }[keyof T] &
+    type ConstructorPropertyNames<T> = {
+        [K in keyof T]: T[K] extends new (...args: any[]) => any ? K : never;
+    }[keyof T] &
         string;
 
     interface DoneCallback {
@@ -338,19 +348,27 @@ declare namespace jest {
 
     interface Each {
         // Exclusively arrays.
-        <T extends any[] | [any]>(cases: ReadonlyArray<T>): (name: string, fn: (...args: T) => any, timeout?: number) => void;
-        <T extends ReadonlyArray<any>>(cases: ReadonlyArray<T>): (name: string, fn: (...args: ExtractEachCallbackArgs<T>) => any, timeout?: number) => void;
+        <T extends any[] | [any]>(cases: ReadonlyArray<T>): (
+            name: string,
+            fn: (...args: T) => any,
+            timeout?: number,
+        ) => void;
+        <T extends ReadonlyArray<any>>(cases: ReadonlyArray<T>): (
+            name: string,
+            fn: (...args: ExtractEachCallbackArgs<T>) => any,
+            timeout?: number,
+        ) => void;
         // Not arrays.
         <T>(cases: ReadonlyArray<T>): (name: string, fn: (...args: T[]) => any, timeout?: number) => void;
         (cases: ReadonlyArray<ReadonlyArray<any>>): (
             name: string,
             fn: (...args: any[]) => any,
-            timeout?: number
+            timeout?: number,
         ) => void;
         (strings: TemplateStringsArray, ...placeholders: any[]): (
             name: string,
             fn: (arg: any) => any,
-            timeout?: number
+            timeout?: number,
         ) => void;
     }
 
@@ -484,7 +502,7 @@ declare namespace jest {
             readonly BOLD_WEIGHT: MatcherColorFn;
             readonly DIM_COLOR: MatcherColorFn;
             readonly SUGGEST_TO_CONTAIN_EQUAL: string;
-            diff(a: any, b: any, options?: import("jest-diff").DiffOptions): string | null;
+            diff(a: any, b: any, options?: import('jest-diff').DiffOptions): string | null;
             ensureActualIsNumber(actual: any, matcherName: string, options?: MatcherHintOptions): void;
             ensureExpectedIsNumber(actual: any, matcherName: string, options?: MatcherHintOptions): void;
             ensureNoExpected(actual: any, matcherName: string, options?: MatcherHintOptions): void;
@@ -494,13 +512,9 @@ declare namespace jest {
                 matcherName: string,
                 received?: string,
                 expected?: string,
-                options?: MatcherHintOptions
+                options?: MatcherHintOptions,
             ): string;
-            matcherErrorMessage(
-              hint: string,
-              generic: string,
-              specific: string
-            ): string;
+            matcherErrorMessage(hint: string, generic: string, specific: string): string;
             pluralize(word: string, count: number): string;
             printReceived(object: any): string;
             printExpected(value: any): string;
@@ -508,7 +522,13 @@ declare namespace jest {
             stringify(object: {}, maxDepth?: number): string;
             highlightTrailingWhitespace(text: string): string;
 
-            printDiffOrStringify(expected: any, received: any, expectedLabel: string, receivedLabel: string, expand: boolean): string;
+            printDiffOrStringify(
+                expected: any,
+                received: any,
+                expectedLabel: string,
+                receivedLabel: string,
+                expand: boolean,
+            ): string;
 
             getLabelPrinter(...strings: string[]): PrintLabel;
 
@@ -684,15 +704,15 @@ declare namespace jest {
          * Use resolves to unwrap the value of a fulfilled promise so any other
          * matcher can be chained. If the promise is rejected the assertion fails.
          */
-        resolves: AndNot<TPromise>,
+        resolves: AndNot<TPromise>;
         /**
          * Unwraps the reason of a rejected promise so any other matcher can be chained.
          * If the promise is fulfilled the assertion fails.
          */
-        rejects: AndNot<TPromise>
+        rejects: AndNot<TPromise>;
     } & AndNot<TNonPromise>;
     type AndNot<T> = T & {
-        not: T
+        not: T;
     };
     // should be R extends void|Promise<void> but getting dtslint error
     interface Matchers<R, T = {}> {
@@ -1002,9 +1022,11 @@ declare namespace jest {
         toThrowErrorMatchingInlineSnapshot(snapshot?: string): R;
     }
 
-    type RemoveFirstFromTuple<T extends any[]> =
-    T['length'] extends 0 ? [] :
-        (((...b: T) => void) extends (a: any, ...b: infer I) => void ? I : []);
+    type RemoveFirstFromTuple<T extends any[]> = T['length'] extends 0
+        ? []
+        : ((...b: T) => void) extends (a: any, ...b: infer I) => void
+        ? I
+        : [];
 
     type Parameters<T extends (...args: any[]) => any> = T extends (...args: infer P) => any ? P : never;
 
@@ -1012,30 +1034,44 @@ declare namespace jest {
         asymmetricMatch(other: unknown): boolean;
     }
     type NonAsyncMatchers<TMatchers extends ExpectExtendMap> = {
-        [K in keyof TMatchers]: ReturnType<TMatchers[K]> extends Promise<CustomMatcherResult>? never: K
+        [K in keyof TMatchers]: ReturnType<TMatchers[K]> extends Promise<CustomMatcherResult> ? never : K;
     }[keyof TMatchers];
-    type CustomAsyncMatchers<TMatchers extends ExpectExtendMap> = {[K in NonAsyncMatchers<TMatchers>]: CustomAsymmetricMatcher<TMatchers[K]>};
-    type CustomAsymmetricMatcher<TMatcher extends (...args: any[]) => any> = (...args: RemoveFirstFromTuple<Parameters<TMatcher>>) => AsymmetricMatcher;
+    type CustomAsyncMatchers<TMatchers extends ExpectExtendMap> = {
+        [K in NonAsyncMatchers<TMatchers>]: CustomAsymmetricMatcher<TMatchers[K]>;
+    };
+    type CustomAsymmetricMatcher<TMatcher extends (...args: any[]) => any> = (
+        ...args: RemoveFirstFromTuple<Parameters<TMatcher>>
+    ) => AsymmetricMatcher;
 
     // should be TMatcherReturn extends void|Promise<void> but getting dtslint error
-    type CustomJestMatcher<TMatcher extends (...args: any[]) => any, TMatcherReturn> = (...args: RemoveFirstFromTuple<Parameters<TMatcher>>) => TMatcherReturn;
+    type CustomJestMatcher<TMatcher extends (...args: any[]) => any, TMatcherReturn> = (
+        ...args: RemoveFirstFromTuple<Parameters<TMatcher>>
+    ) => TMatcherReturn;
 
-    type ExpectProperties= {
-        [K in keyof Expect]: Expect[K]
+    type ExpectProperties = {
+        [K in keyof Expect]: Expect[K];
     };
     // should be TMatcherReturn extends void|Promise<void> but getting dtslint error
     // Use the `void` type for return types only. Otherwise, use `undefined`. See: https://github.com/Microsoft/dtslint/blob/master/docs/void-return.md
     // have added issue https://github.com/microsoft/dtslint/issues/256 - Cannot have type union containing void ( to be used as return type only
-    type ExtendedMatchers<TMatchers extends ExpectExtendMap, TMatcherReturn, TActual> = Matchers<TMatcherReturn, TActual> & {[K in keyof TMatchers]: CustomJestMatcher<TMatchers[K], TMatcherReturn>};
-    type JestExtendedMatchers<TMatchers extends ExpectExtendMap, TActual> = JestMatchersShape<ExtendedMatchers<TMatchers, void, TActual>, ExtendedMatchers<TMatchers, Promise<void>, TActual>>;
+    type ExtendedMatchers<TMatchers extends ExpectExtendMap, TMatcherReturn, TActual> = Matchers<
+        TMatcherReturn,
+        TActual
+    > &
+        { [K in keyof TMatchers]: CustomJestMatcher<TMatchers[K], TMatcherReturn> };
+    type JestExtendedMatchers<TMatchers extends ExpectExtendMap, TActual> = JestMatchersShape<
+        ExtendedMatchers<TMatchers, void, TActual>,
+        ExtendedMatchers<TMatchers, Promise<void>, TActual>
+    >;
 
     // when have called expect.extend
-    type ExtendedExpectFunction<TMatchers extends ExpectExtendMap> = <TActual>(actual: TActual) => JestExtendedMatchers<TMatchers, TActual>;
+    type ExtendedExpectFunction<TMatchers extends ExpectExtendMap> = <TActual>(
+        actual: TActual,
+    ) => JestExtendedMatchers<TMatchers, TActual>;
 
-    type ExtendedExpect<TMatchers extends ExpectExtendMap>=
-    ExpectProperties &
-    AndNot<CustomAsyncMatchers<TMatchers>> &
-    ExtendedExpectFunction<TMatchers>;
+    type ExtendedExpect<TMatchers extends ExpectExtendMap> = ExpectProperties &
+        AndNot<CustomAsyncMatchers<TMatchers>> &
+        ExtendedExpectFunction<TMatchers>;
     /**
      * Construct a type with the properties of T except for those in type K.
      */
@@ -1109,7 +1145,7 @@ declare namespace jest {
             ? MockInstance<ReturnType<T[P]>, ArgsType<T[P]>>
             : T[P] extends Constructable
             ? MockedClass<T[P]>
-            : T[P]
+            : T[P];
     } &
         T;
 

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -28,6 +28,7 @@
 //                 Devansh Jethmalani <https://github.com/devanshj>
 //                 Pawel Fajfer <https://github.com/pawfa>
 //                 Regev Brody <https://github.com/regevbr>
+//                 Mark Skelton <https://github.com/mskelton>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
@@ -299,7 +300,7 @@ declare namespace jest {
     /**
      * Instructs Jest to use fake versions of the standard timer functions.
      */
-    function useFakeTimers(): typeof jest;
+    function useFakeTimers(implementation?: 'modern' | 'legacy'): typeof jest;
     /**
      * Instructs Jest to use the real versions of the standard timer functions.
      */

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -285,6 +285,12 @@ jest.addMatchers(customMatcherFactories)
 jest.advanceTimersToNextTimer();
 jest.advanceTimersToNextTimer(2);
 
+// https://jestjs.io/docs/en/jest-object#jestusefaketimersimplementation-modern--legacy
+jest.useFakeTimers('modern');
+jest.useFakeTimers('legacy');
+// $ExpectError
+jest.useFakeTimers('foo');
+
 // https://jestjs.io/docs/en/jest-object#jestrequireactualmodulename
 // $ExpectType any
 jest.requireActual('./thisReturnsTheActualModule');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jestjs.io/docs/en/jest-object#jestusefaketimersimplementation-modern--legacy
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.