### PR TITLE
[yup] Fix type of `required` to exclude `null`

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -91,7 +91,7 @@ export interface MixedSchema<T extends any = {} | null | undefined> extends Sche
     nullable(isNullable?: true): MixedSchema<T | null>;
     nullable(isNullable: false): MixedSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): MixedSchema<T>;
-    required(message?: TestOptionsMessage): MixedSchema<Exclude<T, undefined>>;
+    required(message?: TestOptionsMessage): MixedSchema<Exclude<T, undefined | null>>;
     defined(): MixedSchema<Exclude<T, undefined>>;
     notRequired(): MixedSchema<T | undefined>;
     optional(): MixedSchema<T | undefined>;
@@ -135,7 +135,7 @@ export interface StringSchema<T extends string | null | undefined = string | und
     nullable(isNullable?: true): StringSchema<T | null>;
     nullable(isNullable: false): StringSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): StringSchema<T>;
-    required(message?: TestOptionsMessage): StringSchema<Exclude<T, undefined>>;
+    required(message?: TestOptionsMessage): StringSchema<Exclude<T, undefined | null>>;
     defined(): StringSchema<Exclude<T, undefined>>;
     notRequired(): StringSchema<T | undefined>;
     oneOf<U extends T>(
@@ -171,7 +171,7 @@ export interface NumberSchema<T extends number | null | undefined = number | und
     nullable(isNullable?: true): NumberSchema<T | null>;
     nullable(isNullable: false): NumberSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): NumberSchema<T>;
-    required(message?: TestOptionsMessage): NumberSchema<Exclude<T, undefined>>;
+    required(message?: TestOptionsMessage): NumberSchema<Exclude<T, undefined | null>>;
     defined(): NumberSchema<Exclude<T, undefined>>;
     notRequired(): NumberSchema<T | undefined>;
     oneOf<U extends T>(
@@ -198,7 +198,7 @@ export interface BooleanSchema<T extends boolean | null | undefined = boolean | 
     nullable(isNullable?: true): BooleanSchema<T | null>;
     nullable(isNullable: false): BooleanSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): BooleanSchema<T>;
-    required(message?: TestOptionsMessage): BooleanSchema<Exclude<T, undefined>>;
+    required(message?: TestOptionsMessage): BooleanSchema<Exclude<T, undefined | null>>;
     defined(): BooleanSchema<Exclude<T, undefined>>;
     notRequired(): BooleanSchema<T | undefined>;
     oneOf<U extends T>(
@@ -227,7 +227,7 @@ export interface DateSchema<T extends Date | null | undefined = Date | undefined
     nullable(isNullable?: true): DateSchema<T | null>;
     nullable(isNullable: false): DateSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): DateSchema<T>;
-    required(message?: TestOptionsMessage): DateSchema<Exclude<T, undefined>>;
+    required(message?: TestOptionsMessage): DateSchema<Exclude<T, undefined | null>>;
     defined(): DateSchema<Exclude<T, undefined>>;
     notRequired(): DateSchema<T | undefined>;
     oneOf<U extends T>(
@@ -274,7 +274,7 @@ export interface NotRequiredNullableArraySchema<T> extends BasicArraySchema<T, T
     nullable(isNullable?: true): NotRequiredNullableArraySchema<T>;
     nullable(isNullable: false): NotRequiredArraySchema<T>;
     nullable(isNullable?: boolean): ArraySchema<T>;
-    required(message?: TestOptionsMessage): NullableArraySchema<T>;
+    required(message?: TestOptionsMessage): ArraySchema<T>;
     defined(): NullableArraySchema<T>;
     notRequired(): NotRequiredNullableArraySchema<T>;
     optional(): NotRequiredNullableArraySchema<T>;
@@ -285,7 +285,7 @@ export interface NullableArraySchema<T> extends BasicArraySchema<T, T[] | null> 
     nullable(isNullable?: true): NullableArraySchema<T>;
     nullable(isNullable: false): ArraySchema<T>;
     nullable(isNullable?: boolean): ArraySchema<T>;
-    required(message?: TestOptionsMessage): NullableArraySchema<T>;
+    required(message?: TestOptionsMessage): ArraySchema<T>;
     defined(): NullableArraySchema<T>;
     notRequired(): NotRequiredNullableArraySchema<T>;
     optional(): NotRequiredNullableArraySchema<T>;
@@ -352,7 +352,7 @@ export interface ObjectSchema<T extends object | null | undefined = object | und
     nullable(isNullable?: true): ObjectSchema<T | null>;
     nullable(isNullable: false): ObjectSchema<Exclude<T, null>>;
     nullable(isNullable?: boolean): ObjectSchema<T>;
-    required(message?: TestOptionsMessage): ObjectSchema<Exclude<T, undefined>>;
+    required(message?: TestOptionsMessage): ObjectSchema<Exclude<T, undefined | null>>;
     defined(): ObjectSchema<Exclude<T, undefined>>;
     notRequired(): ObjectSchema<T | undefined>;
     optional(): ObjectSchema<T | undefined>;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -143,11 +143,12 @@ mixed.nullable(true);
 mixed.nullable();
 mixed.required();
 mixed.required('Foo');
+mixed.nullable().required(); // $ExpectType MixedSchema<{}>
 mixed.required(() => 'Foo');
 mixed.defined();
 mixed.notRequired(); // $ExpectType MixedSchema<{} | null | undefined>
 mixed.optional(); // $ExpectType MixedSchema<{} | null | undefined>
-mixed.required().optional(); // $ExpectType MixedSchema<{} | null | undefined>
+mixed.required().optional(); // $ExpectType MixedSchema<{} | undefined>
 mixed.typeError('type error');
 mixed.typeError(() => 'type error');
 mixed.oneOf(['hello', 'world'], 'message');


### PR DESCRIPTION
@msheakoski pointed out in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44589#issuecomment-633238122 that the type definition for `required` is incorrect. Previously it only excluded `undefined` from the schema, however according to the [documentation](https://github.com/jquense/yup#mixedrequiredmessage-string--function-schema), it also should exclude `null`. This can be confirmed with the following example ([try it](https://codesandbox.io/s/mystifying-gates-yu8io)): 

```ts
const schema = number().nullable().required();
console.log(schema.isValidSync(null)); // false
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquense/yup#mixedrequiredmessage-string--function-schema
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

