### PR TITLE
[cytoscape] add missing style properties, fix ClassNames

### DIFF
--- a/types/cytoscape/cytoscape-tests.ts
+++ b/types/cytoscape/cytoscape-tests.ts
@@ -37,7 +37,10 @@ const showAllStyle: cytoscape.Stylesheet[] = [
       shape: 'rectangle',
       'min-zoomed-font-size': 20,
       opacity: 1,
-      width: 'mapData(weight, 40, 80, 20, 60)'
+      width: 'mapData(weight, 40, 80, 20, 60)',
+      'transition-property': "opacity",
+      'transition-duration': 500,
+      'transition-delay': 500
     }
   },
   {
@@ -499,6 +502,7 @@ eles.unselectify();
 eles.addClass('test');
 eles.toggleClass('test', oneOf(true, false, undefined));
 eles.removeClass('test');
+eles.classes(['lesstext']);
 eles.classes(oneOf('test', undefined));
 eles.flashClass('test flash', oneOf(1000, undefined));
 assert(ele.hasClass('test'));

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -1952,8 +1952,8 @@ declare namespace cytoscape {
      * http://js.cytoscape.org/#collection/style
      */
     type ClassName = string;
-    /** A space-separated list of class names */
-    type ClassNames = string;
+    /** A space-separated list of class names or an array */
+    type ClassNames = string | ClassName[];
 
     interface CollectionStyle {
         /**
@@ -3560,7 +3560,8 @@ declare namespace cytoscape {
          * http://js.cytoscape.org/#style/node-body
          */
         interface Node extends Partial<Overlay>, PaddingNode, Partial<Labels<NodeSingular>>, BackgroundImage,
-            Partial<Ghost>, Partial<Visibility<NodeSingular>>, Partial<PieChartBackground>, Partial<Events<NodeSingular>> {
+            Partial<Ghost>, Partial<Visibility<NodeSingular>>, Partial<PieChartBackground>, Partial<Events<NodeSingular>>,
+            Partial<TransitionAnimation> {
             /**
              * The CSS content field
              */
@@ -3758,7 +3759,8 @@ declare namespace cytoscape {
 
         interface Edge extends EdgeLine, EdgeArrow, Partial<Gradient>, Partial<Overlay>, Partial<BezierEdges>,
             Partial<UnbundledBezierEdges>, Partial<HaystackEdges>, Partial<SegmentsEdges>, Partial<Visibility<EdgeSingular>>,
-            Partial<Labels<EdgeSingular>>, Partial<Events<EdgeSingular>>, Partial<EdgeEndpoints<EdgeSingular>> { }
+            Partial<Labels<EdgeSingular>>, Partial<Events<EdgeSingular>>, Partial<EdgeEndpoints<EdgeSingular>>,
+            Partial<TransitionAnimation> { }
 
         /**
          * These properties affect the styling of an edge’s line:


### PR DESCRIPTION
https://js.cytoscape.org/#style/transition-animation
`TransitionAnimation` was defined, but wasn't actually used as part of the node/edge css properties.

https://js.cytoscape.org/#eles.classes
Types only allowed the space-separated string variant, but docs specify all the methods can take that or an array of class names
