### PR TITLE
Added type definitions for react-mathjax

### DIFF
--- a/types/react-mathjax/index.d.ts
+++ b/types/react-mathjax/index.d.ts
@@ -1,0 +1,30 @@
+// Type definitions for react-mathjax 1.0
+// Project: https://github.com/SamyPesse/react-mathjax#readme
+// Definitions by: ArtoLord <https://github.com/ArtoLord>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as React from 'react';
+
+interface MathJaxContextValue {
+    MathJax?: object;
+    registerNode: () => void;
+}
+
+declare namespace MathJax {
+    class Provider extends React.Component<
+        {
+            script?: string | boolean;
+            options?: object;
+            children: React.ReactNode;
+        },
+        MathJaxContextValue
+    > {}
+
+    class Node extends React.PureComponent<{
+        formula: string;
+        inline?: boolean;
+        onRender?: () => void;
+    }> {}
+}
+
+export default MathJax;

--- a/types/react-mathjax/react-mathjax-tests.tsx
+++ b/types/react-mathjax/react-mathjax-tests.tsx
@@ -1,0 +1,20 @@
+import MathJax from 'react-mathjax';
+import React from 'react';
+
+const tex = `f(x) = \\int_{-\\infty}^\\infty
+    \\hat f(\\xi)\\,e^{2 \\pi i \\xi x}
+    \\,d\\xi`;
+
+export class Component extends React.Component {
+    render() {
+        return (
+            <MathJax.Provider>
+                <div>
+                    This is an inline math formula: <MathJax.Node inline formula={'a = b'} />
+                    And a block one:
+                    <MathJax.Node formula={tex} />
+                </div>
+            </MathJax.Provider>
+        );
+    }
+}

--- a/types/react-mathjax/tsconfig.json
+++ b/types/react-mathjax/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "DOM"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react",
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-mathjax-tests.tsx"
+    ]
+}

--- a/types/react-mathjax/tslint.json
+++ b/types/react-mathjax/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.