### PR TITLE
update(mongodb): unified topology connection options

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -293,7 +293,8 @@ export interface MongoClientOptions extends
     SSLOptions,
     TLSOptions,
     HighAvailabilityOptions,
-    WriteConcern {
+    WriteConcern,
+    UnifiedTopologyOptions {
 
     /**
      * The logging level (error/warn/info/debug)
@@ -336,18 +337,6 @@ export interface MongoClientOptions extends
      * the original parser, and aims to outright replace that parser in the near future.
      */
     useNewUrlParser?: boolean;
-
-    /**
-     * Enables the new unified topology layer
-     */
-    useUnifiedTopology?: boolean;
-
-    /**
-     * With `useUnifiedTopology`, the MongoDB driver will try to find a server to send any given operation to
-     * and keep retrying for `serverSelectionTimeoutMS` milliseconds.
-     * Default: 30000
-     */
-    serverSelectionTimeoutMS?: number;
 
     /**
      * number of retries for a tailable cursor
@@ -560,6 +549,57 @@ export interface DbCreateOptions extends CommonOptions {
      * working connection, default is -1 which is unlimited.
      */
     bufferMaxEntries?: number;
+}
+
+export interface UnifiedTopologyOptions {
+    /**
+     * Enables the new unified topology layer
+     */
+    useUnifiedTopology?: boolean;
+    /**
+     * **Only applies to the unified topology**
+     * The size of the latency window for selecting among multiple suitable servers
+     * @default 15
+     */
+    localThresholdMS?: number;
+    /**
+     * With `useUnifiedTopology`, the MongoDB driver will try to find a server to send any given operation to
+     * and keep retrying for `serverSelectionTimeoutMS` milliseconds.
+     * Default: 30000
+     */
+    serverSelectionTimeoutMS?: number;
+    /**
+     * **Only applies to the unified topology**
+     * The frequency with which topology updates are scheduled
+     * @default 10000
+     */
+    heartbeatFrequencyMS?: number;
+    /**
+     *  **Only applies to the unified topology**
+     * The maximum number of connections that may be associated with a pool at a given time.
+     * This includes in use and available connections
+     * @default 10
+     */
+    maxPoolSize?: number;
+    /**
+     * **Only applies to the unified topology**
+     * The minimum number of connections that MUST exist at any moment in a single connection pool.
+     * @default 0
+     */
+    minPoolSize?: number;
+    /**
+     * **Only applies to the unified topology**
+     * The maximum amount of time a connection should remain idle in the connection pool before being marked idle.
+     * @default Infinity
+     */
+    maxIdleTimeMS?: number;
+    /**
+     * **Only applies to the unified topology**
+     * The maximum amount of time operation execution should wait for a connection to become available.
+     * The default is 0 which means there is no limit.
+     * @default 0
+     */
+    waitQueueTimeoutMS?: number;
 }
 
 /** http://mongodb.github.io/node-mongodb-native/3.1/api/Server.html */

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -556,24 +556,28 @@ export interface UnifiedTopologyOptions {
      * Enables the new unified topology layer
      */
     useUnifiedTopology?: boolean;
+
     /**
      * **Only applies to the unified topology**
      * The size of the latency window for selecting among multiple suitable servers
      * @default 15
      */
     localThresholdMS?: number;
+
     /**
      * With `useUnifiedTopology`, the MongoDB driver will try to find a server to send any given operation to
      * and keep retrying for `serverSelectionTimeoutMS` milliseconds.
      * Default: 30000
      */
     serverSelectionTimeoutMS?: number;
+
     /**
      * **Only applies to the unified topology**
      * The frequency with which topology updates are scheduled
      * @default 10000
      */
     heartbeatFrequencyMS?: number;
+
     /**
      *  **Only applies to the unified topology**
      * The maximum number of connections that may be associated with a pool at a given time.
@@ -581,18 +585,21 @@ export interface UnifiedTopologyOptions {
      * @default 10
      */
     maxPoolSize?: number;
+
     /**
      * **Only applies to the unified topology**
      * The minimum number of connections that MUST exist at any moment in a single connection pool.
      * @default 0
      */
     minPoolSize?: number;
+
     /**
      * **Only applies to the unified topology**
      * The maximum amount of time a connection should remain idle in the connection pool before being marked idle.
      * @default Infinity
      */
     maxIdleTimeMS?: number;
+
     /**
      * **Only applies to the unified topology**
      * The maximum amount of time operation execution should wait for a connection to become available.

--- a/types/mongodb/test/index.ts
+++ b/types/mongodb/test/index.ts
@@ -51,6 +51,19 @@ mongodb.MongoClient.connect(
   },
 );
 
+const unifiedTopologyOptions: mongodb.UnifiedTopologyOptions = {
+    useUnifiedTopology: true,
+    heartbeatFrequencyMS: 20_000,
+    localThresholdMS: 10,
+    maxIdleTimeMS: 1_000,
+    maxPoolSize: 20,
+    minPoolSize: 5,
+    serverSelectionTimeoutMS: 20_000,
+    waitQueueTimeoutMS: 15,
+};
+
+new mongodb.MongoClient('mongodb://localhost:27017', unifiedTopologyOptions);
+
 async function testFunc(): Promise<mongodb.MongoClient> {
   const testClient: mongodb.MongoClient = await mongodb.connect(connectionString);
   return testClient;


### PR DESCRIPTION
This commit:
- moves unified topology connection options into own interface (for
readability purposes mostly);
- adds missing properties from unified topology connection options

https://jira.mongodb.org/browse/NODE-2637
https://github.com/mongodb/node-mongodb-native/pull/2412/files
https://github.com/mongodb/node-mongodb-native/releases/tag/v3.5.9

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)