### PR TITLE
[Nightwatch] Added startWith and endWith to Expect interface

### DIFF
--- a/types/nightwatch/index.d.ts
+++ b/types/nightwatch/index.d.ts
@@ -552,6 +552,10 @@ export interface Expect extends NightwatchLanguageChains, NightwatchBrowser {
     contain(value: string): this;
     contains(value: string): this;
     match(value: string | RegExp): this;
+    startWith(value: string): this;
+    startsWith(value: string): this;
+    endWith(value: string): this;
+    endsWith(value: string): this;
 
     /**
      * Negates any of assertions following in the chain.

--- a/types/nightwatch/nightwatch-tests.ts
+++ b/types/nightwatch/nightwatch-tests.ts
@@ -18,9 +18,9 @@ const testGeneral: NightwatchTests = {
     browser.expect.element('#lst-ib').to.have.css('display');
 
     // expect element <body> to have attribute 'class' which contains text 'vasq'
-    browser.expect.element('body').to.have.attribute('class').which.contains('vasq')  
-    
-    browser.expect.element('#hplogo').to.have.attribute('alt').which.startsWith('G').and.endsWith('oogle')
+    browser.expect.element('body').to.have.attribute('class').which.contains('vasq');
+
+    browser.expect.element('#hplogo').to.have.attribute('alt').which.startsWith('G').and.endsWith('oogle');
 
     // expect element <#lst-ib> to be an input tag
     browser.expect.element('#lst-ib').to.be.an('input');

--- a/types/nightwatch/nightwatch-tests.ts
+++ b/types/nightwatch/nightwatch-tests.ts
@@ -18,7 +18,9 @@ const testGeneral: NightwatchTests = {
     browser.expect.element('#lst-ib').to.have.css('display');
 
     // expect element <body> to have attribute 'class' which contains text 'vasq'
-    browser.expect.element('body').to.have.attribute('class').which.contains('vasq');
+    browser.expect.element('body').to.have.attribute('class').which.contains('vasq')  
+    
+    browser.expect.element('#hplogo').to.have.attribute('alt').which.startsWith('G').and.endsWith('oogle')
 
     // expect element <#lst-ib> to be an input tag
     browser.expect.element('#lst-ib').to.be.an('input');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nightwatchjs.org/api/expect/#expect-startend
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

