### PR TITLE
[lodash] Fixing description for the key parameter of memoize

### DIFF
--- a/types/lodash/common/function.d.ts
+++ b/types/lodash/common/function.d.ts
@@ -801,10 +801,11 @@ declare module "../index" {
 
     interface LoDashStatic {
         /**
-         * Creates a function that memoizes the result of func. If resolver is provided it determines the cache key for
-         * storing the result based on the arguments provided to the memoized function. By default, the first argument
-         * provided to the memoized function is coerced to a string and used as the cache key. The func is invoked with
-         * the this binding of the memoized function.
+         * Creates a function that memoizes the result of `func`. If `resolver` is
+         * provided, it determines the cache key for storing the result based on the
+         * arguments provided to the memoized function. By default, the first argument
+         * provided to the memoized function is used as the map cache key. The `func`
+         * is invoked with the `this` binding of the memoized function.
          *
          * @param func The function to have its output memoized.
          * @param resolver The function to resolve the cache key.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changed the description for the memoize function to match the current version of lodash: https://github.com/lodash/lodash/blob/master/memoize.js
The previous description was from the 3.10 Version which says that key is coerced to a string.

There are no type changes!