### PR TITLE
React tabs ref

### DIFF
--- a/types/react-tabs/index.d.ts
+++ b/types/react-tabs/index.d.ts
@@ -6,12 +6,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as React from "react";
+import * as React from 'react';
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
-export interface TabsProps
-    extends Omit<React.HTMLProps<HTMLDivElement>, "className" | "onSelect"> {
+export interface TabsProps extends Omit<React.HTMLProps<HTMLDivElement>, 'className' | 'onSelect'> {
     className?: string | string[] | { [name: string]: boolean };
     defaultFocus?: boolean;
     defaultIndex?: number;
@@ -24,13 +23,11 @@ export interface TabsProps
     selectedTabPanelClassName?: string;
 }
 
-export interface TabListProps
-    extends Omit<React.HTMLProps<HTMLUListElement>, "className"> {
+export interface TabListProps extends Omit<React.HTMLProps<HTMLUListElement>, 'className'> {
     className?: string | string[] | { [name: string]: boolean };
 }
 
-export interface TabProps
-    extends Omit<React.HTMLProps<HTMLLIElement>, "className" | "tabIndex"> {
+export interface TabProps extends Omit<React.HTMLProps<HTMLLIElement>, 'className' | 'tabIndex'> {
     className?: string | string[] | { [name: string]: boolean };
     disabled?: boolean;
     disabledClassName?: string;
@@ -38,8 +35,7 @@ export interface TabProps
     tabIndex?: string;
 }
 
-export interface TabPanelProps
-    extends Omit<React.HTMLProps<HTMLDivElement>, "className"> {
+export interface TabPanelProps extends Omit<React.HTMLProps<HTMLDivElement>, 'className'> {
     className?: string | string[] | { [name: string]: boolean };
     forceRender?: boolean;
     selectedClassName?: string;

--- a/types/react-tabs/index.d.ts
+++ b/types/react-tabs/index.d.ts
@@ -10,7 +10,7 @@ import * as React from 'react';
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
-export interface TabsProps extends Omit<React.HTMLProps<HTMLDivElement>, 'className' | 'onSelect'> {
+export interface TabsProps extends Omit<React.HTMLProps<HTMLDivElement>, 'className' | 'onSelect' | 'ref'> {
     className?: string | string[] | { [name: string]: boolean };
     defaultFocus?: boolean;
     defaultIndex?: number;

--- a/types/react-tabs/react-tabs-tests.ts
+++ b/types/react-tabs/react-tabs-tests.ts
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import {
     Tabs,
     TabsProps,
@@ -9,8 +9,8 @@ import {
     TabProps,
     TabPanel,
     TabPanelProps,
-    resetIdCounter
-} from "react-tabs";
+    resetIdCounter,
+} from 'react-tabs';
 
 resetIdCounter();
 
@@ -21,24 +21,27 @@ interface TestTabsProps extends TabsProps {}
 
 class TestApp extends React.Component {
     onSelect = (index: number, last: number, event: Event) => {
-        console.log("selected tab: " + index.toString());
-        console.log("last tab: " + last.toString());
-        console.log("event: " + event.type);
-    }
+        console.log('selected tab: ' + index.toString());
+        console.log('last tab: ' + last.toString());
+        console.log('event: ' + event.type);
+    };
 
     render() {
-        return React.createElement(Tabs, { onSelect: this.onSelect, selectedIndex: 1, defaultFocus: true, name: 'Tabs', autoFocus: true },
-            React.createElement(TabList, { className: "test-class" },
-                React.createElement(Tab, { disabled: true }, "Tab1"),
-                React.createElement(Tab, { selectedClassName: "active" }, "Tab2"),
-                React.createElement(Tab, {}, "Tab3")),
-            React.createElement(TabPanel, {}, React.createElement("h2", {}, "Content1")),
-            React.createElement(TabPanel, {}, React.createElement("h2", {}, "Content2")),
-            React.createElement(TabPanel, {}, React.createElement("h2", {}, "Content3")));
+        return React.createElement(
+            Tabs,
+            { onSelect: this.onSelect, selectedIndex: 1, defaultFocus: true, name: 'Tabs', autoFocus: true },
+            React.createElement(
+                TabList,
+                { className: 'test-class' },
+                React.createElement(Tab, { disabled: true }, 'Tab1'),
+                React.createElement(Tab, { selectedClassName: 'active' }, 'Tab2'),
+                React.createElement(Tab, {}, 'Tab3'),
+            ),
+            React.createElement(TabPanel, {}, React.createElement('h2', {}, 'Content1')),
+            React.createElement(TabPanel, {}, React.createElement('h2', {}, 'Content2')),
+            React.createElement(TabPanel, {}, React.createElement('h2', {}, 'Content3')),
+        );
     }
 }
 
-ReactDOM.render(
-    React.createElement(TestApp, {}),
-    document.getElementById("test-app")
-);
+ReactDOM.render(React.createElement(TestApp, {}), document.getElementById('test-app'));

--- a/types/react-tabs/react-tabs-tests.ts
+++ b/types/react-tabs/react-tabs-tests.ts
@@ -24,7 +24,7 @@ class TestApp extends React.Component {
         console.log('selected tab: ' + index.toString());
         console.log('last tab: ' + last.toString());
         console.log('event: ' + event.type);
-    };
+    }
     private readonly tabsRef = React.createRef<Tabs>();
 
     render() {

--- a/types/react-tabs/react-tabs-tests.tsx
+++ b/types/react-tabs/react-tabs-tests.tsx
@@ -28,26 +28,23 @@ class TestApp extends React.Component {
     private readonly tabsRef = React.createRef<Tabs>();
 
     render() {
-        return React.createElement(
-            Tabs,
-            {
-                onSelect: this.onSelect,
-                selectedIndex: 1,
-                defaultFocus: true,
-                name: 'Tabs',
-                autoFocus: true,
-                ref: this.tabsRef,
-            },
-            React.createElement(
-                TabList,
-                { className: 'test-class' },
-                React.createElement(Tab, { disabled: true }, 'Tab1'),
-                React.createElement(Tab, { selectedClassName: 'active' }, 'Tab2'),
-                React.createElement(Tab, {}, 'Tab3'),
-            ),
-            React.createElement(TabPanel, {}, React.createElement('h2', {}, 'Content1')),
-            React.createElement(TabPanel, {}, React.createElement('h2', {}, 'Content2')),
-            React.createElement(TabPanel, {}, React.createElement('h2', {}, 'Content3')),
+        return (
+            <Tabs onSelect={this.onSelect} selectedIndex={1} defaultFocus name="Tabs" autoFocus ref={this.tabsRef}>
+                <TabList className="test-class">
+                    <Tab disabled>Tab1</Tab>
+                    <Tab selectedClassName="active">Tab2</Tab>
+                    <Tab>Tab3</Tab>
+                    <TabPanel>
+                        <h2>Content1</h2>
+                    </TabPanel>
+                    <TabPanel>
+                        <h2>Content2</h2>
+                    </TabPanel>
+                    <TabPanel>
+                        <h2>Content3</h2>
+                    </TabPanel>
+                </TabList>
+            </Tabs>
         );
     }
 }

--- a/types/react-tabs/react-tabs-tests.tsx
+++ b/types/react-tabs/react-tabs-tests.tsx
@@ -24,7 +24,7 @@ class TestApp extends React.Component {
         console.log('selected tab: ' + index.toString());
         console.log('last tab: ' + last.toString());
         console.log('event: ' + event.type);
-    };
+    }
     private readonly tabsRef = React.createRef<Tabs>();
 
     render() {

--- a/types/react-tabs/tsconfig.json
+++ b/types/react-tabs/tsconfig.json
@@ -15,10 +15,12 @@
         ],
         "types": [],
         "noEmit": true,
+        "jsx": "preserve",
         "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",
-        "react-tabs-tests.ts"
+        "react-tabs-tests.ts",
+        "react-tabs-tests.tsx"
     ]
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/docs/refs-and-the-dom.html#creating-refs
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Without ommiting `'ref'` in `TabsProps` I get this errors in `react-tabs-tests.ts` and `react-tabs-tests.tsx` respectively:

```
No overload matches this call.
  The last overload gave the following error.
    Type 'RefObject<Tabs>' is not assignable to type 'string | ((instance: HTMLDivElement | null) => void) | RefObject<HTMLDivElement> | null | undefined'.
      Type 'RefObject<Tabs>' is not assignable to type 'RefObject<HTMLDivElement>'.
        Type 'Tabs' is missing the following properties from type 'HTMLDivElement': align, addEventListener, removeEventListener, accessKey, and 234 more.
```

```
No overload matches this call.
  Overload 1 of 2, '(props: Readonly<TabsProps>): Tabs', gave the following error.
    Type 'RefObject<Tabs>' is not assignable to type 'string | (string & ((instance: HTMLDivElement | null) => void)) | (string & RefObject<HTMLDivElement>) | (RefObject<Tabs> & string) | ... 6 more ... | undefined'.
      Type 'RefObject<Tabs>' is not assignable to type '((instance: Tabs | null) => void) & RefObject<HTMLDivElement>'.
        Type 'RefObject<Tabs>' is not assignable to type '(instance: Tabs | null) => void'.
          Type 'RefObject<Tabs>' provides no match for the signature '(instance: Tabs | null): void'.
  Overload 2 of 2, '(props: TabsProps, context?: any): Tabs', gave the following error.
    Type 'RefObject<Tabs>' is not assignable to type 'string | (string & ((instance: HTMLDivElement | null) => void)) | (string & RefObject<HTMLDivElement>) | (RefObject<Tabs> & string) | ... 6 more ... | undefined'.
      Type 'RefObject<Tabs>' is not assignable to type '((instance: Tabs | null) => void) & RefObject<HTMLDivElement>'.
        Type 'RefObject<Tabs>' is not assignable to type '(instance: Tabs | null) => void'.

The expected type comes from property 'ref' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<Tabs> & Readonly<TabsProps> & Readonly<{ children?: ReactNode; }>'
```
When I try to use `React.createRef<HTMLDivElement>()` the error goes away in `react-tabs-tests.ts` but changes on `react-tabs-tests.tsx` to:

```
No overload matches this call.
  Overload 1 of 2, '(props: Readonly<TabsProps>): Tabs', gave the following error.
    Type 'RefObject<HTMLDivElement>' is not assignable to type 'string | (string & RefObject<HTMLDivElement>) | (string & ((instance: HTMLDivElement | null) => void)) | (((instance: Tabs | null) => void) & string) | ... 6 more ... | undefined'.
      Type 'RefObject<HTMLDivElement>' is not assignable to type 'RefObject<Tabs> & ((instance: HTMLDivElement | null) => void)'.
        Type 'RefObject<HTMLDivElement>' is not assignable to type 'RefObject<Tabs>'.
          Type 'HTMLDivElement' is missing the following properties from type 'Tabs': context, setState, forceUpdate, render, and 3 more.
  Overload 2 of 2, '(props: TabsProps, context?: any): Tabs', gave the following error.
    Type 'RefObject<HTMLDivElement>' is not assignable to type 'string | (string & RefObject<HTMLDivElement>) | (string & ((instance: HTMLDivElement | null) => void)) | (((instance: Tabs | null) => void) & string) | ... 6 more ... | undefined'.
      Type 'RefObject<HTMLDivElement>' is not assignable to type 'RefObject<Tabs> & ((instance: HTMLDivElement | null) => void)'.
        Type 'RefObject<HTMLDivElement>' is not assignable to type 'RefObject<Tabs>'.

The expected type comes from property 'ref' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<Tabs> & Readonly<TabsProps> & Readonly<{ children?: ReactNode; }>'
```

This error goes aways by ommiting `'ref'`.