### PR TITLE
Add type definitions for rn-swipeable-panel

### DIFF
--- a/types/rn-swipeable-panel/index.d.ts
+++ b/types/rn-swipeable-panel/index.d.ts
@@ -1,0 +1,87 @@
+// Type definitions for rn-swipeable-panel 1.1
+// Project: https://github.com/enesozturk/rn-swipeable-panel
+// Definitions by: Enes Öztürk <https://github.com/enesozturk>
+// Definitions: https://github.com/DefinitelyTyped/types/rn-swipeable-panel
+
+import * as React from 'react';
+
+export interface SwipeablePanelProps extends React.Props<SwipeablePanel> {
+    /**
+     * Required prop for panels actual state. Set true if you want to open panel
+     */
+    isActive: boolean;
+
+    /**
+     * Set true if you want to show close button
+     */
+    showCloseButton?: boolean;
+
+    /**
+     * Set true if you want to make full with panel
+     */
+    fullWidth?: boolean;
+
+    /**
+     * Set true if you want to disable black background opacity
+     */
+    noBackgroundOpacity?: boolean;
+
+    /**
+     * Use this prop to override panel style
+     */
+    style?: object;
+
+    /**
+     * Use this prop to override close button background style
+     */
+    closeRootStyle?: object;
+
+    /**
+     * Use this prop to override close button icon style
+     */
+    closeIconStyle?: object;
+
+    /**
+     * Set true if you want to close panel by touching outside
+     */
+    closeOnTouchOutside?: boolean;
+
+    /**
+     * Set true if you want to let panel open just large mode
+     */
+    onlyLarge?: boolean;
+
+    /**
+     * Set true if you want to let panel open just small mode
+     */
+    onlySmall?: boolean;
+
+    /**
+     * Set true if you want to open panel large by default
+     */
+    openLarge?: boolean;
+
+    /**
+     * Set true if you want to remove gray bar
+     */
+    noBar?: boolean;
+
+    /**
+     * Use this prop to override bar style
+     */
+    barStyle?: object;
+
+    /**
+     * Set true if you want to make toucable outside of panel
+     */
+    allowTouchOutside?: boolean;
+
+    // Event Handlers
+
+    /**
+     * Required prop to keep panel's state sync with your parent components'state. Will be fired when panel is closed. See the example project.
+     */
+    onClose: () => void;
+}
+
+export default class SwipeablePanel extends React.Component<SwipeablePanelProps, any> {}

--- a/types/rn-swipeable-panel/rn-swipeable-panel-tests.tsx
+++ b/types/rn-swipeable-panel/rn-swipeable-panel-tests.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import SwipeablePanel from 'rn-swipeable-panel';
+
+export const App: React.FC = () => {
+    const [isActive, setIsActive] = React.useState<boolean>(false);
+
+    const onClosePanel = () => setIsActive(false);
+
+    return <SwipeablePanel isActive={isActive} onClose={onClosePanel}></SwipeablePanel>;
+};

--- a/types/rn-swipeable-panel/tsconfig.json
+++ b/types/rn-swipeable-panel/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+      "module": "commonjs",
+      "lib": [
+          "es6"
+      ],
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": true,
+      "baseUrl": "../",
+      "typeRoots": [
+          "../"
+      ],
+      "types": [],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true,
+      "jsx": "react",
+      "strictFunctionTypes": true
+    },
+    "files": ["index.d.ts", "rn-swipeable-panel-tests.tsx"]
+}
+  

--- a/types/rn-swipeable-panel/tslint.json
+++ b/types/rn-swipeable-panel/tslint.json
@@ -1,0 +1,3 @@
+{ "extends": "dtslint/dt.json" }
+
+  


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
