### PR TITLE
@types/traverson - updating type definitions to match new version of the JS library

### DIFF
--- a/types/traverson/index.d.ts
+++ b/types/traverson/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Traverson v2.0.1
+// Type definitions for Traverson v6.1.1
 // Project: https://github.com/basti1302/traverson
 // Definitions by: Marcin Porębski <https://github.com/marcinporebski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -7,52 +7,68 @@ declare var traverson: Traverson.TraversonMethods;
 
 export = traverson;
 
-declare namespace Traverson
-{
-    interface TraversonMethods
-    {
+declare namespace Traverson {
+    interface TraversonMethods {
         from(uri: string): Builder;
         registerMediaType(name: string, handler: any): TraversonMethods;
     }
 
-    interface Builder
-    {
-        withRequestOptions(options: any): Builder;
-        withTemplateParameters(parameters: any): Builder;
+    interface Builder {
+        newRequest(): Builder;
+        setMediaType(type_name: string): Builder;
+        getLinkType(): string;
         json(): Builder;
         jsonHal(): Builder;
-
-        setMediaType(type_name: string): Builder;
+        useContentNegotiation(): Builder;
+        from(url: string): Builder;
+        follow(first_pattern: string, ...rest_patterns: string[]): Builder;
+        followLocationHeader(): Builder;
+        walk(): Builder; // Alias for follow()
+        withTemplateParameters(parameters: any): Builder;
+        withRequestOptions(options: any): Builder;
+        addRequestOptions(options: any): Builder;
+        withRequestLibrary(request: any): Builder;
+        parseResponseBodiesWith(parser: any): Builder;
+        disableAutoHeaders(): Builder;
+        enableAutoHeaders(): Builder;
+        useAutoHeaders(flag: any): Builder;
+        sendRawPayload(flag: any): Builder;
         convertResponseToObject(): Builder;
-
-        follow(first_pattern: string, ... rest_patterns: string[]): Builder;
-
+        resolveRelative(flag: any): Builder;
+        preferEmbeddedResources(flag: any): Builder;
+        getMediaType(): string;
+        getFrom(): string;
+        getTemplateParameters(): any;
+        getRequestOptions(): any;
+        getRequestLibrary(): any;
+        getJsonParser(): any;
+        setsAutoHeaders(): boolean;
+        sendsRawPayload(): boolean;
+        convertsResponseToObject(): boolean;
+        doesResolveRelative(): boolean;
+        doesPreferEmbeddedResources(): boolean;
+        doesContentNegotiation(): boolean;
         get(callback: (err: any, document: any, traversal?: Traversal) => void): InAction;
         getResource(callback: (err: any, document: any, traversal?: Traversal) => void): InAction;
         getUrl(callback: (err: any, document: any, traversal?: Traversal) => void): InAction;
+        getUri(callback: (err: any, document: any, traversal?: Traversal) => void): InAction; // Alias for getUrl()
         post(data: any, callback: (err: any, document: any, traversal?: Traversal) => void): InAction;
         put(data: any, callback: (err: any, document: any, traversal?: Traversal) => void): InAction;
         patch(data: any, callback: (err: any, document: any, traversal?: Traversal) => void): InAction;
         delete(callback: (err: any, document: any, traversal?: Traversal) => void): InAction;
-
-        newRequest(): Builder;
+        del(callback: (err: any, document: any, traversal?: Traversal) => void): InAction; // Alias for delete()
+        linkHeader(): Builder;
     }
 
-    interface Json
-    {
+    interface Json {
         parseJson(): any;
     }
 
-    interface Traversal
-    {
+    interface Traversal {
         continue(): Builder;
     }
 
-    interface InAction
-    {
+    interface InAction {
         abort(): void;
     }
-
-
-
 }

--- a/types/traverson/index.d.ts
+++ b/types/traverson/index.d.ts
@@ -23,6 +23,7 @@ declare namespace Traverson
         jsonHal(): Builder;
 
         setMediaType(type_name: string): Builder;
+        convertResponseToObject(): Builder;
 
         follow(first_pattern: string, ... rest_patterns: string[]): Builder;
 

--- a/types/traverson/index.d.ts
+++ b/types/traverson/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for Traverson v6.1.1
-// Project: https://github.com/basti1302/traverson
+// Project: https://github.com/traverson/traverson
 // Definitions by: Marcin Porębski <https://github.com/marcinporebski>
+//                 Vladimir Jelovac <https://github.com/jelovac>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var traverson: Traverson.TraversonMethods;

--- a/types/traverson/index.d.ts
+++ b/types/traverson/index.d.ts
@@ -10,8 +10,13 @@ export = traverson;
 
 declare namespace Traverson {
     interface TraversonMethods {
+        newRequest(): Builder;
         from(uri: string): Builder;
+        json(): Builder;
+        jsonHal(): Builder;
         registerMediaType(name: string, handler: any): TraversonMethods;
+        mediaTypes(): TraversonMethods;
+        errors(): TraversonMethods;
     }
 
     interface Builder {

--- a/types/traverson/index.d.ts
+++ b/types/traverson/index.d.ts
@@ -24,7 +24,7 @@ declare namespace Traverson {
         from(url: string): Builder;
         follow(first_pattern: string, ...rest_patterns: string[]): Builder;
         followLocationHeader(): Builder;
-        walk(): Builder; // Alias for follow()
+        walk(first_pattern: string, ...rest_patterns: string[]): Builder; // Alias for follow()
         withTemplateParameters(parameters: any): Builder;
         withRequestOptions(options: any): Builder;
         addRequestOptions(options: any): Builder;

--- a/types/traverson/traverson-tests.ts
+++ b/types/traverson/traverson-tests.ts
@@ -1,19 +1,20 @@
-
-
 import traverson = require('traverson');
 
-function testTraverson()
-{
+function testTraverson() {
     var mediaTypeHandler: any = {};
 
     traverson.registerMediaType('application/some-fancy+json', mediaTypeHandler);
 
-    traverson.from('http://example.api.com/')
+    traverson
+        .from('http://example.api.com/')
         .follow('link_to')
-        .withTemplateParameters({'id': 1})
-        .get(function(error, document, traversal) {
-           traversal.continue().follow('link_back').get(function(error, document, traversal) {
-               ///
-           });
+        .withTemplateParameters({ id: 1 })
+        .get(function (error, document, traversal) {
+            traversal
+                .continue()
+                .follow('link_back')
+                .get(function (error, document, traversal) {
+                    ///
+                });
         });
 }

--- a/types/traverson/traverson-tests.ts
+++ b/types/traverson/traverson-tests.ts
@@ -9,11 +9,11 @@ function testTraverson() {
         .from('http://example.api.com/')
         .follow('link_to')
         .withTemplateParameters({ id: 1 })
-        .get(function (error, document, traversal) {
+        .get((error, document, traversal) => {
             traversal
                 .continue()
                 .follow('link_back')
-                .get(function (error, document, traversal) {
+                .get((error, document, traversal) => {
                     ///
                 });
         });


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/traverson/traverson/blob/6.1.1/lib/builder.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

