### PR TITLE
fix: [node] add missing options parameter for lstat

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -546,7 +546,7 @@ declare module "fs" {
          * Whether the numeric values in the returned fs.Stats object should be bigint.
          * @default false
          */
-        bigint?: number;
+        bigint?: boolean;
     }
 
     /**

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -541,11 +541,25 @@ declare module "fs" {
      */
     export function fstatSync(fd: number): Stats;
 
+    export interface LstatOptions {
+        /**
+         * Whether the numeric values in the returned fs.Stats object should be bigint.
+         * @default false
+         */
+        bigint?: number;
+    }
+
     /**
      * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
     export function lstat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+
+    /**
+     * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     */
+    export function lstat(path: PathLike, options: LstatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     export namespace lstat {
@@ -560,7 +574,7 @@ declare module "fs" {
      * Synchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function lstatSync(path: PathLike): Stats;
+    export function lstatSync(path: PathLike, options?: LstatOptions): Stats;
 
     /**
      * Asynchronous link(2) - Create a new link (also known as a hard link) to an existing file.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v12.x/api/fs.html#fs_fs_lstat_path_options_callback
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.