### PR TITLE
[tapable] Fix .tapX() options, .taps types

### DIFF
--- a/types/tapable/index.d.ts
+++ b/types/tapable/index.d.ts
@@ -237,17 +237,48 @@ export interface HookCompileOptions {
     type: TapType;
 }
 
-export interface Tap {
+type TapFunction<T extends TapType = TapType, TArg1 = any, TArg2 = any, TArg3 = any, TResult = any> =
+    T extends "sync" ? (arg1: TArg1, arg2: TArg2, arg3: TArg3, ...args: any[]) => TResult :
+    T extends "async" ? (arg1: TArg1, arg2: TArg2, arg3: TArg3, ...args: any[]) => void :
+    T extends "promise" ? (arg1: TArg1, arg2: TArg2, arg3: TArg3, ...args: any[]) => Promise<TResult> :
+    never;
+
+export interface Tap<TTapType extends TapType = TapType, TArg1 = any, TArg2 = any, TArg3 = any, THookResult = any> {
     name: string;
-    type: TapType;
-    fn: Function;
-    stage: number;
-    context: boolean;
+    type: TTapType;
+    fn: TapFunction<TTapType, TArg1, TArg2, TArg3, THookResult>;
+    stage?: number;
+    context?: boolean;
+    before?: string | string[];
 }
+
+export type TapOptions<TTapType extends TapType = TapType, TArg1 = any, TArg2 = any, TArg3 = any, THookResult = any> = {
+    name: string;
+    stage?: number;
+    context?: boolean;
+    before?: string | string[];
+} & (
+    TTapType extends "sync" ? {
+        type?: "sync";
+        fn?: TapFunction<"sync", TArg1, TArg2, TArg3, THookResult>;
+    } :
+    TTapType extends "async" ? {
+        type?: "async";
+        fn?: TapFunction<"async", TArg1, TArg2, TArg3, THookResult>;
+    } :
+    TTapType extends "promise" ? {
+        type?: "promise";
+        fn?: TapFunction<"promise", TArg1, TArg2, TArg3, THookResult>;
+    } :
+    {
+        type?: TTapType;
+        fn?: TapFunction<TTapType, TArg1, TArg2, TArg3, THookResult>;
+    }
+);
 
 export class Hook<TArg1 = any, TArg2 = any, TArg3 = any, TTabResult = any, THookResult = any> {
     constructor(tapArgumentNames?: string[]);
-    taps: any[];
+    taps: Tap<TapType, TArg1, TArg2, TArg3, THookResult>[];
     interceptors: HookInterceptor[];
 
     isUsed: () => boolean;
@@ -255,10 +286,10 @@ export class Hook<TArg1 = any, TArg2 = any, TArg3 = any, TTabResult = any, THook
     promise: (arg1?: TArg1, arg2?: TArg2, arg3?: TArg3, ...args: any[]) => Promise<THookResult>;
     callAsync: (arg1?: TArg1, arg2?: TArg2, arg3?: TArg3, ...args: any[]) => THookResult;
 
-    compile(options: HookCompileOptions): Function;
-    tap: (name: string | Tap, fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, ...args: any[]) => TTabResult) => void;
-    tapAsync: (name: string | Tap, fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, ...args: any[]) => void) => void;
-    tapPromise: (name: string | Tap, fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, ...args: any[]) => Promise<TTabResult>) => void;
+    compile: (options: HookCompileOptions) => Function;
+    tap: (name: string | TapOptions<"sync", TArg1, TArg2, TArg3, TTabResult>, fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, ...args: any[]) => TTabResult) => void;
+    tapAsync: (name: string | TapOptions<"async", TArg1, TArg2, TArg3, TTabResult>, fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, ...args: any[]) => void) => void;
+    tapPromise: (name: string | TapOptions<"promise", TArg1, TArg2, TArg3, TTabResult>, fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, ...args: any[]) => Promise<TTabResult>) => void;
     intercept: (interceptor: HookInterceptor) => void;
 }
 
@@ -286,9 +317,9 @@ export class HookMap<T1 = any, T2 = any, T3 = any> {
     constructor(fn: () => Hook);
     get: (key: any) => Hook<T1, T2, T3> | undefined;
     for: (key: any) => Hook<T1, T2, T3>;
-    tap: (key: any, name: string | Tap, fn: (arg1: T1, arg2: T2, arg3: T3, ...args: any[]) => any) => void;
-    tapAsync: (key: any, name: string | Tap, fn: (arg1: T1, arg2: T2, arg3: T3, ...args: any[]) => void) => void;
-    tapPromise: (key: any, name: string | Tap, fn: (arg1: T1, arg2: T2, arg3: T3, ...args: any[]) => Promise<any>) => void;
+    tap: (key: any, name: string | TapOptions<"sync", T1, T2, T3>, fn: (arg1: T1, arg2: T2, arg3: T3, ...args: any[]) => any) => void;
+    tapAsync: (key: any, name: string | TapOptions<"async", T1, T2, T3>, fn: (arg1: T1, arg2: T2, arg3: T3, ...args: any[]) => void) => void;
+    tapPromise: (key: any, name: string | TapOptions<"promise", T1, T2, T3>, fn: (arg1: T1, arg2: T2, arg3: T3, ...args: any[]) => Promise<any>) => void;
     intercept: (interceptor: HookMapInterceptor<T1, T2, T3>) => void;
 }
 

--- a/types/tapable/tapable-tests.ts
+++ b/types/tapable/tapable-tests.ts
@@ -189,4 +189,41 @@ const isBoolean = (val: boolean) => val;
         console.log(isBoolean(hooks.syncWaterfallHook.isUsed()));
         console.log(isBoolean(hooks.asyncSeriesWaterfallHook.isUsed()));
     });
+
+    // Test TapOptions
+    // Minimal params
+    hooks.syncHook.tap({
+        name: 'Hook1',
+    }, () => ('Any Return Value'));
+
+    // All param types
+    hooks.syncHook.tap({
+        name: 'Hook2',
+        type: 'sync',
+        before: 'Hook1',
+        context: true,
+        stage: 10,
+    }, () => ('Any Return Value'));
+
+    hooks.syncHook.tap({
+        name: 'Hook3',
+        before: ['Hook1', 'Hook2'],
+    }, () => ('Any Return Value'));
+
+    // No optional params
+    hooks.syncHook.tap({
+        name: 'Hook4',
+    }, () => ('Any Return Value'));
+
+    // The `fn` param
+    hooks.syncWaterfallHook.tap({
+        name: 'SyncHook',
+        fn: (person) => ({ name: 'sue', age: person.age + 1 }),
+    }, (person) => ({ name: 'sue', age: person.age + 1 }));
+
+    hooks.asyncSeriesWaterfallHook.tapPromise({
+        name: 'PromiseHook',
+        type: 'promise',
+        fn: async (person) => ({ name: 'sue', age: person.age + 1 }),
+    }, async (person) => ({ name: 'sue', age: person.age + 1 }));
 })();


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/tapable/blob/tapable-1/lib/Hook.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.