### PR TITLE
[Ramda] Add an overload function declaration for R.pair

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1306,6 +1306,7 @@ export function over(lens: Lens): <T>(fn: Arity1Fn, value: readonly T[]) => T[];
  * Takes two arguments, fst and snd, and returns [fst, snd].
  */
 export function pair<F, S>(fst: F, snd: S): [F, S];
+export function pair<F>(fst: F): <S>(snd: S) => [F, S];
 
 /**
  * Takes a function `f` and a list of arguments, and returns a function `g`.

--- a/types/ramda/test/pair-tests.ts
+++ b/types/ramda/test/pair-tests.ts
@@ -2,7 +2,12 @@ import * as R from 'ramda';
 
 () => {
   R.pair('foo', 'bar'); // => ['foo', 'bar']
-  const p = R.pair('foo', 1); // => ['foo', 'bar']
+  const p: [string, number] = R.pair('foo', 1); // => ['foo', 1]
   const x: string = p[0];
   const y: number = p[1];
+};
+
+() => {
+  const pairFoo: <S>(snd: S) => [string, S] = R.pair('foo');
+  const p: [string, string] = pairFoo('bar');
 };


### PR DESCRIPTION
A compiler error is encountered if only the first argument is supplied. This is not correct, since R.pair is curried.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/ramda/ramda/blob/v0.27.0/source/pair.js#L20>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.