### PR TITLE
[@types/mongoose]: Add query.getFilter method

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -2155,8 +2155,15 @@ declare module "mongoose" {
     /**
      * Returns the current query conditions as a JSON object.
      * @returns current query conditions
+     * @deprecated You should use getFilter() instead of getQuery() where possible. getQuery() will likely be deprecated in a future release.
      */
     getQuery(): any;
+
+    /**
+     * Returns the current query filter (also known as conditions) as a POJO.
+     * @returns current query filter
+     */
+    getFilter(): any;
 
     /**
      * Returns the current update operations as a JSON object.

--- a/types/mongoose/test/query.ts
+++ b/types/mongoose/test/query.ts
@@ -90,6 +90,7 @@ var polyC = [ 0, 0 ]
 query.where('loc').within().geometry({ type: 'Point', coordinates: polyC })
 query.where('loc').intersects().geometry({ type: 'Point', coordinates: polyC })
 query.getQuery();
+query.getFilter();
 query.getUpdate();
 query.find().where('age').gt(21);
 query.find().gt('age', 21);


### PR DESCRIPTION
According to the official Mongoose documentation, Mongoose.Query has `getQuery` and `getFilter`. However, `@types/mongoose` only has `getQuery` will be deprecated. So I added `@deprecated` to `getQuery` and `getFilter`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://mongoosejs.com/docs/api/query.html#query_Query-getQuery>> and <<https://mongoosejs.com/docs/api/query.html#query_Query-getFilter>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.