### PR TITLE
Mapbox GL - Add rotation/pitch alignment methods to Marker

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -1454,6 +1454,14 @@ declare namespace mapboxgl {
         setDraggable(shouldBeDraggable: boolean): this;
 
         isDraggable(): boolean;
+
+        getRotationAlignment(): Alignment;
+
+        setRotationAlignment(alignment: Alignment): this;
+
+        getPitchAlignment(): Alignment;
+
+        setPitchAlignment(alignment: Alignment): this;
     }
 
     type Alignment = 'map' | 'viewport' | 'auto';

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -603,8 +603,12 @@ let marker = new mapboxgl.Marker(undefined, {
     .setRotationAlignment("viewport")
     .addTo(map);
 
-expectType<mapboxgl.Alignment>(marker.getPitchAlignment());
-expectType<mapboxgl.Alignment>(marker.getRotationAlignment());
+// $ExpectType Alignment
+marker.getPitchAlignment();
+
+// $ExpectType Alignment
+marker.getRotationAlignment();
+
 marker.remove();
 
 /*

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -1,4 +1,5 @@
 import mapboxgl = require('mapbox-gl');
+import { Alignment } from './index';
 
 // These examples adapted from Mapbox's examples (https://www.mapbox.com/mapbox-gl-js/examples)
 
@@ -599,8 +600,12 @@ let marker = new mapboxgl.Marker(undefined, {
     pitchAlignment: 'viewport',
 })
     .setLngLat([-50, 50])
+    .setPitchAlignment("map")
+    .setRotationAlignment("viewport")
     .addTo(map);
 
+expectType<Alignment>(marker.getPitchAlignment());
+expectType<Alignment>(marker.getRotationAlignment());
 marker.remove();
 
 /*

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -1,5 +1,4 @@
 import mapboxgl = require('mapbox-gl');
-import { Alignment } from './index';
 
 // These examples adapted from Mapbox's examples (https://www.mapbox.com/mapbox-gl-js/examples)
 
@@ -604,8 +603,8 @@ let marker = new mapboxgl.Marker(undefined, {
     .setRotationAlignment("viewport")
     .addTo(map);
 
-expectType<Alignment>(marker.getPitchAlignment());
-expectType<Alignment>(marker.getRotationAlignment());
+expectType<mapboxgl.Alignment>(marker.getPitchAlignment());
+expectType<mapboxgl.Alignment>(marker.getRotationAlignment());
 marker.remove();
 
 /*


### PR DESCRIPTION
As requested per https://github.com/Wykks/ngx-mapbox-gl/pull/226