### PR TITLE
[yup] Fix type definitions for `default`

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -68,8 +68,6 @@ export interface Schema<T> {
     strict(isStrict: boolean): this;
     strip(strip: boolean): this;
     withMutation(fn: (current: this) => void): void;
-    default(value: any): this;
-    default(): T;
     typeError(message?: TestOptionsMessage): this;
     notOneOf(arrayOfValues: any[], message?: MixedLocale['notOneOf']): this;
     when(keys: string | any[], builder: WhenOptions<this>): this;
@@ -109,6 +107,8 @@ export interface MixedSchema<T extends any = {} | null | undefined> extends Sche
     test(name: string, message: TestOptionsMessage, test: TestFunction): this;
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>>): MixedSchema<U>;
     test(options: TestOptions<Record<string, any>>): this;
+    default(): T;
+    default(value: T): MixedSchema<T | null | undefined>;
 }
 
 export interface StringSchemaConstructor {
@@ -151,6 +151,8 @@ export interface StringSchema<T extends string | null | undefined = string | und
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>>): StringSchema<U>;
     test(options: TestOptions<Record<string, any>>): this;
     optional(): StringSchema<T | undefined>;
+    default(): T;
+    default(value: T): StringSchema<T | null | undefined>;
 }
 
 export interface NumberSchemaConstructor {
@@ -187,6 +189,8 @@ export interface NumberSchema<T extends number | null | undefined = number | und
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>>): NumberSchema<U>;
     test(options: TestOptions<Record<string, any>>): this;
     optional(): NumberSchema<T | undefined>;
+    default(): T;
+    default(value: T): NumberSchema<T | null | undefined>;
 }
 
 export interface BooleanSchemaConstructor {
@@ -214,6 +218,8 @@ export interface BooleanSchema<T extends boolean | null | undefined = boolean | 
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>>): BooleanSchema<U>;
     test(options: TestOptions<Record<string, any>>): this;
     optional(): BooleanSchema<T | undefined>;
+    default(): T;
+    default(value: T): BooleanSchema<T | null | undefined>;
 }
 
 export interface DateSchemaConstructor {
@@ -243,6 +249,8 @@ export interface DateSchema<T extends Date | null | undefined = Date | undefined
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>>): DateSchema<U>;
     test(options: TestOptions<Record<string, any>>): this;
     optional(): DateSchema<T | undefined>;
+    default(): T;
+    default(value: T): DateSchema<T | null | undefined>;
 }
 
 export interface ArraySchemaConstructor {
@@ -267,6 +275,8 @@ interface BasicArraySchema<E, T extends E[] | null | undefined> extends Schema<T
     test(name: string, message: TestOptionsMessage, test: TestFunction): this;
     test(options: TestOptions<Record<string, any>>): this;
     innerType: Schema<E>;
+    default(): T;
+    default(value: T): NotRequiredNullableArraySchema<E>;
 }
 
 export interface NotRequiredNullableArraySchema<T> extends BasicArraySchema<T, T[] | null | undefined> {
@@ -364,6 +374,8 @@ export interface ObjectSchema<T extends object | null | undefined = object | und
     test(name: string, message: TestOptionsMessage, test: TestFunction): this;
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>>): ObjectSchema<U>;
     test(options: TestOptions<Record<string, any>>): this;
+    default(): T;
+    default(value: T): ObjectSchema<T | null | undefined>;
 }
 
 export type TestFunction = (

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -108,7 +108,7 @@ export interface MixedSchema<T extends any = {} | null | undefined> extends Sche
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>>): MixedSchema<U>;
     test(options: TestOptions<Record<string, any>>): this;
     default(): T;
