### PR TITLE
types/stylus: Fix the Stylus.UrlOptions interface

### DIFF
--- a/types/stylus/index.d.ts
+++ b/types/stylus/index.d.ts
@@ -1421,7 +1421,7 @@ declare namespace Stylus {
     export type RenderCallback = (err: Error, css: string, js: string) => void;
 
     export interface UrlOptions {
-        limit?: number;
+        limit?: number | false | null;
         paths?: string[];
     }
 

--- a/types/stylus/index.d.ts
+++ b/types/stylus/index.d.ts
@@ -605,7 +605,7 @@ declare namespace Stylus {
     }
 
     export interface UrlFunction {
-        (options: UrlOptions): LiteralFunction;
+        (options?: UrlOptions): LiteralFunction;
 
         mimes: {
             ".gif": string;
@@ -1421,7 +1421,7 @@ declare namespace Stylus {
     export type RenderCallback = (err: Error, css: string, js: string) => void;
 
     export interface UrlOptions {
-        limit?: string;
+        limit?: number;
         paths?: string[];
     }
 

--- a/types/stylus/index.d.ts
+++ b/types/stylus/index.d.ts
@@ -1422,7 +1422,7 @@ declare namespace Stylus {
 
     export interface UrlOptions {
         limit?: string;
-        path: string;
+        paths?: string[];
     }
 
     export interface LiteralFunction {

--- a/types/stylus/stylus-tests.ts
+++ b/types/stylus/stylus-tests.ts
@@ -98,3 +98,16 @@ stylus(str)
         if (err) throw err;
         console.log(css);
     });
+
+/**
+ * stylus.url(options)
+ * https://github.com/stylus/stylus/blob/dev/docs/functions.url.md
+ */
+stylus.url();
+stylus.url({});
+stylus.url({ paths: [] });
+stylus.url({ paths: ['./test'] });
+stylus.url({ limit: 100 });
+stylus.url({ paths: ['./test'], limit: 100 });
+stylus.url({ path: './test' }); // $ExpectError
+stylus.url({ limit: '100' }); // $ExpectError

--- a/types/stylus/stylus-tests.ts
+++ b/types/stylus/stylus-tests.ts
@@ -108,6 +108,10 @@ stylus.url({});
 stylus.url({ paths: [] });
 stylus.url({ paths: ['./test'] });
 stylus.url({ limit: 100 });
+stylus.url({ limit: false });
+stylus.url({ limit: null });
 stylus.url({ paths: ['./test'], limit: 100 });
 stylus.url({ path: './test' }); // $ExpectError
 stylus.url({ limit: '100' }); // $ExpectError
+stylus.url({ limit: true }); // $ExpectError
+

--- a/types/stylus/stylus-tests.ts
+++ b/types/stylus/stylus-tests.ts
@@ -114,4 +114,3 @@ stylus.url({ paths: ['./test'], limit: 100 });
 stylus.url({ path: './test' }); // $ExpectError
 stylus.url({ limit: '100' }); // $ExpectError
 stylus.url({ limit: true }); // $ExpectError
-


### PR DESCRIPTION
## Description

The `Stylus.UrlOptions` interface is currently specifying that it has a `path: string` and `limit?: string` properties.

This is not correct. The options should be `limit?: number | false | null` and `paths?: string[]`.

See here for more details: https://stylus-lang.com/docs/functions.url.html#options.

## Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

## If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stylus-lang.com/docs/functions.url.html#options, https://github.com/stylus/stylus/blob/dev/lib/functions/url.js#L68
- [-] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [-] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
