### PR TITLE
add types for Snowpack dev environment

### DIFF
--- a/types/snowpack-env/index.d.ts
+++ b/types/snowpack-env/index.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for snowpack 2.3
+// Project: https://github.com/pikapkg/snowpack#readme
+// Definitions by: Fred K. Schott <https://github.com/FredKSchott>
+//                 Michael Stramel <https://github.com/stramel>
+//                 Drew Powers <https://github.com/drwpow>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.7
+
+interface ImportMetaHot {
+    accept: any;
+    dispose(callback: () => void): void;
+    invalidate(): void;
+    decline(): void;
+}
+
+interface ImportMeta {
+    url: string;
+    hot: ImportMetaHot;
+    env: Record<string, any>;
+}

--- a/types/snowpack-env/snowpack-env-tests.ts
+++ b/types/snowpack-env/snowpack-env-tests.ts
@@ -1,0 +1,10 @@
+// Testing import.meta is not yet possible!
+// Does not work with "module": "commonjs", but linter requires it.
+
+// import.meta.env.NODE_ENV;
+// import.meta.env.FOO;
+// import.meta.hot.accept();
+// import.meta.hot.dispose(() => {});
+// import.meta.hot.invalidate();
+// import.meta.hot.decline();
+'file cannot be empty, but DefinitelyTyped test runner does not support import.meta';

--- a/types/snowpack-env/tsconfig.json
+++ b/types/snowpack-env/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "snowpack-env-tests.ts"]
+}

--- a/types/snowpack-env/tslint.json
+++ b/types/snowpack-env/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "dtslint/dt.json",
+
+    "rules": {
+        "npm-naming": false
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
