### PR TITLE
DT cleanup:

### DIFF
--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -57,7 +57,7 @@ declare namespace clownface {
     node<X extends Term[]>(values: X, options?: NodeOptions): Clownface<X, D>;
 
     node(value: null, options?: NodeOptions): Clownface<BlankNode, D>;
-    node(values: null[], options?: NodeOptions): Clownface<BlankNode[], D>;
+    node(values: Array<null>, options?: NodeOptions): Clownface<BlankNode[], D>;
 
     node(values: Array<boolean | string | number | Term | null>, options?: NodeOptions): Clownface<Term[], D>;
 

--- a/types/js-to-java/index.d.ts
+++ b/types/js-to-java/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/node-modules/js-to-java
 // Definitions by: skyitachi <https://github.com/skyitachi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 interface Currency {
   currencyCode: string;
@@ -89,8 +88,7 @@ declare namespace java {
     function Locale(locale: string[], handle: string): object;
     function BigDecimal(val: string[]): object;
 
-    // Note: it doesn't allow [null, "test"], actually it should be allowed
-    function Currency(value: (null[] | string[] | Currency[])): object;
+    function Currency(value: (Array<null | string | Currency>)): object;
   }
 
   function abstract(abstractClassName: string, className: string, value: any): object;

--- a/types/meteor-astronomy/meteor-astronomy-tests.ts
+++ b/types/meteor-astronomy/meteor-astronomy-tests.ts
@@ -83,7 +83,7 @@ interface UserInterface extends Meteor.User {
 
 const User = Class.create<UserInterface>({
     name: 'User',
-    collection: Meteor.users as Mongo.Collection<UserInterface>,
+    collection: Meteor.users as unknown as Mongo.Collection<UserInterface>,
     fields: {
         createdAt: Number,
         firstName: String,

--- a/types/webpack-config-utils/index.d.ts
+++ b/types/webpack-config-utils/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/kentcdodds/webpack-config-utils#readme
 // Definitions by: Martin Hochel <https://github.com/hotell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
 
 export function getIfUtils<E extends EnvVars | string>(
     env: { [P in E]: boolean | string } | E,

--- a/types/webpack-config-utils/webpack-config-utils-tests.ts
+++ b/types/webpack-config-utils/webpack-config-utils-tests.ts
@@ -82,7 +82,8 @@ import { getIfUtils, removeEmpty, propIf, propIfNot } from 'webpack-config-utils
     // $ExpectType (number | null)[]
     const emptiedArray = removeEmpty([undefined, 0, 1, 2, undefined, 3, undefined, null]); // [0, 1, 2, 3, null]
 
-    // $ExpectType NonEmptyObject<{ a: number; b: string; c: undefined; d: null; }, "b" | "a" | "d">
+    /* tslint:disable-next-line:max-line-length */
+    // $ExpectType NonEmptyObject<{ a: number; b: string; c: undefined; d: null; }, "b" | "a" | "d"> || NonEmptyObject<{ a: number; b: string; c: undefined; d: null; }, DefinedObjKeys<{ a: number; b: string; c: undefined; d: null; }>>
     const emptiedObject = removeEmpty({ a: 1, b: 'b', c: undefined, d: null }); // {a: 1, b: 'b', d: null}
     const {
         a, // $ExpectType number


### PR DESCRIPTION
1. Fix lint error in clownface. Not sure why this wasn't an error before.
2. Fix same error in js-to-java, and also fix the type to match the TODO comment.
2. Fix unsound cast in webpack-config-utils. Again, not sure why this wasn't an error before.
3. Add new 4.0 way of printing type aliases to meteor-astronomy.