### PR TITLE
[sortablejs] Fix types for the onMove callback

### DIFF
--- a/types/sortablejs/index.d.ts
+++ b/types/sortablejs/index.d.ts
@@ -412,7 +412,7 @@ declare namespace Sortable {
         /**
          * Event when you move an item in the list or between lists
          */
-        onMove?: (evt: MoveEvent, originalEvent: Event) => boolean | -1 | 1;
+        onMove?: (evt: MoveEvent, originalEvent: Event) => boolean | -1 | 1 | void;
         /**
          * Called when dragging element changes position
          */

--- a/types/sortablejs/sortablejs-tests.ts
+++ b/types/sortablejs/sortablejs-tests.ts
@@ -400,6 +400,18 @@ Sortable.create(simpleList, {
     },
 });
 
+Sortable.create(simpleList, {
+    handle: '.glyphicon-move',
+    animation: 150,
+    filter: '.disabled',
+    onMove: function(evt, originalEvent) {
+        if (evt.related.className.indexOf('disabled') !== -1) {
+            return false;
+        }
+        // Keep the default insertion place based on the direction.
+    },
+});
+
 // plugins
 const { AutoScroll, MultiDrag, OnSpill, Swap } = Sortable;
 Sortable.mount(new AutoScroll(), new MultiDrag(), new OnSpill(), new Swap());


### PR DESCRIPTION
While return 1 or -1 is supported to override the final position, returning nothing is also supported (keeping the default position which is based on the dragging direction).
To be exact, any returned value other than `false`, `1` and `-1` is treated the same (keeping the default behavior).


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/SortableJS/Sortable/blob/88838bfa5647e278f4cf87fdd4c3e34cd24fb33c/src/Sortable.js#L1247-L1254>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

