### PR TITLE
country-data: allow currencies to be used by key

### DIFF
--- a/types/country-data/index.d.ts
+++ b/types/country-data/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for country-data 0.0
 // Project: https://github.com/OpenBookPrices/country-data
 // Definitions by: Logan Dam <https://github.com/biltongza>
+//                 Mike MacCana <https://github.com/mikemaccana>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -66,7 +67,9 @@ export const callingCountries: {
 };
 
 export const currencies: {
-    readonly all: ReadonlyArray<Currency>;
+    readonly [key: string]: Currency;
+} & {
+    readonly all: ReadonlyArray<Country>;
 };
 
 export const languages: {


### PR DESCRIPTION
Please fill in this template.

- [* ] Use a meaningful title for the pull request. Include the name of the package modified.
- [*] Test the change in your own code. (Compile and run.)
- [*] Add or edit tests to reflect the change. (Run with `npm test`.)
- [*Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [*] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [*] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [*] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/OpenBookPrices/country-data#example-usage
- [*] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. N/A - this fixes an existing type definition
- [*] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing) I have tried the procedure in this link, and it fails with `Invalid module name in augmentation. Module 'country-data' resolves to an untyped module at '/home/mike/Code/mycompany/myapp/node_modules/country-data/index.js', which cannot be augmented.` 
- [*] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. Not a substantial change.
