### PR TITLE
Add support to `MediaRecorder` type for `audioBitrateMode` attribute as defined in updated specification.

### DIFF
--- a/types/dom-mediacapture-record/dom-mediacapture-record-tests.ts
+++ b/types/dom-mediacapture-record/dom-mediacapture-record-tests.ts
@@ -7,7 +7,8 @@ const mediaStream = new MediaStream();
 const mediaRecorderOptions: MediaRecorderOptions = {
     mimeType: 'video/webm',
     audioBitsPerSecond: 1000000,
-    videoBitsPerSecond: 4000000
+    videoBitsPerSecond: 4000000,
+    audioBitrateMode: 'vbr'
 };
 
 const blobEvent = new BlobEvent('dataavailable', {
@@ -39,6 +40,7 @@ recorder.pause();
 recorder.requestData();
 const state: RecordingState = recorder.state;
 const isRecording = state === 'recording';
+const isAudioVariableBitrate = recorder.audioBitrateMode === 'vbr';
 
 recorder.addEventListener('start', onEvent);
 recorder.removeEventListener('start', onEvent);

--- a/types/dom-mediacapture-record/index.d.ts
+++ b/types/dom-mediacapture-record/index.d.ts
@@ -24,11 +24,14 @@ declare class BlobEvent extends Event {
     readonly timecode: number;
 }
 
+type BitrateMode = 'vbr' | 'cbr';
+
 interface MediaRecorderOptions {
     mimeType?: string;
     audioBitsPerSecond?: number;
     videoBitsPerSecond?: number;
     bitsPerSecond?: number;
+    audioBitrateMode?: BitrateMode;
 }
 
 type RecordingState = 'inactive' | 'recording' | 'paused';
@@ -48,6 +51,7 @@ declare class MediaRecorder extends EventTarget {
     readonly state: RecordingState;
     readonly videoBitsPerSecond: number;
     readonly audioBitsPerSecond: number;
+    readonly audioBitrateMode: BitrateMode;
 
     ondataavailable: ((event: BlobEvent) => void) | null;
     onerror: ((event: MediaRecorderErrorEvent) => void) | null;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://w3c.github.io/mediacapture-record/#mediarecorder-api
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~

---

This updates `MediaRecorder` and `MediaRecorderOptions` to include a field recently added to the specification. Chrome does not yet have support for this, but hoping to put in a PR soon.