### PR TITLE
refactor(es‑abstract/scripts): Extract and simplify intrinsics data

### DIFF
--- a/types/es-abstract/scripts/collect-intrinsics.ts
+++ b/types/es-abstract/scripts/collect-intrinsics.ts
@@ -3,540 +3,68 @@
 import path = require('path');
 import fs = require('fs');
 
+import { BaseIntrinsic, Override, BASE_INTRINSICS, LEGACY_ALIASES, BASE_INTRINSIC_DATA } from './intrinsics-data';
+
 const OUT_FILE_PATH = path.resolve(__dirname, '..', 'GetIntrinsic.d.ts');
 
-const hasSymbols = true;
-const { getPrototypeOf: getProto, getOwnPropertyDescriptor: $gOPD } = Reflect as {
-    getPrototypeOf(target: object): object | null;
-    getOwnPropertyDescriptor<T extends object, P extends PropertyKey>(
-        target: T,
-        propertyKey: P,
-    ): (P extends keyof T ? TypedPropertyDescriptor<T[P]> : PropertyDescriptor) | undefined;
-};
+const { getOwnPropertyDescriptor: $gOPD } = Reflect;
 const { getOwnPropertyNames: $gOPN } = Object;
+const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty) as typeof import('has');
 
 function isObject(value: unknown): value is object {
     if (value === undefined || value === null) return false;
     return typeof value === 'object' || typeof value === 'function';
 }
 
