### PR TITLE
[react-file-reader-input] Support InputHTMLAttributes props

### DIFF
--- a/types/react-file-reader-input/index.d.ts
+++ b/types/react-file-reader-input/index.d.ts
@@ -1,8 +1,10 @@
-// Type definitions for react-file-reader-input 1.1
+// Type definitions for react-file-reader-input 2.0
 // Project: https://github.com/ngokevin/react-file-reader-input
-// Definitions by: Dmitry Rogozhny <https://github.com/dmitryrogozhny>, Ali Taheri <https://github.com/alitaheri>
+// Definitions by: Dmitry Rogozhny <https://github.com/dmitryrogozhny>,
+//                 Ali Taheri <https://github.com/alitaheri>,
+//                 bjoluc <https://github.com/bjoluc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.5
 
 import * as React from 'react';
 
@@ -13,7 +15,7 @@ declare namespace FileInput {
     type Format = 'buffer' | 'binary' | 'url' | 'text';
     type Result = [ProgressEvent, File];
 
-    interface Props {
+    interface Props extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
         /**
          * what format the `FileReader` should read the file as
          * (i.e., `'buffer'`, `'binary'`, `'url'`, `'text'`).
@@ -23,7 +25,7 @@ declare namespace FileInput {
         as?: Format;
 
         /**
-         * Callback function called when the files are choosen by the user.
+         * Callback function called when the files are chosen by the user.
          *
          * Results will be an array of arrays, the size of which depending
          * on how many files were selected.
@@ -40,7 +42,7 @@ declare namespace FileInput {
          * @param event The event that triggered file changes
          * @param results The array of files
          */
-        onChange(event: React.SyntheticEvent<any>, results: Result[]): void;
+        onChange(event: React.ChangeEvent<HTMLInputElement>, results: Result[]): void;
     }
 }
 

--- a/types/react-file-reader-input/react-file-reader-input-tests.tsx
+++ b/types/react-file-reader-input/react-file-reader-input-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import FileReaderInput = require('react-file-reader-input');
+import FileReaderInput from 'react-file-reader-input';
 
 class MyComponent extends React.Component {
   handleChange = (event: React.SyntheticEvent<any>, results: FileReaderInput.Result[]) => {
@@ -13,7 +13,7 @@ class MyComponent extends React.Component {
     return (
       <form>
         <label htmlFor="my-file-input">Upload a File: </label>
-        <FileReaderInput as="binary" onChange={this.handleChange} >
+        <FileReaderInput as="binary" onChange={this.handleChange} accept=".txt">
           <button>Select a file!</button>
         </FileReaderInput>
       </form>

--- a/types/react-file-reader-input/tsconfig.json
+++ b/types/react-file-reader-input/tsconfig.json
@@ -5,6 +5,7 @@
             "es6",
             "dom"
         ],
+        "esModuleInterop": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ngokevin/react-file-reader-input#react-file-reader-input
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.