### PR TITLE
[postmate] Added name parameter when initialising new Postmate

### DIFF
--- a/types/postmate/index.d.ts
+++ b/types/postmate/index.d.ts
@@ -34,7 +34,7 @@ declare namespace Postmate {
         /**
          * An element to append the iFrame to. Default: document.body
          */
-        container?: HTMLElement|null;
+        container?: HTMLElement | null;
 
         /**
          * An object literal to represent the default values of the child's model
@@ -50,6 +50,11 @@ declare namespace Postmate {
          * An Array to add classes to the iFrame. Useful for styling
          */
         classListArray?: string[];
+
+        /**
+         * A name which is used for the name attribute of the created iFrame
+         */
+        name?: string;
     }
 
     /**

--- a/types/postmate/postmate-tests.ts
+++ b/types/postmate/postmate-tests.ts
@@ -11,7 +11,8 @@ import Postmate = require('postmate');
 const parentHandshake = new Postmate({
   container: document.getElementById('some-div'),
   url: 'http://child.com/page.html',
-  classListArray: ["myClass"]
+  classListArray: ["myClass"],
+  name: 'some-name',
 });
 
 // When parent <-> child handshake is complete, data may be requested from the child


### PR DESCRIPTION
Please fill in this template.

- [✅] Use a meaningful title for the pull request. Include the name of the package modified.
- [✅ ] Test the change in your own code. (Compile and run.)
- [✅] Add or edit tests to reflect the change. (Run with `npm test`.)
- [✅] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [✅] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [✅] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [✅] Provide a URL to documentation or source code which provides context for the suggested changes: <[https://github.com/dollarshaveclub/postmate/compare/1.5.0...1.5.2#diff-04c6e90faac2675aa89e2176d2eec7d8R73](https://github.com/dollarshaveclub/postmate/compare/1.5.0...1.5.2#diff-04c6e90faac2675aa89e2176d2eec7d8R73)>
- [✅] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [✅] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [❌ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
