### PR TITLE
[mongodb] Fix bulkWrite operation types

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1467,59 +1467,59 @@ export type FilterQuery<T> = {
     RootQuerySelector<T>;
 
 /** https://docs.mongodb.com/manual/reference/method/db.collection.bulkWrite/#insertone */
-export type BulkWriteInsertOneOperation<T> = {
+export type BulkWriteInsertOneOperation<TSchema> = {
     insertOne: {
-        document: T
+        document: OptionalId<TSchema>
     }
 };
 
 /** https://docs.mongodb.com/manual/reference/method/db.collection.bulkWrite/#updateone-and-updatemany */
-export type BulkWriteUpdateOperation<T> = {
+export type BulkWriteUpdateOperation<TSchema> = {
     arrayFilters?: object[];
     collation?: object;
     hint?: string | object;
-    filter: FilterQuery<T>;
-    update: UpdateQuery<T>;
+    filter: FilterQuery<TSchema>;
+    update: UpdateQuery<TSchema>;
     upsert?: boolean;
 };
-export type BulkWriteUpdateOneOperation<T> = {
-    updateOne: BulkWriteUpdateOperation<T>;
+export type BulkWriteUpdateOneOperation<TSchema> = {
+    updateOne: BulkWriteUpdateOperation<TSchema>;
 };
-export type BulkWriteUpdateManyOperation<T> = {
-    updateMany: BulkWriteUpdateOperation<T>;
+export type BulkWriteUpdateManyOperation<TSchema> = {
+    updateMany: BulkWriteUpdateOperation<TSchema>;
 };
 
 /** https://docs.mongodb.com/manual/reference/method/db.collection.bulkWrite/#replaceone */
-export type BulkWriteReplaceOneOperation<T> = {
+export type BulkWriteReplaceOneOperation<TSchema> = {
     replaceOne: {
         collation?: object;
         hint?: string | object;
-        filter: FilterQuery<T>;
-        replacement: T;
+        filter: FilterQuery<TSchema>;
+        replacement: TSchema;
         upsert?: boolean;
     }
 };
 
 /** https://docs.mongodb.com/manual/reference/method/db.collection.bulkWrite/#deleteone-and-deletemany */
-export type BulkWriteDeleteOperation<T> = {
+export type BulkWriteDeleteOperation<TSchema> = {
     collation?: object;
-    filter: FilterQuery<T>;
+    filter: FilterQuery<TSchema>;
 };
-export type BulkWriteDeleteOneOperation<T> = {
-    deleteOne: BulkWriteDeleteOperation<T>;
+export type BulkWriteDeleteOneOperation<TSchema> = {
+    deleteOne: BulkWriteDeleteOperation<TSchema>;
 };
-export type BulkWriteDeleteManyOperation<T> = {
-    deleteMany: BulkWriteDeleteOperation<T>;
+export type BulkWriteDeleteManyOperation<TSchema> = {
+    deleteMany: BulkWriteDeleteOperation<TSchema>;
 };
 
 /** http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#bulkWrite */
-export type BulkWriteOperation<T> =
-    BulkWriteInsertOneOperation<T> |
-    BulkWriteUpdateOneOperation<T> |
-    BulkWriteUpdateManyOperation<T> |
-    BulkWriteReplaceOneOperation<T> |
-    BulkWriteDeleteOneOperation<T> |
-    BulkWriteDeleteManyOperation<T>;
+export type BulkWriteOperation<TSchema> =
+    BulkWriteInsertOneOperation<TSchema> |
+    BulkWriteUpdateOneOperation<TSchema> |
+    BulkWriteUpdateManyOperation<TSchema> |
+    BulkWriteReplaceOneOperation<TSchema> |
+    BulkWriteDeleteOneOperation<TSchema> |
+    BulkWriteDeleteManyOperation<TSchema>;
 
 /** http://docs.mongodb.org/manual/reference/command/collStats/ */
 export interface CollStats {

--- a/types/mongodb/test/collection/bulkWrite.ts
+++ b/types/mongodb/test/collection/bulkWrite.ts
@@ -1,4 +1,4 @@
-import { connect, UpdateQuery } from 'mongodb';
+import { connect, ObjectID, UpdateQuery } from 'mongodb';
 import { connectionString } from '../index';
 
 // collection.bulkWrite tests
@@ -15,6 +15,7 @@ async function run() {
 
     // test with collection type
     interface TestSchema {
+        _id: ObjectID;
         stringField: string;
         numberField: number;
         optionalNumberField?: number;
@@ -27,6 +28,7 @@ async function run() {
     const collectionType = db.collection<TestSchema>('test.update');
 
     const testDocument: TestSchema = {
+        _id: new ObjectID(),
         stringField: 'foo',
         numberField: 123,
         dateField: new Date(),
@@ -37,6 +39,7 @@ async function run() {
         },
         subInterfaceArray: [],
     };
+    const { _id, ...testDocumentWithoutId } = testDocument;
 
     // insertOne
 
@@ -44,6 +47,13 @@ async function run() {
         {
             insertOne: {
                 document: testDocument
+            }
+        }
+    ]);
+    collectionType.bulkWrite([
+        {
+            insertOne: {
+                document: testDocumentWithoutId
             }
         }
     ]);
@@ -99,6 +109,13 @@ async function run() {
         // $ExpectError
         { updateOne: { filter: { stringField: 'foo' }, update: { $set: { numberField: 'bar' } } } }
     ]);
+    collectionType.bulkWrite([
+        // The following code is written all on one line due to
+        // the difference of error lines reported by TS <3.9 and >=3.9
+        // prettier-ignore
+        // $ExpectError
+        { updateOne: { filter: { stringField: 'foo' }, update: { 'dot.notation': true } } }
+    ]);
 
     // updateMany
 
@@ -143,6 +160,13 @@ async function run() {
         // prettier-ignore
         // $ExpectError
         { updateMany: { filter: { stringField: 'foo' }, update: { $set: { numberField: 'bar' } } } }
+    ]);
+    collectionType.bulkWrite([
+        // The following code is written all on one line due to
+        // the difference of error lines reported by TS <3.9 and >=3.9
+        // prettier-ignore
+        // $ExpectError
+        { updateMany: { filter: { stringField: 'foo' }, update: { 'dot.notation': true } } }
     ]);
 
     // replaceOne


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

---

Changes in this PR:

- `insertOne` operations should also accept objects without `_id` - these will get a new `_id` generated by mongo server