### PR TITLE
fix(es‑abstract): Make `Call` type parameters match `Reflect.apply`

### DIFF
--- a/types/es-abstract/es2015.d.ts
+++ b/types/es-abstract/es2015.d.ts
@@ -4,21 +4,20 @@ import ES5 = require('./es5');
 import { Intrinsics } from './GetIntrinsic';
 import { PropertyKey as ESPropertyKey } from './index';
 
+// Utility types:
+type ToApplyArgs<A extends ArrayLike<any>> = Readonly<A> | { readonly [x: number]: A[number]; readonly length: number };
+
 interface ES2015 extends Omit<typeof ES5, 'CheckObjectCoercible' | 'ToPrimitive' | 'Type'> {
-    Call<R, T = unknown>(F: (this: T) => R, thisArg: T): R;
-    Call<R, A extends unknown[] | [unknown], T = unknown>(
-        F: (this: T, ...args: A) => R,
-        thisArg: T,
-        args: Readonly<A>,
-    ): R;
-    // tslint:disable-next-line: ban-types
-    Call<F extends Function>(
-        F: F,
-        thisArg: F extends (this: infer T) => any ? T : unknown,
-        args?:
-            | (F extends (...args: infer A) => any ? Readonly<A> : readonly unknown[])
-            | ArrayLike<F extends (...args: infer A) => any ? (A extends Array<infer T> ? T : unknown) : unknown>,
-    ): F extends (...args: any) => infer R ? R : any;
+    Call<T, R>(F: (this: T) => R, thisArg: T): R;
+    Call<T, A extends readonly unknown[], R>(F: (this: T, ...args: A) => R, thisArg: T, args: Readonly<A>): R;
+
+    Invoke<O extends {}, P extends ESPropertyKey>(
+        O: O,
+        P: P,
+        args?: P extends keyof O
+            ? O[P] extends (...args: infer A) => any ? Readonly<A> : ArrayLike<unknown>
+            : ArrayLike<unknown>,
+    ): P extends keyof O ? (O[P] extends (...args: any) => infer R ? R : never) : unknown;
 
     readonly ToPrimitive: typeof toPrimitive;
     ToInt16(value: unknown): number;
@@ -50,6 +49,7 @@ interface ES2015 extends Omit<typeof ES5, 'CheckObjectCoercible' | 'ToPrimitive'
         : ((...args: any) => any) | undefined;
     Get<O extends object, P extends ESPropertyKey>(O: O, P: P): P extends keyof O ? O[P] : any;
 
+    // prettier-ignore
     Type<T>(x: T)
         : T extends string ? 'String'
         : T extends number ? 'Number'
@@ -105,25 +105,6 @@ interface ES2015 extends Omit<typeof ES5, 'CheckObjectCoercible' | 'ToPrimitive'
     HasProperty(O: object, P: ESPropertyKey): boolean;
 
     IsConcatSpreadable(O: object): boolean;
-    Invoke<O, P extends ESPropertyKey>(
-        O: O,
-        P: P,
-        args?:
-            | (P extends keyof O
-                    ? O[P] extends (...args: infer A) => any
-                        ? Readonly<A>
-                        : readonly unknown[]
-                    : readonly unknown[])
-            | ArrayLike<
-                    P extends keyof O
-                        ? O[P] extends (...args: infer A) => any
-                            ? A extends Array<infer T>
-                                ? T
-                                : unknown
-                            : unknown
-                        : unknown
-              >,
-    ): P extends keyof O ? (O[P] extends (...args: any) => infer R ? R : never) : any;
 
     /**
      * @param obj The iterable

--- a/types/es-abstract/es2015.d.ts
+++ b/types/es-abstract/es2015.d.ts
@@ -4,9 +4,6 @@ import ES5 = require('./es5');
 import { Intrinsics } from './GetIntrinsic';
 import { PropertyKey as ESPropertyKey } from './index';
 
-// Utility types:
-type ToApplyArgs<A extends ArrayLike<any>> = Readonly<A> | { readonly [x: number]: A[number]; readonly length: number };
-
 interface ES2015 extends Omit<typeof ES5, 'CheckObjectCoercible' | 'ToPrimitive' | 'Type'> {
     Call<T, R>(F: (this: T) => R, thisArg: T): R;
     Call<T, A extends readonly unknown[], R>(F: (this: T, ...args: A) => R, thisArg: T, args: Readonly<A>): R;

--- a/types/es-abstract/test/es2015.test.ts
+++ b/types/es-abstract/test/es2015.test.ts
@@ -2,6 +2,7 @@ import ES2015 = require('es-abstract/es2015');
 import { expectType, newType } from './index.test';
 
 declare const any: unknown;
+declare const args: IArguments;
 
 ES2015.Type(undefined); // $ExpectType "Undefined"
 ES2015.Type(null); // $ExpectType "Null"
@@ -41,7 +42,9 @@ ES2015.ToUint8(any); // $ExpectType number
 ES2015.ToUint8Clamp(any); // $ExpectType number
 ES2015.ToLength(any); // $ExpectType number
 
-ES2015.Call(Object.prototype.toString, BigInt(Number.MAX_SAFE_INTEGER)); // $ExpectType string
+ES2015.Call<bigint, readonly [], string>(Object.prototype.toString, BigInt(Number.MAX_SAFE_INTEGER), []); // $ExpectType string
+ES2015.Call(Object.prototype.hasOwnProperty, [], ['length'] as const); // $ExpectType boolean
+ES2015.Call(Object.prototype.hasOwnProperty, any, args as IArguments & [PropertyKey]); // $ExpectType boolean
 
 // $ExpectType IterableIterator<number>
 ES2015.GetIterator([1, 2, 3]);
@@ -60,12 +63,12 @@ declare function iterNext<T, TReturn = any, TNext = unknown>(
 ES2015.Call(iterNext, generable());
 
 // $ExpectType IteratorResult<number, boolean>
-ES2015.Invoke(generable(), 'next', any as IArguments);
-
-ES2015.Invoke(generable(), Symbol.iterator, any as IArguments);
+ES2015.Invoke(generable(), 'next', args as IArguments & [string]);
+ES2015.Invoke(generable(), Symbol.iterator, args);
 
 // $ExpectType boolean
-ES2015.Invoke(Reflect, 'has', any as IArguments);
+ES2015.Invoke(Reflect, 'has', args as IArguments & [object, PropertyKey]);
+ES2015.Invoke(Object as typeof Object & typeof Object.prototype, 'hasOwnProperty', ['prototype']); // $ExpectType boolean
 
 // $ExpectType Generator<number, boolean, string>
 ES2015.GetIterator({ [Symbol.iterator]: generable });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/ljharb/es-abstract/pull/99> <https://github.com/microsoft/TypeScript/pull/35608>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
