### PR TITLE
Define collection.watch with `options` argument

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1275,10 +1275,25 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
         options: UpdateOneOptions,
         callback: MongoCallback<UpdateWriteOpResult>,
     ): void;
-    /** http://mongodb.github.io/node-mongodb-native/3.3/api/Collection.html#watch */
+    /**
+     * @param pipeline - an array of
+     * {@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline/ aggregation pipeline stages}
+     * through which to pass change stream documents. This allows for filtering (using `$match`) and manipulating
+     * the change stream documents.
+     *
+     * @param options - optional settings
+     * @see http://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#watch
+     */
     watch<T = TSchema>(
         pipeline?: object[],
         options?: ChangeStreamOptions & { session?: ClientSession },
+    ): ChangeStream<T>;
+    /**
+     * @param options - optional settings
+     * @see http://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#watch
+     */
+    watch<T = TSchema>(
+      options?: ChangeStreamOptions & { session?: ClientSession },
     ): ChangeStream<T>;
 }
 


### PR DESCRIPTION
`Collection.watch` [allows passing](https://github.com/mongodb/node-mongodb-native/blob/master/lib/collection.js#L1939) the only `options` argument. This PR justifies typings.

Docs are taken from the [official doc](http://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#watch).
