### PR TITLE
update(sanitize-html): update defaults and options

### DIFF
--- a/types/sanitize-html/index.d.ts
+++ b/types/sanitize-html/index.d.ts
@@ -11,6 +11,7 @@
 //                 GP <https://github.com/paambaati>
 //                 tomotetra <https://github.com/tomotetra>
 //                 Dariusz Syncerek <https://github.com/dsyncerek>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -37,10 +38,13 @@ declare namespace sanitize {
     allowedAttributes: { [index: string]: AllowedAttribute[] };
     allowedSchemes: string[];
     allowedSchemesByTag: { [index: string]: string[] };
+    allowedSchemesAppliedToAttributes: string[];
     allowedTags: string[];
+    allowProtocolRelative: boolean;
+    disallowedTagsMode: string;
+    enforceHtmlBoundary: boolean;
     selfClosing: string[];
   }
-
 
   interface IFrame {
     tag: string;
@@ -68,6 +72,13 @@ declare namespace sanitize {
     transformTags?: { [tagName: string]: string | Transformer };
     parser?: ParserOptions;
     disallowedTagsMode?: DisallowedTagsModes;
+    /**
+     * Setting this option to true will instruct sanitize-html to discard all characters outside of html tag boundaries
+     * -- before `<html>` and after `</html>` tags
+     * @see {@link https://github.com/apostrophecms/sanitize-html/#discarding-text-outside-of-htmlhtml-tags}
+     * @default true
+     */
+    enforceHtmlBoundary?: boolean;
   }
 
 

--- a/types/sanitize-html/sanitize-html-tests.ts
+++ b/types/sanitize-html/sanitize-html-tests.ts
@@ -32,8 +32,19 @@ let options: sanitize.IOptions = {
     'a': ['http', 'https']
   },
   allowProtocolRelative: false,
-  disallowedTagsMode: 'escape'
+  disallowedTagsMode: 'escape',
+  enforceHtmlBoundary: true,
 };
+
+sanitize.defaults.allowedAttributes; // $ExpectType { [index: string]: AllowedAttribute[]; }
+sanitize.defaults.allowedSchemes; // $ExpectType string[]
+sanitize.defaults.allowedSchemesAppliedToAttributes; // $ExpectType string[]
+sanitize.defaults.allowedSchemesByTag; // $ExpectType { [index: string]: string[]; }
+sanitize.defaults.allowedTags; // $ExpectType string[]
+sanitize.defaults.allowProtocolRelative; // $ExpectType boolean
+sanitize.defaults.disallowedTagsMode; // $ExpectType string
+sanitize.defaults.enforceHtmlBoundary; // $ExpectType boolean
+sanitize.defaults.selfClosing; // $ExpectType string[]
 
 let unsafe = '<div><script>alert("hello");</script></div>';
 


### PR DESCRIPTION
- `enforceHtmlBoundary` missing in options
https://github.com/apostrophecms/sanitize-html/#discarding-text-outside-of-htmlhtml-tags
- correct defaults to be non-optional (these are defaults) and add
missing props:
https://github.com/apostrophecms/sanitize-html/#what-are-the-default-options
- maintainer added

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)