### PR TITLE
Add @absinthe/socket-apollo-link types

### DIFF
--- a/types/absinthe__socket-apollo-link/absinthe__socket-apollo-link-tests.ts
+++ b/types/absinthe__socket-apollo-link/absinthe__socket-apollo-link-tests.ts
@@ -1,0 +1,18 @@
+import { Socket } from 'phoenix';
+import * as AbsintheSocket from '@absinthe/socket';
+import { createAbsintheSocketLink, AbsintheSocketLink } from '@absinthe/socket-apollo-link';
+
+function testAbsintheApolloLink(phoenixSocket: Socket): AbsintheSocketLink {
+    const absintheSocket = AbsintheSocket.create(phoenixSocket);
+    return createAbsintheSocketLink(
+        absintheSocket,
+        error => {
+            // $ExpectType Error
+            error;
+        },
+        start => {
+            // $ExpectType Notifier<{}, {}>
+            start;
+        },
+    );
+}

--- a/types/absinthe__socket-apollo-link/index.d.ts
+++ b/types/absinthe__socket-apollo-link/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for @absinthe/socket-apollo-link 0.2
 // Project: https://github.com/absinthe-graphql/absinthe-socket/tree/master/packages/absinthe-phoenix-socket-apollo-link#readme
-// Definitions by: Maarten van Vliet <https://github.com/DefinitelyTyped>
+// Definitions by: Maarten van Vliet <https://github.com/maartenvanvliet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.8
 

--- a/types/absinthe__socket-apollo-link/index.d.ts
+++ b/types/absinthe__socket-apollo-link/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for @absinthe/socket-apollo-link 0.2
+// Project: https://github.com/absinthe-graphql/absinthe-socket/tree/master/packages/absinthe-phoenix-socket-apollo-link#readme
+// Definitions by: Maarten van Vliet <https://github.com/DefinitelyTyped>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.8
+
+import { NextLink, Operation, Observable, FetchResult } from 'apollo-link';
+import { AbsintheSocket, Notifier } from '@absinthe/socket';
+
+export interface AbsintheSocketLink {
+    request: (operation: Operation, forward: NextLink | undefined) => Observable<FetchResult> | null;
+}
+
+export function createAbsintheSocketLink(
+    absintheSocket: AbsintheSocket,
+    onError?: (error: Error) => any,
+    onStart?: (notifier: Notifier) => any,
+): AbsintheSocketLink;

--- a/types/absinthe__socket-apollo-link/package.json
+++ b/types/absinthe__socket-apollo-link/package.json
@@ -1,0 +1,8 @@
+{
+    "private": true,
+    "dependencies": {
+        "apollo-link": ">=1.2.5",
+        "apollo-link-http-common": "^0.2.4",
+        "graphql": "^14.5.3"
+    }
+}

--- a/types/absinthe__socket-apollo-link/tsconfig.json
+++ b/types/absinthe__socket-apollo-link/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6", "esnext.asynciterable"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@absinthe/socket": ["absinthe__socket"],
+            "@absinthe/socket-apollo-link": ["absinthe__socket-apollo-link"]
+        }
+    },
+    "files": ["index.d.ts", "absinthe__socket-apollo-link-tests.ts"]
+}

--- a/types/absinthe__socket-apollo-link/tslint.json
+++ b/types/absinthe__socket-apollo-link/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
