### PR TITLE
Adds initial type bindings for @nulogy/components

### DIFF
--- a/types/nulogy__components/index.d.ts
+++ b/types/nulogy__components/index.d.ts
@@ -1,0 +1,54 @@
+// Type definitions for @nulogy/components 2.16
+// Project: http://nulogy.design
+// Definitions by:  Evan Brodie <https://github.com/ecbrodie>
+//                  Marianne Borowiak <https://github.com/marboro92>
+//                  Matt Dunn <https://github.com/matthewlyle>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export { NDSProvider } from './src/NDSProvider';
+export { theme } from './src/theme';
+export { Box } from './src/Box';
+export { Flex } from './src/Flex';
+export { ButtonGroup } from './src/ButtonGroup';
+export { Link } from './src/Link';
+export { InlineValidation } from './src/Validation';
+export { Alert } from './src/Alert';
+export { Input } from './src/Input';
+export { NavBarSearch } from './src/NavBarSearch';
+export { NavBar } from './src/NavBar';
+export { Toggle } from './src/Toggle';
+export { Select } from './src/Select';
+export { Textarea } from './src/Textarea';
+export { Tooltip } from './src/Tooltip';
+export { Modal } from './src/Modal';
+export { Table } from './src/Table';
+export { StatusIndicator } from './src/StatusIndicator';
+export { Pagination } from './src/Pagination';
+export { DatePicker } from './src/DatePicker';
+export { DateRange } from './src/DateRange';
+export { MonthPicker } from './src/MonthPicker';
+export { MonthRange } from './src/MonthRange';
+export { TimePicker } from './src/TimePicker';
+export { TimeRange } from './src/TimeRange';
+export { RangeContainer } from './src/RangeContainer';
+export { Overlay } from './src/Overlay';
+export { LoadingAnimation } from './src/LoadingAnimation';
+export { Breadcrumbs } from './src/Breadcrumbs';
+export { ALL_NDS_LOCALES } from './src/locales.const';
+export { TruncatedText } from './src/TruncatedText';
+export { Toast } from './src/Toast';
+export { PMTable } from './src/PMTable';
+export { PMPagination } from './src/PMPagination';
+export { BrandedNavBar } from './src/BrandedNavBar';
+export { Icon, InlineIcon } from './src/Icon';
+export { Text, Title, SectionTitle, SubsectionTitle } from './src/Type';
+export { Button, PrimaryButton, DangerButton, QuietButton, IconicButton, ControlIcon } from './src/Button';
+export { Branding, BrandingText } from './src/Branding';
+export { DropdownMenu, DropdownLink, DropdownButton, DropdownItem } from './src/DropdownMenu';
+export { HelpText, RequirementText, FieldLabel, MaybeFieldLabel } from './src/FieldLabel';
+export { Checkbox, CheckboxGroup } from './src/Checkbox';
+export { Radio, RadioGroup } from './src/Radio';
+export { Field, Fieldset, Form, FormSection } from './src/Form';
+export { ListItem, List } from './src/List';
+export { Card, CardSet } from './src/Card';
+export { Tab, Tabs } from './src/Tabs';

--- a/types/nulogy__components/nulogy__components-tests.tsx
+++ b/types/nulogy__components/nulogy__components-tests.tsx
@@ -1,0 +1,6 @@
+import * as React from "react";
+import { Link } from "@nulogy/components";
+
+const LinkTest = () => <Link />;
+
+// TODO: Implement me...

--- a/types/nulogy__components/src/Alert.d.ts
+++ b/types/nulogy__components/src/Alert.d.ts
@@ -1,0 +1,1 @@
+export const Alert: any;

--- a/types/nulogy__components/src/Box.d.ts
+++ b/types/nulogy__components/src/Box.d.ts
@@ -1,0 +1,1 @@
+export const Box: any;

--- a/types/nulogy__components/src/BrandedNavBar.d.ts
+++ b/types/nulogy__components/src/BrandedNavBar.d.ts
@@ -1,0 +1,1 @@
+export const BrandedNavBar: any;

--- a/types/nulogy__components/src/Branding.d.ts
+++ b/types/nulogy__components/src/Branding.d.ts
@@ -1,0 +1,2 @@
+export const Branding: any;
+export const BrandingText: any;

--- a/types/nulogy__components/src/Breadcrumbs.d.ts
+++ b/types/nulogy__components/src/Breadcrumbs.d.ts
@@ -1,0 +1,1 @@
+export const Breadcrumbs: any;

--- a/types/nulogy__components/src/Button.d.ts
+++ b/types/nulogy__components/src/Button.d.ts
@@ -1,0 +1,6 @@
+export const Button: any;
+export const PrimaryButton: any;
+export const DangerButton: any;
+export const QuietButton: any;
+export const IconicButton: any;
+export const ControlIcon: any;

