### PR TITLE
source-map-support: Fix return value types for `retrieveSourceMap`

### DIFF
--- a/types/source-map-support/index.d.ts
+++ b/types/source-map-support/index.d.ts
@@ -1,16 +1,24 @@
 // Type definitions for source-map-support 0.5
 // Project: https://github.com/evanw/node-source-map-support
-// Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Jason Cheatham <https://github.com/jason0x43>, Alcedo Nathaniel De Guzman Jr <https://github.com/natealcedo>
+// Definitions by: Bart van der Schoor <https://github.com/Bartvds>
+//                 Jason Cheatham <https://github.com/jason0x43>
+//                 Alcedo Nathaniel De Guzman Jr <https://github.com/natealcedo>
+//                 Griffin Yourick <https://github.com/tough-griff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
 
+import { RawSourceMap } from 'source-map';
+
 /**
  * Output of retrieveSourceMap().
+ * From source-map-support:
+ *   The map field may be either a string or the parsed JSON object (i.e.,
+ *   it must be a valid argument to the SourceMapConsumer constructor).
  */
 export interface UrlAndMap {
     url: string;
-    map: string | Buffer;
+    map: string | RawSourceMap;
 }
 
 /**

--- a/types/source-map-support/package.json
+++ b/types/source-map-support/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "source-map": "^0.6.0"
+    }
+}

--- a/types/source-map-support/source-map-support-tests.ts
+++ b/types/source-map-support/source-map-support-tests.ts
@@ -29,6 +29,25 @@ const options: sms.Options = {
 
 sms.install(options);
 
+sms.install({
+    ...options,
+    retrieveSourceMap(source) {
+        return source
+            ? {
+                  url: 'http://foo',
+                  map: {
+                      version: '3',
+                      sources: ['/path/to/foo.js'],
+                      sourcesContent: ["module.exports = 'foo'"],
+                      names: ['module', 'exports'],
+                      mappings: 'AAAA,a',
+                      file: '/path/to/foo.js',
+                  },
+              }
+            : null;
+    },
+});
+
 let stackFrame: any; // TODO: this should be a StackFrame, but it seems this would need to be defined elsewhere (in e.g. lib.d.ts)
 stackFrame = sms.wrapCallSite(stackFrame);
 


### PR DESCRIPTION
> - [x] Use a meaningful title for the pull request. Include the name of the package modified.
> - [x] Test the change in your own code. (Compile and run.)
> - [x] Add or edit tests to reflect the change. (Run with `npm test`.)
> - [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
> - [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
> - [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
> 
> If changing an existing definition:
> - [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
> - [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
> - [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
> - [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

From the comment [here](https://github.com/evanw/node-source-map-support/blob/master/source-map-support.js#L159) in the `source-map-support` source, the `retrieveSourceMap` return value, named UrlAndMap by these typings, allows the `map` property to be either a `string` or the "parsed JSON object" that SourceMapConsumer expects. This PR adds the `RawSourceMap` type to the accepted types for that field.