### PR TITLE
Add types for passport-spotify

### DIFF
--- a/types/passport-spotify/index.d.ts
+++ b/types/passport-spotify/index.d.ts
@@ -1,0 +1,69 @@
+// Type definitions for passport-spotify 1.1
+// Project: https://github.com/jmperez/passport-spotify#readme
+// Definitions by: Rishi Kodali <https://github.com/rishikodali>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import { Request } from 'express';
+
+export interface Profile {
+    provider: string;
+    id: string;
+    username: string;
+    displayName: string;
+    profileUrl: string | null;
+    photos: [string] | null;
+    country: string;
+    followers: number | null;
+    product: string | null;
+    emails?: [{ value: string; type: null }];
+    _raw: string;
+    _json: any;
+}
+
+export interface _StrategyOptionsBase {
+    clientID: string;
+    clientSecret: string;
+    callbackURL: string;
+    scope?: string[];
+    authorizationURL?: string;
+    tokenURL?: string;
+    scopeSeparator?: string;
+    userProfileURL?: string;
+    showDialog?: boolean;
+}
+
+export interface StrategyOptions extends _StrategyOptionsBase {
+    passReqToCallback?: false | null;
+}
+
+export interface StrategyOptionsWithRequest extends _StrategyOptionsBase {
+    passReqToCallback: true;
+}
+
+export type VerifyCallback = (error?: Error | null, user?: object, info?: object) => void;
+
+export type VerifyFunction = (
+    accessToken: string,
+    refreshToken: string,
+    profile: Profile,
+    done: VerifyCallback,
+    expires_in?: number,
+) => void;
+
+export type VerifyFunctionWithRequest = (
+    req: Request,
+    accessToken: string,
+    refreshToken: string,
+    profile: Profile,
+    done: VerifyCallback,
+    expires_in?: number,
+) => void;
+
+export class Strategy {
+    constructor(options: StrategyOptionsWithRequest, verify: VerifyFunctionWithRequest);
+    constructor(options: StrategyOptions, verify: VerifyFunction);
+
+    name: string;
+    authenticate(req: Request, options?: object): void;
+}

--- a/types/passport-spotify/passport-spotify-tests.ts
+++ b/types/passport-spotify/passport-spotify-tests.ts
@@ -1,0 +1,58 @@
+import { Request } from 'express';
+import {
+    Profile,
+    Strategy,
+    StrategyOptions,
+    StrategyOptionsWithRequest,
+    VerifyCallback,
+    VerifyFunction,
+    VerifyFunctionWithRequest,
+} from 'passport-spotify';
+
+const strategyOptions: StrategyOptions = {
+    clientID: 'clientID',
+    clientSecret: 'clientSecret',
+    callbackURL: 'callbackURL',
+};
+
+const verifyFunction: VerifyFunction = (
+    accessToken: string,
+    refreshToken: string,
+    profile: Profile,
+    done: VerifyCallback,
+) => {
+    const user = {
+        profile,
+        accessToken,
+        refreshToken,
+    };
+
+    done(null, user);
+};
+
+const strategy = new Strategy(strategyOptions, verifyFunction);
+
+const strategyOptionsWithRequest: StrategyOptionsWithRequest = {
+    clientID: 'clientID',
+    clientSecret: 'clientSecret',
+    callbackURL: 'callbackURL',
+    passReqToCallback: true,
+};
+
+const verifyFunctionWithRequest: VerifyFunctionWithRequest = (
+    req: Request,
+    accessToken: string,
+    refreshToken: string,
+    profile: Profile,
+    done: VerifyCallback,
+) => {
+    const user = {
+        profile,
+        accessToken,
+        refreshToken,
+    };
+
+    done(null, user);
+};
+
+const strategyWithRequest = new Strategy(strategyOptionsWithRequest, verifyFunctionWithRequest);

--- a/types/passport-spotify/tsconfig.json
+++ b/types/passport-spotify/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "passport-spotify-tests.ts"]
+}

--- a/types/passport-spotify/tslint.json
+++ b/types/passport-spotify/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.