### PR TITLE
[geodesy] Fix decimal point type

### DIFF
--- a/types/geodesy/geodesy-tests.ts
+++ b/types/geodesy/geodesy-tests.ts
@@ -54,23 +54,23 @@ Dms.parse('51° 28′ 40.12″ N');
 
 Dms.toDms(45);
 Dms.toDms(45, 'dm');
-Dms.toDms(45, 'd', 2);
-Dms.toDms(45, 'dms', 4);
+Dms.toDms(45, 'd', 1);
+Dms.toDms(45, 'dms', 3);
 
 Dms.toLat(45);
 Dms.toLat(45, 'dm');
-Dms.toLat(45, 'd', 2);
-Dms.toLat(45, 'dms', 4);
+Dms.toLat(45, 'd', 1);
+Dms.toLat(45, 'dms', 3);
 
 Dms.toLon(45);
 Dms.toLon(45, 'dm');
-Dms.toLon(45, 'd', 2);
-Dms.toLon(45, 'dms', 4);
+Dms.toLon(45, 'd', 1);
+Dms.toLon(45, 'dms', 3);
 
 Dms.toBrng(90);
 Dms.toBrng(90, 'dm');
-Dms.toBrng(90, 'd', 2);
-Dms.toBrng(90, 'dms', 4);
+Dms.toBrng(90, 'd', 1);
+Dms.toBrng(90, 'dms', 3);
 
 Dms.compassPoint(180);
 Dms.compassPoint(180, 1);

--- a/types/geodesy/index.d.ts
+++ b/types/geodesy/index.d.ts
@@ -12,7 +12,7 @@
  */
 
 export type Format = 'd' | 'dm' | 'dms';
-export type Dp = 0 | 2 | 4;
+export type Dp = number;
 
 export interface Plural<T> {
     [itemName: string]: T;


### PR DESCRIPTION
Before this commit, the Dp type (decimal point) was limiting values to 0, 2, and 4. These values are actually default values only, but geodesy supports any number of decimal points.

See chrisveness/geodesy#83

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chrisveness/geodesy/issues/83
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
