### PR TITLE
[estraverse] Updated definition to support version 5.1

### DIFF
--- a/types/estraverse/estraverse-tests.ts
+++ b/types/estraverse/estraverse-tests.ts
@@ -1,73 +1,70 @@
-import * as estraverse from 'estraverse';
-import * as estree from 'estree';
+import estraverse from 'estraverse';
+import estree from 'estree';
 
-let ast: estree.Node = {
-    "type": "Program",
-    "body": [
-        {
-            "type": "VariableDeclaration",
-            "declarations": [
-                {
-                    "type": "VariableDeclarator",
-                    "id": {
-                        "type": "Identifier",
-                        "name": "answer"
-                    },
-                    "init": {
-                        "type": "BinaryExpression",
-                        "operator": "*",
-                        "left": {
-                            "type": "Literal",
-                            "value": 6,
-                            "raw": "6"
-                        },
-                        "right": {
-                            "type": "Literal",
-                            "value": 7,
-                            "raw": "7"
-                        }
-                    }
-                }
-            ],
-            "kind": "var"
-        }
-    ],
-    "sourceType": "script"
-};
+declare const NODE: estree.Node;
+declare const NODE_VISITOR: estraverse.Visitor;
 
-estraverse.traverse(ast, {
-    enter(node: estree.Node, parentNode: estree.Node | null) {
-        if (node.type === 'Identifier') {
-            return estraverse.VisitorOption.Skip;
-        }
-    },
-    leave: (node: estree.Node, parentNode: estree.Node | null) => {},
-    fallback: 'iteration',
-    keys: {
-        TestExpression: ['argument']
-    }
-});
+declare const FLAG: estraverse.VisitorOption;
 
-estraverse.replace(ast, {
-    enter: (node: estree.Node, parentNode: estree.Node | null) => {
-        return node;
-    },
-    leave: (node: estree.Node, parentNode: estree.Node | null) => {
-        return node;
-    }
-});
-
+// Test cases for `Visitor`
 {
     const visitor: estraverse.Visitor = {
         enter(node, parent) {
-            this.break(); // $ExpectType void
-            this.current(); // $ExpectType Node
-            this.notify(estraverse.VisitorOption.Break); // $ExpectType void
-            this.parents(); // $ExpectType Node[]
-            this.path(); // $ExpectType (string | number)[] | null
-            this.remove(); // $ExpectType void
-            this.skip(); // $ExpectType void
-            this.type(); // $ExpectType string
+            // Test cases for `this`
+            {
+                // $ExpectType Controller
+                this;
+                this.break(); // $ExpectType void
+                this.current(); // $ExpectType Node
+                this.notify(FLAG); // $ExpectType void
+                this.parents(); // $ExpectType Node[]
+                this.path(); // $ExpectType (string | number)[] | null
+                this.remove(); // $ExpectType void
+                this.skip(); // $ExpectType void
+                this.type(); // $ExpectType string
+            }
         },
+        leave(node, parent) {
+            // Test cases for `this
+            {
+                // $ExpectType Controller
+                this;
+                this.break(); // $ExpectType void
+                this.current(); // $ExpectType Node
+                this.notify(FLAG); // $ExpectType void
+                this.parents(); // $ExpectType Node[]
+                this.path(); // $ExpectType (string | number)[] | null
+                this.remove(); // $ExpectType void
+                this.skip(); // $ExpectType void
+                this.type(); // $ExpectType string
+            }
+        },
+        fallback(node) {
+           // Test cases for `this
+            {
+                // $ExpectType Controller
+                this;
+                this.break(); // $ExpectType void
+                this.current(); // $ExpectType Node
+                this.notify(FLAG); // $ExpectType void
+                this.parents(); // $ExpectType Node[]
+                this.path(); // $ExpectType (string | number)[] | null
+                this.remove(); // $ExpectType void
+                this.skip(); // $ExpectType void
+                this.type(); // $ExpectType string
+            }
+
+            return [];
+        }
     };
+}
+
+// Test cases for `traverse`
+{
+    estraverse.traverse(NODE, NODE_VISITOR); // $ExpectType void
+}
+
+// Test cases for `replace`
+{
+    estraverse.replace(NODE, NODE_VISITOR); // $ExpectType Node
 }

--- a/types/estraverse/estraverse-tests.ts
+++ b/types/estraverse/estraverse-tests.ts
@@ -56,3 +56,18 @@ estraverse.replace(ast, {
         return node;
     }
 });
+
+{
+    const visitor: estraverse.Visitor = {
+        enter(node, parent) {
+            this.break(); // $ExpectType void
+            this.current(); // $ExpectType Node
+            this.notify(estraverse.VisitorOption.Break); // $ExpectType void
+            this.parents(); // $ExpectType Node[]
+            this.path(); // $ExpectType (string | number)[] | null
+            this.remove(); // $ExpectType void
+            this.skip(); // $ExpectType void
+            this.type(); // $ExpectType string
+        },
+    };
+}

