### PR TITLE
Make StreamParser typings more accurate

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -151,21 +151,7 @@ export interface StreamParserConstructor {
 }
 export const StreamParser: StreamParserConstructor;
 
-export interface N3StreamParser<Q extends BaseQuad = Quad> extends RDF.Stream<Q>, NodeJS.WritableStream, RDF.Sink<EventEmitter, RDF.Stream<Q>> {
-    // Below are the NodeJS.ReadableStream methods,
-    // we can not extend the interface directly,
-    // as `read` clashes with RDF.Sink.
-    readable: boolean;
-    // read(size?: number): string | Buffer; // Overwritten by RDF.Stream
-    setEncoding(encoding: string | null): void;
-    pause(): this;
-    resume(): this;
-    isPaused(): boolean;
-    pipe<T extends NodeJS.WritableStream | RDF.Stream<Q>>(destination: T, options?: { end?: boolean; }): T;
-    unpipe(destination?: NodeJS.WritableStream | RDF.Stream<Q>): void;
-    unshift(chunk: string | Buffer): void;
-    wrap(oldStream: NodeJS.ReadableStream | RDF.Stream<Q>): NodeJS.ReadableStream;
-}
+export type N3StreamParser<Q extends BaseQuad = Quad> = stream.Transform & RDF.Stream<Q> & RDF.Sink<EventEmitter, RDF.Stream<Q>>;
 
 export interface WriterOptions {
     format?: string;


### PR DESCRIPTION
In the actual code [StreamParser extends a Transform](https://github.com/rdfjs/N3.js/blob/master/src/N3StreamParser.js#L6), so the typings should reflect that, since currently ugly casts are required to fully take advantage of those properties.
Due to TypeScript having [problems](https://github.com/microsoft/TypeScript/issues/16936) with overlapping interfaces, the cleanest solution is a type intersection.
A Transform is a duplex stream so that covers both the Readable and Writable part of the interface that was previously there.
This change actually doesn't change much to the typings, it just makes them a bit more specific, hence all tests were still working.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rdfjs/N3.js/blob/master/src/N3StreamParser.js#L6
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

