### PR TITLE
[rdf-js] Make RDF/JS's NamedNode generic

### DIFF
--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -244,7 +244,7 @@ export interface DataFactory<OutQuad extends BaseQuad = Quad, InQuad extends Bas
      * @return A new instance of NamedNode.
      * @see NamedNode
      */
-    namedNode<Iri extends string = string>(value: Iri): NamedNode<Iri>;
+    namedNode(value: string): NamedNode;
 
     /**
      * @param value The optional blank node identifier.

--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -26,7 +26,7 @@ export type Term = NamedNode | BlankNode | Literal | Variable | DefaultGraph;
 /**
  * Contains an IRI.
  */
-export interface NamedNode {
+export interface NamedNode<Iri extends string = string> {
     /**
      * Contains the constant "NamedNode".
      */
@@ -34,7 +34,7 @@ export interface NamedNode {
     /**
      * The IRI of the named node (example: `http://example.org/resource`)
      */
-    value: string;
+    value: Iri;
 
     /**
      * @param other The term to compare with.
@@ -244,7 +244,7 @@ export interface DataFactory<OutQuad extends BaseQuad = Quad, InQuad extends Bas
      * @return A new instance of NamedNode.
      * @see NamedNode
      */
-    namedNode(value: string): NamedNode;
+    namedNode<Iri extends string = string>(value: Iri): NamedNode<Iri>;
 
     /**
      * @param value The optional blank node identifier.

--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -244,6 +244,9 @@ export interface DataFactory<OutQuad extends BaseQuad = Quad, InQuad extends Bas
      * @return A new instance of NamedNode.
      * @see NamedNode
      */
+    // TODO: This could be changed into a Generic method that returns a NamedNode constained to the
+    //       given `value` - but note that that would be a breaking change. See commit
+    //       16d29e86cd6fe34e6ac6f53bba6ba1a1988d7401.
     namedNode(value: string): NamedNode;
 
     /**

--- a/types/rdf-js/rdf-js-tests.ts
+++ b/types/rdf-js/rdf-js-tests.ts
@@ -69,11 +69,6 @@ function test_datafactory() {
     const dataFactory: DataFactory = <any> {};
 
     const namedNode: NamedNode = dataFactory.namedNode('http://example.org');
-    const constantValue: 'http://example.org' = dataFactory.namedNode('http://example.org').value;
-    // $ExpectError
-    const otherConstantValue: 'http://not-example.org' = dataFactory.namedNode('http://example.org').value;
-    // $ExpectError
-    const otherConstantNamedNode: NamedNode<'http://not-example.org'> = dataFactory.namedNode('http://example.org');
 
     const blankNode1: BlankNode = dataFactory.blankNode('b1');
     const blankNode2: BlankNode = dataFactory.blankNode();

--- a/types/rdf-js/rdf-js-tests.ts
+++ b/types/rdf-js/rdf-js-tests.ts
@@ -17,6 +17,14 @@ function test_terms() {
     namedNodeEqual = namedNode.equals(null);
     namedNodeEqual = namedNode.equals(undefined);
 
+    const namedNodeConstant: NamedNode<'http://example.org'> = <any> {};
+    const constantIri: 'http://example.org' = namedNodeConstant.value;
+    // $ExpectError
+    const otherConstantIri: 'http://not-example.org' = namedNodeConstant.value;
+    // $ExpectError
+    const otherNamedNodeConstant: NamedNode<'http://not-example.org'> = namedNodeConstant;
+    const regularNamedNode: NamedNode = namedNodeConstant;
+
     const blankNode: BlankNode = <any> {};
     const termType2: string = blankNode.termType;
     const value2: string = blankNode.value;
@@ -61,6 +69,11 @@ function test_datafactory() {
     const dataFactory: DataFactory = <any> {};
 
     const namedNode: NamedNode = dataFactory.namedNode('http://example.org');
+    const constantValue: 'http://example.org' = dataFactory.namedNode('http://example.org').value;
+    // $ExpectError
+    const otherConstantValue: 'http://not-example.org' = dataFactory.namedNode('http://example.org').value;
+    // $ExpectError
+    const otherConstantNamedNode: NamedNode<'http://not-example.org'> = dataFactory.namedNode('http://example.org');
 
     const blankNode1: BlankNode = dataFactory.blankNode('b1');
     const blankNode2: BlankNode = dataFactory.blankNode();


### PR DESCRIPTION
This will allow people to use these typings to indicate paramters
whose NamedNodes need to have a specific value. All code that does
not explicitly indicate a generic parameter (i.e. all existing
code) should not be affected.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

I'm getting errors running both `npm test` as well as `npm run lint rdf-js` on current `master`, so I couldn't run those on this branch either :/