--- a/types/estraverse/index.d.ts
+++ b/types/estraverse/index.d.ts
@@ -1,20 +1,170 @@
-// Type definitions for estraverse
+// Type definitions for estraverse 5.1
 // Project: https://github.com/estools/estraverse
 // Definitions by: Sanex3339 <https://github.com/sanex3339>
+//                 Jason Kwok <https://github.com/JasonHK>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as ESTree from 'estree';
 
-export interface Visitor {
-    enter?: (node: ESTree.Node, parentNode: ESTree.Node | null) => VisitorOption | ESTree.Node | void;
-    leave?: (node: ESTree.Node, parentNode: ESTree.Node | null) => VisitorOption | ESTree.Node | void;
+declare namespace ESTraverse {
+    const Syntax: Syntax;
 
-    fallback?: 'iteration'|((node: ESTree.Node) => string[]);
+    const VisitorKeys: VisitorKeys;
+    
+    enum VisitorOption {
+        Break,
+        Skip,
+        Remove,
+    }
+    
+    class Controller {
+        /**
+         * Traverse the AST.
+         */
+        traverse(root: ESTree.Node, visitor: Visitor): void;
+    
+        /**
+         * Traverse and replace the AST.
+         */
+        replace(root: ESTree.Node, visitor: Visitor): ESTree.Node;
+    
+        /**
+         * The current node.
+         */
+        current(): ESTree.Node;
+    
+        /**
+         * The type of current node.
+         */
+        type(): string;
+    
+        /**
+         * Obtain the property paths array from root to the current node.
+         */
+        path(): Array<string | number> | null;
+    
+        /**
+         * An array of parent elements.
+         */
+        parents(): Array<ESTree.Node>;
+    
+        /**
+         * Notify the controller to break the traversals, skip the child nodes of current node or remove the
+         * current node.
+         */
+        notify(flag: VisitorOption): void;
+    
+        /**
+         * Break the traversals.
+         */
+        break(): void;
+    
+        /**
+         * Skip the child nodes of current node.
+         */
+        skip(): void;
+    
+        /**
+         * Remove the current node.
+         */
+        remove(): void;
+    }
+    
+    function traverse(ast: ESTree.Node, visitor: Visitor): void;
+    
+    function replace(ast: ESTree.Node, visitor: Visitor): ESTree.Node;
 
-    keys?: {[nodeType: string]: string[];};
+    function attachComments(tree: ESTree.Node, providedComments: Array<ESTree.Comment>, tokens: Array<ESTree.Node>): ESTree.Node;
+    
+    function cloneEnvironment(): typeof ESTraverse;
+    
+    type NodeType =
+        | "AssignmentExpression"
+        | "AssignmentPattern"
+        | "ArrayExpression"
+        | "ArrayPattern"
+        | "ArrowFunctionExpression"
+        | "AwaitExpression"
+        | "BlockStatement"
+        | "BinaryExpression"
+        | "BreakStatement"
+        | "CallExpression"
+        | "CatchClause"
+        | "ClassBody"
+        | "ClassDeclaration"
+        | "ClassExpression"
+        | "ComprehensionBlock"
+        | "ComprehensionExpression"
+        | "ConditionalExpression"
+        | "ContinueStatement"
+        | "DebuggerStatement"
+        | "DirectiveStatement"
+        | "DoWhileStatement"
+        | "EmptyStatement"
+        | "ExportAllDeclaration"
+        | "ExportDefaultDeclaration"
+        | "ExportNamedDeclaration"
+        | "ExportSpecifier"
+        | "ExpressionStatement"
+        | "ForStatement"
+        | "ForInStatement"
+        | "ForOfStatement"
+        | "FunctionDeclaration"
+        | "FunctionExpression"
+        | "GeneratorExpression"
+        | "Identifier"
+        | "IfStatement"
+        | "ImportExpression"
+        | "ImportDeclaration"
+        | "ImportDefaultSpecifier"
+        | "ImportNamespaceSpecifier"
+        | "ImportSpecifier"
+        | "Literal"
+        | "LabeledStatement"
+        | "LogicalExpression"
+        | "MemberExpression"
+        | "MetaProperty"
+        | "MethodDefinition"
+        | "ModuleSpecifier"
+        | "NewExpression"
+        | "ObjectExpression"
+        | "ObjectPattern"
+        | "Program"
+        | "Property"
+        | "RestElement"
+        | "ReturnStatement"
+        | "SequenceExpression"
+        | "SpreadElement"
+        | "Super"
+        | "SwitchStatement"
+        | "SwitchCase"
+        | "TaggedTemplateExpression"
+        | "TemplateElement"
+        | "TemplateLiteral"
+        | "ThisExpression"
+        | "ThrowStatement"
+        | "TryStatement"
+        | "UnaryExpression"
+        | "UpdateExpression"
+        | "VariableDeclaration"
+        | "VariableDeclarator"
+        | "WhileStatement"
+        | "WithStatement"
+        | "YieldExpression";
+    
+    interface Syntax extends Record<NodeType, NodeType> {}
+    
+    interface VisitorKeys extends Record<NodeType, string[]> {}
+    
+    interface Visitor {
+        enter?: (this: Controller, node: ESTree.Node, parent: ESTree.Node | null) => VisitorOption | ESTree.Node | void;
+    
+        leave?: (this: Controller, node: ESTree.Node, parent: ESTree.Node | null) => VisitorOption | ESTree.Node | void;
+    
+        fallback?: 'iteration' | ((this: Controller, node: ESTree.Node) => string[]);
+    
+        keys?: {[nodeType: string]: string[];};
+    }
 }
 
-export enum VisitorOption {Skip, Break, Remove}
-
-export function traverse(ast: ESTree.Node, visitor: Visitor): void;
-export function replace(ast: ESTree.Node, visitor: Visitor): ESTree.Node;
+export = ESTraverse;

--- a/types/estraverse/index.d.ts
+++ b/types/estraverse/index.d.ts
@@ -10,74 +10,74 @@ declare namespace ESTraverse {
     const Syntax: Syntax;
 
     const VisitorKeys: VisitorKeys;
-    
+
     enum VisitorOption {
         Break,
         Skip,
         Remove,
     }
-    
+
     class Controller {
         /**
          * Traverse the AST.
          */
         traverse(root: ESTree.Node, visitor: Visitor): void;
-    
+
         /**
          * Traverse and replace the AST.
          */
         replace(root: ESTree.Node, visitor: Visitor): ESTree.Node;
-    
+
         /**
          * The current node.
          */
         current(): ESTree.Node;
-    
+
         /**
          * The type of current node.
          */
         type(): string;
-    
+
         /**
          * Obtain the property paths array from root to the current node.
          */
         path(): Array<string | number> | null;
-    
+
         /**
          * An array of parent elements.
          */
-        parents(): Array<ESTree.Node>;
-    
+        parents(): ESTree.Node[];
+
         /**
          * Notify the controller to break the traversals, skip the child nodes of current node or remove the
          * current node.
          */
         notify(flag: VisitorOption): void;
-    
+
         /**
          * Break the traversals.
          */
         break(): void;
-    
+
         /**
          * Skip the child nodes of current node.
          */
         skip(): void;
-    
+
         /**
          * Remove the current node.
          */
         remove(): void;
     }
-    
-    function traverse(ast: ESTree.Node, visitor: Visitor): void;
-    
-    function replace(ast: ESTree.Node, visitor: Visitor): ESTree.Node;
 
-    function attachComments(tree: ESTree.Node, providedComments: Array<ESTree.Comment>, tokens: Array<ESTree.Node>): ESTree.Node;
-    
+    function traverse(root: ESTree.Node, visitor: Visitor): void;
+
+    function replace(root: ESTree.Node, visitor: Visitor): ESTree.Node;
+
+    function attachComments(tree: ESTree.Node, providedComments: ESTree.Comment[], tokens: ESTree.Node[]): ESTree.Node;
+
     function cloneEnvironment(): typeof ESTraverse;
-    
+
     type NodeType =
         | "AssignmentExpression"
         | "AssignmentPattern"
@@ -151,20 +151,21 @@ declare namespace ESTraverse {
         | "WhileStatement"
         | "WithStatement"
         | "YieldExpression";
-    
+
     interface Syntax extends Record<NodeType, NodeType> {}
-    
+
     interface VisitorKeys extends Record<NodeType, string[]> {}
-    
+
     interface Visitor {
         enter?: (this: Controller, node: ESTree.Node, parent: ESTree.Node | null) => VisitorOption | ESTree.Node | void;
-    
+
         leave?: (this: Controller, node: ESTree.Node, parent: ESTree.Node | null) => VisitorOption | ESTree.Node | void;
-    
+
         fallback?: 'iteration' | ((this: Controller, node: ESTree.Node) => string[]);
-    
-        keys?: {[nodeType: string]: string[];};
+
+        keys?: Record<string, string[]>;
     }
 }
 
+// tslint:disable-next-line export-just-namespace
 export = ESTraverse;

--- a/types/estraverse/tsconfig.json
+++ b/types/estraverse/tsconfig.json
@@ -14,7 +14,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/estools/estraverse/blob/master/estraverse.js>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
