### PR TITLE
Add types for changelog-filename-regex

### DIFF
--- a/types/changelog-filename-regex/changelog-filename-regex-tests.ts
+++ b/types/changelog-filename-regex/changelog-filename-regex-tests.ts
@@ -1,0 +1,3 @@
+import changelogFilenameRegex from 'changelog-filename-regex';
+
+changelogFilenameRegex.test('CHANGELOG'); // $ExpectType boolean

--- a/types/changelog-filename-regex/index.d.ts
+++ b/types/changelog-filename-regex/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for changelog-filename-regex 2.0
+// Project: https://github.com/shinnn/changelog-filename-regex#readme
+// Definitions by: Jamie Magee <https://github.com/JamieMagee>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare const changelogFilenameRegex: RegExp;
+export = changelogFilenameRegex;

--- a/types/changelog-filename-regex/tsconfig.json
+++ b/types/changelog-filename-regex/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "esModuleInterop": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "changelog-filename-regex-tests.ts"
+    ]
+}

--- a/types/changelog-filename-regex/tslint.json
+++ b/types/changelog-filename-regex/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.