### PR TITLE
@sap/xsenv is on npm now

### DIFF
--- a/types/sap__xsenv/index.d.ts
+++ b/types/sap__xsenv/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package @sap/xsenv 2.0
+// Type definitions for @sap/xsenv 2.0
 // Project: https://help.sap.com/hana_platform
 // Definitions by: [Michael Müller] <https://github.com/mad-mike>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
So it doesn't need the 'non-npm package' marker.