### PR TITLE
fix(nodegit): fix Tree.diff return type

### DIFF
--- a/types/nodegit/nodegit-tests.ts
+++ b/types/nodegit/nodegit-tests.ts
@@ -18,6 +18,10 @@ tree.getEntry('/').then(entry => {
     // Use entry
 });
 
+tree.diff(new Git.Tree()).then(diff => {
+    diff.patches();
+});
+
 // AnnotatedCommit Tests
 
 Git.AnnotatedCommit.fromFetchhead(repo, 'branch_name', 'remote_url', id).then(annotatedCommit => {

--- a/types/nodegit/tree.d.ts
+++ b/types/nodegit/tree.d.ts
@@ -5,6 +5,7 @@ import { Object } from './object';
 import { Treebuilder } from './tree-builder';
 import { DiffFile } from './diff-file';
 import { TreeUpdate } from './tree-update';
+import { Diff } from './diff';
 
 export namespace Tree {
     const enum WALK_MODE {
@@ -38,11 +39,11 @@ export class Tree {
     /**
      * Diff two trees
      */
-    diff(tree: Tree, callback?: Function): Promise<DiffFile[]>;
+    diff(tree: Tree, callback?: Function): Promise<Diff>;
     /**
      * Diff two trees with options
      */
-    diffWithOptions(tree: Tree, options?: Object, callback?: Function): Promise<DiffFile[]>;
+    diffWithOptions(tree: Tree, options?: Object, callback?: Function): Promise<Diff>;
     /**
      * Get an entry at the ith position.
      */


### PR DESCRIPTION
Hello

I've updated the return type of Tree.diff and Tree.diffWithOptions to `Diff`
SInce the Documentation is not clear (https://www.nodegit.org/api/tree/#diff) and refer to a DiffList wihc not exist, I verify in the source code. as you can see it used Diff. treeToTree under the hood ( https://github.com/nodegit/nodegit/blob/master/lib/tree.js#L37-L50 ) wich return a Diff Object (https://www.nodegit.org/api/diff/#treeToTree)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

