### PR TITLE
update(worker-plugin): v4 update

### DIFF
--- a/types/worker-plugin/index.d.ts
+++ b/types/worker-plugin/index.d.ts
@@ -1,8 +1,8 @@
-// Type definitions for worker-plugin 3.2
+// Type definitions for worker-plugin 4.0
 // Project: https://github.com/GoogleChromeLabs/worker-plugin
 // Definitions by: Artur Androsovych <https://github.com/arturovt>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 import * as webpack from 'webpack';
 
@@ -14,7 +14,23 @@ declare class WorkerPlugin extends webpack.Plugin {
 
 declare namespace WorkerPlugin {
   interface Options {
-    globalObject?: boolean | string;
+    globalObject?: false | string;
     plugins?: Array<string | webpack.Plugin>;
+    /**
+     * If set to `true`, this option enables the bundling of [SharedWorker](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker)
+     */
+    sharedWorker?: boolean;
+    /**
+     * If set to `false`, this option disables the bundling of [Worker].
+     * Intended to be used with `{ sharedWorker: true }` to allow bundling of [SharedWorker] only without also bundling [Worker].
+     */
+    worker?: boolean;
+    preserveTypeModule?: boolean;
+    /**
+     * Normally, WorkerPlugin will transform `new Worker('./a.js', { type: 'module' })`
+     * to completely remove the `type` option, outputting something like `new Worker('a.worker.js')`.
+     * This allows the plugin to compile Module Workers to Classic Workers, which are supported in all browsers.
+     */
+    workerType?: string;
   }
 }

--- a/types/worker-plugin/worker-plugin-tests.ts
+++ b/types/worker-plugin/worker-plugin-tests.ts
@@ -17,6 +17,14 @@ const optionsArray: WorkerPlugin.Options[] = [
           'SomeExistingPlugin',
           new ExistingPlugin(),
         ],
+    },
+    {
+        preserveTypeModule: true,
+        workerType: 'module'
+    },
+    {
+        worker: true,
+        sharedWorker: true
     }
 ];
 


### PR DESCRIPTION
- `sharedWorker` option
- `worker` option
- `preserveTypeModule` option
- `workerType` option
- v4 bump without v3 creation as the api is being amended without
breaking existing usage I believe

https://github.com/GoogleChromeLabs/worker-plugin/compare/3.2.0...4.0.3

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.