### PR TITLE
@wordpress/components: add `isSecondary` prop to `<Button>` component

### DIFF
--- a/types/wordpress__components/button/index.d.ts
+++ b/types/wordpress__components/button/index.d.ts
@@ -4,12 +4,17 @@ declare namespace Button {
     interface BaseProps {
         /**
          * Renders a default button style.
+         * @deprecated use `isSecondary`
          */
         isDefault?: boolean;
         /**
          * Renders a primary button style.
          */
         isPrimary?: boolean;
+        /**
+         * Renders a default button style.
+         */
+        isSecondary?: boolean;
         /**
          * Renders a text-based button style.
          */

--- a/types/wordpress__components/index.d.ts
+++ b/types/wordpress__components/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/components 8.5
+// Type definitions for @wordpress/components 9.0
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/components/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 //                 Jon Surrell <https://github.com/sirreal>

--- a/types/wordpress__components/index.d.ts
+++ b/types/wordpress__components/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/components/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 //                 Jon Surrell <https://github.com/sirreal>
+//                 Philip Jackson <https://github.com/p-jackson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -76,7 +76,7 @@ interface MyCompleteOption {
 <C.Button href="#foo" download="foo.txt" isSmall>
     Anchor Button
 </C.Button>;
-<C.Button autoFocus isDestructive isLarge>
+<C.Button autoFocus isDestructive isLarge isSecondary>
     Button Button
 </C.Button>;
 


### PR DESCRIPTION
The `isSecondary` prop replaces the `isDefault` prop, which has been marked as deprecated.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
  **Shows errors about unexpected @deprecated JSDoc tags, however these appear to be spelled correctly**
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  https://github.com/WordPress/gutenberg/blob/cc4aa891664c60a73273d47427153807daeb36bb/packages/components/src/button/index.js#L48
  https://github.com/WordPress/gutenberg/blob/master/packages/components/src/button/README.md#L131
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.