### PR TITLE
[react-native] Add declaration for URL global type

### DIFF
--- a/types/react-native/globals.d.ts
+++ b/types/react-native/globals.d.ts
@@ -281,7 +281,7 @@ declare class URL {
 }
 
 /**
- * Based on definitions of lib.dom and  lib.dom.iteralbe
+ * Based on definitions of lib.dom and lib.dom.iterable
  */
 declare class URLSearchParams {
     constructor(init?: string[][] | Record<string, string> | string | URLSearchParams);

--- a/types/react-native/globals.d.ts
+++ b/types/react-native/globals.d.ts
@@ -254,6 +254,33 @@ declare var XMLHttpRequestUpload: {
 declare type XMLHttpRequestResponseType = '' | 'arraybuffer' | 'blob' | 'document' | 'json' | 'text';
 
 /**
+ * Based on definition from lib.dom but using class syntax.
+ * The properties are mutable to support users that use a `URL` polyfill, but the implementation
+ * built into React Native (as of 0.63) does not implement all the properties.
+ */
+declare class URL {
+    static createObjectURL(blob: Blob): URL;
+    static revokeObjectURL(url: string): void;
+
+    constructor(url: string, base?: string);
+
+    href: string;
+    readonly origin: string;
+    protocol: string;
+    username: string;
+    password: string;
+    host: string;
+    hostname: string;
+    port: string;
+    pathname: string;
+    search: string;
+    readonly searchParams: URLSearchParams;
+    hash: string;
+
+    toJSON(): string;
+}
+
+/**
  * Based on definitions of lib.dom and  lib.dom.iteralbe
  */
 declare class URLSearchParams {

--- a/types/react-native/test/globals.tsx
+++ b/types/react-native/test/globals.tsx
@@ -36,3 +36,5 @@ xmlRequest.addEventListener('load', ev => {
 });
 
 const test = new URLSearchParams();
+
+const url = new URL("path", "http://localhost/");


### PR DESCRIPTION
React Native has included a global `URL` type since 0.48, and since 0.59 it has an implementation usable for very basic use cases. This declaration enables using the URL type either provided by React Native itself or via a polyfill such as https://www.npmjs.com/package/react-native-url-polyfill when an application needs a more complete implementation.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/blob/master/Libraries/Blob/URL.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
