### PR TITLE
[types/binary-split]: Add new type definitions for module

### DIFF
--- a/types/binary-split/binary-split-tests.ts
+++ b/types/binary-split/binary-split-tests.ts
@@ -6,9 +6,9 @@ splitter.on('data', (chunk: Buffer) => {
     output.push(chunk);
 });
 splitter.on('end', () => {
-    if (output.length !== 2 && output[0].toString('utf8') !== 'A' && output[1].toString('utf8') !== 'B') {
+    // if (output.length !== 2 && output[0].toString('utf8') !== 'A' && output[1].toString('utf8') !== 'B') {
         throw new Error('Test failed');
-    }
+    // }
 });
 
 const input = Buffer.from('A*snip*B');

--- a/types/binary-split/binary-split-tests.ts
+++ b/types/binary-split/binary-split-tests.ts
@@ -11,6 +11,8 @@ splitter.on('end', () => {
     // }
 });
 
+throw new Error('Test failed');
+
 const input = Buffer.from('A*snip*B');
 splitter.write(input);
 splitter.end();

--- a/types/binary-split/binary-split-tests.ts
+++ b/types/binary-split/binary-split-tests.ts
@@ -6,12 +6,10 @@ splitter.on('data', (chunk: Buffer) => {
     output.push(chunk);
 });
 splitter.on('end', () => {
-    // if (output.length !== 2 && output[0].toString('utf8') !== 'A' && output[1].toString('utf8') !== 'B') {
+    if (output.length !== 2 || output[0].toString('utf8') !== 'A' || output[1].toString('utf8') !== 'B') {
         throw new Error('Test failed');
-    // }
+    }
 });
-
-throw new Error('Test failed');
 
 const input = Buffer.from('A*snip*B');
 splitter.write(input);

--- a/types/binary-split/binary-split-tests.ts
+++ b/types/binary-split/binary-split-tests.ts
@@ -1,0 +1,16 @@
+import bsplit = require('binary-split');
+
+const output = new Array<Buffer>();
+const splitter = bsplit('*snip*');
+splitter.on('data', (chunk: Buffer) => {
+    output.push(chunk);
+});
+splitter.on('end', () => {
+    if (output.length !== 2 && output[0].toString('utf8') !== 'A' && output[1].toString('utf8') !== 'B') {
+        throw new Error('Test failed');
+    }
+});
+
+const input = Buffer.from('A*snip*B');
+splitter.write(input);
+splitter.end();

--- a/types/binary-split/index.d.ts
+++ b/types/binary-split/index.d.ts
@@ -15,5 +15,5 @@ export = BinarySplit;
  * @param splitOn The matcher for the splitting points in the stream. Default: os.EOL
  */
 declare function BinarySplit(
-    splitOn: number[] | BigInt[] | Buffer | Uint8Array | ArrayBuffer | SharedArrayBuffer | string | object,
+    splitOn?: string | Buffer | ArrayBuffer | SharedArrayBuffer | number[] | BigInt[] | Uint8Array | object,
 ): Transform;

--- a/types/binary-split/index.d.ts
+++ b/types/binary-split/index.d.ts
@@ -8,7 +8,7 @@
 
 import { Transform } from 'stream';
 
-export = binary_split;
+export = BinarySplit;
 
 /**
  * Split streams of binary data.

--- a/types/binary-split/index.d.ts
+++ b/types/binary-split/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for binary-split 1.0
+// Project: https://github.com/maxogden/binary-split#readme
+// Definitions by: Krisztián Balla <https://github.com/krisztianb>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import { Transform } from 'stream';
+
+export = binary_split;
+
+/**
+ * Split streams of binary data.
+ * @param splitOn The matcher for the splitting points in the stream. Default: os.EOL
+ */
+declare function binary_split(
+    splitOn: number[] | BigInt[] | Buffer | Uint8Array | ArrayBuffer | SharedArrayBuffer | string | object,
+): Transform;

--- a/types/binary-split/index.d.ts
+++ b/types/binary-split/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/maxogden/binary-split#readme
 // Definitions by: Krisztián Balla <https://github.com/krisztianb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.2
 
 /// <reference types="node" />
 

--- a/types/binary-split/index.d.ts
+++ b/types/binary-split/index.d.ts
@@ -14,6 +14,6 @@ export = binary_split;
  * Split streams of binary data.
  * @param splitOn The matcher for the splitting points in the stream. Default: os.EOL
  */
-declare function binary_split(
+declare function BinarySplit(
     splitOn: number[] | BigInt[] | Buffer | Uint8Array | ArrayBuffer | SharedArrayBuffer | string | object,
 ): Transform;

--- a/types/binary-split/tsconfig.json
+++ b/types/binary-split/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "strict": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "binary-split-tests.ts"
+    ]
+}

--- a/types/binary-split/tslint.json
+++ b/types/binary-split/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
