### PR TITLE
feat(glider-js): friction-free selector type

### DIFF
--- a/types/glider-js/glider-js-tests.ts
+++ b/types/glider-js/glider-js-tests.ts
@@ -5,9 +5,31 @@ const options: Glider.Options = {
     dots: '.dots',
     arrows: {
         prev: '.glider-prev',
-        next: '.glider-next',
+        next: document.querySelector('.glider-next'),
     },
 };
+
+// Options.dots
+new Glider(new HTMLDivElement(), {
+    dots: '.dots',
+});
+new Glider(new HTMLDivElement(), {
+    dots: document.querySelector('.dots'),
+});
+
+// Options.arrows
+new Glider(new HTMLDivElement(), {
+    arrows: {
+        prev: '.glider-prev',
+        next: '.glider-next',
+    },
+});
+new Glider(new HTMLDivElement(), {
+    arrows: {
+        prev: document.querySelector('.glider-prev'),
+        next: document.querySelector('.glider-next'),
+    },
+});
 
 // $ExpectType Static<HTMLDivElement>
 const glider = new Glider(new HTMLDivElement(), options);

--- a/types/glider-js/index.d.ts
+++ b/types/glider-js/index.d.ts
@@ -8,7 +8,7 @@ declare namespace Glider {
     // Selectors are either results of querying document DOM or a string
     // Let's default to nullable Element to allow friction free migration
     // from JS to TS
-    type Selector<T> = T extends Element ? Element | null : string;
+    type Selector =  Element | string;
 
     type EasingFunction = (x: number, t: number, b: number, c: number, d: number) => number;
 
@@ -78,14 +78,14 @@ declare namespace Glider {
          * An object containing the prev/next arrow settings
          */
         arrows?: {
-            prev: Selector<HTMLElement | string>;
-            next: Selector<HTMLElement | string>;
+            prev: Selector | null;
+            next: Selector | null;
         };
 
         /**
          * An HTML element or selector containing the dot container
          */
-        dots?: Selector<HTMLElement | string>;
+        dots?: Selector | null;
 
         /**
          * If true, the list can be scrolled by click and dragging with the

--- a/types/glider-js/index.d.ts
+++ b/types/glider-js/index.d.ts
@@ -5,7 +5,10 @@
 // TypeScript Version: 3.7
 
 declare namespace Glider {
-    type Selector = HTMLElement | string;
+    // Selectors are either results of querying document DOM or a string
+    // Let's default to nullable Element to allow friction free migration
+    // from JS to TS
+    type Selector<T> = T extends Element ? Element | null : string;
 
     type EasingFunction = (x: number, t: number, b: number, c: number, d: number) => number;
 
@@ -75,14 +78,14 @@ declare namespace Glider {
          * An object containing the prev/next arrow settings
          */
         arrows?: {
-            prev: Selector;
-            next: Selector;
+            prev: Selector<HTMLElement | string>;
+            next: Selector<HTMLElement | string>;
         };
 
         /**
          * An HTML element or selector containing the dot container
          */
-        dots?: Selector;
+        dots?: Selector<HTMLElement | string>;
 
         /**
          * If true, the list can be scrolled by click and dragging with the


### PR DESCRIPTION
This is a proposal to change a `Selector` type detail.

If selector can allow direct results from querying the DOM for target
element, this would allow the friction free migration path for users of
`glider-js`. Otherwise there is an issue with non-nullable settings as
the DOM querying types return null. If someone just copy-and-paste
library README snips, these snippets won't compile without Selector type
that expect possible nulls.

/cc @martin-badin

Thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)