### PR TITLE
update tests for @testing-library/vue, from dom

### DIFF
--- a/types/testing-library__vue/testing-library__vue-tests.ts
+++ b/types/testing-library__vue/testing-library__vue-tests.ts
@@ -132,8 +132,8 @@ lib.wait(() => { throw new Error("nope"); }, {timeout: 3000, interval: 100});
 lib.waitForDomChange({container: select, timeout: 3000, mutationObserverOptions: {subtree: false}});
 lib.waitForElement(() => input); // $ExpectType Promise<HTMLInputElement>
 lib.waitForElement(() => option, {container: select, timeout: 3000, mutationObserverOptions: {subtree: false}}); // $ExpectType Promise<HTMLOptionElement>
-lib.waitForElementToBeRemoved(() => input); // $ExpectType Promise<HTMLInputElement>
-lib.waitForElementToBeRemoved(() => option, {container: select, timeout: 3000, mutationObserverOptions: {subtree: false}}); // $ExpectType Promise<HTMLOptionElement>
+lib.waitForElementToBeRemoved(() => input); // $ExpectType Promise<void>
+lib.waitForElementToBeRemoved(() => option, {container: select, timeout: 3000, mutationObserverOptions: {subtree: false}}); // $ExpectType Promise<void>
 
 // Reexports utilities from dom-testing-library
 lib.buildQueries((el: HTMLElement) => [el], (_: HTMLElement) => "something", (_: HTMLElement) => "error");


### PR DESCRIPTION
waitForElementToBeRemoved had the wrong return type, and it got fixed in https://github.com/testing-library/dom-testing-library/pull/631

This PR updates @testing-library/vue, which depends on @testing-library/dom.