### PR TITLE
prosemirror-view: Add 'plain' param to two APIs

### DIFF
--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for prosemirror-view 1.11
+// Type definitions for prosemirror-view 1.15
 // Project: https://github.com/ProseMirror/prosemirror-view
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 //                 David Hahn <https://github.com/davidka>
@@ -530,9 +530,10 @@ export interface EditorProps<ThisT = unknown, S extends Schema = any> {
    */
   clipboardParser?: DOMParser<S> | null;
   /**
-   * Transform pasted plain text.
+   * Transform pasted plain text. The `plain` flag will be true when
+   * the text is pasted as plain text.
    */
-  transformPastedText?: ((this: ThisT, text: string) => string) | null;
+  transformPastedText?: ((this: ThisT, text: string, plain: boolean) => string) | null;
   /**
    * A function to parse text from the clipboard into a document
    * slice. Called after
@@ -540,8 +541,10 @@ export interface EditorProps<ThisT = unknown, S extends Schema = any> {
    * The default behavior is to split the text into lines, wrap them
    * in `<p>` tags, and call
    * [`clipboardParser`](#view.EditorProps.clipboardParser) on it.
+   * The `plain` flag will be true when the text is pasted as plain
+   * text.
    */
-  clipboardTextParser?: ((this: ThisT, text: string, $context: ResolvedPos<S>) => Slice<S>) | null;
+  clipboardTextParser?: ((this: ThisT, text: string, $context: ResolvedPos<S>, plain: boolean) => Slice<S>) | null;
   /**
    * Can be used to transform pasted content before it is applied to
    * the document.

--- a/types/prosemirror-view/prosemirror-view-tests.ts
+++ b/types/prosemirror-view/prosemirror-view-tests.ts
@@ -1,6 +1,7 @@
-import * as view from 'prosemirror-view';
-import * as state from 'prosemirror-state';
+import * as model from 'prosemirror-model';
 import * as schema from 'prosemirror-schema-basic';
+import * as state from 'prosemirror-state';
+import * as view from 'prosemirror-view';
 
 const { Decoration } = view;
 const decoration = new Decoration();
@@ -51,4 +52,19 @@ const res5_view = new view.EditorView<typeof schema.schema>(undefined, {
         // Ensure that `this` is bound to type EditorView<schema.schema>
         const v: view.EditorView<typeof schema.schema> = this;
     },
+});
+
+// Test `plain: boolean`
+const res6_plugin = new state.Plugin({
+    props: {
+        transformPastedText(text, plain) {
+            const isPlain: boolean = plain;
+            return text;
+        },
+
+        clipboardTextParser(text, $context, plain) {
+            const isPlain: boolean = plain;
+            return model.Slice.empty;
+        }
+    }
 });


### PR DESCRIPTION
As of prosemirror-view 1.15, transformPastedText() and clipboardTextParser() are passed a `plain: boolean` parameter.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`transformPastedText()`](https://prosemirror.net/docs/ref/#view.EditorProps.transformPastedText), [`clipboardTextParser()`](https://prosemirror.net/docs/ref/#view.EditorProps.clipboardTextParser)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.