### PR TITLE
Fix serverless typing for httpApi logs and Environement

### DIFF
--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -82,7 +82,7 @@ declare namespace Aws {
     }
 
     interface Environment {
-        [key: string]: string;
+        [key: string]: any;
     }
 
     interface ApiGateway {
@@ -239,7 +239,7 @@ declare namespace Aws {
     interface Logs {
         restApi?: RestApiLogs;
         websocket?: WebsocketLogs;
-        httpApi?: HttpApiLogs;
+        httpApi?: boolean | HttpApiLogs;
         frameworkLambda?: boolean;
     }
 

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -342,7 +342,10 @@ const awsServerless: Aws.Serverless = {
             onError: 'testonError',
             awsKmsKeyArn: 'testawsKmsKeyArn',
             environment: {
-                testenvironment: 'testenvironmentvalue'
+                testenvironment: 'testenvironmentvalue',
+                testRefEnvironment: {
+                    Ref: 'MyRessource',
+                }
             },
             tags: {
                 testtagkey: 'testtagvalue'


### PR DESCRIPTION
## Enable boolean for httpApi logs key

As stated in the documentation, `provider.httpApi.logs` can be a boolean instead of specifying a custom log format, if default log format is to be used.
https://www.serverless.com/framework/docs/providers/aws/events/http-api#access-logs

## Enable non string environment variable

Environment type is defined as `string` only. However, you can use Cloudformation references to fill in env variable, for exemple :

```
environment: {
   MY_ENV_VARIABLE : {
      Ref: 'MyCloudformationResource'
   }
}
```

I changed it for `any` as their are many Cloudformation functions that could be used there. Is it worth implementing AWS CloudFormation functions types within this package ?

---- 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.