### PR TITLE
[mem-fs-editor] Improved definition

### DIFF
--- a/types/mem-fs-editor/index.d.ts
+++ b/types/mem-fs-editor/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mem-fs-editor 5.1
+// Type definitions for mem-fs-editor 7.0
 // Project: https://github.com/SBoudrias/mem-fs-editor#readme
 // Definitions by: My Food Bag <https://github.com/MyFoodBag>
 //                 Jason Kwok <https://github.com/JasonHK>

--- a/types/mem-fs-editor/index.d.ts
+++ b/types/mem-fs-editor/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for mem-fs-editor 5.1
 // Project: https://github.com/SBoudrias/mem-fs-editor#readme
 // Definitions by: My Food Bag <https://github.com/MyFoodBag>
+//                 Jason Kwok <https://github.com/JasonHK>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -36,7 +37,7 @@ export interface Editor {
     copy(from: FilePaths, to: string, options?: CopyOptions, context?: TemplateData, templateOptions?: TemplateOptions): void;
 
     copyTpl(from: FilePaths, to: string, context?: TemplateData, templateOptions?: TemplateOptions, copyOptions?: CopyOptions): void;
-    
+
     move(from: FilePaths, to: string, options?: WithGlobOptions): void;
 
     exists(filepath: string): boolean;
