### PR TITLE
`http-errors`: add support for new `isHttpError`

### DIFF
--- a/types/http-errors/http-errors-tests.ts
+++ b/types/http-errors/http-errors-tests.ts
@@ -119,3 +119,7 @@ create(404) instanceof create.HttpError;
 util.isError(create(404));
 util.isError(new create['404']());
 util.isError(new create['500']());
+
+// should support isHttpError
+create.isHttpError(1); // non-http-error type
+create.isHttpError(new create['404']()); // http error type

--- a/types/http-errors/index.d.ts
+++ b/types/http-errors/index.d.ts
@@ -7,7 +7,9 @@
 
 export = createHttpError;
 
-declare const createHttpError: createHttpError.CreateHttpError & createHttpError.NamedConstructors;
+declare const createHttpError: createHttpError.CreateHttpError & createHttpError.NamedConstructors & {
+    isHttpError: createHttpError.IsHttpError
+};
 
 declare namespace createHttpError {
     interface HttpError extends Error {
@@ -25,6 +27,8 @@ declare namespace createHttpError {
     type HttpErrorConstructor = new (msg?: string) => HttpError;
 
     type CreateHttpError = (...args: UnknownError[]) => HttpError;
+
+    type IsHttpError = (error: unknown) => error is HttpError;
 
     type NamedConstructors = {
         [code: string]: HttpErrorConstructor;

--- a/types/http-errors/index.d.ts
+++ b/types/http-errors/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for http-errors 1.6
+// Type definitions for http-errors 1.8
 // Project: https://github.com/jshttp/http-errors
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 //                 BendingBender <https://github.com/BendingBender>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jshttp/http-errors#createerrorishttperrorval
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.