### PR TITLE
Create type for `err-code`

### DIFF
--- a/types/err-code/err-code-tests.ts
+++ b/types/err-code/err-code-tests.ts
@@ -41,3 +41,15 @@ const err3 = errCode<{
 const err3Message = err3.message;
 const err3MProp1 = err3.prop1;
 const err3MProp2a = err3.prop2.a;
+
+// test null code
+const err4 = errCode(new Error('err msg'), null, {
+    prop1: 'prop1 value',
+    prop2: {
+        a: 'prop2.a value',
+    }
+});
+
+const err4Message = err4.message;
+const err4MProp1 = err4.prop1;
+const err4MProp2a = err4.prop2.a;

--- a/types/err-code/err-code-tests.ts
+++ b/types/err-code/err-code-tests.ts
@@ -1,0 +1,43 @@
+import errCode = require('err-code');
+
+// test create without code
+const err1 = errCode(new Error('err msg'), {
+    prop1: 'prop1 value',
+    prop2: {
+        a: 'prop2.a value',
+    }
+});
+
+const err1Message = err1.message;
+const err1MProp1 = err1.prop1;
+const err1MProp2a = err1.prop2.a;
+
+// test create with code
+const err2 = errCode(new Error('err msg'), 'Bad Request', {
+    prop1: 'prop1 value',
+    prop2: {
+        a: 'prop2.a value',
+    }
+});
+
+const err2Message = err2.message;
+const err2MProp1 = err2.prop1;
+const err2MProp2a = err2.prop2.a;
+const err2Code = err2.code;
+
+// test adding type constraint
+const err3 = errCode<{
+    prop1: string
+    prop2: {
+        a: string
+    }
+}>(new Error('err msg'), {
+    prop1: 'prop1 value',
+    prop2: {
+        a: 'prop2.a value',
+    }
+});
+
+const err3Message = err3.message;
+const err3MProp1 = err3.prop1;
+const err3MProp2a = err3.prop2.a;

--- a/types/err-code/index.d.ts
+++ b/types/err-code/index.d.ts
@@ -4,7 +4,7 @@
 //                 Cayman <https://github.com/wemeetagain>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-type Scalar = Exclude<any, object>;
+type Scalar = number | string | boolean | bigint | null | undefined;
 
 declare function createError<Props extends object = object, Err extends Error = Error>(
     error: Err,
@@ -15,7 +15,7 @@ declare function createError<Code extends Scalar = Scalar, Props extends object 
     error: Err,
     code: Code,
     props?: Props,
-): Err & Props & { code: Code };
+): Err & Props & { code: NonNullable<Code> };
 
 declare namespace createError {
 }

--- a/types/err-code/index.d.ts
+++ b/types/err-code/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for err-code 2.0
+// Project: https://github.com/IndigoUnited/js-err-code#readme
+// Definitions by: George <https://github.com/zorji>
+//                 Cayman <https://github.com/wemeetagain>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type Scalar = Exclude<any, object>;
+
+declare function createError<Props extends object = object, Err extends Error = Error>(
+    error: Err,
+    props?: Props,
+): Err & Props;
+
+declare function createError<Code extends Scalar = Scalar, Props extends object = object, Err extends Error = Error>(
+    error: Err,
+    code: Code,
+    props?: Props,
+): Err & Props & { code: Code };
+
+declare namespace createError {
+}
+
+export = createError;

--- a/types/err-code/index.d.ts
+++ b/types/err-code/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: George <https://github.com/zorji>
 //                 Cayman <https://github.com/wemeetagain>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.2
 
 type Scalar = number | string | boolean | bigint | null | undefined;
 

--- a/types/err-code/tsconfig.json
+++ b/types/err-code/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "err-code-tests.ts"
+    ]
+}

--- a/types/err-code/tslint.json
+++ b/types/err-code/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

The package owner prefers to have types defined here: see previous attempts to create type in the package: https://github.com/IndigoUnited/js-err-code/pull/21

CC @wemeetagain 
