### PR TITLE
Fix the bargap and bargroupgap to match the spec

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -341,8 +341,8 @@ export interface Layout {
     scene: Partial<Scene>;
     barmode: 'stack' | 'group' | 'overlay' | 'relative';
     barnorm: '' | 'fraction' | 'percent';
-    bargap: 0 | 1;
-    bargroupgap: 0 | 1;
+    bargap: number;
+    bargroupgap: number;
     selectdirection: 'h' | 'v' | 'd' | 'any';
     hiddenlabels: string[];
     grid: Partial<{


### PR DESCRIPTION
The spec (https://plotly.com/javascript/reference/#layout-bargap) allows a value between 0 and 1 but the types here only allow 0 or 1 which is too restrictive and would require an `as any` assertion to make this option work as intended.

Please fill in this template.

- [y] Use a meaningful title for the pull request. Include the name of the package modified.
- [y] Test the change in your own code. (Compile and run.)
- [] Add or edit tests to reflect the change. (Run with `npm test`.)
- [y] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [y] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [y] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [y] Provide a URL to documentation or source code which provides context for the suggested changes: <https://plotly.com/javascript/reference/#layout-bargap>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
