### PR TITLE
rdf-js: immutable methods cannot return this

### DIFF
--- a/types/rdf-dataset-indexed/dataset.d.ts
+++ b/types/rdf-dataset-indexed/dataset.d.ts
@@ -21,6 +21,7 @@ declare namespace DatasetIndexed {
         some(predicate: (quad: Q) => boolean): boolean;
         toArray(): Q[];
         toStream(): Stream<Q> & Readable;
+        match(subject?: Term | null, predicate?: Term | null, object?: Term | null, graph?: Term | null): DatasetIndexed<Q, InQuad>;
     }
 }
 

--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -450,7 +450,7 @@ export interface DatasetCore<OutQuad extends BaseQuad = Quad, InQuad extends Bas
      * @param object    The optional exact object to match.
      * @param graph     The optional exact graph to match.
      */
-    match(subject?: Term | null, predicate?: Term | null, object?: Term | null, graph?: Term | null): this;
+    match(subject?: Term | null, predicate?: Term | null, object?: Term | null, graph?: Term | null): DatasetCore<OutQuad, InQuad>;
 
     [Symbol.iterator](): Iterator<OutQuad>;
 }
@@ -495,7 +495,7 @@ export interface Dataset<OutQuad extends BaseQuad = Quad, InQuad extends BaseQua
     /**
      * Returns a new dataset that contains all quads from the current dataset, not included in the given dataset.
      */
-    difference(other: Dataset<InQuad>): this;
+    difference(other: Dataset<InQuad>): Dataset<OutQuad, InQuad>;
 
     /**
      * Returns true if the current instance contains the same graph structure as the given dataset.
@@ -521,7 +521,7 @@ export interface Dataset<OutQuad extends BaseQuad = Quad, InQuad extends BaseQua
      *
      * This method is aligned with Array.prototype.filter() in ECMAScript-262.
      */
-    filter(iteratee: QuadFilterIteratee<OutQuad>['test']): this;
+    filter(iteratee: QuadFilterIteratee<OutQuad>['test']): Dataset<OutQuad, InQuad>;
 
     /**
      * Executes the provided `iteratee` once on each quad in the dataset.
@@ -545,7 +545,7 @@ export interface Dataset<OutQuad extends BaseQuad = Quad, InQuad extends BaseQua
     /**
      * Returns a new dataset containing all quads returned by applying `iteratee` to each quad in the current dataset.
      */
-    map(iteratee: QuadMapIteratee<OutQuad>['map']): this;
+    map(iteratee: QuadMapIteratee<OutQuad>['map']): Dataset<OutQuad, InQuad>;
 
     /**
      * This method calls the `iteratee` on each `quad` of the `Dataset`. The first time the `iteratee` is called, the
@@ -598,7 +598,9 @@ export interface Dataset<OutQuad extends BaseQuad = Quad, InQuad extends BaseQua
     /**
      * Returns a new `Dataset` that is a concatenation of this dataset and the quads given as an argument.
      */
-    union(quads: Dataset<InQuad>): this;
+    union(quads: Dataset<InQuad>): Dataset<OutQuad, InQuad>;
+
+    match(subject?: Term | null, predicate?: Term | null, object?: Term | null, graph?: Term | null): Dataset<OutQuad, InQuad>;
 }
 
 export interface DatasetFactory<OutQuad extends BaseQuad = Quad, InQuad extends BaseQuad = OutQuad, D extends Dataset<OutQuad, InQuad> = Dataset<OutQuad, InQuad>>

--- a/types/rdf-js/rdf-js-tests.ts
+++ b/types/rdf-js/rdf-js-tests.ts
@@ -325,3 +325,123 @@ async function test_dataset_covariance(): Promise<Dataset> {
     datasetExt.union(dataset);
     return datasetExt.import(stream);
 }
