### PR TITLE
fix(ember__test-helpers): specify context for getContext

### DIFF
--- a/types/ember__test-helpers/ember__test-helpers-tests.ts
+++ b/types/ember__test-helpers/ember__test-helpers-tests.ts
@@ -39,6 +39,7 @@ test('Context', () => {
     const context = getContext();
 
     context.owner.lookup('service:foo');
+    context.owner.register('service:foo2', class {});
 });
 
 test('DOM interactions', async () => {

--- a/types/ember__test-helpers/ember__test-helpers-tests.ts
+++ b/types/ember__test-helpers/ember__test-helpers-tests.ts
@@ -27,12 +27,19 @@ import {
     visit,
     currentURL,
     currentRouteName,
-    setApplication
+    setApplication,
+    getContext,
 } from '@ember/test-helpers';
 
 const MyApp = Application.extend({ modulePrefix: 'my-app' });
 
 setApplication(MyApp.create());
+
+test('Context', () => {
+    const context = getContext();
+
+    context.owner.lookup('service:foo');
+});
 
 test('DOM interactions', async () => {
     await render(hbs`<div class="message">Hello, world</div>`);

--- a/types/ember__test-helpers/index.d.ts
+++ b/types/ember__test-helpers/index.d.ts
@@ -189,8 +189,21 @@ declare module '@ember/test-helpers/settled' {
 declare module '@ember/test-helpers/setup-context' {
     import Resolver from '@ember/application/resolver';
 
+    interface Owner {
+      lookup: <T>(name: string) => T;
+      register: <T>(name: string, mockService: T) => void;
+    }
+    export interface AppContext {
+      element: HTMLElement;
+      owner: Owner & {
+        application: {
+          inject: (within: string, name: string, injected: string) => void;
+        };
+      };
+    }
+
     export default function<C extends object>(context: C, options?: { resolver?: Resolver }): Promise<C>;
-    export function getContext(): object;
+    export function getContext(): AppContext;
     export function setContext(context: object): void;
     export function unsetContext(): void;
 

--- a/types/ember__test-helpers/index.d.ts
+++ b/types/ember__test-helpers/index.d.ts
@@ -190,8 +190,8 @@ declare module '@ember/test-helpers/setup-context' {
     import Resolver from '@ember/application/resolver';
 
     interface Owner {
-      lookup: <T>(name: string) => T;
-      register: <T>(name: string, mockService: T) => void;
+      lookup: (name: string) => unknown;
+      register: (name: string, mockService: unknown) => void;
     }
     export interface AppContext {
       element: HTMLElement;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
 - official documentation is not writtent with the specifity that typescript needs for `getContext()` to be correct.
 - change tested here: https://github.com/NullVoxPopuli/emberclear/pull/882/commits/f61d9a63bf6c06cc4ee503825a3d37534801c39e
 - https://github.com/emberjs/ember-test-helpers/blob/a8f623d6710e55c1fee670f2be424385345fa347/addon-test-support/%40ember/test-helpers/setup-context.ts#L58
   - actually looks like there are types for this... but not exposed during build :-\
   - more to copy-paste from I guess :-\ 

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
