### PR TITLE
[react-bytesize-icons] Update to version 0.12.2

### DIFF
--- a/types/react-bytesize-icons/index.d.ts
+++ b/types/react-bytesize-icons/index.d.ts
@@ -1,21 +1,27 @@
-// Type definitions for react-bytesize-icons 0.6.4
-// Project: https://github.com/abdelhai/react-bytesize-icons
+// Type definitions for react-bytesize-icons 0.12.2
+// Project: https://github.com/Kilian/react-bytesize-icons
 // Definitions by: rhysd <https://rhysd.github.io>
+//                 Vladimir Liutov <https://github.com/vslutov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as React from "react";
+import * as React from 'react';
 
-export type StrokeLinejoin = "round" | "bevel" | "miter" | "inherit";
-export type StrokeLinecap = "round" | "butt" | "square" | "inherit";
-interface BytesizeIconsProps extends React.Props<any> {
+export type StrokeLinejoin = 'round' | 'bevel' | 'miter' | 'inherit';
+export type StrokeLinecap = 'round' | 'butt' | 'square' | 'inherit';
+interface BytesizeBaseIconsProps extends React.Props<any> {
     width?: number;
     height?: number;
+    color?: string;
+    className?: string;
+    id?: string;
+}
+interface BytesizeIconsProps extends BytesizeBaseIconsProps {
     strokeWidth?: string;
     strokeLinejoin?: StrokeLinejoin;
     strokeLinecap?: StrokeLinecap;
-    color?: string;
 }
+export class BytesizeBaseIconComponent extends React.Component<BytesizeBaseIconsProps> {}
 export class BytesizeIconComponent extends React.Component<BytesizeIconsProps> {}
 
 export class Activity extends BytesizeIconComponent {}
@@ -27,6 +33,7 @@ export class ArrowRight extends BytesizeIconComponent {}
 export class ArrowTop extends BytesizeIconComponent {}
 export class Backwards extends BytesizeIconComponent {}
 export class Ban extends BytesizeIconComponent {}
+export class Bag extends BytesizeIconComponent {}
 export class Bell extends BytesizeIconComponent {}
 export class Bookmark extends BytesizeIconComponent {}
 export class Camera extends BytesizeIconComponent {}
@@ -40,11 +47,13 @@ export class ChevronBottom extends BytesizeIconComponent {}
 export class ChevronLeft extends BytesizeIconComponent {}
 export class ChevronRight extends BytesizeIconComponent {}
 export class ChevronTop extends BytesizeIconComponent {}
+export class Clipboard extends BytesizeIconComponent {}
 export class Clock extends BytesizeIconComponent {}
 export class Close extends BytesizeIconComponent {}
 export class Code extends BytesizeIconComponent {}
 export class Compose extends BytesizeIconComponent {}
-export class Creditcard extends BytesizeIconComponent {}
+export class CreditCard extends BytesizeIconComponent {}
+export class Desktop extends BytesizeIconComponent {}
 export class Download extends BytesizeIconComponent {}
 export class Send extends BytesizeIconComponent {}
 export class Edit extends BytesizeIconComponent {}
@@ -58,14 +67,18 @@ export class Book extends BytesizeIconComponent {}
 export class Calendar extends BytesizeIconComponent {}
 export class Print extends BytesizeIconComponent {}
 export class Eye extends BytesizeIconComponent {}
+export class Feed extends BytesizeIconComponent {}
 export class File extends BytesizeIconComponent {}
+export class Filter extends BytesizeIconComponent {}
 export class Fire extends BytesizeIconComponent {}
 export class Flag extends BytesizeIconComponent {}
 export class FolderOpen extends BytesizeIconComponent {}
 export class Folder extends BytesizeIconComponent {}
 export class Forwards extends BytesizeIconComponent {}
+export class Fullscreen extends BytesizeIconComponent {}
+export class FullscreenExit extends BytesizeIconComponent {}
 export class Gift extends BytesizeIconComponent {}
-export class Github extends BytesizeIconComponent {}
+export class GitHub extends BytesizeBaseIconComponent {}
 export class Heart extends BytesizeIconComponent {}
 export class Home extends BytesizeIconComponent {}
 export class Import extends BytesizeIconComponent {}
@@ -78,6 +91,10 @@ export class Lock extends BytesizeIconComponent {}
 export class Mail extends BytesizeIconComponent {}
 export class Menu extends BytesizeIconComponent {}
 export class Message extends BytesizeIconComponent {}
+export class Microphone extends BytesizeIconComponent {}
+export class Mobile extends BytesizeIconComponent {}
+export class Move extends BytesizeIconComponent {}
+export class Moon extends BytesizeIconComponent {}
 export class Music extends BytesizeIconComponent {}
 export class Mute extends BytesizeIconComponent {}
 export class Options extends BytesizeIconComponent {}
@@ -92,14 +109,20 @@ export class Reload extends BytesizeIconComponent {}
 export class Reply extends BytesizeIconComponent {}
 export class Search extends BytesizeIconComponent {}
 export class Settings extends BytesizeIconComponent {}
+export class SignIn extends BytesizeIconComponent {}
+export class SignOut extends BytesizeIconComponent {}
 export class Star extends BytesizeIconComponent {}
 export class Start extends BytesizeIconComponent {}
 export class Tag extends BytesizeIconComponent {}
+export class Telephone extends BytesizeIconComponent {}
 export class Trash extends BytesizeIconComponent {}
-export class Twitter extends BytesizeIconComponent {}
+export class Twitter extends BytesizeBaseIconComponent {}
 export class Unlock extends BytesizeIconComponent {}
 export class Upload extends BytesizeIconComponent {}
 export class User extends BytesizeIconComponent {}
 export class Video extends BytesizeIconComponent {}
 export class Volume extends BytesizeIconComponent {}
 export class Work extends BytesizeIconComponent {}
+export class ZoomIn extends BytesizeIconComponent {}
+export class ZoomOut extends BytesizeIconComponent {}
+export class ZoomReset extends BytesizeIconComponent {}

--- a/types/react-bytesize-icons/react-bytesize-icons-tests.tsx
+++ b/types/react-bytesize-icons/react-bytesize-icons-tests.tsx
@@ -1,7 +1,31 @@
 import * as React from 'react';
 import { render } from 'react-dom';
-import {Activity, External, Export} from 'react-bytesize-icons';
+import {
+    Activity, Bag, Clipboard, CreditCard, Desktop, External, Export, Feed, Filter,
+    Fullscreen, FullscreenExit, GitHub, Microphone, Mobile, Move, Moon, SignIn, SignOut,
+    Telephone, ZoomIn, ZoomOut, ZoomReset
+} from 'react-bytesize-icons';
 
 render(<Activity/>, document.getElementById('test'));
 render(<External width={42} color="blue"/>, document.getElementById('test'));
-render(<Export width={42} height={21} strokeWidth="10%" strokeLinejoin="bevel" strokeLinecap="butt" color="blue"/>, document.getElementById('test'));
+render(<Export width={42} height={21} strokeWidth="10%" strokeLinejoin="bevel" strokeLinecap="butt" color="blue" className="exportClass" id="export"/>, document.getElementById('test'));
+
+render(<Bag/>, document.getElementById('test'));
+render(<Clipboard/>, document.getElementById('test'));
+render(<CreditCard/>, document.getElementById('test'));
+render(<Desktop/>, document.getElementById('test'));
+render(<Feed/>, document.getElementById('test'));
+render(<Filter/>, document.getElementById('test'));
+render(<Fullscreen/>, document.getElementById('test'));
+render(<FullscreenExit/>, document.getElementById('test'));
+render(<GitHub width={42}/>, document.getElementById('test'));
+render(<Microphone/>, document.getElementById('test'));
+render(<Mobile/>, document.getElementById('test'));
+render(<Move/>, document.getElementById('test'));
+render(<Moon/>, document.getElementById('test'));
+render(<SignIn/>, document.getElementById('test'));
+render(<SignOut/>, document.getElementById('test'));
+render(<Telephone/>, document.getElementById('test'));
+render(<ZoomIn/>, document.getElementById('test'));
+render(<ZoomOut/>, document.getElementById('test'));
+render(<ZoomReset/>, document.getElementById('test'));


### PR DESCRIPTION
- Add new parameters: id, className
- Add new icons: Bag, Clipboard, Desktop, Feed, Filter, Fullscreen, FullscreenExit, Microphone, Mobile, Move, Moon,
SignIn, SignOut, Telephone, ZoomIn, ZoomOut, ZoomReset
- Fix: typos Github->GitHub, Creditcard->CreditCard (was copied from library readme, I suppose)
- Fix: Remove stroke-* parameters from Github and Twitter icons

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Kilian/react-bytesize-icons
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.