### PR TITLE
update(nodegit): add missing exports

### DIFF
--- a/types/nodegit/index.d.ts
+++ b/types/nodegit/index.d.ts
@@ -108,3 +108,6 @@ export { Treebuilder } from './tree-builder';
 export { TreeEntry } from './tree-entry';
 export { TreeUpdate } from './tree-update';
 export { Tree } from './tree';
+export const version: string;
+declare const _: typeof Promise;
+export { _ as Promise };

--- a/types/nodegit/nodegit-tests.ts
+++ b/types/nodegit/nodegit-tests.ts
@@ -81,3 +81,6 @@ repo.getHeadCommit().then(async commit => {
         const filesChanged: Number = stats.filesChanged();
     }
 });
+
+Git.version; // $ExpectType string
+Git.Promise; // $ExpectType PromiseConstructor


### PR DESCRIPTION
This adds two missing exports that comes from autogenerated version:
See:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45185#issuecomment-636386311

- `version`
https://github.com/nodegit/nodegit/blob/master/generate/templates/templates/nodegit.js#L138
- `Promise`
https://github.com/nodegit/nodegit/blob/master/generate/templates/templates/nodegit.js#L141
which is left as backward compatible export because of:
https://github.com/nodegit/nodegit/pull/278/files

Thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).