### PR TITLE
Revert "feat(hapi__joi): add regex method to ObjectSchema (#44252)"

### DIFF
--- a/types/hapi__joi/index.d.ts
+++ b/types/hapi__joi/index.d.ts
@@ -1671,11 +1671,6 @@ declare namespace Joi {
          * Optional settings must be the last argument.
          */
         xor(...peers: Array<string | HierarchySeparatorOptions>): this;
-
-        /**
-         * Requires the object to be a RegExp instance.
-         */
-        regex(): this;
     }
 
     interface BinarySchema extends AnySchema {


### PR DESCRIPTION
This reverts commit d93d95f0d94109061eada537e942dc44a1d6bd51. (#44252)

It was created before https://github.com/DefinitelyTyped/DefinitelyTyped/commit/333833cb15e8727ba28441153458e2f3fbe2feeb which updated all of `@hapi/joi` to a new version, part of which was adding the `regex` method.

Typescript was interpreting the two identical regex method declarations as overloads, and it's not an error to have two identical overloads. However, it is a *lint* error, and the overnight run caught that error.