### PR TITLE
refactor(mui-datatables): updated for v3.1.x

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mui-datatables 2.14
+// Type definitions for mui-datatables 3.1
 // Project: https://github.com/gregnb/mui-datatables
 // Definitions by: Jeroen "Favna" Claassens <https://github.com/favna>
 //                 Ankith Konda <https://github.com/ankithkonda>
@@ -11,10 +11,14 @@
 import * as React from 'react';
 
 export type Display = 'true' | 'false' | 'excluded';
-export type SortDirection = 'asc' | 'desc';
 export type FilterType = 'dropdown' | 'checkbox' | 'multiselect' | 'textField' | 'custom';
-export type Responsive = 'stacked' | 'scrollMaxHeight' | 'scrollFullHeight';
+export type Responsive = 'vertical' | 'standard' | 'simple';
 export type SelectableRows = 'multiple' | 'single' | 'none';
+
+export interface MUISortOptions {
+    name: string;
+    direction: 'asc' | 'desc';
+}
 
 export interface MUIDataTableData {
     data: Array<object | number[] | string[]>;
@@ -32,7 +36,7 @@ export interface MUIDataTableState {
     columns: MUIDataTableColumnState[];
     count: number;
     data: any[];
-    displayData: Array<{dataIndex: number; data: any[]}>;
+    displayData: Array<{ dataIndex: number; data: any[] }>;
     expandedRows: MUIDataTableStateRows;
     filterData: any[];
     filterList: string[][];
@@ -60,6 +64,7 @@ export interface MUIDataTableCustomHeadRenderer extends MUIDataTableColumn {
 export interface MUIDataTableTextLabelsBody {
     noMatch: string;
     toolTip: string;
+    columnHeaderTooltip: (column: MUIDataTableColumn) => string;
 }
 
 export interface MUIDataTableTextLabelsPagination {
@@ -110,9 +115,31 @@ export interface MUIDataTableTextLabels {
 }
 
 export interface MUIDataTableFilterOptions {
+    /**
+     * Custom names for the filter fields.
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/column-filters/index.js Example}
+     */
     names?: string[];
+    /**
+     * Custom rendering inside the filter dialog.
+     * `filterList` must be of the same type in the main column options, that is an array of arrays, where each array corresponds to the filter list for a given column.
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js Example}
+     */
     display?: (filterList: string[], onChange: any, index: number, column: any) => void;
+    /**
+     * custom filter logic.
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js Example}
+     */
     logic?: (prop: string, filterValue: any[]) => boolean;
+    /**
+     * A function to customize filter choices.
+     * Use case: changing empty strings to "(empty)" in a dropdown.
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js Example}
+     *
+     */
+    renderValue?: (value: string) => string;
+    /** Will force a filter option to take up the grid's full width. */
+    fullWidth?: boolean;
 }
 
 export interface MUIDataTableCustomFilterListOptions {
@@ -126,23 +153,37 @@ export interface MUIDataTableColumnState extends MUIDataTableColumnOptions {
 }
 
 export interface MUIDataTableColumnOptions {
-    customBodyRender?: (value: any, tableMeta: MUIDataTableMeta, updateValue: (value: string) => void) => string | React.ReactNode;
-    customHeadRender?: (columnMeta: MUIDataTableCustomHeadRenderer, updateDirection: (params: any) => any) => string | React.ReactNode;
-    customFilterListRender?: (value: any) => string;
+    customBodyRender?: (
+        value: any,
+        tableMeta: MUIDataTableMeta,
+        updateValue: (value: string) => void,
+    ) => string | React.ReactNode;
+    /**
+     * Similar to and performing better than `customBodyRender`, however with the following caveats:
+     * 1. The value returned from this function is not used for filtering, so the filter dialog will use the raw data from the data array.
+     * 2. This method only gives you the dataIndex and rowIndex, leaving you to lookup the column value.
+     */
+    customBodyRenderLite?: (dataIndex: number, rowIndex: number) => string | React.ReactNode;
     customFilterListOptions?: MUIDataTableCustomFilterListOptions;
+    customFilterListRender?: (value: any) => string;
+    customHeadRender?: (
+        columnMeta: MUIDataTableCustomHeadRenderer,
+        updateDirection: (params: any) => any,
+    ) => string | React.ReactNode;
     display?: 'true' | 'false' | 'excluded';
     download?: boolean;
     empty?: boolean;
     filter?: boolean;
-    filterType?: FilterType;
     filterList?: string[];
     filterOptions?: MUIDataTableFilterOptions;
+    filterType?: FilterType;
     hint?: string;
     print?: boolean;
     searchable?: boolean;
     setCellHeaderProps?: (columnMeta: MUIDataTableCustomHeadRenderer) => object;
     setCellProps?: (cellValue: string, rowIndex: number, columnIndex: number) => object;
     sort?: boolean;
+    /** @deprecated use `sortOrder` instead */
     sortDirection?: 'asc' | 'desc' | 'none';
     viewColumns?: boolean;
 }
@@ -159,120 +200,154 @@ export interface MUIDataTableIsRowCheck {
     ];
 }
 
-export interface MUIDataTableOptions {
-    caseSensitive?: boolean;
-    count?: number;
-    customFilterDialogFooter?: (filterList: any[]) => React.ReactNode;
-    customFooter?: (
+export type MUIDataTableOptions = Partial<{
+    caseSensitive: boolean;
+    confirmFilters: boolean;
+    count: number;
+    customFilterDialogFooter: (filterList: any[], applyNewFilters?: (...args: any[]) => any) => React.ReactNode;
+    customFooter: (
         rowCount: number,
         page: number,
         rowsPerPage: number,
         changeRowsPerPage: (page: string | number) => void,
-        changePage: (newPage: number) => void
+        changePage: (newPage: number) => void,
     ) => React.ReactNode;
-    customRowRender?: (data: any[], dataIndex: number, rowIndex: number) => React.ReactNode;
-    customSearch?: (searchQuery: string, currentRow: any[], columns: any[]) => boolean;
-    customSearchRender?: (
+    customRowRender: (data: any[], dataIndex: number, rowIndex: number) => React.ReactNode;
+    customSearch: (searchQuery: string, currentRow: any[], columns: any[]) => boolean;
+    customSearchRender: (
         searchText: string,
         handleSearch: any,
         hideSearch: any,
-        options: any
+        options: any,
     ) => React.Component | JSX.Element;
-    customSort?: (data: any[], colIndex: number, order: string) => any[];
-    customToolbar?: () => React.ReactNode;
-    customToolbarSelect?: (
-        selectedRows: {
-            data: Array<{ index: number; dataIndex: number }>;
-            lookup: { [key: number]: boolean };
-        },
+    customSort: (data: any[], colIndex: number, order: string) => any[];
+    customTableBodyFooterRender: (options: { data: any[]; selectableRows: SelectableRows; columns: any[] }) => any;
+    customToolbar: () => React.ReactNode;
+    customToolbarSelect: (
+        selectedRows: { data: Array<{ index: number; dataIndex: number }>; lookup: { [key: number]: boolean } },
         displayData: Array<{ data: any[]; dataIndex: number }>,
-        setSelectedRows: (rows: number[]) => void
+        setSelectedRows: (rows: number[]) => void,
     ) => React.ReactNode;
-    disableToolbarSelect?: boolean;
-    download?: boolean;
-    downloadOptions?: Partial<{
+    /** @deprecated use `selectToolbarPlacement` instead */
+    disableToolbarSelect: boolean;
+    download: boolean;
+    downloadOptions: Partial<{
         filename: string;
         separator: string;
         filterOptions: Partial<{ useDisplayedColumnsOnly: boolean; useDisplayedRowsOnly: boolean }>;
     }>;
-    elevation?: number;
-    expandableRows?: boolean;
-    expandableRowsOnClick?: boolean;
-    filter?: boolean;
-    filterType?: FilterType;
-    fixedHeader?: boolean;
-    fixedHeaderOptions?: {
+    elevation: number;
+    enableNestedDataAccess: string;
+    expandableRows: boolean;
+    expandableRowsHeader: boolean;
+    expandableRowsOnClick: boolean;
+    filter: boolean;
+    filterType: FilterType;
+    fixedHeader: boolean;
+    /** @deprecated use `fixedHeader` for **X** axis and `fixedSelectColumn` for **Y** axis */
+    fixedHeaderOptions: {
+        /** @deprecated use `fixedHeader` */
         xAxis: boolean;
+        /** @deprecated use `fixedSelectColumn` */
         yAxis: boolean;
     };
-    isRowExpandable?: (dataIndex: number, expandedRows?: MUIDataTableIsRowCheck) => boolean;
-    isRowSelectable?: (dataIndex: number, selectedRows?: MUIDataTableIsRowCheck) => boolean;
-    onCellClick?: (
+    fixedSelectColumn: boolean;
+    isRowExpandable: (dataIndex: number, expandedRows?: MUIDataTableIsRowCheck) => boolean;
+    isRowSelectable: (dataIndex: number, selectedRows?: MUIDataTableIsRowCheck) => boolean;
+    onCellClick: (
         colData: any,
-        cellMeta: { colIndex: number; rowIndex: number; dataIndex: number; event: React.MouseEvent }
+        cellMeta: { colIndex: number; rowIndex: number; dataIndex: number; event: React.MouseEvent },
     ) => void;
-    onChangePage?: (currentPage: number) => void;
-    onChangeRowsPerPage?: (numberOfRows: number) => void;
-    onColumnSortChange?: (changedColumn: string, direction: string) => void;
+    onChangePage: (currentPage: number) => void;
+    onChangeRowsPerPage: (numberOfRows: number) => void;
+    onColumnSortChange: (changedColumn: string, direction: 'asc' | 'desc') => void;
+    /** @deprecated use `onViewColumnsChange` instead */
     onColumnViewChange?: (changedColumn: string, action: string) => void;
     /**
      * A callback function that triggers when the user downloads the CSV file.
      * In the callback, you can control what is written to the CSV file.
      * Return false to cancel download of file.
      */
-    onDownload?: (
+    onDownload: (
         buildHead: (columns: any) => string,
         buildBody: (data: any) => string,
         columns: any,
         data: any,
     ) => string | boolean;
-    onFilterChange?: (changedColumn: string, filterList: any[], type: FilterType | 'chip' | 'reset') => void;
-    onFilterDialogOpen?: () => void;
-    onFilterDialogClose?: () => void;
-    onRowClick?: (rowData: string[], rowMeta: { dataIndex: number; rowIndex: number }) => void;
-    onRowsDelete?: (rowsDeleted: {
+    onFilterChange: (changedColumn: string, filterList: any[], type: FilterType | 'chip' | 'reset') => void;
+    /**
+     * Callback function that is triggered when a user clicks the "X" on a filter chip.
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js Example}
+     */
+    onFilterChipClose: (index: number, removedFilter: string, filterList: any[]) => void;
+    /**
+     * Callback function that is triggered when a user presses the "confirm" button on the filter popover.
+     * This occurs only if you've set `confirmFilters` option to `true`.
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js Example}
+     */
+    onFilterConfirm: (filterList: any[]) => void;
+    onFilterDialogClose: () => void;
+    onFilterDialogOpen: () => void;
+    onRowClick: (rowData: string[], rowMeta: { dataIndex: number; rowIndex: number }) => void;
+    onRowExpansionChange: (currentRowsExpanded: any[], allRowsExpanded: any[], rowsExpanded?: any[]) => void;
+    onRowsDelete: (rowsDeleted: {
         lookup: { [dataIndex: number]: boolean };
         data: Array<{ index: number; dataIndex: number }>;
     }) => void;
-    onRowsExpand?: (currentRowsExpanded: any[], allRowsExpanded: any[]) => void;
-    onRowsSelect?: (currentRowsSelected: any[], rowsSelected: any[]) => void;
-    onSearchChange?: (searchText: string) => void;
-    onSearchOpen?: () => void;
-    onSearchClose?: () => void;
-    onTableChange?: (action: string, tableState: MUIDataTableState) => void;
-    onTableInit?: (action: string, tableState: MUIDataTableState) => void;
-    page?: number;
-    pagination?: boolean;
-    print?: boolean;
-    renderExpandableRow?: (rowData: string[], rowMeta: { dataIndex: number; rowIndex: number }) => React.ReactNode;
-    resizableColumns?: boolean;
-    responsive?: Responsive;
-    rowHover?: boolean;
-    rowsPerPage?: number;
-    rowsPerPageOptions?: number[];
-    rowsExpanded?: any[];
-    rowsSelected?: any[];
-    search?: boolean;
-    searchOpen?: boolean;
-    searchPlaceholder?: string;
-    searchText?: string;
-    selectableRows?: SelectableRows;
-    selectableRowsHeader?: boolean;
-    selectableRowsOnClick?: boolean;
-    setTableProps?: () => object;
-    serverSide?: boolean;
-    serverSideFilterList?: any[];
-    setRowProps?: (row: any[], rowIndex: number) => object;
-    sort?: boolean;
-    sortFilterList?: boolean;
-    textLabels?: Partial<MUIDataTableTextLabels>;
-    viewColumns?: boolean;
-}
+    onRowSelectionChange: (currentRowsSelected: any[], allRowsSelected: any[], rowsSelected?: any[]) => void;
+    onSearchChange: (searchText: string) => void;
+    onSearchClose: () => void;
+    onSearchOpen: () => void;
+    onTableChange: (action: string, tableState: MUIDataTableState) => void;
+    onTableInit: (action: string, tableState: MUIDataTableState) => void;
+    onViewColumnsChange: (changedColumn: string, action: string) => void;
+    page: number;
+    pagination: boolean;
+    print: boolean;
+    renderExpandableRow: (rowData: string[], rowMeta: { dataIndex: number; rowIndex: number }) => React.ReactNode;
+    resizableColumns: boolean;
+    responsive: Responsive;
+    rowHover: boolean;
+    rowsExpanded: any[];
+    rowsPerPage: number;
+    rowsPerPageOptions: number[];
+    rowsSelected: any[];
+    search: boolean;
+    searchOpen: boolean;
+    searchProps: React.HTMLAttributes<HTMLInputElement>;
+    searchPlaceholder: string;
+    searchText: string;
+    selectableRows: SelectableRows;
+    selectableRowsHeader: boolean;
+    selectableRowsHideCheckboxes: boolean;
+    selectableRowsOnClick: boolean;
+    selectToolbarPlacement: 'replace' | 'above' | 'none';
+    serverSide: boolean;
+    setRowProps: (row: any[], rowIndex: number) => object;
+    setTableProps: () => object;
+    sort: boolean;
+    sortFilterList: boolean;
+    sortOrder: MUISortOptions;
+    tableBodyHeight: string;
+    tableBodyMaxHeight: string;
+    textLabels: Partial<MUIDataTableTextLabels>;
+    viewColumns: boolean;
+}>;
 
 export type MUIDataTableColumnDef = string | MUIDataTableColumn;
 
 export interface MUIDataTableProps {
     columns: MUIDataTableColumnDef[];
+    components?: Partial<{
+        TableBody: React.ReactNode;
+        TableFooter: React.ReactNode;
+        TableHead: React.ReactNode;
+        TableResize: React.ReactNode;
+        TableToolbar: React.ReactNode;
+        TableToolbarSelect: React.ReactNode;
+        TableFilterList: React.ReactNode;
+        Tooltip: React.ReactNode;
+    }>;
     data: Array<object | number[] | string[]>;
     options?: MUIDataTableOptions;
     title: string | React.ReactNode;
@@ -299,15 +374,15 @@ export interface MUIDataTableBody {
     onRowClick?: (rowData: string[], rowMeta: { dataIndex: number; rowIndex: number }) => void;
     options: object;
     searchText?: string;
-    selectRowUpdate?: (...args: any) => any;
     selectedRows?: object;
+    selectRowUpdate?: (...args: any) => any;
     toggleExpandRow?: (...args: any) => any;
 }
 
 export interface MUIDataTableBodyCell {
     children?: any;
-    className?: string;
     classes?: object;
+    className?: string;
     colIndex?: number;
     columnHeader?: any;
     dataIndex?: number;
@@ -317,8 +392,8 @@ export interface MUIDataTableBodyCell {
 }
 
 export interface MUIDataTableBodyRow {
-    className?: string;
     classes?: object;
+    className?: string;
     onClick?: (...args: any) => any;
     options: object;
     rowSelected?: boolean;
@@ -365,7 +440,7 @@ export interface MUIDataTableHeadCell {
     hint: string;
     options: object;
     sort: boolean;
-    sortDirection?: SortDirection;
+    sortOrder?: MUISortOptions;
     toggleSort: (...args: any) => any;
 }
 
@@ -394,6 +469,11 @@ export interface MUIDataTableSearch {
     onHide?: (...args: any) => any;
     onSearch?: (...args: any) => any;
     options?: object;
+    searchText?: string;
+}
+
+export interface DebouncedMUIDataTableSearch extends MUIDataTableSearch {
+    debounceWait: number;
 }
 
 export interface MUIDataTableSelectCell {
@@ -461,5 +541,14 @@ export const TableSelectCell: React.Component<MUIDataTableSelectCell>;
 export const TableToolbar: React.Component<MUIDataTableToolbar>;
 export const TableToolbarSelect: React.Component<MUIDataTableToolbarSelect>;
 export const TableViewCol: React.Component<MUIDataTableViewCol>;
+export const DebounceTableSearch: React.Component<DebouncedMUIDataTableSearch>;
+
+// Plugins
+/**
+ * Function that returns a function for the customSearchRender method. This plug-in allows you to create a debounced search which can be useful for server-side tables and tables with large data sets. 
+ * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/large-data-set/index.js Example}
+ * @param debounceWait The amount of time to wait for each action - defaults to 200
+ */
+export function debounceSearchRender(debounceWait?: number): MUIDataTableOptions['customSearchRender'];
 
 export default MUIDataTable;

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -545,7 +545,7 @@ export const DebounceTableSearch: React.Component<DebouncedMUIDataTableSearch>;
 
 // Plugins
 /**
- * Function that returns a function for the customSearchRender method. This plug-in allows you to create a debounced search which can be useful for server-side tables and tables with large data sets. 
+ * Function that returns a function for the customSearchRender method. This plug-in allows you to create a debounced search which can be useful for server-side tables and tables with large data sets.
  * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/large-data-set/index.js Example}
  * @param debounceWait The amount of time to wait for each action - defaults to 200
  */

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -1,4 +1,4 @@
-import MUIDataTable, { MUIDataTableOptions, MUIDataTableTextLabels, MUIDataTableState, MUIDataTableColumn } from 'mui-datatables';
+import MUIDataTable, { MUIDataTableColumn, MUIDataTableOptions, MUIDataTableTextLabels } from 'mui-datatables';
 import * as React from 'react';
 
 interface Props extends MUIDataTableOptions {
@@ -8,7 +8,7 @@ interface Props extends MUIDataTableOptions {
     options?: MUIDataTableOptions;
 }
 
-const MuiCustomTable: React.FC<Props> = (props) => {
+const MuiCustomTable: React.FC<Props> = props => {
     const data: string[][] = props.data.map((asset: any) => Object.values(asset));
     const columns: MUIDataTableColumn[] = [
         {
@@ -20,7 +20,6 @@ const MuiCustomTable: React.FC<Props> = (props) => {
             label: 'Name',
             options: {
                 filterType: 'custom',
-                sortDirection: 'none',
                 customBodyRender: (value, tableMeta, updateValue) => {
                     return (
                         <input
@@ -40,7 +39,7 @@ const MuiCustomTable: React.FC<Props> = (props) => {
                 filter: true,
                 customFilterListOptions: {
                     render: (value: string) => value.toUpperCase()
-                  },
+                }
             }
         },
         {
@@ -50,18 +49,16 @@ const MuiCustomTable: React.FC<Props> = (props) => {
     ];
 
     const TableOptions: MUIDataTableOptions = {
-        fixedHeaderOptions: {
-            xAxis: false,
-            yAxis: true,
-        },
+        fixedHeader: true,
+        fixedSelectColumn: false,
         filterType: 'checkbox',
-        responsive: 'scrollFullHeight',
+        responsive: 'standard',
         selectableRows: 'none',
         elevation: 0,
         rowsPerPageOptions: [5, 10, 20, 25, 50, 100],
         downloadOptions: {
             filename: 'filename.csv',
-            separator: ',',
+            separator: ','
         },
         sortFilterList: false,
         customRowRender: (data, dataIndex, rowIndex) => {
@@ -89,16 +86,6 @@ const MuiCustomTable: React.FC<Props> = (props) => {
                 </span>
             );
         },
-        onTableChange: (action, tableState: MUIDataTableState) => {
-            switch (action) {
-                case 'sort':
-                    tableState.columns.forEach(c => {
-                        if (c.sort && (c.sortDirection === 'asc' || c.sortDirection === 'desc')) {
-                            console.log(`${c.sortDirection} sort set on ${c.name}`);
-                        }
-                    });
-            }
-        },
         onRowsDelete: (rowsDeleted: {
             lookup: { [dataIndex: number]: boolean };
             data: Array<{ index: number; dataIndex: number }>;
@@ -111,58 +98,59 @@ const MuiCustomTable: React.FC<Props> = (props) => {
             body: {
                 noMatch: 'Sorry, no matching records found',
                 toolTip: 'Sort',
+                columnHeaderTooltip: column => (column.label ? `Sort on ${column.label}` : `Sort`)
             },
             pagination: {
                 next: 'Next Page',
                 previous: 'Previous Page',
                 rowsPerPage: 'Rows per page:',
-                displayRows: 'of',
+                displayRows: 'of'
             },
             toolbar: {
                 search: 'Search',
                 downloadCsv: 'Download CSV',
                 print: 'Print',
                 viewColumns: 'View Columns',
-                filterTable: 'Filter Table',
+                filterTable: 'Filter Table'
             },
             filter: {
                 all: 'All',
                 title: 'FILTERS',
-                reset: 'RESET',
+                reset: 'RESET'
             },
             viewColumns: {
                 title: 'Show Columns',
-                titleAria: 'Show/Hide Table Columns',
+                titleAria: 'Show/Hide Table Columns'
             },
             selectedRows: {
                 text: 'rows(s) selected',
                 delete: 'Delete',
-                deleteAria: 'Delete Selected Rows',
-            },
-        },
+                deleteAria: 'Delete Selected Rows'
+            }
+        }
     };
 
-    return (<MUIDataTable title={props.title} data={data} columns={columns} options={TableOptions} />);
+    return <MUIDataTable title={props.title} data={data} columns={columns} options={TableOptions} />;
 };
 
 const TableFruits = [
-    { id: 1, name: "Apple", color: "Red", amount: 1 },
-    { id: 2, name: "Pear", color: "Green", amount: 2 },
-    { id: 3, name: "Strawberry", color: "Red", amount: 5 },
-    { id: 4, name: "Banana", color: "Yellow", amount: 7 },
-    { id: 5, name: "Orange", color: "Orange", amount: 9 },
+    { id: 1, name: 'Apple', color: 'Red', amount: 1 },
+    { id: 2, name: 'Pear', color: 'Green', amount: 2 },
+    { id: 3, name: 'Strawberry', color: 'Red', amount: 5 },
+    { id: 4, name: 'Banana', color: 'Yellow', amount: 7 },
+    { id: 5, name: 'Orange', color: 'Orange', amount: 9 }
 ];
 
 const options: MUIDataTableOptions = {
     filter: true,
     filterType: 'dropdown',
-    responsive: 'scrollMaxHeight',
+    responsive: 'standard',
     onDownload: (buildHead, buildBody, columns, data) => {
         if (data) {
             return buildHead(columns) + buildBody(data);
         }
         return false;
-    },
+    }
 };
 
 <MuiCustomTable title="Awesome Table" data={TableFruits} options={options} />;

--- a/types/mui-datatables/tsconfig.json
+++ b/types/mui-datatables/tsconfig.json
@@ -8,8 +8,8 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": true,
         "strictFunctionTypes": true,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "jsx": "react",
         "typeRoots": [


### PR DESCRIPTION
1. Noticed a missing key on `textLabels.body`, this PR adds it
2. Updated the package to support `mui-datatables` version 3.1.x
3. Also covered the changes to resolve #45264 - no idea what OP there meant with "when I find more cycles", but after @danger-public alerted me of the missing property I figured I should add it.

﻿Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gregnb/mui-datatables/#localization & https://github.com/gregnb/mui-datatables/blob/master/docs/v2_to_v3_guide.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

