### PR TITLE
[echarts] adding xAxis and yAxis properties to markline data

### DIFF
--- a/types/echarts/options/series/boxplot.d.ts
+++ b/types/echarts/options/series/boxplot.d.ts
@@ -5248,6 +5248,20 @@ declare namespace echarts {
                         symbolOffset?: any[];
 
                         /**
+                         * Position according to X-Axis value.
+                         * For a line parallel to Y-Axis
+                         *
+                         */
+                        xAxis?: number;
+
+                        /**
+                         * Position according to Y-Axis value
+                         * For a line parallel to X-Axis
+                         *
+                         */
+                        yAxis?: number;
+
+                        /**
                          * Line style of this data item, which will be merged
                          * with `lineStyle` of starting point and ending point.
                          *
@@ -5861,6 +5875,20 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markLine.data.1.symbolOffset
                          */
                         symbolOffset?: any[];
+
+                        /**
+                         * Position according to X-Axis value.
+                         * For a line parallel to Y-Axis
+                         *
+                         */
+                        xAxis?: number;
+
+                        /**
+                         * Position according to Y-Axis value
+                         * For a line parallel to X-Axis
+                         *
+                         */
+                        yAxis?: number;
 
                         /**
                          * Line style of this data item, which will be merged


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://echarts.apache.org/en/option.html#series-line.markLine.data.0>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


Issue link - https://github.com/DefinitelyTyped/DefinitelyTyped/issues/45389
With typescript version 3.8 markline.data.0.xAxis/yAxis properties not there in doc and used in examples throwing error while compilation
