### PR TITLE
[@types/underscore] Collection and Array Tests - Type Extractors

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -107,11 +107,13 @@ declare module _ {
         (prev: TResult, curr: T, key: string, list: Dictionary<T>): TResult;
     }
 
-    type TypeOfList<V> = V extends _.List<infer T> ? T : never;
+    type TypeOfList<V> = V extends List<infer T> ? T : never;
 
-    type TypeOfDictionary<V> = V extends _.Dictionary<infer T> ? T : never;
+    type TypeOfDictionary<V> = V extends Dictionary<infer T> ? T : never;
 
-    type TypeOfCollection<V> = V extends _.Collection<infer T> ? T : never;
+    type TypeOfCollection<V> = V extends List<infer T> ? T
+        : V extends Dictionary<infer T> ? T
+        : never;
 
     type _ChainSingle<V> = _Chain<TypeOfCollection<V>, V>;
 

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -126,9 +126,7 @@ declare module _ {
          * @param value First argument to Underscore object functions.
          * @returns An Underscore wrapper around the supplied value.
          **/
-        <T extends TypeOfList<V>, V extends List<any> = List<T>>(value: V): Underscore<T, V>;
-        <T extends TypeOfDictionary<V>, V extends Dictionary<any> = Dictionary<T>>(value: V): Underscore<T, V>;
-        <V>(value: V): Underscore<never, V>;
+        <V>(value: V): Underscore<TypeOfCollection<V>, V>;
 
         /* *************
         * Collections *
@@ -4121,9 +4119,7 @@ declare module _ {
          * @param value The object to chain.
          * @returns An underscore chain wrapper around the supplied value.
          **/
-        chain<T extends TypeOfList<V>, V extends List<any> = List<T>>(value: V): _Chain<T, V>;
-        chain<T extends TypeOfDictionary<V>, V extends Dictionary<any> = Dictionary<T>>(value: V): _Chain<T, V>;
-        chain<V>(value: V): _Chain<never, V>;
+        chain<V>(value: V): _Chain<TypeOfCollection<V>, V>;
 
         /**
          * Current version

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -681,26 +681,26 @@ _.chain([1, 2, 3, 4, 5, 6])
     .value();
 
 // common testing types and objects
-interface SimpleStringObject {
+interface StringRecord {
     a: string;
     b: string;
 }
 
-interface SimpleStringObjectListWithExtraProperties extends _.List<SimpleStringObject> {
+interface StringRecordAugmentedList extends _.List<StringRecord> {
     notAListProperty: boolean;
 }
 
-interface StronglyKeyedSimpleStringObjectDictionary extends _.Dictionary<SimpleStringObject> {
-    a: SimpleStringObject;
-    b: SimpleStringObject;
-    c: SimpleStringObject;
+interface StringRecordExplicitDictionary extends _.Dictionary<StringRecord> {
+    a: StringRecord;
+    b: StringRecord;
+    c: StringRecord;
 }
 
-const simpleStringObjectArray: SimpleStringObject[] = [{ a: 'a', b: 'c' }, { a: 'b', b: 'b' }, { a: 'c', b: 'a' }];
-const simpleStringObjectListWithExtraProperties: SimpleStringObjectListWithExtraProperties = { 0: { a: 'a', b: 'c' }, 1: { a: 'b', b: 'b' }, 2: { a: 'c', b: 'a' }, length: 3, notAListProperty: true };
-const simpleStringObjectList: _.List<SimpleStringObject> = simpleStringObjectListWithExtraProperties;
-const stronglyKeyedSimpleStringObjectDictionary: StronglyKeyedSimpleStringObjectDictionary = { a: { a: 'a', b: 'c' }, b: { a: 'b', b: 'b' }, c: { a: 'c', b: 'a' } };
-const simpleStringObjectDictionary: _.Dictionary<SimpleStringObject> = stronglyKeyedSimpleStringObjectDictionary;
+const stringRecordArray: StringRecord[] = [{ a: 'a', b: 'c' }, { a: 'b', b: 'b' }, { a: 'c', b: 'a' }];
+const stringRecordAugmentedList: StringRecordAugmentedList = { 0: { a: 'a', b: 'c' }, 1: { a: 'b', b: 'b' }, 2: { a: 'c', b: 'a' }, length: 3, notAListProperty: true };
+const stringRecordList: _.List<StringRecord> = stringRecordAugmentedList;
+const stringRecordExplicitDictionary: StringRecordExplicitDictionary = { a: { a: 'a', b: 'c' }, b: { a: 'b', b: 'b' }, c: { a: 'c', b: 'a' } };
+const stringRecordDictionary: _.Dictionary<StringRecord> = stringRecordExplicitDictionary;
 
 const simpleString = 'abc';
 
@@ -732,13 +732,13 @@ declare const extractChainTypes: ChainTypeExtractor;
 {
     const length = 2;
 
-    _.chunk(simpleStringObjectArray, length); // $ExpectType SimpleStringObject[][]
-    _(simpleStringObjectArray).chunk(length); // $ExpectType SimpleStringObject[][]
-    extractChainTypes(_.chain(simpleStringObjectArray).chunk(length)); // $ExpectType ChainType<SimpleStringObject[][], SimpleStringObject[]>
+    _.chunk(stringRecordArray, length); // $ExpectType StringRecord[][]
+    _(stringRecordArray).chunk(length); // $ExpectType StringRecord[][]
+    extractChainTypes(_.chain(stringRecordArray).chunk(length)); // $ExpectType ChainType<StringRecord[][], StringRecord[]>
 
-    _.chunk(simpleStringObjectList, length); // $ExpectType SimpleStringObject[][]
-    _(simpleStringObjectList).chunk(length); // $ExpectType SimpleStringObject[][]
-    extractChainTypes(_.chain(simpleStringObjectList).chunk(length)); // $ExpectType ChainType<SimpleStringObject[][], SimpleStringObject[]>
+    _.chunk(stringRecordList, length); // $ExpectType StringRecord[][]
+    _(stringRecordList).chunk(length); // $ExpectType StringRecord[][]
+    extractChainTypes(_.chain(stringRecordList).chunk(length)); // $ExpectType ChainType<StringRecord[][], StringRecord[]>
 
     _.chunk(simpleString, length); // $ExpectType string[][]
     _(simpleString).chunk(length); // $ExpectType string[][]
@@ -749,13 +749,13 @@ declare const extractChainTypes: ChainTypeExtractor;
 
 // underscore
 {
-    extractUnderscoreTypes(_(simpleStringObjectArray)); // $ExpectType UnderscoreType<SimpleStringObject[], SimpleStringObject>
+    extractUnderscoreTypes(_(stringRecordArray)); // $ExpectType UnderscoreType<StringRecord[], StringRecord>
 
-    extractUnderscoreTypes(_(simpleStringObjectListWithExtraProperties)); // $ExpectType UnderscoreType<SimpleStringObjectListWithExtraProperties, SimpleStringObject>
-    extractUnderscoreTypes(_(simpleStringObjectList)); // $ExpectType UnderscoreType<List<SimpleStringObject>, SimpleStringObject>
+    extractUnderscoreTypes(_(stringRecordAugmentedList)); // $ExpectType UnderscoreType<StringRecordAugmentedList, StringRecord>
+    extractUnderscoreTypes(_(stringRecordList)); // $ExpectType UnderscoreType<List<StringRecord>, StringRecord>
 
-    extractUnderscoreTypes(_(stronglyKeyedSimpleStringObjectDictionary)); // $ExpectType UnderscoreType<StronglyKeyedSimpleStringObjectDictionary, SimpleStringObject>
-    extractUnderscoreTypes(_(simpleStringObjectDictionary)); // $ExpectType UnderscoreType<Dictionary<SimpleStringObject>, SimpleStringObject>
+    extractUnderscoreTypes(_(stringRecordExplicitDictionary)); // $ExpectType UnderscoreType<StringRecordExplicitDictionary, StringRecord>
+    extractUnderscoreTypes(_(stringRecordDictionary)); // $ExpectType UnderscoreType<Dictionary<StringRecord>, StringRecord>
 
     extractUnderscoreTypes(_(simpleString)); // $ExpectType UnderscoreType<string, string>
     extractUnderscoreTypes(_(simpleNumber)); // $ExpectType UnderscoreType<number, never>
@@ -766,13 +766,13 @@ declare const extractChainTypes: ChainTypeExtractor;
 // value
 // verify that the object type given to underscore is returned by value
 {
-    _(simpleStringObjectArray).value(); // $ExpectType SimpleStringObject[]
+    _(stringRecordArray).value(); // $ExpectType StringRecord[]
 
-    _(simpleStringObjectListWithExtraProperties).value(); // $ExpectType SimpleStringObjectListWithExtraProperties
-    _(simpleStringObjectList).value(); // $ExpectType List<SimpleStringObject>
+    _(stringRecordAugmentedList).value(); // $ExpectType StringRecordAugmentedList
+    _(stringRecordList).value(); // $ExpectType List<StringRecord>
 
-    _(stronglyKeyedSimpleStringObjectDictionary).value(); // $ExpectType StronglyKeyedSimpleStringObjectDictionary
-    _(simpleStringObjectDictionary).value(); // $ExpectType Dictionary<SimpleStringObject>
+    _(stringRecordExplicitDictionary).value(); // $ExpectType StringRecordExplicitDictionary
+    _(stringRecordDictionary).value(); // $ExpectType Dictionary<StringRecord>
 
     _(simpleString).value(); // $ExpectType string
     _(simpleNumber).value(); // $ExpectType number
@@ -786,20 +786,20 @@ declare const extractChainTypes: ChainTypeExtractor;
 // verify that the right chain item and value types are yielded by calls to chain
 // these tests also check to make sure that _.chain() and _().chain() yield the same types
 {
-    extractChainTypes(_.chain(simpleStringObjectArray)); // $ExpectType ChainType<SimpleStringObject[], SimpleStringObject>
-    extractChainTypes(_(simpleStringObjectArray).chain()); // $ExpectType ChainType<SimpleStringObject[], SimpleStringObject>
+    extractChainTypes(_.chain(stringRecordArray)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    extractChainTypes(_(stringRecordArray).chain()); // $ExpectType ChainType<StringRecord[], StringRecord>
 
-    extractChainTypes(_.chain(simpleStringObjectListWithExtraProperties)); // $ExpectType ChainType<SimpleStringObjectListWithExtraProperties, SimpleStringObject>
-    extractChainTypes(_(simpleStringObjectListWithExtraProperties).chain()); // $ExpectType ChainType<SimpleStringObjectListWithExtraProperties, SimpleStringObject>
+    extractChainTypes(_.chain(stringRecordAugmentedList)); // $ExpectType ChainType<StringRecordAugmentedList, StringRecord>
+    extractChainTypes(_(stringRecordAugmentedList).chain()); // $ExpectType ChainType<StringRecordAugmentedList, StringRecord>
 
-    extractChainTypes(_.chain(simpleStringObjectList)); // $ExpectType ChainType<List<SimpleStringObject>, SimpleStringObject>
-    extractChainTypes(_(simpleStringObjectList).chain()); // $ExpectType ChainType<List<SimpleStringObject>, SimpleStringObject>
+    extractChainTypes(_.chain(stringRecordList)); // $ExpectType ChainType<List<StringRecord>, StringRecord>
+    extractChainTypes(_(stringRecordList).chain()); // $ExpectType ChainType<List<StringRecord>, StringRecord>
 
-    extractChainTypes(_.chain(stronglyKeyedSimpleStringObjectDictionary)); // $ExpectType ChainType<StronglyKeyedSimpleStringObjectDictionary, SimpleStringObject>
-    extractChainTypes(_(stronglyKeyedSimpleStringObjectDictionary).chain()); // $ExpectType ChainType<StronglyKeyedSimpleStringObjectDictionary, SimpleStringObject>
+    extractChainTypes(_.chain(stringRecordExplicitDictionary)); // $ExpectType ChainType<StringRecordExplicitDictionary, StringRecord>
+    extractChainTypes(_(stringRecordExplicitDictionary).chain()); // $ExpectType ChainType<StringRecordExplicitDictionary, StringRecord>
 
-    extractChainTypes(_.chain(simpleStringObjectDictionary)); // $ExpectType ChainType<Dictionary<SimpleStringObject>, SimpleStringObject>
-    extractChainTypes(_(simpleStringObjectDictionary).chain()); // $ExpectType ChainType<Dictionary<SimpleStringObject>, SimpleStringObject>
+    extractChainTypes(_.chain(stringRecordDictionary)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+    extractChainTypes(_(stringRecordDictionary).chain()); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
     extractChainTypes(_.chain(simpleString)); // $ExpectType ChainType<string, string>
     extractChainTypes(_(simpleString).chain()); // $ExpectType ChainType<string, string>
@@ -814,13 +814,13 @@ declare const extractChainTypes: ChainTypeExtractor;
 // value
 // verify that the object type given to chain is returned by value
 {
-    _.chain(simpleStringObjectArray).value(); // $ExpectType SimpleStringObject[]
+    _.chain(stringRecordArray).value(); // $ExpectType StringRecord[]
 
-    _.chain(simpleStringObjectListWithExtraProperties).value(); // $ExpectType SimpleStringObjectListWithExtraProperties
-    _.chain(simpleStringObjectList).value(); // $ExpectType List<SimpleStringObject>
+    _.chain(stringRecordAugmentedList).value(); // $ExpectType StringRecordAugmentedList
+    _.chain(stringRecordList).value(); // $ExpectType List<StringRecord>
 
-    _.chain(stronglyKeyedSimpleStringObjectDictionary).value(); // $ExpectType StronglyKeyedSimpleStringObjectDictionary
-    _.chain(simpleStringObjectDictionary).value(); // $ExpectType Dictionary<SimpleStringObject>
+    _.chain(stringRecordExplicitDictionary).value(); // $ExpectType StringRecordExplicitDictionary
+    _.chain(stringRecordDictionary).value(); // $ExpectType Dictionary<StringRecord>
 
     _.chain(simpleString).value(); // $ExpectType string
     _.chain(simpleNumber).value(); // $ExpectType number

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -706,7 +706,7 @@ const simpleString = 'abc';
 
 const simpleNumber = 7;
 
-declare const collectionNonCollectionMix: number | number[];
+declare const mixedIterabilityValue: number | number[];
 
 // avoid referencing types under test directly by translating them to other types to avoid needing to make lots of changes if
 // the types under test need to be refactored
@@ -760,7 +760,7 @@ declare const extractChainTypes: ChainTypeExtractor;
     extractUnderscoreTypes(_(simpleString)); // $ExpectType UnderscoreType<string, string>
     extractUnderscoreTypes(_(simpleNumber)); // $ExpectType UnderscoreType<number, never>
 
-    extractUnderscoreTypes(_(collectionNonCollectionMix)); // $ExpectType UnderscoreType<number | number[], number>
+    extractUnderscoreTypes(_(mixedIterabilityValue)); // $ExpectType UnderscoreType<number | number[], number>
 }
 
 // value
@@ -777,7 +777,7 @@ declare const extractChainTypes: ChainTypeExtractor;
     _(simpleString).value(); // $ExpectType string
     _(simpleNumber).value(); // $ExpectType number
 
-    _(collectionNonCollectionMix).value(); // $ExpectType number | number[]
+    _(mixedIterabilityValue).value(); // $ExpectType number | number[]
 }
 
 // Chaining
@@ -807,8 +807,8 @@ declare const extractChainTypes: ChainTypeExtractor;
     extractChainTypes(_.chain(simpleNumber)); // $ExpectType ChainType<number, never>
     extractChainTypes(_(simpleNumber).chain()); // $ExpectType ChainType<number, never>
 
-    extractChainTypes(_.chain(collectionNonCollectionMix)); // $ExpectType ChainType<number | number[], number>
-    extractChainTypes(_(collectionNonCollectionMix).chain()); // $ExpectType ChainType<number | number[], number>
+    extractChainTypes(_.chain(mixedIterabilityValue)); // $ExpectType ChainType<number | number[], number>
+    extractChainTypes(_(mixedIterabilityValue).chain()); // $ExpectType ChainType<number | number[], number>
 }
 
 // value
@@ -825,5 +825,5 @@ declare const extractChainTypes: ChainTypeExtractor;
     _.chain(simpleString).value(); // $ExpectType string
     _.chain(simpleNumber).value(); // $ExpectType number
 
-    _.chain(collectionNonCollectionMix).value(); // $ExpectType number | number[]
+    _.chain(mixedIterabilityValue).value(); // $ExpectType number | number[]
 }

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -706,6 +706,24 @@ const simpleString = 'abc';
 
 const simpleNumber = 7;
 
+// avoid referencing types under test directly by translating them to other types to avoid needing to make lots of changes if
+// the types under test need to be refactored
+interface UnderscoreType<TWrappedValue, TItemType> { }
+
+interface UnderscoreTypeExtractor {
+    <T, V>(chainResult: _.Underscore<T, V>): UnderscoreType<V, T>;
+}
+
+declare const extractUnderscoreTypes: UnderscoreTypeExtractor;
+
+interface ChainType<TWrappedValue, TItemType> { }
+
+interface ChainTypeExtractor {
+    <T, V>(chainResult: _._Chain<T, V>): ChainType<V, T>;
+}
+
+declare const extractChainTypes: ChainTypeExtractor;
+
 // Arrays
 
 // chunk
@@ -714,31 +732,32 @@ const simpleNumber = 7;
 
     _.chunk(simpleStringObjectArray, length); // $ExpectType SimpleStringObject[][]
     _(simpleStringObjectArray).chunk(length); // $ExpectType SimpleStringObject[][]
-    _.chain(simpleStringObjectArray).chunk(length); // $ExpectType _Chain<SimpleStringObject[], SimpleStringObject[][]>
+    extractChainTypes(_.chain(simpleStringObjectArray).chunk(length)); // $ExpectType ChainType<SimpleStringObject[][], SimpleStringObject[]>
 
     _.chunk(simpleStringObjectList, length); // $ExpectType SimpleStringObject[][]
     _(simpleStringObjectList).chunk(length); // $ExpectType SimpleStringObject[][]
-    _.chain(simpleStringObjectList).chunk(length); // $ExpectType _Chain<SimpleStringObject[], SimpleStringObject[][]>
+    extractChainTypes(_.chain(simpleStringObjectList).chunk(length)); // $ExpectType ChainType<SimpleStringObject[][], SimpleStringObject[]>
 
     _.chunk(simpleString, length); // $ExpectType string[][]
     _(simpleString).chunk(length); // $ExpectType string[][]
-    _.chain(simpleString).chunk(length); // $ExpectType _Chain<string[], string[][]>
+    extractChainTypes(_.chain(simpleString).chunk(length)); // $ExpectType ChainType<string[][], string[]>
 }
 
 // OOP Style
 
 // underscore
 {
-    _(simpleStringObjectArray); // $ExpectType Underscore<SimpleStringObject, SimpleStringObject[]>
+    extractUnderscoreTypes(_(simpleStringObjectArray)); // $ExpectType UnderscoreType<SimpleStringObject[], SimpleStringObject>
 
-    _(simpleStringObjectListWithExtraProperties) // $ExpectType Underscore<SimpleStringObject, SimpleStringObjectListWithExtraProperties>
-    _(simpleStringObjectList); // $ExpectType Underscore<SimpleStringObject, List<SimpleStringObject>>
+    extractUnderscoreTypes(_(simpleStringObjectListWithExtraProperties)); // $ExpectType UnderscoreType<SimpleStringObjectListWithExtraProperties, SimpleStringObject>
+    extractUnderscoreTypes(_(simpleStringObjectList)); // $ExpectType UnderscoreType<List<SimpleStringObject>, SimpleStringObject>
 
-    _(stronglyKeyedSimpleStringObjectDictionary) // $ExpectType Underscore<SimpleStringObject, StronglyKeyedSimpleStringObjectDictionary>
-    _(simpleStringObjectDictionary); // $ExpectType Underscore<SimpleStringObject, Dictionary<SimpleStringObject>>
+    extractUnderscoreTypes(_(stronglyKeyedSimpleStringObjectDictionary)); // $ExpectType UnderscoreType<StronglyKeyedSimpleStringObjectDictionary, SimpleStringObject>
+    extractUnderscoreTypes(_(simpleStringObjectDictionary)); // $ExpectType UnderscoreType<Dictionary<SimpleStringObject>, SimpleStringObject>
 
-    _(simpleString); // $ExpectType Underscore<string, string>
-    _(simpleNumber); // $ExpectType Underscore<never, number>
+    extractUnderscoreTypes(_(simpleString)); // $ExpectType UnderscoreType<string, string>
+    extractUnderscoreTypes(_(simpleNumber)); // $ExpectType UnderscoreType<number, never>
+
 }
 
 // value
@@ -762,26 +781,26 @@ const simpleNumber = 7;
 // verify that the right chain item and value types are yielded by calls to chain
 // these tests also check to make sure that _.chain() and _().chain() yield the same types
 {
-    _.chain(simpleStringObjectArray); // $ExpectType _Chain<SimpleStringObject, SimpleStringObject[]>
-    _(simpleStringObjectArray).chain(); // $ExpectType _Chain<SimpleStringObject, SimpleStringObject[]>
+    extractChainTypes(_.chain(simpleStringObjectArray)); // $ExpectType ChainType<SimpleStringObject[], SimpleStringObject>
+    extractChainTypes(_(simpleStringObjectArray).chain()); // $ExpectType ChainType<SimpleStringObject[], SimpleStringObject>
 
-    _.chain(simpleStringObjectListWithExtraProperties); // $ExpectType _Chain<SimpleStringObject, SimpleStringObjectListWithExtraProperties>
-    _(simpleStringObjectListWithExtraProperties).chain(); // $ExpectType _Chain<SimpleStringObject, SimpleStringObjectListWithExtraProperties>
+    extractChainTypes(_.chain(simpleStringObjectListWithExtraProperties)); // $ExpectType ChainType<SimpleStringObjectListWithExtraProperties, SimpleStringObject>
+    extractChainTypes(_(simpleStringObjectListWithExtraProperties).chain()); // $ExpectType ChainType<SimpleStringObjectListWithExtraProperties, SimpleStringObject>
 
-    _.chain(simpleStringObjectList); // $ExpectType _Chain<SimpleStringObject, List<SimpleStringObject>>
-    _(simpleStringObjectList).chain(); // $ExpectType _Chain<SimpleStringObject, List<SimpleStringObject>>
+    extractChainTypes(_.chain(simpleStringObjectList)); // $ExpectType ChainType<List<SimpleStringObject>, SimpleStringObject>
+    extractChainTypes(_(simpleStringObjectList).chain()); // $ExpectType ChainType<List<SimpleStringObject>, SimpleStringObject>
 
-    _.chain(stronglyKeyedSimpleStringObjectDictionary); // $ExpectType _Chain<SimpleStringObject, StronglyKeyedSimpleStringObjectDictionary>
-    _(stronglyKeyedSimpleStringObjectDictionary).chain(); // $ExpectType _Chain<SimpleStringObject, StronglyKeyedSimpleStringObjectDictionary>
+    extractChainTypes(_.chain(stronglyKeyedSimpleStringObjectDictionary)); // $ExpectType ChainType<StronglyKeyedSimpleStringObjectDictionary, SimpleStringObject>
+    extractChainTypes(_(stronglyKeyedSimpleStringObjectDictionary).chain()); // $ExpectType ChainType<StronglyKeyedSimpleStringObjectDictionary, SimpleStringObject>
 
-    _.chain(simpleStringObjectDictionary); // $ExpectType _Chain<SimpleStringObject, Dictionary<SimpleStringObject>>
-    _(simpleStringObjectDictionary).chain(); // $ExpectType _Chain<SimpleStringObject, Dictionary<SimpleStringObject>>
+    extractChainTypes(_.chain(simpleStringObjectDictionary)); // $ExpectType ChainType<Dictionary<SimpleStringObject>, SimpleStringObject>
+    extractChainTypes(_(simpleStringObjectDictionary).chain()); // $ExpectType ChainType<Dictionary<SimpleStringObject>, SimpleStringObject>
 
-    _.chain(simpleString); // $ExpectType _Chain<string, string>
-    _(simpleString).chain(); // $ExpectType _Chain<string, string>
+    extractChainTypes(_.chain(simpleString)); // $ExpectType ChainType<string, string>
+    extractChainTypes(_(simpleString).chain()); // $ExpectType ChainType<string, string>
 
-    _.chain(simpleNumber); // $ExpectType _Chain<never, number>
-    _(simpleNumber).chain(); // $ExpectType _Chain<never, number>
+    extractChainTypes(_.chain(simpleNumber)); // $ExpectType ChainType<number, never>
+    extractChainTypes(_(simpleNumber).chain()); // $ExpectType ChainType<number, never>
 }
 
 // value

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -706,6 +706,8 @@ const simpleString = 'abc';
 
 const simpleNumber = 7;
 
+declare const collectionNonCollectionMix: number | number[];
+
 // avoid referencing types under test directly by translating them to other types to avoid needing to make lots of changes if
 // the types under test need to be refactored
 interface UnderscoreType<TWrappedValue, TItemType> { }
@@ -758,6 +760,7 @@ declare const extractChainTypes: ChainTypeExtractor;
     extractUnderscoreTypes(_(simpleString)); // $ExpectType UnderscoreType<string, string>
     extractUnderscoreTypes(_(simpleNumber)); // $ExpectType UnderscoreType<number, never>
 
+    extractUnderscoreTypes(_(collectionNonCollectionMix)); // $ExpectType UnderscoreType<number | number[], number>
 }
 
 // value
@@ -773,6 +776,8 @@ declare const extractChainTypes: ChainTypeExtractor;
 
     _(simpleString).value(); // $ExpectType string
     _(simpleNumber).value(); // $ExpectType number
+
+    _(collectionNonCollectionMix).value(); // $ExpectType number | number[]
 }
 
 // Chaining
@@ -801,6 +806,9 @@ declare const extractChainTypes: ChainTypeExtractor;
 
     extractChainTypes(_.chain(simpleNumber)); // $ExpectType ChainType<number, never>
     extractChainTypes(_(simpleNumber).chain()); // $ExpectType ChainType<number, never>
+
+    extractChainTypes(_.chain(collectionNonCollectionMix)); // $ExpectType ChainType<number | number[], number>
+    extractChainTypes(_(collectionNonCollectionMix).chain()); // $ExpectType ChainType<number | number[], number>
 }
 
 // value
@@ -816,4 +824,6 @@ declare const extractChainTypes: ChainTypeExtractor;
 
     _.chain(simpleString).value(); // $ExpectType string
     _.chain(simpleNumber).value(); // $ExpectType number
+
+    _.chain(collectionNonCollectionMix).value(); // $ExpectType number | number[]
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://underscorejs.org/
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

This PR continues the planned set that will together add up to #45201 and includes the following changes:
- Per conversations with @jgonggrijp, introduces a combination of type extracting interfaces and functions for `UnderscoreStatic` and `UnderscoreStatic.chain` function result evaluation in test code that will hopefully help keep future changes to underlying Underscore types from requiring large swaths of changes to tests.
- Simplifies the `UnderscoreStatic` and `UnderscoreStatic.chain` functions in a way that makes them better at handling types with mixed iterability (e.g. `number | number[]`) which ideally should provide wrapper results that support calls to iterative functions.
- Updates `TypeOfCollection` to check against `List` and `Dictionary` separately rather than checking against `Collection` since inference using the latter type interacts very unpleasantly with `JQuery` objects for some reason in a way that inference from the `List` and `Dictionary` types alone do not replicate.