### PR TITLE
create new definitions for ajv-bsontype

### DIFF
--- a/types/ajv-bsontype/ajv-bsontype-tests.ts
+++ b/types/ajv-bsontype/ajv-bsontype-tests.ts
@@ -1,0 +1,5 @@
+import * as Ajv from 'ajv';
+import ajvBsontype = require('ajv-bsontype');
+
+const ajv = new Ajv();
+ajvBsontype(ajv);

--- a/types/ajv-bsontype/index.d.ts
+++ b/types/ajv-bsontype/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for ajv-bsontype 1.0
+// Project: https://github.com/BoLaMN/ajv-bsontype#readme
+// Definitions by: Alex <https://github.com/adjerbetian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Ajv } from 'ajv';
+
+declare function ajvBsontype(ajv: Ajv): Ajv;
+export = ajvBsontype;

--- a/types/ajv-bsontype/package.json
+++ b/types/ajv-bsontype/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "ajv": "*"
+    }
+}

--- a/types/ajv-bsontype/tsconfig.json
+++ b/types/ajv-bsontype/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ajv-bsontype-tests.ts"
+    ]
+}

--- a/types/ajv-bsontype/tslint.json
+++ b/types/ajv-bsontype/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Those new definitions are mainly copied from [types/ajv-async](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/6970a8fffa0743f0f5fc918e187fa37f0d2675df/types/ajv-async).

---

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
