### PR TITLE
fix(@wordpress/blocks): add element type to normalized icon

### DIFF
--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -7,7 +7,7 @@
 
 import { Dashicon } from '@wordpress/components';
 import { dispatch, select } from '@wordpress/data';
-import { ComponentType } from 'react';
+import { ComponentType, ReactElement } from 'react';
 
 export * from './api';
 export { withBlockContentContext } from './block-content-provider';
@@ -29,7 +29,7 @@ export interface BlockIconNormalized {
     background?: string;
     foreground?: string;
     shadowColor?: string;
-    src: Dashicon.Icon | ComponentType;
+    src: Dashicon.Icon | ReactElement | ComponentType;
 }
 
 export type BlockIcon = BlockIconNormalized['src'] | BlockIconNormalized;

--- a/types/wordpress__blocks/wordpress__blocks-tests.tsx
+++ b/types/wordpress__blocks/wordpress__blocks-tests.tsx
@@ -311,6 +311,18 @@ blocks.registerBlockType('my/foo', {
     category: 'common',
 });
 
+// $ExpectType Block<{}> | undefined
+blocks.registerBlockType('my/foo', {
+    attributes: {},
+    icon: (
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+            <path fill="none" d="M0 0h24v24H0V0z" />
+        </svg>
+    ),
+    title: 'Foo',
+    category: 'common',
+});
+
 // $ExpectType Block<{ foo: string; }> | undefined
 blocks.registerBlockType<{ foo: string }>('my/foo', {
     attributes: {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: (See below).
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

### Relevant URLs

Icon declaration in registerBlockType should also allow for a plain React Element, as noted in the documentation.

- Documentation URL: https://developer.wordpress.org/block-editor/developers/block-api/block-registration/#icon-optional.
- Code lines that demonstrate icon property allows for a React Element: https://github.com/WordPress/gutenberg/blob/969bbe9f4f48250e8b919a12241fd3a17348400e/packages/blocks/src/api/utils.js#L70-L113
