### PR TITLE
Add request agents to newman run options

### DIFF
--- a/types/newman/index.d.ts
+++ b/types/newman/index.d.ts
@@ -5,6 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
+import * as http from 'http';
 import { EventEmitter } from "events";
 import {
     Collection,
@@ -130,6 +131,13 @@ export interface NewmanRunOptions {
      * The secret client key passphrase.
      */
     sslClientPassphrase?: string;
+    /**
+     * Custom HTTP(S) agents which will be used for making the requests. This allows for use of various proxies (e.g. socks)
+     */
+    requestAgents?: {
+        http?: http.Agent;
+        https?: http.Agent;
+    };
 }
 
 export interface NewmanRunSummary {

--- a/types/newman/index.d.ts
+++ b/types/newman/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for newman 4.5
+// Type definitions for newman 5.1
 // Project: https://github.com/postmanlabs/newman
 // Definitions by: Leonid Logvinov <https://github.com/LogvinovLeon>
 //                 Graham McGregor <https://github.com/Graham42>

--- a/types/newman/newman-tests.ts
+++ b/types/newman/newman-tests.ts
@@ -13,6 +13,7 @@ import {
     CollectionDefinition,
     VariableScopeDefinition
 } from "postman-collection";
+import * as http from 'http';
 
 const collection: CollectionDefinition = {};
 const environment: VariableScopeDefinition = {};
@@ -21,6 +22,7 @@ const folder: string | string[] = ['collectionFolderA', 'collectionFolderB'];
 const color = 'auto';
 const workingDir = 'path/to/working/directory';
 const insecureFileRead = true;
+const requestAgent = new http.Agent();
 
 // $ExpectType EventEmitter
 run(
@@ -31,7 +33,11 @@ run(
         folder,
         color,
         workingDir,
-        insecureFileRead
+        insecureFileRead,
+        requestAgents: {
+            http: requestAgent,
+            https: requestAgent,
+        },
     },
     (err, summary: NewmanRunSummary) => {
         summary.run; // $ExpectType NewmanRun


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/postmanlabs/newman/pull/2392
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.