-    default(value: T): MixedSchema<T | null | undefined>;
+    default(value: T): MixedSchema<T | undefined>;
 }
 
 export interface StringSchemaConstructor {
@@ -152,7 +152,7 @@ export interface StringSchema<T extends string | null | undefined = string | und
     test(options: TestOptions<Record<string, any>>): this;
     optional(): StringSchema<T | undefined>;
     default(): T;
-    default(value: T): StringSchema<T | null | undefined>;
+    default(value: T): StringSchema<T | undefined>;
 }
 
 export interface NumberSchemaConstructor {
@@ -190,7 +190,7 @@ export interface NumberSchema<T extends number | null | undefined = number | und
     test(options: TestOptions<Record<string, any>>): this;
     optional(): NumberSchema<T | undefined>;
     default(): T;
-    default(value: T): NumberSchema<T | null | undefined>;
+    default(value: T): NumberSchema<T | undefined>;
 }
 
 export interface BooleanSchemaConstructor {
@@ -219,7 +219,7 @@ export interface BooleanSchema<T extends boolean | null | undefined = boolean | 
     test(options: TestOptions<Record<string, any>>): this;
     optional(): BooleanSchema<T | undefined>;
     default(): T;
-    default(value: T): BooleanSchema<T | null | undefined>;
+    default(value: T): BooleanSchema<T | undefined>;
 }
 
 export interface DateSchemaConstructor {
@@ -250,7 +250,7 @@ export interface DateSchema<T extends Date | null | undefined = Date | undefined
     test(options: TestOptions<Record<string, any>>): this;
     optional(): DateSchema<T | undefined>;
     default(): T;
-    default(value: T): DateSchema<T | null | undefined>;
+    default(value: T): DateSchema<T | undefined>;
 }
 
 export interface ArraySchemaConstructor {
@@ -275,8 +275,6 @@ interface BasicArraySchema<E, T extends E[] | null | undefined> extends Schema<T
     test(name: string, message: TestOptionsMessage, test: TestFunction): this;
     test(options: TestOptions<Record<string, any>>): this;
     innerType: Schema<E>;
-    default(): T;
-    default(value: T): NotRequiredNullableArraySchema<E>;
 }
 
 export interface NotRequiredNullableArraySchema<T> extends BasicArraySchema<T, T[] | null | undefined> {
@@ -288,6 +286,8 @@ export interface NotRequiredNullableArraySchema<T> extends BasicArraySchema<T, T
     defined(): NullableArraySchema<T>;
     notRequired(): NotRequiredNullableArraySchema<T>;
     optional(): NotRequiredNullableArraySchema<T>;
+    default(): T[] | null | undefined;
+    default(value: T[] | null | undefined): NotRequiredNullableArraySchema<T>;
 }
 
 export interface NullableArraySchema<T> extends BasicArraySchema<T, T[] | null> {
@@ -299,6 +299,8 @@ export interface NullableArraySchema<T> extends BasicArraySchema<T, T[] | null> 
     defined(): NullableArraySchema<T>;
     notRequired(): NotRequiredNullableArraySchema<T>;
     optional(): NotRequiredNullableArraySchema<T>;
+    default(): T[] | null;
+    default(value: T[] | null): NotRequiredNullableArraySchema<T>;
 }
 
 export interface NotRequiredArraySchema<T> extends BasicArraySchema<T, T[] | undefined> {
@@ -310,6 +312,8 @@ export interface NotRequiredArraySchema<T> extends BasicArraySchema<T, T[] | und
     defined(): ArraySchema<T>;
     notRequired(): NotRequiredArraySchema<T>;
     optional(): NotRequiredArraySchema<T>;
+    default(): T[] | undefined;
+    default(value: T[] | undefined): NotRequiredArraySchema<T>;
 }
 
 export interface ArraySchema<T> extends BasicArraySchema<T, T[]> {
@@ -320,6 +324,8 @@ export interface ArraySchema<T> extends BasicArraySchema<T, T[]> {
     defined(): ArraySchema<T>;
     notRequired(): NotRequiredArraySchema<T>;
     optional(): NotRequiredArraySchema<T>;
+    default(): T[];
+    default(value: T[]): NotRequiredArraySchema<T>;
 }
 
 export type ObjectSchemaDefinition<T extends object | null | undefined> = {
@@ -375,7 +381,7 @@ export interface ObjectSchema<T extends object | null | undefined = object | und
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>>): ObjectSchema<U>;
     test(options: TestOptions<Record<string, any>>): this;
     default(): T;
-    default(value: T): ObjectSchema<T | null | undefined>;
+    default(value: T): ObjectSchema<T | undefined>;
 }
 
 export type TestFunction = (

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -320,56 +320,54 @@ yup.object()
     });
 
 // String schema
