### PR TITLE
[types/react-tracking] Fix TrackingInfo async repsonse

### DIFF
--- a/types/react-tracking/index.d.ts
+++ b/types/react-tracking/index.d.ts
@@ -51,7 +51,7 @@ export interface Options<T> {
     process?(ownTrackingData: T): T | Falsy;
 }
 
-export type TrackingInfo<T, P, S> = T | ((props: P, state: S, args: any[any]) => T | Falsy);
+export type TrackingInfo<T, P, S> = T | ((props: P, state: S, args: any[any], [resp, err]: [any, any]) => T | Falsy);
 
 // Duplicated from ES6 lib to remove the `void` typing, otherwise `track` can’t be used as a HOC function that passes
 // through a JSX component that be used without casting.

--- a/types/react-tracking/index.d.ts
+++ b/types/react-tracking/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/NYTimes/react-tracking
 // Definitions by: Eloy Durán <https://github.com/alloy>
 //                 Christopher Pappas <https://github.com/damassi>
+//                 Chen Asraf <https://github.com/chenasraf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -51,7 +52,7 @@ export interface Options<T> {
     process?(ownTrackingData: T): T | Falsy;
 }
 
-export type TrackingInfo<T, P, S> = T | ((props: P, state: S, args: any[any], [resp, err]: [any, any]) => T | Falsy);
+export type TrackingInfo<T, P, S> = T | ((props: P, state: S, args: any[any], [value, err]: [any, any]) => T | Falsy);
 
 // Duplicated from ES6 lib to remove the `void` typing, otherwise `track` can’t be used as a HOC function that passes
 // through a JSX component that be used without casting.

--- a/types/react-tracking/test/react-tracking-with-types-tests.tsx
+++ b/types/react-tracking/test/react-tracking-with-types-tests.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-tracking';
 import { string } from 'prop-types';
 
-function customEventReporter(data: { page?: string }) {}
+function customEventReporter(data: { page?: string }) { }
 
 interface Props {
     someProp: string;
@@ -60,6 +60,17 @@ class ClassPage extends React.Component<Props, State> {
                 Click Me!
             </button>
         );
+    }
+
+    @track((_props, _state, _args, [resp, err]) => {
+        if (err || !resp) {
+            return { event: 'Async Error' };
+        }
+        return { event: 'Async Response' };
+    })
+    async handleAsync() {
+        // ... other stuff
+        return 'response';
     }
 }
 

--- a/types/react-tracking/test/react-tracking-without-types-tests.tsx
+++ b/types/react-tracking/test/react-tracking-without-types-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Track, track, TrackingProp, useTracking } from 'react-tracking';
 
-function customEventReporter(data: { page?: string }) {}
+function customEventReporter(data: { page?: string }) { }
 
 @track(
     { page: 'ClassPage' },
@@ -31,6 +31,18 @@ class ClassPage extends React.Component<any> {
     @track((props: any, state: any) => ({ event: `got ${props.someProp} and clicked ${state.isClicked}` }))
     render() {
         return <button onClick={this.handleClick}>Click Me!</button>;
+    }
+
+    @track({ event: 'Async' })
+    @track((_props, _state, _args, [resp, err]) => {
+        if (resp) {
+            return { result: resp, error: null };
+        }
+        return { error: err, result: null };
+    })
+    async handleAsync() {
+        // ... other stuff
+        return 'response';
     }
 }
 


### PR DESCRIPTION
In https://github.com/nytimes/react-tracking#advanced-usage, it is specified:

> When tracking asynchronous methods, you can also receive the resolved or rejected data from the returned promise in the fourth argument of the function passed in for tracking:
> ```js
>   @track((props, state, methodArgs, [{ value }, err]) => {
>   // ...
>   })
> ```

This fixes the type to allow that.

Checklist:
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.