### PR TITLE
fix(reactstrap): correct Table `responsive` prop types

### DIFF
--- a/types/reactstrap/lib/Table.d.ts
+++ b/types/reactstrap/lib/Table.d.ts
@@ -12,7 +12,7 @@ export interface TableProps extends React.HTMLAttributes<HTMLElement> {
     inverse?: boolean;
     hover?: boolean;
     reflow?: boolean;
-    responsive?: boolean;
+    responsive?: boolean | string;
     tag?: string | React.ReactType;
     responsiveTag?: React.ReactType;
 }

--- a/types/reactstrap/reactstrap-tests.tsx
+++ b/types/reactstrap/reactstrap-tests.tsx
@@ -3261,7 +3261,7 @@ class Example98 extends React.Component {
 class Example99 extends React.Component {
   render() {
     return (
-      <Table responsive>
+      <Table responsive="md">
         <thead>
           <tr>
             <th>#</th>


### PR DESCRIPTION
- property type corrected
- test amended to use added property version

https://github.com/reactstrap/reactstrap/blob/master/src/Table.js#L15

Thanks!

/cc @nagiek

Fixes #45545

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)