### PR TITLE
fix(glider-js): add `eventPropagate` option

### DIFF
--- a/types/glider-js/glider-js-tests.ts
+++ b/types/glider-js/glider-js-tests.ts
@@ -7,6 +7,7 @@ const options: Glider.Options = {
         prev: '.glider-prev',
         next: '.glider-next',
     },
+    eventPropagate: true,
 };
 
 // $ExpectType Static<HTMLDivElement>

--- a/types/glider-js/index.d.ts
+++ b/types/glider-js/index.d.ts
@@ -119,12 +119,6 @@ declare namespace Glider {
         itemWidth?: number;
 
         /**
-         * Whether or not Glider.js events should bubble (useful for binding
-         * events to all carousels)
-         */
-        propagateEvent?: boolean;
-
-        /**
          * If true, Glider.js will lock to the nearest slide on resizing of
          * the window
          */

--- a/types/glider-js/index.d.ts
+++ b/types/glider-js/index.d.ts
@@ -160,6 +160,12 @@ declare namespace Glider {
         scrollPropagate?: boolean;
 
         /**
+         * Whether or not the event bubbles up from the container
+         * @default true
+         */
+        eventPropagate?: boolean;
+
+        /**
          * Whether or not Glider.js should skip wrapping its children with a
          * 'glider-track' <div>.
          */


### PR DESCRIPTION
- missing `eventPropagate` option:
https://github.com/NickPiscitelli/Glider.js/blob/e0743bc3fc4da0977ab778c375f6a98e48d0cfb6/README.md#L90
This specific option is missin public facing documentation, see:
NickPiscitelli/Glider.js#111

/cc @martin-badin

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)