### PR TITLE
html-to-text: Add format: blockquote support

### DIFF
--- a/types/html-to-text/html-to-text-tests.ts
+++ b/types/html-to-text/html-to-text-tests.ts
@@ -22,3 +22,53 @@ console.log(fromString(htmlString));
 
 console.log('Processing string with custom options');
 console.log(fromString(htmlString, htmlOptions));
+
+const allElements = '<a>a</a>\
+<blockquote>b</blockquote>\
+<h1>h</h1>\
+<hr />\
+<img />\
+<br />\
+<ol></old>\
+<p>p</p>\
+<table></table>\
+<ul></ul>';
+
+const fmtOptions: HtmlToTextOptions = {
+    format: {
+        anchor: (_el, _walk, _options) => {
+            return "--anchor--\n";
+        },
+        blockquote: (_el, _walk, _options) => {
+            return "--blockquote--\n";
+        },
+        heading: (_el, _walk, _options) => {
+            return "--heading--\n";
+        },
+        horizontalLine: (_el, _walk, _options) => {
+            return "--horizontalLine--\n";
+        },
+        image: (_el, _options) => {
+            return "--image--\n";
+        },
+        lineBreak: (_el, _walk, _options) => {
+            return "--lineBreak--\n";
+        },
+        orderedList: (_el, _walk, _options) => {
+            return "--orderedList--\n";
+        },
+        paragraph: (_el, _walk, _options) => {
+            return "--paragraph--\n";
+        },
+        table: (_el, _walk, _options) => {
+            return "--table--\n";
+        },
+        text: (_el, _options) => {
+            return "--text--\n";
+        },
+        unorderedList: (_el, _walk, _options) => {
+            return "--unorderedList--\n";
+        },
+    },
+};
+console.log(fromString(allElements, fmtOptions));

--- a/types/html-to-text/index.d.ts
+++ b/types/html-to-text/index.d.ts
@@ -137,6 +137,7 @@ export interface Formatters {
     lineBreak?: Formatter;
     paragraph?: Formatter;
     anchor?: Formatter;
+    blockquote?: Formatter;
     heading?: Formatter;
     table?: Formatter;
     orderedList?: Formatter;

--- a/types/html-to-text/lib/formatter.d.ts
+++ b/types/html-to-text/lib/formatter.d.ts
@@ -5,6 +5,7 @@ export const image: LeafFormatter;
 export const lineBreak: Formatter;
 export const paragraph: Formatter;
 export const anchor: Formatter;
+export const blockquote: Formatter;
 export const heading: Formatter;
 export const table: Formatter;
 export const orderedList: Formatter;


### PR DESCRIPTION
Add blockquote as a possible format attribute.  It exists in the present version of html-to-text.

Add all possible formatters to test case.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/werk85/node-html-to-text>>
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
