### PR TITLE
Tweaks to API Gateway proxy v2 definitions

### DIFF
--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -29,6 +29,7 @@ import {
     ProxyCallback,
     ProxyHandler,
     Statement,
+    APIGatewayProxyStructuredResultV2,
 } from "aws-lambda";
 
 interface CustomAuthorizerContext extends APIGatewayAuthorizerResultContext {
@@ -230,7 +231,7 @@ function createProxyResult(): APIGatewayProxyResult {
 }
 
 function createProxyResultV2(): APIGatewayProxyResultV2 {
-    let result: APIGatewayProxyResultV2 = {
+    let result: APIGatewayProxyStructuredResultV2 = {
         statusCode: num,
         body: str,
     };
@@ -246,6 +247,49 @@ function createProxyResultV2(): APIGatewayProxyResultV2 {
     };
     return result;
 }
+
+const proxyHandlerV2ForStringResult: APIGatewayProxyHandlerV2 = async (event, context, callback) => {
+    const result = createProxyStringResultV2();
+
+    callback(new Error());
+    callback(undefined, result);
+    return result;
+};
+
+function createProxyStringResultV2(): APIGatewayProxyResultV2 {
+    const result = 'example';
+    return result;
+}
+
+interface Response {
+    example: string;
+}
+
+const proxyHandlerV2ForObjectResult: APIGatewayProxyHandlerV2<Response> = async (event, context, callback) => {
+    const result = createProxyStringResultV2();
+
+    callback(new Error());
+    callback(undefined, result);
+    return result;
+};
+
+function createProxyObjectResultV2(): APIGatewayProxyResultV2<Response> {
+    const result: Response = {
+        example: 'example squared'
+    };
+    return result;
+}
+
+// $ExpectError
+const proxyHandlerV2ForObjectResultFailure: APIGatewayProxyHandlerV2<Response> = async (event, context, callback) => {
+    const result = {
+        wrongExample: 'wrong example'
+    };
+
+    callback(new Error());
+    callback(undefined, result); // $ExpectError
+    return result;
+};
 
 const authorizer: APIGatewayAuthorizerHandler = async (event, context, callback) => {
     if (event.type === "TOKEN") {

--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -291,6 +291,17 @@ const proxyHandlerV2ForObjectResultFailure: APIGatewayProxyHandlerV2<Response> =
     return result;
 };
 
+// $ExpectError
+const proxyHandlerV2ForObjectResultFailure2: APIGatewayProxyHandlerV2 = async (event, context, callback) => {
+    const result = {
+        wrongExample: 'wrong example',
+    };
+
+    callback(new Error());
+    callback(undefined, result); // $ExpectError
+    return result;
+};
+
 const authorizer: APIGatewayAuthorizerHandler = async (event, context, callback) => {
     if (event.type === "TOKEN") {
         str = event.methodArn;

--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -136,14 +136,16 @@ let proxyHandler: APIGatewayProxyHandler = async (event, context, callback) => {
 };
 
 const proxyHandlerV2: APIGatewayProxyHandlerV2 = async (event, context, callback) => {
-    strOrNull = event.body;
+    strOrUndefined = event.body;
     str = event.headers['example'];
     str = event.routeKey;
     bool = event.isBase64Encoded;
     str = event.rawPath;
     str = event.rawQueryString;
-    strOrUndefinedOrNull = event.cookies[0];
-    str = event.stageVariables['example'];
+    strOrUndefined = event.cookies ? event.cookies[0] : undefined;
+    strOrUndefined = event.queryStringParameters ? event.queryStringParameters['example'] : undefined;
+    strOrUndefined = event.pathParameters ? event.pathParameters['example'] : undefined;
+    strOrUndefined = event.stageVariables ? event.stageVariables['example'] : undefined;
 
     str = event.requestContext.http.protocol;
     str = event.requestContext.http.sourceIp;

--- a/types/aws-lambda/trigger/api-gateway-proxy.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-proxy.d.ts
@@ -19,7 +19,7 @@ export type APIGatewayProxyCallback = Callback<APIGatewayProxyResult>;
  * Works with HTTP API integration Payload Format version 2.0
  * @see - https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
  */
-export type APIGatewayProxyHandlerV2<T = object> = Handler<APIGatewayProxyEventV2, APIGatewayProxyResultV2<T>>;
+export type APIGatewayProxyHandlerV2<T = never> = Handler<APIGatewayProxyEventV2, APIGatewayProxyResultV2<T>>;
 /**
  * Works with HTTP API integration Payload Format version 2.0
  * @see - https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
@@ -139,7 +139,7 @@ export interface APIGatewayProxyEventV2 {
  * Works with HTTP API integration Payload Format version 2.0
  * @see - https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
  */
-export type APIGatewayProxyResultV2<T = object> = APIGatewayProxyStructuredResultV2 | string | T;
+export type APIGatewayProxyResultV2<T = never> = APIGatewayProxyStructuredResultV2 | string | T;
 
 /**
  * Interface for structured response with `statusCode` and`headers`

--- a/types/aws-lambda/trigger/api-gateway-proxy.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-proxy.d.ts
@@ -19,7 +19,7 @@ export type APIGatewayProxyCallback = Callback<APIGatewayProxyResult>;
  * Works with HTTP API integration Payload Format version 2.0
  * @see - https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
  */
-export type APIGatewayProxyHandlerV2 = Handler<APIGatewayProxyEventV2, APIGatewayProxyResultV2>;
+export type APIGatewayProxyHandlerV2<T = object> = Handler<APIGatewayProxyEventV2, APIGatewayProxyResultV2<T>>;
 /**
  * Works with HTTP API integration Payload Format version 2.0
  * @see - https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
@@ -139,12 +139,19 @@ export interface APIGatewayProxyEventV2 {
  * Works with HTTP API integration Payload Format version 2.0
  * @see - https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
  */
-export interface APIGatewayProxyResultV2 {
+export type APIGatewayProxyResultV2<T = object> = APIGatewayProxyStructuredResultV2 | string | T;
+
+/**
+ * Interface for structured response with `statusCode` and`headers`
+ * Works with HTTP API integration Payload Format version 2.0
+ * @see - https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
+ */
+export interface APIGatewayProxyStructuredResultV2 {
     statusCode?: number;
     headers?: {
         [header: string]: boolean | number | string;
     };
-    body?: string | object;
+    body?: string;
     isBase64Encoded?: boolean;
     cookies?: string[];
 }

--- a/types/aws-lambda/trigger/api-gateway-proxy.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-proxy.d.ts
@@ -98,16 +98,17 @@ export interface APIGatewayProxyResult {
  * @see - https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
  */
 export interface APIGatewayProxyEventV2 {
+    version: string;
     routeKey: string;
     rawPath: string;
     rawQueryString: string;
-    cookies: string[];
+    cookies?: string[];
     headers: { [name: string]: string };
-    queryStringParameters: { [name: string]: string };
+    queryStringParameters?: { [name: string]: string };
     requestContext: {
         accountId: string;
         apiId: string;
-        authorizer: {
+        authorizer?: {
             jwt: {
                 claims: { [name: string]: string };
                 scopes: string[];
@@ -128,10 +129,10 @@ export interface APIGatewayProxyEventV2 {
         time: string;
         timeEpoch: number;
     };
-    body: string;
-    pathParameters: { [name: string]: string };
+    body?: string;
+    pathParameters?: { [name: string]: string };
     isBase64Encoded: boolean;
-    stageVariables: { [name: string]: string };
+    stageVariables?: { [name: string]: string };
 }
 
 /**


### PR DESCRIPTION
- Made those properties of `APIGatewayProxyEventV2` interface optional which aren't guaranteed to be available all the time.
- Added support for API Gateway v2's ability to interpret returned strings and objects using optional generics as discussed in previous PR (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45205).
- Changed type of response's `body`. Apparently, an object assigned to `body` is accepted if response object is passed into `callback`, but when it comes to returning response from `async` lambda, this isn't accepted. AWS documentation doesn't say anything about this inconsistency, so I reverted to safety by enforcing `body` to `string` type.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html