### PR TITLE
feat(webpack-cdn-inject): new type definition

### DIFF
--- a/types/webpack-cdn-inject/index.d.ts
+++ b/types/webpack-cdn-inject/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for webpack-cdn-inject 1.0
+// Project: https://github.com/drolsen/webpack-cdn-inject#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Plugin } from 'webpack';
+
+/**
+ * Plugin to inject CDN assets into HTML documents.
+ */
+declare namespace WebpackCDNInject {
+    interface Options {
+        /**
+         * Defines urls to be added to document head (tag type is defined by url's file extension).
+         */
+        head?: string[];
+        /**
+         * Defines urls to be added to document body (tag type is defined by url's file extension).
+         */
+        body?: string[];
+    }
+}
+
+declare class WebpackCDNInject extends Plugin {
+    constructor(options?: WebpackCDNInject.Options);
+}
+
+export = WebpackCDNInject;

--- a/types/webpack-cdn-inject/tsconfig.json
+++ b/types/webpack-cdn-inject/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "webpack-cdn-inject-tests.ts"
+    ]
+}

--- a/types/webpack-cdn-inject/tslint.json
+++ b/types/webpack-cdn-inject/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/webpack-cdn-inject/webpack-cdn-inject-tests.ts
+++ b/types/webpack-cdn-inject/webpack-cdn-inject-tests.ts
@@ -1,0 +1,19 @@
+import { Configuration } from 'webpack';
+import WebpackCDNInject = require('webpack-cdn-inject');
+
+const config: Configuration = {
+    plugins: [
+        new WebpackCDNInject(),
+        new WebpackCDNInject({}),
+        new WebpackCDNInject({
+            body: ['url.js', 'url.css'],
+        }),
+        new WebpackCDNInject({
+            head: ['url.css', 'url.js'],
+        }),
+        new WebpackCDNInject({
+            body: ['url.js', 'url.css'],
+            head: ['url.css', 'url.js'],
+        }),
+    ],
+};


### PR DESCRIPTION
Type definition for small webpack plugin:
- definition file
- tests

https://github.com/drolsen/webpack-cdn-inject#readme

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.