### PR TITLE
[Cheerio] Add a namespace around all types

### DIFF
--- a/types/cheerio/index.d.ts
+++ b/types/cheerio/index.d.ts
@@ -13,294 +13,296 @@
 
 /// <reference types="node" />
 
-declare type AttrFunction = (el: CheerioElement, i: number, currentValue: string) => any;
+declare const cheerioAPI: Cheerio.CheerioAPI;
 
-interface Cheerio {
-    // Document References
-    // Cheerio https://github.com/cheeriojs/cheerio
-    // JQuery http://api.jquery.com
+declare namespace Cheerio {
+    type AttrFunction = (el: CheerioElement, i: number, currentValue: string) => any;
 
-    [index: number]: CheerioElement;
-    cheerio: string;
-    length: number;
+    interface Cheerio {
+        // Document References
+        // Cheerio https://github.com/cheeriojs/cheerio
+        // JQuery http://api.jquery.com
 
-    // Attributes
+        [index: number]: CheerioElement;
+        cheerio: string;
+        length: number;
 
-    attr(): { [attr: string]: string };
-    attr(name: string): string | undefined;
-    attr(name: string, value: AttrFunction): Cheerio;
-    // `value` *can* be `any` here but:
-    // 1. That makes type-checking the function-type useless
-    // 2. It's converted to a string anyways
-    attr(name: string, value: string): Cheerio;
-    // The map's values *can* be `any` but they'll all be cast to strings
-    // regardless.
-    attr(map: { [key: string]: any }): Cheerio;
+        // Attributes
 
-    data(): any;
-    data(name: string): any;
-    data(name: string, value: any): any;
+        attr(): { [attr: string]: string };
+        attr(name: string): string | undefined;
+        attr(name: string, value: AttrFunction): Cheerio;
+        // `value` *can* be `any` here but:
+        // 1. That makes type-checking the function-type useless
+        // 2. It's converted to a string anyways
+        attr(name: string, value: string): Cheerio;
+        // The map's values *can* be `any` but they'll all be cast to strings
+        // regardless.
+        attr(map: { [key: string]: any }): Cheerio;
 
-    val(): string;
-    val(value: string): Cheerio;
+        data(): any;
+        data(name: string): any;
+        data(name: string, value: any): any;
 
-    removeAttr(name: string): Cheerio;
+        val(): string;
+        val(value: string): Cheerio;
 
-    has(selector: string): Cheerio;
-    has(element: CheerioElement): Cheerio;
+        removeAttr(name: string): Cheerio;
 
-    hasClass(className: string): boolean;
-    addClass(classNames: string): Cheerio;
+        has(selector: string): Cheerio;
+        has(element: CheerioElement): Cheerio;
 
-    removeClass(): Cheerio;
-    removeClass(className: string): Cheerio;
-    removeClass(func: (index: number, className: string) => string): Cheerio;
+        hasClass(className: string): boolean;
+        addClass(classNames: string): Cheerio;
 
-    toggleClass(className: string): Cheerio;
-    toggleClass(className: string, toggleSwitch: boolean): Cheerio;
-    toggleClass(toggleSwitch?: boolean): Cheerio;
-    toggleClass(
-        func: (index: number, className: string, toggleSwitch: boolean) => string,
-        toggleSwitch?: boolean,
-    ): Cheerio;
+        removeClass(): Cheerio;
+        removeClass(className: string): Cheerio;
+        removeClass(func: (index: number, className: string) => string): Cheerio;
 
-    is(selector: string): boolean;
-    is(element: CheerioElement): boolean;
-    is(element: CheerioElement[]): boolean;
-    is(selection: Cheerio): boolean;
-    is(func: (index: number, element: CheerioElement) => boolean): boolean;
+        toggleClass(className: string): Cheerio;
+        toggleClass(className: string, toggleSwitch: boolean): Cheerio;
+        toggleClass(toggleSwitch?: boolean): Cheerio;
+        toggleClass(
+            func: (index: number, className: string, toggleSwitch: boolean) => string,
+            toggleSwitch?: boolean,
+        ): Cheerio;
 
-    // Form
-    serialize(): string;
-    serializeArray(): { name: string; value: string }[];
+        is(selector: string): boolean;
+        is(element: CheerioElement): boolean;
+        is(element: CheerioElement[]): boolean;
+        is(selection: Cheerio): boolean;
+        is(func: (index: number, element: CheerioElement) => boolean): boolean;
 
-    // Traversing
+        // Form
+        serialize(): string;
+        serializeArray(): { name: string; value: string }[];
 
-    find(selector: string): Cheerio;
-    find(element: Cheerio): Cheerio;
+        // Traversing
 
-    parent(selector?: string): Cheerio;
-    parents(selector?: string): Cheerio;
-    parentsUntil(selector?: string, filter?: string): Cheerio;
-    parentsUntil(element: CheerioElement, filter?: string): Cheerio;
-    parentsUntil(element: Cheerio, filter?: string): Cheerio;
+        find(selector: string): Cheerio;
+        find(element: Cheerio): Cheerio;
 
-    prop(name: string): any;
-    prop(name: string, value: any): Cheerio;
+        parent(selector?: string): Cheerio;
+        parents(selector?: string): Cheerio;
+        parentsUntil(selector?: string, filter?: string): Cheerio;
+        parentsUntil(element: CheerioElement, filter?: string): Cheerio;
+        parentsUntil(element: Cheerio, filter?: string): Cheerio;
 
-    closest(): Cheerio;
-    closest(selector: string): Cheerio;
+        prop(name: string): any;
+        prop(name: string, value: any): Cheerio;
 
-    next(selector?: string): Cheerio;
-    nextAll(): Cheerio;
-    nextAll(selector: string): Cheerio;
+        closest(): Cheerio;
+        closest(selector: string): Cheerio;
 
-    nextUntil(selector?: string, filter?: string): Cheerio;
-    nextUntil(element: CheerioElement, filter?: string): Cheerio;
-    nextUntil(element: Cheerio, filter?: string): Cheerio;
+        next(selector?: string): Cheerio;
+        nextAll(): Cheerio;
+        nextAll(selector: string): Cheerio;
 
-    prev(selector?: string): Cheerio;
-    prevAll(): Cheerio;
-    prevAll(selector: string): Cheerio;
+        nextUntil(selector?: string, filter?: string): Cheerio;
+        nextUntil(element: CheerioElement, filter?: string): Cheerio;
+        nextUntil(element: Cheerio, filter?: string): Cheerio;
 
-    prevUntil(selector?: string, filter?: string): Cheerio;
-    prevUntil(element: CheerioElement, filter?: string): Cheerio;
-    prevUntil(element: Cheerio, filter?: string): Cheerio;
+        prev(selector?: string): Cheerio;
+        prevAll(): Cheerio;
+        prevAll(selector: string): Cheerio;
 
-    slice(start: number, end?: number): Cheerio;
+        prevUntil(selector?: string, filter?: string): Cheerio;
+        prevUntil(element: CheerioElement, filter?: string): Cheerio;
+        prevUntil(element: Cheerio, filter?: string): Cheerio;
 
-    siblings(selector?: string): Cheerio;
+        slice(start: number, end?: number): Cheerio;
 
-    children(selector?: string): Cheerio;
+        siblings(selector?: string): Cheerio;
 
-    contents(): Cheerio;
+        children(selector?: string): Cheerio;
 
-    each(func: (index: number, element: CheerioElement) => any): Cheerio;
-    map(func: (index: number, element: CheerioElement) => any): Cheerio;
+        contents(): Cheerio;
 
-    filter(selector: string): Cheerio;
-    filter(selection: Cheerio): Cheerio;
-    filter(element: CheerioElement): Cheerio;
-    filter(elements: CheerioElement[]): Cheerio;
-    filter(func: (index: number, element: CheerioElement) => boolean): Cheerio;
+        each(func: (index: number, element: CheerioElement) => any): Cheerio;
+        map(func: (index: number, element: CheerioElement) => any): Cheerio;
 
-    not(selector: string): Cheerio;
-    not(selection: Cheerio): Cheerio;
-    not(element: CheerioElement): Cheerio;
-    not(func: (index: number, element: CheerioElement) => boolean): Cheerio;
+        filter(selector: string): Cheerio;
+        filter(selection: Cheerio): Cheerio;
+        filter(element: CheerioElement): Cheerio;
+        filter(elements: CheerioElement[]): Cheerio;
+        filter(func: (index: number, element: CheerioElement) => boolean): Cheerio;
 
-    first(): Cheerio;
-    last(): Cheerio;
+        not(selector: string): Cheerio;
+        not(selection: Cheerio): Cheerio;
+        not(element: CheerioElement): Cheerio;
+        not(func: (index: number, element: CheerioElement) => boolean): Cheerio;
 
-    eq(index: number): Cheerio;
+        first(): Cheerio;
+        last(): Cheerio;
 
-    get(): any[];
-    get(index: number): any;
+        eq(index: number): Cheerio;
 
-    index(): number;
-    index(selector: string): number;
-    index(selection: Cheerio): number;
+        get(): any[];
+        get(index: number): any;
 
-    end(): Cheerio;
+        index(): number;
+        index(selector: string): number;
+        index(selection: Cheerio): number;
 
-    add(selectorOrHtml: string): Cheerio;
-    add(selector: string, context: Document): Cheerio;
-    add(element: CheerioElement): Cheerio;
-    add(elements: CheerioElement[]): Cheerio;
-    add(selection: Cheerio): Cheerio;
+        end(): Cheerio;
 
-    addBack(): Cheerio;
-    addBack(filter: string): Cheerio;
+        add(selectorOrHtml: string): Cheerio;
+        add(selector: string, context: Document): Cheerio;
+        add(element: CheerioElement): Cheerio;
+        add(elements: CheerioElement[]): Cheerio;
+        add(selection: Cheerio): Cheerio;
 
-    // Manipulation
-    appendTo(target: Cheerio): Cheerio;
-    prependTo(target: Cheerio): Cheerio;
+        addBack(): Cheerio;
+        addBack(filter: string): Cheerio;
 
-    append(content: string, ...contents: any[]): Cheerio;
-    append(content: Document, ...contents: any[]): Cheerio;
-    append(content: Document[], ...contents: any[]): Cheerio;
-    append(content: Cheerio, ...contents: any[]): Cheerio;
+        // Manipulation
+        appendTo(target: Cheerio): Cheerio;
+        prependTo(target: Cheerio): Cheerio;
 
-    prepend(content: string, ...contents: any[]): Cheerio;
-    prepend(content: Document, ...contents: any[]): Cheerio;
-    prepend(content: Document[], ...contents: any[]): Cheerio;
-    prepend(content: Cheerio, ...contents: any[]): Cheerio;
+        append(content: string, ...contents: any[]): Cheerio;
+        append(content: Document, ...contents: any[]): Cheerio;
+        append(content: Document[], ...contents: any[]): Cheerio;
+        append(content: Cheerio, ...contents: any[]): Cheerio;
 
-    after(content: string, ...contents: any[]): Cheerio;
-    after(content: Document, ...contents: any[]): Cheerio;
-    after(content: Document[], ...contents: any[]): Cheerio;
-    after(content: Cheerio, ...contents: any[]): Cheerio;
+        prepend(content: string, ...contents: any[]): Cheerio;
+        prepend(content: Document, ...contents: any[]): Cheerio;
+        prepend(content: Document[], ...contents: any[]): Cheerio;
+        prepend(content: Cheerio, ...contents: any[]): Cheerio;
 
-    insertAfter(content: string): Cheerio;
-    insertAfter(content: Document): Cheerio;
-    insertAfter(content: Cheerio): Cheerio;
+        after(content: string, ...contents: any[]): Cheerio;
+        after(content: Document, ...contents: any[]): Cheerio;
+        after(content: Document[], ...contents: any[]): Cheerio;
+        after(content: Cheerio, ...contents: any[]): Cheerio;
 
-    before(content: string, ...contents: any[]): Cheerio;
-    before(content: Document, ...contents: any[]): Cheerio;
-    before(content: Document[], ...contents: any[]): Cheerio;
-    before(content: Cheerio, ...contents: any[]): Cheerio;
+        insertAfter(content: string): Cheerio;
+        insertAfter(content: Document): Cheerio;
+        insertAfter(content: Cheerio): Cheerio;
 
-    insertBefore(content: string): Cheerio;
-    insertBefore(content: Document): Cheerio;
-    insertBefore(content: Cheerio): Cheerio;
+        before(content: string, ...contents: any[]): Cheerio;
+        before(content: Document, ...contents: any[]): Cheerio;
+        before(content: Document[], ...contents: any[]): Cheerio;
+        before(content: Cheerio, ...contents: any[]): Cheerio;
 
-    remove(selector?: string): Cheerio;
+        insertBefore(content: string): Cheerio;
+        insertBefore(content: Document): Cheerio;
+        insertBefore(content: Cheerio): Cheerio;
 
-    replaceWith(content: string): Cheerio;
-    replaceWith(content: CheerioElement): Cheerio;
-    replaceWith(content: CheerioElement[]): Cheerio;
-    replaceWith(content: Cheerio): Cheerio;
-    replaceWith(content: () => Cheerio): Cheerio;
+        remove(selector?: string): Cheerio;
 
-    empty(): Cheerio;
+        replaceWith(content: string): Cheerio;
+        replaceWith(content: CheerioElement): Cheerio;
+        replaceWith(content: CheerioElement[]): Cheerio;
+        replaceWith(content: Cheerio): Cheerio;
+        replaceWith(content: () => Cheerio): Cheerio;
 
-    html(): string | null;
-    html(html: string): Cheerio;
+        empty(): Cheerio;
 
-    text(): string;
-    text(text: string): Cheerio;
+        html(): string | null;
+        html(html: string): Cheerio;
 
-    wrap(content: string): Cheerio;
-    wrap(content: Document): Cheerio;
-    wrap(content: Cheerio): Cheerio;
+        text(): string;
+        text(text: string): Cheerio;
 
-    css(propertyName: string): string;
-    css(propertyNames: string[]): string[];
-    css(propertyName: string, value: string): Cheerio;
-    css(propertyName: string, value: number): Cheerio;
-    css(propertyName: string, func: (index: number, value: string) => string): Cheerio;
-    css(propertyName: string, func: (index: number, value: string) => number): Cheerio;
-    css(properties: Object): Cheerio;
+        wrap(content: string): Cheerio;
+        wrap(content: Document): Cheerio;
+        wrap(content: Cheerio): Cheerio;
 
-    // Rendering
+        css(propertyName: string): string;
+        css(propertyNames: string[]): string[];
+        css(propertyName: string, value: string): Cheerio;
+        css(propertyName: string, value: number): Cheerio;
+        css(propertyName: string, func: (index: number, value: string) => string): Cheerio;
+        css(propertyName: string, func: (index: number, value: string) => number): Cheerio;
+        css(properties: Object): Cheerio;
 
-    // Miscellaneous
+        // Rendering
 
-    clone(): Cheerio;
+        // Miscellaneous
 
-    // Not Documented
+        clone(): Cheerio;
 
-    toArray(): CheerioElement[];
+        // Not Documented
+
+        toArray(): CheerioElement[];
+    }
+
+    interface CheerioOptionsInterface {
+        // Document References
+        // Cheerio https://github.com/cheeriojs/cheerio
+        // HTMLParser2 https://github.com/fb55/htmlparser2/wiki/Parser-options
+        // DomHandler https://github.com/fb55/DomHandler
+
+        xmlMode?: boolean;
+        decodeEntities?: boolean;
+        lowerCaseTags?: boolean;
+        lowerCaseAttributeNames?: boolean;
+        recognizeCDATA?: boolean;
+        recognizeSelfClosing?: boolean;
+        normalizeWhitespace?: boolean;
+        withStartIndices?: boolean;
+        withEndIndices?: boolean;
+        ignoreWhitespace?: boolean;
+        _useHtmlParser2?: boolean;
+    }
+
+    interface CheerioSelector {
+        (selector: string): Cheerio;
+        (selector: string, context: string): Cheerio;
+        (selector: string, context: CheerioElement): Cheerio;
+        (selector: string, context: CheerioElement[]): Cheerio;
+        (selector: string, context: Cheerio): Cheerio;
+        (selector: string, context: string, root: string): Cheerio;
+        (selector: string, context: CheerioElement, root: string): Cheerio;
+        (selector: string, context: CheerioElement[], root: string): Cheerio;
+        (selector: string, context: Cheerio, root: string): Cheerio;
+        (selector: any): Cheerio;
+    }
+
+    interface CheerioStatic extends CheerioSelector {
+        // Document References
+        // Cheerio https://github.com/cheeriojs/cheerio
+        // JQuery http://api.jquery.com
+        xml(): string;
+        root(): Cheerio;
+        contains(container: CheerioElement, contained: CheerioElement): boolean;
+        parseHTML(data: string, context?: Document, keepScripts?: boolean): Document[];
+
+        html(options?: CheerioOptionsInterface): string;
+        html(selector: string, options?: CheerioOptionsInterface): string;
+        html(element: Cheerio, options?: CheerioOptionsInterface): string;
+        html(element: CheerioElement, options?: CheerioOptionsInterface): string;
+    }
+
+    interface CheerioElement {
+        // Document References
+        // Node Console
+        tagName: string;
+        type: string;
+        name: string;
+        attribs: { [attr: string]: string };
+        children: CheerioElement[];
+        childNodes: CheerioElement[];
+        lastChild: CheerioElement;
+        firstChild: CheerioElement;
+        next: CheerioElement;
+        nextSibling: CheerioElement;
+        prev: CheerioElement;
+        previousSibling: CheerioElement;
+        parent: CheerioElement;
+        parentNode: CheerioElement;
+        nodeValue: string;
+        data?: string;
+        startIndex?: number;
+    }
+
+    interface CheerioAPI extends CheerioSelector, CheerioStatic {
+        load(html: string | Buffer, options?: CheerioOptionsInterface): CheerioStatic;
+        load(element: CheerioElement, options?: CheerioOptionsInterface): CheerioStatic;
+    }
+
+    interface Document {}
 }
 
-interface CheerioOptionsInterface {
-    // Document References
-    // Cheerio https://github.com/cheeriojs/cheerio
-    // HTMLParser2 https://github.com/fb55/htmlparser2/wiki/Parser-options
-    // DomHandler https://github.com/fb55/DomHandler
-
-    xmlMode?: boolean;
-    decodeEntities?: boolean;
-    lowerCaseTags?: boolean;
-    lowerCaseAttributeNames?: boolean;
-    recognizeCDATA?: boolean;
-    recognizeSelfClosing?: boolean;
-    normalizeWhitespace?: boolean;
-    withStartIndices?: boolean;
-    withEndIndices?: boolean;
-    ignoreWhitespace?: boolean;
-    _useHtmlParser2?: boolean;
-}
-
-interface CheerioSelector {
-    (selector: string): Cheerio;
-    (selector: string, context: string): Cheerio;
-    (selector: string, context: CheerioElement): Cheerio;
-    (selector: string, context: CheerioElement[]): Cheerio;
-    (selector: string, context: Cheerio): Cheerio;
-    (selector: string, context: string, root: string): Cheerio;
-    (selector: string, context: CheerioElement, root: string): Cheerio;
-    (selector: string, context: CheerioElement[], root: string): Cheerio;
-    (selector: string, context: Cheerio, root: string): Cheerio;
-    (selector: any): Cheerio;
-}
-
-interface CheerioStatic extends CheerioSelector {
-    // Document References
-    // Cheerio https://github.com/cheeriojs/cheerio
-    // JQuery http://api.jquery.com
-    xml(): string;
-    root(): Cheerio;
-    contains(container: CheerioElement, contained: CheerioElement): boolean;
-    parseHTML(data: string, context?: Document, keepScripts?: boolean): Document[];
-
-    html(options?: CheerioOptionsInterface): string;
-    html(selector: string, options?: CheerioOptionsInterface): string;
-    html(element: Cheerio, options?: CheerioOptionsInterface): string;
-    html(element: CheerioElement, options?: CheerioOptionsInterface): string;
-}
-
-interface CheerioElement {
-    // Document References
-    // Node Console
-    tagName: string;
-    type: string;
-    name: string;
-    attribs: { [attr: string]: string };
-    children: CheerioElement[];
-    childNodes: CheerioElement[];
-    lastChild: CheerioElement;
-    firstChild: CheerioElement;
-    next: CheerioElement;
-    nextSibling: CheerioElement;
-    prev: CheerioElement;
-    previousSibling: CheerioElement;
-    parent: CheerioElement;
-    parentNode: CheerioElement;
-    nodeValue: string;
-    data?: string;
-    startIndex?: number;
-}
-
-interface CheerioAPI extends CheerioSelector, CheerioStatic {
-    load(html: string | Buffer, options?: CheerioOptionsInterface): CheerioStatic;
-    load(element: CheerioElement, options?: CheerioOptionsInterface): CheerioStatic;
-}
-
-interface Document {}
-
-declare const cheerio: CheerioAPI;
-
-declare module 'cheerio' {
-    export = cheerio;
+declare module "cheerio" {
+    export = cheerioAPI;
 }


### PR DESCRIPTION
Similar to a bunch of other packages, I've added a namespace around all types to prevent name collisions with other objects. I've also renamed to global `cheerio` object to `cheerioAPI` to avoid common usages of the `cheerio` object without importing first.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cheeriojs/cheerio/blob/v1.0.0/index.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.