### PR TITLE
chore: remove my codeownership from jest, jest-environment-puppeteer, leaflet-draw, and react-leaflet

### DIFF
--- a/types/jest-environment-puppeteer/index.d.ts
+++ b/types/jest-environment-puppeteer/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/smooth-code/jest-puppeteer/tree/master/packages/jest-environment-puppeteer
 // Definitions by: Josh Goldberg <https://github.com/joshuakgoldberg>
 //                 Ifiok Jr. <https://github.com/ifiokjr>
-//                 Jeroen Claassens <https://github.com/favna>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.4
 

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -18,7 +18,6 @@
 //                 Sebastian Sebald <https://github.com/sebald>
 //                 Andy <https://github.com/andys8>
 //                 Antoine Brault <https://github.com/antoinebrault>
-//                 Jeroen Claassens <https://github.com/favna>
 //                 Gregor Stamać <https://github.com/gstamac>
 //                 ExE Boss <https://github.com/ExE-Boss>
 //                 Alex Bolenok <https://github.com/quassnoi>

--- a/types/leaflet-draw/index.d.ts
+++ b/types/leaflet-draw/index.d.ts
@@ -4,7 +4,6 @@
 //                 Ryan Blace <https://github.com/reblace>
 //                 Yun Shi <https://github.com/YunS-Stacy>
 //                 Kevin Richter <https://github.com/beschoenen>
-//                 Jeroen Claassens <https://github.com/favna>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/react-leaflet/index.d.ts
+++ b/types/react-leaflet/index.d.ts
@@ -3,7 +3,6 @@
 // Definitions by: Dave Leaver <https://github.com/danzel>
 //                 David Schneider <https://github.com/davschne>
 //                 Yui T. <https://github.com/yuit>
-//                 Jeroen Claassens <https://github.com/favna>
 //                 Tom Fenech <https://github.com/fenech>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8


### PR DESCRIPTION
I don't really have any value to add to these packages anymore and would like to no longer be notified when there are changes for these packages.

My reasons:
- jest: I have noticed I do not know the ins-and-outs of Jest well enough to properly judge contributions. I have faith in the people who do to properly judge PRs.
- jest-environment-puppeteer: I no longer use Puppeteer and so I no longer have any interest in the Jest environment for it.
- react-leaflet & leaflet-draw: I no longer use leaflet as it was only for a work assignment and that assignment has since moved to other solutions.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] (N.A.) Test the change in your own code. (Compile and run.)
- [ ] (N.A.) Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] (N.A.) Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] (N.A.) Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] (N.A.) If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] (N.A.) Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] (N.A.) If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.