### PR TITLE
fix(sade): option & parse-lazy types

### DIFF
--- a/types/sade/index.d.ts
+++ b/types/sade/index.d.ts
@@ -27,6 +27,12 @@ declare namespace sade {
         lazy?: boolean;
     }
 
+    interface LazyOutput {
+        name: string;
+        handler: Handler;
+        args: string[];
+    }
+
     interface Sade {
         /**
          * Define one or more aliases for the current Command.
@@ -34,12 +40,15 @@ declare namespace sade {
         alias(...names: string[]): Sade;
         command(str: string, desc?: string, opts?: Readonly<CommandOptions>): Sade;
         describe(str: string | ReadonlyArray<string>): Sade;
-        option(str: string, desc: string, val?: string | number): Sade;
+        option(str: string, desc: string, val?: string | number | boolean): Sade;
         action(handler: Handler): Sade;
         example(str: string): Sade;
         version(str: string): Sade;
-        parse(arr: string[], opts?: Readonly<ParseOptions>): { args: string[]; name: string; handler: Handler } | void;
         help(str: string): void;
+
+        parse(arr: string[]): void;
+        parse(arr: string[], opts?: Readonly<{ lazy?: true } & ParseOptions>): LazyOutput;
+        parse(arr: string[], opts?: Readonly<ParseOptions>): void;
     }
 }
 

--- a/types/sade/index.d.ts
+++ b/types/sade/index.d.ts
@@ -46,9 +46,8 @@ declare namespace sade {
         version(str: string): Sade;
         help(str: string): void;
 
-        parse(arr: string[]): void;
-        parse(arr: string[], opts?: Readonly<{ lazy?: true } & ParseOptions>): LazyOutput;
-        parse(arr: string[], opts?: Readonly<ParseOptions>): void;
+        parse(arr: string[], opts: { lazy: true } & ParseOptions): LazyOutput;
+        parse(arr: string[], opts?: ParseOptions): void;
     }
 }
 

--- a/types/sade/sade-tests.ts
+++ b/types/sade/sade-tests.ts
@@ -11,13 +11,21 @@ prog.version('1.0.5')
 prog.command('build <src> <dest>')
     .describe('Build the source directory. Expects an `index.js` entry file.')
     .option('-o, --output', 'Change the name of the output file', 'bundle.js')
+    .option('-m, --minify', 'Minify production assets', true)
     .example('build src build --global --config my-conf.js')
     .example('build app public -o main.js')
     .action((src: any, dest: any, opts: any) => {});
 
 prog.help('build');
 
+// $ExpectType void
 prog.parse(argv);
+
+// $ExpectType void
+prog.parse(argv, { lazy: false });
+
+// $ExpectType LazyOutput
+prog.parse(argv, { lazy: true });
 
 // $ExpectType Sade
 prog.alias('a');


### PR DESCRIPTION
Hi there, I am `sade`'s author.

There is no `sade` version update – the types just needed some tweaking.

Thanks~!

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
