### PR TITLE
[uikit] UIkit.modal.prompt returns `string` or `null` (when cancelled)

### DIFF
--- a/types/uikit/index.d.ts
+++ b/types/uikit/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Giovanni Silva <https://github.com/giovannicandido>
 //                 Ivo Senner <https://github.com/s0x>
 //                 Weiyu Weng <https://github.com/pcdotfan>
-//                 Johanns Gregorian <<https://github.com/johanns>
+//                 Johanns Gregorian <https://github.com/johanns>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/uikit/index.d.ts
+++ b/types/uikit/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Giovanni Silva <https://github.com/giovannicandido>
 //                 Ivo Senner <https://github.com/s0x>
 //                 Weiyu Weng <https://github.com/pcdotfan>
+//                 Johanns Gregorian <<https://github.com/johanns>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/uikit/index.d.ts
+++ b/types/uikit/index.d.ts
@@ -179,7 +179,7 @@ export namespace UIkit {
         (element: UIkitElement, options?: UIkitModalOptions): UIkitModalElement;
         alert(message: string, options?: UIkitModalOptions): Promise<void>;
         confirm(message: string, options?: UIkitModalOptions): Promise<void>;
-        prompt(content: string, value: string, options?: UIkitModalOptions): Promise<void>;
+        prompt(content: string, value: string, options?: UIkitModalOptions): Promise<string | null>;
         dialog(content: string, options?: UIkitModalOptions): Promise<void>;
         labels: {
             ok: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [UIkit.modal.prompt source](https://github.com/uikit/uikit/blob/cf06a32fb7d5b35e6005518b49bb085c2694f9cf/src/js/core/modal.js#L113)
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~

