### PR TITLE
[react-dates]: change reopenPickerOnClearDates to reopenPickerOnClearDate for SingleDatePickerShape

### DIFF
--- a/types/react-dates/index.d.ts
+++ b/types/react-dates/index.d.ts
@@ -198,7 +198,7 @@ declare namespace ReactDates {
         firstDayOfWeek?: DayOfWeekShape;
         numberOfMonths?: number;
         keepOpenOnDateSelect?: boolean;
-        reopenPickerOnClearDates?: boolean;
+        reopenPickerOnClearDate?: boolean;
         renderCalendarInfo?: () => string | JSX.Element;
         calendarInfoPosition?: CalendarInfoPositionShape;
         hideKeyboardShortcutsPanel?: boolean;
@@ -268,7 +268,7 @@ declare namespace ReactDates {
         keyboardNavigationInstructions?: string;
         chooseAvailableStartDate?: (phraseArg: PhraseArg) => string;
         chooseAvailableEndDate?: (phraseArg: PhraseArg) => string;
-        dateIsUnavailable?: (phraseArg: PhraseArg)  => string;
+        dateIsUnavailable?: (phraseArg: PhraseArg) => string;
         dateIsSelected?: (phraseArg: PhraseArg) => string;
         dateIsSelectedAsStartDate?: (phraseArg: PhraseArg) => string;
         dateIsSelectedAsEndDate?: (phraseArg: PhraseArg) => string;

--- a/types/react-dates/react-dates-tests.tsx
+++ b/types/react-dates/react-dates-tests.tsx
@@ -51,7 +51,7 @@ class SingleDatePickerFullTest extends React.Component {
                     withPortal={false}
                     onDateChange={d => {}}
                     focused={false}
-                    reopenPickerOnClearDates={true}
+                    reopenPickerOnClearDate={true}
                     screenReaderInputMessage="arial-test"
                     withFullScreenPortal={true}
                     onFocusChange={arg => {}}


### PR DESCRIPTION
For SingleDatePicker, the property should be `reopenPickerOnClearDate` instead of `reopenPickerOnClearDates`

Here the ref: https://github.com/airbnb/react-dates#singledatepicker or http://airbnb.io/react-dates/?path=/story/sdp-input-props--reopens-daypicker-on-clear-dates