### PR TITLE
[sanitize-html] fix IOptions["allowedClasses"] type

### DIFF
--- a/types/sanitize-html/index.d.ts
+++ b/types/sanitize-html/index.d.ts
@@ -57,7 +57,7 @@ declare namespace sanitize {
   interface IOptions {
     allowedAttributes?: { [index: string]: AllowedAttribute[] } | boolean;
     allowedStyles?:  { [index: string]: { [index: string]: RegExp[] } };
-    allowedClasses?: { [index: string]: string[] } | boolean;
+    allowedClasses?: { [index: string]: string[] | boolean };
     allowedIframeHostnames?: string[];
     allowIframeRelativeUrls?: boolean;
     allowedSchemes?: string[] | boolean;

--- a/types/sanitize-html/sanitize-html-tests.ts
+++ b/types/sanitize-html/sanitize-html-tests.ts
@@ -6,6 +6,10 @@ let options: sanitize.IOptions = {
     'a': sanitize.defaults.allowedAttributes['a'].concat('rel'),
     'img': ['src', 'height', 'width', 'alt', 'style']
   },
+  allowedClasses: {
+    a: ['className'],
+    p: false,
+  },
   allowedStyles: {
     '*': {
         color: [/^red$/],


### PR DESCRIPTION
The source code does not support setting boolean to allowedClasses. It only supports this for individual tags in allowedClasses. E.g. { p: false } will allow all classes for the p tag.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [source code](https://github.com/apostrophecms/sanitize-html/blob/master/src/index.js)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (It doesn't)
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
