### PR TITLE
sanitize-html: textFilter signature missing tagName parameter

### DIFF
--- a/types/sanitize-html/index.d.ts
+++ b/types/sanitize-html/index.d.ts
@@ -61,7 +61,7 @@ declare namespace sanitize {
     allowedSchemesAppliedToAttributes?: string[];
     allowProtocolRelative?: boolean;
     allowedTags?: string[] | boolean;
-    textFilter?: (text: string) => string; 
+    textFilter?: (text: string, tagName: string) => string; 
     exclusiveFilter?: (frame: IFrame) => boolean;
     nonTextTags?: string[];
     selfClosing?: string[];

--- a/types/sanitize-html/sanitize-html-tests.ts
+++ b/types/sanitize-html/sanitize-html-tests.ts
@@ -23,7 +23,7 @@ let options: sanitize.IOptions = {
       return img;
     }
   },
-  textFilter: text => text,
+  textFilter: (text, _) => text,
   allowIframeRelativeUrls: false,
   exclusiveFilter: function(frame: sanitize.IFrame) {
     return frame.tag === 'a' && !frame.text.trim();


### PR DESCRIPTION
Please fill in this template.

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apostrophecms/sanitize-html/blob/master/README.md#filters
- [ x ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ x ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ x ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.