### PR TITLE
Correct type of SymbolLayout 'text-max-width' property in 'mapbox-gl'

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -2046,7 +2046,7 @@ declare namespace mapboxgl {
         'text-field'?: string | StyleFunction | Expression;
         'text-font'?: string | string[] | Expression;
         'text-size'?: number | StyleFunction | Expression;
-        'text-max-width'?: number | Expression;
+        'text-max-width'?: number | StyleFunction | Expression;
         'text-line-height'?: number | Expression;
         'text-letter-spacing'?: number | Expression;
         'text-justify'?: 'left' | 'center' | 'right' | Expression;

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -133,6 +133,12 @@ map.on('load', function () {
         layout: {
             'icon-image': 'marker-15',
             'text-field': ['get', 'property'],
+            'text-max-width': {
+                stops: [
+                    [10, 2],
+                    [12, 5],
+                ],
+            },
         },
     });
 
@@ -599,11 +605,11 @@ let marker = new mapboxgl.Marker(undefined, {
     rotation: 15,
     rotationAlignment: 'map',
     pitchAlignment: 'viewport',
-    scale: 5.5
+    scale: 5.5,
 })
     .setLngLat([-50, 50])
-    .setPitchAlignment("map")
-    .setRotationAlignment("viewport")
+    .setPitchAlignment('map')
+    .setRotationAlignment('viewport')
     .addTo(map);
 
 // $ExpectType Alignment
@@ -1411,7 +1417,7 @@ const symbolLayout: mapboxgl.SymbolLayout = {
     'text-field': eitherType('#000', styleFunction, expression),
     'text-font': eitherType('arial', ['arial'], expression),
     'text-size': eitherType(0, styleFunction, expression),
-    'text-max-width': eitherType(0, expression),
+    'text-max-width': eitherType(0, styleFunction, expression),
     'text-line-height': eitherType(0, expression),
     'text-letter-spacing': eitherType(0, expression),
     'text-justify': eitherType('left', 'center', 'right', expression),


### PR DESCRIPTION
- Add StyleFunction to the existing type union

Tested and used @[GaiaGPS](https://www.gaiagps.com/) 

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#layout-symbol-text-max-width
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