--- a/types/nulogy__components/src/ButtonGroup.d.ts
+++ b/types/nulogy__components/src/ButtonGroup.d.ts
@@ -1,0 +1,1 @@
+export const ButtonGroup: any;

--- a/types/nulogy__components/src/Card.d.ts
+++ b/types/nulogy__components/src/Card.d.ts
@@ -1,0 +1,2 @@
+export const Card: any;
+export const CardSet: any;

--- a/types/nulogy__components/src/Checkbox.d.ts
+++ b/types/nulogy__components/src/Checkbox.d.ts
@@ -1,0 +1,2 @@
+export const Checkbox: any;
+export const CheckboxGroup: any;

--- a/types/nulogy__components/src/DatePicker.d.ts
+++ b/types/nulogy__components/src/DatePicker.d.ts
@@ -1,0 +1,1 @@
+export const DatePicker: any;

--- a/types/nulogy__components/src/DateRange.d.ts
+++ b/types/nulogy__components/src/DateRange.d.ts
@@ -1,0 +1,1 @@
+export const DateRange: any;

--- a/types/nulogy__components/src/DropdownMenu.d.ts
+++ b/types/nulogy__components/src/DropdownMenu.d.ts
@@ -1,0 +1,4 @@
+export const DropdownMenu: any;
+export const DropdownLink: any;
+export const DropdownButton: any;
+export const DropdownItem: any;

--- a/types/nulogy__components/src/FieldLabel.d.ts
+++ b/types/nulogy__components/src/FieldLabel.d.ts
@@ -1,0 +1,4 @@
+export const HelpText: any;
+export const RequirementText: any;
+export const FieldLabel: any;
+export const MaybeFieldLabel: any;

--- a/types/nulogy__components/src/Flex.d.ts
+++ b/types/nulogy__components/src/Flex.d.ts
@@ -1,0 +1,1 @@
+export const Flex: any;

--- a/types/nulogy__components/src/Form.d.ts
+++ b/types/nulogy__components/src/Form.d.ts
@@ -1,0 +1,4 @@
+export const Field: any;
+export const Fieldset: any;
+export const Form: any;
+export const FormSection: any;

--- a/types/nulogy__components/src/Icon.d.ts
+++ b/types/nulogy__components/src/Icon.d.ts
@@ -1,0 +1,2 @@
+export const Icon: any;
+export const InlineIcon: any;

--- a/types/nulogy__components/src/Input.d.ts
+++ b/types/nulogy__components/src/Input.d.ts
@@ -1,0 +1,1 @@
+export const Input: any;

--- a/types/nulogy__components/src/Link.d.ts
+++ b/types/nulogy__components/src/Link.d.ts
@@ -1,0 +1,3 @@
+import { ComponentType } from "react";
+
+export const Link: ComponentType;

--- a/types/nulogy__components/src/List.d.ts
+++ b/types/nulogy__components/src/List.d.ts
@@ -1,0 +1,2 @@
+export const ListItem: any;
+export const List: any;

--- a/types/nulogy__components/src/LoadingAnimation.d.ts
+++ b/types/nulogy__components/src/LoadingAnimation.d.ts
@@ -1,0 +1,1 @@
+export const LoadingAnimation: any;

--- a/types/nulogy__components/src/Modal.d.ts
+++ b/types/nulogy__components/src/Modal.d.ts
@@ -1,0 +1,1 @@
+export const Modal: any;

--- a/types/nulogy__components/src/MonthPicker.d.ts
+++ b/types/nulogy__components/src/MonthPicker.d.ts
@@ -1,0 +1,1 @@
+export const MonthPicker: any;

--- a/types/nulogy__components/src/MonthRange.d.ts
+++ b/types/nulogy__components/src/MonthRange.d.ts
@@ -1,0 +1,1 @@
+export const MonthRange: any;

--- a/types/nulogy__components/src/NDSProvider.d.ts
+++ b/types/nulogy__components/src/NDSProvider.d.ts
@@ -1,0 +1,1 @@
+export const NDSProvider: any;

--- a/types/nulogy__components/src/NavBar.d.ts
+++ b/types/nulogy__components/src/NavBar.d.ts
@@ -1,0 +1,1 @@
+export const NavBar: any;

--- a/types/nulogy__components/src/NavBarSearch.d.ts
+++ b/types/nulogy__components/src/NavBarSearch.d.ts
@@ -1,0 +1,1 @@
+export const NavBarSearch: any;

--- a/types/nulogy__components/src/Overlay.d.ts
+++ b/types/nulogy__components/src/Overlay.d.ts
@@ -1,0 +1,1 @@
+export const Overlay: any;

