### PR TITLE
update(semver): `subset` method and 7.3 version bump

### DIFF
--- a/types/semver/index.d.ts
+++ b/types/semver/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for semver 7.2
+// Type definitions for semver 7.3
 // Project: https://github.com/npm/node-semver
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 //                 BendingBender <https://github.com/BendingBender>
@@ -80,6 +80,7 @@ import semverGtr = require('./ranges/gtr');
 import semverLtr = require('./ranges/ltr');
 import semverIntersects = require('./ranges/intersects');
 import simplifyRange = require('./ranges/simplify');
+import rangeSubset = require('./ranges/subset');
 
 export {
     semverSatisfies as satisfies,
@@ -93,6 +94,7 @@ export {
     semverLtr as ltr,
     semverIntersects as intersects,
     simplifyRange as simplify,
+    rangeSubset as subset,
 };
 
 // classes

--- a/types/semver/ranges/subset.d.ts
+++ b/types/semver/ranges/subset.d.ts
@@ -1,0 +1,13 @@
+import Range = require('../classes/range');
+import semver = require('../');
+
+/**
+ * Return true if the subRange range is entirely contained by the superRange range.
+ */
+declare function subset(
+    sub: string | Range,
+    dom: string | Range,
+    options?: semver.Options,
+): boolean;
+
+export = subset;

--- a/types/semver/semver-tests.ts
+++ b/types/semver/semver-tests.ts
@@ -169,6 +169,10 @@ semver.simplify(versions, '>=3.0.0 <3.1.0'); // $ExpectType string | Range
 semver.simplify(versions, '3.0.0 || 3.1 || 3.2 || 3.3'); // $ExpectType string | Range
 semver.simplify(versions, '1 || 2 || 3'); // $ExpectType string | Range
 semver.simplify(versions, '2.1 || 2.2 || 2.3'); // $ExpectType string | Range
+semver.subset('1.x', '1.x'); // $ExpectType boolean
+semver.subset(new Range('1.2.3'), new Range('1.2.3')); // $ExpectType boolean
+semver.subset('^1.2.3-pre.0', '1.x', { includePrerelease: true }); // $ExpectType boolean
+semver.subset('', ''); // $ExpectType boolean
 
 // Coercion
 sem = semver.coerce(str);


### PR DESCRIPTION
This PR:
- adds new `subset` function
- bumps minor version from 7.2 to 7.3

Source code change: [npm/node-semver@v7.2.3...v7.3.2](https://github.com/npm/node-semver/compare/v7.2.3...v7.3.2)

Thank you!

-------

Template steps:
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
