### PR TITLE
"mosca" Added 'ready' possibility to Server.on events

### DIFF
--- a/types/mosca/index.d.ts
+++ b/types/mosca/index.d.ts
@@ -42,6 +42,7 @@ export class Server {
     on(when: 'clientConnected' | 'clientDisconnecting' | 'clientDisconnected', callback: (client: Client) => void): void;
     on(when: 'subscribed' | 'unsubscribed', callback: (topic: string, client: Client) => void): void;
     on(when: 'published', callback: (packet: Packet, client: Client) => void): void;
+    on(when: 'ready', callback: () => void): void;
     once(when: string, callback: () => void): void;
     toString(): string;
     subscribe(topic: string, callback: () => void, done: () => void): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/moscajs/mosca/wiki/Mosca-basic-usage#c-then-we-just-pass-the-pubsub-settings-object-the-one-we-created-above-to-our-server-into-our-moscasettings-through-the-backend-key
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.