### PR TITLE
leaflet Map.invalidateSize() can take "pan" and "debounceMoveend" opt…

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -7,6 +7,7 @@
 //                 Sandra Frischmuth <https://github.com/sanfrisc>
 //                 Vladimir Dashukevich <https://github.com/life777>
 //                 Henry Thasler <https://github.com/henrythasler>
+//                 Colin Doig <https://github.com/captain-igloo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -1541,6 +1542,11 @@ export interface PanOptions {
 // This is not empty, it extends two interfaces into one...
 export interface ZoomPanOptions extends ZoomOptions, PanOptions {}
 
+export interface InvalidateSizeOptions extends ZoomPanOptions {
+    debounceMoveend?: boolean;
+    pan?: boolean;
+}
+
 export interface FitBoundsOptions extends ZoomOptions, PanOptions {
     paddingTopLeft?: PointExpression;
     paddingBottomRight?: PointExpression;
@@ -1741,7 +1747,7 @@ export class Map extends Evented {
     /**
      * Boolean for animate or advanced ZoomPanOptions
      */
-    invalidateSize(options?: boolean | ZoomPanOptions): this;
+    invalidateSize(options?: boolean | InvalidateSizeOptions): this;
     stop(): this;
     flyTo(latlng: LatLngExpression, zoom?: number, options?: ZoomPanOptions): this;
     flyToBounds(bounds: LatLngBoundsExpression, options?: FitBoundsOptions): this;

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -147,6 +147,16 @@ zoomPanOptions = {
     noMoveStart: true
 };
 
+let invalidateSizeOptions: L.InvalidateSizeOptions = {};
+invalidateSizeOptions = {
+    animate: false,
+    debounceMoveend: true,
+    duration: 0.5,
+    easeLinearity: 0.6,
+    noMoveStart: true,
+    pan: false,
+};
+
 const zoomOptions: L.ZoomOptions = {};
 
 const panOptions: L.PanOptions = {};
@@ -451,8 +461,9 @@ map = map
     .panInsideBounds(latLngBounds, panOptions)
     .panInsideBounds(latLngBoundsLiteral)
     .panInsideBounds(latLngBoundsLiteral, panOptions)
-    .invalidateSize(zoomPanOptions)
+    .invalidateSize(invalidateSizeOptions)
     .invalidateSize(false)
+    .invalidateSize({ debounceMoveend: true, pan: false })
     .stop()
     .flyTo(latLng)
     .flyTo(latLng, 12)


### PR DESCRIPTION
…ions, see https://leafletjs.com/reference-1.6.0.html (scroll down to scroll down to invalidateSize()).

I made an earlier [pull request](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44904) for this which was approved but then closed without being merged, so I'm trying again.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://leafletjs.com/reference-1.6.0.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
