### PR TITLE
fix(knex-db-manager): Fix truncateDb parameter ignoreTables syntax

### DIFF
--- a/types/knex-db-manager/index.d.ts
+++ b/types/knex-db-manager/index.d.ts
@@ -15,7 +15,7 @@ export interface KnexDbManager {
     dbVersion(): Promise<string>;
     populateDb(glob?: string): Promise<void>;
     copyDb(fromDbName?: string, toDbName?: string): Promise<void>;
-    truncateDb(ignoreTables?: [string]): Promise<void>;
+    truncateDb(ignoreTables?: string[]): Promise<void>;
     knexInstance(): QueryBuilder;
 }
 


### PR DESCRIPTION
The parameter `ingoreTables` was incorrectly typed as:
```
truncateDb(ignoreTables?: [string])
```
when it should have been:
```
truncateDb(ignoreTables?: string[])
```

The URL to the appropriate documentation:

https://github.com/Vincit/knex-db-manager#truncatedbignoretables-string-promisevoid

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
