### PR TITLE
[workerpool] Remove WorkerPool.clear and WorkerPoolOptions.nodeWorker.

### DIFF
--- a/types/workerpool/index.d.ts
+++ b/types/workerpool/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for workerpool 5.0
+// Type definitions for workerpool 6.0
 // Project: https://github.com/josdejong/workerpool
 // Definitions by: Alorel <https://github.com/Alorel>
 //                 Seulgi Kim <https://github.com/sgkim126>
@@ -50,14 +50,6 @@ export interface WorkerPool {
      * If timeout is provided, worker will be forced to terminal when the timeout expires and the worker has not finished.
      */
     terminate(force?: boolean, timeout?: number): Promise<any[]>;
-
-    /**
-     * Clear all workers from the pool.
-     * If parameter force is false (default), workers will finish the tasks they are working on before terminating themselves.
-     * When force is true, all workers are terminated immediately without finishing running tasks.
-     * @deprecated
-     */
-    clear(force?: boolean): Promise<any[]>;
 }
 
 export class Promise<T, E = Error> {
@@ -97,13 +89,6 @@ export interface WorkerPoolOptions {
      * When the number of CPU's could not be determined (for example in older browsers), maxWorkers is set to 3.
      */
     maxWorkers?: number;
-    /**
-     * In case of 'process' (default), child_process will be used.
-     * In case of 'thread', worker_threads will be used. If worker_threads are not available, an error is thrown.
-     * In case of 'auto', worker_threads will be used if available (Node.js >= 11.7.0), else child_process will be used as fallback.
-     * @deprecated
-     */
-    nodeWorker?: 'process' | 'thread' | 'auto';
 
     /**
      * - In case of `'auto'` (default), workerpool will automatically pick a suitable type of worker:

--- a/types/workerpool/workerpool-tests.ts
+++ b/types/workerpool/workerpool-tests.ts
@@ -6,9 +6,6 @@ wp.pool({minWorkers: 'max'});
 wp.pool({minWorkers: 'max', maxWorkers: 1});
 wp.pool({minWorkers: 1, maxWorkers: 1});
 wp.pool({maxWorkers: 1});
-wp.pool({nodeWorker: 'process'});
-wp.pool({nodeWorker: 'thread'});
-wp.pool({nodeWorker: 'auto'});
 wp.pool({workerType: 'process'});
 wp.pool({workerType: 'thread'});
 wp.pool({workerType: 'web'});
@@ -16,11 +13,11 @@ wp.pool({workerType: 'auto'});
 wp.pool({forkArgs: ['foo', 'bar']});
 wp.pool({forkOpts: {cwd: '/tmp'}});
 const pool = wp.pool();
-pool.clear()
+pool.terminate()
     .then(() => pool.terminate())
-    .then(() => pool.clear())
-    .then(() => pool.clear(true))
-    .then(() => pool.clear(false))
+    .then(() => pool.terminate())
+    .then(() => pool.terminate(true))
+    .then(() => pool.terminate(false))
     .then(() => pool.terminate(true))
     .then(() => pool.terminate(false))
     .then(() => pool.terminate(false, 1000));


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/josdejong/workerpool/blob/master/HISTORY.md#2020-05-13-version-600
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

`WorkerPool.clear` and `WorkerPoolOptions.nodeWorker` have been removed.

