### PR TITLE
kdbxweb: fix nullability

### DIFF
--- a/types/kdbxweb/index.d.ts
+++ b/types/kdbxweb/index.d.ts
@@ -36,8 +36,8 @@ export interface editingStateDict {
 
 export class Credentials {
     constructor(
-        password: ProtectedValue,
-        keyFile: string | ArrayBuffer | Uint8Array
+        password: ProtectedValue | null,
+        keyFile: string | ArrayBuffer | Uint8Array | null
     );
 
     getHash(): Promise<ArrayBuffer>;

--- a/types/kdbxweb/kdbxweb-tests.ts
+++ b/types/kdbxweb/kdbxweb-tests.ts
@@ -7,6 +7,9 @@ const credentials = new kdbxweb.Credentials(
     "nFWx&e5SzT"
 );
 
+// allow null credentials
+new kdbxweb.Credentials(null, null);
+
 kdbxweb.Kdbx.load(dataarr, credentials).then(db => db);
 kdbxweb.Kdbx.loadXml("data", credentials).then(db => db);
 


### PR DESCRIPTION
Fix typing for two methods, allowing nulls where they are allowed. See related kdbxweb PR: https://github.com/keeweb/kdbxweb/pull/36

null handling in [setPassword](https://github.com/keeweb/kdbxweb/blob/master/lib/format/kdbx-credentials.js#L33) and [setKeyFile](https://github.com/keeweb/kdbxweb/blob/master/lib/format/kdbx-credentials.js#L80)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/keeweb/kdbxweb/pull/36
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
