### PR TITLE
video.js: make log level parameter optional

### DIFF
--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -3093,7 +3093,7 @@ declare namespace videojs {
          *
          * @return The current logging level.
          */
-        level(lvl: string): string;
+        level(lvl?: string): string;
 
         /**
          * Enumeration of available logging levels, where the keys are the level names

--- a/types/video.js/video.js-tests.ts
+++ b/types/video.js/video.js-tests.ts
@@ -182,4 +182,7 @@ function testLogger() {
     videojs.log('hello');
     mylogger('how are you');
     anotherlogger('today');
+
+    const currentLevel = videojs.log.level();
+    videojs.log.level(videojs.log.levels.DEFAULT);
 }


### PR DESCRIPTION
The function `videojs.log.level` can be called without an argument to use it as a getter, but the current definition doesn't allow for it.

Documentation: https://docs.videojs.com/tutorial-debugging.html#log-levels

> Levels are exposed through the videojs.log.level method. This method acts as
> both a getter and setter for the current logging level. With no arguments, it
> returns the current logging level

Implementation: https://github.com/videojs/video.js/blob/2e6199074dc77259f45943e5f7bce4d65f70931d/src/js/utils/create-logger.js#L160-L168

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.videojs.com/tutorial-debugging.html#log-levels
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.