### PR TITLE
fix(es‑abstract/helpers): Fix ES namespace argument type

### DIFF
--- a/types/es-abstract/helpers/getIteratorMethod.d.ts
+++ b/types/es-abstract/helpers/getIteratorMethod.d.ts
@@ -2,6 +2,7 @@ import { PropertyKey as ESPropertyKey } from '../index';
 
 declare function getIteratorMethod<T>(
     ES: {
+        AdvanceStringIndex?(S: string, index: number, unicode: boolean): number;
         GetMethod(O: unknown, P: ESPropertyKey): ((...args: any) => any) | undefined;
         IsArray?(O: unknown): boolean;
         Type?(O: unknown): string | undefined;

--- a/types/es-abstract/helpers/isPropertyDescriptor.d.ts
+++ b/types/es-abstract/helpers/isPropertyDescriptor.d.ts
@@ -1,14 +1,10 @@
-import {
-    AccessorDescriptor as ESAccessorDescriptor,
-    DataDescriptor as ESDataDescriptor,
-    PropertyDescriptor as ESPropertyDescriptor,
-} from '../index';
+import { PropertyDescriptor as ESPropertyDescriptor } from '../index';
 
 declare function IsPropertyDescriptor(
     ES: {
         Type(O: unknown): string | undefined;
-        IsAccessorDescriptor(Desc: unknown): Desc is ESAccessorDescriptor;
-        IsDataDescriptor(Desc: unknown): Desc is ESDataDescriptor;
+        IsAccessorDescriptor(Desc: unknown): boolean;
+        IsDataDescriptor(Desc: unknown): boolean;
     },
     Desc: unknown,
 ): Desc is ESPropertyDescriptor;

--- a/types/es-abstract/helpers/isSamePropertyDescriptor.d.ts
+++ b/types/es-abstract/helpers/isSamePropertyDescriptor.d.ts
@@ -1,7 +1,9 @@
 import { PropertyDescriptor as ESPropertyDescriptor } from '../index';
 
 declare function isSamePropertyDescriptor(
-    ES: { SameValue(x: unknown, y: unknown): boolean },
+    ES: {
+        SameValue(x: unknown, y: unknown): boolean;
+    },
     D1: ESPropertyDescriptor,
     D2: ESPropertyDescriptor,
 ): boolean;

--- a/types/es-abstract/test/helpers/assertRecord.test.ts
+++ b/types/es-abstract/test/helpers/assertRecord.test.ts
@@ -1,10 +1,10 @@
-import assertRecord = require("es-abstract/helpers/assertRecord");
-import ESAbstract = require("es-abstract");
+import assertRecord = require('es-abstract/helpers/assertRecord');
+import ES5 = require('es-abstract/es5');
 
-declare const desc: ESAbstract.PropertyDescriptor;
+declare const desc: ES5.PropertyDescriptor;
 
 // $ExpectType void
-assertRecord(ESAbstract, "Property Descriptor", "desc", desc);
+assertRecord(ES5, 'Property Descriptor', 'desc', desc);
 
 // $ExpectError
-assertRecord(ESAbstract, "Property Descriptor", "desc", null);
+assertRecord(ES5, 'Property Descriptor', 'desc', null);

--- a/types/es-abstract/test/helpers/getIteratorMethod.test.ts
+++ b/types/es-abstract/test/helpers/getIteratorMethod.test.ts
@@ -1,4 +1,5 @@
 import getIteratorMethod = require('es-abstract/helpers/getIteratorMethod');
+import ES5 = require('es-abstract/es5');
 import ES2015 = require('es-abstract/es2015');
 
 declare const any: unknown;
@@ -13,3 +14,6 @@ getIteratorMethod(ES2015, undefined); // $ExpectType undefined
 getIteratorMethod(ES2015, {}); // $ExpectType undefined
 getIteratorMethod<any>(ES2015, any); // $ExpectType (() => Iterator<any, any, any>) | undefined
 getIteratorMethod(ES2015, never); // $ExpectType never
+
+// $ExpectError
+getIteratorMethod(ES5, [1]);


### PR DESCRIPTION
## Blocks:

- <https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44805>

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/ljharb/es-abstract/blob/v1.16.0/helpers/getIteratorMethod.js#L34>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
