### PR TITLE
@types/assert: fail never returns

### DIFF
--- a/types/assert/assert-tests.ts
+++ b/types/assert/assert-tests.ts
@@ -15,3 +15,5 @@ assert.throws(
 assert['fail'](true, true, 'works like a charm');
 
 assert.strict; // $ExpectType typeof assert
+
+assert.fail(); // $ExpectType never

--- a/types/assert/index.d.ts
+++ b/types/assert/index.d.ts
@@ -8,7 +8,7 @@
 declare function assert(value: any, message?: string): void;
 
 declare namespace assert {
-    function fail(actual?: any, expected?: any, message?: string, operator?: string): void;
+    function fail(actual?: any, expected?: any, message?: string, operator?: string): never;
 
     function ok(value: any, message?: string): void;
 

--- a/types/assert/ts3.7/assert-tests.ts
+++ b/types/assert/ts3.7/assert-tests.ts
@@ -59,3 +59,5 @@ assert['fail'](true, true, 'works like a charm');
 }
 
 assert.strict; // $ExpectType typeof assert
+
+assert.fail(); // $ExpectType never

--- a/types/assert/ts3.7/index.d.ts
+++ b/types/assert/ts3.7/index.d.ts
@@ -1,7 +1,7 @@
 declare function assert(value: any, message?: string): asserts value;
 
 declare namespace assert {
-    function fail(actual?: any, expected?: any, message?: string, operator?: string): void;
+    function fail(actual?: any, expected?: any, message?: string, operator?: string): never;
 
     function ok(value: any, message?: string): asserts value;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: assert.fail always throws: https://github.com/browserify/commonjs-assert/blob/bba838e9ba9e28edf3127ce6974624208502f6bc/assert.js#L132
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
