### PR TITLE
Updates Netlify Identity Widget User Interface

### DIFF
--- a/types/netlify-identity-widget/index.d.ts
+++ b/types/netlify-identity-widget/index.d.ts
@@ -34,6 +34,7 @@ export interface User {
     };
     app_metadata: {
         provider: string;
+        roles: string[];
     };
     aud: string;
     audience?: any;


### PR DESCRIPTION
It seems roles are now part of the `app_metadata` attr
![Screen Shot 2020-06-28 at 5 44 23 PM](https://user-images.githubusercontent.com/1621720/85960192-7261bf00-b967-11ea-9999-050dd0d2bd8a.png)

