### PR TITLE
docs(react): Link better explanation for non-generic target

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1160,7 +1160,7 @@ declare namespace React {
      *
      * target - a reference to the element from which the event was originally dispatched.
      * This might be a child element to the element on which the event listener is registered.
-     * If you thought this should be `EventTarget & T`, see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/12239
+     * If you thought this should be `EventTarget & T`, see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/11508#issuecomment-256045682
      */
     interface SyntheticEvent<T = Element, E = Event> extends BaseSyntheticEvent<E, EventTarget & T, EventTarget> {}
 


### PR DESCRIPTION
JSDOC is visible in vscode. 

The current link is not very helpful immediately and requires some navigating of linked prs/issues.  At some point you land on https://github.com/DefinitelyTyped/DefinitelyTyped/issues/11508#issuecomment-256045682 which is in my opinion a better explanation. Especially because the very first sentence relates to the issue ("generic target").