### PR TITLE
prosemirror-state and prosemirror-view: Specify 'this' binding

### DIFF
--- a/types/prosemirror-state/index.d.ts
+++ b/types/prosemirror-state/index.d.ts
@@ -5,7 +5,7 @@
 //                 Tim Baumann <https://github.com/timjb>
 //                 Patrick Simmelbauer <https://github.com/patsimm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import {
   Mark,
@@ -28,7 +28,7 @@ export interface PluginSpec<T = any, S extends Schema = any> {
    * that are functions will be bound to have the plugin instance as
    * their `this` binding.
    */
-  props?: EditorProps<S> | null;
+  props?: EditorProps<T, S> | null;
   /**
    * Allows a plugin to define a [state field](#state.StateField), an
    * extra slot in the state object in which it can keep its own data.
@@ -90,7 +90,7 @@ export class Plugin<T = any, S extends Schema = any> {
   /**
    * The [props](#view.EditorProps) exported by this plugin.
    */
-  props: EditorProps<S>;
+  props: EditorProps<T, S>;
   /**
    * The plugin's [spec object](#state.PluginSpec).
    */
@@ -113,24 +113,24 @@ export interface StateField<T = any, S extends Schema = Schema> {
    * that `instance` is a half-initialized state instance, and will
    * not have values for plugin fields initialized after this one.
    */
-  init(config: { [key: string]: any }, instance: EditorState<S>): T;
+  init(this: Plugin<T, S>, config: { [key: string]: any }, instance: EditorState<S>): T;
   /**
    * Apply the given transaction to this state field, producing a new
    * field value. Note that the `newState` argument is again a partially
    * constructed state does not yet contain the state from plugins
    * coming after this one.
    */
-  apply(tr: Transaction<S>, value: T, oldState: EditorState<S>, newState: EditorState<S>): T;
+  apply(this: Plugin<T, S>, tr: Transaction<S>, value: T, oldState: EditorState<S>, newState: EditorState<S>): T;
   /**
    * Convert this field to JSON. Optional, can be left off to disable
    * JSON serialization for the field.
    */
-  toJSON?: ((value: T) => any) | null;
+  toJSON?: ((this: Plugin<T, S>, value: T) => any) | null;
   /**
    * Deserialize the JSON representation of this field. Note that the
    * `state` argument is again a half-initialized state.
    */
-  fromJSON?: ((config: { [key: string]: any }, value: any, state: EditorState<S>) => T) | null;
+  fromJSON?: ((this: Plugin<T, S>, config: { [key: string]: any }, value: any, state: EditorState<S>) => T) | null;
 }
 /**
  * A key is used to [tag](#state.PluginSpec.key)

--- a/types/prosemirror-state/index.d.ts
+++ b/types/prosemirror-state/index.d.ts
@@ -6,7 +6,7 @@
 //                 Patrick Simmelbauer <https://github.com/patsimm>
 //                 Mike Morearty <https://github.com/mmorearty>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 import {
   Mark,
@@ -29,7 +29,7 @@ export interface PluginSpec<T = any, S extends Schema = any> {
    * that are functions will be bound to have the plugin instance as
    * their `this` binding.
    */
-  props?: EditorProps<T, S> | null;
+  props?: EditorProps<Plugin<T, S>, S> | null;
   /**
    * Allows a plugin to define a [state field](#state.StateField), an
    * extra slot in the state object in which it can keep its own data.
@@ -91,7 +91,7 @@ export class Plugin<T = any, S extends Schema = any> {
   /**
    * The [props](#view.EditorProps) exported by this plugin.
    */
-  props: EditorProps<T, S>;
+  props: EditorProps<Plugin<T, S>, S>;
   /**
    * The plugin's [spec object](#state.PluginSpec).
    */

--- a/types/prosemirror-state/index.d.ts
+++ b/types/prosemirror-state/index.d.ts
@@ -4,6 +4,7 @@
 //                 David Hahn <https://github.com/davidka>
 //                 Tim Baumann <https://github.com/timjb>
 //                 Patrick Simmelbauer <https://github.com/patsimm>
+//                 Mike Morearty <https://github.com/mmorearty>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/prosemirror-state/prosemirror-state-tests.ts
+++ b/types/prosemirror-state/prosemirror-state-tests.ts
@@ -1,11 +1,25 @@
 import * as state from 'prosemirror-state';
 import * as model from 'prosemirror-model';
 import * as transform from 'prosemirror-transform';
+import * as view from 'prosemirror-view';
 
 let plugin: state.Plugin;
 
-plugin = new state.Plugin({});
 plugin = new state.Plugin({
+    state: {
+        init() {
+            // ensure that within state.init(), 'this' is of type Plugin
+            const p: state.Plugin = this;
+            return null;
+        },
+
+        apply(tr, value, oldState, newState) {
+            // ensure that within state.apply(), 'this' is of type Plugin
+            const p: state.Plugin = this;
+            return null;
+        },
+    },
+
     props: {}
 });
 

--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -7,7 +7,7 @@
 //                 Ifiok Jr. <https://github.com/ifiokjr>
 //                 Mike Morearty <https://github.com/mmorearty>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 import {
   DOMParser,
@@ -18,7 +18,7 @@ import {
   Schema,
   Mark
 } from 'prosemirror-model';
-import { EditorState, Plugin, Selection, Transaction } from 'prosemirror-state';
+import { EditorState, Selection, Transaction } from 'prosemirror-state';
 import { Mapping } from 'prosemirror-transform';
 
 // Exported for testing
@@ -395,7 +395,7 @@ export class EditorView<S extends Schema = any> {
  * them returns true. For some props, the first plugin that yields a
  * value gets precedence.
  */
-export interface EditorProps<T = any, S extends Schema = any> {
+export interface EditorProps<ThisT = unknown, S extends Schema = any> {
   /**
    * Can be an object mapping DOM event type names to functions that
    * handle them. Such functions will be called before any handling
@@ -405,22 +405,22 @@ export interface EditorProps<T = any, S extends Schema = any> {
    * `preventDefault` yourself (or not, if you want to allow the
    * default behavior).
    */
-  handleDOMEvents?: { [name: string]: (this: Plugin<T, S>, view: EditorView<S>, event: Event) => boolean } | null;
+  handleDOMEvents?: { [name: string]: (this: ThisT, view: EditorView<S>, event: Event) => boolean } | null;
   /**
    * Called when the editor receives a `keydown` event.
    */
-  handleKeyDown?: ((this: Plugin<T, S>, view: EditorView<S>, event: KeyboardEvent) => boolean) | null;
+  handleKeyDown?: ((this: ThisT, view: EditorView<S>, event: KeyboardEvent) => boolean) | null;
   /**
    * Handler for `keypress` events.
    */
-  handleKeyPress?: ((this: Plugin<T, S>, view: EditorView<S>, event: KeyboardEvent) => boolean) | null;
+  handleKeyPress?: ((this: ThisT, view: EditorView<S>, event: KeyboardEvent) => boolean) | null;
   /**
    * Whenever the user directly input text, this handler is called
    * before the input is applied. If it returns `true`, the default
    * behavior of actually inserting the text is suppressed.
    */
   handleTextInput?:
-  | ((this: Plugin<T, S>, view: EditorView<S>, from: number, to: number, text: string) => boolean)
+  | ((this: ThisT, view: EditorView<S>, from: number, to: number, text: string) => boolean)
   | null;
   /**
    * Called for each node around a click, from the inside out. The
@@ -428,7 +428,7 @@ export interface EditorProps<T = any, S extends Schema = any> {
    */
   handleClickOn?:
   | ((
-    this: Plugin<T, S>,
+    this: ThisT,
     view: EditorView<S>,
     pos: number,
     node: ProsemirrorNode<S>,
@@ -441,13 +441,13 @@ export interface EditorProps<T = any, S extends Schema = any> {
    * Called when the editor is clicked, after `handleClickOn` handlers
    * have been called.
    */
-  handleClick?: ((this: Plugin<T, S>, view: EditorView<S>, pos: number, event: MouseEvent) => boolean) | null;
+  handleClick?: ((this: ThisT, view: EditorView<S>, pos: number, event: MouseEvent) => boolean) | null;
   /**
    * Called for each node around a double click.
    */
   handleDoubleClickOn?:
   | ((
-    this: Plugin<T, S>,
+    this: ThisT,
     view: EditorView<S>,
     pos: number,
     node: ProsemirrorNode<S>,
@@ -459,13 +459,13 @@ export interface EditorProps<T = any, S extends Schema = any> {
   /**
    * Called when the editor is double-clicked, after `handleDoubleClickOn`.
    */
-  handleDoubleClick?: ((this: Plugin<T, S>, view: EditorView<S>, pos: number, event: MouseEvent) => boolean) | null;
+  handleDoubleClick?: ((this: ThisT, view: EditorView<S>, pos: number, event: MouseEvent) => boolean) | null;
   /**
    * Called for each node around a triple click.
    */
   handleTripleClickOn?:
   | ((
-    this: Plugin<T, S>,
+    this: ThisT,
     view: EditorView<S>,
     pos: number,
     node: ProsemirrorNode<S>,
@@ -477,20 +477,20 @@ export interface EditorProps<T = any, S extends Schema = any> {
   /**
    * Called when the editor is triple-clicked, after `handleTripleClickOn`.
    */
-  handleTripleClick?: ((this: Plugin<T, S>, view: EditorView<S>, pos: number, event: MouseEvent) => boolean) | null;
+  handleTripleClick?: ((this: ThisT, view: EditorView<S>, pos: number, event: MouseEvent) => boolean) | null;
   /**
    * Can be used to override the behavior of pasting. `slice` is the
    * pasted content parsed by the editor, but you can directly access
    * the event to get at the raw content.
    */
-  handlePaste?: ((this: Plugin<T, S>, view: EditorView<S>, event: ClipboardEvent, slice: Slice<S>) => boolean) | null;
+  handlePaste?: ((this: ThisT, view: EditorView<S>, event: ClipboardEvent, slice: Slice<S>) => boolean) | null;
   /**
    * Called when something is dropped on the editor. `moved` will be
    * true if this drop moves from the current selection (which should
    * thus be deleted).
    */
   handleDrop?:
-  | ((this: Plugin<T, S>, view: EditorView<S>, event: Event, slice: Slice<S>, moved: boolean) => boolean)
+  | ((this: ThisT, view: EditorView<S>, event: Event, slice: Slice<S>, moved: boolean) => boolean)
   | null;
   /**
    * Called when the view, after updating its state, tries to scroll
@@ -498,14 +498,14 @@ export interface EditorProps<T = any, S extends Schema = any> {
    * indicate that it did not handle the scrolling and further
    * handlers or the default behavior should be tried.
    */
-  handleScrollToSelection?: ((this: Plugin<T, S>, view: EditorView<S>) => boolean) | null;
+  handleScrollToSelection?: ((this: ThisT, view: EditorView<S>) => boolean) | null;
   /**
    * Can be used to override the way a selection is created when
    * reading a DOM selection between the given anchor and head.
    */
   createSelectionBetween?:
   | ((
-    this: Plugin<T, S>,
+    this: ThisT,
     view: EditorView<S>,
     anchor: ResolvedPos<S>,
     head: ResolvedPos<S>
@@ -522,7 +522,7 @@ export interface EditorProps<T = any, S extends Schema = any> {
    * Can be used to transform pasted HTML text, _before_ it is parsed,
    * for example to clean it up.
    */
-  transformPastedHTML?: ((this: Plugin<T, S>, html: string) => string) | null;
+  transformPastedHTML?: ((this: ThisT, html: string) => string) | null;
   /**
    * The [parser](#model.DOMParser) to use when reading content from
    * the clipboard. When not given, the value of the
@@ -532,7 +532,7 @@ export interface EditorProps<T = any, S extends Schema = any> {
   /**
    * Transform pasted plain text.
    */
-  transformPastedText?: ((this: Plugin<T, S>, text: string) => string) | null;
+  transformPastedText?: ((this: ThisT, text: string) => string) | null;
   /**
    * A function to parse text from the clipboard into a document
    * slice. Called after
@@ -541,12 +541,12 @@ export interface EditorProps<T = any, S extends Schema = any> {
    * in `<p>` tags, and call
    * [`clipboardParser`](#view.EditorProps.clipboardParser) on it.
    */
-  clipboardTextParser?: ((this: Plugin<T, S>, text: string, $context: ResolvedPos<S>) => Slice<S>) | null;
+  clipboardTextParser?: ((this: ThisT, text: string, $context: ResolvedPos<S>) => Slice<S>) | null;
   /**
    * Can be used to transform pasted content before it is applied to
    * the document.
    */
-  transformPasted?: ((this: Plugin<T, S>, p: Slice<S>) => Slice<S>) | null;
+  transformPasted?: ((this: ThisT, p: Slice<S>) => Slice<S>) | null;
   /**
    * Allows you to pass custom rendering and behavior logic for nodes
    * and marks. Should map node and mark names to constructor
@@ -584,17 +584,17 @@ export interface EditorProps<T = any, S extends Schema = any> {
    * editor will use [`textBetween`](#model.Node.textBetween) on the
    * selected range.
    */
-  clipboardTextSerializer?: ((this: Plugin<T, S>, p: Slice<S>) => string) | null;
+  clipboardTextSerializer?: ((this: ThisT, p: Slice<S>) => string) | null;
   /**
    * A set of [document decorations](#view.Decoration) to show in the
    * view.
    */
-  decorations?: ((this: Plugin<T, S>, state: EditorState<S>) => DecorationSet<S> | null | undefined) | null;
+  decorations?: ((this: ThisT, state: EditorState<S>) => DecorationSet<S> | null | undefined) | null;
   /**
    * When this returns false, the content of the view is not directly
    * editable.
    */
-  editable?: ((this: Plugin<T, S>, state: EditorState<S>) => boolean) | null;
+  editable?: ((this: ThisT, state: EditorState<S>) => boolean) | null;
   /**
    * Control the DOM attributes of the editable element. May be either
    * an object or a function going from an editor state to an object.
@@ -607,7 +607,7 @@ export interface EditorProps<T = any, S extends Schema = any> {
    */
   attributes?:
   | { [name: string]: string }
-  | ((this: Plugin<T, S>, p: EditorState<S>) => { [name: string]: string } | null | undefined | void)
+  | ((this: ThisT, p: EditorState<S>) => { [name: string]: string } | null | undefined | void)
   | null;
   /**
    * Determines the distance (in pixels) between the cursor and the
@@ -625,7 +625,7 @@ export interface EditorProps<T = any, S extends Schema = any> {
  * The props object given directly to the editor view supports two
  * fields that can't be used in plugins:
  */
-export interface DirectEditorProps<S extends Schema = any> extends EditorProps<any, S> {
+export interface DirectEditorProps<S extends Schema = any> extends EditorProps<unknown, S> {
   /**
    * The current state of the editor.
    */

--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -5,6 +5,7 @@
 //                 Tim Baumann <https://github.com/timjb>
 //                 Patrick Simmelbauer <https://github.com/patsimm>
 //                 Ifiok Jr. <https://github.com/ifiokjr>
+//                 Mike Morearty <https://github.com/mmorearty>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -6,7 +6,7 @@
 //                 Patrick Simmelbauer <https://github.com/patsimm>
 //                 Ifiok Jr. <https://github.com/ifiokjr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import {
   DOMParser,
@@ -17,7 +17,7 @@ import {
   Schema,
   Mark
 } from 'prosemirror-model';
-import { EditorState, Selection, Transaction } from 'prosemirror-state';
+import { EditorState, Plugin, Selection, Transaction } from 'prosemirror-state';
 import { Mapping } from 'prosemirror-transform';
 
 // Exported for testing
@@ -394,7 +394,7 @@ export class EditorView<S extends Schema = any> {
  * them returns true. For some props, the first plugin that yields a
  * value gets precedence.
  */
-export interface EditorProps<S extends Schema = any> {
+export interface EditorProps<T = any, S extends Schema = any> {
   /**
    * Can be an object mapping DOM event type names to functions that
    * handle them. Such functions will be called before any handling
@@ -404,22 +404,22 @@ export interface EditorProps<S extends Schema = any> {
    * `preventDefault` yourself (or not, if you want to allow the
    * default behavior).
    */
-  handleDOMEvents?: { [name: string]: (view: EditorView<S>, event: Event) => boolean } | null;
+  handleDOMEvents?: { [name: string]: (this: Plugin<T, S>, view: EditorView<S>, event: Event) => boolean } | null;
   /**
    * Called when the editor receives a `keydown` event.
    */
-  handleKeyDown?: ((view: EditorView<S>, event: KeyboardEvent) => boolean) | null;
+  handleKeyDown?: ((this: Plugin<T, S>, view: EditorView<S>, event: KeyboardEvent) => boolean) | null;
   /**
    * Handler for `keypress` events.
    */
-  handleKeyPress?: ((view: EditorView<S>, event: KeyboardEvent) => boolean) | null;
+  handleKeyPress?: ((this: Plugin<T, S>, view: EditorView<S>, event: KeyboardEvent) => boolean) | null;
   /**
    * Whenever the user directly input text, this handler is called
    * before the input is applied. If it returns `true`, the default
    * behavior of actually inserting the text is suppressed.
    */
   handleTextInput?:
-  | ((view: EditorView<S>, from: number, to: number, text: string) => boolean)
+  | ((this: Plugin<T, S>, view: EditorView<S>, from: number, to: number, text: string) => boolean)
   | null;
   /**
    * Called for each node around a click, from the inside out. The
@@ -427,6 +427,7 @@ export interface EditorProps<S extends Schema = any> {
    */
   handleClickOn?:
   | ((
+    this: Plugin<T, S>,
     view: EditorView<S>,
     pos: number,
     node: ProsemirrorNode<S>,
@@ -439,12 +440,13 @@ export interface EditorProps<S extends Schema = any> {
    * Called when the editor is clicked, after `handleClickOn` handlers
    * have been called.
    */
-  handleClick?: ((view: EditorView<S>, pos: number, event: MouseEvent) => boolean) | null;
+  handleClick?: ((this: Plugin<T, S>, view: EditorView<S>, pos: number, event: MouseEvent) => boolean) | null;
   /**
    * Called for each node around a double click.
    */
   handleDoubleClickOn?:
   | ((
+    this: Plugin<T, S>,
     view: EditorView<S>,
     pos: number,
     node: ProsemirrorNode<S>,
@@ -456,12 +458,13 @@ export interface EditorProps<S extends Schema = any> {
   /**
    * Called when the editor is double-clicked, after `handleDoubleClickOn`.
    */
-  handleDoubleClick?: ((view: EditorView<S>, pos: number, event: MouseEvent) => boolean) | null;
+  handleDoubleClick?: ((this: Plugin<T, S>, view: EditorView<S>, pos: number, event: MouseEvent) => boolean) | null;
   /**
    * Called for each node around a triple click.
    */
   handleTripleClickOn?:
   | ((
+    this: Plugin<T, S>,
     view: EditorView<S>,
     pos: number,
     node: ProsemirrorNode<S>,
@@ -473,20 +476,20 @@ export interface EditorProps<S extends Schema = any> {
   /**
    * Called when the editor is triple-clicked, after `handleTripleClickOn`.
    */
-  handleTripleClick?: ((view: EditorView<S>, pos: number, event: MouseEvent) => boolean) | null;
+  handleTripleClick?: ((this: Plugin<T, S>, view: EditorView<S>, pos: number, event: MouseEvent) => boolean) | null;
   /**
    * Can be used to override the behavior of pasting. `slice` is the
    * pasted content parsed by the editor, but you can directly access
    * the event to get at the raw content.
    */
-  handlePaste?: ((view: EditorView<S>, event: ClipboardEvent, slice: Slice<S>) => boolean) | null;
+  handlePaste?: ((this: Plugin<T, S>, view: EditorView<S>, event: ClipboardEvent, slice: Slice<S>) => boolean) | null;
   /**
    * Called when something is dropped on the editor. `moved` will be
    * true if this drop moves from the current selection (which should
    * thus be deleted).
    */
   handleDrop?:
-  | ((view: EditorView<S>, event: Event, slice: Slice<S>, moved: boolean) => boolean)
+  | ((this: Plugin<T, S>, view: EditorView<S>, event: Event, slice: Slice<S>, moved: boolean) => boolean)
   | null;
   /**
    * Called when the view, after updating its state, tries to scroll
@@ -494,13 +497,14 @@ export interface EditorProps<S extends Schema = any> {
    * indicate that it did not handle the scrolling and further
    * handlers or the default behavior should be tried.
    */
-  handleScrollToSelection?: ((view: EditorView<S>) => boolean) | null;
+  handleScrollToSelection?: ((this: Plugin<T, S>, view: EditorView<S>) => boolean) | null;
   /**
    * Can be used to override the way a selection is created when
    * reading a DOM selection between the given anchor and head.
    */
   createSelectionBetween?:
   | ((
+    this: Plugin<T, S>,
     view: EditorView<S>,
     anchor: ResolvedPos<S>,
     head: ResolvedPos<S>
@@ -517,7 +521,7 @@ export interface EditorProps<S extends Schema = any> {
    * Can be used to transform pasted HTML text, _before_ it is parsed,
    * for example to clean it up.
    */
-  transformPastedHTML?: ((html: string) => string) | null;
+  transformPastedHTML?: ((this: Plugin<T, S>, html: string) => string) | null;
   /**
    * The [parser](#model.DOMParser) to use when reading content from
    * the clipboard. When not given, the value of the
@@ -527,7 +531,7 @@ export interface EditorProps<S extends Schema = any> {
   /**
    * Transform pasted plain text.
    */
-  transformPastedText?: ((text: string) => string) | null;
+  transformPastedText?: ((this: Plugin<T, S>, text: string) => string) | null;
   /**
    * A function to parse text from the clipboard into a document
    * slice. Called after
@@ -536,12 +540,12 @@ export interface EditorProps<S extends Schema = any> {
    * in `<p>` tags, and call
    * [`clipboardParser`](#view.EditorProps.clipboardParser) on it.
    */
-  clipboardTextParser?: ((text: string, $context: ResolvedPos<S>) => Slice<S>) | null;
+  clipboardTextParser?: ((this: Plugin<T, S>, text: string, $context: ResolvedPos<S>) => Slice<S>) | null;
   /**
    * Can be used to transform pasted content before it is applied to
    * the document.
    */
-  transformPasted?: ((p: Slice<S>) => Slice<S>) | null;
+  transformPasted?: ((this: Plugin<T, S>, p: Slice<S>) => Slice<S>) | null;
   /**
    * Allows you to pass custom rendering and behavior logic for nodes
    * and marks. Should map node and mark names to constructor
@@ -579,17 +583,17 @@ export interface EditorProps<S extends Schema = any> {
    * editor will use [`textBetween`](#model.Node.textBetween) on the
    * selected range.
    */
-  clipboardTextSerializer?: ((p: Slice<S>) => string) | null;
+  clipboardTextSerializer?: ((this: Plugin<T, S>, p: Slice<S>) => string) | null;
   /**
    * A set of [document decorations](#view.Decoration) to show in the
    * view.
    */
-  decorations?: ((state: EditorState<S>) => DecorationSet<S> | null | undefined) | null;
+  decorations?: ((this: Plugin<T, S>, state: EditorState<S>) => DecorationSet<S> | null | undefined) | null;
   /**
    * When this returns false, the content of the view is not directly
    * editable.
    */
-  editable?: ((state: EditorState<S>) => boolean) | null;
+  editable?: ((this: Plugin<T, S>, state: EditorState<S>) => boolean) | null;
   /**
    * Control the DOM attributes of the editable element. May be either
    * an object or a function going from an editor state to an object.
@@ -602,7 +606,7 @@ export interface EditorProps<S extends Schema = any> {
    */
   attributes?:
   | { [name: string]: string }
-  | ((p: EditorState<S>) => { [name: string]: string } | null | undefined | void)
+  | ((this: Plugin<T, S>, p: EditorState<S>) => { [name: string]: string } | null | undefined | void)
   | null;
   /**
    * Determines the distance (in pixels) between the cursor and the
@@ -620,7 +624,7 @@ export interface EditorProps<S extends Schema = any> {
  * The props object given directly to the editor view supports two
  * fields that can't be used in plugins:
  */
-export interface DirectEditorProps<S extends Schema = any> extends EditorProps<S> {
+export interface DirectEditorProps<S extends Schema = any> extends EditorProps<any, S> {
   /**
    * The current state of the editor.
    */
@@ -634,7 +638,7 @@ export interface DirectEditorProps<S extends Schema = any> extends EditorProps<S
    * [applied](#state.EditorState.apply). The callback will be bound to have
    * the view instance as its `this` binding.
    */
-  dispatchTransaction?: ((tr: Transaction<S>) => void) | null;
+  dispatchTransaction?: ((this: EditorView<S>, tr: Transaction<S>) => void) | null;
 }
 /**
  * By default, document nodes are rendered using the result of the

--- a/types/prosemirror-view/prosemirror-view-tests.ts
+++ b/types/prosemirror-view/prosemirror-view-tests.ts
@@ -1,5 +1,6 @@
 import * as view from 'prosemirror-view';
 import * as state from 'prosemirror-state';
+import * as schema from 'prosemirror-schema-basic';
 
 const { Decoration } = view;
 const decoration = new Decoration();
@@ -22,9 +23,32 @@ const res1_2: { pos: number, inside: number } = res1_1.posAtCoords({ left: 0, to
 const res1_3: boolean = res1_1.editable;
 
 const res2_1: view.EditorProps = {} as any;
-const res2_2: state.Selection = res2_1.createSelectionBetween!({} as any, {} as any, {} as any)!;
-const res2_3: view.DecorationSet = res2_1.decorations!({} as any)!;
+const res2_plugin = new state.Plugin({});
+const res2_2: state.Selection = res2_1.createSelectionBetween!.call(res2_plugin, {}, {}, {});
+const res2_3: view.DecorationSet = res2_1.decorations!.call(res2_plugin, {});
 
 const res3_1: view.EditorProps["attributes"] = () => {};
 const res3_2: view.EditorProps["attributes"] = () => null;
 const res3_3: view.EditorProps["attributes"] = () => undefined;
+
+// Test binding of 'this'
+const res4_plugin = new state.Plugin<string, typeof schema.schema>({
+    props: {
+        decorations(editorState) {
+            // Just testing one function from EditorProps.
+            // Ensure that `this` is bound to type Plugin<string>
+            const p: state.Plugin<string, typeof schema.schema> = this;
+            return null;
+        },
+    },
+});
+
+const res5_view = new view.EditorView<typeof schema.schema>(undefined, {
+    state: {} as any, // this is not part of the test
+
+    dispatchTransaction(tr) {
+        // From DirectEditorProps
+        // Ensure that `this` is bound to type EditorView<schema.schema>
+        const v: view.EditorView<typeof schema.schema> = this;
+    },
+});


### PR DESCRIPTION
Various functions in prosemirror-state and prosemirror-view have specific,
documented bindings for 'this':

* All functions in EditorProps and StateField have their 'this' binding set to
  type 'Plugin' (the plugin instance)
* DirectEditorProps.dispatchTransaction() has its 'this' binding set to type
  'EditorView' (the view instance)

This change touches two subdirs of `types`, `prosemirror-state` and `prosemirror-view`, because the changes are interrelated and I'm not sure if they can be separated — those two projects have a circular dependency.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [EditorProps](https://prosemirror.net/docs/ref/#state.PluginSpec.props), [StateField](https://prosemirror.net/docs/ref/#state.PluginSpec.props), and [dispatchTransaction()](https://prosemirror.net/docs/ref/#state.PluginSpec.props)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
