### PR TITLE
[Cheerio] Do not expose `cheerio` object globally

### DIFF
--- a/types/cheerio/index.d.ts
+++ b/types/cheerio/index.d.ts
@@ -299,8 +299,7 @@ interface CheerioAPI extends CheerioSelector, CheerioStatic {
 
 interface Document {}
 
-declare const cheerio: CheerioAPI;
-
 declare module 'cheerio' {
+    const cheerio: CheerioAPI;
     export = cheerio;
 }


### PR DESCRIPTION
This change prevents one to use `cheerio` without importing the object first. I'm not totally aware if this change has any major implications as I'm no TypeScript definitions expert, but looks okay to me. Please advise if otherwise, I'd love to understand how could this be improved/fixed.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cheeriojs/cheerio/blob/v1.0.0/index.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.