### PR TITLE
fix(theme-ui): add missing Theme configuration flags

### DIFF
--- a/types/theme-ui/index.d.ts
+++ b/types/theme-ui/index.d.ts
@@ -80,14 +80,52 @@ export interface Theme extends Omit<StyledSystemTheme, 'colors' | 'buttons'> {
      * Enable/disable custom CSS properties/variables if lower browser
      * support is required (for eg. IE 11).
      *
-     * References: https://theme-ui.com/color-modes/#turn-off-custom-properties
+     * @defaultValue true
+     * @see https://theme-ui.com/color-modes/#turn-off-custom-properties
      */
     useCustomProperties?: boolean;
 
     /**
-     * Provide a value here to enable color modes
+     * Adds styles defined in `theme.styles.roo`t to the `<body>` element along
+     * with `color` and `background-color`.
+     *
+     * @defaultValue true
+     * @see https://theme-ui.com/color-modes#applying-colors
+     */
+    useBodyStyles?: boolean;
+
+    /**
+     * The key used for the top-level color palette in `theme.colors`.
+     *
+     * @defaultValue 'default'
+     * @see https://theme-ui.com/theming#configuration-flags
      */
     initialColorModeName?: string;
+
+    /**
+     * Initializes the color mode based on the `prefers-color-scheme` media
+     * query.
+     *
+     * @defaultValue false
+     * @see https://theme-ui.com/color-modes#initialize-mode-with-prefers-color-scheme-media-query
+     */
+    useColorSchemeMediaQuery?: boolean;
+
+    /**
+     * Adds a global `box-sizing: border-box` style.
+     *
+     * @defaultValue true
+     * @see https://theme-ui.com/theming#configuration-flags
+     */
+    useBorderBox?: boolean;
+
+    /**
+     * Persists the color mode in `localStorage`.
+     *
+     * @defaultValue true
+     * @see https://theme-ui.com/color-modes#disable-persisting-color-mode-on-localstorage
+     */
+    useLocalStorage?: boolean;
 
     /**
      * Define the colors that are available through this theme

--- a/types/theme-ui/theme-ui-tests.tsx
+++ b/types/theme-ui/theme-ui-tests.tsx
@@ -150,6 +150,20 @@ const themeWithInvalidVariants: Theme = { layouts: { // $ExpectError
     },
 };
 
+const themeWithValidOptions: Theme = {
+    useCustomProperties: true,
+    useBodyStyles: true,
+    initialColorModeName: 'default',
+    useColorSchemeMediaQuery: false,
+    useBorderBox: true,
+    useLocalStorage: true,
+    colors: {
+        text: '#000',
+        background: '#fff',
+        primary: '#07c',
+    },
+};
+
 function SpreadingAndMergingInSxProp() {
     const buttonStyles: SxStyleProp = {
         font: 'inherit',


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://theme-ui.com/theming/#configuration-flags
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
