### PR TITLE
Add types for linkify-markdown

### DIFF
--- a/types/linkify-markdown/index.d.ts
+++ b/types/linkify-markdown/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for linkify-markdown 1.0
+// Project: https://github.com/nitin42/linkify-markdown#readme
+// Definitions by: Jamie Magee <https://github.com/JamieMagee>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function linkify(source: string, options?: LinkifyOptions): string;
+export interface LinkifyOptions {
+    strong?: boolean;
+    repository?: string;
+}

--- a/types/linkify-markdown/linkify-markdown-tests.ts
+++ b/types/linkify-markdown/linkify-markdown-tests.ts
@@ -1,0 +1,4 @@
+import { linkify } from 'linkify-markdown';
+
+linkify(''); // $ExpectedType string
+linkify('', { strong: true, repository: '' }); // $ExpectedType string

--- a/types/linkify-markdown/tsconfig.json
+++ b/types/linkify-markdown/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "linkify-markdown-tests.ts"
+    ]
+}

--- a/types/linkify-markdown/tslint.json
+++ b/types/linkify-markdown/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.