### PR TITLE
Calidation: allow types to flow through to configuration

### DIFF
--- a/types/calidation/calidation-tests.tsx
+++ b/types/calidation/calidation-tests.tsx
@@ -25,7 +25,7 @@ const config: FieldsConfig<FieldTypes> = {
         isGreaterThan: {
             message: 'This field must be greater than 7',
             value: 7,
-            validateIf: ({ isDirty, fields }) => isDirty && !!fields.bar.length,
+            validateIf: ({ isDirty, fields }) => isDirty && fields.bar.some(b => b === 'test'),
         },
     },
     bar: {},

--- a/types/calidation/calidation-tests.tsx
+++ b/types/calidation/calidation-tests.tsx
@@ -25,7 +25,7 @@ const config: FieldsConfig<FieldTypes> = {
         isGreaterThan: {
             message: 'This field must be greater than 7',
             value: 7,
-            validateIf: ({ isDirty }: ValidatorContext<FieldTypes>) => isDirty,
+            validateIf: ({ isDirty, fields }) => isDirty && !!fields.bar.length,
         },
     },
     bar: {},

--- a/types/calidation/index.d.ts
+++ b/types/calidation/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for calidation 1.16
+// Type definitions for calidation 2.0
 // Project: https://github.com/selbekk/calidation#readme
 // Definitions by: Ray Knight <https://github.com/ArrayKnight>
 //                 Lisa Tassone <https://github.com/lisatassone>
@@ -7,81 +7,81 @@
 
 import * as React from 'react';
 
-export type Dirty<T extends object = any> = Record<keyof T, boolean>;
+export type Dirty<T extends object> = Record<keyof T, boolean>;
 
-export type Errors<T extends object = any> = Record<keyof T, string | null>;
+export type Errors<T extends object> = Record<keyof T, string | null>;
 
-export type Fields<T extends object = any> = T;
+export type Fields<T extends object> = T;
 
-export type Transform<T extends object = any> = Record<keyof T, (value: any) => T[keyof T]>;
+export type Transform<T extends object> = Record<keyof T, (value: any) => T[keyof T]>;
 
-export type Transforms<T extends object = any> = Partial<Transform<T>>;
+export type Transforms<T extends object> = Partial<Transform<T>>;
 
