### PR TITLE
fix: hls.js media type should be HTMLMediaElement

### DIFF
--- a/types/hls.js/hls.js-tests.ts
+++ b/types/hls.js/hls.js-tests.ts
@@ -1,5 +1,36 @@
 import * as Hls from 'hls.js';
 
+// How to write DTS tests: https://github.com/Microsoft/dtslint#write-tests
+const mockHTMLVideoElement: HTMLVideoElement = {}; // $ExpectError
+const mockHTMLAudioElement: HTMLAudioElement = {}; // $ExpectError
+const emptyObj = {};
+
+const hls = new Hls();
+hls.attachMedia(mockHTMLVideoElement);
+hls.attachMedia(mockHTMLAudioElement);
+hls.attachMedia(emptyObj); // $ExpectError
+
+hls.on(Hls.Events.MEDIA_ATTACHING, (event: typeof Hls.Events.MEDIA_ATTACHING, data: Hls.mediaAttachingData) => {
+    const mediaElement: HTMLMediaElement = data.media;
+    // HTMLAudioElement matches HTMLMediaElement
+    const audioElement: HTMLAudioElement = data.media;
+
+    let videoElement: HTMLVideoElement = data.media; // $ExpectError
+    if (data instanceof HTMLVideoElement) {
+        videoElement = data.media as HTMLVideoElement;
+    }
+});
+hls.on(Hls.Events.MEDIA_ATTACHED, (event: typeof Hls.Events.MEDIA_ATTACHED, data: Hls.mediaAttachedData) => {
+    const mediaElement: HTMLMediaElement = data.media;
+    // HTMLAudioElement matches HTMLMediaElement
+    const audioElement: HTMLAudioElement = data.media;
+
+    let videoElement: HTMLVideoElement = data.media; // $ExpectError
+    if (data instanceof HTMLVideoElement) {
+        videoElement = data.media as HTMLVideoElement;
+    }
+});
+
 function process(playlist: string) {
     return playlist;
 }

--- a/types/hls.js/index.d.ts
+++ b/types/hls.js/index.d.ts
@@ -805,12 +805,12 @@ declare namespace Hls {
     }
 
     interface mediaAttachingData {
-        video: HTMLVideoElement;
+        media: HTMLMediaElement;
         mediaSource: string;
     }
 
     interface mediaAttachedData {
-        video: HTMLVideoElement;
+        media: HTMLMediaElement;
         mediaSource: string;
     }
 
@@ -1677,9 +1677,9 @@ declare class Hls {
      */
     startLevel: number;
     /**
-     * get: Return the bound videoElement from the hls instance
+     * get: Return the bound mediaElement (of type HTMLMediaElement, aka. HTMLVideoElement or HTMLAudioElement) from the hls instance
      */
-    readonly media?: HTMLVideoElement | null;
+    readonly media?: HTMLMediaElement | null;
     /**
      *  hls.js config
      */
@@ -1732,16 +1732,16 @@ declare class Hls {
     subtitleDisplay: boolean;
     /**
      * calling this method will:
-     *      bind videoElement and hls instances
-     *      create MediaSource and set it as video source
+     *      bind mediaElement (of type HTMLMediaElement, aka. HTMLVideoElement or HTMLAudioElement) and hls instances
+     *      create MediaSource and set it as video or audio source
      *      once MediaSource object is successfully created, MEDIA_ATTACHED event will be fired
      */
-    attachMedia(videoElement: HTMLVideoElement): void;
+    attachMedia(mediaElement: HTMLMediaElement): void;
     /**
      * calling this method will:
-     *      unbind VideoElement from hls instance
+     *      unbind HTMLMediaElement (aka. HTMLVideoElement or HTMLAudioElement) from hls instance
      *      signal the end of the stream on MediaSource
-     *      reset video source ( video.src = '' )
+     *      resets media source ( media.src = '',  )
      */
     detachMedia(): void;
     /**

--- a/types/hls.js/index.d.ts
+++ b/types/hls.js/index.d.ts
@@ -1784,7 +1784,7 @@ declare class Hls {
     /**
      * hls.js event listener
      */
-    on(event: K_MEDIA_ATTACHING, callback: (event: K_MEDIA_ATTACHING, data: Hls.mediaAttachedData) => void): void;
+    on(event: K_MEDIA_ATTACHING, callback: (event: K_MEDIA_ATTACHING, data: Hls.mediaAttachingData) => void): void;
     on(event: K_MEDIA_ATTACHED, callback: (event: K_MEDIA_ATTACHED, data: Hls.mediaAttachedData) => void): void;
     on(event: K_MEDIA_DETACHING, callback: (event: K_MEDIA_DETACHING, data: {}) => void): void;
     on(event: K_MEDIA_DETACHED, callback: (event: K_MEDIA_DETACHED, data: {}) => void): void;

--- a/types/hls.js/index.d.ts
+++ b/types/hls.js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for hls.js 0.12
+// Type definitions for hls.js 0.13
 // Project: https://github.com/video-dev/hls.js
 // Definitions by: John G. Gainfort, Jr. <https://github.com/jgainfort>
 //                 Johan Brook <https://github.com/brookback>


### PR DESCRIPTION
### This PR
hls.js works with both HTMLVideoElement and HTMLAudioElement. However, the type definition was locking it to HTMLVideoElement.
- set `hls.attachMedia` to HTMLMediaElement in order to match definitions from the base project.
- fixed declaration for `mediaAttachingData`
- fixed declaration for `mediaAttachedData`

> Note:
> `hls.mediaAttachingData` and `hls.mediaAttachedData` both declare a `mediaSource`, however I do not believe that that property is ever sent along (see triggers [here (hls.ts)](https://github.com/video-dev/hls.js/blob/e28108e401fbb4a639926f8c598c868b8e726e79/src/hls.ts#L267) and [here (buffer-controller.ts)](https://github.com/video-dev/hls.js/blob/e28108e401fbb4a639926f8c598c868b8e726e79/src/controller/buffer-controller.ts#L239))  
> Please let me know if you'd like me to update that type definition as well.

### Checklist
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

if changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
 - fix `HTMLVideoElement` to `HTMLMediaElement` source: https://github.com/video-dev/hls.js/blob/e28108e401fbb4a639926f8c598c868b8e726e79/src/hls.ts#L264
 - fix `mediaAttachingData.video` to `mediaAttachingData.media` source: https://github.com/video-dev/hls.js/blob/e28108e401fbb4a639926f8c598c868b8e726e79/src/hls.ts#L267
 - fix `mediaAttachedData.video` to `mediaAttachedData.media` source: https://github.com/video-dev/hls.js/blob/e28108e401fbb4a639926f8c598c868b8e726e79/src/controller/buffer-controller.ts#L239
 
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