--- a/types/nulogy__components/src/PMPagination.d.ts
+++ b/types/nulogy__components/src/PMPagination.d.ts
@@ -1,0 +1,1 @@
+export const PMPagination: any;

--- a/types/nulogy__components/src/PMTable.d.ts
+++ b/types/nulogy__components/src/PMTable.d.ts
@@ -1,0 +1,1 @@
+export const PMTable: any;

--- a/types/nulogy__components/src/Pagination.d.ts
+++ b/types/nulogy__components/src/Pagination.d.ts
@@ -1,0 +1,1 @@
+export const Pagination: any;

--- a/types/nulogy__components/src/Radio.d.ts
+++ b/types/nulogy__components/src/Radio.d.ts
@@ -1,0 +1,2 @@
+export const Radio: any;
+export const RadioGroup: any;

--- a/types/nulogy__components/src/RangeContainer.d.ts
+++ b/types/nulogy__components/src/RangeContainer.d.ts
@@ -1,0 +1,1 @@
+export const RangeContainer: any;

--- a/types/nulogy__components/src/Select.d.ts
+++ b/types/nulogy__components/src/Select.d.ts
@@ -1,0 +1,1 @@
+export const Select: any;

--- a/types/nulogy__components/src/StatusIndicator.d.ts
+++ b/types/nulogy__components/src/StatusIndicator.d.ts
@@ -1,0 +1,1 @@
+export const StatusIndicator: any;

--- a/types/nulogy__components/src/Table.d.ts
+++ b/types/nulogy__components/src/Table.d.ts
@@ -1,0 +1,1 @@
+export const Table: any;

--- a/types/nulogy__components/src/Tabs.d.ts
+++ b/types/nulogy__components/src/Tabs.d.ts
@@ -1,0 +1,2 @@
+export const Tab: any;
+export const Tabs: any;

--- a/types/nulogy__components/src/Textarea.d.ts
+++ b/types/nulogy__components/src/Textarea.d.ts
@@ -1,0 +1,1 @@
+export const Textarea: any;

--- a/types/nulogy__components/src/TimePicker.d.ts
+++ b/types/nulogy__components/src/TimePicker.d.ts
@@ -1,0 +1,1 @@
+export const TimePicker: any;

--- a/types/nulogy__components/src/TimeRange.d.ts
+++ b/types/nulogy__components/src/TimeRange.d.ts
@@ -1,0 +1,1 @@
+export const TimeRange: any;

--- a/types/nulogy__components/src/Toast.d.ts
+++ b/types/nulogy__components/src/Toast.d.ts
@@ -1,0 +1,1 @@
+export const Toast: any;

--- a/types/nulogy__components/src/Toggle.d.ts
+++ b/types/nulogy__components/src/Toggle.d.ts
@@ -1,0 +1,1 @@
+export const Toggle: any;

--- a/types/nulogy__components/src/Tooltip.d.ts
+++ b/types/nulogy__components/src/Tooltip.d.ts
@@ -1,0 +1,1 @@
+export const Tooltip: any;

--- a/types/nulogy__components/src/TruncatedText.d.ts
+++ b/types/nulogy__components/src/TruncatedText.d.ts
@@ -1,0 +1,1 @@
+export const TruncatedText: any;

--- a/types/nulogy__components/src/Type.d.ts
+++ b/types/nulogy__components/src/Type.d.ts
@@ -1,0 +1,4 @@
+export const Text: any;
+export const Title: any;
+export const SectionTitle: any;
+export const SubsectionTitle: any;

--- a/types/nulogy__components/src/Validation.d.ts
+++ b/types/nulogy__components/src/Validation.d.ts
@@ -1,0 +1,1 @@
+export const InlineValidation: any;

--- a/types/nulogy__components/src/locales.const.d.ts
+++ b/types/nulogy__components/src/locales.const.d.ts
@@ -1,0 +1,1 @@
+export const ALL_NDS_LOCALES: ReadonlyArray<object>;

--- a/types/nulogy__components/src/theme.d.ts
+++ b/types/nulogy__components/src/theme.d.ts
@@ -1,0 +1,1 @@
+export const theme: any;

--- a/types/nulogy__components/tsconfig.json
+++ b/types/nulogy__components/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "strict": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "jsx": "react",
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@nulogy/components": [
+                "nulogy__components"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "nulogy__components-tests.tsx"
+    ]
+}

--- a/types/nulogy__components/tslint.json
+++ b/types/nulogy__components/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
### Description

This adds initial type bindings to the project `@nulogy/components`. It is a vanilla JS React library. For now, I just set (almost) everything to the `any` type, just so that auto-imports can be supported in TypeScript. The plan is to work with others in my organization to gradually port type bindings to this project. Doing it all in one-shot would have been a very long and painful process.

### Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
