### PR TITLE
@types/weighted: exported default and corrected definitions

### DIFF
--- a/types/weighted/index.d.ts
+++ b/types/weighted/index.d.ts
@@ -1,13 +1,16 @@
 // Type definitions for weighted
 // Project: https://github.com/Schoonology/weighted
 // Definitions by: Craig Citro <https://github.com/ccitro>
+//                 Dmitry Minkovsky <https://github.com/dminkovsky>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module 'weighted' {
     export interface RandomFunc {
-        (): Number;
+        (): number;
     }  
 
-    export function select<T> (set: T[], weights: Number[], rand?: RandomFunc): T;
-    export function select<T> (obj: Object, rand?: RandomFunc): T;
+    export default select;
+
+    export function select<T> (set: T[], weights: number[], rand?: RandomFunc): T;
+    export function select (obj: {[index: string]: number}, rand?: RandomFunc): string;
 }

--- a/types/weighted/weighted-tests.ts
+++ b/types/weighted/weighted-tests.ts
@@ -1,10 +1,11 @@
-import * as weighted from 'weighted';
+import weighted, { select } from 'weighted';
 
 function testSet() {
     var options = ['Wake Up', 'Snooze Alarm'];
     var weights = [0.25, 0.75];
 
-    console.log('Decision:', weighted.select(options, weights));
+    console.log('Decision:', weighted(options, weights));
+    console.log('Decision:', select(options, weights));
 }
 
 function testObj() {
@@ -13,7 +14,8 @@ function testObj() {
         'Snooze Alarm': 0.75
     };
 
-    console.log('Decision:', weighted.select(options));
+    console.log('Decision:', weighted(options));
+    console.log('Decision:', select(options));
 }
 
 function testOverrideRand() {
@@ -25,5 +27,6 @@ function testOverrideRand() {
                   // guaranteed to be random.
     }
 
-    console.log('Decision:', weighted.select(options, weights, rand));
+    console.log('Decision:', weighted(options, weights, rand));
+    console.log('Decision:', select(options, weights, rand));
 }


### PR DESCRIPTION
This commit:

- Defines the default export, which is exported by 'weighted':
  https://github.com/Schoonology/weighted/blob/d152a4622f35b0ccf5729a401eb4ddc725a59ba1/lib/weighted.js#L97

- Replaces `Number` with `number`

- Fixes one of the overloads of `select`, which is not generic, but
  actually picks a JS object key and therefore always returns a string.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Re: non-generic overload that always returns an object key (string)
https://github.com/Schoonology/weighted/blob/d152a4622f35b0ccf5729a401eb4ddc725a59ba1/lib/weighted.js#L52-L59
  - Re: default export https://github.com/Schoonology/weighted/blob/d152a4622f35b0ccf5729a401eb4ddc725a59ba1/lib/weighted.js#L97
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
