### PR TITLE
@types/assert: Update definitions to version 1.5

### DIFF
--- a/types/assert/assert-tests.ts
+++ b/types/assert/assert-tests.ts
@@ -13,3 +13,5 @@ assert.throws(
 );
 
 assert['fail'](true, true, 'works like a charm');
+
+assert.strict; // $ExpectType typeof assert

--- a/types/assert/index.d.ts
+++ b/types/assert/index.d.ts
@@ -54,6 +54,8 @@ declare namespace assert {
             stackStartFunction?: () => void;
         });
     }
+
+    const strict: typeof assert;
 }
 
 export = assert;

--- a/types/assert/index.d.ts
+++ b/types/assert/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for commonjs-assert 1.4
+// Type definitions for commonjs-assert 1.5
 // Project: https://github.com/browserify/commonjs-assert, https://github.com/defunctzombie/commonjs-assert
 // Definitions by: Nico Gallinal <https://github.com/nicoabie>
 //                 Linus Unnebäck <https://github.com/LinusU>
@@ -21,6 +21,8 @@ declare namespace assert {
     function notDeepEqual(actual: any, expected: any, message?: string): void;
 
     function deepStrictEqual(actual: any, expected: any, message?: string): void;
+
+    function notDeepStrictEqual(actual: any, expected: any, message?: string): void;
 
     function strictEqual(actual: any, expected: any, message?: string): void;
 

--- a/types/assert/ts3.7/assert-tests.ts
+++ b/types/assert/ts3.7/assert-tests.ts
@@ -57,3 +57,5 @@ assert['fail'](true, true, 'works like a charm');
     assert.deepStrictEqual(a, { b: 2 });
     a; // $ExpectType { b: number; }
 }
+
+assert.strict; // $ExpectType typeof assert

--- a/types/assert/ts3.7/index.d.ts
+++ b/types/assert/ts3.7/index.d.ts
@@ -53,6 +53,8 @@ declare namespace assert {
             stackStartFunction?: () => void;
         });
     }
+
+    const strict: typeof assert;
 }
 
 export = assert;


### PR DESCRIPTION
Add strict object that was added in version 1.5 and missing notDeepStrictEqual function 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/browserify/commonjs-assert/pull/41
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

