### PR TITLE
Calidation generic type support

### DIFF
--- a/types/calidation/calidation-tests.tsx
+++ b/types/calidation/calidation-tests.tsx
@@ -11,10 +11,12 @@ import {
     ValidatorsProvider,
     Fields,
     ValidatorsProviderProps,
+    TransformsFunction,
 } from 'calidation';
 
 interface FieldTypes {
     foo: string;
+    bar: string | null;
 }
 
 const config: FieldsConfig<FieldTypes> = {
@@ -27,11 +29,19 @@ const config: FieldsConfig<FieldTypes> = {
             validateIf: ({ isDirty }: ValidatorContext<FieldTypes>) => isDirty,
         },
     },
+    bar: {},
 };
 
-const initialValues: Fields<FieldTypes> = { foo: '0' };
+const initialValues: Fields<FieldTypes> = { foo: '0', bar: null };
 
 const transforms: Transforms<FieldTypes> = { foo: parseInt };
+
+const transformFn: TransformsFunction<FieldTypes> = (key, transformFn) => transformFn;
+
+const typedTransform: Transforms<FieldTypes> = {
+    foo: transformFn('foo', parseInt),
+    bar: transformFn('bar', value => !!value),
+};
 
 function onChange(event: React.ChangeEvent<HTMLFormElement>): void {
     console.log(event);
@@ -116,7 +126,7 @@ const ValidatorsProviderTest = () => (
             onUpdate={onUpdate}
             config={configWithCustomValidators}
             initialValues={initialValues}
-            transforms={transforms}
+            transforms={typedTransform}
         >
             {({ dirty, errors, fields }: ValidationContext<FieldTypes>) => (
                 <div>

--- a/types/calidation/calidation-tests.tsx
+++ b/types/calidation/calidation-tests.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {
-    Dictionary,
     FieldsConfig,
     Form,
     FormContext,
@@ -9,23 +8,30 @@ import {
     Validation,
     ValidationContext,
     ValidatorContext,
+    ValidatorsProvider,
+    Fields,
+    ValidatorsProviderProps,
 } from 'calidation';
 
-const config: FieldsConfig = {
+interface FieldTypes {
+    foo: string;
+}
+
+const config: FieldsConfig<FieldTypes> = {
     foo: {
         isRequired: 'This field is required',
         isNumber: 'This field must be a number',
         isGreaterThan: {
             message: 'This field must be greater than 7',
             value: 7,
-            validateIf: ({ isDirty }: ValidatorContext) => isDirty,
+            validateIf: ({ isDirty }: ValidatorContext<FieldTypes>) => isDirty,
         },
     },
 };
 
-const initialValues: Dictionary = { foo: 0 };
+const initialValues: Fields<FieldTypes> = { foo: '0' };
 
-const transforms: Transforms = { foo: parseInt };
+const transforms: Transforms<FieldTypes> = { foo: parseInt };
 
 function onChange(event: React.ChangeEvent<HTMLFormElement>): void {
     console.log(event);
@@ -35,18 +41,42 @@ function onReset(): void {
     console.log('form has been reset');
 }
 
-function onSubmit(context: FormContext): void {
+function onSubmit(context: FormContext<FieldTypes>): void {
     console.log(context);
 }
 
-function onUpdate(context: FormContext): void {
+function onUpdate(context: FormContext<FieldTypes>): void {
     console.log(context);
 }
 
+const extraValidators: ValidatorsProviderProps<FieldTypes>['validators'] = {
+    isEven: config => value => (Number(value) % 2 !== 0 ? config.message : null),
+    isOdd: (config, { errors, fields, isDirty }: ValidatorContext<FieldTypes>) => value => {
+        if (!isDirty) {
+            return null;
+        }
+        if (!fields.foo) {
+            return null;
+        }
+        if (errors.foo) {
+            return `Please address these errors ${errors.foo}`;
+        }
+        return Number(value) % 2 !== 1 ? config.message : null;
+    },
+};
+
+const configWithCustomValidators: FieldsConfig<FieldTypes> = {
+    foo: {
+        isRequired: 'This field is required',
+        isEven: {
+            message: 'This needs to be an even number',
+        },
+    },
+};
 const FormTest = () => (
     <Form onChange={onChange} onReset={onReset} onSubmit={onSubmit} onUpdate={onUpdate}>
         <Validation config={config} initialValues={initialValues} transforms={transforms}>
-            {({ dirty, errors, fields }: ValidationContext) => (
+            {({ dirty, errors, fields }: ValidationContext<FieldTypes>) => (
                 <div>
                     <label>Input</label>
                     <input name="foo" value={`${fields.foo}`} />
@@ -67,7 +97,7 @@ const FormValidationTest = () => (
         initialValues={initialValues}
         transforms={transforms}
     >
-        {({ dirty, errors, fields }: ValidationContext) => (
+        {({ dirty, errors, fields }: ValidationContext<FieldTypes>) => (
             <div>
                 <label>Input</label>
                 <input name="foo" value={`${fields.foo}`} />
@@ -75,4 +105,26 @@ const FormValidationTest = () => (
             </div>
         )}
     </FormValidation>
+);
+
+const ValidatorsProviderTest = () => (
+    <ValidatorsProvider validators={extraValidators}>
+        <FormValidation
+            onChange={onChange}
+            onReset={onReset}
+            onSubmit={onSubmit}
+            onUpdate={onUpdate}
+            config={configWithCustomValidators}
+            initialValues={initialValues}
+            transforms={transforms}
+        >
+            {({ dirty, errors, fields }: ValidationContext<FieldTypes>) => (
+                <div>
+                    <label>Input</label>
+                    <input name="foo" value={`${fields.foo}`} />
+                    {dirty.foo && errors.foo && <p>{errors.foo}</p>}
+                </div>
+            )}
+        </FormValidation>
+    </ValidatorsProvider>
 );

--- a/types/calidation/calidation-tests.tsx
+++ b/types/calidation/calidation-tests.tsx
@@ -11,12 +11,11 @@ import {
     ValidatorsProvider,
     Fields,
     ValidatorsProviderProps,
-    TransformsFunction,
 } from 'calidation';
 
 interface FieldTypes {
-    foo: string;
-    bar: string | null;
+    foo: number;
+    bar: string[];
 }
 
 const config: FieldsConfig<FieldTypes> = {
@@ -32,15 +31,10 @@ const config: FieldsConfig<FieldTypes> = {
     bar: {},
 };
 
-const initialValues: Fields<FieldTypes> = { foo: '0', bar: null };
+const initialValues: Fields<FieldTypes> = { foo: 0, bar: [] };
 
-const transforms: Transforms<FieldTypes> = { foo: parseInt };
-
-const transformFn: TransformsFunction<FieldTypes> = (key, transformFn) => transformFn;
-
-const typedTransform: Transforms<FieldTypes> = {
-    foo: transformFn('foo', parseInt),
-    bar: transformFn('bar', value => !!value),
+const transforms: Transforms<FieldTypes> = {
+    foo: parseInt,
 };
 
 function onChange(event: React.ChangeEvent<HTMLFormElement>): void {
@@ -89,7 +83,7 @@ const FormTest = () => (
             {({ dirty, errors, fields }: ValidationContext<FieldTypes>) => (
                 <div>
                     <label>Input</label>
-                    <input name="foo" value={`${fields.foo}`} />
+                    <input name="foo" type="number" value={`${fields.foo}`} />
                     {dirty.foo && errors.foo && <p>{errors.foo}</p>}
                 </div>
             )}
@@ -126,7 +120,6 @@ const ValidatorsProviderTest = () => (
             onUpdate={onUpdate}
             config={configWithCustomValidators}
             initialValues={initialValues}
-            transforms={typedTransform}
         >
             {({ dirty, errors, fields }: ValidationContext<FieldTypes>) => (
                 <div>

--- a/types/calidation/index.d.ts
+++ b/types/calidation/index.d.ts
@@ -1,134 +1,149 @@
-// Type definitions for calidation 1.16
+// Type definitions for calidation 2.0
 // Project: https://github.com/selbekk/calidation#readme
 // Definitions by: Ray Knight <https://github.com/ArrayKnight>
+//                 Lisa Tassone <https://github.com/lisatassone>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 3.8
 
 import * as React from 'react';
 
-export interface Dictionary<T = any> {
-    [key: string]: T;
-}
+export type Dirty<T extends object> = Record<keyof T, boolean>;
 
-export type Dirty = Dictionary<boolean>;
+export type Errors<T extends object> = Record<keyof T, string | null>;
 
-export type Errors = Dictionary<string | null>;
+export type Fields<T extends object> = T;
 
-export type Fields = Dictionary;
+export type Transforms<T extends object> = Record<keyof T, (value: T[keyof T]) => any>;
 
-export type Transforms = Dictionary<(value: any) => any>;
-
-export interface ValidatorContext {
-    errors: Errors;
-    fields: Fields;
+export interface ValidatorContext<T extends object> {
+    errors: Errors<T>;
+    fields: Fields<T>;
     isDirty: boolean;
 }
 
-export interface SimpleValidatorConfig {
+export interface SimpleValidatorConfig<T extends object> {
     message: string;
-    validateIf?: ((context: ValidatorContext) => boolean) | boolean;
+    validateIf?: ((context: ValidatorContext<T>) => boolean) | boolean;
 }
 
-export type SimpleValidator = string | SimpleValidatorConfig | ((context: ValidatorContext) => SimpleValidatorConfig);
+export type SimpleValidator<T extends object> =
+    | string
+    | SimpleValidatorConfig<T>
+    | ((context: ValidatorContext<T>) => SimpleValidatorConfig<T>);
 
-export interface BlacklistValidatorConfig extends SimpleValidatorConfig {
+export interface BlacklistValidatorConfig<T extends object> extends SimpleValidatorConfig<T> {
     blacklist: string[];
 }
 
-export type BlacklistValidator = BlacklistValidatorConfig | ((context: ValidatorContext) => BlacklistValidatorConfig);
+export type BlacklistValidator<T extends object> =
+    | BlacklistValidatorConfig<T>
+    | ((context: ValidatorContext<T>) => BlacklistValidatorConfig<T>);
 
-export interface ValueValidatorConfig<T> extends SimpleValidatorConfig {
-    value: T;
+export interface ValueValidatorConfig<T extends object, P> extends SimpleValidatorConfig<T> {
+    value: P;
 }
 
-export type ValueValidator<T> = ValueValidatorConfig<T> | ((context: ValidatorContext) => ValueValidatorConfig<T>);
+export type ValueValidator<T extends object, P> =
+    | ValueValidatorConfig<T, P>
+    | ((context: ValidatorContext<T>) => ValueValidatorConfig<T, P>);
 
-export interface RegexValidatorConfig extends SimpleValidatorConfig {
+export interface RegexValidatorConfig<T extends object> extends SimpleValidatorConfig<T> {
     regex: RegExp;
 }
 
-export type RegexValidator = RegexValidatorConfig | ((context: ValidatorContext) => RegexValidatorConfig);
+export type RegexValidator<T extends object> =
+    | RegexValidatorConfig<T>
+    | ((context: ValidatorContext<T>) => RegexValidatorConfig<T>);
 
-export interface WhitelistValidatorConfig extends SimpleValidatorConfig {
+export interface WhitelistValidatorConfig<T extends object> extends SimpleValidatorConfig<T> {
     whitelist: string[];
 }
 
-export type WhitelistValidator = WhitelistValidatorConfig | ((context: ValidatorContext) => RegexValidatorConfig);
+export type WhitelistValidator<T extends object> =
+    | WhitelistValidatorConfig<T>
+    | ((context: ValidatorContext<T>) => RegexValidatorConfig<T>);
 
-export interface LengthValidatorConfig extends SimpleValidatorConfig {
+export interface LengthValidatorConfig<T extends object> extends SimpleValidatorConfig<T> {
     length: number;
 }
 
-export type LengthValidator = LengthValidatorConfig | ((context: ValidatorContext) => LengthValidatorConfig);
+export type LengthValidator<T extends object> =
+    | LengthValidatorConfig<T>
+    | ((context: ValidatorContext<T>) => LengthValidatorConfig<T>);
 
-export type Validator =
-    | SimpleValidator
-    | BlacklistValidator
-    | ValueValidator<any>
-    | RegexValidator
-    | WhitelistValidator
-    | LengthValidator;
+export type Validator<T extends object> =
+    | SimpleValidator<T>
+    | BlacklistValidator<T>
+    | ValueValidator<T, any>
+    | RegexValidator<T>
+    | WhitelistValidator<T>
+    | LengthValidator<T>;
 
-export interface FieldConfig {
-    isBlacklisted?: BlacklistValidator;
-    isEmail?: SimpleValidator;
-    isEqual?: ValueValidator<any>;
-    isGreaterThan?: ValueValidator<number>;
-    isLessThan?: ValueValidator<number>;
-    isRequired?: SimpleValidator;
-    isNumber?: SimpleValidator;
-    isRegexMatch?: RegexValidator;
-    isWhitelisted?: WhitelistValidator;
-    isMinLength?: LengthValidator;
-    isMaxLength?: LengthValidator;
-    isExactLength?: LengthValidator;
+export interface FieldConfig<T extends object> {
+    isBlacklisted?: BlacklistValidator<T>;
+    isEmail?: SimpleValidator<T>;
+    isEqual?: ValueValidator<T, any>;
+    isGreaterThan?: ValueValidator<T, number>;
+    isLessThan?: ValueValidator<T, number>;
+    isRequired?: SimpleValidator<T>;
+    isNumber?: SimpleValidator<T>;
+    isRegexMatch?: RegexValidator<T>;
+    isWhitelisted?: WhitelistValidator<T>;
+    isMinLength?: LengthValidator<T>;
+    isMaxLength?: LengthValidator<T>;
+    isExactLength?: LengthValidator<T>;
 }
 
-export type FieldsConfig = Dictionary<FieldConfig>;
+export type FieldsConfig<T extends object> = Record<string, FieldConfig<T> | Record<string, SimpleValidatorConfig<T>>>;
 
-export interface FormContext {
-    dirty: Dirty;
-    errors: Errors;
-    fields: Fields;
+export interface FormContext<T extends object> {
+    dirty: Dirty<T>;
+    errors: Errors<T>;
+    fields: Fields<T>;
     isValid: boolean;
     resetAll: () => void;
-    register: (config: FieldsConfig, transforms: Transforms, initialValues: Dictionary) => void;
-    unregister: (config: FieldsConfig) => void;
-    setError: (delta: Errors) => void;
-    setField: (delta: Fields) => void;
+    register: (config: FieldsConfig<T>, transforms: Transforms<T>, initialValues: T) => void;
+    unregister: (config: FieldsConfig<T>) => void;
+    setError: (delta: Errors<T>) => void;
+    setField: (delta: Fields<T>) => void;
     submit: () => void;
     submitted: boolean;
 }
 
-export interface FormProps
+export interface FormProps<T extends object>
     extends Omit<React.DetailedHTMLProps<React.FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>, 'onSubmit'> {
     onChange?: (event: React.ChangeEvent<HTMLFormElement>) => void;
     onReset?: () => void;
-    onSubmit?: (context: FormContext) => void;
-    onUpdate?: (context: FormContext) => void;
+    onSubmit?: (context: FormContext<T>) => void;
+    onUpdate?: (context: FormContext<T>) => void;
 }
 
-export class Form extends React.Component<FormProps> {}
+export class Form<T extends object> extends React.Component<FormProps<T>> {}
 
-export type ValidationContext = Omit<FormContext, 'register' | 'unregister'>;
+export type ValidationContext<T extends object> = Omit<FormContext<T>, 'register' | 'unregister'>;
 
-export interface ValidationProps {
-    children: (context: ValidationContext) => React.ReactNode;
-    config: FieldsConfig;
-    initialValues?: Dictionary;
-    transforms?: Transforms;
+export interface ValidationProps<T extends object> {
+    children: (context: ValidationContext<T>) => React.ReactNode;
+    config: FieldsConfig<T>;
+    initialValues?: T;
+    transforms?: Transforms<T>;
 }
 
-export class Validation extends React.Component<ValidationProps> {}
+export class Validation<T extends object> extends React.Component<ValidationProps<T>> {}
 
-export interface FormValidationProps extends FormProps, ValidationProps {
-    children: (context: ValidationContext) => React.ReactNode;
+export interface FormValidationProps<T extends object> extends FormProps<T>, ValidationProps<T> {
+    children: (context: ValidationContext<T>) => React.ReactNode;
 }
 
-export class FormValidation extends React.Component<FormValidationProps> {}
+export class FormValidation<T extends object> extends React.Component<FormValidationProps<T>> {}
 
-export interface ValidatorsProviderProps {
-    validators: Dictionary<(config: SimpleValidatorConfig) => (value: any) => string | null>;
+export type CustomValidatorFunction<T extends object> = (
+    config: SimpleValidatorConfig<T>,
+    context: ValidatorContext<T>,
+) => (value: T[keyof T]) => string | null;
+
+export interface ValidatorsProviderProps<T extends object> {
+    validators: Record<string, CustomValidatorFunction<T>>;
 }
 
-export class ValidatorsProvider extends React.Component<ValidatorsProviderProps> {}
+export class ValidatorsProvider<T extends object> extends React.Component<ValidatorsProviderProps<T>> {}

--- a/types/calidation/index.d.ts
+++ b/types/calidation/index.d.ts
@@ -1,97 +1,92 @@
-// Type definitions for calidation 2.0
+// Type definitions for calidation 1.16
 // Project: https://github.com/selbekk/calidation#readme
 // Definitions by: Ray Knight <https://github.com/ArrayKnight>
 //                 Lisa Tassone <https://github.com/lisatassone>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.8
+// TypeScript Version: 3.5
 
 import * as React from 'react';
 
-export type Dirty<T extends object> = Record<keyof T, boolean>;
+export type Dirty<T extends object = any> = Record<keyof T, boolean>;
 
-export type Errors<T extends object> = Record<keyof T, string | null>;
+export type Errors<T extends object = any> = Record<keyof T, string | null>;
 
-export type Fields<T extends object> = T;
+export type Fields<T extends object = any> = T;
 
-export type Transform<T extends object> = Record<keyof T, (value: any) => any>;
+export type Transform<T extends object = any> = Record<keyof T, (value: any) => T[keyof T]>;
 
-export type TransformsFunction<T extends object> = <K extends keyof T>(
-    key: K,
-    transformFn: (value: T[K]) => any,
-) => (value: T[K]) => any;
+export type Transforms<T extends object = any> = Partial<Transform<T>>;
 
-export type Transforms<T extends object> = Partial<Transform<T>>;
-
-export interface ValidatorContext<T extends object> {
+export interface ValidatorContext<T extends object = any> {
     errors: Errors<T>;
     fields: Fields<T>;
     isDirty: boolean;
 }
 
-export interface SimpleValidatorConfig<T extends object> {
+export interface SimpleValidatorConfig<T extends object = any> {
     message: string;
     validateIf?: ((context: ValidatorContext<T>) => boolean) | boolean;
 }
 
-export type SimpleValidator<T extends object> =
+export type SimpleValidator<T extends object = any> =
     | string
     | SimpleValidatorConfig<T>
     | ((context: ValidatorContext<T>) => SimpleValidatorConfig<T>);
 
-export interface BlacklistValidatorConfig<T extends object> extends SimpleValidatorConfig<T> {
+export interface BlacklistValidatorConfig<T extends object = any> extends SimpleValidatorConfig<T> {
     blacklist: string[];
 }
 
-export type BlacklistValidator<T extends object> =
+export type BlacklistValidator<T extends object = any> =
     | BlacklistValidatorConfig<T>
     | ((context: ValidatorContext<T>) => BlacklistValidatorConfig<T>);
 
-export interface ValueValidatorConfig<T extends object, P> extends SimpleValidatorConfig<T> {
+export interface ValueValidatorConfig<P, T extends object = any> extends SimpleValidatorConfig<T> {
     value: P;
 }
 
-export type ValueValidator<T extends object, P> =
-    | ValueValidatorConfig<T, P>
-    | ((context: ValidatorContext<T>) => ValueValidatorConfig<T, P>);
+export type ValueValidator<P, T extends object = any> =
+    | ValueValidatorConfig<P, T>
+    | ((context: ValidatorContext<T>) => ValueValidatorConfig<P, T>);
 
-export interface RegexValidatorConfig<T extends object> extends SimpleValidatorConfig<T> {
+export interface RegexValidatorConfig<T extends object = any> extends SimpleValidatorConfig<T> {
     regex: RegExp;
 }
 
-export type RegexValidator<T extends object> =
+export type RegexValidator<T extends object = any> =
     | RegexValidatorConfig<T>
     | ((context: ValidatorContext<T>) => RegexValidatorConfig<T>);
 
-export interface WhitelistValidatorConfig<T extends object> extends SimpleValidatorConfig<T> {
+export interface WhitelistValidatorConfig<T extends object = any> extends SimpleValidatorConfig<T> {
     whitelist: string[];
 }
 
-export type WhitelistValidator<T extends object> =
+export type WhitelistValidator<T extends object = any> =
     | WhitelistValidatorConfig<T>
     | ((context: ValidatorContext<T>) => RegexValidatorConfig<T>);
 
-export interface LengthValidatorConfig<T extends object> extends SimpleValidatorConfig<T> {
+export interface LengthValidatorConfig<T extends object = any> extends SimpleValidatorConfig<T> {
     length: number;
 }
 
-export type LengthValidator<T extends object> =
+export type LengthValidator<T extends object = any> =
     | LengthValidatorConfig<T>
     | ((context: ValidatorContext<T>) => LengthValidatorConfig<T>);
 
-export type Validator<T extends object> =
+export type Validator<T extends object = any> =
     | SimpleValidator<T>
     | BlacklistValidator<T>
-    | ValueValidator<T, any>
+    | ValueValidator<T>
     | RegexValidator<T>
     | WhitelistValidator<T>
     | LengthValidator<T>;
 
-export interface FieldConfig<T extends object> {
+export interface FieldConfig<T extends object = any> {
     isBlacklisted?: BlacklistValidator<T>;
     isEmail?: SimpleValidator<T>;
-    isEqual?: ValueValidator<T, any>;
-    isGreaterThan?: ValueValidator<T, number>;
-    isLessThan?: ValueValidator<T, number>;
+    isEqual?: ValueValidator<any, T>;
+    isGreaterThan?: ValueValidator<number, T>;
+    isLessThan?: ValueValidator<number, T>;
     isRequired?: SimpleValidator<T>;
     isNumber?: SimpleValidator<T>;
     isRegexMatch?: RegexValidator<T>;
@@ -101,12 +96,12 @@ export interface FieldConfig<T extends object> {
     isExactLength?: LengthValidator<T>;
 }
 
-export type FieldsConfig<T extends object> = Record<
+export type FieldsConfig<T extends object = any> = Record<
     string,
-    FieldConfig<T> | Record<string, SimpleValidator<T>> | Record<string, ValueValidator<T, any>>
+    FieldConfig<T> | Record<string, SimpleValidator<T>> | Record<string, ValueValidator<T>>
 >;
 
-export interface FormContext<T extends object> {
+export interface FormContext<T extends object = any> {
     dirty: Dirty<T>;
     errors: Errors<T>;
     fields: Fields<T>;
@@ -120,7 +115,7 @@ export interface FormContext<T extends object> {
     submitted: boolean;
 }
 
-export interface FormProps<T extends object>
+export interface FormProps<T extends object = any>
     extends Omit<React.DetailedHTMLProps<React.FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>, 'onSubmit'> {
     onChange?: (event: React.ChangeEvent<HTMLFormElement>) => void;
     onReset?: () => void;
@@ -128,32 +123,32 @@ export interface FormProps<T extends object>
     onUpdate?: (context: FormContext<T>) => void;
 }
 
-export class Form<T extends object> extends React.Component<FormProps<T>> {}
+export class Form<T extends object = any> extends React.Component<FormProps<T>> {}
 
-export type ValidationContext<T extends object> = Omit<FormContext<T>, 'register' | 'unregister'>;
+export type ValidationContext<T extends object = any> = Omit<FormContext<T>, 'register' | 'unregister'>;
 
-export interface ValidationProps<T extends object> {
+export interface ValidationProps<T extends object = any> {
     children: (context: ValidationContext<T>) => React.ReactNode;
     config: FieldsConfig<T>;
     initialValues?: T;
     transforms?: Transforms<T>;
 }
 
-export class Validation<T extends object> extends React.Component<ValidationProps<T>> {}
+export class Validation<T extends object = any> extends React.Component<ValidationProps<T>> {}
 
-export interface FormValidationProps<T extends object> extends FormProps<T>, ValidationProps<T> {
+export interface FormValidationProps<T extends object = any> extends FormProps<T>, ValidationProps<T> {
     children: (context: ValidationContext<T>) => React.ReactNode;
 }
 
-export class FormValidation<T extends object> extends React.Component<FormValidationProps<T>> {}
+export class FormValidation<T extends object = any> extends React.Component<FormValidationProps<T>> {}
 
-export type CustomValidatorFunction<T extends object> = (
+export type CustomValidatorFunction<T extends object = any> = (
     config: SimpleValidatorConfig<T>,
     context: ValidatorContext<T>,
 ) => (value: T[keyof T]) => string | null;
 
-export interface ValidatorsProviderProps<T extends object> {
+export interface ValidatorsProviderProps<T extends object = any> {
     validators: Record<string, CustomValidatorFunction<T>>;
 }
 
-export class ValidatorsProvider<T extends object> extends React.Component<ValidatorsProviderProps<T>> {}
+export class ValidatorsProvider<T extends object = any> extends React.Component<ValidatorsProviderProps<T>> {}

--- a/types/calidation/index.d.ts
+++ b/types/calidation/index.d.ts
@@ -13,7 +13,14 @@ export type Errors<T extends object> = Record<keyof T, string | null>;
 
 export type Fields<T extends object> = T;
 
-export type Transforms<T extends object> = Record<keyof T, (value: T[keyof T]) => any>;
+export type Transform<T extends object> = Record<keyof T, (value: any) => any>;
+
+export type TransformsFunction<T extends object> = <K extends keyof T>(
+    key: K,
+    transformFn: (value: T[K]) => any,
+) => (value: T[K]) => any;
+
+export type Transforms<T extends object> = Partial<Transform<T>>;
 
 export interface ValidatorContext<T extends object> {
     errors: Errors<T>;
@@ -94,7 +101,10 @@ export interface FieldConfig<T extends object> {
     isExactLength?: LengthValidator<T>;
 }
 
-export type FieldsConfig<T extends object> = Record<string, FieldConfig<T> | Record<string, SimpleValidatorConfig<T>>>;
+export type FieldsConfig<T extends object> = Record<
+    string,
+    FieldConfig<T> | Record<string, SimpleValidator<T>> | Record<string, ValueValidator<T, any>>
+>;
 
 export interface FormContext<T extends object> {
     dirty: Dirty<T>;
@@ -105,7 +115,7 @@ export interface FormContext<T extends object> {
     register: (config: FieldsConfig<T>, transforms: Transforms<T>, initialValues: T) => void;
     unregister: (config: FieldsConfig<T>) => void;
     setError: (delta: Errors<T>) => void;
-    setField: (delta: Fields<T>) => void;
+    setField: (delta: Partial<T>) => void;
     submit: () => void;
     submitted: boolean;
 }

--- a/types/calidation/tslint.json
+++ b/types/calidation/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
 }

--- a/types/calidation/tslint.json
+++ b/types/calidation/tslint.json
@@ -1,6 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "npm-naming": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
PR for adding generics to the calidation library types. I have added this as a breaking change because it's currently enforcing you pass through a type (even though that can be any of course). If this is a problem, I can update it to default to any, but this is meant to be a more type safe version. Although the original is helpful to know what the signatures are for the libraries methods and interfaces, working with the data you pass through to the form is always untyped which for my purposes, is not ideal.

First PR, so please let me know if there is anything further I need to do. I have tested these in a production app.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
