### PR TITLE
fix(mysql): correct `raw` method return type

### DIFF
--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -81,7 +81,9 @@ export function createPoolCluster(config?: PoolClusterConfig): PoolCluster;
  * format().
  * @param sql
  */
-export function raw(sql: string): () => string;
+export function raw(sql: string): {
+    toSqlString: () => string
+};
 
 export interface Connection extends EscapeFunctions {
     config: ConnectionConfig;

--- a/types/mysql/mysql-tests.ts
+++ b/types/mysql/mysql-tests.ts
@@ -258,6 +258,11 @@ const poolClusterWithOptions = mysql.createPoolCluster({
     defaultSelector: 'RR'
 });
 
+// raw
+// $ExpectType { toSqlString: () => string; }
+const CURRENT_TIMESTAMP = mysql.raw('CURRENT_TIMESTAMP()');
+const sqlString = mysql.format('UPDATE posts SET modified = ? WHERE id = ?', [CURRENT_TIMESTAMP, 42]);
+
 // destroy
 poolCluster.end();
 


### PR DESCRIPTION
The `raw` wraps string value into object with callable interface to work
with SQL params/placeholders.

https://github.com/mysqljs/sqlstring/commit/b22d66f427b195a432d8d2e60c2e731fde16f8dc

Thanks!

/cc @lgarczyn

Fixes #45549

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)