### PR TITLE
fix(@types/xmldom): Move `dom` from tsconfig to `index.d.ts`

### DIFF
--- a/types/xmldom/index.d.ts
+++ b/types/xmldom/index.d.ts
@@ -1,8 +1,9 @@
 // Type definitions for xmldom 0.1.22
-// Project: https://github.com/jindw/xmldom.git
+// Project: https://github.com/xmldom/xmldom
 // Definitions by: Qubo <https://github.com/tkqubo>
+//                 Karfau <https://github.com/karfau>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
+/// <reference lib="dom" />
 
 declare namespace xmldom {
     var DOMParser: DOMParserStatic;

--- a/types/xmldom/tsconfig.json
+++ b/types/xmldom/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
By adding `/// <reference lib="dom" />` to the type definition [as described in the handbook](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-lib-) it's no longer required to add `"lib":[...,"dom"]` to `tsconfig.json`

I also added myself as a maintainer of these types and fixed the project location to the maintained one.

fixes #26745
https://github.com/xmldom/xmldom

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes:
  _information is provided in the description above_
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
  _The old tests still work although the `tsconfig.json` was changed, so I think it's sufficient._
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
