### PR TITLE
Jest: add Date to setSystemTime param types

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -140,7 +140,7 @@ declare namespace jest {
      * > Note: This function is only available when using modern fake timers
      * > implementation
      */
-    function setSystemTime(now?: number): void;
+    function setSystemTime(now?: number | Date): void;
     /**
      * When mocking time, Date.now() will also be mocked. If you for some
      * reason need access to the real current time, you can invoke this

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -294,6 +294,7 @@ jest.useFakeTimers('foo');
 // https://jestjs.io/docs/en/jest-object#jestsetsystemtimenow-number--date
 jest.setSystemTime();
 jest.setSystemTime(0);
+jest.setSystemTime(new Date(0));
 // $ExpectError
 jest.setSystemTime('foo');
 


### PR DESCRIPTION
Following up on https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45496, this PR adds support for `Date` arguments to `jest.setSystemTime` now that https://github.com/facebook/jest/pull/10169 is merged and [released](https://github.com/facebook/jest/releases/tag/v26.1.0).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://jestjs.io/docs/en/jest-object#jestsetsystemtime, support for `| Date` was added in https://github.com/facebook/jest/pull/10169
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. 
  - (This currently says `16.0`, so it's pretty far out of date, but I can make the change if that's desirable)
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.