### PR TITLE
allow FileCoverageData in CoverageMapData

### DIFF
--- a/types/istanbul-lib-coverage/index.d.ts
+++ b/types/istanbul-lib-coverage/index.d.ts
@@ -25,7 +25,7 @@ export class CoverageSummary {
 }
 
 export interface CoverageMapData {
-    [key: string]: FileCoverage;
+    [key: string]: FileCoverage | FileCoverageData;
 }
 
 export class CoverageMap {

--- a/types/istanbul-lib-coverage/istanbul-lib-coverage-tests.ts
+++ b/types/istanbul-lib-coverage/istanbul-lib-coverage-tests.ts
@@ -2,6 +2,7 @@ import {
     CoverageMapData,
     CoverageSummaryData,
     FileCoverageData,
+    FileCoverage,
     createCoverageSummary,
     createCoverageMap,
     createFileCoverage
@@ -70,3 +71,10 @@ fileCoverage1.resetHits();
 fileCoverage1.computeBranchTotals().skipped;
 fileCoverage1.computeSimpleTotals().skipped;
 isNaN(fileCoverage1.toSummary().branches.total);
+
+// CoverageMapData can contain FileCoverageData
+const coverageMapData2: CoverageMapData = {
+    abc: fileCoverageData
+  };
+const map3 = createCoverageMap(coverageMapData2);
+const fileCoverage4: FileCoverage = map3.fileCoverageFor('abc');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/istanbuljs/istanbuljs/blob/a3ebc6f7250f8021569a96a9d7b13ddf7c3a7ecc/packages/istanbul-lib-coverage/lib/coverage-map.js#L25
a raw FileCoverage (FileCoverageData) will be converted in  theline above.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


