### PR TITLE
[react] readonly array for value attr in DOM elements

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1740,7 +1740,7 @@ declare namespace React {
     interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
         // React-specific Attributes
         defaultChecked?: boolean;
-        defaultValue?: string | number | string[];
+        defaultValue?: string | number | ReadonlyArray<string>;
         suppressContentEditableWarning?: boolean;
         suppressHydrationWarning?: boolean;
 
@@ -1909,7 +1909,7 @@ declare namespace React {
         target?: string;
         type?: string;
         useMap?: string;
-        value?: string | string[] | number;
+        value?: string | ReadonlyArray<string> | number;
         width?: number | string;
         wmode?: string;
         wrap?: string;
@@ -1962,7 +1962,7 @@ declare namespace React {
         formTarget?: string;
         name?: string;
         type?: 'submit' | 'reset' | 'button';
-        value?: string | string[] | number;
+        value?: string | ReadonlyArray<string> | number;
     }
 
     interface CanvasHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -1980,7 +1980,7 @@ declare namespace React {
     }
 
     interface DataHTMLAttributes<T> extends HTMLAttributes<T> {
-        value?: string | string[] | number;
+        value?: string | ReadonlyArray<string> | number;
     }
 
     interface DetailsHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -2092,7 +2092,7 @@ declare namespace React {
         src?: string;
         step?: number | string;
         type?: string;
-        value?: string | string[] | number;
+        value?: string | ReadonlyArray<string> | number;
         width?: number | string;
 
         onChange?: ChangeEventHandler<T>;
@@ -2114,7 +2114,7 @@ declare namespace React {
     }
 
     interface LiHTMLAttributes<T> extends HTMLAttributes<T> {
-        value?: string | string[] | number;
+        value?: string | ReadonlyArray<string> | number;
     }
 
     interface LinkHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -2165,7 +2165,7 @@ declare namespace React {
         max?: number | string;
         min?: number | string;
         optimum?: number;
-        value?: string | string[] | number;
+        value?: string | ReadonlyArray<string> | number;
     }
 
     interface QuoteHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -2199,7 +2199,7 @@ declare namespace React {
         disabled?: boolean;
         label?: string;
         selected?: boolean;
-        value?: string | string[] | number;
+        value?: string | ReadonlyArray<string> | number;
     }
 
     interface OutputHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -2210,12 +2210,12 @@ declare namespace React {
 
     interface ParamHTMLAttributes<T> extends HTMLAttributes<T> {
         name?: string;
-        value?: string | string[] | number;
+        value?: string | ReadonlyArray<string> | number;
     }
 
     interface ProgressHTMLAttributes<T> extends HTMLAttributes<T> {
         max?: number | string;
-        value?: string | string[] | number;
+        value?: string | ReadonlyArray<string> | number;
     }
 
     interface SlotHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -2243,7 +2243,7 @@ declare namespace React {
         name?: string;
         required?: boolean;
         size?: number;
-        value?: string | string[] | number;
+        value?: string | ReadonlyArray<string> | number;
         onChange?: ChangeEventHandler<T>;
     }
 
@@ -2282,7 +2282,7 @@ declare namespace React {
         readOnly?: boolean;
         required?: boolean;
         rows?: number;
-        value?: string | string[] | number;
+        value?: string | ReadonlyArray<string> | number;
         wrap?: string;
 
         onChange?: ChangeEventHandler<T>;

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -26,5 +26,8 @@ const testCases = [
     <span autoCorrect="on" />,
     <span translate="no" />,
     <span translate="yes" />,
-    <svg><image crossOrigin="anonymous"/></svg>,
+    <svg><image crossOrigin="anonymous" /></svg>,
+    <input value={['one', 'two'] as ReadonlyArray<string>} />,
+    <input value={['one', 'two'] as string[]} />,
+    <input value={['one', 'two']} />
 ];


### PR DESCRIPTION
Reopening https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44174 since CI seems to be fixed now.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://html.spec.whatwg.org/multipage/input.html#the-input-element
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
