### PR TITLE
Add types for node-hook

### DIFF
--- a/types/node-hook/index.d.ts
+++ b/types/node-hook/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for node-hook 1.0
+// Project: https://github.com/bahmutov/node-hook#readme
+// Definitions by: Nathan Hardy <https://github.com/nhardy>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface Options {
+    verbose?: boolean;
+}
+
+type Transform = (source: string, filename: string) => string;
+
+interface NodeHook {
+    hook: {
+        (extension: string, transform: Transform, options?: Options): void;
+        (transform: Transform, _?: undefined, options?: Options): void;
+    };
+    unhook(extension?: string): void;
+}
+
+declare const hook: NodeHook;
+
+export = hook;

--- a/types/node-hook/node-hook-tests.ts
+++ b/types/node-hook/node-hook-tests.ts
@@ -1,0 +1,12 @@
+import hook = require("node-hook");
+
+function logLoadedFilename(source: string, filename: string) {
+    return `console.log(${JSON.stringify(filename)});\n${source}`;
+}
+
+hook.hook(logLoadedFilename);
+hook.hook(logLoadedFilename, undefined, { verbose: true });
+hook.hook(".ts", logLoadedFilename);
+hook.hook(".ts", logLoadedFilename, {});
+hook.unhook();
+hook.unhook(".ts");

--- a/types/node-hook/tsconfig.json
+++ b/types/node-hook/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "node-hook-tests.ts"
+    ]
+}

--- a/types/node-hook/tslint.json
+++ b/types/node-hook/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.