### PR TITLE
chrome: add 'deletable' to chrome.omnibox.SuggestResult & tests for omnibox

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -11,6 +11,7 @@
 //                 Brian Wilson <https://github.com/echoabstract>
 //                 Sebastiaan Pasma <https://github.com/spasma>
 //                 bdbai <https://github.com/bdbai>
+//                 pokutuna <https://github.com/pokutuna>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -4761,6 +4762,11 @@ declare namespace chrome.omnibox {
         content: string;
         /** The text that is displayed in the URL dropdown. Can contain XML-style markup for styling. The supported tags are 'url' (for a literal URL), 'match' (for highlighting text that matched what the user's query), and 'dim' (for dim helper text). The styles can be nested, eg. dimmed match. You must escape the five predefined entities to display them as text: stackoverflow.com/a/1091953/89484 */
         description: string;
+        /**
+        * Whether the suggest result can be deleted by the user.
+        * @since Chrome 63.
+        */
+        deletable?: boolean;
     }
 
     export interface Suggestion {

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -495,3 +495,39 @@ function testAssistiveWindow() {
             `${details.buttonID} button in ${details.windowType} window clicked`);
         });
 }
+
+// https://developer.chrome.com/extensions/omnibox#types
+function testOmnibox() {
+    const suggestion: chrome.omnibox.Suggestion = { description: 'description' };
+    chrome.omnibox.setDefaultSuggestion(suggestion);
+
+    function onInputEnteredCallback(text: string, disposition: chrome.omnibox.OnInputEnteredDisposition) {
+        if (disposition === 'currentTab') {
+        }
+        if (disposition === 'newForegroundTab') {
+        }
+        if (disposition === 'newBackgroundTab') {
+        }
+    }
+    chrome.omnibox.onInputEntered.addListener(onInputEnteredCallback);
+
+    const suggestResult1: chrome.omnibox.SuggestResult = {
+        content: 'content',
+        description: 'description',
+    };
+    const suggestResult2: chrome.omnibox.SuggestResult = {
+        content: 'content',
+        description: 'description',
+        deletable: true,
+    };
+    function onInputChangedCallback(text: string, suggest: (suggestResults: chrome.omnibox.SuggestResult[]) => void) {
+        suggest([suggestResult1, suggestResult2]);
+    }
+    chrome.omnibox.onInputChanged.addListener(onInputChangedCallback);
+
+    chrome.omnibox.onInputStarted.addListener(() => {});
+
+    chrome.omnibox.onInputCancelled.addListener(() => {});
+
+    chrome.omnibox.onDeleteSuggestion.addListener((text: string) => {});
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/extensions/omnibox#type-SuggestResult
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.