### PR TITLE
[js-yaml] Update safeLoad return types for js-yaml

### DIFF
--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -8,7 +8,7 @@
 
 export as namespace jsyaml;
 
-export function safeLoad(str: string, opts?: LoadOptions): any;
+export function safeLoad(str: string, opts?: LoadOptions): string | object | undefined;
 export function load(str: string, opts?: LoadOptions): any;
 
 export class Type {

--- a/types/js-yaml/js-yaml-tests.ts
+++ b/types/js-yaml/js-yaml-tests.ts
@@ -125,9 +125,9 @@ type.styleAliases;
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
-// $ExpectType any
+// $ExpectType string | object | undefined
 yaml.safeLoad(str);
-// $ExpectType any
+// $ExpectType string | object | undefined
 yaml.safeLoad(str, loadOpts);
 
 // $ExpectType any


### PR DESCRIPTION
This pull request changes the return type for `safeLoad`. The documentation states that it can return a string, an object, or undefined.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/nodeca/js-yaml#safeload-string---options->
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

