### PR TITLE
fix(mongoose): allow specifying objectids as strings in create

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -101,7 +101,7 @@ declare module "mongoose" {
 
   type OmitReadonly<T> = Omit<T, ReadonlyKeysOf<T>>;
 
-  type MongooseBuiltIns = mongodb.ObjectID | mongodb.Decimal128 | Date | string | number | boolean;
+  type MongooseBuiltIns = mongodb.ObjectID | mongodb.Decimal128 | Date | number | boolean;
 
   type ImplicitMongooseConversions<T> = 
     T extends MongooseBuiltIns 
@@ -111,6 +111,10 @@ declare module "mongoose" {
 
   // used to exclude functions from all levels of the schema
   type DeepNonFunctionProperties<T> =
+    // bypass builtins
+    T extends MongooseBuiltIns 
+      ? T 
+      : 
     T extends Map<infer KM, infer KV> 
       // handle map values
       // Maps are not scrubbed, replace below line with this once minimum TS version is 3.7:

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -105,35 +105,32 @@ declare module "mongoose" {
 
   type ImplicitMongooseConversions<T> = 
     T extends MongooseBuiltIns 
-      ? T extends (boolean | mongodb.Decimal128) ? T | string | number
+      ? T extends (boolean | mongodb.Decimal128 | Date) ? T | string | number // accept numbers for these
       : T | string 
     : T;
 
-  // used to exclude functions from all levels of the schema
-  type DeepNonFunctionProperties<T> =
-    // bypass builtins
-    T extends MongooseBuiltIns 
-      ? T 
-      : 
+  type DeepCreateObjectTransformer<T> =
+    T extends MongooseBuiltIns
+      ? T
+      : T extends object
+        ? { [V in keyof NonFunctionProperties<OmitReadonly<T>>]: T[V] extends object | undefined
+          ? ImplicitMongooseConversions<DeepCreateTransformer<NonNullable<T[V]>>>
+          : ImplicitMongooseConversions<T[V]> }
+        :
+      T;
+
+  // removes functions from schema from all levels
+  type DeepCreateTransformer<T> =
     T extends Map<infer KM, infer KV> 
       // handle map values
       // Maps are not scrubbed, replace below line with this once minimum TS version is 3.7:
       // ? Map<KM, DeepNonFunctionProperties<KV>>
-      ? { [key: string]: DeepNonFunctionProperties<KV> } | [KM, KV][] | Map<KM, KV>
+      ? { [key: string]: DeepCreateTransformer<KV> } | [KM, KV][] | Map<KM, KV>
       : 
     T extends Array<infer U>
-      ? (U extends object 
-        ? { [V in keyof NonFunctionProperties<OmitReadonly<U>>]: U[V] extends object | undefined
-          ? DeepNonFunctionProperties<NonNullable<ImplicitMongooseConversions<U[V]>>> 
-          : ImplicitMongooseConversions<U[V]> }
-        : ImplicitMongooseConversions<U>)[]
+      ? Array<DeepCreateObjectTransformer<U>>
       : 
-    T extends object
-      ? { [V in keyof NonFunctionProperties<OmitReadonly<T>>]: T[V] extends object | undefined
-        ? DeepNonFunctionProperties<NonNullable<ImplicitMongooseConversions<T[V]>>> 
-        : ImplicitMongooseConversions<T[V]> }
-      :
-    ImplicitMongooseConversions<T>;
+    DeepCreateObjectTransformer<T>;
 
   // mongoose allows Map<K, V> to be specified either as a Map or a Record<K, V>
   type DeepMapAsObject<T> = T extends object | undefined
@@ -152,7 +149,7 @@ declare module "mongoose" {
   /* Helper type to extract a definition type from a Document type */
   type DocumentDefinition<T> = Omit<T, Exclude<keyof Document, '_id'>>;
 
-  type ScrubCreateDefinition<T> = DeepMapAsObject<DeepNonFunctionProperties<T>>
+  type ScrubCreateDefinition<T> = DeepMapAsObject<DeepCreateTransformer<T>>
 
   type CreateDocumentDefinition<T> = ScrubCreateDefinition<DocumentDefinition<T>>;
 

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -111,7 +111,6 @@ declare module "mongoose" {
 
   // used to exclude functions from all levels of the schema
   type DeepNonFunctionProperties<T> =
-    T extends MongooseBuiltIns ? T :
     T extends Map<infer KM, infer KV> 
       // handle map values
       // Maps are not scrubbed, replace below line with this once minimum TS version is 3.7:
@@ -121,7 +120,7 @@ declare module "mongoose" {
     T extends Array<infer U>
       ? (U extends object 
         ? { [V in keyof NonFunctionProperties<OmitReadonly<U>>]: U[V] extends object | undefined
-          ? DeepNonFunctionProperties<NonNullable<U[V]>> 
+          ? DeepNonFunctionProperties<NonNullable<ImplicitMongooseConversions<U[V]>>> 
           : ImplicitMongooseConversions<U[V]> }
         : ImplicitMongooseConversions<U>)[]
       : 

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -101,15 +101,17 @@ declare module "mongoose" {
 
   type OmitReadonly<T> = Omit<T, ReadonlyKeysOf<T>>;
 
-  type ImplicitMongooseConversions<T> = 
-    T extends (mongodb.ObjectID | Date) 
-      ? T | string 
-      : T;
+  type MongooseBuiltIns = mongodb.ObjectID | mongodb.Decimal128 | Date | string | number | boolean;
 
-  type BuiltIns = mongodb.ObjectID | Date | string | number;
+  type ImplicitMongooseConversions<T> = 
+    T extends MongooseBuiltIns 
+      ? T extends boolean ? T | string | number
+      : T | string 
+    : T;
+
   // used to exclude functions from all levels of the schema
   type DeepNonFunctionProperties<T> =
-    T extends BuiltIns ? T :
+    T extends MongooseBuiltIns ? T :
     T extends Map<infer KM, infer KV> 
       // handle map values
       // Maps are not scrubbed, replace below line with this once minimum TS version is 3.7:

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -105,7 +105,7 @@ declare module "mongoose" {
 
   type ImplicitMongooseConversions<T> = 
     T extends MongooseBuiltIns 
-      ? T extends boolean ? T | string | number
+      ? T extends (boolean | mongodb.Decimal128) ? T | string | number
       : T | string 
     : T;
 

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -668,6 +668,7 @@ interface ModelWithFunction extends mongoose.Document {
             title: string, 
             func: () => {}, // should be excluded in CreateQuery<T>
             tuple?: [number, number]
+            objectId?: mongoose.Types.ObjectId;
 
             mapWithFuncs?: Map<string, { 
                 title: string, 
@@ -676,6 +677,7 @@ interface ModelWithFunction extends mongoose.Document {
                     title: string, 
                     func: () => {} // should be excluded in CreateQuery<T>
                     readonly readonly: unknown; // should be excluded in CreateQuery<T>
+                    objectId?: mongoose.Types.ObjectId;
                 }> 
             }>;
         }>
@@ -717,13 +719,15 @@ ModelWithFunctionInSchema.create({
         deepArray: [{ 
             title: "test", 
             tuple: [1, 2], 
+            objectId: "valid-object-id-source",
             mapWithFuncs: { 
                 test: { 
                     title: "test", 
                     innerMap: { 
                         test: { 
-                            title: "hello" 
-                        }
+                            title: "hello",
+                            objectId: "valid-object-id-source"
+                        },
                     }
                 }
             } 

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -793,4 +793,5 @@ ModelWithFunctionInSchema.create({ name: "test", jobs: [], date: "2020-01-01" })
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], boolean: "true" });
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], boolean: 1 });
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], decimal: "1" });
+ModelWithFunctionInSchema.create({ name: "test", jobs: [], decimal: 1 });
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], number: "1" });

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -617,6 +617,10 @@ interface ModelWithFunction extends mongoose.Document {
 
     someFunc: () => any;
 
+    objectId?: mongoose.Types.ObjectId;
+
+    date?: Date;
+
     enum?: SchemaEnum;
 
     selfRef?: ModelWithFunction | mongodb.ObjectID;
@@ -762,3 +766,19 @@ ModelWithFunctionInSchema.create({ name: "test", jobs: [] }).then(ref => {
     ModelWithFunctionInSchema.create({ name: "test", jobs: [], selfRefArray2: [id, id] });
     ModelWithFunctionInSchema.create({ name: "test", jobs: [], selfRefArray2: [ref, ref] });
 });
+
+ModelWithFunctionInSchema.create({ name: "test", jobs: [], objectId: "valid-object-id-source" });
+ModelWithFunctionInSchema.create({ 
+    name: "test", 
+    jobs: [], 
+    //$ExpectType: mongoose.Types.ObjectId | string | undefined
+    objectId: new mongodb.ObjectID("valid-object-id-source") 
+});
+
+ModelWithFunctionInSchema.create({ 
+    name: "test", 
+    jobs: [], 
+    //$ExpectType: Date | string | undefined
+    date: new Date() 
+});
+ModelWithFunctionInSchema.create({ name: "test", jobs: [], date: "2020-01-01" });

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -612,6 +612,11 @@ enum SchemaEnum {
     Bar
 }
 
+enum StringSchemaEnum {
+    Foo = "foo",
+    Bar = "bar"
+}
+
 interface ModelWithFunction extends mongoose.Document {
     name: string;
 
@@ -628,6 +633,9 @@ interface ModelWithFunction extends mongoose.Document {
     number?: number;
 
     enum?: SchemaEnum;
+
+    enum2?: StringSchemaEnum;
+
 
     selfRef?: ModelWithFunction | mongodb.ObjectID;
 
@@ -777,14 +785,12 @@ ModelWithFunctionInSchema.create({ name: "test", jobs: [], objectId: "valid-obje
 ModelWithFunctionInSchema.create({ 
     name: "test", 
     jobs: [], 
-    //$ExpectType: mongoose.Types.ObjectId | string | undefined
     objectId: new mongodb.ObjectID("valid-object-id-source") 
 });
 
 ModelWithFunctionInSchema.create({ 
     name: "test", 
     jobs: [], 
-    //$ExpectType: Date | string | undefined
     date: new Date() 
 });
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], date: "2020-01-01" });
@@ -795,3 +801,12 @@ ModelWithFunctionInSchema.create({ name: "test", jobs: [], boolean: 1 });
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], decimal: "1" });
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], decimal: 1 });
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], number: "1" });
+
+// $ExpectError
+ModelWithFunctionInSchema.create({ name: "test", jobs: [], enum2: "bad value" });
+
+// $ExpectError
+ModelWithFunctionInSchema.create({ name: "test", jobs: [], date: [123] });
+
+// $ExpectError
+ModelWithFunctionInSchema.create({ name: "test", jobs: [], objectId: [123] });

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -621,6 +621,12 @@ interface ModelWithFunction extends mongoose.Document {
 
     date?: Date;
 
+    boolean?: boolean;
+
+    decimal?: mongodb.Decimal128;
+
+    number?: number;
+
     enum?: SchemaEnum;
 
     selfRef?: ModelWithFunction | mongodb.ObjectID;
@@ -782,3 +788,9 @@ ModelWithFunctionInSchema.create({
     date: new Date() 
 });
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], date: "2020-01-01" });
+
+// allow strings, since mongoose can cast them
+ModelWithFunctionInSchema.create({ name: "test", jobs: [], boolean: "true" });
+ModelWithFunctionInSchema.create({ name: "test", jobs: [], boolean: 1 });
+ModelWithFunctionInSchema.create({ name: "test", jobs: [], decimal: "1" });
+ModelWithFunctionInSchema.create({ name: "test", jobs: [], number: "1" });


### PR DESCRIPTION
Fixes #45609

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
