### PR TITLE
Add new types for ethjs-util

### DIFF
--- a/types/ethjs-util/ethjs-util-tests.ts
+++ b/types/ethjs-util/ethjs-util-tests.ts
@@ -1,0 +1,32 @@
+import {
+    isHexPrefixed,
+    stripHexPrefix,
+    padToEven,
+    intToHex,
+    intToBuffer,
+    getBinarySize,
+    arrayContainsArray,
+    toUtf8,
+    toAscii,
+    fromUtf8,
+    fromAscii,
+    getKeys,
+    isHexString,
+} from 'ethjs-util';
+
+const isHexPrefixedResult: boolean = isHexPrefixed('hoo');
+const stripHexPrefixResult: string = stripHexPrefix('hoo');
+const padToEvenResult: string = padToEven('hoo');
+const intToHexResult: string = intToHex(1);
+const intToBufferResult: Buffer = intToBuffer(1);
+const getBinarySizeResult: number = getBinarySize('hoo');
+const arrayContainsArraySomeResult: boolean = arrayContainsArray([1], [1], true);
+const arrayContainsArrayResult: boolean = arrayContainsArray([1], [1]);
+const toUtf8Result: string = toUtf8('hoo');
+const toAsciiResult: string = toAscii('hoo');
+const fromUtf8Result: string = fromUtf8('hoo');
+const fromAsciiResult: string = fromAscii('hoo');
+const getKeysResult: any[] = getKeys([{ hoo: 123 }], 'hoo');
+const getKeysAlloEmptyResult: any[] = getKeys([{ hoo: 123 }], 'hoo', true);
+const isHexStringResult: boolean = isHexString('hoo');
+const isHexStringWithNumberResult: boolean = isHexString('hoo', 123);

--- a/types/ethjs-util/index.d.ts
+++ b/types/ethjs-util/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for ethjs-util 0.1
+// Project: https://github.com/ethjs/ethjs-util#readme
+// Definitions by: tomonari-t <https://github.com/tomoari-t>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+export function isHexPrefixed(str: string): boolean;
+
+export function stripHexPrefix(str: string): string;
+
+export function padToEven(value: string): string;
+
+export function intToHex(i: number): string;
+
+export function intToBuffer(i: number): Buffer;
+
+export function getBinarySize(str: string): number;
+
+export function arrayContainsArray(superset: any[], subset: any[], some?: boolean): boolean;
+
+export function toUtf8(hex: string): string;
+
+export function toAscii(hex: string): string;
+
+export function fromUtf8(stringValue: string): string;
+
+export function fromAscii(stringValue: string): string;
+
+export function getKeys(params: any[], key: string, allowEmpty?: boolean): any[];
+
+export function isHexString(value: string, length?: number): boolean;

--- a/types/ethjs-util/tsconfig.json
+++ b/types/ethjs-util/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ethjs-util-tests.ts"
+    ]
+}

--- a/types/ethjs-util/tslint.json
+++ b/types/ethjs-util/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

