### PR TITLE
[puppeteer] Fixed return type for `Frame.executionContext` and `ExecutionContext.queryObjects`

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -863,7 +863,7 @@ export interface ElementHandle<E extends Element = Element> extends JSHandle<E>,
 
 /** The class represents a context for JavaScript execution. */
 export interface ExecutionContext extends JSEvalable {
-  queryObjects(prototypeHandle: JSHandle): JSHandle;
+  queryObjects(prototypeHandle: JSHandle): Promise<JSHandle>;
 }
 
 /** JSHandle represents an in-page JavaScript object. */
@@ -1280,7 +1280,7 @@ export interface FrameBase extends Evalable, JSEvalable {
 export interface Frame extends FrameBase {
   childFrames(): Frame[];
   /** Execution context associated with this frame. */
-  executionContext(): ExecutionContext;
+  executionContext(): Promise<ExecutionContext>;
   /** Returns `true` if the frame has been detached, or `false` otherwise. */
   isDetached(): boolean;
   /** Returns frame's name attribute as specified in the tag. */

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -707,3 +707,17 @@ puppeteer.launch().then(async browser => {
 
   const selected: string[] = await elementHandle.select('a', 'b', 'c');
 })();
+
+// .executionContext on Frame, and ExecutionContext.queryObjects
+(async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+
+  const frame = page.mainFrame();
+  frame.executionContext().then(() => {});
+
+  const context = await frame.executionContext();
+
+  const queryObjectsRes = context.queryObjects(await context.evaluateHandle(() => {}));
+  queryObjectsRes.then(() => {});
+})();


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/puppeteer/puppeteer/blob/v3.3.0/docs/api.md#frameexecutioncontext
  - https://github.com/puppeteer/puppeteer/blob/v3.3.0/docs/api.md#pagequeryobjectsprototypehandle
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Fixes #45744

_(I just wonder why the package written in TypeScript isn't able to provide its own types generated from the source code so we don't need to sync types between 2 repos...)_