### PR TITLE
[stream-json] - Add types missing from v1.5.0, Disassembler, Batch and Verifier

### DIFF
--- a/types/stream-json/Disassembler.d.ts
+++ b/types/stream-json/Disassembler.d.ts
@@ -1,0 +1,40 @@
+import { Transform, TransformOptions } from 'stream';
+
+export = Disassembler;
+
+declare class Disassembler extends Transform {
+    constructor(options?: Disassembler.DisassemblerOptions);
+}
+
+declare namespace Disassembler {
+    type ReplacerFunction = (val1: any, val2: any) => any;
+
+    type ReplaceArray = Array<string | number>;
+
+    interface DisassemblerOptions extends TransformOptions {
+        packValues?: boolean;
+        packKeys?: boolean;
+        packStrings?: boolean;
+        packNumbers?: boolean;
+        streamValues?: boolean;
+        streamKeys?: boolean;
+        streamStrings?: boolean;
+        streamNumbers?: boolean;
+        jsonStreaming?: boolean;
+        replacer?: ReplacerFunction | ReplaceArray;
+    }
+
+    function make(options?: DisassemblerOptions): Disassembler;
+
+    namespace make {
+        type Constructor = Disassembler;
+        const Constructor: typeof Disassembler;
+    }
+
+    function disassembler(options?: DisassemblerOptions): Disassembler;
+
+    namespace disassembler {
+        type Constructor = Disassembler;
+        const Constructor: typeof Disassembler;
+    }
+}

--- a/types/stream-json/Stringer.d.ts
+++ b/types/stream-json/Stringer.d.ts
@@ -12,6 +12,7 @@ declare namespace Stringer {
         useKeyValues?: boolean;
         useStringValues?: boolean;
         useNumberValues?: boolean;
+        makeArray?: boolean;
     }
 
     function make(options?: StringerOptions): Stringer;

--- a/types/stream-json/index.d.ts
+++ b/types/stream-json/index.d.ts
@@ -6,6 +6,7 @@
 /// <reference types="node" />
 
 import * as Assembler from './Assembler';
+import * as Disassembler from './Disassembler';
 import * as Emitter from './Emitter';
 import * as Parser from './Parser';
 import * as Stringer from './Stringer';
@@ -20,6 +21,8 @@ import * as StreamArray from './streamers/StreamArray';
 import * as StreamObject from './streamers/StreamObject';
 import * as StreamValues from './streamers/StreamValues';
 
+import * as Batch from "./utils/Batch";
+import * as Verifier from "./utils/Verifier";
 import * as emit from './utils/emit';
 import * as withParser from './utils/withParser';
 

--- a/types/stream-json/index.d.ts
+++ b/types/stream-json/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for stream-json 1.0
+// Type definitions for stream-json 1.5
 // Project: http://github.com/uhop/stream-json
 // Definitions by: Eugene Lazutkin <https://github.com/uhop>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/stream-json/stream-json-tests.ts
+++ b/types/stream-json/stream-json-tests.ts
@@ -115,8 +115,9 @@ const used = (array: any[]) => array.forEach(value => console.log(!!value));
     const s3: Stringer = Stringer.stringer({ useKeyValues: true });
     const s4: Stringer.make.Constructor = Stringer.make();
     const s5: Stringer.stringer.Constructor = Stringer.stringer();
+    const s6: Stringer = Stringer.stringer({ makeArray: true });
 
-    used([s1, s2, s3, s4, s5]);
+    used([s1, s2, s3, s4, s5, s6]);
 }
 
 {

--- a/types/stream-json/utils/Batch.d.ts
+++ b/types/stream-json/utils/Batch.d.ts
@@ -1,0 +1,34 @@
+import * as Chain from 'stream-chain';
+import { Transform, TransformOptions } from 'stream';
+
+export = Batch;
+
+declare class Batch extends Transform {
+    constructor(options?: Batch.BatchOptions);
+}
+
+declare namespace Batch {
+    interface BatchOptions extends TransformOptions {
+        /**
+         * The size of each batch. Defaults to 1000. Ignored
+         * if not a positive number.
+         */
+        batchSize?: number;
+    }
+
+    function make(options?: BatchOptions): Batch;
+
+    namespace make {
+        type Constructor = Batch;
+        const Constructor: typeof Batch;
+    }
+
+    function batch(options?: BatchOptions): Batch;
+
+    namespace batch {
+        type Constructor = Batch;
+        const Constructor: typeof Batch;
+    }
+
+    function withParser(options?: BatchOptions): Chain;
+}

--- a/types/stream-json/utils/Verifier.d.ts
+++ b/types/stream-json/utils/Verifier.d.ts
@@ -1,0 +1,27 @@
+import { Writable, WritableOptions } from 'stream';
+
+export = Verifier;
+
+declare class Verifier extends Writable {
+    constructor(options?: Verifier.VerifierOptions);
+}
+
+declare namespace Verifier {
+    interface VerifierOptions extends WritableOptions {
+        jsonStreaming?: boolean;
+    }
+
+    function make(options?: VerifierOptions): Verifier;
+
+    namespace make {
+        type Constructor = Verifier;
+        const Constructor: typeof Verifier;
+    }
+
+    function parser(options?: VerifierOptions): Verifier;
+
+    namespace parser {
+        type Constructor = Verifier;
+        const Constructor: typeof Verifier;
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/uhop/stream-json, Disassembler, Batch and Verifier in v1.5.0 are missing from the current version of the types
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

