### PR TITLE
types/ltijs: Add custom express response locals

### DIFF
--- a/types/ltijs/index.d.ts
+++ b/types/ltijs/index.d.ts
@@ -5,6 +5,18 @@
 
 /// <reference types="express" />
 
+import { IdToken } from './lib/IdToken';
+import { PlatformContext } from './lib/Utils/Platform';
+
+declare module 'express' {
+    interface Response {
+        locals: {
+            token?: IdToken;
+            context?: PlatformContext;
+        };
+    }
+}
+
 export * from './lib/Provider/Provider';
 export * from './lib/Provider/Services/DeepLinking';
 export * from './lib/Provider/Services/GradeService';

--- a/types/ltijs/lib/Utils/Platform.d.ts
+++ b/types/ltijs/lib/Utils/Platform.d.ts
@@ -19,6 +19,36 @@ export interface PlatformConfig {
     authConfig: PlatformAuthConfig;
 }
 
+export interface PlatformContext {
+    context: {
+        id: string;
+        label: string;
+        title: string;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        type: any[];
+    };
+    resource: {
+        title: string;
+        id: string;
+    };
+    path: string;
+    user: string;
+    deploymentId: string;
+    targetLinkUri: string;
+    launchPresentation: {
+        locale: string;
+        document_target: string;
+        return_url: string;
+    };
+    messageType: string;
+    version: string;
+    createdAt: Date;
+    __v: number;
+    __id: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    custom: any;
+}
+
 export interface Platform {
     platformName(name?: string): Promise<string | boolean>;
 

--- a/types/ltijs/ltijs-tests.ts
+++ b/types/ltijs/ltijs-tests.ts
@@ -54,7 +54,7 @@ const ltiAdvanced = new Provider(
             secure: true,
             sameSite: 'None',
         },
-        serverAddon: app => {},
+        serverAddon: app => { },
     },
 );
 
@@ -143,3 +143,11 @@ ltiAdvanced.Grade.result(idToken, { userId: true });
 
 // $ExpectType Promise<false | MembersResult>
 ltiAdvanced.NamesAndRoles.getMembers(idToken);
+
+ltiAdvanced.app.get('/any', (request: Request, response: Response) => {
+    // $ExpectType PlatformContext | undefined
+    response.locals.context;
+
+    // $ExpectType IdToken | undefined
+    response.locals.token;
+});


### PR DESCRIPTION
- Augment express Response object with custom 'locals' properties token
and context
- Add PlatformContext interface

@Cvmcosta

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: e.g. [here](https://github.com/Cvmcosta/ltijs/blob/master/docs/provider.md#the-onconnect-method)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
