### PR TITLE
Update types for Shopify

### DIFF
--- a/types/shopify-buy/index.d.ts
+++ b/types/shopify-buy/index.d.ts
@@ -1,10 +1,11 @@
-// Type definitions for shopify-buy 1.11
+// Type definitions for shopify-buy 2.10
 // Project: http://shopify.github.io/js-buy-sdk/api/
 // Definitions by: Martin Köhn <https://github.com/openminder>
 //                 Stephen Traiforos <https://github.com/straiforos>
 //                 Rosana Ruiz <https://github.com/totemika>
 //                 Juan Manuel Incaurgarat <https://github.com/kilinkis>
 //                 Chris Worman <https://github.com/chrisworman-pela>
+//                 Maciej Baron <https://github.com/MaciekBaron>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
@@ -68,7 +69,7 @@ declare namespace ShopifyBuy {
 
         fetch(id: string): Promise<Cart>;
 
-        addLineItems(checkoutId: string | number, lineItems: LineItem[]): Promise<Cart>;
+        addLineItems(checkoutId: string | number, lineItems: LineItemToAdd[]): Promise<Cart>;
 
         /**
          * Remove all line items from cart
@@ -281,6 +282,11 @@ declare namespace ShopifyBuy {
         value: any;
     }
 
+    export interface CustomAttribute {
+        key: string;
+        value: string;
+    }
+
     export interface Collection {
         handle: string;
         body_html: string;
@@ -323,6 +329,11 @@ declare namespace ShopifyBuy {
          * Example: two items have been added to the cart that cost $1.25 then the subtotal will be 2.50
          */
         subtotalPrice: string;
+
+        /**
+         * Get completed at date.
+         */
+        completedAt: string | null;
     }
 
     export interface LineItem extends GraphModel {
@@ -331,7 +342,7 @@ declare namespace ShopifyBuy {
          * previously before the product went on sale.
          * If no compareAtPrice is set then this value will be null. An example value: "5.00".
          */
-        compare_at_price: string | null;
+        compareAtPrice: string | null;
 
         /**
          * Variant's weight in grams. If no weight is set then 0 is returned.
@@ -352,7 +363,7 @@ declare namespace ShopifyBuy {
          * The total price for this line item. For instance if the variant costs 1.50 and you have a
          * quantity of 2 then line_price will be 3.00.
          */
-        line_price: string;
+        linePrice: string;
 
         /**
          * Price of the variant. For example: "5.00".
@@ -362,7 +373,7 @@ declare namespace ShopifyBuy {
         /**
          * ID of variant's product.
          */
-        product_id: string | number;
+        productId: string | number;
 
         /**
          * Count of variants to order.
@@ -377,12 +388,18 @@ declare namespace ShopifyBuy {
         /**
          * ID of line item variant.
          */
-        variant_id: string | number;
+        variantId: string | number;
 
         /**
          * Title of variant.
          */
-        variant_title: string;
+        variantTitle: string;
+    }
+
+    export interface LineItemToAdd {
+        variantId: string | number;
+        quantity: number;
+        customAttributes?: CustomAttribute[];
     }
 
     export interface Item {

--- a/types/shopify-buy/shopify-buy-tests.ts
+++ b/types/shopify-buy/shopify-buy-tests.ts
@@ -257,7 +257,7 @@ function closeCart() {
 ============================================================ */
 function findCartItemByVariantId(variantId : string | number) {
     return cart.lineItems.filter(function (item) {
-        return (item.variant_id === variantId);
+        return (item.variantId === variantId);
     })[0];
 }
 
@@ -279,7 +279,7 @@ function addOrUpdateVariant(variant : ShopifyBuy.ProductVariant, quantity : numb
 /* Update details for item already in cart. Remove if necessary
 ============================================================ */
 function updateVariantInCart(cartLineItem : ShopifyBuy.LineItem, quantity : number) {
-    var variantId : string | number = cartLineItem.variant_id;
+    var variantId : string | number = cartLineItem.variantId;
     var cartLength : number = cart.lineItems.length;
     let lineItemVariant: ShopifyBuy.AttributeInput = {
         id: cartLineItem.id,
@@ -289,7 +289,7 @@ function updateVariantInCart(cartLineItem : ShopifyBuy.LineItem, quantity : numb
         var $cartItem = $('.cart').find('.cart-item[data-variant-id="' + variantId + '"]');
         if (updatedCart.lineItems.length >= cartLength) {
             $cartItem.find('.cart-item__quantity').val(cartLineItem.quantity);
-            $cartItem.find('.cart-item__price').text(formatAsMoney(cartLineItem.line_price));
+            $cartItem.find('.cart-item__price').text(formatAsMoney(cartLineItem.linePrice));
         } else {
             $cartItem.addClass('js-hidden').bind('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd', function() {
                 $cartItem.remove();
@@ -314,7 +314,7 @@ function addVariantToCart(variant : ShopifyBuy.ProductVariant, quantity : number
 
     client.checkout.addVariants({ variant: variant, quantity: quantity }).then(function() {
         var cartItem : ShopifyBuy.LineItem = cart.lineItems.filter(function (item : ShopifyBuy.LineItem ) {
-            return (item.variant_id === variant.id);
+            return (item.variantId === variant.id);
         })[0];
         var $cartItem = renderCartItem(cartItem);
         var $cartItemContainer = $('.cart-item-container');
@@ -338,15 +338,15 @@ function renderCartItem(lineItem : ShopifyBuy.LineItem) {
     var lineItemEmptyTemplate = $('#CartItemTemplate').html();
     var $lineItemTemplate = $(lineItemEmptyTemplate);
     var itemImage = lineItem.image.src;
-    $lineItemTemplate.attr('data-variant-id', lineItem.variant_id);
+    $lineItemTemplate.attr('data-variant-id', lineItem.variantId);
     $lineItemTemplate.addClass('js-hidden');
     $lineItemTemplate.find('.cart-item__img').css('background-image', 'url(' + itemImage + ')');
     $lineItemTemplate.find('.cart-item__title').text(lineItem.title);
-    $lineItemTemplate.find('.cart-item__variant-title').text(lineItem.variant_title);
-    $lineItemTemplate.find('.cart-item__price').text(formatAsMoney(lineItem.line_price));
+    $lineItemTemplate.find('.cart-item__variant-title').text(lineItem.variantTitle);
+    $lineItemTemplate.find('.cart-item__price').text(formatAsMoney(lineItem.linePrice));
     $lineItemTemplate.find('.cart-item__quantity').attr('value', lineItem.quantity);
-    $lineItemTemplate.find('.quantity-decrement').attr('data-variant-id', lineItem.variant_id);
-    $lineItemTemplate.find('.quantity-increment').attr('data-variant-id', lineItem.variant_id);
+    $lineItemTemplate.find('.quantity-decrement').attr('data-variant-id', lineItem.variantId);
+    $lineItemTemplate.find('.quantity-increment').attr('data-variant-id', lineItem.variantId);
 
     return $lineItemTemplate;
 }


### PR DESCRIPTION
The existing version seems quite out of date.

* Recapitalised properties - all of them use camel case now
* `CompletedAt` was missing
* `addLineItems` does not require a whole `LineItem` to be provided, just the `VariantId` and `quantity`

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://shopify.dev/docs/storefront-api/reference
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
