### PR TITLE
Add live-server type declarations

### DIFF
--- a/types/live-server/index.d.ts
+++ b/types/live-server/index.d.ts
@@ -33,3 +33,8 @@ export interface LiveServerParams {
  * Start live-server.
  */
 export function start(params: LiveServerParams): void;
+
+/**
+ * Shutdown live-server.
+ */
+export function shutdown(): void;

--- a/types/live-server/index.d.ts
+++ b/types/live-server/index.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for live-server 1.2
+// Project: https://github.com/tapio/live-server#readme
+// Definitions by: Josh Cummings <https://github.com/joshcummingsdesign>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * The live-server start params.
+ */
+export interface LiveServerParams {
+    /** Set the server port. Defaults to 8080. */
+    port?: number;
+    /**  Set the address to bind to. Defaults to 0.0.0.0 or process.env.IP. */
+    host?: string;
+    /** Set root directory that's being served. Defaults to cwd. */
+    root?: string;
+    /** When false, it won't load your browser by default. */
+    open?: boolean;
+    /** Comma-separated string for paths to ignore. */
+    ignore?: string;
+    /** When set, serve this file (server root relative) for every 404 (useful for single-page applications). */
+    file?: string;
+    /** Waits for all changes, before reloading. Defaults to 0 sec. */
+    wait?: number;
+    /** Mount a directory to a route. */
+    mount?: string[][];
+    /** 0 = errors only, 1 = some, 2 = lots */
+    logLevel?: 0 | 1 | 2;
+    /** Takes an array of Connect-compatible middleware that are injected into the server middleware stack. */
+    middleware?: Array<(req: any, res: any, next: any) => void>;
+}
+
+/**
+ * Start live-server.
+ */
+export function start(params: LiveServerParams): void;

--- a/types/live-server/live-server-tests.ts
+++ b/types/live-server/live-server-tests.ts
@@ -16,3 +16,5 @@ liveServer.start({
         },
     ],
 });
+
+liveServer.shutdown();

--- a/types/live-server/live-server-tests.ts
+++ b/types/live-server/live-server-tests.ts
@@ -1,0 +1,18 @@
+import liveServer = require('live-server');
+
+liveServer.start({
+    port: 8181,
+    host: '0.0.0.0',
+    root: '/public',
+    open: false,
+    ignore: 'scss,my/templates',
+    file: 'index.html',
+    wait: 1000,
+    mount: [['/components', './node_modules']],
+    logLevel: 2,
+    middleware: [
+        (req: any, res: any, next: any) => {
+            next();
+        },
+    ],
+});

--- a/types/live-server/tsconfig.json
+++ b/types/live-server/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "live-server-tests.ts"
+    ]
+}

--- a/types/live-server/tslint.json
+++ b/types/live-server/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR adds the type declarations for the [live-server](https://github.com/tapio/live-server) node module.