-function strSchemaTests(strSchema: yup.StringSchema) {
-    strSchema.type;
-    strSchema.isValid('hello'); // => true
-    strSchema.required();
-    strSchema.required('req');
-    strSchema.required(() => 'req');
-    strSchema.length(5, 'message');
-    strSchema.length(5, () => 'message');
-    strSchema.length(5, ({ length }) => `must be ${length}`);
-    // $ExpectError
-    strSchema.length(5, ({ min }) => `must be ${min}`);
-    strSchema.min(5, 'message');
-    strSchema.min(5, () => 'message');
-    strSchema.min(5, ({ min }) => `more than ${min}`);
-    // $ExpectError
-    strSchema.min(5, ({ max }) => `more than ${max}`);
-    strSchema.max(5, 'message');
-    strSchema.max(5, () => 'message');
-    strSchema.max(5, ({ max }) => `less than ${max}`);
-    // $ExpectError
-    strSchema.max(5, ({ min }) => `less than ${min}`);
-    strSchema.matches(/(hi|bye)/);
-    strSchema.matches(/(hi|bye)/, 'invalid');
-    strSchema.matches(/(hi|bye)/, () => 'invalid');
-    strSchema.matches(/(hi|bye)/, ({ regex }) => `Does not match ${regex}`);
-    strSchema.email();
-    strSchema.email('invalid');
-    strSchema.email(() => 'invalid');
-    strSchema.email(({ regex }) => `Does not match ${regex}`);
-    strSchema.url();
-    strSchema.url('bad url');
-    strSchema.url(() => 'bad url');
-    strSchema.url(({ regex }) => `Does not match ${regex}`);
-    strSchema.ensure();
-    strSchema.trim();
-    strSchema.trim('trimmed');
-    strSchema.trim(() => 'trimmed');
-    strSchema.lowercase();
-    strSchema.lowercase('lower');
-    strSchema.lowercase(() => 'lower');
-    strSchema.uppercase();
-    strSchema.uppercase('upper');
-    strSchema.uppercase(() => 'upper');
-    strSchema.defined();
-}
-
 const strSchema = yup.string(); // $ExpectType StringSchema<string | undefined>
 strSchema.oneOf(["hello", "world"] as const); // $ExpectType StringSchema<"hello" | "world" | undefined>
 strSchema.required().oneOf(["hello", "world"] as const); // $ExpectType StringSchema<"hello" | "world">
-strSchemaTests(strSchema);
+strSchema.type;
+strSchema.isValid('hello'); // => true
+strSchema.required();
+strSchema.required('req');
+strSchema.required(() => 'req');
+strSchema.length(5, 'message');
+strSchema.length(5, () => 'message');
+strSchema.length(5, ({ length }) => `must be ${length}`);
+// $ExpectError
+strSchema.length(5, ({ min }) => `must be ${min}`);
+strSchema.min(5, 'message');
+strSchema.min(5, () => 'message');
+strSchema.min(5, ({ min }) => `more than ${min}`);
+// $ExpectError
+strSchema.min(5, ({ max }) => `more than ${max}`);
+strSchema.max(5, 'message');
+strSchema.max(5, () => 'message');
+strSchema.max(5, ({ max }) => `less than ${max}`);
+// $ExpectError
+strSchema.max(5, ({ min }) => `less than ${min}`);
+strSchema.matches(/(hi|bye)/);
+strSchema.matches(/(hi|bye)/, 'invalid');
+strSchema.matches(/(hi|bye)/, () => 'invalid');
+strSchema.matches(/(hi|bye)/, ({ regex }) => `Does not match ${regex}`);
+strSchema.email();
+strSchema.email('invalid');
+strSchema.email(() => 'invalid');
+strSchema.email(({ regex }) => `Does not match ${regex}`);
+strSchema.url();
+strSchema.url('bad url');
+strSchema.url(() => 'bad url');
+strSchema.url(({ regex }) => `Does not match ${regex}`);
+strSchema.ensure();
+strSchema.trim();
+strSchema.trim('trimmed');
+strSchema.trim(() => 'trimmed');
+strSchema.lowercase();
+strSchema.lowercase('lower');
+strSchema.lowercase(() => 'lower');
+strSchema.uppercase();
+strSchema.uppercase('upper');
+strSchema.uppercase(() => 'upper');
+strSchema.defined();
+strSchema.default();
+strSchema.defined().default("abc"); // $ExpectType StringSchema<string | null | undefined>
 
 // $ExpectError
 yup.string<123>();
@@ -415,6 +413,8 @@ numSchema.oneOf([1, 2] as const); // $ExpectType NumberSchema<1 | 2 | undefined>
 numSchema.equals([1, 2] as const); // $ExpectType NumberSchema<1 | 2 | undefined>
 numSchema.required().oneOf([1, 2] as const); // $ExpectType NumberSchema<1 | 2>
 numSchema.defined();
+numSchema.default();
+numSchema.defined().default(1); // $ExpectType NumberSchema<number | null | undefined>
 
 // Boolean Schema
 const boolSchema = yup.boolean(); // $ExpectType BooleanSchema<boolean | undefined>
@@ -424,6 +424,8 @@ boolSchema.oneOf([true] as const); // $ExpectType BooleanSchema<true | undefined
 boolSchema.equals([true] as const); // $ExpectType BooleanSchema<true | undefined>
 boolSchema.required().oneOf([true] as const); // $ExpectType BooleanSchema<true>
 boolSchema.defined();
+boolSchema.default();
+boolSchema.defined().default(true); // $ExpectType BooleanSchema<boolean | null | undefined>
 
 // Date Schema
 const dateSchema = yup.date(); // $ExpectType DateSchema<Date | undefined>
@@ -442,6 +444,8 @@ dateSchema.max('2017-11-12', () => 'message');
 dateSchema.oneOf([new Date()] as const); // $ExpectType DateSchema<Date | undefined>
 dateSchema.equals([new Date()] as const); // $ExpectType DateSchema<Date | undefined>
 dateSchema.required().oneOf([new Date()] as const); // $ExpectType DateSchema<Date>
