### PR TITLE
loader-utils: fix return type of getOptions

### DIFF
--- a/types/loader-utils/index.d.ts
+++ b/types/loader-utils/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Gyusun Yeom <https://github.com/Perlmint>
 //                 Totooria Hyperion <https://github.com/TotooriaHyperion>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+//                 Jesse Katsumata <https://github.com/Naturalclar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -31,7 +32,7 @@ export type DigestType = 'hex' | 'base26' | 'base32' | 'base36' | 'base49' | 'ba
  * Recommended way to retrieve the options of a loader invocation
  * {@link https://github.com/webpack/loader-utils#getoptions}
  */
-export function getOptions(loaderContext: loader.LoaderContext): Readonly<OptionObject> | null;
+export function getOptions(loaderContext: loader.LoaderContext): Readonly<OptionObject>;
 
 /**
  * Parses a passed string (e.g. loaderContext.resourceQuery) as a query string, and returns an object.


### PR DESCRIPTION
From version 2.0 of loader-utils, the getOptions method no longer returns `null` on empty queries.
https://github.com/webpack/loader-utils/releases

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/loader-utils/blob/master/lib/getOptions.js
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

