### PR TITLE
fix: mysql raw function return type

### DIFF
--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -81,7 +81,7 @@ export function createPoolCluster(config?: PoolClusterConfig): PoolCluster;
  * format().
  * @param sql
  */
-export function raw(sql: string): () => string;
+export function raw(sql: string): { toSqlString: () => string };
 
 export interface Connection extends EscapeFunctions {
     config: ConnectionConfig;

--- a/types/mysql/mysql-tests.ts
+++ b/types/mysql/mysql-tests.ts
@@ -438,3 +438,5 @@ connection = mysql.createConnection({dateStrings: ['DATE']});
 connection = mysql.createConnection({dateStrings: true});
 connection = mysql.createConnection({flags: '-FOUND_ROWS'});
 connection = mysql.createConnection({flags: ['-FOUND_ROWS']});
+
+const mysqlRawResult = mysql.raw('SELECT * FROM tableName'); // $ExpectType { toSqlString: () => string; }


### PR DESCRIPTION
Fixing mysql.raw() function return type. The return type should be an object with a toSqlString property that has a value of a function returning a string, which matches what is in the mysql package and the SqlString package that the mysql function is using.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Please see mysql package https://github.com/mysqljs/mysql/blob/master/index.js#L103 and the SqlString package which it references https://github.com/mysqljs/sqlstring/blob/master/lib/SqlString.js#L192
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