+
+class DatasetCoreExt implements DatasetCore {
+    size: number;
+
+    add(): this {
+        throw new Error("Method not implemented.");
+    }
+
+    delete(): this {
+        throw new Error("Method not implemented.");
+    }
+
+    has(): boolean {
+        throw new Error("Method not implemented.");
+    }
+
+    match(): DatasetCore<Quad, Quad> {
+        const newInstance: DatasetCoreExt = <any> {};
+        return newInstance;
+    }
+
+    [Symbol.iterator](): Iterator<Quad> {
+        throw new Error("Method not implemented.");
+    }
+}
+
+class DatasetExt extends DatasetCoreExt implements Dataset {
+    addAll(): this {
+        throw new Error("Method not implemented.");
+    }
+
+    contains(): boolean {
+        throw new Error("Method not implemented.");
+    }
+
+    deleteMatches(): this {
+        throw new Error("Method not implemented.");
+    }
+
+    difference(): Dataset<Quad, Quad> {
+        const newInstance: DatasetExt = <any> {};
+        return newInstance;
+    }
+
+    equals(): boolean {
+        throw new Error("Method not implemented.");
+    }
+
+    every(): boolean {
+        throw new Error("Method not implemented.");
+    }
+
+    filter(): Dataset<Quad, Quad> {
+        const newInstance: DatasetExt = <any> {};
+        return newInstance;
+    }
+
+    forEach(): void {
+        throw new Error("Method not implemented.");
+    }
+
+    import(): Promise<this> {
+        throw new Error("Method not implemented.");
+    }
+
+    intersection(): this {
+        throw new Error("Method not implemented.");
+    }
+
+    map(): Dataset<Quad, Quad> {
+        const newInstance: DatasetExt = <any> {};
+        return newInstance;
+    }
+
+    match(): Dataset<Quad, Quad> {
+        const newInstance: DatasetExt = <any> {};
+        return newInstance;
+    }
+
+    reduce(): any {
+        throw new Error("Method not implemented.");
+    }
+
+    some(): boolean {
+        throw new Error("Method not implemented.");
+    }
+
+    toArray(): Quad[] {
+        throw new Error("Method not implemented.");
+    }
+
+    toCanonical(): string {
+        throw new Error("Method not implemented.");
+    }
+
+    toStream(): Stream {
+        throw new Error("Method not implemented.");
+    }
+
+    toString(): string {
+        throw new Error("Method not implemented.");
+    }
+
+    union(): Dataset<Quad, Quad> {
+        const newInstance: DatasetExt = <any> {};
+        return newInstance;
+    }
+}
+
+function testInheritance() {
+    const datasetCoreExt: DatasetCoreExt = new DatasetCoreExt();
+    const datasetCoreMatch: DatasetCore = datasetCoreExt.match();
+
+    const datasetExt: DatasetExt = new DatasetExt();
+    const datasetMatch: Dataset = datasetExt.match();
+    const datasetMap: Dataset = datasetExt.map();
+    const datasetUnion: Dataset = datasetExt.union();
+    const datasetFilter: Dataset = datasetExt.filter();
+    const datasetDifference: Dataset = datasetExt.difference();
+}

--- a/types/rdfjs__dataset/DatasetCore.d.ts
+++ b/types/rdfjs__dataset/DatasetCore.d.ts
@@ -1,7 +1,8 @@
 import * as RDF from 'rdf-js';
 
-// tslint:disable-next-line no-empty-interface
-interface DatasetCore<InQuad extends RDF.BaseQuad = RDF.Quad> extends RDF.DatasetCore<RDF.Quad, InQuad> {}
+interface DatasetCore<InQuad extends RDF.BaseQuad = RDF.Quad> extends RDF.DatasetCore<RDF.Quad, InQuad> {
+    match(subject?: RDF.Term | null, predicate?: RDF.Term | null, object?: RDF.Term | null, graph?: RDF.Term | null): DatasetCore<InQuad>;
+}
 
 // tslint:disable-next-line no-unnecessary-class
 declare class DatasetCore<InQuad> {


### PR DESCRIPTION
Dataset methods which return a new instance have to return the actual type.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://gitter.im/rdfjs/public?at=5ef507a56c06cd1bf4548898>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

