### PR TITLE
Fix react-router hooks test

### DIFF
--- a/types/react-router/test/hooks.tsx
+++ b/types/react-router/test/hooks.tsx
@@ -21,7 +21,7 @@ interface LocationState {
 const HooksTest: React.FC = () => {
     const history = useHistory<LocationState>();
     const location = useLocation<LocationState>();
-    const { id } = useParams();
+    const { id } = useParams<Params>();
     const params = useParams<Params>();
     // $ExpectType OptionalParams
     const optionalParams = useParams<OptionalParams>();


### PR DESCRIPTION
microsoft/TypeScript#39081, which ships in Typescript 4.0, stops using binding patterns as contextual types for return type inference. react-router's `useParams` relied on this to fill in an object with `any`s in case a binding pattern was used but no type argument was provided. This no longer works in 4.0.

This fix just adds a type argument to the tests to reflect what users of TS 4.0 will have to do to use react-router.

For two other, more complete fixes, see

https://github.com/microsoft/TypeScript/pull/39081#issuecomment-644393729

Briefly, the options are (1) go back to returning `any`-filled object types or (2) tries to default to `string`.

The second fix is probably the right one, but it may hurt compilation/IDE performance, so I'll leave it to the contributors to decide whether to make that change.