### PR TITLE
Update types/react-native-auth0 to reflect new API

### DIFF
--- a/types/react-native-auth0/index.d.ts
+++ b/types/react-native-auth0/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-native-auth0 2.5.0
+// Type definitions for react-native-auth0 2.5
 // Project: https://github.com/auth0/react-native-auth0
 // Definitions by: Andrea Ascari <https://github.com/ascariandrea>
 //                 Mark Nelissen <https://github.com/marknelissen>

--- a/types/react-native-auth0/index.d.ts
+++ b/types/react-native-auth0/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-native-auth0 2.0
+// Type definitions for react-native-auth0 2.5.0
 // Project: https://github.com/auth0/react-native-auth0
 // Definitions by: Andrea Ascari <https://github.com/ascariandrea>
 //                 Mark Nelissen <https://github.com/marknelissen>

--- a/types/react-native-auth0/index.d.ts
+++ b/types/react-native-auth0/index.d.ts
@@ -180,12 +180,16 @@ export interface AuthorizeParams {
     prompt?: string;
 }
 
+export interface AuthorizeOptions {
+    ephemeralSession?: boolean;
+}
+
 export interface ClearSessionParams {
     federated: boolean;
 }
 
 export class WebAuth {
-    authorize(parameters: AuthorizeParams): Promise<any>;
+    authorize(parameters: AuthorizeParams, options?: AuthorizeOptions): Promise<any>;
     clearSession(parameters?: ClearSessionParams): Promise<any>;
 }
 

--- a/types/react-native-auth0/react-native-auth0-tests.ts
+++ b/types/react-native-auth0/react-native-auth0-tests.ts
@@ -70,6 +70,34 @@ auth0.webAuth.authorize({
     prompt: 'login',
 });
 
+// handle additional options object
+auth0.webAuth.authorize(
+    {
+        state: 'state',
+        nonce: 'nonce',
+        scope: 'openid',
+        language: 'en',
+        prompt: 'login',
+    },
+    {
+        ephemeralSession: true,
+    },
+);
+
+// additional options with incorrect values
+auth0.webAuth.authorize(
+    {
+        state: 'state',
+        nonce: 'nonce',
+        scope: 'openid',
+        language: 'en',
+        prompt: 'login',
+    },
+    {
+        incorrectValue: true, // $ExpectError
+    },
+);
+
 auth0.webAuth.clearSession({ federated: false });
 auth0.webAuth.clearSession();
 


### PR DESCRIPTION
Please fill in this template.

Add AuthorizeOptions to WebAuth.authorize arguments

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Specific commit adding to the `webAuth.authorize` arguments](https://github.com/auth0/react-native-auth0/commit/a24bb310a5f01a3132186bd374eebc0f3c04620f) and [general changelog for the release](https://github.com/auth0/react-native-auth0/compare/v2.3.1...v2.4.0)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
