### PR TITLE
Add missing lineSeparator property to options

### DIFF
--- a/types/xml-formatter/index.d.ts
+++ b/types/xml-formatter/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for xml-formatter 1.1
+// Type definitions for xml-formatter 1.2
 // Project: https://github.com/chrisbottin/xml-formatter/
 // Definitions by: Joachim Holwech <https://github.com/holwech>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/xml-formatter/index.d.ts
+++ b/types/xml-formatter/index.d.ts
@@ -13,5 +13,6 @@ declare namespace Format {
         indentation?: string;
         stripComments?: boolean;
         collapseContent?: boolean;
+        lineSeparator?: string;
     }
 }

--- a/types/xml-formatter/xml-formatter-tests.ts
+++ b/types/xml-formatter/xml-formatter-tests.ts
@@ -9,6 +9,7 @@ const options: format.Options = {
     indentation: '   ',
     stripComments: true,
     debug: true,
+    lineSeparator: '\n'
 };
 
 format(testXml, options);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chrisbottin/xml-formatter/blob/master/README.md#options
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
