### PR TITLE
[@types/relay-runtime]: RelayModernEnvironment & IEnvironment v9.1.0

### DIFF
--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -130,7 +130,7 @@ export { ConcreteRequest, GeneratedNode, RequestParameters } from './lib/util/Re
 export { CacheConfig, DataID, Disposable, OperationType, Variables } from './lib/util/RelayRuntimeTypes';
 
 // Core API
-export { RelayModernEnvironment as Environment } from './lib/store/RelayModernEnvironment';
+export { default as Environment } from './lib/store/RelayModernEnvironment';
 export { RelayNetwork as Network } from './lib/network/RelayNetwork';
 export { RelayObservable as Observable } from './lib/network/RelayObservable';
 import QueryResponseCache from './lib/network/RelayQueryResponseCache';

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -7,6 +7,7 @@
 //                 Stephen Pittman <https://github.com/Stephen2>
 //                 Martin Zlámal <https://github.com/mrtnzlml>
 //                 Christian Ivicevic <https://github.com/ChristianIvicevic>
+//                 Lorenzo Di Giacomo <https://github.com/morrys>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/relay-runtime/lib/store/RelayModernEnvironment.d.ts
+++ b/types/relay-runtime/lib/store/RelayModernEnvironment.d.ts
@@ -32,12 +32,12 @@ export interface EnvironmentConfig {
     readonly store: Store;
     readonly missingFieldHandlers?: ReadonlyArray<MissingFieldHandler> | null;
     readonly operationTracker?: OperationTracker | null;
-    readonly options?: any;
+    readonly options?: unknown;
     readonly isServer?: boolean;
 }
 
 export default class RelayModernEnvironment implements Environment {
-    options: any;
+    options: unknown;
     configName: string | null | undefined;
     constructor(config: EnvironmentConfig);
     getStore(): Store;

--- a/types/relay-runtime/lib/store/RelayModernEnvironment.d.ts
+++ b/types/relay-runtime/lib/store/RelayModernEnvironment.d.ts
@@ -1,6 +1,5 @@
 import { HandlerProvider } from '../handlers/RelayDefaultHandlerProvider';
 import {
-    CheckOptions,
     OperationLoader,
     Store,
     MissingFieldHandler,
@@ -25,6 +24,7 @@ import { RelayObservable } from '../network/RelayObservable';
 export interface EnvironmentConfig {
     readonly configName?: string;
     readonly handlerProvider?: HandlerProvider | null;
+    readonly treatMissingFieldsAsNull?: boolean;
     readonly log?: LogFunction | null;
     readonly operationLoader?: OperationLoader | null;
     readonly network: Network;
@@ -32,36 +32,43 @@ export interface EnvironmentConfig {
     readonly store: Store;
     readonly missingFieldHandlers?: ReadonlyArray<MissingFieldHandler> | null;
     readonly operationTracker?: OperationTracker | null;
+    readonly options?: any;
+    readonly isServer?: boolean;
 }
 
-export class RelayModernEnvironment implements Environment {
+export default class RelayModernEnvironment implements Environment {
+    options: any;
     configName: string | null | undefined;
     constructor(config: EnvironmentConfig);
     getStore(): Store;
     getNetwork(): Network;
     getOperationTracker(): RelayOperationTracker;
+    isRequestActive(requestIdentifier: string): boolean;
     applyUpdate(optimisticUpdate: OptimisticUpdateFunction): Disposable;
     revertUpdate(update: OptimisticUpdateFunction): void;
     replaceUpdate(update: OptimisticUpdateFunction, newUpdate: OptimisticUpdateFunction): void;
     applyMutation(optimisticConfig: OptimisticResponseConfig): Disposable;
-    check(operation: OperationDescriptor, options?: CheckOptions): OperationAvailability;
+    check(operation: OperationDescriptor): OperationAvailability;
     commitPayload(operationDescriptor: OperationDescriptor, payload: PayloadData): void;
     commitUpdate(updater: StoreUpdater): void;
     lookup(readSelector: SingularReaderSelector): Snapshot;
     subscribe(snapshot: Snapshot, callback: (snapshot: Snapshot) => void): Disposable;
     retain(operation: OperationDescriptor): Disposable;
+    isServer(): boolean;
     execute(data: {
         operation: OperationDescriptor;
         cacheConfig?: CacheConfig | null;
         updater?: SelectorStoreUpdater | null;
     }): RelayObservable<GraphQLResponse>;
     executeMutation({
+        cacheConfig,
         operation,
         optimisticResponse,
         optimisticUpdater,
         updater,
         uploadables,
     }: {
+        cacheConfig: CacheConfig | null;
         operation: OperationDescriptor;
         optimisticUpdater?: SelectorStoreUpdater | null;
         optimisticResponse?: { [key: string]: any } | null;

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -476,7 +476,7 @@ export interface Environment {
     /**
      * Extra information attached to the environment instance
      */
-    options: any;
+    options: unknown;
 
     /**
      * Determine if the operation can be resolved with data in the store (i.e. no

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -474,6 +474,11 @@ export type LogFunction = (logEvent: LogEvent) => void;
  */
 export interface Environment {
     /**
+     * Extra information attached to the environment instance
+     */
+    options: any;
+
+    /**
      * Determine if the operation can be resolved with data in the store (i.e. no
      * fields are missing).
      *

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -58,10 +58,22 @@ const cache = new QueryResponseCache({ size: 250, ttl: 60000 });
 // ~~~~~~~~~~~~~~~~~~~~~
 // Environment
 // ~~~~~~~~~~~~~~~~~~~~~
+
+const isServer = false;
+
+const options = {
+    test: true,
+};
+
+const treatMissingFieldsAsNull = false;
+
 const environment = new Environment({
     handlerProvider, // Can omit.
     network,
     store,
+    isServer,
+    options,
+    treatMissingFieldsAsNull,
     missingFieldHandlers: [
         ...getDefaultMissingFieldHandlers(),
         // Example from https://relay.dev/docs/en/experimental/a-guided-tour-of-relay


### PR DESCRIPTION
Hi @alloy,
in this PR I have updated RelayModernEnvironment and the IEnvironment interface to version 9.1.0.
I also followed your advice and added myself as a maintainer

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
[RelayModernEnvironment](https://github.com/facebook/relay/blob/v9.1.0/packages/relay-runtime/store/RelayModernEnvironment.js)
[IEnvironment](https://github.com/facebook/relay/blob/v9.1.0/packages/relay-runtime/store/RelayStoreTypes.js#L459)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
