### PR TITLE
Add arrayify-stream typings

### DIFF
--- a/types/arrayify-stream/arrayify-stream-tests.ts
+++ b/types/arrayify-stream/arrayify-stream-tests.ts
@@ -1,0 +1,14 @@
+import arrayifyStream from 'arrayify-stream';
+import { Readable } from 'stream';
+
+async function test() {
+    const readable = new Readable();
+    const items = [1, 2, 3];
+    items.forEach(item => readable.push(item));
+
+    const result: Promise<any[]> = arrayifyStream(readable);
+    const arr: any[] = await result;
+
+    // $ExpectError
+    arrayifyStream();
+}

--- a/types/arrayify-stream/index.d.ts
+++ b/types/arrayify-stream/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for arrayify-stream 1.0
+// Project: https://github.com/rubensworks/arrayify-stream.js#readme
+// Definitions by: Joachim Van Herwegen <https://github.com/joachimvh>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import { Readable } from 'stream';
+
+/**
+ * Converts a Node readable stream into an array that is returned as a promise.
+ */
+declare function arrayifyStream(input: Readable): Promise<any[]>;
+
+export = arrayifyStream;

--- a/types/arrayify-stream/tsconfig.json
+++ b/types/arrayify-stream/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "esModuleInterop": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "arrayify-stream-tests.ts"
+    ]
+}

--- a/types/arrayify-stream/tslint.json
+++ b/types/arrayify-stream/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
