### PR TITLE
[@types/node-forge] - change return type of publicKeyFromPem() and privateKeyFromPem()

### DIFF
--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -229,8 +229,8 @@ declare module "node-forge" {
                 hash: any;
             };
             extensions: any[];
-            privateKey: rsa.PrivateKey;
-            publicKey: rsa.PublicKey;
+            privateKey: PrivateKey;
+            publicKey: PublicKey;
             md: any;
             /**
              * Sets the subject of this certificate.

--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -14,6 +14,7 @@
 //                 Rogier Schouten  <https://github.com/rogierschouten>
 //                 Ivan Aseev       <https://github.com/aseevia>
 //                 Wiktor Kwapisiewicz <https://github.com/wiktor-k>
+//                 Ligia Frangello  <https://github.com/frangello>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -228,8 +229,8 @@ declare module "node-forge" {
                 hash: any;
             };
             extensions: any[];
-            privateKey: PrivateKey;
-            publicKey: PublicKey;
+            privateKey: rsa.PrivateKey;
+            publicKey: rsa.PublicKey;
             md: any;
             /**
              * Sets the subject of this certificate.
@@ -378,9 +379,9 @@ declare module "node-forge" {
 
         function publicKeyToRSAPublicKeyPem(key: PublicKey, maxline?: number): PEM;
 
-        function publicKeyFromPem(pem: PEM): PublicKey;
+        function publicKeyFromPem(pem: PEM): rsa.PublicKey;
 
-        function privateKeyFromPem(pem: PEM): PrivateKey;
+        function privateKeyFromPem(pem: PEM): rsa.PrivateKey;
 
         function decryptPrivateKeyInfo(obj: asn1.Asn1, password: string): asn1.Asn1;
 

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -418,6 +418,4 @@ if (forge.util.fillString('1', 5) !== '11111') throw Error('forge.util.fillStrin
 {
   publicKeyRsa.encrypt('content');
   privateKeyRsa.decrypt('content');
-  cert.publicKey.encrypt('content');
-  cert.privateKey.decrypt('content');
 }

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -414,3 +414,10 @@ if (forge.util.fillString('1', 5) !== '11111') throw Error('forge.util.fillStrin
     p7.encrypt();
     let asn1: forge.asn1.Asn1 = p7.toAsn1();
 }
+
+{
+  publicKeyRsa.encrypt('content');
+  privateKeyRsa.decrypt('content');
+  cert.publicKey.encrypt('content');
+  cert.privateKey.decrypt('content');
+}


### PR DESCRIPTION
Fixes #38541 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
publicKeyFromPem(): https://github.com/digitalbazaar/forge/blob/master/lib/x509.js#L748
privateKeyFromPem(): https://github.com/digitalbazaar/forge/blob/master/lib/pki.js#L45
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

