### PR TITLE
[exif] Add missing type definitions for GPS Tags

### DIFF
--- a/types/exif/index.d.ts
+++ b/types/exif/index.d.ts
@@ -69,15 +69,42 @@ declare namespace Exif {
             UserComment?: Buffer;
             WhiteBalance?: number;
         };
+        /**
+         * Entire GPS Tags from https://exiftool.org/TagNames/GPS.html are listed.
+         * And their types are determined from http://www.exif.org/Exif2-2.PDF.
+         */
         gps: {
             GPSAltitude?: number;
             GPSAltitudeRef?: number;
+            GPSAreaInformation?: Buffer;
             GPSDateStamp?: string;
+            GPSDestBearing?: number;
+            GPSDestBearingRef?: string;
+            GPSDestDistance?: number;
+            GPSDestDistanceRef?: string;
+            GPSDestLatitude?: number[];
+            GPSDestLatitudeRef?: string;
+            GPSDestLongitude?: number[];
+            GPSDestLongitudeRef?: string;
+            GPSDifferential?: number;
+            GPSDOP?: number;
+            GPSHPositioningError?: number;
+            GPSImgDirection?: number;
+            GPSImgDirectionRef?: string;
             GPSLatitude?: number[];
             GPSLatitudeRef?: string;
             GPSLongitude?: number[];
             GPSLongitudeRef?: string;
+            GPSMapDatum?: string;
+            GPSMeasureMode?: string;
+            GPSProcessingMethod?: Buffer;
             GPSTimeStamp?: number[];
+            GPSSatellites?: string;
+            GPSSpeed?: number;
+            GPSSpeedRef?: string;
+            GPSStatus?: string;
+            GPSTrack?: number;
+            GPSTrackRef?: string;
             GPSVersionId?: number[];
         };
         interoperability: {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [List of GPS Tags from ExifTool](https://exiftool.org/TagNames/GPS.html)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
