### PR TITLE
Serverless: Add id authorizer to http api event

### DIFF
--- a/types/serverless/index.d.ts
+++ b/types/serverless/index.d.ts
@@ -5,6 +5,7 @@
 //                 Alex Pavlenko <https://github.com/a-pavlenko>
 //                 Frédéric Barthelet <https://github.com/fredericbarthelet>
 //                 Bryan Hunter <https://github.com/bryan-hunter>
+//                 Thomas Aribart <https://github.com/thomasaribart>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import Service = require('./classes/Service');

--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -294,15 +294,20 @@ declare namespace Aws {
         request?: HttpRequestValidation;
     }
 
-    interface HttpApiEventAuthorizer {
+    interface NamedHttpApiEventAuthorizer {
         name: string;
+        scopes?: string[];
+    }
+
+    interface IdRefHttpApiEventAuthorizer {
+        id: string;
         scopes?: string[];
     }
 
     interface HttpApiEvent {
         method: string;
         path: string;
-        authorizer?: HttpApiEventAuthorizer;
+        authorizer?: NamedHttpApiEventAuthorizer | IdRefHttpApiEventAuthorizer;
     }
 
     interface WebsocketAuthorizer {

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -417,6 +417,16 @@ const awsServerless: Aws.Serverless = {
                             scopes: ['testscopes']
                         }
                     }
+                },
+                {
+                    httpApi: {
+                        method: 'testmethod',
+                        path: 'testpath',
+                        authorizer: {
+                            id: 'testid',
+                            scopes: ['testscopes'],
+                        },
+                    },
                 }, {
                     websocket: {
                         route: 'testroute',


### PR DESCRIPTION
Adding HTTP API id ref authorizer to HTTP API events as stated in the docs: https://www.serverless.com/framework/docs/providers/aws/events/http-api#shared-authorizer

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
