### PR TITLE
Add types for get-installed-path

### DIFF
--- a/types/get-installed-path/get-installed-path-tests.ts
+++ b/types/get-installed-path/get-installed-path-tests.ts
@@ -1,0 +1,4 @@
+import { getInstalledPath, getInstalledPathSync } from 'get-installed-path';
+
+getInstalledPath(''); // $ExpectedType Promise<string>
+getInstalledPathSync('', { cwd: '', local: true, paths: [] }); // $ExpectedType string

--- a/types/get-installed-path/index.d.ts
+++ b/types/get-installed-path/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/tunnckoCore/get-installed-path
 // Definitions by: Jamie Magee <https://github.com/JamieMagee>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.4
 
 export function getInstalledPath(name: string, opts?: Options): Promise<string>;
 export function getInstalledPathSync(name: string, opts?: Options): string;

--- a/types/get-installed-path/index.d.ts
+++ b/types/get-installed-path/index.d.ts
@@ -9,5 +9,5 @@ export function getInstalledPathSync(name: string, opts?: Options): string;
 export interface Options {
     cwd?: string;
     local?: boolean;
-    paths?: string[];
+    paths?: readonly string[];
 }

--- a/types/get-installed-path/index.d.ts
+++ b/types/get-installed-path/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for get-installed-path 4.0
+// Project: https://github.com/tunnckoCore/get-installed-path
+// Definitions by: Jamie Magee <https://github.com/JamieMagee>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function getInstalledPath(name: string, opts?: Options): Promise<string>;
+export function getInstalledPathSync(name: string, opts?: Options): string;
+
+export interface Options {
+    cwd?: string;
+    local?: boolean;
+    paths?: string[];
+}

--- a/types/get-installed-path/tsconfig.json
+++ b/types/get-installed-path/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "get-installed-path-tests.ts"
+    ]
+}

--- a/types/get-installed-path/tslint.json
+++ b/types/get-installed-path/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.