### PR TITLE
[@types/hapi__joi]: fix SchemaInternals.$_getRule return type

### DIFF
--- a/types/hapi__joi/hapi__joi-tests.ts
+++ b/types/hapi__joi/hapi__joi-tests.ts
@@ -1158,6 +1158,13 @@ schema = Joi.symbol().map({
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
+const rule = Joi.string().case('upper').$_getRule('case');
+if (rule && rule.args) {
+    const direction = rule.args.direction;
+}
+
+// --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
+
 schema = Joi.any();
 const terms = schema.$_terms;
 

--- a/types/hapi__joi/index.d.ts
+++ b/types/hapi__joi/index.d.ts
@@ -726,6 +726,13 @@ declare namespace Joi {
         };
     }
 
+    interface GetRuleOptions {
+        args?: Record<string, any>;
+        method?: string;
+        name: string;
+        operator?: string;
+    }
+
     interface SchemaInternals {
         /**
          * Parent schema object.
@@ -767,7 +774,7 @@ declare namespace Joi {
         /**
          * Retrieve some rule configuration.
          */
-        $_getRule(name: string): ExtensionRule;
+        $_getRule(name: string): GetRuleOptions | undefined;
 
         $_mapLabels(path: string | string[]): string;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/joi/blob/b3728a27513f88469022183814a8c4416ee709b1/lib/base.js#L374-L380
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
