### PR TITLE
update(auth0-js): WebAuth.checkSession minor changes

### DIFF
--- a/types/auth0-js/auth0-js-tests.ts
+++ b/types/auth0-js/auth0-js-tests.ts
@@ -238,6 +238,15 @@ webAuth.checkSession({
     // Renewed tokens or error
 });
 
+//  use case; get a new token for the API
+webAuth.checkSession({}, (err, authResult: auth0.Auth0Result) => {
+    if (err) {
+        err; // $ExpectType Auth0Error
+    } else {
+        authResult.accessToken; // $ExpectType string
+    }
+});
+
 const authentication = new auth0.Authentication({
     domain: 'me.auth0.com',
     clientID: '...',

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -296,9 +296,10 @@ export class WebAuth {
      * Renews an existing session on Auth0's servers using `response_mode=web_message` (i.e. Auth0's hosted login page)
      *
      * @param options options used in {@link authorize} call
-     * @param callback: any(err, token_payload)
+     * @param cb
+     * @see {@link https://auth0.com/docs/libraries/auth0js/v9#using-checksession-to-acquire-new-tokens}
      */
-    checkSession(options: CheckSessionOptions, callback: Auth0Callback<any>): void;
+    checkSession(options: CheckSessionOptions, cb: Auth0Callback<any>): void;
 }
 
 export class Redirect {


### PR DESCRIPTION
From 9.13.* version:
- correct parameter name (`callback` => `cb`) to match original source
- add JSDoc external link for common use case (token refresh)
- udpate tests to cover token refresh code (requiring empty options
object)

Ref:
https://github.com/auth0/auth0.js/compare/v9.13.2...v9.13.3

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)