### PR TITLE
added package.json to peg typescript versions - alt, airbnb-prop-types, agiledigital__mule-preview

### DIFF
--- a/types/agiledigital__mule-preview/package.json
+++ b/types/agiledigital__mule-preview/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "typescript": "~3.4.0" 
+    }
+}

--- a/types/airbnb-prop-types/package.json
+++ b/types/airbnb-prop-types/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "typescript": "~3.0.0" 
+    }
+}

--- a/types/alt/package.json
+++ b/types/alt/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "typescript": "~2.8.0" 
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I only added package.json files so that these packages can have a specific typescript version. There seems to be an issue with the benchmark build that relates to the package.json file specifically in `agiledigital__mule-preview` which is blocking https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44671.

```
🌯  ~/projects/DefinitelyTyped 🌮  add-packagejson 🍔
npm run lint agiledigital__mule-preview

> definitely-typed@0.0.3 lint /Users/daletan/projects/DefinitelyTyped
> dtslint types "agiledigital__mule-preview"

🌯  ~/projects/DefinitelyTyped 🌮  add-packagejson 🍔
npm run lint airbnb-prop-types

> definitely-typed@0.0.3 lint /Users/daletan/projects/DefinitelyTyped
> dtslint types "airbnb-prop-types"

🌯  ~/projects/DefinitelyTyped 🌮  add-packagejson 🍔
npm run lint alt

> definitely-typed@0.0.3 lint /Users/daletan/projects/DefinitelyTyped
> dtslint types "alt"

🌯  ~/projects/DefinitelyTyped 🌮  add-packagejson 🍔
```
