### PR TITLE
[react-modal]: improve overlay element type

### DIFF
--- a/types/react-modal/index.d.ts
+++ b/types/react-modal/index.d.ts
@@ -142,7 +142,7 @@ declare class ReactModal extends React.Component<ReactModal.Props> {
     static setAppElement(appElement: string | HTMLElement): void;
 
     portal: null | {
-        overlay: null | Element;
+        overlay: null | HTMLDivElement;
         content: null | HTMLDivElement;
     };
 }


### PR DESCRIPTION
`overlay` is always a div, so HTMLDivElement can be used over wider Element

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactjs/react-modal/blob/bd07d56ecfebc8807cbb958aa35ef545dfc7efa0/src/components/ModalPortal.js#L350-L356
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
