### PR TITLE
update react-lazy-load-image-component: version 1.5.0

### DIFF
--- a/types/react-lazy-load-image-component/index.d.ts
+++ b/types/react-lazy-load-image-component/index.d.ts
@@ -7,7 +7,14 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.5
 
-import { ComponentType, CSSProperties, FunctionComponent, ImgHTMLAttributes, ReactElement, ReactNode } from 'react';
+import {
+    ComponentType,
+    CSSProperties,
+    FunctionComponent,
+    ImgHTMLAttributes,
+    ReactElement,
+    ReactNode
+} from 'react';
 
 export type DelayMethod = 'debounce' | 'throttle';
 export type Effect = 'blur' | 'black-and-white' | 'opacity';
@@ -38,9 +45,7 @@ export interface CommonProps {
     scrollPosition?: ScrollPosition;
 }
 
-export interface LazyLoadImageProps
-    extends CommonProps,
-        Omit<ImgHTMLAttributes<HTMLImageElement>, 'placeholder' | 'onload'> {
+export interface LazyLoadImageProps extends CommonProps, Omit<ImgHTMLAttributes<HTMLImageElement>, 'placeholder' | 'onload'>  {
     /** Name of the effect to use. Requires importing CSS, see README.md. */
     effect?: Effect;
     /** Image src to display while the image is not visible or loaded. */

--- a/types/react-lazy-load-image-component/index.d.ts
+++ b/types/react-lazy-load-image-component/index.d.ts
@@ -8,7 +8,7 @@
 // TypeScript Version: 3.5
 
 import {
-	CSSProperties,
+    CSSProperties,
     ComponentType,
     FunctionComponent,
     ImgHTMLAttributes,

--- a/types/react-lazy-load-image-component/index.d.ts
+++ b/types/react-lazy-load-image-component/index.d.ts
@@ -1,19 +1,13 @@
-// Type definitions for react-lazy-load-image-component 1.3
+// Type definitions for react-lazy-load-image-component 1.5
 // Project: https://github.com/Aljullu/react-lazy-load-image-component#readme
 // Definitions by: Dan Vanderkam <https://github.com/danvk>
 //                 Diego Chavez <https://github.com/diegochavez>
 //                 Truong Hoang Dung <https://github.com/revskill10>
+//                 Kodai Suzuki <https://github.com/kodai3>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.5
 
-import {
-    CSSProperties,
-    ComponentType,
-    FunctionComponent,
-    ImgHTMLAttributes,
-    ReactElement,
-    ReactNode,
-} from 'react';
+import { ComponentType, CSSProperties, FunctionComponent, ImgHTMLAttributes, ReactElement, ReactNode } from 'react';
 
 export type DelayMethod = 'debounce' | 'throttle';
 export type Effect = 'blur' | 'black-and-white' | 'opacity';
@@ -44,13 +38,17 @@ export interface CommonProps {
     scrollPosition?: ScrollPosition;
 }
 
-export interface LazyLoadImageProps extends CommonProps, Omit<ImgHTMLAttributes<HTMLImageElement>, 'placeholder' | 'onload'>  {
+export interface LazyLoadImageProps
+    extends CommonProps,
+        Omit<ImgHTMLAttributes<HTMLImageElement>, 'placeholder' | 'onload'> {
     /** Name of the effect to use. Requires importing CSS, see README.md. */
     effect?: Effect;
     /** Image src to display while the image is not visible or loaded. */
     placeholderSrc?: string;
     /** In some occasions (for example, when using a placeholderSrc) a wrapper span tag is rendered. This prop allows setting a class to that element. */
     wrapperClassName?: string;
+    /** Props that should be passed to the wrapper span when it is rendered (for example, when using placeholderSrc or effect) */
+    wrapperProps?: React.HTMLAttributes<HTMLSpanElement>;
 }
 
 export const LazyLoadImage: FunctionComponent<LazyLoadImageProps>;

--- a/types/react-lazy-load-image-component/index.d.ts
+++ b/types/react-lazy-load-image-component/index.d.ts
@@ -8,12 +8,12 @@
 // TypeScript Version: 3.5
 
 import {
+	CSSProperties,
     ComponentType,
-    CSSProperties,
     FunctionComponent,
     ImgHTMLAttributes,
     ReactElement,
-    ReactNode
+    ReactNode,
 } from 'react';
 
 export type DelayMethod = 'debounce' | 'throttle';

--- a/types/react-lazy-load-image-component/react-lazy-load-image-component-tests.tsx
+++ b/types/react-lazy-load-image-component/react-lazy-load-image-component-tests.tsx
@@ -1,107 +1,119 @@
 import * as React from 'react';
-import { LazyLoadComponent, LazyLoadImage, LazyLoadImageProps, trackWindowScroll, ScrollPosition } from 'react-lazy-load-image-component';
+import {
+    LazyLoadComponent,
+    LazyLoadImage,
+    LazyLoadImageProps,
+    ScrollPosition,
+    trackWindowScroll,
+} from 'react-lazy-load-image-component';
 
 interface ImageProps {
-  key: string;
-  src: string;
-  alt: string;
-  height: number;
-  width: number;
-  caption: string;
+    key: string;
+    src: string;
+    alt: string;
+    height: number;
+    width: number;
+    caption: string;
 }
 
 // From https://github.com/Aljullu/react-lazy-load-image-component#lazyloadimage-usage
-const MyImage = ({ image }: {image: ImageProps}) => (
-  <div>
-    <LazyLoadImage
-      alt={image.alt}
-      height={image.height}
-      src={image.src} // use normal <img> attributes as props
-      width={image.width} />
-    <span>{image.caption}</span>
-    <img />
-  </div>
+const MyImage = ({ image }: { image: ImageProps }) => (
+    <div>
+        <LazyLoadImage
+            alt={image.alt}
+            height={image.height}
+            src={image.src} // use normal <img> attributes as props
+            width={image.width}
+        />
+        <span>{image.caption}</span>
+        <img />
+    </div>
 );
 
 const ImageWithCallbacks = () => (
-  <LazyLoadImage
-    src="foo.png"
-    title="title"
-    delayMethod="debounce"
-    delayTime={500}
-    threshold={200}
-    beforeLoad={() => {}}
-    afterLoad={() => {}}
-    placeholder={<span/>}
-  />
+    <LazyLoadImage
+        src="foo.png"
+        title="title"
+        delayMethod="debounce"
+        delayTime={500}
+        threshold={200}
+        beforeLoad={() => {}}
+        afterLoad={() => {}}
+        placeholder={<span />}
+        wrapperProps={{
+            style: {
+                background: '#FFFFFF',
+            },
+        }}
+    />
 );
 
 {
-  // From src/components/LazyLoadImage.spec.js
-  const props: LazyLoadImageProps = {
-    beforeLoad: () => null,
-    delayMethod: 'debounce',
-    delayTime: 600,
-    placeholder: null,
-    scrollPosition: { x: 0, y: 0 },
-    style: {},
-    src: 'http://localhost/lorem-ipsum.jpg',
-    visibleByDefault: false,
-  };
-  const lazyLoadImage = (
-    <LazyLoadImage
-      beforeLoad={props.beforeLoad}
-      delayMethod={props.delayMethod}
-      delayTime={props.delayTime}
-      placeholder={props.placeholder}
-      scrollPosition={props.scrollPosition}
-      src={props.src}
-      style={props.style}
-      visibleByDefault={props.visibleByDefault} />
-  );
-}
-
-{
-  const el = (
-    <LazyLoadComponent>
-      <p style={{}}>Lorem Ipsum</p>
-    </LazyLoadComponent>
-  );
-
-  const elWithStyle = (
-    <LazyLoadComponent
-      style={{ marginTop: 100000 }}
-    >
-      <p>Lorem Ipsum</p>
-    </LazyLoadComponent>
-  );
-}
-
-{
-  // From README.md
-
-  const Gallery = ({ images, scrollPosition }: {images: ImageProps[]; scrollPosition: ScrollPosition}) => (
-    <div>
-      {images.map((image) =>
+    // From src/components/LazyLoadImage.spec.js
+    const props: LazyLoadImageProps = {
+        beforeLoad: () => null,
+        delayMethod: 'debounce',
+        delayTime: 600,
+        placeholder: null,
+        scrollPosition: { x: 0, y: 0 },
+        style: {},
+        src: 'http://localhost/lorem-ipsum.jpg',
+        visibleByDefault: false,
+    };
+    const lazyLoadImage = (
         <LazyLoadImage
-          key={image.key}
-          alt={image.alt}
-          height={image.height}
-          // Make sure to pass down the scrollPosition,
-          // this will be used by the component to know
-          // whether it must track the scroll position or not
-          scrollPosition={scrollPosition}
-          src={image.src}
-          width={image.width} />
-      )}
-    </div>
-  );
-  // Wrap Gallery with trackWindowScroll HOC so it receives
-  // a scrollPosition prop to pass down to the images
-  const WrappedGallery = trackWindowScroll(Gallery);
+            beforeLoad={props.beforeLoad}
+            delayMethod={props.delayMethod}
+            delayTime={props.delayTime}
+            placeholder={props.placeholder}
+            scrollPosition={props.scrollPosition}
+            src={props.src}
+            style={props.style}
+            visibleByDefault={props.visibleByDefault}
+        />
+    );
+}
 
-  // Omitting scrollPosition is OK but omitting images is not.
-  <WrappedGallery images={[]} />;
-  // $ExpectError
-  <WrappedGallery />;
+{
+    const el = (
+        <LazyLoadComponent>
+            <p style={{}}>Lorem Ipsum</p>
+        </LazyLoadComponent>
+    );
+
+    const elWithStyle = (
+        <LazyLoadComponent style={{ marginTop: 100000 }}>
+            <p>Lorem Ipsum</p>
+        </LazyLoadComponent>
+    );
+}
+
+{
+    // From README.md
+
+    const Gallery = ({ images, scrollPosition }: { images: ImageProps[]; scrollPosition: ScrollPosition }) => (
+        <div>
+            {images.map(image => (
+                <LazyLoadImage
+                    key={image.key}
+                    alt={image.alt}
+                    height={image.height}
+                    // Make sure to pass down the scrollPosition,
+                    // this will be used by the component to know
+                    // whether it must track the scroll position or not
+                    scrollPosition={scrollPosition}
+                    src={image.src}
+                    width={image.width}
+                />
+            ))}
+        </div>
+    );
+    // Wrap Gallery with trackWindowScroll HOC so it receives
+    // a scrollPosition prop to pass down to the images
+    const WrappedGallery = trackWindowScroll(Gallery);
+
+    // Omitting scrollPosition is OK but omitting images is not.
+    <WrappedGallery images={[]} />;
+    // $ExpectError
+    <WrappedGallery />;
 }

--- a/types/react-lazy-load-image-component/react-lazy-load-image-component-tests.tsx
+++ b/types/react-lazy-load-image-component/react-lazy-load-image-component-tests.tsx
@@ -1,119 +1,112 @@
 import * as React from 'react';
-import {
-    LazyLoadComponent,
-    LazyLoadImage,
-    LazyLoadImageProps,
-    ScrollPosition,
-    trackWindowScroll,
-} from 'react-lazy-load-image-component';
+import { LazyLoadComponent, LazyLoadImage, LazyLoadImageProps, ScrollPosition, trackWindowScroll } from 'react-lazy-load-image-component';
 
 interface ImageProps {
-    key: string;
-    src: string;
-    alt: string;
-    height: number;
-    width: number;
-    caption: string;
+  key: string;
+  src: string;
+  alt: string;
+  height: number;
+  width: number;
+  caption: string;
 }
 
 // From https://github.com/Aljullu/react-lazy-load-image-component#lazyloadimage-usage
-const MyImage = ({ image }: { image: ImageProps }) => (
-    <div>
-        <LazyLoadImage
-            alt={image.alt}
-            height={image.height}
-            src={image.src} // use normal <img> attributes as props
-            width={image.width}
-        />
-        <span>{image.caption}</span>
-        <img />
-    </div>
+const MyImage = ({ image }: {image: ImageProps}) => (
+  <div>
+    <LazyLoadImage
+      alt={image.alt}
+      height={image.height}
+      src={image.src} // use normal <img> attributes as props
+      width={image.width} />
+    <span>{image.caption}</span>
+    <img />
+  </div>
 );
 
 const ImageWithCallbacks = () => (
-    <LazyLoadImage
-        src="foo.png"
-        title="title"
-        delayMethod="debounce"
-        delayTime={500}
-        threshold={200}
-        beforeLoad={() => {}}
-        afterLoad={() => {}}
-        placeholder={<span />}
-        wrapperProps={{
-            style: {
-                background: '#FFFFFF',
-            },
-        }}
-    />
+  <LazyLoadImage
+    src="foo.png"
+    title="title"
+    delayMethod="debounce"
+    delayTime={500}
+    threshold={200}
+    beforeLoad={() => {}}
+    afterLoad={() => {}}
+    placeholder={<span/>}
+    wrapperProps={{
+        style: {
+            background: '#FFFFFF',
+        },
+    }}
+  />
 );
 
 {
-    // From src/components/LazyLoadImage.spec.js
-    const props: LazyLoadImageProps = {
-        beforeLoad: () => null,
-        delayMethod: 'debounce',
-        delayTime: 600,
-        placeholder: null,
-        scrollPosition: { x: 0, y: 0 },
-        style: {},
-        src: 'http://localhost/lorem-ipsum.jpg',
-        visibleByDefault: false,
-    };
-    const lazyLoadImage = (
+  // From src/components/LazyLoadImage.spec.js
+  const props: LazyLoadImageProps = {
+    beforeLoad: () => null,
+    delayMethod: 'debounce',
+    delayTime: 600,
+    placeholder: null,
+    scrollPosition: { x: 0, y: 0 },
+    style: {},
+    src: 'http://localhost/lorem-ipsum.jpg',
+    visibleByDefault: false,
+  };
+  const lazyLoadImage = (
+    <LazyLoadImage
+      beforeLoad={props.beforeLoad}
+      delayMethod={props.delayMethod}
+      delayTime={props.delayTime}
+      placeholder={props.placeholder}
+      scrollPosition={props.scrollPosition}
+      src={props.src}
+      style={props.style}
+      visibleByDefault={props.visibleByDefault} />
+  );
+}
+
+{
+  const el = (
+    <LazyLoadComponent>
+      <p style={{}}>Lorem Ipsum</p>
+    </LazyLoadComponent>
+  );
+
+  const elWithStyle = (
+    <LazyLoadComponent
+      style={{ marginTop: 100000 }}
+    >
+      <p>Lorem Ipsum</p>
+    </LazyLoadComponent>
+  );
+}
+
+{
+  // From README.md
+
+  const Gallery = ({ images, scrollPosition }: {images: ImageProps[]; scrollPosition: ScrollPosition}) => (
+    <div>
+      {images.map((image) =>
         <LazyLoadImage
-            beforeLoad={props.beforeLoad}
-            delayMethod={props.delayMethod}
-            delayTime={props.delayTime}
-            placeholder={props.placeholder}
-            scrollPosition={props.scrollPosition}
-            src={props.src}
-            style={props.style}
-            visibleByDefault={props.visibleByDefault}
-        />
-    );
-}
+          key={image.key}
+          alt={image.alt}
+          height={image.height}
+          // Make sure to pass down the scrollPosition,
+          // this will be used by the component to know
+          // whether it must track the scroll position or not
+          scrollPosition={scrollPosition}
+          src={image.src}
+          width={image.width} />
+      )}
+    </div>
+  );
+  // Wrap Gallery with trackWindowScroll HOC so it receives
+  // a scrollPosition prop to pass down to the images
+  const WrappedGallery = trackWindowScroll(Gallery);
 
-{
-    const el = (
-        <LazyLoadComponent>
-            <p style={{}}>Lorem Ipsum</p>
-        </LazyLoadComponent>
-    );
-
-    const elWithStyle = (
-        <LazyLoadComponent style={{ marginTop: 100000 }}>
-            <p>Lorem Ipsum</p>
-        </LazyLoadComponent>
-    );
-}
-
-{
-    // From README.md
-
-    const Gallery = ({ images, scrollPosition }: { images: ImageProps[]; scrollPosition: ScrollPosition }) => (
-        <div>
-            {images.map(image => (
-                <LazyLoadImage
-                    key={image.key}
-                    alt={image.alt}
-                    height={image.height}
-                    // Make sure to pass down the scrollPosition,
-                    // this will be used by the component to know
-                    // whether it must track the scroll position or not
-                    scrollPosition={scrollPosition}
-                    src={image.src}
-                    width={image.width}
-                />
-            ))}
-        </div>
-    );
-    // Wrap Gallery with trackWindowScroll HOC so it receives
-    // a scrollPosition prop to pass down to the images
-    const WrappedGallery = trackWindowScroll(Gallery);
-
-    // Omitting scrollPosition is OK but omitting images is not.
-    <WrappedGallery images={[]} />;
-    // $ExpectError
-    <WrappedGallery />;
+  // Omitting scrollPosition is OK but omitting images is not.
+  <WrappedGallery images={[]} />;
+  // $ExpectError
+  <WrappedGallery />;
 }

--- a/types/react-lazy-load-image-component/react-lazy-load-image-component-tests.tsx
+++ b/types/react-lazy-load-image-component/react-lazy-load-image-component-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { LazyLoadComponent, LazyLoadImage, LazyLoadImageProps, ScrollPosition, trackWindowScroll } from 'react-lazy-load-image-component';
+import { LazyLoadComponent, LazyLoadImage, LazyLoadImageProps, trackWindowScroll, ScrollPosition } from 'react-lazy-load-image-component';
 
 interface ImageProps {
   key: string;


### PR DESCRIPTION
added `wrapperProps` property
which was featured on [version 1.5.0 update](https://github.com/Aljullu/react-lazy-load-image-component/releases/tag/1.5.0)

Thanks! 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Aljullu/react-lazy-load-image-component/pull/70
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.