### PR TITLE
[@types/parse] TestCollection generic argument fix for changes to Underscore

### DIFF
--- a/types/parse/v1/parse-tests.ts
+++ b/types/parse/v1/parse-tests.ts
@@ -148,7 +148,7 @@ function test_query() {
     const testQuery = Parse.Query.or(query, query);
 }
 
-class TestCollection extends Parse.Collection<Object> {
+class TestCollection extends Parse.Collection<Parse.Object> {
 
     constructor(models?: Parse.Object[]) {
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: #45201, ~[underscore-tests-map-pluck-filter-groupBy-flatten branch diff](https://github.com/DefinitelyTyped/DefinitelyTyped/compare/master...reubenrybnik:underscore-tests-map-pluck-filter-groupBy-flatten)~ #45763

Hello Parse folks! I'm working on writing tests for Underscore and updating definitions that don't pass those tests, and I ran into a minor issue with my next iteration of changes [here](https://github.com/DefinitelyTyped/DefinitelyTyped/compare/master...reubenrybnik:underscore-tests-map-pluck-filter-groupBy-flatten) where a Parse test becomes unhappy. The small change in this PR fixes the unhappiness, and while it seems reasonable to me in context I'm admittedly not 100% sure that it is correct.

I'd prefer to make this change in its own separate PR because it's a very small change that seems reasonable to make on its own and I'm trying not to waste DT maintainer time if I can help it since PRs that edit multiple packages at once require maintainer review. However, if anyone feels that it would be better to not make this change in a separate PR or if I don't receive any response within a week, I will close this PR and include this change in the PR for the referenced Underscore changes instead.

Thank you very much for your time!