### PR TITLE
Fix nullable return type of RDF/JS Stream

### DIFF
--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -96,7 +96,7 @@ function test_doc_rdf_stream_to_triples_1() {
     parser.parse('abc', console.log);
 
     const streamParser: N3.N3StreamParser = new N3.StreamParser();
-    const quad: RDF.Quad = streamParser.read();
+    const quad: RDF.Quad | null = streamParser.read();
     const rdfStream = fs.createReadStream('cartoons.ttl');
     const pipedStreamParser: N3.N3StreamParser = rdfStream.pipe(streamParser);
     streamParser.pipe(new class SlowConsumer extends stream.Writable {

--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -317,7 +317,7 @@ export interface Stream<Q extends BaseQuad = Quad> extends EventEmitter {
      *
      * @return A quad from the internal buffer, or null if none is available.
      */
-    read(): Q;
+    read(): Q | null;
 }
 
 /**

--- a/types/rdf-js/rdf-js-tests.ts
+++ b/types/rdf-js/rdf-js-tests.ts
@@ -94,7 +94,7 @@ function test_datafactory() {
 
 function test_stream() {
     const stream: Stream = <any> {};
-    const quad: Quad = stream.read();
+    const quad: Quad | null = stream.read();
 
     const term: Term = <any> {};
     const source: Source = <any> {};


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

As can be seen in the jsdoc, the return type should include `null`. This is problematic when tsc runs in strict mode.