### PR TITLE
[gapi.client.gmail] Move user into gmail to match the API

### DIFF
--- a/types/gapi.client.gmail/gapi.client.gmail-tests.ts
+++ b/types/gapi.client.gmail/gapi.client.gmail-tests.ts
@@ -47,15 +47,15 @@ gapi.load('client', () => {
 
     async function run() {
         /** Gets the current user's Gmail profile. */
-        await gapi.client.users.getProfile({
+        await gapi.client.gmail.users.getProfile({
             userId: "userId",
         });
         /** Stop receiving push notifications for the given user mailbox. */
-        await gapi.client.users.stop({
+        await gapi.client.gmail.users.stop({
             userId: "userId",
         });
         /** Set up or update a push notification watch on the given user mailbox. */
-        await gapi.client.users.watch({
+        await gapi.client.gmail.users.watch({
             userId: "userId",
         });
     }

--- a/types/gapi.client.gmail/index.d.ts
+++ b/types/gapi.client.gmail/index.d.ts
@@ -16,8 +16,6 @@ declare namespace gapi.client {
     function load(name: "gmail", version: "v1"): PromiseLike<void>;
     function load(name: "gmail", version: "v1", callback: () => any): void;
 
-    const users: gmail.UsersResource;
-
     namespace gmail {
         interface AutoForwarding {
             /** The state that a message should be left in after it has been forwarded. */
@@ -2048,5 +2046,7 @@ declare namespace gapi.client {
             settings: SettingsResource;
             threads: ThreadsResource;
         }
+
+        const users: UsersResource;
     }
 }

--- a/types/gapi.client.gmail/readme.md
+++ b/types/gapi.client.gmail/readme.md
@@ -13,9 +13,9 @@ npm install @types/gapi.client.gmail@v1 --save-dev
 
 You need to initialize Google API client in your code:
 ```typescript
-gapi.load("client", () => { 
+gapi.load("client", () => {
     // now we can use gapi.client
-    // ... 
+    // ...
 });
 ```
 
@@ -23,7 +23,7 @@ Then load api client wrapper:
 ```typescript
 gapi.client.load('gmail', 'v1', () => {
     // now we can use gapi.client.gmail
-    // ... 
+    // ...
 });
 ```
 
@@ -32,34 +32,34 @@ Don't forget to authenticate your client before sending any request to resources
 
 // declare client_id registered in Google Developers Console
 var client_id = '',
-    scope = [     
+    scope = [
         // Read, send, delete, and manage your email
         'https://mail.google.com/',
-    
+
         // Manage drafts and send emails
         'https://www.googleapis.com/auth/gmail.compose',
-    
+
         // Insert mail into your mailbox
         'https://www.googleapis.com/auth/gmail.insert',
-    
+
         // Manage mailbox labels
         'https://www.googleapis.com/auth/gmail.labels',
-    
+
         // View your email message metadata such as labels and headers, but not the email body
         'https://www.googleapis.com/auth/gmail.metadata',
-    
+
         // View and modify but not delete your email
         'https://www.googleapis.com/auth/gmail.modify',
-    
+
         // View your email messages and settings
         'https://www.googleapis.com/auth/gmail.readonly',
-    
+
         // Send email on your behalf
         'https://www.googleapis.com/auth/gmail.send',
-    
+
         // Manage your basic mail settings
         'https://www.googleapis.com/auth/gmail.settings.basic',
-    
+
         // Manage your sensitive mail settings, including who can manage your mail
         'https://www.googleapis.com/auth/gmail.settings.sharing',
     ],
@@ -72,25 +72,25 @@ gapi.auth.authorize({ client_id: client_id, scope: scope, immediate: immediate }
     } else {
         /* handle authorization error */
     }
-});            
+});
 ```
 
 After that you can use Gmail API resources:
 
-```typescript 
-    
-/* 
-Gets the current user's Gmail profile.  
+```typescript
+
+/*
+Gets the current user's Gmail profile.
 */
-await gapi.client.users.getProfile({ userId: "userId",  }); 
-    
-/* 
-Stop receiving push notifications for the given user mailbox.  
+await gapi.client.gmail.users.getProfile({ userId: "userId",  });
+
+/*
+Stop receiving push notifications for the given user mailbox.
 */
-await gapi.client.users.stop({ userId: "userId",  }); 
-    
-/* 
-Set up or update a push notification watch on the given user mailbox.  
+await gapi.client.gmail.users.stop({ userId: "userId",  });
+
+/*
+Set up or update a push notification watch on the given user mailbox.
 */
-await gapi.client.users.watch({ userId: "userId",  });
+await gapi.client.gmail.users.watch({ userId: "userId",  });
 ```


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gsuitedevs/browser-samples/blob/c561a38dd2807fab7e0bd0c9aaa084f2677d8cc1/gmail/quickstart/index.html#L123
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---
According to the [document](https://developers.google.com/gmail/api/quickstart/js), the `user` should be in `gapi.client.gmail` namespace instead of `gapi.client`.