### PR TITLE
Fixed missing `visible` property in updateProperties

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -1194,6 +1194,7 @@ declare namespace chrome.contextMenus {
         /** Optional. Note: You cannot change an item to be a child of one of its own descendants.  */
         parentId?: any;
         type?: string;
+        visible?: boolean;
     }
 
     export interface MenuClickedEvent extends chrome.events.Event<(info: OnClickData, tab?: chrome.tabs.Tab) => void> { }

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -1194,6 +1194,11 @@ declare namespace chrome.contextMenus {
         /** Optional. Note: You cannot change an item to be a child of one of its own descendants.  */
         parentId?: any;
         type?: string;
+        /**
+         * Optional.
+         * @since Chrome 62.
+         * Whether the item is visible in the menu.
+         */
         visible?: boolean;
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://developer.chrome.com/extensions/contextMenus#method-update](https://developer.chrome.com/extensions/contextMenus#method-update)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.