### PR TITLE
update(capitalize): version 2 bump

### DIFF
--- a/types/capitalize/capitalize-tests.ts
+++ b/types/capitalize/capitalize-tests.ts
@@ -2,13 +2,25 @@ import * as capitalize from 'capitalize';
 // tslint:disable-next-line:no-duplicate-imports
 import { words } from 'capitalize';
 
+// $ExpectError
+capitalize();
+// $ExpectType string
 capitalize('united states');
-capitalize('uniTed staTes', true); // $ExpectType string
-
+// $ExpectType string
+capitalize('uniTed staTes', true);
+// $ExpectType string
 capitalize.words('united states');
-capitalize.words('uniTed staTes', true); // $ExpectType string
-
+// $ExpectType string
+capitalize.words('uniTed staTes', true);
+// $ExpectType string
+capitalize.words('uniTed staTes', false);
+// $ExpectType string
 capitalize.words('hello-cañapolísas');
-capitalize.words("it's a nice day");
-
+// $ExpectType string
+capitalize.words("it's a nice day", false);
+// $ExpectError
+words();
+// $ExpectType string
 words('united states');
+// $ExpectType string
+words('united states', false);

--- a/types/capitalize/capitalize-tests.ts
+++ b/types/capitalize/capitalize-tests.ts
@@ -1,12 +1,14 @@
-import * as capitalize from "capitalize";
-import { words } from "capitalize";
+import * as capitalize from 'capitalize';
+// tslint:disable-next-line:no-duplicate-imports
+import { words } from 'capitalize';
 
-capitalize("united states");
+capitalize('united states');
+capitalize('uniTed staTes', true); // $ExpectType string
 
-capitalize.words("united states");
+capitalize.words('united states');
+capitalize.words('uniTed staTes', true); // $ExpectType string
 
 capitalize.words('hello-cañapolísas');
-
 capitalize.words("it's a nice day");
 
-words("united states");
+words('united states');

--- a/types/capitalize/index.d.ts
+++ b/types/capitalize/index.d.ts
@@ -1,19 +1,21 @@
-// Type definitions for capitalize 1.0
+// Type definitions for capitalize 2.0
 // Project: https://github.com/grncdr/js-capitalize
 // Definitions by: Frederick Fogerty <https://github.com/frederickfogerty>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
 
 /**
  * Capitalize the first letter of a string
  * @param input the string to capitalize
+ * @param [preserve] preserve casing of the rest of the strings content
  */
-declare function capitalize(input: string): string;
+declare function capitalize(input: string, preserve?: boolean): string;
 declare namespace capitalize {
     /**
      * Capitalize each word in a string
      * @param input the string to capitalize
+     * @param [preserve] preserve casing of the rest of the strings content
      */
-    function words(input: string): string;
+    function words(input: string, preserve?: boolean): string;
 }
 export = capitalize;

--- a/types/capitalize/tslint.json
+++ b/types/capitalize/tslint.json
@@ -1,6 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "no-duplicate-imports": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
This updates definition to v2. As the changes are completely
non-breaking (optional params added) the version is just updated without
creating v1 at the same time.

- optional `preserve` parameter added
- version bump
- maintainer added
- minor changes to DT trivia (TS version no longer required, TSLint
exclusion added inline for clariy, instead of in-file).

https://github.com/grncdr/js-capitalize/compare/v1.0.0...v2.0.2#diff-168726dbe96b3ce427e7fedce31bb0bc

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)