### PR TITLE
Update ESLint types for version 7

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -1,5 +1,5 @@
 import { Comment } from 'estree';
-import { AST, SourceCode, Rule, Linter, CLIEngine, RuleTester, Scope } from 'eslint';
+import { AST, SourceCode, Rule, Linter, ESLint, CLIEngine, RuleTester, Scope } from 'eslint';
 
 const SOURCE = `var foo = bar;`;
 
@@ -513,6 +513,96 @@ linter.defineParser('custom-parser', {
             parserServices: {},
             scopeManager,
         };
+    },
+});
+
+//#endregion
+
+//#region ESLint
+
+let eslint: ESLint;
+
+eslint = new ESLint({ allowInlineConfig: false });
+eslint = new ESLint({ baseConfig: {} });
+eslint = new ESLint({ overrideConfig: {} });
+eslint = new ESLint({ overrideConfigFile: 'foo' });
+eslint = new ESLint({ cache: true });
+eslint = new ESLint({ cacheLocation: 'foo' });
+eslint = new ESLint({ cwd: 'foo' });
+eslint = new ESLint({ errorOnUnmatchedPattern: true });
+eslint = new ESLint({ extensions: ['js'] });
+eslint = new ESLint({ fix: true });
+eslint = new ESLint({ fix: message => false });
+eslint = new ESLint({ fixTypes: ['problem'] });
+eslint = new ESLint({ globInputPaths: true });
+eslint = new ESLint({ ignore: true });
+eslint = new ESLint({ ignorePath: 'foo' });
+eslint = new ESLint({ useEslintrc: false });
+eslint = new ESLint({ plugins: { foo: {} } });
+eslint = new ESLint({ reportUnusedDisableDirectives: 'error' });
+eslint = new ESLint({ resolvePluginsRelativeTo: 'test' });
+eslint = new ESLint({ rulePaths: ['foo'] });
+
+let resultsPromise = eslint.lintFiles(['myfile.js', 'lib/']);
+
+resultsPromise = eslint.lintText(SOURCE, { filePath: 'foo' });
+
+eslint.calculateConfigForFile('./config.json');
+
+eslint.isPathIgnored('./dist/index.js');
+
+let formatterPromise: Promise<ESLint.Formatter>;
+
+formatterPromise = eslint.loadFormatter('codeframe');
+formatterPromise = eslint.loadFormatter();
+
+let data: ESLint.LintResultData;
+const meta: Rule.RuleMetaData = {
+    type: 'suggestion',
+    docs: {
+        description: 'disallow unnecessary semicolons',
+        category: 'Possible Errors',
+        recommended: true,
+        url: 'https://eslint.org/docs/rules/no-extra-semi'
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+        unexpected: 'Unnecessary semicolon.'
+    }
+};
+
+data = { rulesMeta: { 'no-extra-semi': meta } };
+
+const version: string = ESLint.version;
+
+resultsPromise.then(results => {
+    formatterPromise.then(formatter => formatter(results));
+    formatterPromise.then(formatter => formatter(results, data));
+
+    ESLint.getErrorResults(results);
+
+    ESLint.outputFixes(results);
+
+    results[0].errorCount = 0;
+    results[0].warningCount = 0;
+    results[0].fixableErrorCount = 0;
+    results[0].fixableWarningCount = 0;
+
+    for (const file of results) {
+        file.filePath = 'foo.js';
+
+        file.errorCount = 0;
+        file.warningCount = 0;
+        file.fixableErrorCount = 0;
+        file.fixableWarningCount = 0;
+
+        file.source = 'foo';
+        file.output = 'foo';
+
+        for (const message of file.messages) {
+            message.ruleId = 'foo';
+        }
     }
 });
 
@@ -558,38 +648,38 @@ cli.addPlugin('my-fancy-plugin', {});
 
 cli.isPathIgnored('./dist/index.js');
 
-let formatter: CLIEngine.Formatter;
+let cliFormatter: CLIEngine.Formatter;
 
-formatter = cli.getFormatter('codeframe');
-formatter = cli.getFormatter();
+cliFormatter = cli.getFormatter('codeframe');
+cliFormatter = cli.getFormatter();
 
