### PR TITLE
Add missing chai-as-promised assert functions

### DIFF
--- a/types/chai-as-promised/index.d.ts
+++ b/types/chai-as-promised/index.d.ts
@@ -5,6 +5,7 @@
 //                 Leonard Thieu <https://github.com/leonard-thieu>,
 //                 Mike Lazer-Walker <https://github.com/lazerwalker>,
 //                 Matt Bishop <https://github.com/mattbishop>
+//                 William Orr <https://github.com/worr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -313,6 +314,7 @@ declare namespace Chai {
 
         isNumber(val: any, msg?: string): PromiseLike<void>;
         isNotNumber(val: any, msg?: string): PromiseLike<void>;
+        isFinite(val: number, msg?: string): PromiseLike<void>;
 
         isBoolean(val: any, msg?: string): PromiseLike<void>;
         isNotBoolean(val: any, msg?: string): PromiseLike<void>;
@@ -329,6 +331,24 @@ declare namespace Chai {
         notInclude(exp: string, inc: any, msg?: string): PromiseLike<void>;
         notInclude(exp: any[], inc: any, msg?: string): PromiseLike<void>;
 
+        deepInclude(exp: string, inc: any, msg?: string): PromiseLike<void>;
+        deepInclude(exp: any[], inc: any, msg?: string): PromiseLike<void>;
+
+        notDeepInclude(exp: string, inc: any, msg?: string): PromiseLike<void>;
+        notDeepInclude(exp: any[], inc: any, msg?: string): PromiseLike<void>;
+
+        nestedInclude(exp: Object, inc: Object, msg?: string): PromiseLike<void>;
+        notNestedInclude(exp: Object, inc: Object, msg?: string): PromiseLike<void>;
+
+        deepNestedInclude(exp: Object, inc: Object, msg?: string): PromiseLike<void>;
+        notDeepNestedInclude(exp: Object, inc: Object, msg?: string): PromiseLike<void>;
+
+        ownInclude(exp: Object, inc: Object, msg?: string): PromiseLike<void>;
+        notOwnInclude(exp: Object, inc: Object, msg?: string): PromiseLike<void>;
+
+        deepOwnInclude(exp: Object, inc: Object, msg?: string): PromiseLike<void>;
+        notDeepOwnInclude(exp: Object, inc: Object, msg?: string): PromiseLike<void>;
+
         match(exp: any, re: RegExp, msg?: string): PromiseLike<void>;
         notMatch(exp: any, re: RegExp, msg?: string): PromiseLike<void>;
 
@@ -343,7 +363,46 @@ declare namespace Chai {
         deepPropertyVal(obj: Object, prop: string, val: any, msg?: string): PromiseLike<void>;
         deepPropertyNotVal(obj: Object, prop: string, val: any, msg?: string): PromiseLike<void>;
 
+        nestedProperty(obj: object, prop: string, msg?: string): PromiseLike<void>;
+        notNestedProperty(obj: object, prop: string, msg?: string): PromiseLike<void>;
+        nestedPropertyVal(obj: object, prop: string, val: any, msg?: string): PromiseLike<void>;
+        notNestedPropertyVal(obj: object, prop: string, val: any, msg?: string): PromiseLike<void>;
+
+        deepNestedPropertyVal(obj: object, prop: string, val: any, msg?: string): PromiseLike<void>;
+        notDeepNestedPropertyVal(obj: object, prop: string, val: any, msg?: string): PromiseLike<void>;
+
         lengthOf(exp: any, len: number, msg?: string): PromiseLike<void>;
+
+        hasAnyKeys(obj: any, keys: any[], msg?: string): PromiseLike<void>;
+        hasAnyKeys(obj: any, keys: object, msg?: string): PromiseLike<void>;
+
+        hasAllKeys(obj: any, keys: any[], msg?: string): PromiseLike<void>;
+        hasAllKeys(obj: any, keys: object, msg?: string): PromiseLike<void>;
+
+        containsAllKeys(obj: any, keys: any[], msg?: string): PromiseLike<void>;
+        containsAllKeys(obj: any, keys: object, msg?: string): PromiseLike<void>;
+
+        doesNotHaveAnyKeys(obj: any, keys: any[], msg?: string): PromiseLike<void>;
+        doesNotHaveAnyKeys(obj: any, keys: object, msg?: string): PromiseLike<void>;
+
+        doesNotHaveAllKeys(obj: any, keys: any[], msg?: string): PromiseLike<void>;
+        doesNotHaveAllKeys(obj: any, keys: object, msg?: string): PromiseLike<void>;
+
+        hasAnyDeepKeys(obj: any, keys: any[], msg?: string): PromiseLike<void>;
+        hasAnyDeepKeys(obj: any, keys: object, msg?: string): PromiseLike<void>;
+
+        hasAllDeepKeys(obj: any, keys: any[], msg?: string): PromiseLike<void>;
+        hasAllDeepKeys(obj: any, keys: object, msg?: string): PromiseLike<void>;
+
+        containsAllDeepKeys(obj: any, keys: any[], msg?: string): PromiseLike<void>;
+        containsAllDeepKeys(obj: any, keys: object, msg?: string): PromiseLike<void>;
+
+        doesNotHaveAnyDeepKeys(obj: any, keys: any[], msg?: string): PromiseLike<void>;
+        doesNotHaveAnyDeepKeys(obj: any, keys: object, msg?: string): PromiseLike<void>;
+
+        doesNotHaveAllDeepKeys(obj: any, keys: any[], msg?: string): PromiseLike<void>;
+        doesNotHaveAllDeepKeys(obj: any, keys: object, msg?: string): PromiseLike<void>;
+
         //alias frenzy
         throw(fn: Function, msg?: string): PromiseLike<void>;
         throw(fn: Function, regExp: RegExp): PromiseLike<void>;
@@ -385,11 +444,17 @@ declare namespace Chai {
         oneOf(val: any, list: any[], msg?: string): PromiseLike<void>;
 
         changes(modifier: Function, obj: Object, property: string, msg?: string): PromiseLike<void>;
+        changesBy(modifier: Function, obj: object, property: string, change: number, msg?: string): PromiseLike<void>;
         doesNotChange(modifier: Function, obj: Object, property: string, msg?: string): PromiseLike<void>;
+        changesButNotBy(modifier: Function, obj: object, property: string, change: number, msg?: string): PromiseLike<void>;
         increases(modifier: Function, obj: Object, property: string, msg?: string): PromiseLike<void>;
+        increasesBy(modifier: Function, obj: Object, property: string, change: number, msg?: string): PromiseLike<void>;
         doesNotIncrease(modifier: Function, obj: Object, property: string, msg?: string): PromiseLike<void>;
+        increasesButNotBy(modifier: Function, obj: Object, property: string, change: number, msg?: string): PromiseLike<void>;
         decreases(modifier: Function, obj: Object, property: string, msg?: string): PromiseLike<void>;
+        decreasesBy(modifier: Function, obj: Object, property: string, change: number, msg?: string): PromiseLike<void>;
         doesNotDecrease(modifier: Function, obj: Object, property: string, msg?: string): PromiseLike<void>;
+        decreasesButNotBy(modifier: Function, obj: Object, property: string, change: number, msg?: string): PromiseLike<void>;
 
         ifError(val: any, msg?: string): PromiseLike<void>;
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). -- not able to, `npm run lint` is broken on OpenBSD
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://www.chaijs.com/api/assert/>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.