### PR TITLE
Update relay network types

### DIFF
--- a/types/relay-runtime/lib/network/RelayNetworkTypes.d.ts
+++ b/types/relay-runtime/lib/network/RelayNetworkTypes.d.ts
@@ -46,7 +46,25 @@ export interface GraphQLResponseWithoutData {
     label?: string;
     path?: Array<string | number>;
 }
-export type GraphQLResponse = GraphQLResponseWithData | GraphQLResponseWithoutData;
+export interface GraphQLResponseWithExtensionsOnly {
+    // Per https://spec.graphql.org/June2018/#sec-Errors
+    // > If the data entry in the response is not present, the errors entry
+    // > in the response must not be empty. It must contain at least one error
+    // This means a payload has to have either a data key or an errors key:
+    // but the spec leaves room for the combination of data: null plus extensions
+    // since `data: null` is a *required* output if there was an error during
+    // execution, but the inverse is not described in the sepc: `data: null`
+    // does not necessarily indicate that there was an error.
+    data: null;
+    extensions: PayloadExtensions;
+}
+
+export type GraphQLSingularResponse =
+    | GraphQLResponseWithData
+    | GraphQLResponseWithExtensionsOnly
+    | GraphQLResponseWithoutData;
+
+export type GraphQLResponse = GraphQLSingularResponse | ReadonlyArray<GraphQLSingularResponse>;
 
 /**
  * A function that returns an Observable representing the response of executing


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/relay/blob/master/packages/relay-runtime/network/RelayNetworkTypes.js#L48-L85
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