-let data: CLIEngine.LintResultData;
-const meta: Rule.RuleMetaData = {
-    type: "suggestion",
+let cliData: CLIEngine.LintResultData;
+const cliMeta: Rule.RuleMetaData = {
+    type: 'suggestion',
     docs: {
-        description: "disallow unnecessary semicolons",
-        category: "Possible Errors",
+        description: 'disallow unnecessary semicolons',
+        category: 'Possible Errors',
         recommended: true,
-        url: "https://eslint.org/docs/rules/no-extra-semi"
+        url: 'https://eslint.org/docs/rules/no-extra-semi'
     },
-    fixable: "code",
+    fixable: 'code',
     schema: [],
     messages: {
-        unexpected: "Unnecessary semicolon."
+        unexpected: 'Unnecessary semicolon.'
     }
 };
 
-data = {rulesMeta: {"no-extra-semi": meta}};
+cliData = { rulesMeta: { 'no-extra-semi': cliMeta } };
 
-formatter(cliReport.results);
-formatter(cliReport.results, data);
+cliFormatter(cliReport.results);
+cliFormatter(cliReport.results, cliData);
 
-const version: string = CLIEngine.version;
+const cliVersion: string = CLIEngine.version;
 
 CLIEngine.getErrorResults(cliReport.results);
 
-formatter = CLIEngine.getFormatter();
-formatter = CLIEngine.getFormatter('codeframe');
+cliFormatter = CLIEngine.getFormatter();
+cliFormatter = CLIEngine.getFormatter('codeframe');
 
 CLIEngine.outputFixes(cliReport);
 

--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -577,8 +577,8 @@ data = { rulesMeta: { 'no-extra-semi': meta } };
 const version: string = ESLint.version;
 
 resultsPromise.then(results => {
-    formatterPromise.then(formatter => formatter(results));
-    formatterPromise.then(formatter => formatter(results, data));
+    formatterPromise.then(formatter => formatter.format(results));
+    formatterPromise.then(formatter => formatter.format(results, data));
 
     ESLint.getErrorResults(results);
 

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -470,11 +470,12 @@ export namespace Linter {
         ruleId: string | null;
         message: string;
         messageId?: string;
-        nodeType: string;
+        nodeType?: string;
         fatal?: true;
         severity: Severity;
         fix?: Rule.Fix;
-        source: string | null;
+        /** @deprecated Use `linter.getSourceCode()` */
+        source?: string | null;
         suggestions?: LintSuggestion[];
     }
 

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for eslint 6.8
+// Type definitions for eslint 7.2
 // Project: https://eslint.org
 // Definitions by: Pierre-Marie Dartus <https://github.com/pmdartus>
 //                 Jed Fox <https://github.com/j-f1>
@@ -366,7 +366,11 @@ export namespace Rule {
 //#region Linter
 
 export class Linter {
+    static version: string;
+
     version: string;
+
+    constructor(options?: { cwd?: string });
 
     verify(code: SourceCode | string, config: Linter.Config, filename?: string): Linter.LintMessage[];
     verify(code: SourceCode | string, config: Linter.Config, options: Linter.LintOptions): Linter.LintMessage[];
@@ -446,6 +450,8 @@ export namespace Linter {
         filename?: string;
         preprocess?: (code: string) => string[];
         postprocess?: (problemLists: LintMessage[][]) => LintMessage[];
+        filterCodeBlock?: boolean;
+        disableFixes?: boolean;
         allowInlineConfig?: boolean;
         reportUnusedDisableDirectives?: boolean;
     }
@@ -500,8 +506,92 @@ export namespace Linter {
 
 //#endregion
 
+//#region ESLint
+
+export class ESLint {
+    static version: string;
+
+    static outputFixes(results: ESLint.LintResult[]): Promise<void>;
+
+    static getErrorResults(results: ESLint.LintResult[]): ESLint.LintResult[];
+
+    constructor(options: ESLint.Options);
+
+    lintFiles(patterns: string | string[]): Promise<ESLint.LintResult[]>;
+
+    lintText(code: string, options?: { filePath?: string; warnIgnored?: boolean }): Promise<ESLint.LintResult[]>;
+
+    calculateConfigForFile(filePath: string): Promise<any>;
+
+    isPathIgnored(filePath: string): Promise<boolean>;
+
+    loadFormatter(nameOrPath?: string): Promise<ESLint.Formatter>;
+}
+
+export namespace ESLint {
+    interface Options {
+        // File enumeration
+        cwd?: string;
+        errorOnUnmatchedPattern?: boolean;
+        extensions?: string[];
+        globInputPaths?: boolean;
+        ignore?: boolean;
+        ignorePath?: string;
+
+        // Linting
+        allowInlineConfig?: boolean;
+        baseConfig?: Linter.Config;
+        overrideConfig?: Linter.Config;
+        overrideConfigFile?: string;
+        plugins?: Record<string, any>;
+        reportUnusedDisableDirectives?: Linter.RuleLevel;
+        resolvePluginsRelativeTo?: string;
+        rulePaths?: string[];
+        useEslintrc?: boolean;
+
+        // Autofix
+        fix?: boolean | ((message: Linter.LintMessage) => boolean);
+        fixTypes?: Array<Rule.RuleMetaData['type']>;
+
+        // Cache-related
+        cache?: boolean;
+        cacheLocation?: string;
+    }
+
+    interface LintResult {
+        filePath: string;
+        messages: Linter.LintMessage[];
+        errorCount: number;
+        warningCount: number;
+        fixableErrorCount: number;
+        fixableWarningCount: number;
+        output?: string;
+        source?: string;
+        usedDeprecatedRules: DeprecatedRuleUse[];
+    }
+
+    interface LintResultData {
+        rulesMeta: {
+            [ruleId: string]: Rule.RuleMetaData;
+        };
+    }
+
+    interface DeprecatedRuleUse {
+        ruleId: string;
+        replacedBy: string[];
+    }
+
+    type Formatter = (results: LintResult[], data?: LintResultData) => string;
+
+    // Docs reference the type by this name
+    type EditInfo = Rule.Fix;
+}
+
+//#endregion
+
 //#region CLIEngine
 
+/** @deprecated Deprecated in favor of `ESLint` */
 export class CLIEngine {
     static version: string;
 
@@ -530,6 +620,7 @@ export class CLIEngine {
     static outputFixes(report: CLIEngine.LintReport): void;
 }
 
+/** @deprecated Deprecated in favor of `ESLint` */
 export namespace CLIEngine {
     class Options {
         allowInlineConfig?: boolean;
@@ -559,22 +650,9 @@ export namespace CLIEngine {
         reportUnusedDisableDirectives?: boolean;
     }
 
-    interface LintResult {
-        filePath: string;
-        messages: Linter.LintMessage[];
-        errorCount: number;
-        warningCount: number;
-        fixableErrorCount: number;
-        fixableWarningCount: number;
-        output?: string;
-        source?: string;
-    }
+    type LintResult = ESLint.LintResult;
 
-    interface LintResultData {
-        rulesMeta: {
-            [ruleId: string]: Rule.RuleMetaData;
-        };
-    }
+    type LintResultData = ESLint.LintResultData;
 
     interface LintReport {
         results: LintResult[];
@@ -585,12 +663,9 @@ export namespace CLIEngine {
         usedDeprecatedRules: DeprecatedRuleUse[];
     }
 
-    interface DeprecatedRuleUse {
-      ruleId: string;
-      replacedBy: string[];
-    }
+    type DeprecatedRuleUse = ESLint.DeprecatedRuleUse;
 
-    type Formatter = (results: LintResult[], data?: LintResultData) => string;
+    type Formatter = ESLint.Formatter;
 }
 
 //#endregion

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -581,7 +581,9 @@ export namespace ESLint {
         replacedBy: string[];
     }
 
-    type Formatter = (results: LintResult[], data?: LintResultData) => string;
+    interface Formatter {
+        format(results: LintResult[], data?: LintResultData): string;
+    }
 
     // Docs reference the type by this name
     type EditInfo = Rule.Fix;
@@ -665,7 +667,7 @@ export namespace CLIEngine {
 
     type DeprecatedRuleUse = ESLint.DeprecatedRuleUse;
 
-    type Formatter = ESLint.Formatter;
+    type Formatter = (results: LintResult[], data?: LintResultData) => string;
 }
 
 //#endregion

--- a/types/eslint/ts3.1/eslint-tests.ts
+++ b/types/eslint/ts3.1/eslint-tests.ts
@@ -1,5 +1,5 @@
 import { Comment } from 'estree';
-import { AST, SourceCode, Rule, Linter, CLIEngine, RuleTester, Scope } from 'eslint';
+import { AST, SourceCode, Rule, Linter, ESLint, CLIEngine, RuleTester, Scope } from 'eslint';
 
 const SOURCE = `var foo = bar;`;
 
@@ -513,6 +513,96 @@ linter.defineParser('custom-parser', {
             parserServices: {},
             scopeManager,
         };
+    },
+});
+
+//#endregion
+
+//#region ESLint
+
+let eslint: ESLint;
+
+eslint = new ESLint({ allowInlineConfig: false });
+eslint = new ESLint({ baseConfig: {} });
+eslint = new ESLint({ overrideConfig: {} });
+eslint = new ESLint({ overrideConfigFile: 'foo' });
+eslint = new ESLint({ cache: true });
+eslint = new ESLint({ cacheLocation: 'foo' });
+eslint = new ESLint({ cwd: 'foo' });
+eslint = new ESLint({ errorOnUnmatchedPattern: true });
+eslint = new ESLint({ extensions: ['js'] });
+eslint = new ESLint({ fix: true });
+eslint = new ESLint({ fix: message => false });
+eslint = new ESLint({ fixTypes: ['problem'] });
+eslint = new ESLint({ globInputPaths: true });
+eslint = new ESLint({ ignore: true });
+eslint = new ESLint({ ignorePath: 'foo' });
+eslint = new ESLint({ useEslintrc: false });
+eslint = new ESLint({ plugins: { foo: {} } });
+eslint = new ESLint({ reportUnusedDisableDirectives: 'error' });
+eslint = new ESLint({ resolvePluginsRelativeTo: 'test' });
+eslint = new ESLint({ rulePaths: ['foo'] });
+
+let resultsPromise = eslint.lintFiles(['myfile.js', 'lib/']);
+
+resultsPromise = eslint.lintText(SOURCE, { filePath: 'foo' });
+
+eslint.calculateConfigForFile('./config.json');
+
+eslint.isPathIgnored('./dist/index.js');
+
+let formatterPromise: Promise<ESLint.Formatter>;
+
+formatterPromise = eslint.loadFormatter('codeframe');
+formatterPromise = eslint.loadFormatter();
+
+let data: ESLint.LintResultData;
+const meta: Rule.RuleMetaData = {
+    type: 'suggestion',
+    docs: {
+        description: 'disallow unnecessary semicolons',
+        category: 'Possible Errors',
+        recommended: true,
+        url: 'https://eslint.org/docs/rules/no-extra-semi'
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+        unexpected: 'Unnecessary semicolon.'
+    }
+};
+
+data = { rulesMeta: { 'no-extra-semi': meta } };
+
+const version: string = ESLint.version;
+
+resultsPromise.then(results => {
+    formatterPromise.then(formatter => formatter(results));
+    formatterPromise.then(formatter => formatter(results, data));
+
+    ESLint.getErrorResults(results);
+
+    ESLint.outputFixes(results);
+
+    results[0].errorCount = 0;
+    results[0].warningCount = 0;
+    results[0].fixableErrorCount = 0;
+    results[0].fixableWarningCount = 0;
+
+    for (const file of results) {
+        file.filePath = 'foo.js';
+
+        file.errorCount = 0;
+        file.warningCount = 0;
+        file.fixableErrorCount = 0;
+        file.fixableWarningCount = 0;
+
+        file.source = 'foo';
+        file.output = 'foo';
+
+        for (const message of file.messages) {
+            message.ruleId = 'foo';
+        }
     }
 });
 
@@ -558,38 +648,38 @@ cli.addPlugin('my-fancy-plugin', {});
 
 cli.isPathIgnored('./dist/index.js');
 
-let formatter: CLIEngine.Formatter;
+let cliFormatter: CLIEngine.Formatter;
 
-formatter = cli.getFormatter('codeframe');
-formatter = cli.getFormatter();
+cliFormatter = cli.getFormatter('codeframe');
+cliFormatter = cli.getFormatter();
 
-let data: CLIEngine.LintResultData;
-const meta: Rule.RuleMetaData = {
-    type: "suggestion",
+let cliData: CLIEngine.LintResultData;
+const cliMeta: Rule.RuleMetaData = {
+    type: 'suggestion',
     docs: {
-        description: "disallow unnecessary semicolons",
-        category: "Possible Errors",
+        description: 'disallow unnecessary semicolons',
+        category: 'Possible Errors',
         recommended: true,
-        url: "https://eslint.org/docs/rules/no-extra-semi"
+        url: 'https://eslint.org/docs/rules/no-extra-semi'
     },
-    fixable: "code",
+    fixable: 'code',
     schema: [],
     messages: {
-        unexpected: "Unnecessary semicolon."
+        unexpected: 'Unnecessary semicolon.'
     }
 };
 
-data = {rulesMeta: {"no-extra-semi": meta}};
+cliData = { rulesMeta: { 'no-extra-semi': cliMeta } };
 
-formatter(cliReport.results);
-formatter(cliReport.results, data);
+cliFormatter(cliReport.results);
+cliFormatter(cliReport.results, cliData);
 
-const version: string = CLIEngine.version;
+const cliVersion: string = CLIEngine.version;
 
 CLIEngine.getErrorResults(cliReport.results);
 
-formatter = CLIEngine.getFormatter();
-formatter = CLIEngine.getFormatter('codeframe');
+cliFormatter = CLIEngine.getFormatter();
+cliFormatter = CLIEngine.getFormatter('codeframe');
 
 CLIEngine.outputFixes(cliReport);
 

--- a/types/eslint/ts3.1/eslint-tests.ts
+++ b/types/eslint/ts3.1/eslint-tests.ts
@@ -577,8 +577,8 @@ data = { rulesMeta: { 'no-extra-semi': meta } };
 const version: string = ESLint.version;
 
 resultsPromise.then(results => {
-    formatterPromise.then(formatter => formatter(results));
-    formatterPromise.then(formatter => formatter(results, data));
+    formatterPromise.then(formatter => formatter.format(results));
+    formatterPromise.then(formatter => formatter.format(results, data));
 
     ESLint.getErrorResults(results);
 

--- a/types/eslint/ts3.1/index.d.ts
+++ b/types/eslint/ts3.1/index.d.ts
@@ -571,7 +571,9 @@ export namespace ESLint {
         replacedBy: string[];
     }
 
-    type Formatter = (results: LintResult[], data?: LintResultData) => string;
+    interface Formatter {
+        format(results: LintResult[], data?: LintResultData): string;
+    }
 
     // Docs reference the type by this name
     type EditInfo = Rule.Fix;
@@ -655,7 +657,7 @@ export namespace CLIEngine {
 
     type DeprecatedRuleUse = ESLint.DeprecatedRuleUse;
 
-    type Formatter = ESLint.Formatter;
+    type Formatter = (results: LintResult[], data?: LintResultData) => string;
 }
 
 //#endregion

--- a/types/eslint/ts3.1/index.d.ts
+++ b/types/eslint/ts3.1/index.d.ts
@@ -460,11 +460,12 @@ export namespace Linter {
         ruleId: string | null;
         message: string;
         messageId?: string;
-        nodeType: string;
+        nodeType?: string;
         fatal?: true;
         severity: Severity;
         fix?: Rule.Fix;
-        source: string | null;
+        /** @deprecated Use `linter.getSourceCode()` */
+        source?: string | null;
         suggestions?: LintSuggestion[];
     }
 

--- a/types/eslint/ts3.1/index.d.ts
+++ b/types/eslint/ts3.1/index.d.ts
@@ -358,7 +358,11 @@ export namespace Rule {
 //#region Linter
 
 export class Linter {
+    static version: string;
+
     version: string;
+
+    constructor(options?: { cwd?: string });
 
     verify(code: SourceCode | string, config: Linter.Config, filename?: string): Linter.LintMessage[];
     verify(code: SourceCode | string, config: Linter.Config, options: Linter.LintOptions): Linter.LintMessage[];
@@ -436,6 +440,8 @@ export namespace Linter {
         filename?: string;
         preprocess?: (code: string) => string[];
         postprocess?: (problemLists: LintMessage[][]) => LintMessage[];
+        filterCodeBlock?: boolean;
+        disableFixes?: boolean;
         allowInlineConfig?: boolean;
         reportUnusedDisableDirectives?: boolean;
     }
@@ -490,8 +496,92 @@ export namespace Linter {
 
 //#endregion
 
+//#region ESLint
+
+export class ESLint {
+    static version: string;
+
+    static outputFixes(results: ESLint.LintResult[]): Promise<void>;
+
+    static getErrorResults(results: ESLint.LintResult[]): ESLint.LintResult[];
+
+    constructor(options: ESLint.Options);
+
+    lintFiles(patterns: string | string[]): Promise<ESLint.LintResult[]>;
+
+    lintText(code: string, options?: { filePath?: string; warnIgnored?: boolean }): Promise<ESLint.LintResult[]>;
+
+    calculateConfigForFile(filePath: string): Promise<any>;
+
+    isPathIgnored(filePath: string): Promise<boolean>;
+
+    loadFormatter(nameOrPath?: string): Promise<ESLint.Formatter>;
+}
+
+export namespace ESLint {
+    interface Options {
+        // File enumeration
+        cwd?: string;
+        errorOnUnmatchedPattern?: boolean;
+        extensions?: string[];
+        globInputPaths?: boolean;
+        ignore?: boolean;
+        ignorePath?: string;
+
+        // Linting
+        allowInlineConfig?: boolean;
+        baseConfig?: Linter.Config;
+        overrideConfig?: Linter.Config;
+        overrideConfigFile?: string;
+        plugins?: Record<string, any>;
+        reportUnusedDisableDirectives?: Linter.RuleLevel;
+        resolvePluginsRelativeTo?: string;
+        rulePaths?: string[];
+        useEslintrc?: boolean;
+
+        // Autofix
+        fix?: boolean | ((message: Linter.LintMessage) => boolean);
+        fixTypes?: Array<Rule.RuleMetaData['type']>;
+
+        // Cache-related
+        cache?: boolean;
+        cacheLocation?: string;
+    }
+
+    interface LintResult {
+        filePath: string;
+        messages: Linter.LintMessage[];
+        errorCount: number;
+        warningCount: number;
+        fixableErrorCount: number;
+        fixableWarningCount: number;
+        output?: string;
+        source?: string;
+        usedDeprecatedRules: DeprecatedRuleUse[];
+    }
+
+    interface LintResultData {
+        rulesMeta: {
+            [ruleId: string]: Rule.RuleMetaData;
+        };
+    }
+
+    interface DeprecatedRuleUse {
+        ruleId: string;
+        replacedBy: string[];
+    }
+
+    type Formatter = (results: LintResult[], data?: LintResultData) => string;
+
+    // Docs reference the type by this name
+    type EditInfo = Rule.Fix;
+}
+
+//#endregion
+
 //#region CLIEngine
 
+/** @deprecated Deprecated in favor of `ESLint` */
 export class CLIEngine {
     static version: string;
 
@@ -520,6 +610,7 @@ export class CLIEngine {
     static outputFixes(report: CLIEngine.LintReport): void;
 }
 
+/** @deprecated Deprecated in favor of `ESLint` */
 export namespace CLIEngine {
     class Options {
         allowInlineConfig?: boolean;
@@ -549,22 +640,9 @@ export namespace CLIEngine {
         reportUnusedDisableDirectives?: boolean;
     }
 
-    interface LintResult {
-        filePath: string;
-        messages: Linter.LintMessage[];
-        errorCount: number;
-        warningCount: number;
-        fixableErrorCount: number;
-        fixableWarningCount: number;
-        output?: string;
-        source?: string;
-    }
+    type LintResult = ESLint.LintResult;
 
-    interface LintResultData {
-        rulesMeta: {
-            [ruleId: string]: Rule.RuleMetaData;
-        };
-    }
+    type LintResultData = ESLint.LintResultData;
 
     interface LintReport {
         results: LintResult[];
@@ -575,12 +653,9 @@ export namespace CLIEngine {
         usedDeprecatedRules: DeprecatedRuleUse[];
     }
 
-    interface DeprecatedRuleUse {
-        ruleId: string;
-        replacedBy: string[];
-    }
+    type DeprecatedRuleUse = ESLint.DeprecatedRuleUse;
 
-    type Formatter = (results: LintResult[], data?: LintResultData) => string;
+    type Formatter = ESLint.Formatter;
 }
 
 //#endregion


### PR DESCRIPTION
Updating ESLint types to reflect changes in version 7, in particular the addition of the `ESLint` class/namespace and deprecation of `CLIEngine`. (I did *not* update the rule definition types since my concern is primarily with the Node API.)

I looked at the [major version guidance](https://github.com/DefinitelyTyped/DefinitelyTyped#if-a-library-is-updated-to-a-new-major-version-with-breaking-changes-how-should-i-update-its-type-declaration-package) but wasn't entirely sure what (if anything) I need to do in this case besides updating the version number in `index.d.ts`. (No types were removed, just added or deprecated.)

Closes #44799.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://eslint.org/docs/developer-guide/nodejs-api (and [this compare link](https://github.com/eslint/eslint/compare/v5.16.0..v7.2.0) which shows changes to the source of the doc file)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.