### PR TITLE
fix(dygraphs): Allow nullable `valueRange` array type

### DIFF
--- a/types/dygraphs/dygraphs-tests.ts
+++ b/types/dygraphs/dygraphs-tests.ts
@@ -1,4 +1,4 @@
-// These tests are copied more or less directly from http://dygraphs.com/tests/ 
+// These tests are copied more or less directly from http://dygraphs.com/tests/
 
 function demo() {
     const g14 = new Dygraph(
@@ -44,7 +44,7 @@ function twoAxes() {
                 y2label: 'Secondary y-axis',
             }
     );
-    
+
     var g2 = new Dygraph(
             document.getElementById("demodiv_y2_primary"),
             data,
@@ -75,7 +75,7 @@ function twoAxes() {
                 }
             }
     );
-    
+
     var g3 = new Dygraph(
             document.getElementById("demodiv_two_grids"),
             data,
@@ -113,7 +113,7 @@ function twoAxes() {
             y2label: 'Secondary y-axis',
         }
     );
-    
+
     var g5 = new Dygraph(
         document.getElementById("demodiv_one_right"),
         data,
@@ -150,7 +150,7 @@ function twoAxes() {
             }
         }
     );
-    
+
     function update(el: HTMLInputElement) {
         g.updateOptions( { fillGraph: el.checked } );
         g2.updateOptions( { fillGraph: el.checked } );
@@ -594,4 +594,18 @@ var eventDiv = document.getElementById("events");
             num++;
         }
     });
+}
+
+function valueRangeTest() {
+  new Dygraph(
+          document.getElementById("valueRange-test"),
+          [],
+          {
+            axes: {
+              x: { valueRange: [0, 100] },
+              y: { valueRange: [0, null] },
+              y2: { valueRange: null },
+            }
+          }
+      );
 }

--- a/types/dygraphs/index.d.ts
+++ b/types/dygraphs/index.d.ts
@@ -252,7 +252,7 @@ declare namespace dygraphs {
          * be calculated automatically (e.g. [null, 30] to automatically calculate just the lower
          * bound)
          */
-        valueRange?: number[];
+        valueRange?: [number | null, number | null];
 
         /**
          * Whether to display gridlines in the chart. This may be set on a per-axis basis to define

--- a/types/dygraphs/index.d.ts
+++ b/types/dygraphs/index.d.ts
@@ -252,7 +252,7 @@ declare namespace dygraphs {
          * be calculated automatically (e.g. [null, 30] to automatically calculate just the lower
          * bound)
          */
-        valueRange?: [number | null, number | null];
+        valueRange?: [number | null, number | null] | null;
 
         /**
          * Whether to display gridlines in the chart. This may be set on a per-axis basis to define


### PR DESCRIPTION
When setting a `valueRange` option on a dygraph chart, it is valid to provide a `null` value for the range, in which case the chart range will auto-detect the upper or lower bound.

Doc reference: http://dygraphs.com/options.html#valueRange

This change modifies the required option type to accept an array with `null` elements, as well as constrains the value to be a tuple array of length 2.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://dygraphs.com/options.html#valueRange
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.