### PR TITLE
fix: `morgan` is not tightly coupled to `express`

### DIFF
--- a/types/morgan/index.d.ts
+++ b/types/morgan/index.d.ts
@@ -5,14 +5,17 @@
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import express = require('express');
+/// <reference types="node" />
+
+import http = require('http');
+import connect = require('connect');
 
 declare namespace morgan {
-    type FormatFn = (tokens: TokenIndexer, req: express.Request, res: express.Response) => string | undefined | null;
+    type FormatFn = (tokens: TokenIndexer, req: http.IncomingMessage, res: http.ServerResponse) => string | undefined | null;
 
     type TokenCallbackFn = (
-        req: express.Request,
-        res: express.Response,
+        req: http.IncomingMessage,
+        res: http.ServerResponse,
         arg?: string | number | boolean,
     ) => string | undefined;
 
@@ -32,21 +35,21 @@ declare namespace morgan {
          * @param format
          * @param options
          */
-        (format: string, options?: Options): express.RequestHandler;
+        (format: string, options?: Options): connect.NextHandleFunction;
         /***
          * Standard Apache combined log output.
          * :remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"
          * @param format
          * @param options
          */
-        (format: 'combined', options?: Options): express.RequestHandler;
+        (format: 'combined', options?: Options): connect.NextHandleFunction;
         /***
          * Standard Apache common log output.
          * :remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length]
          * @param format
          * @param options
          */
-        (format: 'common', options?: Options): express.RequestHandler;
+        (format: 'common', options?: Options): connect.NextHandleFunction;
         /**
          * Concise output colored by response status for development use. The
          * :status token will be colored red for server error codes, yellow for
@@ -54,7 +57,7 @@ declare namespace morgan {
          * all other codes.
          * :method :url :status :response-time ms - :res[content-length]
          */
-        (format: 'dev', options?: Options): express.RequestHandler;
+        (format: 'dev', options?: Options): connect.NextHandleFunction;
 
         /***
          * Shorter than default, also including response time.
@@ -62,7 +65,7 @@ declare namespace morgan {
          * @param format
          * @param options
          */
-        (format: 'short', options?: Options): express.RequestHandler;
+        (format: 'short', options?: Options): connect.NextHandleFunction;
 
         /***
          * The minimal output.
@@ -70,7 +73,7 @@ declare namespace morgan {
          * @param format
          * @param options
          */
-        (format: 'tiny', options?: Options): express.RequestHandler;
+        (format: 'tiny', options?: Options): connect.NextHandleFunction;
 
         /***
          * Create a new morgan logger middleware function using the given format
@@ -79,7 +82,7 @@ declare namespace morgan {
          * @param format
          * @param options
          */
-        (format: FormatFn, options?: Options): express.RequestHandler;
+        (format: FormatFn, options?: Options): connect.NextHandleFunction;
 
         /**
          * Define a custom token which can be used in custom morgan logging
@@ -153,7 +156,7 @@ declare namespace morgan {
          * Function to determine if logging is skipped, defaults to false. This
          * function will be called as skip(req, res).
          */
-        skip?(req: express.Request, res: express.Response): boolean;
+        skip?(req: http.IncomingMessage, res: http.ServerResponse): boolean;
 
         /***
          * Output stream for writing log lines, defaults to process.stdout.
@@ -170,7 +173,7 @@ declare namespace morgan {
  * @param format
  * @param options
  */
-declare function morgan(format: string, options?: morgan.Options): express.RequestHandler;
+declare function morgan(format: string, options?: morgan.Options): connect.NextHandleFunction;
 
 /***
  * Standard Apache combined log output.
@@ -178,7 +181,7 @@ declare function morgan(format: string, options?: morgan.Options): express.Reque
  * @param format
  * @param options
  */
-declare function morgan(format: 'combined', options?: morgan.Options): express.RequestHandler;
+declare function morgan(format: 'combined', options?: morgan.Options): connect.NextHandleFunction;
 
 /***
  * Standard Apache common log output.
@@ -186,7 +189,7 @@ declare function morgan(format: 'combined', options?: morgan.Options): express.R
  * @param format
  * @param options
  */
-declare function morgan(format: 'common', options?: morgan.Options): express.RequestHandler;
+declare function morgan(format: 'common', options?: morgan.Options): connect.NextHandleFunction;
 
 /***
  * Concise output colored by response status for development use. The :status
@@ -196,7 +199,7 @@ declare function morgan(format: 'common', options?: morgan.Options): express.Req
  * @param format
  * @param options
  */
-declare function morgan(format: 'dev', options?: morgan.Options): express.RequestHandler;
+declare function morgan(format: 'dev', options?: morgan.Options): connect.NextHandleFunction;
 
 /***
  * Shorter than default, also including response time.
@@ -204,7 +207,7 @@ declare function morgan(format: 'dev', options?: morgan.Options): express.Reques
  * @param format
  * @param options
  */
-declare function morgan(format: 'short', options?: morgan.Options): express.RequestHandler;
+declare function morgan(format: 'short', options?: morgan.Options): connect.NextHandleFunction;
 
 /***
  * The minimal output.
@@ -212,7 +215,7 @@ declare function morgan(format: 'short', options?: morgan.Options): express.Requ
  * @param format
  * @param options
  */
-declare function morgan(format: 'tiny', options?: morgan.Options): express.RequestHandler;
+declare function morgan(format: 'tiny', options?: morgan.Options): connect.NextHandleFunction;
 
 /***
  * Create a new morgan logger middleware function using the given format and
@@ -221,6 +224,6 @@ declare function morgan(format: 'tiny', options?: morgan.Options): express.Reque
  * @param format
  * @param options
  */
-declare function morgan(format: morgan.FormatFn, options?: morgan.Options): express.RequestHandler;
+declare function morgan(format: morgan.FormatFn, options?: morgan.Options): connect.NextHandleFunction;
 
 export = morgan;

--- a/types/morgan/index.d.ts
+++ b/types/morgan/index.d.ts
@@ -12,7 +12,11 @@ import http = require('http');
 type Handler<Request extends http.IncomingMessage, Response extends http.ServerResponse> = (req: Request, res: Response, callback: (err?: Error) => void) => void;
 
 declare namespace morgan {
-    type FormatFn<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse> = (tokens: TokenIndexer<Request, Response>, req: Request, res: Response) => string | undefined | null;
+    type FormatFn<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse> = (
+        tokens: TokenIndexer<Request, Response>,
+        req: Request,
+        res: Response,
+    ) => string | undefined | null;
 
     type TokenCallbackFn<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse> = (
         req: Request,
@@ -110,7 +114,10 @@ declare namespace morgan {
     /**
      * Define a custom token which can be used in custom morgan logging formats.
      */
-    function token<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(name: string, callback: TokenCallbackFn<Request, Response>): Morgan<Request, Response>;
+    function token<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(
+        name: string,
+        callback: TokenCallbackFn<Request, Response>,
+    ): Morgan<Request, Response>;
 
     /**
      * Define a named custom format by specifying a format string in token
@@ -121,7 +128,10 @@ declare namespace morgan {
     /**
      * Define a named custom format by specifying a format function.
      */
-    function format<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(name: string, fmt: FormatFn<Request, Response>): Morgan<Request, Response>;
+    function format<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(
+        name: string,
+        fmt: FormatFn<Request, Response>,
+    ): Morgan<Request, Response>;
 
     /**
      * Compile a format string in token notation into a format function.
@@ -174,7 +184,10 @@ declare namespace morgan {
  * @param format
  * @param options
  */
-declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(format: string, options?: morgan.Options<Request, Response>): Handler<Request, Response>;
+declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(
+    format: string,
+    options?: morgan.Options<Request, Response>,
+): Handler<Request, Response>;
 
 /***
  * Standard Apache combined log output.
@@ -182,7 +195,10 @@ declare function morgan<Request extends http.IncomingMessage = http.IncomingMess
  * @param format
  * @param options
  */
-declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(format: 'combined', options?: morgan.Options<Request, Response>): Handler<Request, Response>;
+declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(
+    format: 'combined',
+    options?: morgan.Options<Request, Response>,
+): Handler<Request, Response>;
 
 /***
  * Standard Apache common log output.
@@ -190,7 +206,10 @@ declare function morgan<Request extends http.IncomingMessage = http.IncomingMess
  * @param format
  * @param options
  */
-declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(format: 'common', options?: morgan.Options<Request, Response>): Handler<Request, Response>;
+declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(
+    format: 'common',
+    options?: morgan.Options<Request, Response>,
+): Handler<Request, Response>;
 
 /***
  * Concise output colored by response status for development use. The :status
@@ -200,7 +219,10 @@ declare function morgan<Request extends http.IncomingMessage = http.IncomingMess
  * @param format
  * @param options
  */
-declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(format: 'dev', options?: morgan.Options<Request, Response>): Handler<Request, Response>;
+declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(
+    format: 'dev',
+    options?: morgan.Options<Request, Response>,
+): Handler<Request, Response>;
 
 /***
  * Shorter than default, also including response time.
@@ -208,7 +230,10 @@ declare function morgan<Request extends http.IncomingMessage = http.IncomingMess
  * @param format
  * @param options
  */
-declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(format: 'short', options?: morgan.Options<Request, Response>): Handler<Request, Response>;
+declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(
+    format: 'short',
+    options?: morgan.Options<Request, Response>,
+): Handler<Request, Response>;
 
 /***
  * The minimal output.
@@ -216,7 +241,10 @@ declare function morgan<Request extends http.IncomingMessage = http.IncomingMess
  * @param format
  * @param options
  */
-declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(format: 'tiny', options?: morgan.Options<Request, Response>): Handler<Request, Response>;
+declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(
+    format: 'tiny',
+    options?: morgan.Options<Request, Response>,
+): Handler<Request, Response>;
 
 /***
  * Create a new morgan logger middleware function using the given format and
@@ -225,6 +253,9 @@ declare function morgan<Request extends http.IncomingMessage = http.IncomingMess
  * @param format
  * @param options
  */
-declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(format: morgan.FormatFn<Request, Response>, options?: morgan.Options<Request, Response>): Handler<Request, Response>;
+declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(
+    format: morgan.FormatFn<Request, Response>,
+    options?: morgan.Options<Request, Response>,
+): Handler<Request, Response>;
 
 export = morgan;

--- a/types/morgan/index.d.ts
+++ b/types/morgan/index.d.ts
@@ -123,6 +123,7 @@ declare namespace morgan {
      * Define a named custom format by specifying a format string in token
      * notation.
      */
+    // tslint:disable-next-line
     function format<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(name: string, fmt: string): Morgan<Request, Response>;
 
     /**
@@ -136,6 +137,7 @@ declare namespace morgan {
     /**
      * Compile a format string in token notation into a format function.
      */
+    // tslint:disable-next-line
     function compile<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(format: string): FormatFn<Request, Response>;
 
     interface StreamOptions {

--- a/types/morgan/index.d.ts
+++ b/types/morgan/index.d.ts
@@ -9,25 +9,25 @@
 
 import http = require('http');
 
-type Handler = (req: http.IncomingMessage, res: http.ServerResponse, callback: (err?: Error) => void) => void;
+type Handler<Request extends http.IncomingMessage, Response extends http.ServerResponse> = (req: Request, res: Response, callback: (err?: Error) => void) => void;
 
 declare namespace morgan {
-    type FormatFn = (tokens: TokenIndexer, req: http.IncomingMessage, res: http.ServerResponse) => string | undefined | null;
+    type FormatFn<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse> = (tokens: TokenIndexer<Request, Response>, req: Request, res: Response) => string | undefined | null;
 
-    type TokenCallbackFn = (
-        req: http.IncomingMessage,
-        res: http.ServerResponse,
+    type TokenCallbackFn<Request extends http.IncomingMessage, Response extends http.ServerResponse> = (
+        req: Request,
+        res: Response,
         arg?: string | number | boolean,
     ) => string | undefined;
 
-    interface TokenIndexer {
-        [tokenName: string]: TokenCallbackFn;
+    interface TokenIndexer<Request extends http.IncomingMessage, Response extends http.ServerResponse> {
+        [tokenName: string]: TokenCallbackFn<Request, Response>;
     }
 
     /**
      * Public interface of morgan logger.
      */
-    interface Morgan {
+    interface Morgan<Request extends http.IncomingMessage, Response extends http.ServerResponse> {
         /***
          * Create a new morgan logger middleware function using the given format
          * and options. The format argument may be a string of a predefined name
@@ -36,21 +36,21 @@ declare namespace morgan {
          * @param format
          * @param options
          */
-        (format: string, options?: Options): Handler;
+        (format: string, options?: Options<Request, Response>): Handler<Request, Response>;
         /***
          * Standard Apache combined log output.
          * :remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"
          * @param format
          * @param options
          */
-        (format: 'combined', options?: Options): Handler;
+        (format: 'combined', options?: Options<Request, Response>): Handler<Request, Response>;
         /***
          * Standard Apache common log output.
          * :remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length]
          * @param format
          * @param options
          */
-        (format: 'common', options?: Options): Handler;
+        (format: 'common', options?: Options<Request, Response>): Handler<Request, Response>;
         /**
          * Concise output colored by response status for development use. The
          * :status token will be colored red for server error codes, yellow for
@@ -58,7 +58,7 @@ declare namespace morgan {
          * all other codes.
          * :method :url :status :response-time ms - :res[content-length]
          */
-        (format: 'dev', options?: Options): Handler;
+        (format: 'dev', options?: Options<Request, Response>): Handler<Request, Response>;
 
         /***
          * Shorter than default, also including response time.
@@ -66,7 +66,7 @@ declare namespace morgan {
          * @param format
          * @param options
          */
-        (format: 'short', options?: Options): Handler;
+        (format: 'short', options?: Options<Request, Response>): Handler<Request, Response>;
 
         /***
          * The minimal output.
@@ -74,7 +74,7 @@ declare namespace morgan {
          * @param format
          * @param options
          */
-        (format: 'tiny', options?: Options): Handler;
+        (format: 'tiny', options?: Options<Request, Response>): Handler<Request, Response>;
 
         /***
          * Create a new morgan logger middleware function using the given format
@@ -83,50 +83,50 @@ declare namespace morgan {
          * @param format
          * @param options
          */
-        (format: FormatFn, options?: Options): Handler;
+        (format: FormatFn<Request, Response>, options?: Options<Request, Response>): Handler<Request, Response>;
 
         /**
          * Define a custom token which can be used in custom morgan logging
          * formats.
          */
-        token(name: string, callback: TokenCallbackFn): Morgan;
+        token(name: string, callback: TokenCallbackFn<Request, Response>): Morgan<Request, Response>;
         /**
          * Define a named custom format by specifying a format string in token
          * notation.
          */
-        format(name: string, fmt: string): Morgan;
+        format(name: string, fmt: string): Morgan<Request, Response>;
 
         /**
          * Define a named custom format by specifying a format function.
          */
-        format(name: string, fmt: FormatFn): Morgan;
+        format(name: string, fmt: FormatFn<Request, Response>): Morgan<Request, Response>;
 
         /**
          * Compile a format string in token notation into a format function.
          */
-        compile(format: string): FormatFn;
+        compile(format: string): FormatFn<Request, Response>;
     }
 
     /**
      * Define a custom token which can be used in custom morgan logging formats.
      */
-    function token(name: string, callback: TokenCallbackFn): Morgan;
+    function token<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(name: string, callback: TokenCallbackFn<Request, Response>): Morgan<Request, Response>;
 
     /**
      * Define a named custom format by specifying a format string in token
      * notation.
      */
-    function format(name: string, fmt: string): Morgan;
+    function format<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(name: string, fmt: string): Morgan<Request, Response>;
 
     /**
      * Define a named custom format by specifying a format function.
      */
-    function format(name: string, fmt: FormatFn): Morgan;
+    function format<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(name: string, fmt: FormatFn<Request, Response>): Morgan<Request, Response>;
 
     /**
      * Compile a format string in token notation into a format function.
      */
-    function compile(format: string): FormatFn;
+    function compile<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(format: string): FormatFn<Request, Response>;
 
     interface StreamOptions {
         /**
@@ -138,7 +138,7 @@ declare namespace morgan {
     /***
      * Morgan accepts these properties in the options object.
      */
-    interface Options {
+    interface Options<Request extends http.IncomingMessage, Response extends http.ServerResponse> {
         /***
          * Buffer duration before writing logs to the stream, defaults to false.
          * When set to true, defaults to 1000 ms.
@@ -157,7 +157,7 @@ declare namespace morgan {
          * Function to determine if logging is skipped, defaults to false. This
          * function will be called as skip(req, res).
          */
-        skip?(req: http.IncomingMessage, res: http.ServerResponse): boolean;
+        skip?(req: Request, res: Response): boolean;
 
         /***
          * Output stream for writing log lines, defaults to process.stdout.
@@ -174,7 +174,7 @@ declare namespace morgan {
  * @param format
  * @param options
  */
-declare function morgan(format: string, options?: morgan.Options): Handler;
+declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(format: string, options?: morgan.Options<Request, Response>): Handler<Request, Response>;
 
 /***
  * Standard Apache combined log output.
@@ -182,7 +182,7 @@ declare function morgan(format: string, options?: morgan.Options): Handler;
  * @param format
  * @param options
  */
-declare function morgan(format: 'combined', options?: morgan.Options): Handler;
+declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(format: 'combined', options?: morgan.Options<Request, Response>): Handler<Request, Response>;
 
 /***
  * Standard Apache common log output.
@@ -190,7 +190,7 @@ declare function morgan(format: 'combined', options?: morgan.Options): Handler;
  * @param format
  * @param options
  */
-declare function morgan(format: 'common', options?: morgan.Options): Handler;
+declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(format: 'common', options?: morgan.Options<Request, Response>): Handler<Request, Response>;
 
 /***
  * Concise output colored by response status for development use. The :status
@@ -200,7 +200,7 @@ declare function morgan(format: 'common', options?: morgan.Options): Handler;
  * @param format
  * @param options
  */
-declare function morgan(format: 'dev', options?: morgan.Options): Handler;
+declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(format: 'dev', options?: morgan.Options<Request, Response>): Handler<Request, Response>;
 
 /***
  * Shorter than default, also including response time.
@@ -208,7 +208,7 @@ declare function morgan(format: 'dev', options?: morgan.Options): Handler;
  * @param format
  * @param options
  */
-declare function morgan(format: 'short', options?: morgan.Options): Handler;
+declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(format: 'short', options?: morgan.Options<Request, Response>): Handler<Request, Response>;
 
 /***
  * The minimal output.
@@ -216,7 +216,7 @@ declare function morgan(format: 'short', options?: morgan.Options): Handler;
  * @param format
  * @param options
  */
-declare function morgan(format: 'tiny', options?: morgan.Options): Handler;
+declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(format: 'tiny', options?: morgan.Options<Request, Response>): Handler<Request, Response>;
 
 /***
  * Create a new morgan logger middleware function using the given format and
@@ -225,6 +225,6 @@ declare function morgan(format: 'tiny', options?: morgan.Options): Handler;
  * @param format
  * @param options
  */
-declare function morgan(format: morgan.FormatFn, options?: morgan.Options): Handler;
+declare function morgan<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse>(format: morgan.FormatFn<Request, Response>, options?: morgan.Options<Request, Response>): Handler<Request, Response>;
 
 export = morgan;

--- a/types/morgan/index.d.ts
+++ b/types/morgan/index.d.ts
@@ -8,7 +8,8 @@
 /// <reference types="node" />
 
 import http = require('http');
-import connect = require('connect');
+
+type Handler = (req: http.IncomingMessage, res: http.ServerResponse, callback: (err?: Error) => void) => void;
 
 declare namespace morgan {
     type FormatFn = (tokens: TokenIndexer, req: http.IncomingMessage, res: http.ServerResponse) => string | undefined | null;
@@ -35,21 +36,21 @@ declare namespace morgan {
          * @param format
          * @param options
          */
-        (format: string, options?: Options): connect.NextHandleFunction;
+        (format: string, options?: Options): Handler;
         /***
          * Standard Apache combined log output.
          * :remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"
          * @param format
          * @param options
          */
-        (format: 'combined', options?: Options): connect.NextHandleFunction;
+        (format: 'combined', options?: Options): Handler;
         /***
          * Standard Apache common log output.
          * :remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length]
          * @param format
          * @param options
          */
-        (format: 'common', options?: Options): connect.NextHandleFunction;
+        (format: 'common', options?: Options): Handler;
         /**
          * Concise output colored by response status for development use. The
          * :status token will be colored red for server error codes, yellow for
@@ -57,7 +58,7 @@ declare namespace morgan {
          * all other codes.
          * :method :url :status :response-time ms - :res[content-length]
          */
-        (format: 'dev', options?: Options): connect.NextHandleFunction;
+        (format: 'dev', options?: Options): Handler;
 
         /***
          * Shorter than default, also including response time.
@@ -65,7 +66,7 @@ declare namespace morgan {
          * @param format
          * @param options
          */
-        (format: 'short', options?: Options): connect.NextHandleFunction;
+        (format: 'short', options?: Options): Handler;
 
         /***
          * The minimal output.
@@ -73,7 +74,7 @@ declare namespace morgan {
          * @param format
          * @param options
          */
-        (format: 'tiny', options?: Options): connect.NextHandleFunction;
+        (format: 'tiny', options?: Options): Handler;
 
         /***
          * Create a new morgan logger middleware function using the given format
@@ -82,7 +83,7 @@ declare namespace morgan {
          * @param format
          * @param options
          */
-        (format: FormatFn, options?: Options): connect.NextHandleFunction;
+        (format: FormatFn, options?: Options): Handler;
 
         /**
          * Define a custom token which can be used in custom morgan logging
@@ -173,7 +174,7 @@ declare namespace morgan {
  * @param format
  * @param options
  */
-declare function morgan(format: string, options?: morgan.Options): connect.NextHandleFunction;
+declare function morgan(format: string, options?: morgan.Options): Handler;
 
 /***
  * Standard Apache combined log output.
@@ -181,7 +182,7 @@ declare function morgan(format: string, options?: morgan.Options): connect.NextH
  * @param format
  * @param options
  */
-declare function morgan(format: 'combined', options?: morgan.Options): connect.NextHandleFunction;
+declare function morgan(format: 'combined', options?: morgan.Options): Handler;
 
 /***
  * Standard Apache common log output.
@@ -189,7 +190,7 @@ declare function morgan(format: 'combined', options?: morgan.Options): connect.N
  * @param format
  * @param options
  */
-declare function morgan(format: 'common', options?: morgan.Options): connect.NextHandleFunction;
+declare function morgan(format: 'common', options?: morgan.Options): Handler;
 
 /***
  * Concise output colored by response status for development use. The :status
@@ -199,7 +200,7 @@ declare function morgan(format: 'common', options?: morgan.Options): connect.Nex
  * @param format
  * @param options
  */
-declare function morgan(format: 'dev', options?: morgan.Options): connect.NextHandleFunction;
+declare function morgan(format: 'dev', options?: morgan.Options): Handler;
 
 /***
  * Shorter than default, also including response time.
@@ -207,7 +208,7 @@ declare function morgan(format: 'dev', options?: morgan.Options): connect.NextHa
  * @param format
  * @param options
  */
-declare function morgan(format: 'short', options?: morgan.Options): connect.NextHandleFunction;
+declare function morgan(format: 'short', options?: morgan.Options): Handler;
 
 /***
  * The minimal output.
@@ -215,7 +216,7 @@ declare function morgan(format: 'short', options?: morgan.Options): connect.Next
  * @param format
  * @param options
  */
-declare function morgan(format: 'tiny', options?: morgan.Options): connect.NextHandleFunction;
+declare function morgan(format: 'tiny', options?: morgan.Options): Handler;
 
 /***
  * Create a new morgan logger middleware function using the given format and
@@ -224,6 +225,6 @@ declare function morgan(format: 'tiny', options?: morgan.Options): connect.NextH
  * @param format
  * @param options
  */
-declare function morgan(format: morgan.FormatFn, options?: morgan.Options): connect.NextHandleFunction;
+declare function morgan(format: morgan.FormatFn, options?: morgan.Options): Handler;
 
 export = morgan;

--- a/types/morgan/index.d.ts
+++ b/types/morgan/index.d.ts
@@ -14,13 +14,13 @@ type Handler<Request extends http.IncomingMessage, Response extends http.ServerR
 declare namespace morgan {
     type FormatFn<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse> = (tokens: TokenIndexer<Request, Response>, req: Request, res: Response) => string | undefined | null;
 
-    type TokenCallbackFn<Request extends http.IncomingMessage, Response extends http.ServerResponse> = (
+    type TokenCallbackFn<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse> = (
         req: Request,
         res: Response,
         arg?: string | number | boolean,
     ) => string | undefined;
 
-    interface TokenIndexer<Request extends http.IncomingMessage, Response extends http.ServerResponse> {
+    interface TokenIndexer<Request extends http.IncomingMessage = http.IncomingMessage, Response extends http.ServerResponse = http.ServerResponse> {
         [tokenName: string]: TokenCallbackFn<Request, Response>;
     }
 

--- a/types/morgan/morgan-tests.ts
+++ b/types/morgan/morgan-tests.ts
@@ -105,8 +105,9 @@ morgan.token('status', (req, res) => {
 });
 
 express().use(morgan('combined'));
+express().use(morgan('combined', {skip: (req) => req.header('user-agent') === 'fake'}));
 
-http.createServer(function (req, res) {
+http.createServer((req, res) => {
     morgan('combined')(req, res, (err) => {
         // respond to request
         res.setHeader('content-type', 'text/plain');

--- a/types/morgan/morgan-tests.ts
+++ b/types/morgan/morgan-tests.ts
@@ -4,6 +4,7 @@
 
 import http = require('http');
 import morgan = require('morgan');
+import express = require('express');
 
 // a pre-defined name
 morgan('combined');
@@ -102,6 +103,8 @@ morgan.format('dev-extended', developmentExtendedFormatLine);
 morgan.token('status', (req, res) => {
     return res.headersSent ? String(res.statusCode) : undefined;
 });
+
+express().use(morgan('combined'));
 
 http.createServer(function (req, res) {
     morgan('combined')(req, res, (err) => {

--- a/types/morgan/morgan-tests.ts
+++ b/types/morgan/morgan-tests.ts
@@ -2,6 +2,7 @@
  * Created by staticfunction on 8/3/14.
  */
 
+import http = require('http');
 import morgan = require('morgan');
 
 // a pre-defined name
@@ -100,4 +101,12 @@ morgan.format('dev-extended', developmentExtendedFormatLine);
 
 morgan.token('status', (req, res) => {
     return res.headersSent ? String(res.statusCode) : undefined;
+});
+
+http.createServer(function (req, res) {
+    morgan('combined')(req, res, (err) => {
+        // respond to request
+        res.setHeader('content-type', 'text/plain');
+        res.end('hello, world!');
+    });
 });

--- a/types/morgan/morgan-tests.ts
+++ b/types/morgan/morgan-tests.ts
@@ -3,7 +3,6 @@
  */
 
 import morgan = require('morgan');
-import express = require('express');
 
 // a pre-defined name
 morgan('combined');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expressjs/morgan/blob/19a6aa5369220b522e9dac007975ee66b1c38283/README.md#expressconnect
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

As can be seen in the linked docs, the middleware works with plain `http` module as well, not just the `express`-enhanced ones.

One thing to not, is that `skip` etc will be called with the request passed in. So we might wanna do some sort of generic handling so people using `express` stuff (like `req.header('user-agent')`) can still do that if they're using `express`. I'm not sure how to best do that, though.