+dateSchema.default();
+dateSchema.defined().default(new Date()); // $ExpectType DateSchema<Date | null | undefined>
 
 // Array Schema
 const arrSchema = yup.array().of(yup.number().defined().min(2));
@@ -469,6 +473,8 @@ arrSchema.compact((value, index, array) => value === array[index]);
 arrSchema.oneOf([]); // $ExpectType NotRequiredArraySchema<number>
 arrSchema.equals([]); // $ExpectType NotRequiredArraySchema<number>
 arrSchema.defined();
+arrSchema.default();
+arrSchema.defined().default([123]); // $ExpectType NotRequiredNullableArraySchema<number>
 
 const arrOfObjSchema = yup.array().defined().of(
     yup.object().defined().shape({
@@ -515,6 +521,13 @@ objSchema.transformKeys(key => key.toUpperCase());
 objSchema.camelCase();
 objSchema.snakeCase();
 objSchema.constantCase();
+objSchema.default();
+objSchema.defined().default({
+    name: "John Doe",
+    age: 35,
+    email: "john@example.com",
+    website: "example.com"
+});
 interface LiteralExampleObject {
     name: "John Doe";
     age: 35;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -367,7 +367,7 @@ strSchema.uppercase('upper');
 strSchema.uppercase(() => 'upper');
 strSchema.defined();
 strSchema.default();
-strSchema.defined().default("abc"); // $ExpectType StringSchema<string | null | undefined>
+strSchema.defined().default("abc"); // $ExpectType StringSchema<string | undefined>
 
 // $ExpectError
 yup.string<123>();
@@ -414,7 +414,7 @@ numSchema.equals([1, 2] as const); // $ExpectType NumberSchema<1 | 2 | undefined
 numSchema.required().oneOf([1, 2] as const); // $ExpectType NumberSchema<1 | 2>
 numSchema.defined();
 numSchema.default();
-numSchema.defined().default(1); // $ExpectType NumberSchema<number | null | undefined>
+numSchema.defined().default(1); // $ExpectType NumberSchema<number | undefined>
 
 // Boolean Schema
 const boolSchema = yup.boolean(); // $ExpectType BooleanSchema<boolean | undefined>
@@ -425,7 +425,7 @@ boolSchema.equals([true] as const); // $ExpectType BooleanSchema<true | undefine
 boolSchema.required().oneOf([true] as const); // $ExpectType BooleanSchema<true>
 boolSchema.defined();
 boolSchema.default();
-boolSchema.defined().default(true); // $ExpectType BooleanSchema<boolean | null | undefined>
+boolSchema.defined().default(true); // $ExpectType BooleanSchema<boolean | undefined>
 
 // Date Schema
 const dateSchema = yup.date(); // $ExpectType DateSchema<Date | undefined>
@@ -445,7 +445,7 @@ dateSchema.oneOf([new Date()] as const); // $ExpectType DateSchema<Date | undefi
 dateSchema.equals([new Date()] as const); // $ExpectType DateSchema<Date | undefined>
 dateSchema.required().oneOf([new Date()] as const); // $ExpectType DateSchema<Date>
 dateSchema.default();
-dateSchema.defined().default(new Date()); // $ExpectType DateSchema<Date | null | undefined>
+dateSchema.defined().default(new Date()); // $ExpectType DateSchema<Date | undefined>
 
 // Array Schema
 const arrSchema = yup.array().of(yup.number().defined().min(2));
@@ -474,7 +474,7 @@ arrSchema.oneOf([]); // $ExpectType NotRequiredArraySchema<number>
 arrSchema.equals([]); // $ExpectType NotRequiredArraySchema<number>
 arrSchema.defined();
 arrSchema.default();
-arrSchema.defined().default([123]); // $ExpectType NotRequiredNullableArraySchema<number>
+arrSchema.defined().default([123]); // $ExpectType NotRequiredArraySchema<number>
 
 const arrOfObjSchema = yup.array().defined().of(
     yup.object().defined().shape({


### PR DESCRIPTION
Based on a comment in a previous PR (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44589#issuecomment-637610183), I realized that `default` is typed incorrectly. It is typed as not modifying the schema type, but in reality it adds ~~`null` and~~ `undefined` to the allowable types. This PR makes the types accurate for `default()`:

```ts
// This should have type StringSchema<string | undefined>, but it previously had StringSchema<string>
yup.string().defined().default("abc");

// This should have type StringSchema<string | undefined>, but it previously had StringSchema<string>
yup.string().required().default("abc");
```

Also adds test for this.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. 
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: DEMO: https://codesandbox.io/s/async-feather-w5u7f
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (it doesn't)
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