@@ -84,7 +85,9 @@ export interface AppendOptions {
 
 //#region Editor#copy
 export interface CopyOptions extends WithGlobOptions {
+    ignoreNoMatch?: boolean;
     process?: ProcessingFunction;
+    processDestinationPath?: (path: string) => string;
 }
 
 export type ProcessingFunction = (contents: Buffer, path: string) => WriteContents;

--- a/types/mem-fs-editor/index.d.ts
+++ b/types/mem-fs-editor/index.d.ts
@@ -6,42 +6,93 @@
 
 /// <reference types="node" />
 
-import * as Buffer from 'buffer';
-import { Transform } from 'stream';
-import { Store } from 'mem-fs';
 import { Options as TemplateOptions, Data as TemplateData } from 'ejs';
 import { IOptions as GlobOptions } from 'glob';
+import { JSONSchema7Type } from "json-schema";
+import { Store } from 'mem-fs';
+import { Transform } from 'stream';
+import * as File from 'vinyl';
 
-type ReplacerFunc = (key: string, value: any) => any;
+export function create(store: Store): Editor;
 
-type Space = string|number;
+//#region Editor
+export interface Editor {
+    read(filepath: string, options?: ReadStringOptions): string;
+    read(filepath: string, options: ReadRawOptions): ReadRawContents;
 
-type Contents = string|Buffer;
+    readJSON(filepath: string): JSONSchema7Type | undefined;
+    readJSON(filepath: string, defaults: JSONSchema7Type): JSONSchema7Type;
 
-type Callback = (err: any) => any;
+    write(filepath: string, contents: WriteContents): string;
 
-export type ProcessingFunc = (contents: Buffer, path: string) => Contents;
+    writeJSON(filepath: string, contents: any, replacer?: WriteJsonReplacer, space?: WriteJsonSpace): string;
 
-export interface CopyOptions {
-    process?: ProcessingFunc;
+    append(filepath: string, contents: WriteContents, options?: AppendOptions): string;
+
+    extendJSON(filepath: string, contents: any, replacer?: WriteJsonReplacer, space?: WriteJsonSpace): void;
+
+    delete(filepath: FilePaths, options?: WithGlobOptions): void;
+
+    copy(from: FilePaths, to: string, options?: CopyOptions, context?: TemplateData, templateOptions?: TemplateOptions): void;
+
+    copyTpl(from: FilePaths, to: string, context?: TemplateData, templateOptions?: TemplateOptions, copyOptions?: CopyOptions): void;
+    
+    move(from: FilePaths, to: string, options?: WithGlobOptions): void;
+
+    exists(filepath: string): boolean;
+
+    commit(callback: CommitCallback): void;
+    commit(filters: ReadonlyArray<Transform>, callback: CommitCallback): void;
+}
+
+export interface WithGlobOptions {
     globOptions?: GlobOptions;
 }
 
-export interface Editor {
-    read(filepath: string, options?: { raw?: boolean, defaults: string }): string;
-    readJSON(filepath: string, defaults?: any): any;
-    exists(filepath: string): boolean;
-    write(filepath: string, contents: Contents): string;
-    writeJSON(filepath: string, contents: any, replacer?: ReplacerFunc, space?: Space): string;
-    append(to: string, contents: Contents, options?: { trimEnd?: boolean, separator?: string }): string;
-    delete(paths: string|string[], options?: { globOptions?: GlobOptions }): void;
-    copy(from: string|string[], to: string, options?: CopyOptions, context?: TemplateData, templateOptions?: TemplateOptions): void;
-    copyTpl(from: string|string[], to: string, context?: TemplateData, templateOptions?: TemplateOptions, copyOptions?: CopyOptions): void;
-    move(from: string|string[], to: string, options?: { globOptions: GlobOptions }): void;
-    commit(callback: Callback): void;
-    commit(filters: ReadonlyArray<Transform>, callback: Callback): void;
+type FilePaths = string | string[];
+
+//#region Editor#read
+export interface ReadStringOptions {
+    raw?: false;
+    defaults?: string;
 }
 
-export function create(store: Store): Editor;
+export interface ReadRawOptions {
+    raw: true;
+    defaults?: ReadRawContents;
+}
+
+type ReadRawContents = Exclude<File["contents"], null>;
+//#endregion
+
+//#region Editor#write
+type WriteContents = string | Buffer;
+//#endregion
+
+//#region Editor#writeJSON
+type WriteJsonReplacer = ((key: string, value: any) => any) | Array<string | number>;
+
+type WriteJsonSpace = number | string;
+//#endregion
+
+//#region Editor#append
+export interface AppendOptions {
+    trimEnd?: boolean;
+    separator?: string;
+}
+//#endregion
+
+//#region Editor#copy
+export interface CopyOptions extends WithGlobOptions {
+    process?: ProcessingFunction;
+}
+
+export type ProcessingFunction = (contents: Buffer, path: string) => WriteContents;
+//#endregion
+
+//#region Editor#commit
+type CommitCallback = (err: any) => void;
+//#endregion
+//#endregion
 
 export {};

--- a/types/mem-fs-editor/mem-fs-editor-tests.ts
+++ b/types/mem-fs-editor/mem-fs-editor-tests.ts
@@ -1,34 +1,158 @@
+// tslint:disable:no-mergeable-namespace no-namespace
+
+import { Options as TemplateOptions, Data as TemplateData } from 'ejs';
+import { JSONSchema7Type } from 'json-schema';
+import * as MemFs from 'mem-fs';
+import * as MemFsEditor from 'mem-fs-editor';
 import { Transform } from 'stream';
 
-import * as memFs from 'mem-fs';
-import * as editor from 'mem-fs-editor';
+declare const STORE: MemFs.Store;
 
-const store = memFs.create();
-const fs = editor.create(store);
+// Tests for `MemFsEditor.create`
+namespace create {
+    let editor: MemFsEditor.Editor;
+    editor = MemFsEditor.create(STORE);
+}
 
-fs.write('template.js', 'var a = 1; console.log(\'<%= foo %>\', a);');
-fs.append('template.js', 'var b = 2;');
+declare const EDITOR: MemFsEditor.Editor;
+declare const FILE_PATH: string;
+declare const FILE_PATHS: string | string[];
 
-fs.copy('template.js', 'template.tpl', {
-    globOptions: {
-        cwd: '.'
-    },
-    process: (contents) => contents
-});
+// Tests for `MemFsEditor.Editor#read`
+namespace Editor.read {
+    declare const STRING_DEFAULTS: string;
+    declare const RAW_DEFAULTS: Buffer | NodeJS.ReadableStream;
 
-fs.copyTpl('template.tpl', 'output.js', {
-    foo: 'bar'
-});
+    {
+        let contents: string;
 
-const obj = fs.readJSON('template.json');
-fs.writeJSON('template.json', obj);
+        contents = EDITOR.read(FILE_PATH);
+        contents = EDITOR.read(FILE_PATH, { raw: false });
+        contents = EDITOR.read(FILE_PATH, { raw: false, defaults: STRING_DEFAULTS });
+        contents = EDITOR.read(FILE_PATH, { defaults: RAW_DEFAULTS }); // $ExpectError
+        contents = EDITOR.read(FILE_PATH, { raw: false, defaults: RAW_DEFAULTS }); // $ExpectError
+    }
 
-fs.writeJSON('template.json', 'qwer'); // should not be an error, because the parameter is passed to JSON.stringify and it accepts the string
-// fs.extendJSON('template.json', 'qwer'); // should be an error, because it does not make sense to extend a json with string
+    {
+        let contents: Buffer | NodeJS.ReadableStream;
 
-// should accept both versions of commit - with filters and without:
-const cb = (err: any) => ({adsf: 'adsf'});
-fs.commit(cb);
+        contents = EDITOR.read(FILE_PATH, { raw: true });
+        contents = EDITOR.read(FILE_PATH, { raw: true, defaults: RAW_DEFAULTS });
+        contents = EDITOR.read(FILE_PATH, { raw: true, defaults: STRING_DEFAULTS }); // $ExpectError
+    }
+}
 
-const filters: Transform[] = [];
-fs.commit(filters, cb);
+// Tests for `MemFsEditor.Editor#readJSON`
+namespace Editor.readJSON {
+    declare const DEFAULTS: JSONSchema7Type;
+
+    {
+        let json: JSONSchema7Type | undefined;
+        json = EDITOR.readJSON(FILE_PATH);
+    }
+
+    {
+        let json: JSONSchema7Type;
+        json = EDITOR.readJSON(FILE_PATH, DEFAULTS);
+    }
+}
+
+// Tests for `MemFsEditor.Editor#write`
+namespace Editor.write {
+    declare const CONTENTS: string | Buffer;
+
+    let contents: string;
+    contents = EDITOR.write(FILE_PATH, CONTENTS);
+}
+
+// Tests for `MemFsEditor.Editor#writeJSON`
+namespace Editor.writeJSON {
+    declare const CONTENTS: JSONSchema7Type;
+    declare const REPLACER: ((key: string, value: any) => any) | Array<string | number>;
+    declare const SPACE: number | string;
+
+    let contents: string;
+
+    contents = EDITOR.writeJSON(FILE_PATH, CONTENTS);
+    contents = EDITOR.writeJSON(FILE_PATH, CONTENTS, REPLACER);
+    contents = EDITOR.writeJSON(FILE_PATH, CONTENTS, REPLACER, SPACE);
+    contents = EDITOR.writeJSON(FILE_PATH, CONTENTS, undefined, SPACE);
+}
+
+// Tests for `MemFsEditor.Editor#append`
+namespace Editor.append {
+    declare const CONTENTS: string | Buffer;
+    declare const OPTIONS: MemFsEditor.AppendOptions;
+
+    let contents: string;
+
+    contents = EDITOR.append(FILE_PATH, CONTENTS);
+    contents = EDITOR.append(FILE_PATH, CONTENTS, OPTIONS);
+}
+
+// Tests for `MemFsEditor.Editor#extendJSON`
+namespace Editor.extendJSON {
+    declare const CONTENTS: JSONSchema7Type;
+    declare const REPLACER: ((key: string, value: any) => any) | Array<string | number>;
+    declare const SPACE: number | string;
+
+    EDITOR.extendJSON(FILE_PATH, CONTENTS);
+    EDITOR.extendJSON(FILE_PATH, CONTENTS, REPLACER);
+    EDITOR.extendJSON(FILE_PATH, CONTENTS, REPLACER, SPACE);
+    EDITOR.extendJSON(FILE_PATH, CONTENTS, undefined, SPACE);
+}
+
+// Tests for `MemFsEditor.Editor#delete`
+namespace Editor._delete {
+    declare const OPTIONS: MemFsEditor.WithGlobOptions;
+
+    EDITOR.delete(FILE_PATHS);
+    EDITOR.delete(FILE_PATHS, OPTIONS);
+}
+
+// Tests for `MemFsEditor.Editor#copy`
+namespace Editor.copy {
+    declare const COPY_OPTIONS: MemFsEditor.CopyOptions;
+    declare const CONTEXT: TemplateData;
+    declare const TEMPLATE_OPTIONS: TemplateOptions;
+
+    EDITOR.copy(FILE_PATHS, FILE_PATH);
+    EDITOR.copy(FILE_PATHS, FILE_PATH, COPY_OPTIONS);
+    EDITOR.copy(FILE_PATHS, FILE_PATH, COPY_OPTIONS, CONTEXT);
+    EDITOR.copy(FILE_PATHS, FILE_PATH, COPY_OPTIONS, CONTEXT, TEMPLATE_OPTIONS);
+}
+
+// Tests for `MemFsEditor.Editor#copyTpl`
+namespace Editor.copyTpl {
+    declare const CONTEXT: TemplateData;
+    declare const TEMPLATE_OPTIONS: TemplateOptions;
+    declare const COPY_OPTIONS: MemFsEditor.CopyOptions;
+
+    EDITOR.copyTpl(FILE_PATHS, FILE_PATH);
+    EDITOR.copyTpl(FILE_PATHS, FILE_PATH, CONTEXT);
+    EDITOR.copyTpl(FILE_PATHS, FILE_PATH, CONTEXT, TEMPLATE_OPTIONS);
+    EDITOR.copyTpl(FILE_PATHS, FILE_PATH, CONTEXT, TEMPLATE_OPTIONS, COPY_OPTIONS);
+}
+
+// Tests for `MemFsEditor.Editor#move`
+namespace Editor.move {
+    declare const OPTIONS: MemFsEditor.WithGlobOptions;
+
+    EDITOR.move(FILE_PATHS, FILE_PATH);
+    EDITOR.move(FILE_PATHS, FILE_PATH, OPTIONS);
+}
+
+// Tests for `MemFsEditor.Editor#exists`
+namespace Editor.exists {
+    let exists: boolean;
+    exists = EDITOR.exists(FILE_PATH);
+}
+
+// Tests for `MemFsEditor.Editor#commit`
+namespace Editor.commit {
+    declare const CALLBACK: (err: any) => void;
+    declare const FILTERS: Transform[];
+
+    EDITOR.commit(CALLBACK);
+    EDITOR.commit(FILTERS, CALLBACK);
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/SBoudrias/mem-fs-editor/tree/v7.0.0>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
