### PR TITLE
vscode-notebook-renderer: init

### DIFF
--- a/types/vscode-notebook-renderer/index.d.ts
+++ b/types/vscode-notebook-renderer/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for non-npm package vscode-notebook-renderer 1.47
 // Project: https://github.com/microsoft/vscode-docs/blob/notebook/api/extension-guides/notebook.md
-// Definitions by: Connor Peet <https://github.com/me>
+// Definitions by: Connor Peet <https://github.com/connor4312>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.0
 

--- a/types/vscode-notebook-renderer/index.d.ts
+++ b/types/vscode-notebook-renderer/index.d.ts
@@ -1,0 +1,49 @@
+// Type definitions for non-npm package vscode-notebook-renderer 1.47
+// Project: https://github.com/microsoft/vscode-docs/blob/notebook/api/extension-guides/notebook.md
+// Definitions by: Connor Peet <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.0
+
+// todo: update "Project" link above to docs site, once it becomes available
+
+export interface Disposable {
+    dispose(): void;
+}
+
+export interface VSCodeEvent<T> {
+    (listener: (e: T) => any, thisArgs?: any, disposables?: Disposable[]): Disposable;
+}
+
+export interface NotebookRendererApi<T> {
+    setState(value: T): void;
+    getState(): T | undefined;
+
+    /**
+     * Sends a message to the renderer extension code. Can be received in
+     * the `onDidReceiveMessage` event in `NotebookCommunication`.
+     */
+    postMessage(msg: unknown): void;
+
+    /**
+     * Fired before an output is destroyed, with its output ID, or undefined if
+     * all cells are about to unmount.
+     */
+    onWillDestroyOutput: VSCodeEvent<{ outputId: string } | undefined>;
+
+    /**
+     * Fired when an output is rendered. The `outputId` provided is the same
+     * as the one given in `NotebookOutputRenderer.render` in the extension
+     * API, and `onWillDestroyOutput`.
+     */
+    onDidCreateOutput: VSCodeEvent<{ element: HTMLElement; outputId: string }>;
+
+    /**
+     * Called when the renderer uses `postMessage` on the NotebookCommunication
+     * instance for this renderer.
+     */
+    onDidReceiveMessage: VSCodeEvent<any>;
+}
+
+declare global {
+    function acquireNotebookRendererApi(rendererId: string): NotebookRendererApi<any>;
+}

--- a/types/vscode-notebook-renderer/tsconfig.json
+++ b/types/vscode-notebook-renderer/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "DOM"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "vscode-notebook-renderer-tests.ts"
+    ]
+}

--- a/types/vscode-notebook-renderer/tslint.json
+++ b/types/vscode-notebook-renderer/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "dtslint/dt.json",
+  "rules": {
+    "npm-naming": false
+  }
+}

--- a/types/vscode-notebook-renderer/vscode-notebook-renderer-tests.ts
+++ b/types/vscode-notebook-renderer/vscode-notebook-renderer-tests.ts
@@ -1,0 +1,35 @@
+import { NotebookRendererApi } from 'vscode-notebook-renderer';
+
+const notebookApi: NotebookRendererApi<{ cool: boolean }> = acquireNotebookRendererApi('myRendererId');
+
+const prevState = notebookApi.getState();
+
+// $ExpectError
+prevState.cool;
+
+if (prevState) {
+    console.log('cool?', prevState.cool);
+}
+
+notebookApi.setState({ cool: true });
+
+const listener = notebookApi.onDidCreateOutput(({ element, outputId }) => {
+    // $ExpectType string
+    outputId;
+    // $ExpectType HTMLElement
+    element;
+});
+
+listener.dispose();
+
+notebookApi.onDidReceiveMessage(msg => {
+    // $ExpectType any
+    msg;
+
+    notebookApi.postMessage(msg);
+});
+
+notebookApi.onWillDestroyOutput(evt => {
+    // $ExpectType { outputId: string; } | undefined
+    evt;
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

This is for a new set of VS Code APIs. Unlike our existing APIs published in @types/vscode, this package adds type information for globals exposed only in [notebook renderers](https://github.com/microsoft/vscode-docs/blob/notebook/api/extension-guides/notebook.md#output-renderer).

In this package I've added the `acquire` method as a global, and kept the additional types as part of the 'module' to avoid polluting the global namespace.

Fixes https://github.com/microsoft/vscode/issues/99320