### PR TITLE
[@types/mongoose]: fix array handling in create

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -114,15 +114,15 @@ declare module "mongoose" {
       ? T 
       :
     T extends Array<infer U>
-      ? U extends object | undefined
+      ? (U extends object | undefined
         ? { [V in keyof NonFunctionProperties<OmitReadonly<U>>]: U[V] extends object | undefined
-          ? DeepNonFunctionProperties<U[V]> 
-          : U[V] }[]
-        : T
+          ? DeepNonFunctionProperties<NonNullable<U[V]>> 
+          : U[V] }
+        : U)[]
       : 
     T extends object | undefined 
       ? { [V in keyof NonFunctionProperties<OmitReadonly<T>>]: T[V] extends object | undefined
-        ?  DeepNonFunctionProperties<T[V]> 
+        ? DeepNonFunctionProperties<NonNullable<T[V]>> 
         : T[V] }
       :
     T;

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -109,6 +109,10 @@ declare module "mongoose" {
       // ? Map<KM, DeepNonFunctionProperties<KV>>
       ? { [key: string]: DeepNonFunctionProperties<KV> } | [KM, KV][] | Map<KM, KV>
       : 
+    // short circuit to handle enums
+    T extends Array<string | number> 
+      ? T 
+      :
     T extends Array<infer U>
       ? U extends object | undefined
         ? { [V in keyof NonFunctionProperties<OmitReadonly<U>>]: U[V] extends object | undefined

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -114,13 +114,13 @@ declare module "mongoose" {
       ? T 
       :
     T extends Array<infer U>
-      ? (U extends object | undefined
+      ? (U extends object 
         ? { [V in keyof NonFunctionProperties<OmitReadonly<U>>]: U[V] extends object | undefined
           ? DeepNonFunctionProperties<NonNullable<U[V]>> 
           : U[V] }
         : U)[]
       : 
-    T extends object | undefined 
+    T extends object
       ? { [V in keyof NonFunctionProperties<OmitReadonly<T>>]: T[V] extends object | undefined
         ? DeepNonFunctionProperties<NonNullable<T[V]>> 
         : T[V] }

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -116,13 +116,13 @@ declare module "mongoose" {
     T extends Array<infer U>
       ? U extends object | undefined
         ? { [V in keyof NonFunctionProperties<OmitReadonly<U>>]: U[V] extends object | undefined
-          ? DeepNonFunctionProperties<NonNullable<U[V]>> 
+          ? DeepNonFunctionProperties<U[V]> 
           : U[V] }[]
         : T
       : 
     T extends object | undefined 
       ? { [V in keyof NonFunctionProperties<OmitReadonly<T>>]: T[V] extends object | undefined
-        ?  DeepNonFunctionProperties<NonNullable<T[V]>> 
+        ?  DeepNonFunctionProperties<T[V]> 
         : T[V] }
       :
     T;

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -109,10 +109,6 @@ declare module "mongoose" {
       // ? Map<KM, DeepNonFunctionProperties<KV>>
       ? { [key: string]: DeepNonFunctionProperties<KV> } | [KM, KV][] | Map<KM, KV>
       : 
-    // short circuit to handle enums
-    T extends Array<string | number> 
-      ? T 
-      :
     T extends Array<infer U>
       ? (U extends object 
         ? { [V in keyof NonFunctionProperties<OmitReadonly<U>>]: U[V] extends object | undefined

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -619,6 +619,12 @@ interface ModelWithFunction extends mongoose.Document {
 
     enum?: SchemaEnum;
 
+    selfRef?: ModelWithFunction | mongodb.ObjectID;
+
+    selfRef2?: ModelWithFunction | mongodb.ObjectID;
+
+    selfRefArray?: (ModelWithFunction | mongodb.ObjectID)[];
+
     enumArray?: SchemaEnum[];
 
     deeperFuncTest?: {
@@ -728,3 +734,7 @@ ModelWithFunctionInSchema.create({ name: "test", jobs: [], mapWithFuncs: { test:
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], enum: SchemaEnum.Bar });
 
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], enumArray: [SchemaEnum.Bar, SchemaEnum.Foo] });
+
+ModelWithFunctionInSchema.create({ name: "test", jobs: [] }).then(ref => {
+    ModelWithFunctionInSchema.create({ name: "test", jobs: [], selfRef: ref });
+});

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -607,10 +607,19 @@ LocModel.create({ address: "foo", coords: [1, 2], facilities: ["foo", "bar"] });
 LocModel.create({ address: "foo", coords: [1, 2], facilities: ["foo", "bar"], name: "bar", openingTimes: ["foo"], rating: 10, reviews: ["foo"], notes: [] });
 LocModel.create<{address: string}>({ address: "foo" });
 
+enum SchemaEnum {
+    Foo,
+    Bar
+}
+
 interface ModelWithFunction extends mongoose.Document {
     name: string;
 
     someFunc: () => any;
+
+    enum?: SchemaEnum;
+
+    enumArray?: SchemaEnum[];
 
     deeperFuncTest?: {
         test: string;
@@ -715,3 +724,7 @@ ModelWithFunctionInSchema.create({ name: "test", jobs: [{ title: "hello" }] });
 ModelWithFunctionInSchema.create({ name: "test", jobs: [{ title: "hello" }], titles: [{ title: "test" }] });
 
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], mapWithFuncs: { test: { title: "hello", innerMap: { test: { title: "hello" } } }} });
+
+ModelWithFunctionInSchema.create({ name: "test", jobs: [], enum: SchemaEnum.Bar });
+
+ModelWithFunctionInSchema.create({ name: "test", jobs: [], enumArray: [SchemaEnum.Bar, SchemaEnum.Foo] });

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -623,7 +623,14 @@ interface ModelWithFunction extends mongoose.Document {
 
     selfRef2?: ModelWithFunction | mongodb.ObjectID;
 
-    selfRefArray?: (ModelWithFunction | mongodb.ObjectID)[];
+    selfRefArray?: (ModelWithFunction | mongodb.ObjectID | undefined)[];
+
+    parent?: {
+        ref: { 
+            _id: mongodb.ObjectId; 
+            child: ModelWithFunction
+        } | mongodb.ObjectID;
+    }
 
     enumArray?: SchemaEnum[];
 

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -625,6 +625,8 @@ interface ModelWithFunction extends mongoose.Document {
 
     selfRefArray?: (ModelWithFunction | mongodb.ObjectID | undefined)[];
 
+    selfRefArray2?: ModelWithFunction[] | mongodb.ObjectID[];
+
     parent?: {
         ref: { 
             _id: mongodb.ObjectId; 
@@ -755,5 +757,8 @@ ModelWithFunctionInSchema.create({ name: "test", jobs: [], enum: SchemaEnum.Bar 
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], enumArray: [SchemaEnum.Bar, SchemaEnum.Foo] });
 
 ModelWithFunctionInSchema.create({ name: "test", jobs: [] }).then(ref => {
-    ModelWithFunctionInSchema.create({ name: "test", jobs: [], selfRef: ref, selfRef2: ref._id, selfRefArray: [ref, ref._id] });
+    const id: mongodb.ObjectID = ref._id;
+    ModelWithFunctionInSchema.create({ name: "test", jobs: [], selfRef: ref, selfRef2: ref._id, selfRefArray: [ref, id] });
+    ModelWithFunctionInSchema.create({ name: "test", jobs: [], selfRefArray2: [id, id] });
+    ModelWithFunctionInSchema.create({ name: "test", jobs: [], selfRefArray2: [ref, ref] });
 });

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -705,14 +705,26 @@ ModelWithFunctionInSchema.create({
 });
 
 
-//! note that these tests does not properly pass $ExpectError on TS 3.3
+// ------------------------------------------------------------------------------------
+// TESTS DISABLED: note that these tests does not properly pass $ExpectError on TS 3.3
 // they can be re-enabled once minimum TS version is bumped 
 
-// !$ExpectError
-// ModelWithFunctionInSchema.create({ name: "test", jobs: [], deeperFuncTest: { deepArray: [{ title1: "test" }] } });
+//! $ExpectError
+//ModelWithFunctionInSchema.create({ name: "test", jobs: [], deeperFuncTest: { deepArray: [{ title1: "test" }] } });
 
-// !$ExpectError
-//ModelWithFunctionInSchema.create({ name: "test", jobs:[], deeperFuncTest: { test: "hello", deepArray: [{ title1: "test" }] } });
+//! $ExpectError
+//ModelWithFunctionInSchema.create({ name: "test", jobs: [], deeperFuncTest: { test: "hello", deepArray: [{ title1: "test" }] } });
+
+//! $ExpectError
+//ModelWithFunctionInSchema.create({ name: "test", jobs: [], deeperFuncTest: { foo: "bar" } });
+// ------------------------------------------------------------------------------------
+
+// $ExpectError
+ModelWithFunctionInSchema.create({ foo: "bar" });
+
+// $ExpectError
+ModelWithFunctionInSchema.create({ name: "test", jobs: [], foo: "bar" });
+
 
 // $ExpectError
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], someFunc: {} as any });

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -736,5 +736,5 @@ ModelWithFunctionInSchema.create({ name: "test", jobs: [], enum: SchemaEnum.Bar 
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], enumArray: [SchemaEnum.Bar, SchemaEnum.Foo] });
 
 ModelWithFunctionInSchema.create({ name: "test", jobs: [] }).then(ref => {
-    ModelWithFunctionInSchema.create({ name: "test", jobs: [], selfRef: ref });
+    ModelWithFunctionInSchema.create({ name: "test", jobs: [], selfRef: ref, selfRef2: ref._id, selfRefArray: [ref, ref._id] });
 });


### PR DESCRIPTION
This PR fixes two edge cases when using the new types added for `.create()`.

I have added two tests that were previously failing.

Reported on https://github.com/typegoose/typegoose/pull/290

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
