### PR TITLE
Adding "translateExtent" prop type to ZoomableGroupsProps interface in react-simple-maps

### DIFF
--- a/types/react-simple-maps/index.d.ts
+++ b/types/react-simple-maps/index.d.ts
@@ -81,6 +81,7 @@ export interface ZoomableGroupProps extends React.SVGAttributes<SVGGElement> {
     onMoveEnd?: (event: any, position: Position) => void;
     onZoomStart?: (event: any, position: Position) => void;
     onZoomEnd?: (event: any, position: Position) => void;
+    translateExtent?: [[number, number], [number, number]]
 }
 
 interface GeographiesChildrenArgument {

--- a/types/react-simple-maps/index.d.ts
+++ b/types/react-simple-maps/index.d.ts
@@ -81,7 +81,7 @@ export interface ZoomableGroupProps extends React.SVGAttributes<SVGGElement> {
     onMoveEnd?: (event: any, position: Position) => void;
     onZoomStart?: (event: any, position: Position) => void;
     onZoomEnd?: (event: any, position: Position) => void;
-    translateExtent?: [[number, number], [number, number]]
+    translateExtent?: [[number, number], [number, number]];
 }
 
 interface GeographiesChildrenArgument {


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.react-simple-maps.io/docs/zoomable-group/
