### PR TITLE
fix(sawtooth-sdk): use correct return types on secp256k1 functions

### DIFF
--- a/types/sawtooth-sdk/signing/secp256k1.d.ts
+++ b/types/sawtooth-sdk/signing/secp256k1.d.ts
@@ -43,13 +43,13 @@ export class Secp256k1PrivateKey extends PrivateKey {
      * @return a private key instance
      * @throws if the private key is not valid
      */
-    static fromHex(privateKeyHex: string): PrivateKey;
+    static fromHex(privateKeyHex: string): Secp256k1PrivateKey;
 
     /**
      * @return generates a random PrivateKey
      *
      */
-    static newRandom(): PrivateKey;
+    static newRandom(): Secp256k1PrivateKey;
 }
 
 /**
@@ -75,10 +75,7 @@ export class Secp256k1PublicKey extends PublicKey {
      * @return a public key instance
      * @throws if the public key is not valid
      */
-    static fromHex(publicKeyHex: string): PublicKey;
-
-    /** Generate a new random public key */
-    static newRandom(): PublicKey;
+    static fromHex(publicKeyHex: string): Secp256k1PublicKey;
 }
 
 export class Secp256k1Context extends Context {

--- a/types/sawtooth-sdk/test/signing-tests.ts
+++ b/types/sawtooth-sdk/test/signing-tests.ts
@@ -66,10 +66,10 @@ const privAlgoName = privateKey.getAlgorithmName();
 // $ExpectType Buffer
 const privAsBytes = privateKey.asBytes();
 
-// $ExpectType PrivateKey
+// $ExpectType Secp256k1PrivateKey
 const privFromHex = Secp256k1PrivateKey.fromHex('test');
 
-// $ExpectType PrivateKey
+// $ExpectType Secp256k1PrivateKey
 const privNewRandom = Secp256k1PrivateKey.newRandom();
 
 // $ExpectType Buffer
@@ -81,11 +81,8 @@ const pubAlgoName = publicKey.getAlgorithmName();
 // $ExpectType Buffer
 const pubAsBytes = publicKey.asBytes();
 
-// $ExpectType PublicKey
+// $ExpectType Secp256k1PublicKey
 const pubFromHex = Secp256k1PublicKey.fromHex('test');
-
-// $ExpectType PublicKey
-const pubNewRandom = Secp256k1PublicKey.newRandom();
 
 // $ExpectType string
 const contextAlgoName = cryptoContext.getAlgorithmName();


### PR DESCRIPTION
Signed-off-by: Patrick-Erichsen <Patrick.Erichsen@target.com>

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

- Updates to [`Secp256k1PublicKey.fromHex()`](https://github.com/hyperledger/sawtooth-sdk-javascript/blob/master/signing/secp256k1.js#L111)
- Updates to [`Secp256k1PrivateKey.fromHex()`](https://github.com/hyperledger/sawtooth-sdk-javascript/blob/master/signing/secp256k1.js#L63)
- Updates to [`Secp256k1PrivateKey.newRandom()`](https://github.com/hyperledger/sawtooth-sdk-javascript/blob/master/signing/secp256k1.js#L72)

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
