### PR TITLE
Reactour: add missing accessibility definitions

### DIFF
--- a/types/reactour/index.d.ts
+++ b/types/reactour/index.d.ts
@@ -58,6 +58,15 @@ export interface ReactourStep {
     navDotAriaLabel?: string;
 }
 
+export interface ReactourAccessibilityOptions {
+    // attribute to associate the dialog with a title for screen readers
+    ariaLabelledBy?: string;
+    // aria-label attribute for the close button
+    closeButtonAriaLabel?: string;
+    // Show/Hide Navigation Dots for screen reader software
+    showNavigationScreenReaders?: boolean;
+}
+
 export interface ReactourProps {
     /**
      * You know…
@@ -249,6 +258,11 @@ export interface ReactourProps {
      * @default false
      */
     disableFocusLock?: boolean;
+
+    /**
+     * Configure accessibility related accessibility options
+     */
+    accessibilityOptions?: ReactourAccessibilityOptions;
 }
 
 export interface ReactourState {

--- a/types/reactour/reactour-tests.tsx
+++ b/types/reactour/reactour-tests.tsx
@@ -140,6 +140,11 @@ class CustomTour extends React.Component<{}, { isTourOpen: boolean }> {
                     update={this.state.update}
                     updateDelay={2}
                     disableFocusLock={false}
+                    accessibilityOptions={{
+                        ariaLabelledBy: "Tour aria label",
+                        closeButtonAriaLabel: "Close",
+                        showNavigationScreenReaders: true
+                    }}
                 >
                     <div>Something</div>
                 </Tour>


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [accessibilityOptions in Readme](https://github.com/elrumordelaluz/reactour#accessibilityoptions)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
