### PR TITLE
fix (readable-stream): fixed  type compatibility with node v10

### DIFF
--- a/types/readable-stream/index.d.ts
+++ b/types/readable-stream/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for readable-stream 2.3
 // Project: https://github.com/nodejs/readable-stream
 // Definitions by: TeamworkGuy2 <https://github.com/TeamworkGuy2>
+//                   markdreyer <https://github.com/markdreyer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/readable-stream/index.d.ts
+++ b/types/readable-stream/index.d.ts
@@ -5,7 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-/// <reference types="node/v10" />
+/// <reference types="node" />
 
 import * as stream from "stream";
 import * as SafeBuffer from "safe-buffer";

--- a/types/readable-stream/index.d.ts
+++ b/types/readable-stream/index.d.ts
@@ -4,11 +4,16 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-/// <reference types="node" />
+/// <reference types="node/v10" />
 
 import * as stream from "stream";
 import * as SafeBuffer from "safe-buffer";
-import { StringDecoder } from "string_decoder";
+
+declare class StringDecoder {
+    constructor(encoding?: BufferEncoding | string);
+    write(buffer: Buffer): string;
+    end(buffer?: Buffer): string;
+}
 
 declare class _Readable extends stream.Readable {
     // static ReadableState: _Readable.ReadableState;
@@ -74,6 +79,7 @@ declare namespace _Readable {
         readonly readableHighWaterMark: number;
         readonly readableLength: number;
         readonly readableObjectMode: boolean;
+        readonly writableObjectMode: boolean;
         _readableState: ReadableState;
 
         _read(size?: number): void;
@@ -103,7 +109,7 @@ declare namespace _Readable {
     class PassThrough extends Transform implements stream.PassThrough {
         constructor(options?: TransformOptions);
 
-        _transform<T>(chunk: T, encoding: BufferEncoding | null | undefined, callback: (error: any, data: T) => void): void;
+        _transform<T>(chunk: T, encoding: BufferEncoding | string | null | undefined, callback: (error?: Error, data?: T) => void): void;
     }
 
     // ==== _stream_readable ====
@@ -236,8 +242,8 @@ declare namespace _Readable {
     }
 
     type WritableOptions = WritableStateOptions & {
-        write?(this: Writable, chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
-        writev?(this: Writable, chunk: ArrayLike<{ chunk: any; encoding: BufferEncoding }>, callback: (error?: Error | null) => void): void;
+        write?(this: Writable, chunk: any, encoding: BufferEncoding | string, callback: (error?: Error | null) => void): void;
+        writev?(this: Writable, chunk: ArrayLike<{ chunk: any; encoding: BufferEncoding | string }>, callback: (error?: Error | null) => void): void;
         destroy?(this: Writable, error: Error | null, callback: (error: Error | null) => void): void;
         final?(this: Writable, callback: (error?: Error | null) => void): void;
     };

--- a/types/readable-stream/readable-stream-tests.ts
+++ b/types/readable-stream/readable-stream-tests.ts
@@ -84,7 +84,8 @@ function test() {
             assertType<any>(chunk);
             assertType<string>(enc);
             assertType<(err?: Error | null) => void>(cb);
-        }
+        },
+        writableObjectMode: false
     });
     assertType<boolean>(streamD.allowHalfOpen);
     assertType<boolean>(streamD.readable);
@@ -92,6 +93,14 @@ function test() {
     assertType<boolean>(streamD.readableObjectMode);
     assertType<boolean>(streamD.writableObjectMode);
     streamD.pipe(streamW);
+    const typedEncoding: BufferEncoding = "binary";
+    streamD.setEncoding(typedEncoding);
+
+    const testBufferEncoding = new RS_Duplex({
+        write(chunk: any, enc: BufferEncoding, cb: (err?: Error | null) => void) {
+            assertType<BufferEncoding>(enc);
+        }
+    });
 
     rs.addListener("read", (...args: any[]) => console.log(args));
     rs.emit("read", 1, 2, 3);


### PR DESCRIPTION
Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/DefinitelyTyped/DefinitelyTyped/issues/45371>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
