### PR TITLE
fix(semver): correct exported name for simplify

### DIFF
--- a/types/semver/index.d.ts
+++ b/types/semver/index.d.ts
@@ -79,7 +79,7 @@ import semverOutside = require('./ranges/outside');
 import semverGtr = require('./ranges/gtr');
 import semverLtr = require('./ranges/ltr');
 import semverIntersects = require('./ranges/intersects');
-import simplifyRange = require('./ranges/simplify');
+import simplify = require('./ranges/simplify');
 import rangeSubset = require('./ranges/subset');
 
 export {
@@ -93,7 +93,7 @@ export {
     semverGtr as gtr,
     semverLtr as ltr,
     semverIntersects as intersects,
-    simplifyRange as simplify,
+    simplify as simplifyRange,
     rangeSubset as subset,
 };
 

--- a/types/semver/semver-tests.ts
+++ b/types/semver/semver-tests.ts
@@ -162,13 +162,13 @@ bool = semver.ltr(version, str, loose);
 bool = semver.outside(version, str, '<', loose);
 bool = semver.intersects(str, str, loose);
 sem = semver.minVersion(str, loose);
-semver.simplify(versions, '1.x'); // $ExpectType string | Range
-semver.simplify(versions, '1.0.0 || 1.0.1 || 1.0.2 || 1.0.3 || 1.0.4'); // $ExpectType string | Range
-semver.simplify(versions, new Range('1.0.0 || 1.0.1 || 1.0.2 || 1.0.3 || 1.0.4')); // $ExpectType string | Range
-semver.simplify(versions, '>=3.0.0 <3.1.0'); // $ExpectType string | Range
-semver.simplify(versions, '3.0.0 || 3.1 || 3.2 || 3.3'); // $ExpectType string | Range
-semver.simplify(versions, '1 || 2 || 3'); // $ExpectType string | Range
-semver.simplify(versions, '2.1 || 2.2 || 2.3'); // $ExpectType string | Range
+semver.simplifyRange(versions, '1.x'); // $ExpectType string | Range
+semver.simplifyRange(versions, '1.0.0 || 1.0.1 || 1.0.2 || 1.0.3 || 1.0.4'); // $ExpectType string | Range
+semver.simplifyRange(versions, new Range('1.0.0 || 1.0.1 || 1.0.2 || 1.0.3 || 1.0.4')); // $ExpectType string | Range
+semver.simplifyRange(versions, '>=3.0.0 <3.1.0'); // $ExpectType string | Range
+semver.simplifyRange(versions, '3.0.0 || 3.1 || 3.2 || 3.3'); // $ExpectType string | Range
+semver.simplifyRange(versions, '1 || 2 || 3'); // $ExpectType string | Range
+semver.simplifyRange(versions, '2.1 || 2.2 || 2.3'); // $ExpectType string | Range
 semver.subset('1.x', '1.x'); // $ExpectType boolean
 semver.subset(new Range('1.2.3'), new Range('1.2.3')); // $ExpectType boolean
 semver.subset('^1.2.3-pre.0', '1.x', { includePrerelease: true }); // $ExpectType boolean


### PR DESCRIPTION
It looks the name should be `simplifyRange`, not `simplify`.
When used as direct import the name is `simplify`

https://github.com/npm/node-semver#ranges-1
https://github.com/npm/node-semver/blob/master/index.js#L46

Noticed here:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45693#issuecomment-648993595

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Provide a URL to documentation or source code which provides context for the suggested changes