### PR TITLE
mailgun-js: update generic request method types

### DIFF
--- a/types/mailgun-js/index.d.ts
+++ b/types/mailgun-js/index.d.ts
@@ -77,7 +77,8 @@ declare namespace Mailgun {
 
     interface MailgunRequest {
         (resource: string, data: any, callback: (error: Error, response: any) => void): void;
-        (resource: string, data: any): Promise<any>;
+        (resource: string, callback: (error: Error, response: any) => void): void;
+        (resource: string, data?: any): Promise<any>;
     }
 
     namespace messages {

--- a/types/mailgun-js/index.d.ts
+++ b/types/mailgun-js/index.d.ts
@@ -112,7 +112,7 @@ declare namespace Mailgun {
         }
 
         interface BatchData extends SendData {
-            'recipient-variables'?: BatchSendRecipientVars;
+            'recipient-variables'?: string | BatchSendRecipientVars;
         }
 
         type SendTemplateData = SendData & {
@@ -121,10 +121,7 @@ declare namespace Mailgun {
         };
 
         interface BatchSendRecipientVars {
-            [email: string]: {
-                first: string;
-                id: number;
-            };
+            [email: string]: {[key: string]: any};
         }
 
         interface SendResponse {

--- a/types/mailgun-js/mailgun-js-tests.ts
+++ b/types/mailgun-js/mailgun-js-tests.ts
@@ -85,6 +85,34 @@ const exampleSendDataWithTemplate2: mailgunFactory.messages.SendTemplateData = {
     },
 };
 
+const exampleBatchDataWithRecipientVariables1: mailgunFactory.messages.BatchData = {
+    to: 'someone@email.com',
+    subject: 'Hello, %recipient.name%',
+    text: 'You have %recipient.invitations% new invitations',
+    'recipient-variables': {
+        'alice@example.com': {
+            name: 'Alice',
+            invitations: 3
+        },
+        'bob@example.com': {
+            name: 'Bob',
+            invitations: 2
+        },
+    }
+};
+
+const exampleBatchDataWithRecipientVariables2: mailgunFactory.messages.BatchData = {
+    to: 'someone@email.com',
+    subject: 'Hello, %recipient.name%',
+    text: 'You have %recipient.invitations% new invitations',
+    'recipient-variables': JSON.stringify({
+        'alice@example.com': {
+            name: 'Alice',
+            invitations: 3
+        },
+    })
+};
+
 const exampleSendDataTemplateResponse: Promise<mailgunFactory.messages.SendResponse> = mailgun
     .messages()
     .send(exampleSendDataWithTemplate);

--- a/types/mailgun-js/mailgun-js-tests.ts
+++ b/types/mailgun-js/mailgun-js-tests.ts
@@ -143,4 +143,6 @@ const validationResult6: mailgunFactory.validation.ValidateResponse = {
 
 // Generic requests
 mailgun.get('/samples.mailgun.org/stats', { event: ['sent', 'delivered'] }, (error: any, body: any) => {});
-const response: Promise<any> = mailgun.get('/samples.mailgun.org/stats', { event: ['sent', 'delivered'] });
+mailgun.get('/samples.mailgun.org/stats', (error: any, body: any) => {});
+const response1: Promise<any> = mailgun.get('/samples.mailgun.org/stats', { event: ['sent', 'delivered'] });
+const response2: Promise<any> = mailgun.get('/samples.mailgun.org/stats');


### PR DESCRIPTION
The generic request methods support a variety of signatures, as can be seen here: https://github.com/highlycaffeinated/mailgun-js/blob/a1cd9a5ef1001e39fb6480d844d5e8f9699cc571/lib/request.js#L152-L161. This updates the types to match this behavior.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/highlycaffeinated/mailgun-js/blob/a1cd9a5ef1001e39fb6480d844d5e8f9699cc571/lib/request.js#L152-L161
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
