### PR TITLE
[socketio-jwt] Make decodedPropertyName not required in socketio-jwt

### DIFF
--- a/types/socketio-jwt/index.d.ts
+++ b/types/socketio-jwt/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for socketio-jwt 0.0
+// Type definitions for socketio-jwt 0.2
 // Project: https://github.com/auth0/socketio-jwt
 // Definitions by: Eric Hallander <https://github.com/ehallander9591>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -21,7 +21,7 @@ export interface JwtAuthOptions {
     secret: string | JwtSecretFunc;
     timeout?: number; // In milliseconds to handle the second round trip.
     callback?: boolean; // To disconnect socket server-side without a client-side callback if no valid token.
-    decodedPropertyName: string; // Property to store the docoded token to.
+    decodedPropertyName?: string; // Property to store the decoded token to.
     handshake?: boolean; // Used to trigger a single round trip authentication.
 }
 

--- a/types/socketio-jwt/socketio-jwt-tests.ts
+++ b/types/socketio-jwt/socketio-jwt-tests.ts
@@ -21,13 +21,12 @@ const io = SocketIo(app);
 // This example test code is using the Node Http Server
 
 io.on('connection', authorize({
-    secret: 'Your Secret Here',
-    decodedPropertyName: 'anyNameYouWant'
+    secret: 'Your Secret Here'
 }));
 
 io.on('authenticated', (socket: SocketIo.Socket) => {
-    console.log('authenticated!!');
-    console.log(JSON.stringify((socket as any).anyNameYouWant));
+    console.log('Authenticated!');
+    console.log(JSON.stringify((socket as any).decoded_token));
 });
 
 const secrets: any = {
@@ -42,6 +41,5 @@ function secretFunc(request: any, payload: any, callback: JwtSecretFuncCallback)
 
 // This example test code provides a callback function to get the secret
 io.on('connection', authorize({
-    secret: secretFunc,
-    decodedPropertyName: 'anyNameYouWant'
+    secret: secretFunc
 }));


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://github.com/auth0-community/auth0-socketio-jwt/blob/master/lib/index.js#L120 https://github.com/auth0-community/auth0-socketio-jwt#altering-the-value-of-the-decoded-token
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
