### PR TITLE
Add types for write-file-webpack-plugin

### DIFF
--- a/types/write-file-webpack-plugin/index.d.ts
+++ b/types/write-file-webpack-plugin/index.d.ts
@@ -1,0 +1,43 @@
+// Type definitions for write-file-webpack-plugin 4.5
+// Project: https://github.com/gajus/write-file-webpack-plugin#readme
+// Definitions by: Nathan Hardy <https://github.com/nhardy>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import webpack = require("webpack");
+
+export interface UserOptionsType {
+    /**
+     * Atomically replace files content (i.e., to prevent programs like test watchers from seeing partial files).
+     * @default true
+     */
+    atomicReplace?: boolean;
+    /**
+     * Stop writing files on webpack errors
+     * @default true
+     */
+    exitOnErrors?: boolean;
+    /**
+     * A regular expression or function used to test if file should be written.
+     * When not present, all bundle will be written.
+     */
+    test?: RegExp;
+    /**
+     * Use hash index to write only files that have changed since the last iteration.
+     * @default true
+     */
+    useHashIndex?: boolean;
+    /**
+     * Logs names of the files that are being written (or skipped because they have not changed)
+     * @default true
+     */
+    log?: boolean;
+    /**
+     * Forces the execution of the plugin regardless of being using `webpack-dev-server` or not
+     * @default false
+     */
+    force?: boolean;
+}
+
+export default class WriteFilePlugin extends webpack.Plugin {
+    constructor(userOptions?: UserOptionsType);
+}

--- a/types/write-file-webpack-plugin/tsconfig.json
+++ b/types/write-file-webpack-plugin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "write-file-webpack-plugin-tests.ts"
+    ]
+}

--- a/types/write-file-webpack-plugin/tslint.json
+++ b/types/write-file-webpack-plugin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/write-file-webpack-plugin/write-file-webpack-plugin-tests.ts
+++ b/types/write-file-webpack-plugin/write-file-webpack-plugin-tests.ts
@@ -1,0 +1,15 @@
+import webpack = require("webpack");
+import WriteFileWebpackPlugin from "write-file-webpack-plugin";
+
+export const plugins: webpack.Plugin[] = [
+    new WriteFileWebpackPlugin(),
+    new WriteFileWebpackPlugin({}),
+    new WriteFileWebpackPlugin({
+        atomicReplace: false,
+        exitOnErrors: false,
+        test: /\.css$/,
+        useHashIndex: false,
+        log: false,
+        force: true,
+    }),
+];


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Relates to https://github.com/gajus/write-file-webpack-plugin/issues/67
