### PR TITLE
Add support for Promises in redux-api-middleware

### DIFF
--- a/types/redux-api-middleware/index.d.ts
+++ b/types/redux-api-middleware/index.d.ts
@@ -9,7 +9,7 @@
 
 import { Dispatch, Middleware, MiddlewareAPI } from 'redux';
 
-type TypeOrResolver<Arg, Type> = Type | ((arg: Arg) => Type);
+type TypeOrResolver<Arg, Type> = Type | ((arg: Arg) => Promise<Type>) | ((arg: Arg) => Type);
 
 /**
  * This module is also a UMD module that exposes a global variable 'ReduxApiMiddleware'
@@ -64,20 +64,20 @@ export function createMiddleware(options?: CreateMiddlewareOptions): Middleware;
 
 export interface RSAARequestTypeDescriptor<State = any, Payload = any, Meta = any> {
     type: string | symbol;
-    payload?: ((action: RSAAAction, state: State) => Payload) | Payload;
-    meta?: ((action: RSAAAction, state: State) => Meta) | Meta;
+    payload?: ((action: RSAAAction, state: State) => Payload) | ((action: RSAAAction, state: State) => Promise<Payload>) | Payload;
+    meta?: ((action: RSAAAction, state: State) => Meta) | ((action: RSAAAction, state: State) => Promise<Meta>) | Meta;
 }
 
 export interface RSAASuccessTypeDescriptor<State = any, Payload = any, Meta = any> {
     type: string | symbol;
-    payload?: ((action: RSAAAction, state: State, res: Response) => Payload) | Payload;
-    meta?: ((action: RSAAAction, state: State, res: Response) => Meta) | Meta;
+    payload?: ((action: RSAAAction, state: State, res: Response) => Payload) | ((action: RSAAAction, state: State, res: Response) => Promise<Payload>) | Payload;
+    meta?: ((action: RSAAAction, state: State, res: Response) => Meta) | ((action: RSAAAction, state: State, res: Response) => Promise<Meta>) | Meta;
 }
 
 export interface RSAAFailureTypeDescriptor<State = any, Payload = any, Meta = any> {
     type: string | symbol;
-    payload?: ((action: RSAAAction, state: State, res: Response) => Payload) | Payload;
-    meta?: ((action: RSAAAction, state: State, res: Response) => Meta) | Meta;
+    payload?: ((action: RSAAAction, state: State, res: Response) => Payload) | ((action: RSAAAction, state: State, res: Response) => Promise<Payload>) | Payload;
+    meta?: ((action: RSAAAction, state: State, res: Response) => Meta) | ((action: RSAAAction, state: State, res: Response) => Promise<Meta>) | Meta;
 }
 
 export type RSAARequestType<State = any, Payload = any, Meta = any> =

--- a/types/redux-api-middleware/index.d.ts
+++ b/types/redux-api-middleware/index.d.ts
@@ -9,7 +9,7 @@
 
 import { Dispatch, Middleware, MiddlewareAPI } from 'redux';
 
-type TypeOrResolver<Arg, Type> = Type | ((arg: Arg) => Promise<Type>) | ((arg: Arg) => Type);
+type TypeOrResolver<Arg, Type> = Type | ((arg: Arg) => Type | Promise<Type>);
 
 /**
  * This module is also a UMD module that exposes a global variable 'ReduxApiMiddleware'
@@ -64,20 +64,20 @@ export function createMiddleware(options?: CreateMiddlewareOptions): Middleware;
 
 export interface RSAARequestTypeDescriptor<State = any, Payload = any, Meta = any> {
     type: string | symbol;
-    payload?: ((action: RSAAAction, state: State) => Payload) | ((action: RSAAAction, state: State) => Promise<Payload>) | Payload;
-    meta?: ((action: RSAAAction, state: State) => Meta) | ((action: RSAAAction, state: State) => Promise<Meta>) | Meta;
+    payload?: ((action: RSAAAction, state: State) => Payload | Promise<Payload>) | Payload;
+    meta?: ((action: RSAAAction, state: State) => Meta | Promise<Meta>) | Meta;
 }
 
 export interface RSAASuccessTypeDescriptor<State = any, Payload = any, Meta = any> {
     type: string | symbol;
-    payload?: ((action: RSAAAction, state: State, res: Response) => Payload) | ((action: RSAAAction, state: State, res: Response) => Promise<Payload>) | Payload;
-    meta?: ((action: RSAAAction, state: State, res: Response) => Meta) | ((action: RSAAAction, state: State, res: Response) => Promise<Meta>) | Meta;
+    payload?: ((action: RSAAAction, state: State, res: Response) => Payload | Promise<Payload>) | Payload;
+    meta?: ((action: RSAAAction, state: State, res: Response) => Meta | Promise<Meta>) | Meta;
 }
 
 export interface RSAAFailureTypeDescriptor<State = any, Payload = any, Meta = any> {
     type: string | symbol;
-    payload?: ((action: RSAAAction, state: State, res: Response) => Payload) | ((action: RSAAAction, state: State, res: Response) => Promise<Payload>) | Payload;
-    meta?: ((action: RSAAAction, state: State, res: Response) => Meta) | ((action: RSAAAction, state: State, res: Response) => Promise<Meta>) | Meta;
+    payload?: ((action: RSAAAction, state: State, res: Response) => Payload | Promise<Payload>) | Payload;
+    meta?: ((action: RSAAAction, state: State, res: Response) => Meta | Promise<Meta>) | Meta;
 }
 
 export type RSAARequestType<State = any, Payload = any, Meta = any> =

--- a/types/redux-api-middleware/redux-api-middleware-tests.ts
+++ b/types/redux-api-middleware/redux-api-middleware-tests.ts
@@ -145,6 +145,26 @@ import {
         types: ['REQ_TYPE', 'SUCCESS_TYPE', 'FAILURE_TYPE'];
     }
 
+    class PromiseStateDrivenRSAACall implements RSAACall<State> {
+        endpoint(state: State) {
+            return Promise.resolve(state.path);
+        }
+        headers(state: State) {
+            return Promise.resolve(state.headers);
+        }
+        options(state: State) {
+            return Promise.resolve(state.options);
+        }
+        body(state: State) {
+            return Promise.resolve(state.body);
+        }
+        bailout(state: State) {
+            return Promise.resolve(state.bailout);
+        }
+        method: 'GET';
+        types: ['REQ_TYPE', 'SUCCESS_TYPE', 'FAILURE_TYPE'];
+    }
+
     class NonStateDrivenRSAACall implements RSAACall<State> {
         endpoint: '/test/endpoint';
         method: 'GET';
@@ -199,6 +219,11 @@ import {
         payload: '', // $ExpectError
         meta: (action: RSAAAction, state: number) => '', // $ExpectError
     };
+    const requestDescriptor3: RSAARequestTypeDescriptor<number, number, number> = {
+        type: Symbol(),
+        payload: (action: RSAAAction, state: number) => Promise.resolve(state),
+        meta: (action: RSAAAction, state: number) => Promise.resolve(state),
+    };
 
     const successDescriptor0: RSAASuccessTypeDescriptor<number, number, number> = {
         type: '',
@@ -215,6 +240,11 @@ import {
         payload: '', // $ExpectError
         meta: (action: RSAAAction, state: number) => '', // $ExpectError
     };
+    const successDescriptor3: RSAASuccessTypeDescriptor<number, number, number> = {
+        type: Symbol(),
+        payload: (action: RSAAAction, state: number, res: Response) => Promise.resolve(state),
+        meta: (action: RSAAAction, state: number, res: Response) => Promise.resolve(state),
+    };
 
     const failureDescriptor0: RSAAFailureTypeDescriptor<number, number, number> = {
         type: '',
@@ -230,6 +260,11 @@ import {
         type: 0, // $ExpectError
         payload: '', // $ExpectError
         meta: (action: RSAAAction, state: number) => '', // $ExpectError
+    };
+    const failureDescriptor3: RSAAFailureTypeDescriptor<number, number, number> = {
+        type: Symbol(),
+        payload: (action: RSAAAction, state: number, res: Response) => Promise.resolve(state),
+        meta: (action: RSAAAction, state: number, res: Response) => Promise.resolve(state),
     };
 }
 


### PR DESCRIPTION
fix

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/agraboso/redux-api-middleware/pull/235
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.