### PR TITLE
Add typings for react-native-shared-group-preferences

### DIFF
--- a/types/react-native-shared-group-preferences/index.d.ts
+++ b/types/react-native-shared-group-preferences/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for react-native-shared-group-preferences 1.1
+// Project: https://github.com/KjellConnelly/react-native-shared-group-preferences#readme
+// Definitions by: Cambo <https://github.com/indentedspace>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface SharedGroupPreferenceOptions {
+    useAndroidSharedPreferences?: boolean;
+}
+
+export namespace SharedGroupPreferences {
+    function isAppInstalledAndroid(packageName: string): Promise<void>;
+    function getItem(key: string, appGroup: string, options?: SharedGroupPreferenceOptions): Promise<any>;
+    function setItem(key: string, value: any, appGroup: string, options?: SharedGroupPreferenceOptions): Promise<void>;
+}
+
+export default SharedGroupPreferences;

--- a/types/react-native-shared-group-preferences/react-native-shared-group-preferences-tests.ts
+++ b/types/react-native-shared-group-preferences/react-native-shared-group-preferences-tests.ts
@@ -1,0 +1,24 @@
+import SharedGroupPreferences, { SharedGroupPreferenceOptions } from 'react-native-shared-group-preferences';
+
+const isAppInstalledAndroid = async (packageName: string) => {
+    let appIsInstalled;
+    try {
+        await SharedGroupPreferences.isAppInstalledAndroid(packageName);
+        appIsInstalled = true;
+    } catch (e) {
+        appIsInstalled = false;
+    }
+
+    return appIsInstalled;
+};
+
+const getItem = async (key: string, appGroup: string, options: SharedGroupPreferenceOptions) => {
+    const result = await SharedGroupPreferences.getItem(key, appGroup);
+    return result;
+};
+
+const setItem = async (key: string, data: any, appGroup: string, options: SharedGroupPreferenceOptions) => {
+    await SharedGroupPreferences.setItem(key, data, appGroup);
+};
+
+export default { isAppInstalledAndroid, getItem, setItem };

--- a/types/react-native-shared-group-preferences/tsconfig.json
+++ b/types/react-native-shared-group-preferences/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-native-shared-group-preferences-tests.ts"
+    ]
+}

--- a/types/react-native-shared-group-preferences/tslint.json
+++ b/types/react-native-shared-group-preferences/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.