### PR TITLE
nedb: Make errors in callbacks nullable

### DIFF
--- a/types/nedb/index.d.ts
+++ b/types/nedb/index.d.ts
@@ -21,7 +21,7 @@ declare class Nedb<G = any> extends EventEmitter {
     /**
      * Load the database from the datafile, and trigger the execution of buffered commands if any
      */
-    loadDatabase(cb?: (err: Error) => void): void;
+    loadDatabase(cb?: (err: Error | null) => void): void;
 
     /**
      * Get an array of all the data in the database
@@ -39,13 +39,13 @@ declare class Nedb<G = any> extends EventEmitter {
      * We use an async API for consistency with the rest of the code
      * @param cb Optional callback, signature: err
      */
-    ensureIndex(options: Nedb.EnsureIndexOptions, cb?: (err: Error) => void): void;
+    ensureIndex(options: Nedb.EnsureIndexOptions, cb?: (err: Error | null) => void): void;
 
     /**
      * Remove an index
      * @param cb Optional callback, signature: err
      */
-    removeIndex(fieldName: string, cb?: (err: Error) => void): void;
+    removeIndex(fieldName: string, cb?: (err: Error | null) => void): void;
 
     /**
      * Add one or several document(s) to all indexes
@@ -80,14 +80,14 @@ declare class Nedb<G = any> extends EventEmitter {
      * Insert one or more new documents
      * @param cb Optional callback, signature: err, insertedDoc
      */
-    insert<T extends G>(newDoc: T, cb?: (err: Error, document: T) => void): void;
-    insert<T extends G>(newDocs: T[], cb?: (err: Error, documents: T[]) => void): void;
+    insert<T extends G>(newDoc: T, cb?: (err: Error | null, document: T) => void): void;
+    insert<T extends G>(newDocs: T[], cb?: (err: Error | null, documents: T[]) => void): void;
 
     /**
      * Count all documents matching the query
      * @param query MongoDB-style query
      */
-    count(query: any, callback: (err: Error, n: number) => void): void;
+    count(query: any, callback: (err: Error | null, n: number) => void): void;
     count(query: any): Nedb.CursorCount;
 
     /**
@@ -96,7 +96,7 @@ declare class Nedb<G = any> extends EventEmitter {
      * @param query MongoDB-style query
      * @param projection MongoDB-style projection
      */
-    find<T extends G>(query: any, projection: T, callback: (err: Error, documents: T[]) => void): void;
+    find<T extends G>(query: any, projection: T, callback: (err: Error | null, documents: T[]) => void): void;
     find<T extends G>(query: any, projection?: T): Nedb.Cursor<T>;
 
     /**
@@ -104,20 +104,20 @@ declare class Nedb<G = any> extends EventEmitter {
      * If no callback is passed, we return the cursor so that user can limit, skip and finally exec
      * * @param {any} query MongoDB-style query
      */
-    find<T extends G>(query: any, callback: (err: Error, documents: T[]) => void): void;
+    find<T extends G>(query: any, callback: (err: Error | null, documents: T[]) => void): void;
 
     /**
      * Find one document matching the query
      * @param query MongoDB-style query
      * @param projection MongoDB-style projection
      */
-    findOne<T extends G>(query: any, projection: T, callback: (err: Error, document: T) => void): void;
+    findOne<T extends G>(query: any, projection: T, callback: (err: Error | null, document: T) => void): void;
 
     /**
      * Find one document matching the query
      * @param query MongoDB-style query
      */
-    findOne<T extends G>(query: any, callback: (err: Error, document: T) => void): void;
+    findOne<T extends G>(query: any, callback: (err: Error | null, document: T) => void): void;
 
     /**
      * Update all docs matching query v1.7.4 and prior signature.
@@ -131,7 +131,7 @@ declare class Nedb<G = any> extends EventEmitter {
      *
      * @api private Use Datastore.update which has the same signature
      */
-    update(query: any, updateQuery: any, options?: Nedb.UpdateOptions, cb?: (err: Error, numberOfUpdated: number, upsert: boolean) => void): void;
+    update(query: any, updateQuery: any, options?: Nedb.UpdateOptions, cb?: (err: Error | null, numberOfUpdated: number, upsert: boolean) => void): void;
 
     /**
      * Update all docs matching query v1.8 signature.
@@ -146,7 +146,7 @@ declare class Nedb<G = any> extends EventEmitter {
      *
      * @api private Use Datastore.update which has the same signature
      */
-    update<T extends G>(query: any, updateQuery: any, options?: Nedb.UpdateOptions, cb?: (err: Error, numberOfUpdated: number, affectedDocuments: any, upsert: boolean) => void): void;
+    update<T extends G>(query: any, updateQuery: any, options?: Nedb.UpdateOptions, cb?: (err: Error | null, numberOfUpdated: number, affectedDocuments: any, upsert: boolean) => void): void;
 
     /**
      * Remove all docs matching the query
@@ -157,8 +157,8 @@ declare class Nedb<G = any> extends EventEmitter {
      *
      * @api private Use Datastore.remove which has the same signature
      */
-    remove(query: any, options: Nedb.RemoveOptions, cb?: (err: Error, n: number) => void): void;
-    remove(query: any, cb?: (err: Error, n: number) => void): void;
+    remove(query: any, options: Nedb.RemoveOptions, cb?: (err: Error | null, n: number) => void): void;
+    remove(query: any, cb?: (err: Error | null, n: number) => void): void;
 
     addListener(event: 'compaction.done', listener: () => void): this;
     on(event: 'compaction.done', listener: () => void): this;
@@ -178,11 +178,11 @@ declare namespace Nedb {
         skip(n: number): Cursor<T>;
         limit(n: number): Cursor<T>;
         projection(query: any): Cursor<T>;
-        exec(callback: (err: Error, documents: T[]) => void): void;
+        exec(callback: (err: Error | null, documents: T[]) => void): void;
     }
 
     interface CursorCount {
-        exec(callback: (err: Error, count: number) => void): void;
+        exec(callback: (err: Error | null, count: number) => void): void;
     }
 
     interface DataStoreOptions {
@@ -191,7 +191,7 @@ declare namespace Nedb {
         nodeWebkitAppName?: boolean; // Optional, specify the name of your NW app if you want options.filename to be relative to the directory where
         autoload?: boolean; // Optional, defaults to false
         // Optional, if autoload is used this will be called after the load database with the error object as parameter. If you don't pass it the error will be thrown
-        onload?(error: Error): any;
+        onload?(error: Error | null): any;
         // (optional): hook you can use to transform data after it was serialized and before it is written to disk.
         // Can be used for example to encrypt data before writing database to disk.
         // This function takes a string as parameter (one line of an NeDB data file) and outputs the transformed string, which must absolutely not contain a \n character (or data will be lost)

--- a/types/nedb/nedb-tests.ts
+++ b/types/nedb/nedb-tests.ts
@@ -15,7 +15,7 @@ class BaseCollection<T> {
 
     insert(document: T): Promise<T> {
         return new Promise((resolve, reject) => {
-            this.dataStore.insert<T>(document, (err: Error, newDoc: T) => {   // Callback is optional
+            this.dataStore.insert<T>(document, (err: Error | null, newDoc: T) => {   // Callback is optional
                 // newDoc is the newly inserted document, including its _id
                 if (err) {
                     reject(err);
@@ -28,7 +28,7 @@ class BaseCollection<T> {
 
     count(): Promise<number> {
         return new Promise((resolve, reject) => {
-            this.dataStore.count({}, (err: Error, count: number) => {
+            this.dataStore.count({}, (err: Error | null, count: number) => {
                 if (err) {
                     reject(err);
                 } else {
@@ -40,7 +40,7 @@ class BaseCollection<T> {
 
     countBy(criteria: any): Promise<number> {
         return new Promise((resolve, reject) => {
-            this.dataStore.count(criteria, (err: Error, count: number) => {
+            this.dataStore.count(criteria, (err: Error | null, count: number) => {
                 if (err) {
                     reject(err);
                 } else {
@@ -52,7 +52,7 @@ class BaseCollection<T> {
 
     findByID(id: string): Promise<T> {
         return new Promise((resolve, reject) => {
-            this.dataStore.findOne<T>({ _id: id }, (err: Error, doc: T) => {
+            this.dataStore.findOne<T>({ _id: id }, (err: Error | null, doc: T) => {
                 if (err) {
                     reject(err);
                 } else {
@@ -64,7 +64,7 @@ class BaseCollection<T> {
 
     findOne(criteria: any): Promise<T> {
         return new Promise((resolve, reject) => {
-            this.dataStore.findOne<T>(criteria, (err: Error, doc: T) => {
+            this.dataStore.findOne<T>(criteria, (err: Error | null, doc: T) => {
                 if (err) {
                     reject(err);
                 } else {
@@ -76,7 +76,7 @@ class BaseCollection<T> {
 
     find(criteria: any): Promise<T[]> {
         return new Promise((resolve, reject) => {
-            this.dataStore.find(criteria, (err: Error, docs: T[]) => {
+            this.dataStore.find(criteria, (err: Error | null, docs: T[]) => {
                 if (err) {
                     reject(err);
                 } else {
@@ -100,7 +100,7 @@ class BaseCollection<T> {
 
     upsert(query: any, updateQuery: any): Promise<T[]> {
         const a: Promise<T[]> = new Promise((resolve, reject) => {
-            this.dataStore.update(query, updateQuery, { upsert: true }, (err: Error, numberOfUpdated: number, upsert: boolean) => {
+            this.dataStore.update(query, updateQuery, { upsert: true }, (err: Error | null, numberOfUpdated: number, upsert: boolean) => {
                 if (err) {
                     reject(err);
                 } else {
@@ -110,7 +110,7 @@ class BaseCollection<T> {
         });
 
         const b: Promise<T[]> = new Promise((resolve, reject) => {
-            this.dataStore.update(query, updateQuery, { upsert: true }, (err: Error, numberOfUpdated: number, affectedDocs: any, upsert: boolean) => {
+            this.dataStore.update(query, updateQuery, { upsert: true }, (err: Error | null, numberOfUpdated: number, affectedDocs: any, upsert: boolean) => {
                 if (err) {
                     reject(err);
                 } else {
@@ -124,7 +124,7 @@ class BaseCollection<T> {
 
     update(query: {}, updateQuery: {}, options?: any): Promise<number> {
         return new Promise((resolve, reject) => {
-            this.dataStore.update(query, updateQuery, options, (err: Error, numberOfUpdated: number) => {
+            this.dataStore.update(query, updateQuery, options, (err: Error | null, numberOfUpdated: number) => {
                 if (err) {
                     reject(err);
                 } else {
@@ -136,7 +136,7 @@ class BaseCollection<T> {
 
     remove(criteria: any): Promise<number> {
         return new Promise((resolve, reject) => {
-            this.dataStore.remove(criteria, (err: Error, numberOfDeletedEntrys: number) => {
+            this.dataStore.remove(criteria, (err: Error | null, numberOfDeletedEntrys: number) => {
                 if (err) {
                     reject(err);
                 } else {
@@ -186,127 +186,127 @@ const doc: any = {
     infos: { name: 'nedb' }
 };
 
-db.insert(doc, (err: Error, newDoc: any) => {   // Callback is optional
+db.insert(doc, (err: Error | null, newDoc: any) => {   // Callback is optional
     // newDoc is the newly inserted document, including its _id
     // newDoc has no key called notToBeSaved since its value was undefined
 });
 
-db.insert([{ a: 5 }, { a: 42 }], (err: Error, newdocs: any[]) => {
+db.insert([{ a: 5 }, { a: 42 }], (err: Error | null, newdocs: any[]) => {
     // Two documents were inserted in the database
     // newDocs is an array with these documents, augmented with their _id
 });
 
 // If there is a unique constraint on field 'a', this will fail
-db.insert([{ a: 5 }, { a: 42 }, { a: 5 }], (err: Error) => {
+db.insert([{ a: 5 }, { a: 42 }, { a: 5 }], (err: Error | null) => {
     // err is a 'uniqueViolated' error
     // The database was not modified
 });
 
 // Finding all planets in the solar system
-db.find({ system: 'solar' }, (err: Error, docs: any[]) => {
+db.find({ system: 'solar' }, (err: Error | null, docs: any[]) => {
     // docs is an array containing documents Mars, Earth, Jupiter
     // If no document is found, docs is equal to []
 });
 
 // Finding all planets whose name contain the substring 'ar' using a regular expression
-db.find({ planet: /ar/ }, (err: Error, docs: any[]) => {
+db.find({ planet: /ar/ }, (err: Error | null, docs: any[]) => {
     // docs contains Mars and Earth
 });
 
 // Finding all inhabited planets in the solar system
-db.find({ system: 'solar', inhabited: true }, (err: Error, docs: any[]) => {
+db.find({ system: 'solar', inhabited: true }, (err: Error | null, docs: any[]) => {
     // docs is an array containing document Earth only
 });
 
 // Use the dot-notation to match fields in subdocuments
-db.find({ "humans.genders": 2 }, (err: Error, docs: any[]) => {
+db.find({ "humans.genders": 2 }, (err: Error | null, docs: any[]) => {
     // docs contains Earth
 });
 
 // Use the dot-notation to navigate arrays of subdocuments
-db.find({ "completeData.planets.name": "Mars" }, (err: Error, docs: any[]) => {
+db.find({ "completeData.planets.name": "Mars" }, (err: Error | null, docs: any[]) => {
     // docs contains document 5
 });
 
-db.find({ "completeData.planets.name": "Jupiter" }, (err: Error, docs: any[]) => {
+db.find({ "completeData.planets.name": "Jupiter" }, (err: Error | null, docs: any[]) => {
     // docs is empty
 });
 
-db.find({ "completeData.planets.0.name": "Earth" }, (err: Error, docs: any[]) => {
+db.find({ "completeData.planets.0.name": "Earth" }, (err: Error | null, docs: any[]) => {
     // docs contains document 5
     // If we had tested against "Mars" docs would be empty because we are matching against a specific array element
 });
 
 // You can also deep-compare objects. Don't confuse this with dot-notation!
-db.find({ humans: { genders: 2 } }, (err: Error, docs: any[]) => {
+db.find({ humans: { genders: 2 } }, (err: Error | null, docs: any[]) => {
     // docs is empty, because { genders: 2 } is not equal to { genders: 2, eyes: true }
 });
 
 // Find all documents in the collection
-db.find({}, (err: Error, docs: any[]) => {
+db.find({}, (err: Error | null, docs: any[]) => {
 });
 
 // The same rules apply when you want to only find one document
-db.findOne({ _id: 'id1' }, (err: Error, doc: any) => {
+db.findOne({ _id: 'id1' }, (err: Error | null, doc: any) => {
     // doc is the document Mars
     // If no document is found, doc is null
 });
 
 // $lt, $lte, $gt and $gte work on numbers and strings
-db.find({ "humans.genders": { $gt: 5 } }, (err: Error, docs: any[]) => {
+db.find({ "humans.genders": { $gt: 5 } }, (err: Error | null, docs: any[]) => {
     // docs contains Omicron Persei 8, whose humans have more than 5 genders (7).
 });
 
 // When used with strings, lexicographical order is used
-db.find({ planet: { $gt: 'Mercury' } }, (err: Error, docs: any[]) => {
+db.find({ planet: { $gt: 'Mercury' } }, (err: Error | null, docs: any[]) => {
     // docs contains Omicron Persei 8
 });
 
 // Using $in. $nin is used in the same way
-db.find({ planet: { $in: ['Earth', 'Jupiter'] } }, (err: Error, docs: any[]) => {
+db.find({ planet: { $in: ['Earth', 'Jupiter'] } }, (err: Error | null, docs: any[]) => {
     // docs contains Earth and Jupiter
 });
 
 // Using $exists
-db.find({ satellites: { $exists: true } }, (err: Error, docs: any[]) => {
+db.find({ satellites: { $exists: true } }, (err: Error | null, docs: any[]) => {
     // docs contains only Mars
 });
 
 // Using $regex with another operator
-db.find({ planet: { $regex: /ar/, $nin: ['Jupiter', 'Earth'] } }, (err: Error, docs: any[]) => {
+db.find({ planet: { $regex: /ar/, $nin: ['Jupiter', 'Earth'] } }, (err: Error | null, docs: any[]) => {
     // docs only contains Mars because Earth was excluded from the match by $nin
 });
 
 // Using an array-specific comparison function
 // Note: you can't use nested comparison functions, e.g. { $size: { $lt: 5 } } will throw an error
-db.find({ satellites: { $size: 2 } }, (err: Error, docs: any[]) => {
+db.find({ satellites: { $size: 2 } }, (err: Error | null, docs: any[]) => {
     // docs contains Mars
 });
 
-db.find({ satellites: { $size: 1 } }, (err: Error, docs: any[]) => {
+db.find({ satellites: { $size: 1 } }, (err: Error | null, docs: any[]) => {
     // docs is empty
 });
 
 // If a document's field is an array, matching it means matching any element of the array
-db.find({ satellites: 'Phobos' }, (err: Error, docs: any[]) => {
+db.find({ satellites: 'Phobos' }, (err: Error | null, docs: any[]) => {
     // docs contains Mars. Result would have been the same if query had been { satellites: 'Deimos' }
 });
 
 // This also works for queries that use comparison operators
-db.find({ satellites: { $lt: 'Amos' } }, (err: Error, docs: any[]) => {
+db.find({ satellites: { $lt: 'Amos' } }, (err: Error | null, docs: any[]) => {
     // docs is empty since Phobos and Deimos are after Amos in lexicographical order
 });
 
 // This also works with the $in and $nin operator
-db.find({ satellites: { $in: ['Moon', 'Deimos'] } }, (err: Error, docs: any[]) => {
+db.find({ satellites: { $in: ['Moon', 'Deimos'] } }, (err: Error | null, docs: any[]) => {
     // docs contains Mars (the Earth document is not complete!)
 });
 
-db.find({ $or: [{ planet: 'Earth' }, { planet: 'Mars' }] }, (err: Error, docs: any[]) => {
+db.find({ $or: [{ planet: 'Earth' }, { planet: 'Mars' }] }, (err: Error | null, docs: any[]) => {
     // docs contains Earth and Mars
 });
 
-db.find({ $not: { planet: 'Earth' } }, (err: Error, docs: any[]) => {
+db.find({ $not: { planet: 'Earth' } }, (err: Error | null, docs: any[]) => {
     // docs contains Mars, Jupiter, Omicron Persei 8
 });
 
@@ -314,22 +314,22 @@ db.find({
     $where() {
         return parseInt(Object.keys(this)[0], 10) > 6;
     }
-}, (err: Error, docs: any[]) => {
+}, (err: Error | null, docs: any[]) => {
     // docs with more than 6 properties
 });
 
 // You can mix normal queries, comparison queries and logical operators
-db.find({ $or: [{ planet: 'Earth' }, { planet: 'Mars' }], inhabited: true }, (err: Error, docs: any[]) => {
+db.find({ $or: [{ planet: 'Earth' }, { planet: 'Mars' }], inhabited: true }, (err: Error | null, docs: any[]) => {
     // docs contains Earth
 });
 
 // No query used means all results are returned (before the Cursor modifiers)
-db.find({}).sort({ planet: 1 }).skip(1).limit(2).exec((err: Error, docs: any[]) => {
+db.find({}).sort({ planet: 1 }).skip(1).limit(2).exec((err: Error | null, docs: any[]) => {
     // docs is [doc3, doc1]
 });
 
 // You can sort in reverse order like this
-db.find({ system: 'solar' }).sort({ planet: -1 }).exec((err: Error, docs: any[]) => {
+db.find({ system: 'solar' }).sort({ planet: -1 }).exec((err: Error | null, docs: any[]) => {
     // docs is [doc1, doc3, doc2]
 });
 
@@ -339,38 +339,38 @@ db.find({}).sort({ firstField: 1, secondField: -1 });
 // Same database as above
 
 // Keeping only the given fields
-db.find({ planet: 'Mars' }, { planet: 1, system: 1 }, (err: Error, docs: any[]) => {
+db.find({ planet: 'Mars' }, { planet: 1, system: 1 }, (err: Error | null, docs: any[]) => {
     // docs is [{ planet: 'Mars', system: 'solar', _id: 'id1' }]
 });
 
 // Keeping only the given fields but removing _id
-db.find({ planet: 'Mars' }, { planet: 1, system: 1, _id: 0 }, (err: Error, docs: any[]) => {
+db.find({ planet: 'Mars' }, { planet: 1, system: 1, _id: 0 }, (err: Error | null, docs: any[]) => {
     // docs is [{ planet: 'Mars', system: 'solar' }]
 });
 
 // Omitting only the given fields and removing _id
-db.find({ planet: 'Mars' }, { planet: 0, system: 0, _id: 0 }, (err: Error, docs: any[]) => {
+db.find({ planet: 'Mars' }, { planet: 0, system: 0, _id: 0 }, (err: Error | null, docs: any[]) => {
     // docs is [{ inhabited: false, satellites: ['Phobos', 'Deimos'] }]
 });
 
 // Failure: using both modes at the same time
-db.find({ planet: 'Mars' }, { planet: 0, system: 1 }, (err: Error, docs: any[]) => {
+db.find({ planet: 'Mars' }, { planet: 0, system: 1 }, (err: Error | null, docs: any[]) => {
     // err is the error message, docs is undefined
 });
 
 // You can also use it in a Cursor way but this syntax is not compatible with MongoDB
 // If upstream compatibility is important don't use this method
-db.find({ planet: 'Mars' }).projection({ planet: 1, system: 1 }).exec((err: Error, docs: any[]) => {
+db.find({ planet: 'Mars' }).projection({ planet: 1, system: 1 }).exec((err: Error | null, docs: any[]) => {
     // docs is [{ planet: 'Mars', system: 'solar', _id: 'id1' }]
 });
 
 // Count all planets in the solar system
-db.count({ system: 'solar' }, (err: Error, count: number) => {
+db.count({ system: 'solar' }, (err: Error | null, count: number) => {
     // count equals to 3
 });
 
 // Count all documents in the datastore
-db.count({}, (err: Error, count: number) => {
+db.count({}, (err: Error | null, count: number) => {
     // count equals to 4
 });
 
@@ -381,7 +381,7 @@ db.count({}, (err: Error, count: number) => {
 // { _id: 'id4', planet: 'Omicron Persia 8', system: 'futurama', inhabited: true }
 
 // Replace a document by another
-db.update({ planet: 'Jupiter' }, { planet: 'Pluton' }, {}, (err: Error, numReplaced: number) => {
+db.update({ planet: 'Jupiter' }, { planet: 'Pluton' }, {}, (err: Error | null, numReplaced: number) => {
     // numReplaced = 1
     // The doc #3 has been replaced by { _id: 'id3', planet: 'Pluton' }
     // Note that the _id is kept unchanged, and the document has been replaced
@@ -389,7 +389,7 @@ db.update({ planet: 'Jupiter' }, { planet: 'Pluton' }, {}, (err: Error, numRepla
 });
 
 // Set an existing field's value
-db.update({ system: 'solar' }, { $set: { system: 'solar system' } }, { multi: true }, (err: Error, numReplaced: number) => {
+db.update({ system: 'solar' }, { $set: { system: 'solar system' } }, { multi: true }, (err: Error | null, numReplaced: number) => {
     // numReplaced = 3
     // Field 'system' on Mars, Earth, Jupiter now has value 'solar system'
 });
@@ -419,7 +419,7 @@ db.update({ planet: 'Mars' }, { $unset: { planet: true } }, {}, () => {
 db.update({ planet: 'Pluton' }, {
     planet: 'Pluton',
     inhabited: false
-}, { upsert: true }, (err: Error, numReplaced: number, upsert: boolean) => {
+}, { upsert: true }, (err: Error | null, numReplaced: number, upsert: boolean) => {
     // numReplaced = 1, upsert = { _id: 'id5', planet: 'Pluton', inhabited: false }
     // A new document { _id: 'id5', planet: 'Pluton', inhabited: false } has been added to the collection
 });
@@ -474,37 +474,37 @@ db.update({ _id: 'id6' }, { $push: { fruits: { $each: ['banana', 'orange'] } } }
 
 // Remove one document from the collection
 // options set to {} since the default for multi is false
-db.remove({ _id: 'id2' }, {}, (err: Error, numRemoved: number) => {
+db.remove({ _id: 'id2' }, {}, (err: Error | null, numRemoved: number) => {
     // numRemoved = 1
 });
 
 // Remove multiple documents
-db.remove({ system: 'solar' }, { multi: true }, (err: Error, numRemoved: number) => {
+db.remove({ system: 'solar' }, { multi: true }, (err: Error | null, numRemoved: number) => {
     // numRemoved = 3
     // All planets from the solar system were removed
 });
 
-db.ensureIndex({ fieldName: 'somefield' }, (err: Error) => {
+db.ensureIndex({ fieldName: 'somefield' }, (err: Error | null) => {
     // If there was an error, err is not null
 });
 
 // Using a unique constraint with the index
-db.ensureIndex({ fieldName: 'somefield', unique: true }, (err: Error) => {
+db.ensureIndex({ fieldName: 'somefield', unique: true }, (err: Error | null) => {
 });
 
 // Using a sparse unique index
-db.ensureIndex({ fieldName: 'somefield', unique: true, sparse: true }, (err: Error) => {
+db.ensureIndex({ fieldName: 'somefield', unique: true, sparse: true }, (err: Error | null) => {
 });
 
 // Example of using expireAfterSeconds to remove documents 1 hour
 // after their creation (db's timestampData option is true here)
-db.ensureIndex({ fieldName: 'somefield', expireAfterSeconds: 3600 }, (err: Error) => {
+db.ensureIndex({ fieldName: 'somefield', expireAfterSeconds: 3600 }, (err: Error | null) => {
 });
 
 // Format of the error message when the unique constraint is not met
-db.insert({ somefield: 'nedb' }, (err: Error) => {
+db.insert({ somefield: 'nedb' }, (err: Error | null) => {
     // err is null
-    db.insert({ somefield: 'nedb' }, (err: Error) => {
+    db.insert({ somefield: 'nedb' }, (err: Error | null) => {
         // err is { errorType: 'uniqueViolated'
         //        , key: 'name'
         //        , message: 'Unique constraint violated for key name' }
@@ -512,7 +512,7 @@ db.insert({ somefield: 'nedb' }, (err: Error) => {
 });
 
 // Remove index on field somefield
-db.removeIndex('somefield', (err: Error) => {
+db.removeIndex('somefield', (err: Error | null) => {
 });
 
 db.addListener("compaction.done", () => {});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - The [`this.executor.push`](https://github.com/louischatriot/nedb/blob/master/lib/executor.js#L55) in some of these links ends up [applying the arguments to `fn`](https://github.com/louischatriot/nedb/blob/master/lib/executor.js#L40).
  - `Nedb`
    - `loadDatabase` (and `DataStoreOptions.onload`): [1](https://github.com/louischatriot/nedb/blob/master/lib/datastore.js#L88) [2](https://github.com/louischatriot/nedb/blob/master/lib/persistence.js#L271)
    - [`ensureIndex`](https://github.com/louischatriot/nedb/blob/master/lib/datastore.js#L133)
    - [`removeIndex`](https://github.com/louischatriot/nedb/blob/master/lib/datastore.js#L165)
    - `insert`: [1](https://github.com/louischatriot/nedb/blob/master/lib/datastore.js#L435) [2](https://github.com/louischatriot/nedb/blob/master/lib/datastore.js#L356)
    - [`count`](https://github.com/louischatriot/nedb/blob/master/lib/datastore.js#L446)
    - [`find`](https://github.com/louischatriot/nedb/blob/master/lib/datastore.js#L485)
    - [`findOne`](https://github.com/louischatriot/nedb/blob/master/lib/datastore.js#L519)
    - `update`: [1](https://github.com/louischatriot/nedb/blob/master/lib/datastore.js#L656) [2](https://github.com/louischatriot/nedb/blob/master/lib/datastore.js#L601)
    - `remove`: [1](https://github.com/louischatriot/nedb/blob/master/lib/datastore.js#L700) [2](https://github.com/louischatriot/nedb/blob/master/lib/datastore.js#L694)
  - `Cursor.exec` and `CursorCount.exec`: [1](https://github.com/louischatriot/nedb/blob/master/lib/cursor.js#L198) [2](https://github.com/louischatriot/nedb/blob/master/lib/cursor.js#L120)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
