### PR TITLE
[string-natural-compare] Add type definition

### DIFF
--- a/types/string-natural-compare/index.d.ts
+++ b/types/string-natural-compare/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for string-natural-compare 3.0
+// Project: https://github.com/nwoltman/string-natural-compare
+// Definitions by: Anton Rieder <https://github.com/DefinitelyTyped>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export default function naturalCompare(
+    a: string,
+    b: string,
+    options?: { caseInsensitive?: boolean; alphabet?: string },
+): number;

--- a/types/string-natural-compare/index.d.ts
+++ b/types/string-natural-compare/index.d.ts
@@ -3,8 +3,10 @@
 // Definitions by: Anton Rieder <https://github.com/DefinitelyTyped>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export default function naturalCompare(
+declare function naturalCompare(
     a: string,
     b: string,
     options?: { caseInsensitive?: boolean; alphabet?: string },
 ): number;
+
+export = naturalCompare;

--- a/types/string-natural-compare/string-natural-compare-tests.ts
+++ b/types/string-natural-compare/string-natural-compare-tests.ts
@@ -1,0 +1,5 @@
+import naturalCompare from 'string-natural-compare';
+
+naturalCompare('a', 'b');
+naturalCompare('a', 'b', { caseInsensitive: true });
+naturalCompare('a', 'b', { alphabet: 'ba' });

--- a/types/string-natural-compare/tsconfig.json
+++ b/types/string-natural-compare/tsconfig.json
@@ -14,7 +14,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
     },
     "files": [
         "index.d.ts",

--- a/types/string-natural-compare/tsconfig.json
+++ b/types/string-natural-compare/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "string-natural-compare-tests.ts"
+    ]
+}

--- a/types/string-natural-compare/tslint.json
+++ b/types/string-natural-compare/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Adds types for https://github.com/nwoltman/string-natural-compare

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
