### PR TITLE
[@types/express-fileupload] Fix: type 'UploadedFile | UploadedFile[], property that doesn't exist

### DIFF
--- a/types/express-fileupload/express-fileupload-tests.ts
+++ b/types/express-fileupload/express-fileupload-tests.ts
@@ -13,6 +13,7 @@ function isUploadedFile(file: UploadedFile | UploadedFile[]): file is UploadedFi
 const uploadHandler: RequestHandler = (req: Request, res: Response, next: NextFunction) => {
     if (typeof req.files === 'object') {
         const fileField = req.files.field;
+        console.log(fileField.mimetype); 
         if (isUploadedFile(fileField)) {
             console.log(fileField.name);
             fileField.mv('/tmp/test', err => {

--- a/types/express-fileupload/express-fileupload-tests.ts
+++ b/types/express-fileupload/express-fileupload-tests.ts
@@ -13,7 +13,7 @@ function isUploadedFile(file: UploadedFile | UploadedFile[]): file is UploadedFi
 const uploadHandler: RequestHandler = (req: Request, res: Response, next: NextFunction) => {
     if (typeof req.files === 'object') {
         const fileField = req.files.field;
-        console.log(fileField.mimetype); 
+        console.log(fileField.mimetype);
         if (isUploadedFile(fileField)) {
             console.log(fileField.name);
             fileField.mv('/tmp/test', err => {

--- a/types/express-fileupload/index.d.ts
+++ b/types/express-fileupload/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for express-fileupload 1.1
+// Type definitions for express-fileupload 1.1.6
 // Project: https://github.com/richardgirges/express-fileupload#readme
 // Definitions by: Gintautas Miselis <https://github.com/Naktibalda>
 //                 Sefa Ilkimen <https://github.com/silkimen>
@@ -11,7 +11,7 @@ import express = require('express');
 declare global {
     namespace Express {
         interface Request {
-            files?: fileUpload.FileArray;
+            files?: fileUpload.FileObject;
         }
     }
 }
@@ -19,8 +19,8 @@ declare global {
 declare function fileUpload(options?: fileUpload.Options): express.RequestHandler;
 
 declare namespace fileUpload {
-    class FileArray {
-        [index: string]: UploadedFile | UploadedFile[];
+    interface FileObject {
+        [key: string]: UploadedFile;
     }
 
     interface UploadedFile {

--- a/types/express-fileupload/index.d.ts
+++ b/types/express-fileupload/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for express-fileupload 1.1.6
+// Type definitions for express-fileupload 1.1
 // Project: https://github.com/richardgirges/express-fileupload#readme
 // Definitions by: Gintautas Miselis <https://github.com/Naktibalda>
 //                 Sefa Ilkimen <https://github.com/silkimen>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/richardgirges/express-fileupload](https://github.com/richardgirges/express-fileupload)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

That PR, fix that issue #38334. 