### PR TITLE
[@types/mongoose]: recursively remove Document properties from nested subschemas

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -140,6 +140,13 @@ declare module "mongoose" {
   /* Helper type to extract a definition type from a Document type */
   type DocumentToPlain<T> = Omit<T, Exclude<keyof Document, "_id">>;
   
+  type DeepPartial<T> = {
+    [P in keyof T]?:
+      T[P] extends (infer U)[] ? DeepPartial<U>[] :
+      T[P] extends (object | undefined) ? DeepPartial<T[P]> :
+      T[P];
+  };
+
   type DeepDocumentDefinition<T> =
     T extends Map<infer KM, infer KV> 
       // handle map values
@@ -201,7 +208,7 @@ declare module "mongoose" {
    */
   export type MongooseUpdateQuery<S> = mongodb.UpdateQuery<S> & mongodb.MatchKeysAndValues<S>;
 
-  export type UpdateQuery<D> = MongooseUpdateQuery<DocumentDefinition<D>>;
+  export type UpdateQuery<D> = MongooseUpdateQuery<DeepPartial<DocumentDefinition<D>>>;
 
   // check whether a type consists just of {_id: T} and no other properties
   type HasJustId<T> = keyof Omit<T, "_id"> extends never ? true : false;

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -284,7 +284,9 @@ interface Location extends mongoose.Document {
   coords: number[];
   openingTimes: any[];
   reviews: any[];
-  notes: Note[]
+  notes: Note[];
+  notesById?: Map<string, Note[]>;
+  note?: Note
 };
 const locationSchema = new mongoose.Schema({
   name: { type: String, required: true },
@@ -525,6 +527,15 @@ LocModel.findOneAndUpdate({ name: "aa" }, { $set: { name: "bb" } }, { lean: true
         doc.save();
     }
 });
+LocModel.findOneAndUpdate({ _id: 'someId' },
+  { $push: { notes: { text: '' } } }
+)
+LocModel.findOneAndUpdate({ _id: 'someId' },
+  { note: { text: '', _id: '' } }
+)
+LocModel.findOneAndUpdate({ _id: 'someId' },
+  { notesById: { foo: [{ text: '', _id: '' }] } }
+)
 LocModel.geoSearch({}, {
     near: [1, 2],
     maxDistance: 22

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -531,10 +531,10 @@ LocModel.findOneAndUpdate({ _id: 'someId' },
   { $push: { notes: { text: '' } } }
 )
 LocModel.findOneAndUpdate({ _id: 'someId' },
-  { note: { text: '', _id: '' } }
+  { note: { text: '' } }
 )
 LocModel.findOneAndUpdate({ _id: 'someId' },
-  { notesById: { foo: [{ text: '', _id: '' }] } }
+  { notesById: { foo: [{ text: '' }] } }
 )
 LocModel.geoSearch({}, {
     near: [1, 2],


### PR DESCRIPTION
Fixes #44752

When using a subschema that extends from mongoose.Document, errors such as the ones in #44752 would surface. This reuses the logic from #44619 to recursively process all sublevels of the schema.

cc @avaly - I think you wrote the original logic here. 

~There is still a problem with `_id` turning required in updates of subdocuments so any suggestions on how to get around it would be great. The below works but turns `_id` optional in `lean` queries, so additional work is needed.~

Edit: this has been fixed as per latest commits by adding a DeepPartial type.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