-export interface ValidatorContext<T extends object = any> {
+export interface ValidatorContext<T extends object> {
     errors: Errors<T>;
     fields: Fields<T>;
     isDirty: boolean;
 }
 
-export interface SimpleValidatorConfig<T extends object = any> {
+export interface SimpleValidatorConfig<T extends object> {
     message: string;
     validateIf?: ((context: ValidatorContext<T>) => boolean) | boolean;
 }
 
-export type SimpleValidator<T extends object = any> =
+export type SimpleValidator<T extends object> =
     | string
     | SimpleValidatorConfig<T>
     | ((context: ValidatorContext<T>) => SimpleValidatorConfig<T>);
 
-export interface BlacklistValidatorConfig<T extends object = any> extends SimpleValidatorConfig<T> {
+export interface BlacklistValidatorConfig<T extends object> extends SimpleValidatorConfig<T> {
     blacklist: string[];
 }
 
-export type BlacklistValidator<T extends object = any> =
+export type BlacklistValidator<T extends object> =
     | BlacklistValidatorConfig<T>
     | ((context: ValidatorContext<T>) => BlacklistValidatorConfig<T>);
 
-export interface ValueValidatorConfig<P, T extends object = any> extends SimpleValidatorConfig<T> {
+export interface ValueValidatorConfig<P, T extends object> extends SimpleValidatorConfig<T> {
     value: P;
 }
 
-export type ValueValidator<P, T extends object = any> =
+export type ValueValidator<P, T extends object> =
     | ValueValidatorConfig<P, T>
     | ((context: ValidatorContext<T>) => ValueValidatorConfig<P, T>);
 
-export interface RegexValidatorConfig<T extends object = any> extends SimpleValidatorConfig<T> {
+export interface RegexValidatorConfig<T extends object> extends SimpleValidatorConfig<T> {
     regex: RegExp;
 }
 
-export type RegexValidator<T extends object = any> =
+export type RegexValidator<T extends object> =
     | RegexValidatorConfig<T>
     | ((context: ValidatorContext<T>) => RegexValidatorConfig<T>);
 
-export interface WhitelistValidatorConfig<T extends object = any> extends SimpleValidatorConfig<T> {
+export interface WhitelistValidatorConfig<T extends object> extends SimpleValidatorConfig<T> {
     whitelist: string[];
 }
 
-export type WhitelistValidator<T extends object = any> =
+export type WhitelistValidator<T extends object> =
     | WhitelistValidatorConfig<T>
     | ((context: ValidatorContext<T>) => RegexValidatorConfig<T>);
 
-export interface LengthValidatorConfig<T extends object = any> extends SimpleValidatorConfig<T> {
+export interface LengthValidatorConfig<T extends object> extends SimpleValidatorConfig<T> {
     length: number;
 }
 
-export type LengthValidator<T extends object = any> =
+export type LengthValidator<T extends object> =
     | LengthValidatorConfig<T>
     | ((context: ValidatorContext<T>) => LengthValidatorConfig<T>);
 
-export type Validator<T extends object = any> =
+export type Validator<T extends object> =
     | SimpleValidator<T>
     | BlacklistValidator<T>
-    | ValueValidator<T>
+    | ValueValidator<any, T>
     | RegexValidator<T>
     | WhitelistValidator<T>
     | LengthValidator<T>;
 
-export interface FieldConfig<T extends object = any> {
+export interface FieldConfig<T extends object> {
     isBlacklisted?: BlacklistValidator<T>;
     isEmail?: SimpleValidator<T>;
     isEqual?: ValueValidator<any, T>;
@@ -96,12 +96,12 @@ export interface FieldConfig<T extends object = any> {
     isExactLength?: LengthValidator<T>;
 }
 
-export type FieldsConfig<T extends object = any> = Record<
+export type FieldsConfig<T extends object> = Record<
     string,
-    FieldConfig<T> | Record<string, SimpleValidator<T>> | Record<string, ValueValidator<T>>
+    FieldConfig<T> | Record<string, SimpleValidator<T>> | Record<string, ValueValidator<any, T>>
 >;
 
-export interface FormContext<T extends object = any> {
+export interface FormContext<T extends object> {
     dirty: Dirty<T>;
     errors: Errors<T>;
     fields: Fields<T>;
@@ -115,7 +115,7 @@ export interface FormContext<T extends object = any> {
     submitted: boolean;
 }
 
-export interface FormProps<T extends object = any>
+export interface FormProps<T extends object>
     extends Omit<React.DetailedHTMLProps<React.FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>, 'onSubmit'> {
     onChange?: (event: React.ChangeEvent<HTMLFormElement>) => void;
     onReset?: () => void;
@@ -123,32 +123,32 @@ export interface FormProps<T extends object = any>
     onUpdate?: (context: FormContext<T>) => void;
 }
 
-export class Form<T extends object = any> extends React.Component<FormProps<T>> {}
+export class Form<T extends object> extends React.Component<FormProps<T>> {}
 
-export type ValidationContext<T extends object = any> = Omit<FormContext<T>, 'register' | 'unregister'>;
+export type ValidationContext<T extends object> = Omit<FormContext<T>, 'register' | 'unregister'>;
 
-export interface ValidationProps<T extends object = any> {
+export interface ValidationProps<T extends object> {
     children: (context: ValidationContext<T>) => React.ReactNode;
     config: FieldsConfig<T>;
     initialValues?: T;
     transforms?: Transforms<T>;
 }
 
-export class Validation<T extends object = any> extends React.Component<ValidationProps<T>> {}
+export class Validation<T extends object> extends React.Component<ValidationProps<T>> {}
 
-export interface FormValidationProps<T extends object = any> extends FormProps<T>, ValidationProps<T> {
+export interface FormValidationProps<T extends object> extends FormProps<T>, ValidationProps<T> {
     children: (context: ValidationContext<T>) => React.ReactNode;
 }
 
-export class FormValidation<T extends object = any> extends React.Component<FormValidationProps<T>> {}
+export class FormValidation<T extends object> extends React.Component<FormValidationProps<T>> {}
 
-export type CustomValidatorFunction<T extends object = any> = (
+export type CustomValidatorFunction<T extends object> = (
     config: SimpleValidatorConfig<T>,
     context: ValidatorContext<T>,
 ) => (value: T[keyof T]) => string | null;
 
-export interface ValidatorsProviderProps<T extends object = any> {
+export interface ValidatorsProviderProps<T extends object> {
     validators: Record<string, CustomValidatorFunction<T>>;
 }
 
-export class ValidatorsProvider<T extends object = any> extends React.Component<ValidatorsProviderProps<T>> {}
+export class ValidatorsProvider<T extends object> extends React.Component<ValidatorsProviderProps<T>> {}

--- a/types/calidation/index.d.ts
+++ b/types/calidation/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for calidation 2.0
+// Type definitions for calidation 1.16
 // Project: https://github.com/selbekk/calidation#readme
 // Definitions by: Ray Knight <https://github.com/ArrayKnight>
 //                 Lisa Tassone <https://github.com/lisatassone>

--- a/types/calidation/tslint.json
+++ b/types/calidation/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
 }

--- a/types/calidation/tslint.json
+++ b/types/calidation/tslint.json
@@ -1,6 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "npm-naming": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
While the previous minor version was great for adding generic support, using the types can still be  cumbersome because the generics are set to `any` to allow for compatibility with the previous major version. As such, one needs to expressly use type annotations for the configuration object functions as the types to not flow through to it. With the removal of any, both configuration and contexts have typing.

If there is a better way to achieve this, please let me know.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
