### PR TITLE
[react-native-material-ui] Fix type of size to

### DIFF
--- a/types/react-native-material-ui/index.d.ts
+++ b/types/react-native-material-ui/index.d.ts
@@ -54,7 +54,7 @@ export class Avatar extends Component<AvatarProps, any> {}
 export interface BadgeProps {
     children?: JSX.Element;
     text?: string;
-    icon?: string | { name: string, color: string, size: string };
+    icon?: string | { name: string, color: string, size: number };
     size?: number;
     stroke?: number;
     accent?: boolean;

--- a/types/react-native-material-ui/react-native-material-ui-tests.tsx
+++ b/types/react-native-material-ui/react-native-material-ui-tests.tsx
@@ -38,6 +38,10 @@ const Example = () =>
             <Avatar icon="mic" size={75} />
 
             <Badge />
+            <Badge text="3" />
+            <Badge icon="grade" />
+            <Badge icon={{ name: 'grade', color: 'blue', size: 10 }} />
+            <Badge size={10} />
 
             <IconToggle testID="iconToggleTestID" name="anIconToggle" />
             <Button testID="buttonTestID" text="I'm a button" />


### PR DESCRIPTION
Expected type is number:
https://github.com/xotahal/react-native-material-ui/blob/master/src/Badge/Badge.react.js#L27

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/xotahal/react-native-material-ui/blob/master/src/Badge/Badge.react.js#L27
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
