### PR TITLE
Make children optional in react-beautiful-dnd

### DIFF
--- a/types/react-beautiful-dnd/index.d.ts
+++ b/types/react-beautiful-dnd/index.d.ts
@@ -555,7 +555,7 @@ export interface DragDropContextProps {
     onDragStart?(initial: DragStart, provided: ResponderProvided): void;
     onDragUpdate?(initial: DragUpdate, provided: ResponderProvided): void;
     onDragEnd(result: DropResult, provided: ResponderProvided): void;
-    children: React.ReactNode | null;
+    children?: React.ReactNode | null;
     dragHandleUsageInstructions?: string;
     nonce?: string;
     enableDefaultSensors?: boolean;


### PR DESCRIPTION
If children can be `null`, they should not be required.