### PR TITLE
fix(aws-lambda): approximateArrivalTimestamp should be number

### DIFF
--- a/types/aws-lambda/test/kinesis-tests.ts
+++ b/types/aws-lambda/test/kinesis-tests.ts
@@ -1,4 +1,5 @@
 import {
+    FirehoseRecordMetadata,
     FirehoseRecordTransformationStatus,
     FirehoseTransformationHandler, FirehoseTransformationResult,
     KinesisStreamHandler,
@@ -32,7 +33,14 @@ const handler: KinesisStreamHandler = async (event, context, callback) => {
 };
 
 const firehoseHandler: FirehoseTransformationHandler = async (event, context, callback) => {
+    let firehoseRecordMetadata: FirehoseRecordMetadata | undefined;
+
     str = event.records[0].recordId;
+    firehoseRecordMetadata = event.records[0].kinesisRecordMetadata;
+
+    if (firehoseRecordMetadata) {
+        numOrUndefined = firehoseRecordMetadata.approximateArrivalTimestamp;
+    }
 
     const result: FirehoseTransformationResult = {
         records: [

--- a/types/aws-lambda/trigger/kinesis-firehose-transformation.d.ts
+++ b/types/aws-lambda/trigger/kinesis-firehose-transformation.d.ts
@@ -26,7 +26,7 @@ export interface FirehoseTransformationEventRecord {
 export interface FirehoseRecordMetadata {
     shardId: string;
     partitionKey: string;
-    approximateArrivalTimestamp: string;
+    approximateArrivalTimestamp: number;
     sequenceNumber: string;
     subsequenceNumber: string;
 }


### PR DESCRIPTION
### Evidence/Context for change 

There are some official sources:

- `aws/aws-lambda-go` says [it's a number](https://github.com/aws/aws-lambda-go/blob/26aa36445a99488623e4b21c0e5c0b4dc684eff9/events/firehose.go#L43)
- The AWS Lambda console has a "test events" facility, which I can't link to directly (you'd find it at e.g. https://us-west-2.console.aws.amazon.com/lambda/home after logging in), but it looks like this: ![image](https://user-images.githubusercontent.com/97427/84143229-5080c500-aaaa-11ea-98cd-8deb81e6bd25.png)
- If you install the AWS Serverless Application Model (SAM) CLI, you can run: `sam local generate-event kinesis streams-as-source` to see the same thing:

  ```
  $ sam local generate-event kinesis streams-as-source | jq '.records[0].kinesisRecordMetadata.approximateArrivalTimestamp'
  1495072949453
  ```

But beware, there are some contradictory sources:

- I have confirmed (via runtime logging in an actual lambda) that [the Lambda documentation for the same event](https://docs.aws.amazon.com/lambda/latest/dg/services-kinesisfirehose.html) is inaccurate/out of date (and submitted detailed feedback to AWS)! The above, more "indirect" sources are the correct ones.

And what should be the authoritative source ([AWS Kinesis Firehose developer guide](https://docs.aws.amazon.com/firehose/latest/dev/data-transformation.html)) specifies e.g. the error handling behavior, but doesn't include any relevant examples of Kinesis Firehose transformation events themselves.

### Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)