-// tslint:disable: only-arrow-functions space-before-function-paren
-const ThrowTypeError = (function () {
-    return $gOPD(arguments, 'callee')!.get;
-})();
-
-// tslint:disable: no-async-without-await
-const generator = function* () {};
-const asyncFn = async function () {};
-const asyncGen = async function* () {};
-// tslint:enable
-
-const generatorFunction = generator ? /** @type {GeneratorFunctionConstructor} */ generator.constructor : undefined;
-const generatorFunctionPrototype = generatorFunction ? generatorFunction.prototype : undefined;
-const generatorPrototype = generatorFunctionPrototype ? generatorFunctionPrototype.prototype : undefined;
-
-const asyncFunction = asyncFn ? /** @type {FunctionConstructor} */ asyncFn.constructor : undefined;
-
-const asyncGenFunction = asyncGen ? /** @type {AsyncGeneratorFunctionConstructor} */ asyncGen.constructor : undefined;
-const asyncGenFunctionPrototype = asyncGenFunction ? asyncGenFunction.prototype : undefined;
-const asyncGenPrototype = asyncGenFunctionPrototype ? asyncGenFunctionPrototype.prototype : undefined;
-
-// tslint:disable-next-line: ban-types
-const TypedArray = typeof Uint8Array === 'undefined' ? undefined : (getProto(Uint8Array) as Function);
-
-interface BaseIntrinsic {
-    getterType?: string;
-    get?: string;
-    overrides?: { [property: string]: string | Override | null };
-}
-
-interface Override extends BaseIntrinsic {
-    type?: string;
-}
-
-interface Intrinsic extends Override {
-    type: string;
-}
-
-const $ObjectPrototype = Object.prototype;
-const $ArrayIteratorPrototype = hasSymbols ? (getProto([][Symbol.iterator]()) as IterableIterator<any>) : undefined;
-
-// prettier-ignore
-const BASE_INTRINSICS: { [intrinsic: string]: unknown } = {
-    '%Array%': Array,
-    '%ArrayBuffer%': typeof ArrayBuffer === 'undefined' ? undefined : ArrayBuffer,
-    '%ArrayBufferPrototype%': typeof ArrayBuffer === 'undefined' ? undefined : ArrayBuffer.prototype,
-    '%ArrayIteratorPrototype%': $ArrayIteratorPrototype,
-    '%ArrayPrototype%': Array.prototype,
-    '%ArrayProto_entries%': Array.prototype.entries,
-    '%ArrayProto_forEach%': Array.prototype.forEach,
-    '%ArrayProto_keys%': Array.prototype.keys,
-    '%ArrayProto_values%': Array.prototype.values,
-    '%AsyncFromSyncIteratorPrototype%': undefined,
-    '%AsyncFunction%': asyncFunction,
-    '%AsyncFunctionPrototype%': asyncFunction ? asyncFunction.prototype : undefined,
-    '%AsyncGenerator%': asyncGenFunctionPrototype,
-    '%AsyncGeneratorFunction%': asyncGenFunction,
-    '%AsyncGeneratorPrototype%': asyncGenPrototype,
-    '%AsyncIteratorPrototype%': asyncGenPrototype ? getProto(asyncGenPrototype) : undefined,
-    '%Atomics%': typeof Atomics === 'undefined' ? undefined : Atomics,
-    '%Boolean%': Boolean,
-    '%BooleanPrototype%': Boolean.prototype,
-    '%DataView%': typeof DataView === 'undefined' ? undefined : DataView,
-    '%DataViewPrototype%': typeof DataView === 'undefined' ? undefined : DataView.prototype,
-    '%Date%': Date,
-    '%DatePrototype%': Date.prototype,
-    '%decodeURI%': decodeURI,
-    '%decodeURIComponent%': decodeURIComponent,
-    '%encodeURI%': encodeURI,
-    '%encodeURIComponent%': encodeURIComponent,
-    '%Error%': Error,
-    '%ErrorPrototype%': Error.prototype,
-    '%eval%': eval, // eslint-disable-line no-eval
-    '%EvalError%': EvalError,
-    '%EvalErrorPrototype%': EvalError.prototype,
-    '%Float32Array%': typeof Float32Array === 'undefined' ? undefined : Float32Array,
-    '%Float32ArrayPrototype%': typeof Float32Array === 'undefined' ? undefined : Float32Array.prototype,
-    '%Float64Array%': typeof Float64Array === 'undefined' ? undefined : Float64Array,
-    '%Float64ArrayPrototype%': typeof Float64Array === 'undefined' ? undefined : Float64Array.prototype,
-    '%Function%': Function,
-    '%FunctionPrototype%': Function.prototype,
-    '%Generator%': generatorFunctionPrototype,
-    '%GeneratorFunction%': generatorFunction,
-    '%GeneratorPrototype%': generatorPrototype,
-    '%Int8Array%': typeof Int8Array === 'undefined' ? undefined : Int8Array,
-    '%Int8ArrayPrototype%': typeof Int8Array === 'undefined' ? undefined : Int8Array.prototype,
-    '%Int16Array%': typeof Int16Array === 'undefined' ? undefined : Int16Array,
-    '%Int16ArrayPrototype%': typeof Int16Array === 'undefined' ? undefined : Int8Array.prototype,
-    '%Int32Array%': typeof Int32Array === 'undefined' ? undefined : Int32Array,
-    '%Int32ArrayPrototype%': typeof Int32Array === 'undefined' ? undefined : Int32Array.prototype,
-    '%isFinite%': isFinite,
-    '%isNaN%': isNaN,
-    '%IteratorPrototype%': hasSymbols ? getProto($ArrayIteratorPrototype!) : undefined,
-    '%JSON%': typeof JSON === 'object' ? JSON : undefined,
-    '%JSONParse%': typeof JSON === 'object' ? JSON.parse : undefined,
-    '%Map%': typeof Map === 'undefined' ? undefined : Map,
-    '%MapIteratorPrototype%': typeof Map === 'undefined' || !hasSymbols ? undefined : getProto(new Map()[Symbol.iterator]())!,
-    '%MapPrototype%': typeof Map === 'undefined' ? undefined : Map.prototype,
-    '%Math%': Math,
-    '%Number%': Number,
-    '%NumberPrototype%': Number.prototype,
-    '%Object%': Object,
-    '%ObjectPrototype%': $ObjectPrototype,
-    '%ObjProto_toString%': $ObjectPrototype.toString,
-    '%ObjProto_valueOf%': $ObjectPrototype.valueOf,
-    '%parseFloat%': parseFloat,
-    '%parseInt%': parseInt,
-    '%Promise%': typeof Promise === 'undefined' ? undefined : Promise,
-    '%PromisePrototype%': typeof Promise === 'undefined' ? undefined : Promise.prototype,
-    '%PromiseProto_then%': typeof Promise === 'undefined' ? undefined : Promise.prototype.then,
-    '%Promise_all%': typeof Promise === 'undefined' ? undefined : Promise.all,
-    '%Promise_reject%': typeof Promise === 'undefined' ? undefined : Promise.reject,
-    '%Promise_resolve%': typeof Promise === 'undefined' ? undefined : Promise.resolve,
-    '%Proxy%': typeof Proxy === 'undefined' ? undefined : Proxy,
-    '%RangeError%': RangeError,
-    '%RangeErrorPrototype%': RangeError.prototype,
-    '%ReferenceError%': ReferenceError,
-    '%ReferenceErrorPrototype%': ReferenceError.prototype,
-    '%Reflect%': typeof Reflect === 'undefined' ? undefined : Reflect,
-    '%RegExp%': RegExp,
-    '%RegExpPrototype%': RegExp.prototype,
-    '%Set%': typeof Set === 'undefined' ? undefined : Set,
-    '%SetIteratorPrototype%': typeof Set === 'undefined' || !hasSymbols ? undefined : getProto(new Set()[Symbol.iterator]()),
-    '%SetPrototype%': typeof Set === 'undefined' ? undefined : Set.prototype,
-    '%SharedArrayBuffer%': typeof SharedArrayBuffer === 'undefined' ? undefined : SharedArrayBuffer,
-    '%SharedArrayBufferPrototype%': typeof SharedArrayBuffer === 'undefined' ? undefined : SharedArrayBuffer.prototype,
-    '%String%': String,
-    '%StringIteratorPrototype%': hasSymbols ? getProto(''[Symbol.iterator]()) : undefined,
-    '%StringPrototype%': String.prototype,
-    '%Symbol%': hasSymbols ? Symbol : undefined,
-    '%SymbolPrototype%': hasSymbols ? Symbol.prototype : undefined,
-    '%SyntaxError%': SyntaxError,
-    '%SyntaxErrorPrototype%': SyntaxError.prototype,
-    '%ThrowTypeError%': ThrowTypeError,
-    '%TypedArray%': TypedArray,
-    '%TypedArrayPrototype%': TypedArray ? TypedArray.prototype : undefined,
-    '%TypeError%': TypeError,
-    '%TypeErrorPrototype%': TypeError.prototype,
-    '%Uint8Array%': typeof Uint8Array === 'undefined' ? undefined : Uint8Array,
-    '%Uint8ArrayPrototype%': typeof Uint8Array === 'undefined' ? undefined : Uint8Array.prototype,
-    '%Uint8ClampedArray%': typeof Uint8ClampedArray === 'undefined' ? undefined : Uint8ClampedArray,
-    '%Uint8ClampedArrayPrototype%': typeof Uint8ClampedArray === 'undefined' ? undefined : Uint8ClampedArray.prototype,
-    '%Uint16Array%': typeof Uint16Array === 'undefined' ? undefined : Uint16Array,
-    '%Uint16ArrayPrototype%': typeof Uint16Array === 'undefined' ? undefined : Uint16Array.prototype,
-    '%Uint32Array%': typeof Uint32Array === 'undefined' ? undefined : Uint32Array,
-    '%Uint32ArrayPrototype%': typeof Uint32Array === 'undefined' ? undefined : Uint32Array.prototype,
-    '%URIError%': URIError,
-    '%URIErrorPrototype%': URIError.prototype,
-    '%WeakMap%': typeof WeakMap === 'undefined' ? undefined : WeakMap,
-    '%WeakMapPrototype%': typeof WeakMap === 'undefined' ? undefined : WeakMap.prototype,
-    '%WeakSet%': typeof WeakSet === 'undefined' ? undefined : WeakSet,
-    '%WeakSetPrototype%': typeof WeakSet === 'undefined' ? undefined : WeakSet.prototype,
-};
-
-let override: Intrinsic;
-const BASE_INTRINSIC_DATA: { [intrinsic: string]: string | Intrinsic } = {
-    '%Array%': { type: 'ArrayConstructor', get: 'typeof Array' },
-    '%ArrayBuffer%': {
-        type: 'ArrayBufferConstructor',
-        get: 'typeof ArrayBuffer',
-        overrides: {
-            prototype: override = { type: 'ArrayBuffer', get: 'typeof ArrayBuffer.prototype' },
-        },
-    },
-    '%ArrayBufferPrototype%': override,
-    '%ArrayIteratorPrototype%': 'IterableIterator<any>',
-    '%ArrayPrototype%': 'typeof Array.prototype',
-    '%ArrayProto_entries%': 'typeof Array.prototype.entries',
-    '%ArrayProto_forEach%': 'typeof Array.prototype.forEach',
-    '%ArrayProto_keys%': 'typeof Array.prototype.keys',
-    '%ArrayProto_values%': 'typeof Array.prototype.values',
-    '%AsyncFromSyncIteratorPrototype%': {
-        type: 'AsyncGenerator<any>',
-        overrides: {
-            next: "AsyncGenerator<any>['next']",
-            return: "AsyncGenerator<any>['return']",
-            throw: "AsyncGenerator<any>['throw']",
-        },
-    },
-    '%AsyncFunction%': { type: 'FunctionConstructor', get: 'typeof Function' },
-    '%AsyncFunctionPrototype%': 'typeof Function.prototype',
-    '%AsyncGenerator%': override = { type: 'AsyncGeneratorFunction', overrides: { prototype: 'AsyncGenerator<any>' } },
-    '%AsyncGeneratorFunction%': { type: 'AsyncGeneratorFunctionConstructor', overrides: { prototype: override } },
-    '%AsyncGeneratorPrototype%': 'AsyncGenerator<any>',
-    '%AsyncIteratorPrototype%': 'AsyncIterable<any>',
-    '%Atomics%': { type: 'Atomics', get: 'typeof Atomics' },
-    '%BigInt64Array%': {
-        type: 'BigInt64ArrayConstructor',
-        get: 'typeof BigInt64Array',
-        overrides: { prototype: { type: 'BigInt64Array', get: 'typeof BigInt64Array.prototype' } },
-    },
-    '%BigUint64Array%': {
-        type: 'BigUint64ArrayConstructor',
-        get: 'typeof BigUint64Array',
-        overrides: { prototype: { type: 'BigUint64Array', get: 'typeof BigUint64Array.prototype' } },
-    },
-    '%Boolean%': { type: 'BooleanConstructor', get: 'typeof Boolean' },
-    '%BooleanPrototype%': 'typeof Boolean.prototype',
-    '%DataView%': {
-        type: 'DataViewConstructor',
-        get: 'typeof DataView',
-        overrides: {
-            prototype: override = { type: 'DataView', get: 'typeof DataView.prototype' },
-        },
-    },
-    '%DataViewPrototype%': override,
-    '%Date%': {
-        type: 'DateConstructor',
-        get: 'typeof Date',
-        overrides: {
-            prototype: override = {
-                type: 'Date',
-                get: 'typeof Date.prototype',
-                overrides: {
-                    getYear: null,
-                    setYear: null,
-                    toGMTString: null,
-                },
-            },
-        },
-    },
-    '%DatePrototype%': override,
-    '%decodeURI%': 'typeof decodeURI',
-    '%decodeURIComponent%': 'typeof decodeURIComponent',
-    '%encodeURI%': 'typeof encodeURI',
-    '%encodeURIComponent%': 'typeof encodeURIComponent',
-    '%Error%': {
-        type: 'ErrorConstructor',
-        get: 'typeof Error',
-        overrides: {
-            captureStackTrace: null,
-            prepareStackTrace: null,
-            stackTraceLimit: null,
-            prototype: override = { type: 'Error', get: 'typeof Error.prototype' },
-        },
-    },
-    '%ErrorPrototype%': override,
-    '%eval%': 'typeof eval',
-    '%EvalError%': {
-        type: 'EvalErrorConstructor',
-        get: 'typeof EvalError',
-        overrides: {
-            prototype: override = { type: 'EvalError', get: 'typeof EvalError.prototype' },
-        },
-    },
-    '%EvalErrorPrototype%': override,
-    '%Float32Array%': {
-        type: 'Float32ArrayConstructor',
-        get: 'typeof Float32Array',
-        overrides: {
-            prototype: override = { type: 'Float32Array', get: 'typeof Float32Array.prototype' },
-        },
-    },
-    '%Float32ArrayPrototype%': override,
-    '%Float64Array%': {
-        type: 'Float64ArrayConstructor',
-        get: 'typeof Float64Array',
-        overrides: {
-            prototype: override = { type: 'Float64Array', get: 'typeof Float64Array.prototype' },
-        },
-    },
-    '%Float64ArrayPrototype%': override,
-    '%Function%': {
-        type: 'FunctionConstructor',
-        get: 'typeof Function',
-        overrides: {
-            prototype: override = {
-                type: 'typeof Function.prototype',
-                overrides: { arguments: null, callee: null, caller: null },
-            },
-        },
-    },
-    '%FunctionPrototype%': override,
-    '%Generator%': override = { type: 'GeneratorFunction', overrides: { prototype: 'Generator<any>' } },
-    '%GeneratorFunction%': { type: 'GeneratorFunctionConstructor', overrides: { prototype: override } },
-    '%GeneratorPrototype%': 'Generator<any>',
-    '%Int8Array%': {
-        type: 'Int8ArrayConstructor',
-        get: 'typeof Int8Array',
-        overrides: {
-            prototype: override = { type: 'Int8Array', get: 'typeof Int8Array.prototype' },
-        },
-    },
-    '%Int8ArrayPrototype%': override,
-    '%Int16Array%': {
-        type: 'Int16ArrayConstructor',
-        get: 'typeof Int16Array',
-        overrides: {
-            prototype: override = { type: 'Int16Array', get: 'typeof Int16Array.prototype' },
-        },
-    },
-    '%Int16ArrayPrototype%': override,
-    '%Int32Array%': {
-        type: 'Int32ArrayConstructor',
-        get: 'typeof Int32Array',
-        overrides: {
-            prototype: override = { type: 'Int32Array', get: 'typeof Int32Array.prototype' },
-        },
-    },
-    '%Int32ArrayPrototype%': override,
-    '%isFinite%': 'typeof isFinite',
-    '%isNaN%': 'typeof isNaN',
-    '%IteratorPrototype%': 'Iterable<any>',
-    '%JSON%': { type: 'JSON', get: 'typeof JSON' },
-    '%JSONParse%': 'typeof JSON.parse',
-    '%Map%': {
-        type: 'MapConstructor',
-        get: 'typeof Map',
-        overrides: {
-            prototype: override = { type: 'typeof Map.prototype', getterType: 'Map<any, any>' },
-        },
-    },
-    '%MapIteratorPrototype%': 'IterableIterator<any>',
-    '%MapPrototype%': override,
-    '%Math%': { type: 'Math', get: 'typeof Math' },
-    '%Number%': { type: 'NumberConstructor', get: 'typeof Number' },
-    '%NumberPrototype%': 'typeof Number.prototype',
-    '%Object%': {
-        type: 'ObjectConstructor',
-        get: 'typeof Object',
-        overrides: {
-            prototype: override = {
-                type: 'typeof Object.prototype',
-                overrides: {
-                    ['__proto__']: null,
-                    __defineGetter__: null,
-                    __defineSetter__: null,
-                    __lookupGetter__: null,
-                    __lookupSetter__: null,
-                },
-            },
-        },
-    },
-    '%ObjectPrototype%': override,
-    '%ObjProto_toString%': 'typeof Object.prototype.toString',
-    '%ObjProto_valueOf%': 'typeof Object.prototype.valueOf',
-    '%parseFloat%': 'typeof parseFloat',
-    '%parseInt%': 'typeof parseInt',
-    '%Promise%': {
-        type: 'PromiseConstructor',
-        get: 'typeof Promise',
-        overrides: {
-            // TODO: Delete in v1.17:
-            allSettled: null,
-        },
-    },
-    '%PromisePrototype%': 'typeof Promise.prototype',
-    '%PromiseProto_then%': 'typeof Promise.prototype.then',
-    '%Promise_all%': 'typeof Promise.all',
-    '%Promise_reject%': 'typeof Promise.reject',
-    '%Promise_resolve%': 'typeof Promise.resolve',
-    '%Proxy%': { type: 'ProxyConstructor', get: 'typeof Proxy' },
-    '%RangeError%': {
-        type: 'RangeErrorConstructor',
-        get: 'typeof RangeError',
-        overrides: {
-            prototype: override = { type: 'RangeError', get: 'typeof RangeError.prototype' },
-        },
-    },
-    '%RangeErrorPrototype%': override,
-    '%ReferenceError%': {
-        type: 'ReferenceErrorConstructor',
-        get: 'typeof ReferenceError',
-        overrides: {
-            prototype: override = { type: 'ReferenceError', get: 'typeof ReferenceError.prototype' },
-        },
-    },
-    '%ReferenceErrorPrototype%': override,
-    '%Reflect%': 'typeof Reflect',
-    '%RegExp%': {
-        type: 'RegExpConstructor',
-        get: 'typeof RegExp',
-        overrides: {
-            input: null,
-            lastMatch: null,
-            lastParen: null,
-            leftContext: null,
-            rightContext: null,
-            prototype: override = { type: 'RegExp', get: 'typeof RegExp.prototype' },
-        },
-    },
-    '%RegExpPrototype%': override,
-    '%Set%': {
-        type: 'SetConstructor',
-        get: 'typeof Set',
-        overrides: {
-            prototype: override = { type: 'typeof Set.prototype', getterType: 'Set<any>' },
-        },
-    },
-    '%SetIteratorPrototype%': 'IterableIterator<any>',
-    '%SetPrototype%': override,
-    '%SharedArrayBuffer%': {
-        type: 'SharedArrayBufferConstructor',
-        get: 'typeof SharedArrayBuffer',
-        overrides: {
-            prototype: override = { type: 'SharedArrayBuffer', get: 'typeof SharedArrayBuffer.prototype' },
-        },
-    },
-    '%SharedArrayBufferPrototype%': override,
-    '%String%': {
-        type: 'StringConstructor',
-        get: 'typeof String',
-        overrides: {
-            prototype: override = {
-                type: 'typeof String.prototype',
-                overrides: {
-                    // TODO: Delete in v1.17:
-                    matchAll: null,
-                },
-            },
-        },
-    },
-    '%StringIteratorPrototype%': 'IterableIterator<string>',
-    '%StringPrototype%': override,
-    '%Symbol%': {
-        type: 'SymbolConstructor',
-        get: 'typeof Symbol',
-        overrides: {
-            prototype: override = { type: 'typeof Symbol.prototype', getterType: 'symbol | Symbol' },
-            // TODO: Delete in v1.17:
-            matchAll: null,
-        },
-    },
-    '%SymbolPrototype%': override,
-    '%SyntaxError%': {
-        type: 'SyntaxErrorConstructor',
-        get: 'typeof SyntaxError',
-        overrides: {
-            prototype: override = { type: 'SyntaxError', get: 'typeof SyntaxError.prototype' },
-        },
-    },
-    '%SyntaxErrorPrototype%': override,
-    '%ThrowTypeError%': '() => never',
-    // TODO: Add types for %TypedArray% and %TypedArrayPrototype%
-    '%TypeError%': {
-        type: 'TypeErrorConstructor',
-        get: 'typeof TypeError',
-        overrides: {
-            prototype: override = { type: 'TypeError', get: 'typeof TypeError.prototype' },
-        },
-    },
-    '%TypeErrorPrototype%': override,
-    '%Uint8Array%': {
-        type: 'Uint8ArrayConstructor',
-        get: 'typeof Uint8Array',
-        overrides: {
-            prototype: override = { type: 'Uint8Array', get: 'typeof Uint8Array.prototype' },
-        },
-    },
-    '%Uint8ArrayPrototype%': override,
-    '%Uint8ClampedArray%': {
-        type: 'Uint8ClampedArrayConstructor',
-        get: 'typeof Uint8ClampedArray',
-        overrides: {
-            prototype: override = { type: 'Uint8ClampedArray', get: 'typeof Uint8ClampedArray.prototype' },
-        },
-    },
-    '%Uint8ClampedArrayPrototype%': override,
-    '%Uint16Array%': {
-        type: 'Uint16ArrayConstructor',
-        get: 'typeof Uint16Array',
-        overrides: {
-            prototype: override = { type: 'Uint16Array', get: 'typeof Uint16Array.prototype' },
-        },
-    },
-    '%Uint16ArrayPrototype%': override,
-    '%Uint32Array%': {
-        type: 'Uint32ArrayConstructor',
-        get: 'typeof Uint32Array',
-        overrides: {
-            prototype: override = { type: 'Uint32Array', get: 'typeof Uint32Array.prototype' },
-        },
-    },
-    '%Uint32ArrayPrototype%': override,
-    '%URIError%': {
-        type: 'URIErrorConstructor',
-        get: 'typeof URIError',
-        overrides: {
-            prototype: override = { type: 'URIError', get: 'typeof URIError.prototype' },
-        },
-    },
-    '%URIErrorPrototype%': override,
-    '%WeakMap%': { type: 'WeakMapConstructor', get: 'typeof WeakMap' },
-    '%WeakMapPrototype%': 'typeof WeakMap.prototype',
-    '%WeakSet%': { type: 'WeakSetConstructor', get: 'typeof WeakSet' },
-    '%WeakSetPrototype%': 'typeof WeakSet.prototype',
-};
-
-interface NestedIntrinsic extends Intrinsic {
+interface NestedIntrinsic extends PrintOptions {
     isGetter: boolean;
-    propertyName: string;
+    intrinsicName: string;
     parentPath: string;
     parentType: string;
     parentGetterType?: string;
     value: unknown;
 }
 
-const nestedIntrinsics: {
-    [intrinsic: string]: NestedIntrinsic;
-} = {};
+const nestedIntrinsics: NestedIntrinsic[] = [];
 
 function appendType(parentType: string, propertyName: string) {
+    if (parentType === 'unknown' || parentType === 'any') {
+        return parentType;
+    }
     if (parentType.startsWith('typeof ') && !parentType.includes('[')) {
         return `${parentType}.${propertyName}`;
     }
     return `${parentType}['${propertyName}']`;
 }
 
-interface PrintData extends BaseIntrinsic {
+interface PrintOptions {
+    intrinsicName: string;
+    type: string;
+    value?: unknown;
+    parentPath?: string;
+    parentType?: string;
+    parentGetterType?: string;
     isGetter?: boolean;
+    data?: BaseIntrinsic;
+}
+
+enum PropertyKind {
+    UNDEFINED = 0,
+    DATA = 1,
+    ACCESSOR = 2,
 }
 
 const GENERATED_MARKER = '// ------------------------ >8 ------------------------';
 
 const fileHead = (() => {
     let fh = fs.readFileSync(OUT_FILE_PATH, { encoding: 'utf-8' });
-    fh = fh.substring(0, fh.indexOf(`\n${GENERATED_MARKER}`));
+
+    const markerIndex = fh.indexOf(`\n${GENERATED_MARKER}`);
+    if (markerIndex < 0) {
+        throw new Error('Cannot find GENERATED_MARKER in GetIntrinsic.d.ts');
+    }
+
+    fh = fh.substring(0, markerIndex);
     return fh;
 })();
 
@@ -551,87 +79,70 @@ function printIntrinsic(
         parentPath = '',
         parentType = 'unknown',
         parentGetterType = '',
+        isGetter = false,
         data,
-    }: {
-        intrinsicName: string;
-        type: string;
-        value?: unknown;
-        parentPath?: string;
-        parentType?: string;
-        parentGetterType?: string;
-        data?: PrintData;
-    },
+    }: PrintOptions,
     skipNested: boolean = false,
 ) {
     const path = parentPath ? `${parentPath}.${intrinsicName}` : intrinsicName;
     const overrides = data?.overrides;
     const get = data?.get;
-    const isGetter = data?.isGetter || false;
+    const getterType = data?.getterType;
 
-    outStream.write(`        '%${path}%': ${isGetter ? `(this: ${parentGetterType || parentType}) => ` : ''}${type};
+    outStream.write(`\
+        '%${path}%': ${isGetter ? `(this: ${parentGetterType || parentType}) => ` : ''}${type};
 `);
 
-    const propertyNames = isObject(value) && type !== 'any' && type !== 'unknown' ? $gOPN(value) : [];
-    for (const propertyName of propertyNames) {
-        if (propertyName === 'constructor') {
+    // if (hasOwn(LEGACY_ALIASES, `%${path}%`)) return;
+
+    const isObj = isObject(value);
+    const propertyNames = isObj && type !== 'any' && type !== 'unknown' ? $gOPN(value) : [];
+    for (const intrinsicName of propertyNames) {
+        if (intrinsicName === 'constructor') {
             continue;
         }
 
-        if (typeof value === 'function' && (propertyName === 'length' || propertyName === 'name')) {
+        if (typeof value === 'function' && (intrinsicName === 'length' || intrinsicName === 'name')) {
             continue;
         }
 
         if (
             // tslint:disable-next-line: strict-comparisons
             value === RegExp &&
-            propertyName.startsWith('$')
+            intrinsicName.startsWith('$')
         ) {
             continue;
         }
 
-        const desc = $gOPD(value as object, propertyName);
-        if (!desc) continue;
-
-        const isGetter = 'get' in desc;
-        const propertyValue = isGetter ? desc.get : desc.value;
-
-        let override = overrides?.[propertyName];
+        const override = overrides?.[intrinsicName];
         if (override === null) {
             continue;
         }
 
-        let propertyType;
-        if (typeof override === 'string') {
-            propertyType = override;
-            override = undefined;
-        } else {
-            propertyType = override?.type || appendType(get || type, propertyName);
-        }
+        const { kind, type: propertyType, value: propertyValue, data } = resolveProperty(
+            intrinsicName,
+            value,
+            type,
+            get,
+            override,
+        );
+        if (kind === PropertyKind.UNDEFINED) continue;
+
+        const nestedIntrinsic = {
+            intrinsicName,
+            type: propertyType,
+            value: propertyValue,
+            parentPath: path,
+            parentType: type,
+            parentGetterType: getterType,
+            isGetter: kind === PropertyKind.ACCESSOR,
+            data,
+        };
 
         if (skipNested) {
-            nestedIntrinsics[`${path}.${propertyName}`] = {
-                ...override,
-                isGetter,
-                type: propertyType,
-                value: propertyValue,
-                parentPath: path,
-                parentType: type,
-                parentGetterType: data?.getterType,
-                propertyName,
-            };
+            nestedIntrinsics[nestedIntrinsics.length] = nestedIntrinsic;
         } else {
-            printIntrinsic({
-                intrinsicName: propertyName,
-                type: propertyType,
-                value: propertyValue,
-                parentPath: path,
-                parentType: type,
-                parentGetterType: data?.getterType,
-                data: {
-                    ...override,
-                    isGetter,
-                },
-            });
+            printIntrinsic(nestedIntrinsic);
         }
     }
 
@@ -643,46 +154,72 @@ function printIntrinsic(
         })).length > 0
     ) {
         for (const propertyName of overrideNames) {
-            // tslint:disable-next-line: no-null-undefined-union
-            let override: typeof overrides[keyof typeof overrides] | undefined = overrides[propertyName];
+            const override = overrides[propertyName];
             if (override === null) {
                 continue;
             }
 
-            let propertyType;
-            if (typeof override === 'string') {
-                propertyType = override;
-                override = undefined;
-            } else {
-                propertyType = override?.type || appendType(get || type, propertyName);
-            }
+            const { kind, type: propertyType, value: propertyValue, data } = resolveProperty(
+                propertyName,
+                value,
+                type,
+                get,
+                override,
+            );
+
+            const nestedIntrinsic = {
+                intrinsicName: propertyName,
+                type: propertyType,
+                value: propertyValue,
+                parentPath: path,
+                parentType: type,
+                parentGetterType: getterType,
+                isGetter: kind === PropertyKind.ACCESSOR,
+                data,
+            };
 
             if (skipNested) {
-                nestedIntrinsics[`${path}.${propertyName}`] = {
-                    ...override,
-                    isGetter,
-                    type: propertyType,
-                    value: undefined,
-                    parentPath: path,
-                    parentType: type,
-                    parentGetterType: data?.getterType,
-                    propertyName,
-                };
+                nestedIntrinsics[nestedIntrinsics.length] = nestedIntrinsic;
             } else {
-                printIntrinsic({
-                    intrinsicName: propertyName,
-                    type: propertyType,
-                    parentPath: path,
-                    parentType: type,
-                    parentGetterType: data?.getterType,
-                    data: {
-                        ...override,
-                        isGetter,
-                    },
-                });
+                printIntrinsic(nestedIntrinsic);
             }
         }
     }
+}
+
+function resolveProperty(
+    propertyName: string,
+    value: unknown,
+    type: string,
+    get?: string,
+    override?: string | Override,
+) {
+    let propertyType;
+    if (typeof override === 'string') {
+        propertyType = override;
+        override = undefined;
+    } else {
+        propertyType = override?.type || appendType(get || type, propertyName);
+    }
+
+    let propertyValue;
+    let propertyKind: PropertyKind | null = null;
+    if (isObject(value)) {
+        propertyKind = PropertyKind.UNDEFINED;
+        const desc = $gOPD(value, propertyName);
+        if (desc) {
+            const isGetter = 'get' in desc;
+            propertyValue = isGetter ? desc.get : desc.value;
+            propertyKind = isGetter ? PropertyKind.ACCESSOR : PropertyKind.DATA;
+        }
+    }
+
+    return {
+        kind: propertyKind,
+        type: propertyType,
+        value: propertyValue,
+        data: override,
+    };
 }
 
 outStream.write(`
@@ -696,8 +233,9 @@ declare namespace GetIntrinsic {
 `);
 
 for (const intrinsicName of $gOPN(BASE_INTRINSICS)) {
-    let data: string | Intrinsic | undefined = BASE_INTRINSIC_DATA[intrinsicName];
-    const baseName = intrinsicName.slice(1, -1);
+    const alias = LEGACY_ALIASES[intrinsicName];
+    let baseName = alias ? alias[0] : intrinsicName.slice(1, -1);
+    let data: string | Override | undefined = BASE_INTRINSIC_DATA[baseName];
 
     let type: string;
     if (typeof data === 'string') {
@@ -707,40 +245,59 @@ for (const intrinsicName of $gOPN(BASE_INTRINSICS)) {
         type = data?.type || 'unknown';
     }
 
-    printIntrinsic(
-        {
-            intrinsicName: baseName,
+    let value = BASE_INTRINSICS[`%${baseName}%`];
+    let printOptions: PrintOptions = {
+        intrinsicName: baseName,
+        type,
+        value,
+        data,
+    };
+
+    if (alias) {
+        const { length } = alias;
+        let parentType;
+        let kind;
+        for (let i = 1; i < length; i++) {
+            const get = data?.get;
+            const propertyName = alias[i];
+            baseName += `.${propertyName}`;
+
+            const override = data?.overrides?.[propertyName];
+            if (override === null) {
+                throw new Error("Legacy alias can't point to `null` override");
+            }
+
+            parentType = type;
+            ({ kind, value, type, data } = resolveProperty(propertyName, value, type, get, override));
+        }
+
+        printOptions = {
+            intrinsicName: intrinsicName.slice(1, -1),
             type,
-            value: BASE_INTRINSICS[intrinsicName],
+            value,
+            parentType,
+            parentGetterType: printOptions.data?.getterType,
+            isGetter: kind === PropertyKind.ACCESSOR,
             data,
-        },
-        true,
-    );
+        };
+    }
+
+    printIntrinsic(printOptions, true);
 }
 
 outStream.write('    }\n');
 
-const nestedIntrinsicNames = $gOPN(nestedIntrinsics);
-if (nestedIntrinsicNames.length > 0) {
+if (nestedIntrinsics.length > 0) {
     outStream.write(`
     interface Intrinsics {
 `);
 
-    for (const intrinsicName of nestedIntrinsicNames) {
-        const data = nestedIntrinsics[intrinsicName];
-        const { propertyName, type, value, parentType, parentPath, parentGetterType } = data;
-        printIntrinsic({
-            intrinsicName: propertyName,
-            type,
-            value,
-            parentType,
-            parentPath,
-            parentGetterType,
-            data,
-        });
+    for (const nestedIntrinsic of nestedIntrinsics) {
+        printIntrinsic(nestedIntrinsic);
     }
 
     outStream.write('    }\n');
 }
 
 outStream.write('}\n');
+outStream.close();

--- a/types/es-abstract/scripts/intrinsics-data.ts
+++ b/types/es-abstract/scripts/intrinsics-data.ts
@@ -1,0 +1,511 @@
+const hasSymbols = true;
+const { getPrototypeOf: getProto, getOwnPropertyDescriptor: $gOPD, setPrototypeOf: setProto } = Reflect as {
+    getPrototypeOf(target: object): object | null;
+    getOwnPropertyDescriptor<T extends object, P extends PropertyKey>(
+        target: T,
+        propertyKey: P,
+    ): (P extends keyof T ? TypedPropertyDescriptor<T[P]> : PropertyDescriptor) | undefined;
+    setPrototypeOf(target: object, proto: object | null): boolean;
+};
+
+// tslint:disable: only-arrow-functions space-before-function-paren
+const ThrowTypeError = (function () {
+    return $gOPD(arguments, 'callee')!.get;
+})();
+
+// tslint:disable: no-async-without-await
+const generator = function* () {};
+const asyncFn = async function () {};
+const asyncGen = async function* () {};
+// tslint:enable
+
+const generatorFunction = generator ? /** @type {GeneratorFunctionConstructor} */ generator.constructor : undefined;
+const generatorFunctionPrototype = generatorFunction ? generatorFunction.prototype : undefined;
+const generatorPrototype = generatorFunctionPrototype ? generatorFunctionPrototype.prototype : undefined;
+
+const asyncFunction = asyncFn ? /** @type {FunctionConstructor} */ asyncFn.constructor : undefined;
+
+const asyncGenFunction = asyncGen ? /** @type {AsyncGeneratorFunctionConstructor} */ asyncGen.constructor : undefined;
+const asyncGenFunctionPrototype = asyncGenFunction ? asyncGenFunction.prototype : undefined;
+const asyncGenPrototype = asyncGenFunctionPrototype ? asyncGenFunctionPrototype.prototype : undefined;
+
+// tslint:disable-next-line: ban-types
+const TypedArray = typeof Uint8Array === 'undefined' ? undefined : (getProto(Uint8Array) as Function);
+
+const $ObjectPrototype = Object.prototype;
+const $ArrayIteratorPrototype = hasSymbols ? (getProto([][Symbol.iterator]()) as IterableIterator<any>) : undefined;
+
+export interface BaseIntrinsic {
+    getterType?: string;
+    get?: string;
+    overrides?: { [property: string]: string | Override | null };
+}
+
+export interface Override extends BaseIntrinsic {
+    type?: string;
+}
+
+export interface Intrinsic extends Override {
+    type: string;
+}
+
+// prettier-ignore
+export const BASE_INTRINSICS: { [intrinsic: string]: unknown } = {
+    '%Array%': Array,
+    '%ArrayBuffer%': typeof ArrayBuffer === 'undefined' ? undefined : ArrayBuffer,
+    '%ArrayBufferPrototype%': typeof ArrayBuffer === 'undefined' ? undefined : ArrayBuffer.prototype,
+    '%ArrayIteratorPrototype%': $ArrayIteratorPrototype,
+    '%ArrayPrototype%': Array.prototype,
+    '%ArrayProto_entries%': Array.prototype.entries,
+    '%ArrayProto_forEach%': Array.prototype.forEach,
+    '%ArrayProto_keys%': Array.prototype.keys,
+    '%ArrayProto_values%': Array.prototype.values,
+    '%AsyncFromSyncIteratorPrototype%': undefined,
+    '%AsyncFunction%': asyncFunction,
+    '%AsyncFunctionPrototype%': asyncFunction ? asyncFunction.prototype : undefined,
+    '%AsyncGenerator%': asyncGenFunctionPrototype,
+    '%AsyncGeneratorFunction%': asyncGenFunction,
+    '%AsyncGeneratorPrototype%': asyncGenPrototype,
+    '%AsyncIteratorPrototype%': asyncGenPrototype ? getProto(asyncGenPrototype) : undefined,
+    '%Atomics%': typeof Atomics === 'undefined' ? undefined : Atomics,
+    '%Boolean%': Boolean,
+    '%BooleanPrototype%': Boolean.prototype,
+    '%DataView%': typeof DataView === 'undefined' ? undefined : DataView,
+    '%DataViewPrototype%': typeof DataView === 'undefined' ? undefined : DataView.prototype,
+    '%Date%': Date,
+    '%DatePrototype%': Date.prototype,
+    '%decodeURI%': decodeURI,
+    '%decodeURIComponent%': decodeURIComponent,
+    '%encodeURI%': encodeURI,
+    '%encodeURIComponent%': encodeURIComponent,
+    '%Error%': Error,
+    '%ErrorPrototype%': Error.prototype,
+    '%eval%': eval, // eslint-disable-line no-eval
+    '%EvalError%': EvalError,
+    '%EvalErrorPrototype%': EvalError.prototype,
+    '%Float32Array%': typeof Float32Array === 'undefined' ? undefined : Float32Array,
+    '%Float32ArrayPrototype%': typeof Float32Array === 'undefined' ? undefined : Float32Array.prototype,
+    '%Float64Array%': typeof Float64Array === 'undefined' ? undefined : Float64Array,
+    '%Float64ArrayPrototype%': typeof Float64Array === 'undefined' ? undefined : Float64Array.prototype,
+    '%Function%': Function,
+    '%FunctionPrototype%': Function.prototype,
+    '%Generator%': generatorFunctionPrototype,
+    '%GeneratorFunction%': generatorFunction,
+    '%GeneratorPrototype%': generatorPrototype,
+    '%Int8Array%': typeof Int8Array === 'undefined' ? undefined : Int8Array,
+    '%Int8ArrayPrototype%': typeof Int8Array === 'undefined' ? undefined : Int8Array.prototype,
+    '%Int16Array%': typeof Int16Array === 'undefined' ? undefined : Int16Array,
+    '%Int16ArrayPrototype%': typeof Int16Array === 'undefined' ? undefined : Int8Array.prototype,
+    '%Int32Array%': typeof Int32Array === 'undefined' ? undefined : Int32Array,
+    '%Int32ArrayPrototype%': typeof Int32Array === 'undefined' ? undefined : Int32Array.prototype,
+    '%isFinite%': isFinite,
+    '%isNaN%': isNaN,
+    '%IteratorPrototype%': hasSymbols ? getProto($ArrayIteratorPrototype!) : undefined,
+    '%JSON%': typeof JSON === 'object' ? JSON : undefined,
+    '%JSONParse%': typeof JSON === 'object' ? JSON.parse : undefined,
+    '%Map%': typeof Map === 'undefined' ? undefined : Map,
+    '%MapIteratorPrototype%': typeof Map === 'undefined' || !hasSymbols ? undefined : getProto(new Map()[Symbol.iterator]())!,
+    '%MapPrototype%': typeof Map === 'undefined' ? undefined : Map.prototype,
+    '%Math%': Math,
+    '%Number%': Number,
+    '%NumberPrototype%': Number.prototype,
+    '%Object%': Object,
+    '%ObjectPrototype%': $ObjectPrototype,
+    '%ObjProto_toString%': $ObjectPrototype.toString,
+    '%ObjProto_valueOf%': $ObjectPrototype.valueOf,
+    '%parseFloat%': parseFloat,
+    '%parseInt%': parseInt,
+    '%Promise%': typeof Promise === 'undefined' ? undefined : Promise,
+    '%PromisePrototype%': typeof Promise === 'undefined' ? undefined : Promise.prototype,
+    '%PromiseProto_then%': typeof Promise === 'undefined' ? undefined : Promise.prototype.then,
+    '%Promise_all%': typeof Promise === 'undefined' ? undefined : Promise.all,
+    '%Promise_reject%': typeof Promise === 'undefined' ? undefined : Promise.reject,
+    '%Promise_resolve%': typeof Promise === 'undefined' ? undefined : Promise.resolve,
+    '%Proxy%': typeof Proxy === 'undefined' ? undefined : Proxy,
+    '%RangeError%': RangeError,
+    '%RangeErrorPrototype%': RangeError.prototype,
+    '%ReferenceError%': ReferenceError,
+    '%ReferenceErrorPrototype%': ReferenceError.prototype,
+    '%Reflect%': typeof Reflect === 'undefined' ? undefined : Reflect,
+    '%RegExp%': RegExp,
+    '%RegExpPrototype%': RegExp.prototype,
+    '%Set%': typeof Set === 'undefined' ? undefined : Set,
+    '%SetIteratorPrototype%': typeof Set === 'undefined' || !hasSymbols ? undefined : getProto(new Set()[Symbol.iterator]()),
+    '%SetPrototype%': typeof Set === 'undefined' ? undefined : Set.prototype,
+    '%SharedArrayBuffer%': typeof SharedArrayBuffer === 'undefined' ? undefined : SharedArrayBuffer,
+    '%SharedArrayBufferPrototype%': typeof SharedArrayBuffer === 'undefined' ? undefined : SharedArrayBuffer.prototype,
+    '%String%': String,
+    '%StringIteratorPrototype%': hasSymbols ? getProto(''[Symbol.iterator]()) : undefined,
+    '%StringPrototype%': String.prototype,
+    '%Symbol%': hasSymbols ? Symbol : undefined,
+    '%SymbolPrototype%': hasSymbols ? Symbol.prototype : undefined,
+    '%SyntaxError%': SyntaxError,
+    '%SyntaxErrorPrototype%': SyntaxError.prototype,
+    '%ThrowTypeError%': ThrowTypeError,
+    '%TypedArray%': TypedArray,
+    '%TypedArrayPrototype%': TypedArray ? TypedArray.prototype : undefined,
+    '%TypeError%': TypeError,
+    '%TypeErrorPrototype%': TypeError.prototype,
+    '%Uint8Array%': typeof Uint8Array === 'undefined' ? undefined : Uint8Array,
+    '%Uint8ArrayPrototype%': typeof Uint8Array === 'undefined' ? undefined : Uint8Array.prototype,
+    '%Uint8ClampedArray%': typeof Uint8ClampedArray === 'undefined' ? undefined : Uint8ClampedArray,
+    '%Uint8ClampedArrayPrototype%': typeof Uint8ClampedArray === 'undefined' ? undefined : Uint8ClampedArray.prototype,
+    '%Uint16Array%': typeof Uint16Array === 'undefined' ? undefined : Uint16Array,
+    '%Uint16ArrayPrototype%': typeof Uint16Array === 'undefined' ? undefined : Uint16Array.prototype,
+    '%Uint32Array%': typeof Uint32Array === 'undefined' ? undefined : Uint32Array,
+    '%Uint32ArrayPrototype%': typeof Uint32Array === 'undefined' ? undefined : Uint32Array.prototype,
+    '%URIError%': URIError,
+    '%URIErrorPrototype%': URIError.prototype,
+    '%WeakMap%': typeof WeakMap === 'undefined' ? undefined : WeakMap,
+    '%WeakMapPrototype%': typeof WeakMap === 'undefined' ? undefined : WeakMap.prototype,
+    '%WeakSet%': typeof WeakSet === 'undefined' ? undefined : WeakSet,
+    '%WeakSetPrototype%': typeof WeakSet === 'undefined' ? undefined : WeakSet.prototype,
+};
+setProto(BASE_INTRINSICS, null);
+
+// prettier-ignore
+export const LEGACY_ALIASES: { [intrinsic: string]: string[] } = {
+    '%ArrayBufferPrototype%': ['ArrayBuffer', 'prototype'],
+    '%ArrayPrototype%': ['Array', 'prototype'],
+    '%ArrayProto_entries%': ['Array', 'prototype', 'entries'],
+    '%ArrayProto_forEach%': ['Array', 'prototype', 'forEach'],
+    '%ArrayProto_keys%': ['Array', 'prototype', 'keys'],
+    '%ArrayProto_values%': ['Array', 'prototype', 'values'],
+    '%AsyncFunctionPrototype%': ['AsyncFunction', 'prototype'],
+    '%BooleanPrototype%': ['Boolean', 'prototype'],
+    '%DataViewPrototype%': ['DataView', 'prototype'],
+    '%DatePrototype%': ['Date', 'prototype'],
+    '%ErrorPrototype%': ['Error', 'prototype'],
+    '%EvalErrorPrototype%': ['EvalError', 'prototype'],
+    '%Float32ArrayPrototype%': ['Float32Array', 'prototype'],
+    '%Float64ArrayPrototype%': ['Float64Array', 'prototype'],
+    '%FunctionPrototype%': ['Function', 'prototype'],
+    '%Int8ArrayPrototype%': ['Int8Array', 'prototype'],
+    '%Int16ArrayPrototype%': ['Int16Array', 'prototype'],
+    '%Int32ArrayPrototype%': ['Int32Array', 'prototype'],
+    '%JSONParse%': ['JSON', 'parse'],
+    '%JSONStringify%': ['JSON', 'stringify'],
+    '%MapPrototype%': ['Map', 'prototype'],
+    '%NumberPrototype%': ['Number', 'prototype'],
+    '%ObjectPrototype%': ['Object', 'prototype'],
+    '%ObjProto_toString%': ['Object', 'prototype', 'toString'],
+    '%ObjProto_valueOf%': ['Object', 'prototype', 'valueOf'],
+    '%PromisePrototype%': ['Promise', 'prototype'],
+    '%PromiseProto_then%': ['Promise', 'prototype', 'then'],
+    '%Promise_all%': ['Promise', 'all'],
+    '%Promise_reject%': ['Promise', 'reject'],
+    '%Promise_resolve%': ['Promise', 'resolve'],
+    '%RangeErrorPrototype%': ['RangeError', 'prototype'],
+    '%ReferenceErrorPrototype%': ['ReferenceError', 'prototype'],
+    '%RegExpPrototype%': ['RegExp', 'prototype'],
+    '%SetPrototype%': ['Set', 'prototype'],
+    '%SharedArrayBufferPrototype%': ['SharedArrayBuffer', 'prototype'],
+    '%StringPrototype%': ['String', 'prototype'],
+    '%SymbolPrototype%': ['Symbol', 'prototype'],
+    '%SyntaxErrorPrototype%': ['SyntaxError', 'prototype'],
+    '%TypedArrayPrototype%': ['TypedArray', 'prototype'],
+    '%TypeErrorPrototype%': ['TypeError', 'prototype'],
+    '%Uint8ArrayPrototype%': ['Uint8Array', 'prototype'],
+    '%Uint8ClampedArrayPrototype%': ['Uint8ClampedArray', 'prototype'],
+    '%Uint16ArrayPrototype%': ['Uint16Array', 'prototype'],
+    '%Uint32ArrayPrototype%': ['Uint32Array', 'prototype'],
+    '%URIErrorPrototype%': ['URIError', 'prototype'],
+    '%WeakMapPrototype%': ['WeakMap', 'prototype'],
+    '%WeakSetPrototype%': ['WeakSet', 'prototype']
+};
+setProto(LEGACY_ALIASES, null);
+
+let override: Intrinsic;
+export const BASE_INTRINSIC_DATA: { [intrinsic: string]: string | Intrinsic } = {
+    Array: { type: 'ArrayConstructor', get: 'typeof Array' },
+    ArrayBuffer: {
+        type: 'ArrayBufferConstructor',
+        get: 'typeof ArrayBuffer',
+        overrides: {
+            prototype: { type: 'ArrayBuffer', get: 'typeof ArrayBuffer.prototype' },
+        },
+    },
+    ArrayIteratorPrototype: 'IterableIterator<any>',
+    AsyncFromSyncIteratorPrototype: {
+        type: 'AsyncGenerator<any>',
+        overrides: {
+            next: "AsyncGenerator<any>['next']",
+            return: "AsyncGenerator<any>['return']",
+            throw: "AsyncGenerator<any>['throw']",
+        },
+    },
+    AsyncFunction: { type: 'FunctionConstructor', get: 'typeof Function' },
+    AsyncGenerator: override = { type: 'AsyncGeneratorFunction', overrides: { prototype: 'AsyncGenerator<any>' } },
+    AsyncGeneratorFunction: { type: 'AsyncGeneratorFunctionConstructor', overrides: { prototype: override } },
+    AsyncGeneratorPrototype: 'AsyncGenerator<any>',
+    AsyncIteratorPrototype: 'AsyncIterable<any>',
+    Atomics: { type: 'Atomics', get: 'typeof Atomics' },
+    BigInt: { type: 'BigIntConstructor', get: 'typeof BigInt' },
+    BigInt64Array: {
+        type: 'BigInt64ArrayConstructor',
+        get: 'typeof BigInt64Array',
+        overrides: { prototype: { type: 'BigInt64Array', get: 'typeof BigInt64Array.prototype' } },
+    },
+    BigUint64Array: {
+        type: 'BigUint64ArrayConstructor',
+        get: 'typeof BigUint64Array',
+        overrides: { prototype: { type: 'BigUint64Array', get: 'typeof BigUint64Array.prototype' } },
+    },
+    Boolean: { type: 'BooleanConstructor', get: 'typeof Boolean' },
+    DataView: {
+        type: 'DataViewConstructor',
+        get: 'typeof DataView',
+        overrides: {
+            prototype: { type: 'DataView', get: 'typeof DataView.prototype' },
+        },
+    },
+    Date: {
+        type: 'DateConstructor',
+        get: 'typeof Date',
+        overrides: {
+            prototype: {
+                type: 'Date',
+                get: 'typeof Date.prototype',
+                overrides: {
+                    getYear: null,
+                    setYear: null,
+                    toGMTString: null,
+                },
+            },
+        },
+    },
+    decodeURI: 'typeof decodeURI',
+    decodeURIComponent: 'typeof decodeURIComponent',
+    encodeURI: 'typeof encodeURI',
+    encodeURIComponent: 'typeof encodeURIComponent',
+    Error: {
+        type: 'ErrorConstructor',
+        get: 'typeof Error',
+        overrides: {
+            captureStackTrace: null,
+            prepareStackTrace: null,
+            stackTraceLimit: null,
+            prototype: { type: 'Error', get: 'typeof Error.prototype' },
+        },
+    },
+    eval: 'typeof eval',
+    EvalError: {
+        type: 'EvalErrorConstructor',
+        get: 'typeof EvalError',
+        overrides: {
+            prototype: { type: 'EvalError', get: 'typeof EvalError.prototype' },
+        },
+    },
+    Float32Array: {
+        type: 'Float32ArrayConstructor',
+        get: 'typeof Float32Array',
+        overrides: {
+            prototype: { type: 'Float32Array', get: 'typeof Float32Array.prototype' },
+        },
+    },
+    Float64Array: {
+        type: 'Float64ArrayConstructor',
+        get: 'typeof Float64Array',
+        overrides: {
+            prototype: { type: 'Float64Array', get: 'typeof Float64Array.prototype' },
+        },
+    },
+    Function: {
+        type: 'FunctionConstructor',
+        get: 'typeof Function',
+        overrides: {
+            prototype: {
+                type: 'typeof Function.prototype',
+                overrides: {
+                    arguments: null,
+                    callee: null,
+                    caller: null,
+                },
+            },
+        },
+    },
+    Generator: override = { type: 'GeneratorFunction', overrides: { prototype: 'Generator<any>' } },
+    GeneratorFunction: { type: 'GeneratorFunctionConstructor', overrides: { prototype: override } },
+    GeneratorPrototype: 'Generator<any>',
+    Int8Array: {
+        type: 'Int8ArrayConstructor',
+        get: 'typeof Int8Array',
+        overrides: {
+            prototype: { type: 'Int8Array', get: 'typeof Int8Array.prototype' },
+        },
+    },
+    Int16Array: {
+        type: 'Int16ArrayConstructor',
+        get: 'typeof Int16Array',
+        overrides: {
+            prototype: { type: 'Int16Array', get: 'typeof Int16Array.prototype' },
+        },
+    },
+    Int32Array: {
+        type: 'Int32ArrayConstructor',
+        get: 'typeof Int32Array',
+        overrides: {
+            prototype: { type: 'Int32Array', get: 'typeof Int32Array.prototype' },
+        },
+    },
+    isFinite: 'typeof isFinite',
+    isNaN: 'typeof isNaN',
+    IteratorPrototype: 'Iterable<any>',
+    JSON: { type: 'JSON', get: 'typeof JSON' },
+    Map: {
+        type: 'MapConstructor',
+        get: 'typeof Map',
+        overrides: {
+            prototype: { type: 'typeof Map.prototype', getterType: 'Map<any, any>' },
+        },
+    },
+    MapIteratorPrototype: 'IterableIterator<any>',
+    Math: { type: 'Math', get: 'typeof Math' },
+    Number: { type: 'NumberConstructor', get: 'typeof Number' },
+    Object: {
+        type: 'ObjectConstructor',
+        get: 'typeof Object',
+        overrides: {
+            prototype: {
+                type: 'typeof Object.prototype',
+                overrides: {
+                    ['__proto__']: null,
+                    __defineGetter__: null,
+                    __defineSetter__: null,
+                    __lookupGetter__: null,
+                    __lookupSetter__: null,
+                },
+            },
+        },
+    },
+    parseFloat: 'typeof parseFloat',
+    parseInt: 'typeof parseInt',
+    Promise: {
+        type: 'PromiseConstructor',
+        get: 'typeof Promise',
+        overrides: {
+            // TODO: Delete in v1.17:
+            allSettled: null,
+        },
+    },
+    Proxy: { type: 'ProxyConstructor', get: 'typeof Proxy' },
+    RangeError: {
+        type: 'RangeErrorConstructor',
+        get: 'typeof RangeError',
+        overrides: {
+            prototype: { type: 'RangeError', get: 'typeof RangeError.prototype' },
+        },
+    },
+    ReferenceError: {
+        type: 'ReferenceErrorConstructor',
+        get: 'typeof ReferenceError',
+        overrides: {
+            prototype: { type: 'ReferenceError', get: 'typeof ReferenceError.prototype' },
+        },
+    },
+    Reflect: 'typeof Reflect',
+    RegExp: {
+        type: 'RegExpConstructor',
+        get: 'typeof RegExp',
+        overrides: {
+            input: null,
+            lastMatch: null,
+            lastParen: null,
+            leftContext: null,
+            rightContext: null,
+            prototype: { type: 'RegExp', get: 'typeof RegExp.prototype' },
+        },
+    },
+    Set: {
+        type: 'SetConstructor',
+        get: 'typeof Set',
+        overrides: {
+            prototype: { type: 'typeof Set.prototype', getterType: 'Set<any>' },
+        },
+    },
+    SetIteratorPrototype: 'IterableIterator<any>',
+    SharedArrayBuffer: {
+        type: 'SharedArrayBufferConstructor',
+        get: 'typeof SharedArrayBuffer',
+        overrides: {
+            prototype: { type: 'SharedArrayBuffer', get: 'typeof SharedArrayBuffer.prototype' },
+        },
+    },
+    String: {
+        type: 'StringConstructor',
+        get: 'typeof String',
+        overrides: {
+            prototype: {
+                type: 'typeof String.prototype',
+                overrides: {
+                    // TODO: Delete in v1.17:
+                    matchAll: null,
+                },
+            },
+        },
+    },
+    StringIteratorPrototype: 'IterableIterator<string>',
+    Symbol: {
+        type: 'SymbolConstructor',
+        get: 'typeof Symbol',
+        overrides: {
+            prototype: { type: 'typeof Symbol.prototype', getterType: 'symbol | Symbol' },
+            // TODO: Delete in v1.17:
+            matchAll: null,
+        },
+    },
+    SyntaxError: {
+        type: 'SyntaxErrorConstructor',
+        get: 'typeof SyntaxError',
+        overrides: {
+            prototype: { type: 'SyntaxError', get: 'typeof SyntaxError.prototype' },
+        },
+    },
+    ThrowTypeError: '() => never',
+    // TODO: Add types for %TypedArray%
+    TypeError: {
+        type: 'TypeErrorConstructor',
+        get: 'typeof TypeError',
+        overrides: {
+            prototype: { type: 'TypeError', get: 'typeof TypeError.prototype' },
+        },
+    },
+    Uint8Array: {
+        type: 'Uint8ArrayConstructor',
+        get: 'typeof Uint8Array',
+        overrides: {
+            prototype: { type: 'Uint8Array', get: 'typeof Uint8Array.prototype' },
+        },
+    },
+    Uint8ClampedArray: {
+        type: 'Uint8ClampedArrayConstructor',
+        get: 'typeof Uint8ClampedArray',
+        overrides: {
+            prototype: { type: 'Uint8ClampedArray', get: 'typeof Uint8ClampedArray.prototype' },
+        },
+    },
+    Uint16Array: {
+        type: 'Uint16ArrayConstructor',
+        get: 'typeof Uint16Array',
+        overrides: {
+            prototype: { type: 'Uint16Array', get: 'typeof Uint16Array.prototype' },
+        },
+    },
+    Uint32Array: {
+        type: 'Uint32ArrayConstructor',
+        get: 'typeof Uint32Array',
+        overrides: {
+            prototype: { type: 'Uint32Array', get: 'typeof Uint32Array.prototype' },
+        },
+    },
+    URIError: {
+        type: 'URIErrorConstructor',
+        get: 'typeof URIError',
+        overrides: {
+            prototype: { type: 'URIError', get: 'typeof URIError.prototype' },
+        },
+    },
+    WeakMap: { type: 'WeakMapConstructor', get: 'typeof WeakMap' },
+    WeakSet: { type: 'WeakSetConstructor', get: 'typeof WeakSet' },
+};
+setProto(BASE_INTRINSIC_DATA, null);

--- a/types/es-abstract/test/GetIntrinsic.test.ts
+++ b/types/es-abstract/test/GetIntrinsic.test.ts
@@ -4,447 +4,815 @@ declare const boolean: boolean;
 // allowMissing = undefined
 {
     GetIntrinsic('%Array%'); // $ExpectType ArrayConstructor
-    GetIntrinsic('%ArrayBuffer%'); // $ExpectType ArrayBufferConstructor
-    GetIntrinsic('%ArrayBufferPrototype%'); // $ExpectType ArrayBuffer
-    GetIntrinsic('%ArrayIteratorPrototype%'); // $ExpectType IterableIterator<any>
+    GetIntrinsic('%Array.prototype%'); // $ExpectType any[]
+    GetIntrinsic('%Array.prototype.entries%'); // $ExpectType () => IterableIterator<[number, any]>
+    GetIntrinsic('%Array.prototype.forEach%'); // $ExpectType (callbackfn: (value: any, index: number, array: any[]) => void, thisArg?: any) => void
+    GetIntrinsic('%Array.prototype.keys%'); // $ExpectType () => IterableIterator<number>
+    GetIntrinsic('%Array.prototype.values%'); // $ExpectType () => IterableIterator<any>
+
     GetIntrinsic('%ArrayPrototype%'); // $ExpectType any[]
     GetIntrinsic('%ArrayProto_entries%'); // $ExpectType () => IterableIterator<[number, any]>
     GetIntrinsic('%ArrayProto_forEach%'); // $ExpectType (callbackfn: (value: any, index: number, array: any[]) => void, thisArg?: any) => void
     GetIntrinsic('%ArrayProto_keys%'); // $ExpectType () => IterableIterator<number>
     GetIntrinsic('%ArrayProto_values%'); // $ExpectType () => IterableIterator<any>
+
+    GetIntrinsic('%ArrayBuffer%'); // $ExpectType ArrayBufferConstructor
+    GetIntrinsic('%ArrayBuffer.prototype%'); // $ExpectType ArrayBuffer
+    GetIntrinsic('%ArrayBufferPrototype%'); // $ExpectType ArrayBuffer
+
+    GetIntrinsic('%ArrayIteratorPrototype%'); // $ExpectType IterableIterator<any>
     GetIntrinsic('%AsyncFromSyncIteratorPrototype%'); // $ExpectType AsyncGenerator<any, any, unknown>
+
     GetIntrinsic('%AsyncFunction%'); // $ExpectType FunctionConstructor
+    GetIntrinsic('%AsyncFunction.prototype%'); // $ExpectType Function
     GetIntrinsic('%AsyncFunctionPrototype%'); // $ExpectType Function
+
     GetIntrinsic('%AsyncGenerator%'); // $ExpectType AsyncGeneratorFunction
     GetIntrinsic('%AsyncGeneratorFunction%'); // $ExpectType AsyncGeneratorFunctionConstructor
     GetIntrinsic('%AsyncGeneratorPrototype%'); // $ExpectType AsyncGenerator<any, any, unknown>
     GetIntrinsic('%AsyncIteratorPrototype%'); // $ExpectType AsyncIterable<any>
+
     GetIntrinsic('%Atomics%'); // $ExpectType Atomics
+
     GetIntrinsic('%Boolean%'); // $ExpectType BooleanConstructor
+    GetIntrinsic('%Boolean.prototype%'); // $ExpectType Boolean
     GetIntrinsic('%BooleanPrototype%'); // $ExpectType Boolean
+
     GetIntrinsic('%DataView%'); // $ExpectType DataViewConstructor
+    GetIntrinsic('%DataView.prototype%'); // $ExpectType DataView
     GetIntrinsic('%DataViewPrototype%'); // $ExpectType DataView
+
     GetIntrinsic('%Date%'); // $ExpectType DateConstructor
+    GetIntrinsic('%Date.prototype%'); // $ExpectType Date
     GetIntrinsic('%DatePrototype%'); // $ExpectType Date
+
     GetIntrinsic('%decodeURI%'); // $ExpectType (encodedURI: string) => string
     GetIntrinsic('%decodeURIComponent%'); // $ExpectType (encodedURIComponent: string) => string
+
     GetIntrinsic('%encodeURI%'); // $ExpectType (uri: string) => string
     GetIntrinsic('%encodeURIComponent%'); // $ExpectType (uriComponent: string | number | boolean) => string
+
     GetIntrinsic('%Error%'); // $ExpectType ErrorConstructor
+    GetIntrinsic('%Error.prototype%'); // $ExpectType Error
     GetIntrinsic('%ErrorPrototype%'); // $ExpectType Error
+
     GetIntrinsic('%eval%'); // $ExpectType (x: string) => any
+
     GetIntrinsic('%EvalError%'); // $ExpectType EvalErrorConstructor
+    GetIntrinsic('%EvalError.prototype%'); // $ExpectType EvalError
     GetIntrinsic('%EvalErrorPrototype%'); // $ExpectType EvalError
+
     GetIntrinsic('%Float32Array%'); // $ExpectType Float32ArrayConstructor
+    GetIntrinsic('%Float32Array.prototype%'); // $ExpectType Float32Array
     GetIntrinsic('%Float32ArrayPrototype%'); // $ExpectType Float32Array
+
     GetIntrinsic('%Float64Array%'); // $ExpectType Float64ArrayConstructor
+    GetIntrinsic('%Float64Array.prototype%'); // $ExpectType Float64Array
     GetIntrinsic('%Float64ArrayPrototype%'); // $ExpectType Float64Array
+
     GetIntrinsic('%Function%'); // $ExpectType FunctionConstructor
+    GetIntrinsic('%Function.prototype%'); // $ExpectType Function
     GetIntrinsic('%FunctionPrototype%'); // $ExpectType Function
+
     GetIntrinsic('%Generator%'); // $ExpectType GeneratorFunction
     GetIntrinsic('%GeneratorFunction%'); // $ExpectType GeneratorFunctionConstructor
     GetIntrinsic('%GeneratorPrototype%'); // $ExpectType Generator<any, any, unknown>
+    GetIntrinsic('%IteratorPrototype%'); // $ExpectType Iterable<any>
+
     GetIntrinsic('%Int8Array%'); // $ExpectType Int8ArrayConstructor
+    GetIntrinsic('%Int8Array.prototype%'); // $ExpectType Int8Array
     GetIntrinsic('%Int8ArrayPrototype%'); // $ExpectType Int8Array
+
     GetIntrinsic('%Int16Array%'); // $ExpectType Int16ArrayConstructor
+    GetIntrinsic('%Int16Array.prototype%'); // $ExpectType Int16Array
     GetIntrinsic('%Int16ArrayPrototype%'); // $ExpectType Int16Array
+
     GetIntrinsic('%Int32Array%'); // $ExpectType Int32ArrayConstructor
+    GetIntrinsic('%Int32Array.prototype%'); // $ExpectType Int32Array
     GetIntrinsic('%Int32ArrayPrototype%'); // $ExpectType Int32Array
+
     GetIntrinsic('%isFinite%'); // $ExpectType (number: number) => boolean
     GetIntrinsic('%isNaN%'); // $ExpectType (number: number) => boolean
-    GetIntrinsic('%IteratorPrototype%'); // $ExpectType Iterable<any>
+
     GetIntrinsic('%JSON%'); // $ExpectType JSON
     GetIntrinsic('%JSONParse%'); // $ExpectType (text: string, reviver?: ((this: any, key: string, value: any) => any) | undefined) => any
+
     GetIntrinsic('%Map%'); // $ExpectType MapConstructor
-    GetIntrinsic('%MapIteratorPrototype%'); // $ExpectType IterableIterator<any>
+    GetIntrinsic('%Map.prototype%'); // $ExpectType Map<any, any>
     GetIntrinsic('%MapPrototype%'); // $ExpectType Map<any, any>
+    GetIntrinsic('%MapIteratorPrototype%'); // $ExpectType IterableIterator<any>
+
     GetIntrinsic('%Math%'); // $ExpectType Math
+
     GetIntrinsic('%Number%'); // $ExpectType NumberConstructor
+    GetIntrinsic('%Number.prototype%'); // $ExpectType Number
     GetIntrinsic('%NumberPrototype%'); // $ExpectType Number
+
     GetIntrinsic('%Object%'); // $ExpectType ObjectConstructor
+    GetIntrinsic('%Object.prototype%'); // $ExpectType Object
     GetIntrinsic('%ObjectPrototype%'); // $ExpectType Object
     GetIntrinsic('%ObjProto_toString%'); // $ExpectType () => string
     GetIntrinsic('%ObjProto_valueOf%'); // $ExpectType () => Object
+
     GetIntrinsic('%parseFloat%'); // $ExpectType (string: string) => number
     GetIntrinsic('%parseInt%'); // $ExpectType (s: string, radix?: number | undefined) => number
+
     GetIntrinsic('%Promise%'); // $ExpectType PromiseConstructor
+    GetIntrinsic('%Promise.prototype%'); // $ExpectType Promise<any>
+    GetIntrinsic('%Promise.reject%'); // $ExpectType <T = never>(reason?: any) => Promise<T>
+    GetIntrinsic('%Promise.resolve%'); // $ExpectType { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+
     GetIntrinsic('%PromisePrototype%'); // $ExpectType Promise<any>
     GetIntrinsic('%Promise_reject%'); // $ExpectType <T = never>(reason?: any) => Promise<T>
     GetIntrinsic('%Promise_resolve%'); // $ExpectType { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+
     GetIntrinsic('%Proxy%'); // $ExpectType ProxyConstructor
+
     GetIntrinsic('%RangeError%'); // $ExpectType RangeErrorConstructor
+    GetIntrinsic('%RangeError.prototype%'); // $ExpectType RangeError
     GetIntrinsic('%RangeErrorPrototype%'); // $ExpectType RangeError
+
     GetIntrinsic('%ReferenceError%'); // $ExpectType ReferenceErrorConstructor
+    GetIntrinsic('%ReferenceError.prototype%'); // $ExpectType ReferenceError
     GetIntrinsic('%ReferenceErrorPrototype%'); // $ExpectType ReferenceError
+
     GetIntrinsic('%Reflect%'); // $ExpectType typeof Reflect
+
     GetIntrinsic('%RegExp%'); // $ExpectType RegExpConstructor
+    GetIntrinsic('%RegExp.prototype%'); // $ExpectType RegExp
     GetIntrinsic('%RegExpPrototype%'); // $ExpectType RegExp
+
     GetIntrinsic('%Set%'); // $ExpectType SetConstructor
-    GetIntrinsic('%SetIteratorPrototype%'); // $ExpectType IterableIterator<any>
+    GetIntrinsic('%Set.prototype%'); // $ExpectType Set<any>
     GetIntrinsic('%SetPrototype%'); // $ExpectType Set<any>
+    GetIntrinsic('%SetIteratorPrototype%'); // $ExpectType IterableIterator<any>
+
     GetIntrinsic('%SharedArrayBuffer%'); // $ExpectType SharedArrayBufferConstructor
+    GetIntrinsic('%SharedArrayBuffer.prototype%'); // $ExpectType SharedArrayBuffer
     GetIntrinsic('%SharedArrayBufferPrototype%'); // $ExpectType SharedArrayBuffer
+
     GetIntrinsic('%String%'); // $ExpectType StringConstructor
-    GetIntrinsic('%StringIteratorPrototype%'); // $ExpectType IterableIterator<string>
+    GetIntrinsic('%String.prototype%'); // $ExpectType String
     GetIntrinsic('%StringPrototype%'); // $ExpectType String
+    GetIntrinsic('%StringIteratorPrototype%'); // $ExpectType IterableIterator<string>
+
     GetIntrinsic('%Symbol%'); // $ExpectType SymbolConstructor
+    GetIntrinsic('%Symbol.prototype%'); // $ExpectType Symbol
     GetIntrinsic('%SymbolPrototype%'); // $ExpectType Symbol
+
     GetIntrinsic('%SyntaxError%'); // $ExpectType SyntaxErrorConstructor
+    GetIntrinsic('%SyntaxError.prototype%'); // $ExpectType SyntaxError
     GetIntrinsic('%SyntaxErrorPrototype%'); // $ExpectType SyntaxError
+
     GetIntrinsic('%ThrowTypeError%'); // $ExpectType () => never
+
     GetIntrinsic('%TypedArray%'); // $ExpectType unknown
+    GetIntrinsic('%TypedArray.prototype%'); // $ExpectType unknown
     GetIntrinsic('%TypedArrayPrototype%'); // $ExpectType unknown
+
     GetIntrinsic('%TypeError%'); // $ExpectType TypeErrorConstructor
+    GetIntrinsic('%TypeError.prototype%'); // $ExpectType TypeError
     GetIntrinsic('%TypeErrorPrototype%'); // $ExpectType TypeError
+
     GetIntrinsic('%Uint8Array%'); // $ExpectType Uint8ArrayConstructor
+    GetIntrinsic('%Uint8Array.prototype%'); // $ExpectType Uint8Array
     GetIntrinsic('%Uint8ArrayPrototype%'); // $ExpectType Uint8Array
+
     GetIntrinsic('%Uint8ClampedArray%'); // $ExpectType Uint8ClampedArrayConstructor
+    GetIntrinsic('%Uint8ClampedArray.prototype%'); // $ExpectType Uint8ClampedArray
     GetIntrinsic('%Uint8ClampedArrayPrototype%'); // $ExpectType Uint8ClampedArray
+
     GetIntrinsic('%Uint16Array%'); // $ExpectType Uint16ArrayConstructor
+    GetIntrinsic('%Uint16Array.prototype%'); // $ExpectType Uint16Array
     GetIntrinsic('%Uint16ArrayPrototype%'); // $ExpectType Uint16Array
+
     GetIntrinsic('%Uint32Array%'); // $ExpectType Uint32ArrayConstructor
+    GetIntrinsic('%Uint32Array.prototype%'); // $ExpectType Uint32Array
     GetIntrinsic('%Uint32ArrayPrototype%'); // $ExpectType Uint32Array
+
     GetIntrinsic('%URIError%'); // $ExpectType URIErrorConstructor
+    GetIntrinsic('%URIError.prototype%'); // $ExpectType URIError
     GetIntrinsic('%URIErrorPrototype%'); // $ExpectType URIError
+
     GetIntrinsic('%WeakMap%'); // $ExpectType WeakMapConstructor
+    GetIntrinsic('%WeakMap.prototype%'); // $ExpectType WeakMap<object, any>
     GetIntrinsic('%WeakMapPrototype%'); // $ExpectType WeakMap<object, any>
+
     GetIntrinsic('%WeakSet%'); // $ExpectType WeakSetConstructor
+    GetIntrinsic('%WeakSet.prototype%'); // $ExpectType WeakSet<object>
     GetIntrinsic('%WeakSetPrototype%'); // $ExpectType WeakSet<object>
+
     GetIntrinsic('unknown'); // $ExpectType unknown
 }
 
 // allowMissing = false
 {
     GetIntrinsic('%Array%', false); // $ExpectType ArrayConstructor
-    GetIntrinsic('%ArrayBuffer%', false); // $ExpectType ArrayBufferConstructor
-    GetIntrinsic('%ArrayBufferPrototype%', false); // $ExpectType ArrayBuffer
-    GetIntrinsic('%ArrayIteratorPrototype%', false); // $ExpectType IterableIterator<any>
+    GetIntrinsic('%Array.prototype%', false); // $ExpectType any[]
+    GetIntrinsic('%Array.prototype.entries%', false); // $ExpectType () => IterableIterator<[number, any]>
+    GetIntrinsic('%Array.prototype.forEach%', false); // $ExpectType (callbackfn: (value: any, index: number, array: any[]) => void, thisArg?: any) => void
+    GetIntrinsic('%Array.prototype.keys%', false); // $ExpectType () => IterableIterator<number>
+    GetIntrinsic('%Array.prototype.values%', false); // $ExpectType () => IterableIterator<any>
+
     GetIntrinsic('%ArrayPrototype%', false); // $ExpectType any[]
     GetIntrinsic('%ArrayProto_entries%', false); // $ExpectType () => IterableIterator<[number, any]>
     GetIntrinsic('%ArrayProto_forEach%', false); // $ExpectType (callbackfn: (value: any, index: number, array: any[]) => void, thisArg?: any) => void
     GetIntrinsic('%ArrayProto_keys%', false); // $ExpectType () => IterableIterator<number>
     GetIntrinsic('%ArrayProto_values%', false); // $ExpectType () => IterableIterator<any>
+
+    GetIntrinsic('%ArrayBuffer%', false); // $ExpectType ArrayBufferConstructor
+    GetIntrinsic('%ArrayBuffer.prototype%', false); // $ExpectType ArrayBuffer
+    GetIntrinsic('%ArrayBufferPrototype%', false); // $ExpectType ArrayBuffer
+
+    GetIntrinsic('%ArrayIteratorPrototype%', false); // $ExpectType IterableIterator<any>
     GetIntrinsic('%AsyncFromSyncIteratorPrototype%', false); // $ExpectType AsyncGenerator<any, any, unknown>
+
     GetIntrinsic('%AsyncFunction%', false); // $ExpectType FunctionConstructor
+    GetIntrinsic('%AsyncFunction.prototype%', false); // $ExpectType Function
     GetIntrinsic('%AsyncFunctionPrototype%', false); // $ExpectType Function
+
     GetIntrinsic('%AsyncGenerator%', false); // $ExpectType AsyncGeneratorFunction
     GetIntrinsic('%AsyncGeneratorFunction%', false); // $ExpectType AsyncGeneratorFunctionConstructor
     GetIntrinsic('%AsyncGeneratorPrototype%', false); // $ExpectType AsyncGenerator<any, any, unknown>
     GetIntrinsic('%AsyncIteratorPrototype%', false); // $ExpectType AsyncIterable<any>
+
     GetIntrinsic('%Atomics%', false); // $ExpectType Atomics
+
     GetIntrinsic('%Boolean%', false); // $ExpectType BooleanConstructor
+    GetIntrinsic('%Boolean.prototype%', false); // $ExpectType Boolean
     GetIntrinsic('%BooleanPrototype%', false); // $ExpectType Boolean
+
     GetIntrinsic('%DataView%', false); // $ExpectType DataViewConstructor
+    GetIntrinsic('%DataView.prototype%', false); // $ExpectType DataView
     GetIntrinsic('%DataViewPrototype%', false); // $ExpectType DataView
+
     GetIntrinsic('%Date%', false); // $ExpectType DateConstructor
+    GetIntrinsic('%Date.prototype%', false); // $ExpectType Date
     GetIntrinsic('%DatePrototype%', false); // $ExpectType Date
+
     GetIntrinsic('%decodeURI%', false); // $ExpectType (encodedURI: string) => string
     GetIntrinsic('%decodeURIComponent%', false); // $ExpectType (encodedURIComponent: string) => string
+
     GetIntrinsic('%encodeURI%', false); // $ExpectType (uri: string) => string
     GetIntrinsic('%encodeURIComponent%', false); // $ExpectType (uriComponent: string | number | boolean) => string
+
     GetIntrinsic('%Error%', false); // $ExpectType ErrorConstructor
+    GetIntrinsic('%Error.prototype%', false); // $ExpectType Error
     GetIntrinsic('%ErrorPrototype%', false); // $ExpectType Error
+
     GetIntrinsic('%eval%', false); // $ExpectType (x: string) => any
+
     GetIntrinsic('%EvalError%', false); // $ExpectType EvalErrorConstructor
+    GetIntrinsic('%EvalError.prototype%', false); // $ExpectType EvalError
     GetIntrinsic('%EvalErrorPrototype%', false); // $ExpectType EvalError
+
     GetIntrinsic('%Float32Array%', false); // $ExpectType Float32ArrayConstructor
+    GetIntrinsic('%Float32Array.prototype%', false); // $ExpectType Float32Array
     GetIntrinsic('%Float32ArrayPrototype%', false); // $ExpectType Float32Array
+
     GetIntrinsic('%Float64Array%', false); // $ExpectType Float64ArrayConstructor
+    GetIntrinsic('%Float64Array.prototype%', false); // $ExpectType Float64Array
     GetIntrinsic('%Float64ArrayPrototype%', false); // $ExpectType Float64Array
+
     GetIntrinsic('%Function%', false); // $ExpectType FunctionConstructor
+    GetIntrinsic('%Function.prototype%', false); // $ExpectType Function
     GetIntrinsic('%FunctionPrototype%', false); // $ExpectType Function
+
     GetIntrinsic('%Generator%', false); // $ExpectType GeneratorFunction
     GetIntrinsic('%GeneratorFunction%', false); // $ExpectType GeneratorFunctionConstructor
     GetIntrinsic('%GeneratorPrototype%', false); // $ExpectType Generator<any, any, unknown>
+    GetIntrinsic('%IteratorPrototype%', false); // $ExpectType Iterable<any>
+
     GetIntrinsic('%Int8Array%', false); // $ExpectType Int8ArrayConstructor
+    GetIntrinsic('%Int8Array.prototype%', false); // $ExpectType Int8Array
     GetIntrinsic('%Int8ArrayPrototype%', false); // $ExpectType Int8Array
+
     GetIntrinsic('%Int16Array%', false); // $ExpectType Int16ArrayConstructor
+    GetIntrinsic('%Int16Array.prototype%', false); // $ExpectType Int16Array
     GetIntrinsic('%Int16ArrayPrototype%', false); // $ExpectType Int16Array
+
     GetIntrinsic('%Int32Array%', false); // $ExpectType Int32ArrayConstructor
+    GetIntrinsic('%Int32Array.prototype%', false); // $ExpectType Int32Array
     GetIntrinsic('%Int32ArrayPrototype%', false); // $ExpectType Int32Array
+
     GetIntrinsic('%isFinite%', false); // $ExpectType (number: number) => boolean
     GetIntrinsic('%isNaN%', false); // $ExpectType (number: number) => boolean
-    GetIntrinsic('%IteratorPrototype%', false); // $ExpectType Iterable<any>
+
     GetIntrinsic('%JSON%', false); // $ExpectType JSON
     GetIntrinsic('%JSONParse%', false); // $ExpectType (text: string, reviver?: ((this: any, key: string, value: any) => any) | undefined) => any
+
     GetIntrinsic('%Map%', false); // $ExpectType MapConstructor
-    GetIntrinsic('%MapIteratorPrototype%', false); // $ExpectType IterableIterator<any>
+    GetIntrinsic('%Map.prototype%', false); // $ExpectType Map<any, any>
     GetIntrinsic('%MapPrototype%', false); // $ExpectType Map<any, any>
+    GetIntrinsic('%MapIteratorPrototype%', false); // $ExpectType IterableIterator<any>
+
     GetIntrinsic('%Math%', false); // $ExpectType Math
+
     GetIntrinsic('%Number%', false); // $ExpectType NumberConstructor
+    GetIntrinsic('%Number.prototype%', false); // $ExpectType Number
     GetIntrinsic('%NumberPrototype%', false); // $ExpectType Number
+
     GetIntrinsic('%Object%', false); // $ExpectType ObjectConstructor
+    GetIntrinsic('%Object.prototype%', false); // $ExpectType Object
     GetIntrinsic('%ObjectPrototype%', false); // $ExpectType Object
     GetIntrinsic('%ObjProto_toString%', false); // $ExpectType () => string
     GetIntrinsic('%ObjProto_valueOf%', false); // $ExpectType () => Object
+
     GetIntrinsic('%parseFloat%', false); // $ExpectType (string: string) => number
     GetIntrinsic('%parseInt%', false); // $ExpectType (s: string, radix?: number | undefined) => number
+
     GetIntrinsic('%Promise%', false); // $ExpectType PromiseConstructor
+    GetIntrinsic('%Promise.prototype%', false); // $ExpectType Promise<any>
+    GetIntrinsic('%Promise.reject%', false); // $ExpectType <T = never>(reason?: any) => Promise<T>
+    GetIntrinsic('%Promise.resolve%', false); // $ExpectType { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+
     GetIntrinsic('%PromisePrototype%', false); // $ExpectType Promise<any>
     GetIntrinsic('%Promise_reject%', false); // $ExpectType <T = never>(reason?: any) => Promise<T>
     GetIntrinsic('%Promise_resolve%', false); // $ExpectType { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+
     GetIntrinsic('%Proxy%', false); // $ExpectType ProxyConstructor
+
     GetIntrinsic('%RangeError%', false); // $ExpectType RangeErrorConstructor
+    GetIntrinsic('%RangeError.prototype%', false); // $ExpectType RangeError
     GetIntrinsic('%RangeErrorPrototype%', false); // $ExpectType RangeError
+
     GetIntrinsic('%ReferenceError%', false); // $ExpectType ReferenceErrorConstructor
+    GetIntrinsic('%ReferenceError.prototype%', false); // $ExpectType ReferenceError
     GetIntrinsic('%ReferenceErrorPrototype%', false); // $ExpectType ReferenceError
+
     GetIntrinsic('%Reflect%', false); // $ExpectType typeof Reflect
+
     GetIntrinsic('%RegExp%', false); // $ExpectType RegExpConstructor
+    GetIntrinsic('%RegExp.prototype%', false); // $ExpectType RegExp
     GetIntrinsic('%RegExpPrototype%', false); // $ExpectType RegExp
+
     GetIntrinsic('%Set%', false); // $ExpectType SetConstructor
-    GetIntrinsic('%SetIteratorPrototype%', false); // $ExpectType IterableIterator<any>
+    GetIntrinsic('%Set.prototype%', false); // $ExpectType Set<any>
     GetIntrinsic('%SetPrototype%', false); // $ExpectType Set<any>
+    GetIntrinsic('%SetIteratorPrototype%', false); // $ExpectType IterableIterator<any>
+
     GetIntrinsic('%SharedArrayBuffer%', false); // $ExpectType SharedArrayBufferConstructor
+    GetIntrinsic('%SharedArrayBuffer.prototype%', false); // $ExpectType SharedArrayBuffer
     GetIntrinsic('%SharedArrayBufferPrototype%', false); // $ExpectType SharedArrayBuffer
+
     GetIntrinsic('%String%', false); // $ExpectType StringConstructor
-    GetIntrinsic('%StringIteratorPrototype%', false); // $ExpectType IterableIterator<string>
+    GetIntrinsic('%String.prototype%', false); // $ExpectType String
     GetIntrinsic('%StringPrototype%', false); // $ExpectType String
+    GetIntrinsic('%StringIteratorPrototype%', false); // $ExpectType IterableIterator<string>
+
     GetIntrinsic('%Symbol%', false); // $ExpectType SymbolConstructor
+    GetIntrinsic('%Symbol.prototype%', false); // $ExpectType Symbol
     GetIntrinsic('%SymbolPrototype%', false); // $ExpectType Symbol
+
     GetIntrinsic('%SyntaxError%', false); // $ExpectType SyntaxErrorConstructor
+    GetIntrinsic('%SyntaxError.prototype%', false); // $ExpectType SyntaxError
     GetIntrinsic('%SyntaxErrorPrototype%', false); // $ExpectType SyntaxError
+
     GetIntrinsic('%ThrowTypeError%', false); // $ExpectType () => never
+
     GetIntrinsic('%TypedArray%', false); // $ExpectType unknown
+    GetIntrinsic('%TypedArray.prototype%', false); // $ExpectType unknown
     GetIntrinsic('%TypedArrayPrototype%', false); // $ExpectType unknown
+
     GetIntrinsic('%TypeError%', false); // $ExpectType TypeErrorConstructor
+    GetIntrinsic('%TypeError.prototype%', false); // $ExpectType TypeError
     GetIntrinsic('%TypeErrorPrototype%', false); // $ExpectType TypeError
+
     GetIntrinsic('%Uint8Array%', false); // $ExpectType Uint8ArrayConstructor
+    GetIntrinsic('%Uint8Array.prototype%', false); // $ExpectType Uint8Array
     GetIntrinsic('%Uint8ArrayPrototype%', false); // $ExpectType Uint8Array
+
     GetIntrinsic('%Uint8ClampedArray%', false); // $ExpectType Uint8ClampedArrayConstructor
+    GetIntrinsic('%Uint8ClampedArray.prototype%', false); // $ExpectType Uint8ClampedArray
     GetIntrinsic('%Uint8ClampedArrayPrototype%', false); // $ExpectType Uint8ClampedArray
+
     GetIntrinsic('%Uint16Array%', false); // $ExpectType Uint16ArrayConstructor
+    GetIntrinsic('%Uint16Array.prototype%', false); // $ExpectType Uint16Array
     GetIntrinsic('%Uint16ArrayPrototype%', false); // $ExpectType Uint16Array
+
     GetIntrinsic('%Uint32Array%', false); // $ExpectType Uint32ArrayConstructor
+    GetIntrinsic('%Uint32Array.prototype%', false); // $ExpectType Uint32Array
     GetIntrinsic('%Uint32ArrayPrototype%', false); // $ExpectType Uint32Array
+
     GetIntrinsic('%URIError%', false); // $ExpectType URIErrorConstructor
+    GetIntrinsic('%URIError.prototype%', false); // $ExpectType URIError
     GetIntrinsic('%URIErrorPrototype%', false); // $ExpectType URIError
+
     GetIntrinsic('%WeakMap%', false); // $ExpectType WeakMapConstructor
+    GetIntrinsic('%WeakMap.prototype%', false); // $ExpectType WeakMap<object, any>
     GetIntrinsic('%WeakMapPrototype%', false); // $ExpectType WeakMap<object, any>
+
     GetIntrinsic('%WeakSet%', false); // $ExpectType WeakSetConstructor
+    GetIntrinsic('%WeakSet.prototype%', false); // $ExpectType WeakSet<object>
     GetIntrinsic('%WeakSetPrototype%', false); // $ExpectType WeakSet<object>
+
     GetIntrinsic('unknown', false); // $ExpectType unknown
 }
 
 // allowMissing = true
 {
     GetIntrinsic('%Array%', true); // $ExpectType ArrayConstructor | undefined
-    GetIntrinsic('%ArrayBuffer%', true); // $ExpectType ArrayBufferConstructor | undefined
-    GetIntrinsic('%ArrayBufferPrototype%', true); // $ExpectType ArrayBuffer | undefined
-    GetIntrinsic('%ArrayIteratorPrototype%', true); // $ExpectType IterableIterator<any> | undefined
+    GetIntrinsic('%Array.prototype%', true); // $ExpectType any[] | undefined
+    GetIntrinsic('%Array.prototype.entries%', true); // $ExpectType (() => IterableIterator<[number, any]>) | undefined
+    GetIntrinsic('%Array.prototype.forEach%', true); // $ExpectType ((callbackfn: (value: any, index: number, array: any[]) => void, thisArg?: any) => void) | undefined
+    GetIntrinsic('%Array.prototype.keys%', true); // $ExpectType (() => IterableIterator<number>) | undefined
+    GetIntrinsic('%Array.prototype.values%', true); // $ExpectType (() => IterableIterator<any>) | undefined
+
     GetIntrinsic('%ArrayPrototype%', true); // $ExpectType any[] | undefined
     GetIntrinsic('%ArrayProto_entries%', true); // $ExpectType (() => IterableIterator<[number, any]>) | undefined
     GetIntrinsic('%ArrayProto_forEach%', true); // $ExpectType ((callbackfn: (value: any, index: number, array: any[]) => void, thisArg?: any) => void) | undefined
     GetIntrinsic('%ArrayProto_keys%', true); // $ExpectType (() => IterableIterator<number>) | undefined
     GetIntrinsic('%ArrayProto_values%', true); // $ExpectType (() => IterableIterator<any>) | undefined
+
+    GetIntrinsic('%ArrayBuffer%', true); // $ExpectType ArrayBufferConstructor | undefined
+    GetIntrinsic('%ArrayBuffer.prototype%', true); // $ExpectType ArrayBuffer | undefined
+    GetIntrinsic('%ArrayBufferPrototype%', true); // $ExpectType ArrayBuffer | undefined
+
+    GetIntrinsic('%ArrayIteratorPrototype%', true); // $ExpectType IterableIterator<any> | undefined
     GetIntrinsic('%AsyncFromSyncIteratorPrototype%', true); // $ExpectType AsyncGenerator<any, any, unknown> | undefined
+
     GetIntrinsic('%AsyncFunction%', true); // $ExpectType FunctionConstructor | undefined
+    GetIntrinsic('%AsyncFunction.prototype%', true); // $ExpectType Function | undefined
     GetIntrinsic('%AsyncFunctionPrototype%', true); // $ExpectType Function | undefined
+
     GetIntrinsic('%AsyncGenerator%', true); // $ExpectType AsyncGeneratorFunction | undefined
     GetIntrinsic('%AsyncGeneratorFunction%', true); // $ExpectType AsyncGeneratorFunctionConstructor | undefined
     GetIntrinsic('%AsyncGeneratorPrototype%', true); // $ExpectType AsyncGenerator<any, any, unknown> | undefined
     GetIntrinsic('%AsyncIteratorPrototype%', true); // $ExpectType AsyncIterable<any> | undefined
+
     GetIntrinsic('%Atomics%', true); // $ExpectType Atomics | undefined
+
     GetIntrinsic('%Boolean%', true); // $ExpectType BooleanConstructor | undefined
+    GetIntrinsic('%Boolean.prototype%', true); // $ExpectType Boolean | undefined
     GetIntrinsic('%BooleanPrototype%', true); // $ExpectType Boolean | undefined
+
     GetIntrinsic('%DataView%', true); // $ExpectType DataViewConstructor | undefined
+    GetIntrinsic('%DataView.prototype%', true); // $ExpectType DataView | undefined
     GetIntrinsic('%DataViewPrototype%', true); // $ExpectType DataView | undefined
+
     GetIntrinsic('%Date%', true); // $ExpectType DateConstructor | undefined
+    GetIntrinsic('%Date.prototype%', true); // $ExpectType Date | undefined
     GetIntrinsic('%DatePrototype%', true); // $ExpectType Date | undefined
+
     GetIntrinsic('%decodeURI%', true); // $ExpectType ((encodedURI: string) => string) | undefined
     GetIntrinsic('%decodeURIComponent%', true); // $ExpectType ((encodedURIComponent: string) => string) | undefined
+
     GetIntrinsic('%encodeURI%', true); // $ExpectType ((uri: string) => string) | undefined
     GetIntrinsic('%encodeURIComponent%', true); // $ExpectType ((uriComponent: string | number | boolean) => string) | undefined
+
     GetIntrinsic('%Error%', true); // $ExpectType ErrorConstructor | undefined
+    GetIntrinsic('%Error.prototype%', true); // $ExpectType Error | undefined
     GetIntrinsic('%ErrorPrototype%', true); // $ExpectType Error | undefined
+
     GetIntrinsic('%eval%', true); // $ExpectType ((x: string) => any) | undefined
+
     GetIntrinsic('%EvalError%', true); // $ExpectType EvalErrorConstructor | undefined
+    GetIntrinsic('%EvalError.prototype%', true); // $ExpectType EvalError | undefined
     GetIntrinsic('%EvalErrorPrototype%', true); // $ExpectType EvalError | undefined
+
     GetIntrinsic('%Float32Array%', true); // $ExpectType Float32ArrayConstructor | undefined
+    GetIntrinsic('%Float32Array.prototype%', true); // $ExpectType Float32Array | undefined
     GetIntrinsic('%Float32ArrayPrototype%', true); // $ExpectType Float32Array | undefined
+
     GetIntrinsic('%Float64Array%', true); // $ExpectType Float64ArrayConstructor | undefined
+    GetIntrinsic('%Float64Array.prototype%', true); // $ExpectType Float64Array | undefined
     GetIntrinsic('%Float64ArrayPrototype%', true); // $ExpectType Float64Array | undefined
+
     GetIntrinsic('%Function%', true); // $ExpectType FunctionConstructor | undefined
+    GetIntrinsic('%Function.prototype%', true); // $ExpectType Function | undefined
     GetIntrinsic('%FunctionPrototype%', true); // $ExpectType Function | undefined
+
     GetIntrinsic('%Generator%', true); // $ExpectType GeneratorFunction | undefined
     GetIntrinsic('%GeneratorFunction%', true); // $ExpectType GeneratorFunctionConstructor | undefined
     GetIntrinsic('%GeneratorPrototype%', true); // $ExpectType Generator<any, any, unknown> | undefined
+    GetIntrinsic('%IteratorPrototype%', true); // $ExpectType Iterable<any> | undefined
+
     GetIntrinsic('%Int8Array%', true); // $ExpectType Int8ArrayConstructor | undefined
+    GetIntrinsic('%Int8Array.prototype%', true); // $ExpectType Int8Array | undefined
     GetIntrinsic('%Int8ArrayPrototype%', true); // $ExpectType Int8Array | undefined
+
     GetIntrinsic('%Int16Array%', true); // $ExpectType Int16ArrayConstructor | undefined
+    GetIntrinsic('%Int16Array.prototype%', true); // $ExpectType Int16Array | undefined
     GetIntrinsic('%Int16ArrayPrototype%', true); // $ExpectType Int16Array | undefined
+
     GetIntrinsic('%Int32Array%', true); // $ExpectType Int32ArrayConstructor | undefined
+    GetIntrinsic('%Int32Array.prototype%', true); // $ExpectType Int32Array | undefined
     GetIntrinsic('%Int32ArrayPrototype%', true); // $ExpectType Int32Array | undefined
+
     GetIntrinsic('%isFinite%', true); // $ExpectType ((number: number) => boolean) | undefined
     GetIntrinsic('%isNaN%', true); // $ExpectType ((number: number) => boolean) | undefined
-    GetIntrinsic('%IteratorPrototype%', true); // $ExpectType Iterable<any> | undefined
+
     GetIntrinsic('%JSON%', true); // $ExpectType JSON | undefined
     GetIntrinsic('%JSONParse%', true); // $ExpectType ((text: string, reviver?: ((this: any, key: string, value: any) => any) | undefined) => any) | undefined
+
     GetIntrinsic('%Map%', true); // $ExpectType MapConstructor | undefined
-    GetIntrinsic('%MapIteratorPrototype%', true); // $ExpectType IterableIterator<any> | undefined
+    GetIntrinsic('%Map.prototype%', true); // $ExpectType Map<any, any> | undefined
     GetIntrinsic('%MapPrototype%', true); // $ExpectType Map<any, any> | undefined
+    GetIntrinsic('%MapIteratorPrototype%', true); // $ExpectType IterableIterator<any> | undefined
+
     GetIntrinsic('%Math%', true); // $ExpectType Math | undefined
+
     GetIntrinsic('%Number%', true); // $ExpectType NumberConstructor | undefined
+    GetIntrinsic('%Number.prototype%', true); // $ExpectType Number | undefined
     GetIntrinsic('%NumberPrototype%', true); // $ExpectType Number | undefined
+
     GetIntrinsic('%Object%', true); // $ExpectType ObjectConstructor | undefined
+    GetIntrinsic('%Object.prototype%', true); // $ExpectType Object | undefined
     GetIntrinsic('%ObjectPrototype%', true); // $ExpectType Object | undefined
     GetIntrinsic('%ObjProto_toString%', true); // $ExpectType (() => string) | undefined
     GetIntrinsic('%ObjProto_valueOf%', true); // $ExpectType (() => Object) | undefined
+
     GetIntrinsic('%parseFloat%', true); // $ExpectType ((string: string) => number) | undefined
     GetIntrinsic('%parseInt%', true); // $ExpectType ((s: string, radix?: number | undefined) => number) | undefined
+
     GetIntrinsic('%Promise%', true); // $ExpectType PromiseConstructor | undefined
+    GetIntrinsic('%Promise.prototype%', true); // $ExpectType Promise<any> | undefined
+    GetIntrinsic('%Promise.reject%', true); // $ExpectType (<T = never>(reason?: any) => Promise<T>) | undefined
+    GetIntrinsic('%Promise.resolve%', true); // $ExpectType { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; } | undefined
+
     GetIntrinsic('%PromisePrototype%', true); // $ExpectType Promise<any> | undefined
     GetIntrinsic('%Promise_reject%', true); // $ExpectType (<T = never>(reason?: any) => Promise<T>) | undefined
     GetIntrinsic('%Promise_resolve%', true); // $ExpectType { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; } | undefined
+
     GetIntrinsic('%Proxy%', true); // $ExpectType ProxyConstructor | undefined
+
     GetIntrinsic('%RangeError%', true); // $ExpectType RangeErrorConstructor | undefined
+    GetIntrinsic('%RangeError.prototype%', true); // $ExpectType RangeError | undefined
     GetIntrinsic('%RangeErrorPrototype%', true); // $ExpectType RangeError | undefined
+
     GetIntrinsic('%ReferenceError%', true); // $ExpectType ReferenceErrorConstructor | undefined
+    GetIntrinsic('%ReferenceError.prototype%', true); // $ExpectType ReferenceError | undefined
     GetIntrinsic('%ReferenceErrorPrototype%', true); // $ExpectType ReferenceError | undefined
+
     GetIntrinsic('%Reflect%', true); // $ExpectType typeof Reflect | undefined
+
     GetIntrinsic('%RegExp%', true); // $ExpectType RegExpConstructor | undefined
+    GetIntrinsic('%RegExp.prototype%', true); // $ExpectType RegExp | undefined
     GetIntrinsic('%RegExpPrototype%', true); // $ExpectType RegExp | undefined
+
     GetIntrinsic('%Set%', true); // $ExpectType SetConstructor | undefined
-    GetIntrinsic('%SetIteratorPrototype%', true); // $ExpectType IterableIterator<any> | undefined
+    GetIntrinsic('%Set.prototype%', true); // $ExpectType Set<any> | undefined
     GetIntrinsic('%SetPrototype%', true); // $ExpectType Set<any> | undefined
+    GetIntrinsic('%SetIteratorPrototype%', true); // $ExpectType IterableIterator<any> | undefined
+
     GetIntrinsic('%SharedArrayBuffer%', true); // $ExpectType SharedArrayBufferConstructor | undefined
+    GetIntrinsic('%SharedArrayBuffer.prototype%', true); // $ExpectType SharedArrayBuffer | undefined
     GetIntrinsic('%SharedArrayBufferPrototype%', true); // $ExpectType SharedArrayBuffer | undefined
+
     GetIntrinsic('%String%', true); // $ExpectType StringConstructor | undefined
-    GetIntrinsic('%StringIteratorPrototype%', true); // $ExpectType IterableIterator<string> | undefined
+    GetIntrinsic('%String.prototype%', true); // $ExpectType String | undefined
     GetIntrinsic('%StringPrototype%', true); // $ExpectType String | undefined
+    GetIntrinsic('%StringIteratorPrototype%', true); // $ExpectType IterableIterator<string> | undefined
+
     GetIntrinsic('%Symbol%', true); // $ExpectType SymbolConstructor | undefined
+    GetIntrinsic('%Symbol.prototype%', true); // $ExpectType Symbol | undefined
     GetIntrinsic('%SymbolPrototype%', true); // $ExpectType Symbol | undefined
+
     GetIntrinsic('%SyntaxError%', true); // $ExpectType SyntaxErrorConstructor | undefined
+    GetIntrinsic('%SyntaxError.prototype%', true); // $ExpectType SyntaxError | undefined
     GetIntrinsic('%SyntaxErrorPrototype%', true); // $ExpectType SyntaxError | undefined
+
     GetIntrinsic('%ThrowTypeError%', true); // $ExpectType (() => never) | undefined
+
     GetIntrinsic('%TypedArray%', true); // $ExpectType unknown
+    GetIntrinsic('%TypedArray.prototype%', true); // $ExpectType unknown
     GetIntrinsic('%TypedArrayPrototype%', true); // $ExpectType unknown
+
     GetIntrinsic('%TypeError%', true); // $ExpectType TypeErrorConstructor | undefined
+    GetIntrinsic('%TypeError.prototype%', true); // $ExpectType TypeError | undefined
     GetIntrinsic('%TypeErrorPrototype%', true); // $ExpectType TypeError | undefined
+
     GetIntrinsic('%Uint8Array%', true); // $ExpectType Uint8ArrayConstructor | undefined
+    GetIntrinsic('%Uint8Array.prototype%', true); // $ExpectType Uint8Array | undefined
     GetIntrinsic('%Uint8ArrayPrototype%', true); // $ExpectType Uint8Array | undefined
+
     GetIntrinsic('%Uint8ClampedArray%', true); // $ExpectType Uint8ClampedArrayConstructor | undefined
+    GetIntrinsic('%Uint8ClampedArray.prototype%', true); // $ExpectType Uint8ClampedArray | undefined
     GetIntrinsic('%Uint8ClampedArrayPrototype%', true); // $ExpectType Uint8ClampedArray | undefined
+
     GetIntrinsic('%Uint16Array%', true); // $ExpectType Uint16ArrayConstructor | undefined
+    GetIntrinsic('%Uint16Array.prototype%', true); // $ExpectType Uint16Array | undefined
     GetIntrinsic('%Uint16ArrayPrototype%', true); // $ExpectType Uint16Array | undefined
+
     GetIntrinsic('%Uint32Array%', true); // $ExpectType Uint32ArrayConstructor | undefined
+    GetIntrinsic('%Uint32Array.prototype%', true); // $ExpectType Uint32Array | undefined
     GetIntrinsic('%Uint32ArrayPrototype%', true); // $ExpectType Uint32Array | undefined
+
     GetIntrinsic('%URIError%', true); // $ExpectType URIErrorConstructor | undefined
+    GetIntrinsic('%URIError.prototype%', true); // $ExpectType URIError | undefined
     GetIntrinsic('%URIErrorPrototype%', true); // $ExpectType URIError | undefined
+
     GetIntrinsic('%WeakMap%', true); // $ExpectType WeakMapConstructor | undefined
+    GetIntrinsic('%WeakMap.prototype%', true); // $ExpectType WeakMap<object, any> | undefined
     GetIntrinsic('%WeakMapPrototype%', true); // $ExpectType WeakMap<object, any> | undefined
+
     GetIntrinsic('%WeakSet%', true); // $ExpectType WeakSetConstructor | undefined
+    GetIntrinsic('%WeakSet.prototype%', true); // $ExpectType WeakSet<object> | undefined
     GetIntrinsic('%WeakSetPrototype%', true); // $ExpectType WeakSet<object> | undefined
+
     GetIntrinsic('unknown', true); // $ExpectType unknown
 }
 
 // allowMissing = boolean
 {
     GetIntrinsic('%Array%', boolean); // $ExpectType ArrayConstructor | undefined
-    GetIntrinsic('%ArrayBuffer%', boolean); // $ExpectType ArrayBufferConstructor | undefined
-    GetIntrinsic('%ArrayBufferPrototype%', boolean); // $ExpectType ArrayBuffer | undefined
-    GetIntrinsic('%ArrayIteratorPrototype%', boolean); // $ExpectType IterableIterator<any> | undefined
+    GetIntrinsic('%Array.prototype%', boolean); // $ExpectType any[] | undefined
+    GetIntrinsic('%Array.prototype.entries%', boolean); // $ExpectType (() => IterableIterator<[number, any]>) | undefined
+    GetIntrinsic('%Array.prototype.forEach%', boolean); // $ExpectType ((callbackfn: (value: any, index: number, array: any[]) => void, thisArg?: any) => void) | undefined
+    GetIntrinsic('%Array.prototype.keys%', boolean); // $ExpectType (() => IterableIterator<number>) | undefined
+    GetIntrinsic('%Array.prototype.values%', boolean); // $ExpectType (() => IterableIterator<any>) | undefined
+
     GetIntrinsic('%ArrayPrototype%', boolean); // $ExpectType any[] | undefined
     GetIntrinsic('%ArrayProto_entries%', boolean); // $ExpectType (() => IterableIterator<[number, any]>) | undefined
     GetIntrinsic('%ArrayProto_forEach%', boolean); // $ExpectType ((callbackfn: (value: any, index: number, array: any[]) => void, thisArg?: any) => void) | undefined
     GetIntrinsic('%ArrayProto_keys%', boolean); // $ExpectType (() => IterableIterator<number>) | undefined
     GetIntrinsic('%ArrayProto_values%', boolean); // $ExpectType (() => IterableIterator<any>) | undefined
+
+    GetIntrinsic('%ArrayBuffer%', boolean); // $ExpectType ArrayBufferConstructor | undefined
+    GetIntrinsic('%ArrayBuffer.prototype%', boolean); // $ExpectType ArrayBuffer | undefined
+    GetIntrinsic('%ArrayBufferPrototype%', boolean); // $ExpectType ArrayBuffer | undefined
+
+    GetIntrinsic('%ArrayIteratorPrototype%', boolean); // $ExpectType IterableIterator<any> | undefined
     GetIntrinsic('%AsyncFromSyncIteratorPrototype%', boolean); // $ExpectType AsyncGenerator<any, any, unknown> | undefined
+
     GetIntrinsic('%AsyncFunction%', boolean); // $ExpectType FunctionConstructor | undefined
+    GetIntrinsic('%AsyncFunction.prototype%', boolean); // $ExpectType Function | undefined
     GetIntrinsic('%AsyncFunctionPrototype%', boolean); // $ExpectType Function | undefined
+
     GetIntrinsic('%AsyncGenerator%', boolean); // $ExpectType AsyncGeneratorFunction | undefined
     GetIntrinsic('%AsyncGeneratorFunction%', boolean); // $ExpectType AsyncGeneratorFunctionConstructor | undefined
     GetIntrinsic('%AsyncGeneratorPrototype%', boolean); // $ExpectType AsyncGenerator<any, any, unknown> | undefined
     GetIntrinsic('%AsyncIteratorPrototype%', boolean); // $ExpectType AsyncIterable<any> | undefined
+
     GetIntrinsic('%Atomics%', boolean); // $ExpectType Atomics | undefined
+
     GetIntrinsic('%Boolean%', boolean); // $ExpectType BooleanConstructor | undefined
+    GetIntrinsic('%Boolean.prototype%', boolean); // $ExpectType Boolean | undefined
     GetIntrinsic('%BooleanPrototype%', boolean); // $ExpectType Boolean | undefined
+
     GetIntrinsic('%DataView%', boolean); // $ExpectType DataViewConstructor | undefined
+    GetIntrinsic('%DataView.prototype%', boolean); // $ExpectType DataView | undefined
     GetIntrinsic('%DataViewPrototype%', boolean); // $ExpectType DataView | undefined
+
     GetIntrinsic('%Date%', boolean); // $ExpectType DateConstructor | undefined
+    GetIntrinsic('%Date.prototype%', boolean); // $ExpectType Date | undefined
     GetIntrinsic('%DatePrototype%', boolean); // $ExpectType Date | undefined
+
     GetIntrinsic('%decodeURI%', boolean); // $ExpectType ((encodedURI: string) => string) | undefined
     GetIntrinsic('%decodeURIComponent%', boolean); // $ExpectType ((encodedURIComponent: string) => string) | undefined
+
     GetIntrinsic('%encodeURI%', boolean); // $ExpectType ((uri: string) => string) | undefined
     GetIntrinsic('%encodeURIComponent%', boolean); // $ExpectType ((uriComponent: string | number | boolean) => string) | undefined
+
     GetIntrinsic('%Error%', boolean); // $ExpectType ErrorConstructor | undefined
+    GetIntrinsic('%Error.prototype%', boolean); // $ExpectType Error | undefined
     GetIntrinsic('%ErrorPrototype%', boolean); // $ExpectType Error | undefined
+
     GetIntrinsic('%eval%', boolean); // $ExpectType ((x: string) => any) | undefined
+
     GetIntrinsic('%EvalError%', boolean); // $ExpectType EvalErrorConstructor | undefined
+    GetIntrinsic('%EvalError.prototype%', boolean); // $ExpectType EvalError | undefined
     GetIntrinsic('%EvalErrorPrototype%', boolean); // $ExpectType EvalError | undefined
+
     GetIntrinsic('%Float32Array%', boolean); // $ExpectType Float32ArrayConstructor | undefined
+    GetIntrinsic('%Float32Array.prototype%', boolean); // $ExpectType Float32Array | undefined
     GetIntrinsic('%Float32ArrayPrototype%', boolean); // $ExpectType Float32Array | undefined
+
     GetIntrinsic('%Float64Array%', boolean); // $ExpectType Float64ArrayConstructor | undefined
+    GetIntrinsic('%Float64Array.prototype%', boolean); // $ExpectType Float64Array | undefined
     GetIntrinsic('%Float64ArrayPrototype%', boolean); // $ExpectType Float64Array | undefined
+
     GetIntrinsic('%Function%', boolean); // $ExpectType FunctionConstructor | undefined
+    GetIntrinsic('%Function.prototype%', boolean); // $ExpectType Function | undefined
     GetIntrinsic('%FunctionPrototype%', boolean); // $ExpectType Function | undefined
+
     GetIntrinsic('%Generator%', boolean); // $ExpectType GeneratorFunction | undefined
     GetIntrinsic('%GeneratorFunction%', boolean); // $ExpectType GeneratorFunctionConstructor | undefined
     GetIntrinsic('%GeneratorPrototype%', boolean); // $ExpectType Generator<any, any, unknown> | undefined
+    GetIntrinsic('%IteratorPrototype%', boolean); // $ExpectType Iterable<any> | undefined
+
     GetIntrinsic('%Int8Array%', boolean); // $ExpectType Int8ArrayConstructor | undefined
+    GetIntrinsic('%Int8Array.prototype%', boolean); // $ExpectType Int8Array | undefined
     GetIntrinsic('%Int8ArrayPrototype%', boolean); // $ExpectType Int8Array | undefined
+
     GetIntrinsic('%Int16Array%', boolean); // $ExpectType Int16ArrayConstructor | undefined
+    GetIntrinsic('%Int16Array.prototype%', boolean); // $ExpectType Int16Array | undefined
     GetIntrinsic('%Int16ArrayPrototype%', boolean); // $ExpectType Int16Array | undefined
+
     GetIntrinsic('%Int32Array%', boolean); // $ExpectType Int32ArrayConstructor | undefined
+    GetIntrinsic('%Int32Array.prototype%', boolean); // $ExpectType Int32Array | undefined
     GetIntrinsic('%Int32ArrayPrototype%', boolean); // $ExpectType Int32Array | undefined
+
     GetIntrinsic('%isFinite%', boolean); // $ExpectType ((number: number) => boolean) | undefined
     GetIntrinsic('%isNaN%', boolean); // $ExpectType ((number: number) => boolean) | undefined
-    GetIntrinsic('%IteratorPrototype%', boolean); // $ExpectType Iterable<any> | undefined
+
     GetIntrinsic('%JSON%', boolean); // $ExpectType JSON | undefined
     GetIntrinsic('%JSONParse%', boolean); // $ExpectType ((text: string, reviver?: ((this: any, key: string, value: any) => any) | undefined) => any) | undefined
+
     GetIntrinsic('%Map%', boolean); // $ExpectType MapConstructor | undefined
-    GetIntrinsic('%MapIteratorPrototype%', boolean); // $ExpectType IterableIterator<any> | undefined
+    GetIntrinsic('%Map.prototype%', boolean); // $ExpectType Map<any, any> | undefined
     GetIntrinsic('%MapPrototype%', boolean); // $ExpectType Map<any, any> | undefined
+    GetIntrinsic('%MapIteratorPrototype%', boolean); // $ExpectType IterableIterator<any> | undefined
+
     GetIntrinsic('%Math%', boolean); // $ExpectType Math | undefined
+
     GetIntrinsic('%Number%', boolean); // $ExpectType NumberConstructor | undefined
+    GetIntrinsic('%Number.prototype%', boolean); // $ExpectType Number | undefined
     GetIntrinsic('%NumberPrototype%', boolean); // $ExpectType Number | undefined
+
     GetIntrinsic('%Object%', boolean); // $ExpectType ObjectConstructor | undefined
+    GetIntrinsic('%Object.prototype%', boolean); // $ExpectType Object | undefined
     GetIntrinsic('%ObjectPrototype%', boolean); // $ExpectType Object | undefined
     GetIntrinsic('%ObjProto_toString%', boolean); // $ExpectType (() => string) | undefined
     GetIntrinsic('%ObjProto_valueOf%', boolean); // $ExpectType (() => Object) | undefined
+
     GetIntrinsic('%parseFloat%', boolean); // $ExpectType ((string: string) => number) | undefined
     GetIntrinsic('%parseInt%', boolean); // $ExpectType ((s: string, radix?: number | undefined) => number) | undefined
+
     GetIntrinsic('%Promise%', boolean); // $ExpectType PromiseConstructor | undefined
+    GetIntrinsic('%Promise.prototype%', boolean); // $ExpectType Promise<any> | undefined
+    GetIntrinsic('%Promise.reject%', boolean); // $ExpectType (<T = never>(reason?: any) => Promise<T>) | undefined
+    GetIntrinsic('%Promise.resolve%', boolean); // $ExpectType { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; } | undefined
+
     GetIntrinsic('%PromisePrototype%', boolean); // $ExpectType Promise<any> | undefined
     GetIntrinsic('%Promise_reject%', boolean); // $ExpectType (<T = never>(reason?: any) => Promise<T>) | undefined
     GetIntrinsic('%Promise_resolve%', boolean); // $ExpectType { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; } | undefined
+
     GetIntrinsic('%Proxy%', boolean); // $ExpectType ProxyConstructor | undefined
+
     GetIntrinsic('%RangeError%', boolean); // $ExpectType RangeErrorConstructor | undefined
+    GetIntrinsic('%RangeError.prototype%', boolean); // $ExpectType RangeError | undefined
     GetIntrinsic('%RangeErrorPrototype%', boolean); // $ExpectType RangeError | undefined
+
     GetIntrinsic('%ReferenceError%', boolean); // $ExpectType ReferenceErrorConstructor | undefined
+    GetIntrinsic('%ReferenceError.prototype%', boolean); // $ExpectType ReferenceError | undefined
     GetIntrinsic('%ReferenceErrorPrototype%', boolean); // $ExpectType ReferenceError | undefined
+
     GetIntrinsic('%Reflect%', boolean); // $ExpectType typeof Reflect | undefined
+
     GetIntrinsic('%RegExp%', boolean); // $ExpectType RegExpConstructor | undefined
+    GetIntrinsic('%RegExp.prototype%', boolean); // $ExpectType RegExp | undefined
     GetIntrinsic('%RegExpPrototype%', boolean); // $ExpectType RegExp | undefined
+
     GetIntrinsic('%Set%', boolean); // $ExpectType SetConstructor | undefined
-    GetIntrinsic('%SetIteratorPrototype%', boolean); // $ExpectType IterableIterator<any> | undefined
+    GetIntrinsic('%Set.prototype%', boolean); // $ExpectType Set<any> | undefined
     GetIntrinsic('%SetPrototype%', boolean); // $ExpectType Set<any> | undefined
+    GetIntrinsic('%SetIteratorPrototype%', boolean); // $ExpectType IterableIterator<any> | undefined
+
     GetIntrinsic('%SharedArrayBuffer%', boolean); // $ExpectType SharedArrayBufferConstructor | undefined
+    GetIntrinsic('%SharedArrayBuffer.prototype%', boolean); // $ExpectType SharedArrayBuffer | undefined
     GetIntrinsic('%SharedArrayBufferPrototype%', boolean); // $ExpectType SharedArrayBuffer | undefined
+
     GetIntrinsic('%String%', boolean); // $ExpectType StringConstructor | undefined
-    GetIntrinsic('%StringIteratorPrototype%', boolean); // $ExpectType IterableIterator<string> | undefined
+    GetIntrinsic('%String.prototype%', boolean); // $ExpectType String | undefined
     GetIntrinsic('%StringPrototype%', boolean); // $ExpectType String | undefined
+    GetIntrinsic('%StringIteratorPrototype%', boolean); // $ExpectType IterableIterator<string> | undefined
+
     GetIntrinsic('%Symbol%', boolean); // $ExpectType SymbolConstructor | undefined
+    GetIntrinsic('%Symbol.prototype%', boolean); // $ExpectType Symbol | undefined
     GetIntrinsic('%SymbolPrototype%', boolean); // $ExpectType Symbol | undefined
+
     GetIntrinsic('%SyntaxError%', boolean); // $ExpectType SyntaxErrorConstructor | undefined
+    GetIntrinsic('%SyntaxError.prototype%', boolean); // $ExpectType SyntaxError | undefined
     GetIntrinsic('%SyntaxErrorPrototype%', boolean); // $ExpectType SyntaxError | undefined
+
     GetIntrinsic('%ThrowTypeError%', boolean); // $ExpectType (() => never) | undefined
+
     GetIntrinsic('%TypedArray%', boolean); // $ExpectType unknown
+    GetIntrinsic('%TypedArray.prototype%', boolean); // $ExpectType unknown
     GetIntrinsic('%TypedArrayPrototype%', boolean); // $ExpectType unknown
+
     GetIntrinsic('%TypeError%', boolean); // $ExpectType TypeErrorConstructor | undefined
+    GetIntrinsic('%TypeError.prototype%', boolean); // $ExpectType TypeError | undefined
     GetIntrinsic('%TypeErrorPrototype%', boolean); // $ExpectType TypeError | undefined
+
     GetIntrinsic('%Uint8Array%', boolean); // $ExpectType Uint8ArrayConstructor | undefined
+    GetIntrinsic('%Uint8Array.prototype%', boolean); // $ExpectType Uint8Array | undefined
     GetIntrinsic('%Uint8ArrayPrototype%', boolean); // $ExpectType Uint8Array | undefined
+
     GetIntrinsic('%Uint8ClampedArray%', boolean); // $ExpectType Uint8ClampedArrayConstructor | undefined
+    GetIntrinsic('%Uint8ClampedArray.prototype%', boolean); // $ExpectType Uint8ClampedArray | undefined
     GetIntrinsic('%Uint8ClampedArrayPrototype%', boolean); // $ExpectType Uint8ClampedArray | undefined
+
     GetIntrinsic('%Uint16Array%', boolean); // $ExpectType Uint16ArrayConstructor | undefined
+    GetIntrinsic('%Uint16Array.prototype%', boolean); // $ExpectType Uint16Array | undefined
     GetIntrinsic('%Uint16ArrayPrototype%', boolean); // $ExpectType Uint16Array | undefined
+
     GetIntrinsic('%Uint32Array%', boolean); // $ExpectType Uint32ArrayConstructor | undefined
+    GetIntrinsic('%Uint32Array.prototype%', boolean); // $ExpectType Uint32Array | undefined
     GetIntrinsic('%Uint32ArrayPrototype%', boolean); // $ExpectType Uint32Array | undefined
+
     GetIntrinsic('%URIError%', boolean); // $ExpectType URIErrorConstructor | undefined
+    GetIntrinsic('%URIError.prototype%', boolean); // $ExpectType URIError | undefined
     GetIntrinsic('%URIErrorPrototype%', boolean); // $ExpectType URIError | undefined
+
     GetIntrinsic('%WeakMap%', boolean); // $ExpectType WeakMapConstructor | undefined
+    GetIntrinsic('%WeakMap.prototype%', boolean); // $ExpectType WeakMap<object, any> | undefined
     GetIntrinsic('%WeakMapPrototype%', boolean); // $ExpectType WeakMap<object, any> | undefined
+
     GetIntrinsic('%WeakSet%', boolean); // $ExpectType WeakSetConstructor | undefined
+    GetIntrinsic('%WeakSet.prototype%', boolean); // $ExpectType WeakSet<object> | undefined
     GetIntrinsic('%WeakSetPrototype%', boolean); // $ExpectType WeakSet<object> | undefined
+
     GetIntrinsic('unknown', boolean); // $ExpectType unknown
 }


### PR DESCRIPTION
~~It doesn’t make much sense to include these, especially since [`callBound` doesn’t actually support them](https://github.com/ljharb/es-abstract/blob/7a963e3939da431e994d2181875f95b1e8ab239e/helpers/callBound.js#L11).~~

I’ve also refactored the intrinsics data so that it’s in a separate file and doesn’t require as much duplication as before.

## Blocks:

- <https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44805>

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/ljharb/es-abstract/blob/master/helpers/callBound.js#L11>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
