### PR TITLE
Fix field defs for Document of  forge-viewer

### DIFF
--- a/types/forge-viewer/forge-viewer-tests.ts
+++ b/types/forge-viewer/forge-viewer-tests.ts
@@ -1,0 +1,36 @@
+let viewer: Autodesk.Viewing.GuiViewer3D;
+const options = {
+    env: 'AutodeskProduction',
+    api: 'derivativeV2',  // for models uploaded to EMEA change this option to 'derivativeV2_EU'
+    accessToken: ''
+};
+
+Autodesk.Viewing.Initializer(options, () => {
+    const htmlDiv = document.getElementById('forgeViewer');
+    if (!htmlDiv)
+        return;
+
+    viewer = new Autodesk.Viewing.GuiViewer3D(htmlDiv);
+    const startedCode = viewer.start();
+    if (startedCode > 0) {
+        console.error('Failed to create a Viewer: WebGL not supported.');
+        return;
+    }
+
+    const documentId = 'urn:dXJuOmFkc2sub2JqZWN0czpvcy5vYmplY3Q6bXktYnVja2V0L215LWF3ZXNvbWUtZm9yZ2UtZmlsZS5ydnQ';
+    Autodesk.Viewing.Document.load(documentId, onDocumentLoadSuccess, onDocumentLoadFailure);
+
+    async function onDocumentLoadSuccess(doc: Autodesk.Viewing.Document) {
+        await doc.downloadAecModelData();
+
+        const docRoot: Autodesk.Viewing.BubbleNode = doc.getRoot();
+        const aecModelData = await Autodesk.Viewing.Document.getAecModelData(docRoot);
+        const defaultModel = docRoot.getDefaultGeometry();
+
+        await viewer.loadDocumentNode(doc, defaultModel);
+    }
+
+    function onDocumentLoadFailure() {
+        console.error('Failed fetching Forge manifest');
+    }
+});

--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -386,7 +386,7 @@ declare namespace Autodesk {
             myData: any;
 
             downloadAecModelData(onFinished?: (data: any) => void): Promise<any>;
-            getAecModelData(node: BubbleNode): any;
+            static getAecModelData(node: BubbleNode): any;
             getFullPath(urn: string): string;
             getItemById(id: string): object;
             getMessages(itemId: string, excludeGlobal: boolean): object;

--- a/types/forge-viewer/tsconfig.json
+++ b/types/forge-viewer/tsconfig.json
@@ -18,6 +18,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "forge-viewer-tests.ts"
     ]
 }


### PR DESCRIPTION
Fix incorrect definitions of Document

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://forge.autodesk.com/en/docs/viewer/v7/change_history/changelog_v7/migration_guide_v6_to_v7/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
