### PR TITLE
Jest: Add setSystemTime and getRealSystemTime fn types

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -132,6 +132,26 @@ declare namespace jest {
      */
     function getTimerCount(): number;
     /**
+     * Set the current system time used by fake timers. Simulates a user
+     * changing the system clock while your program is running. It affects the
+     * current time but it does not in itself cause e.g. timers to fire; they
+     * will fire exactly as they would have done without the call to
+     * jest.setSystemTime().
+     *
+     * > Note: This function is only available when using modern fake timers
+     * > implementation
+     */
+    function setSystemTime(now?: number | Date): void;
+    /**
+     * When mocking time, Date.now() will also be mocked. If you for some
+     * reason need access to the real current time, you can invoke this
+     * function.
+     *
+     * > Note: This function is only available when using modern fake timers
+     * > implementation
+     */
+    function getRealSystemTime(): number;
+    /**
      * Indicates that the module system should never return a mocked version
      * of the specified module, including all of the specificied module's dependencies.
      */

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -141,7 +141,7 @@ declare namespace jest {
      * > Note: This function is only available when using modern fake timers
      * > implementation
      */
-    function setSystemTime(now?: number | Date): void;
+    function setSystemTime(now?: number): void;
     /**
      * When mocking time, Date.now() will also be mocked. If you for some
      * reason need access to the real current time, you can invoke this

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -291,6 +291,18 @@ jest.useFakeTimers('legacy');
 // $ExpectError
 jest.useFakeTimers('foo');
 
+// https://jestjs.io/docs/en/jest-object#jestsetsystemtimenow-number--date
+jest.setSystemTime();
+jest.setSystemTime(0);
+jest.setSystemTime(new Date(0));
+// $ExpectError
+jest.setSystemTime('foo');
+
+// https://jestjs.io/docs/en/jest-object#jestgetrealsystemtime
+const realSystemTime1: number = jest.getRealSystemTime();
+// $ExpectError
+const realSystemTime2: number = jest.getRealSystemTime('foo');
+
 // https://jestjs.io/docs/en/jest-object#jestrequireactualmodulename
 // $ExpectType any
 jest.requireActual('./thisReturnsTheActualModule');

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -294,7 +294,6 @@ jest.useFakeTimers('foo');
 // https://jestjs.io/docs/en/jest-object#jestsetsystemtimenow-number--date
 jest.setSystemTime();
 jest.setSystemTime(0);
-jest.setSystemTime(new Date(0));
 // $ExpectError
 jest.setSystemTime('foo');
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://jestjs.io/docs/en/jest-object#jestsetsystemtime, https://jestjs.io/docs/en/jest-object#jestgetrealsystemtime
  - These are based on Jest's internal types, but I've got a PR open to update them, this PR assumes that update has happened on their end: https://github.com/facebook/jest/pull/10169 (you can see the internal types I'm using in that PR).
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
  - Not sure if I'll need to make a change here - these types are valid and work at runtime for the current version of jest. The PR I have open for essentially just updates jest's internal types and docs to reflect that, so I'm not sure if it would be better to update the version reference, given that it should be compatible with both. Regardless, the current header says `26.0` and if my jest PR is accepted I would assume it would be a patch release.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
