### PR TITLE
fix openseadragon types to represent addSimpleImage correctly

### DIFF
--- a/types/openseadragon/index.d.ts
+++ b/types/openseadragon/index.d.ts
@@ -1090,8 +1090,7 @@ declare namespace OpenSeadragon {
         );
     }
 
-    interface TiledImageOptions {
-        tileSource: string | object;
+    interface ImageOptions {
         index?: number;
         replace?: boolean;
         x?: number;
@@ -1113,6 +1112,14 @@ declare namespace OpenSeadragon {
         error?: (error: Error) => void;
         collectionImmediately?: boolean;
         placeholderFillStyle?: string | CanvasGradient | CanvasPattern;
+    }
+
+    interface TiledImageOptions extends ImageOptions {
+        tileSource: string | object;
+    }
+
+    interface SimpleImageOptions extends ImageOptions {
+        url: string;
     }
 
     class Viewer extends ControlDock {
@@ -1150,7 +1157,7 @@ declare namespace OpenSeadragon {
             ) => void
         ): Viewer;
         addReferenceStrip(): void;
-        addSimpleImage(options: TiledImageOptions): void; // TODO: check options type
+        addSimpleImage(options: SimpleImageOptions): void;
         addTiledImage(options: TiledImageOptions): void;
         bindSequenceControls(): Viewer;
         bindStandardControls(): Viewer;

--- a/types/openseadragon/index.d.ts
+++ b/types/openseadragon/index.d.ts
@@ -101,23 +101,16 @@ declare namespace OpenSeadragon {
         element: Element | string,
         eventName: string,
         handler: (event: Event) => void,
-        useCapture?: boolean
+        useCapture?: boolean,
     ): void;
 
     function cancelEvent(event?: OSDEvent<any>): void;
 
     function capitalizeFirstLetter(value: string): string;
 
-    function createCallback(
-        object: object,
-        method: (...args: any[]) => void,
-        ...args: any[]
-    ): (...args: any[]) => void;
+    function createCallback(object: object, method: (...args: any[]) => void, ...args: any[]): (...args: any[]) => void;
 
-    function delegate(
-        object: object,
-        method: (...args: any[]) => void
-    ): (object: any, ...args: any[]) => void; // REVIEW: unsure of return type
+    function delegate(object: object, method: (...args: any[]) => void): (object: any, ...args: any[]) => void; // REVIEW: unsure of return type
 
     function extend(): any;
 
@@ -145,11 +138,7 @@ declare namespace OpenSeadragon {
 
     function imageFormatSupported(extension?: string): boolean;
 
-    function indexOf(
-        array: any[],
-        searchElement: object,
-        fromIndex?: number
-    ): number;
+    function indexOf(array: any[], searchElement: object, fromIndex?: number): number;
 
     // (missing jquery functions)
 
@@ -184,14 +173,10 @@ declare namespace OpenSeadragon {
         element: Element | string,
         eventName: string,
         handler: EventHandler<any>,
-        useCapture?: boolean
+        useCapture?: boolean,
     ): void;
 
-    function setElementOpacity(
-        element: Element | string,
-        opacity: number,
-        usesAlpha?: boolean
-    ): void;
+    function setElementOpacity(element: Element | string, opacity: number, usesAlpha?: boolean): void;
 
     function setElementTouchActionNone(element: Element | string): void;
 
@@ -272,17 +257,17 @@ declare namespace OpenSeadragon {
         opacity?: number;
         preload?: boolean;
         compositeOperation?:
-            | "source-over"
-            | "source-atop"
-            | "source-in"
-            | "source-out"
-            | "destination-over"
-            | "destination-atop"
-            | "destination-in"
-            | "destination-out"
-            | "lighter"
-            | "copy"
-            | "xor";
+            | 'source-over'
+            | 'source-atop'
+            | 'source-in'
+            | 'source-out'
+            | 'destination-over'
+            | 'destination-atop'
+            | 'destination-in'
+            | 'destination-out'
+            | 'lighter'
+            | 'copy'
+            | 'xor';
         placeholderFillStyle?: string | CanvasGradient | CanvasPattern;
         degrees?: number;
         flipped?: boolean;
@@ -321,12 +306,7 @@ declare namespace OpenSeadragon {
         zoomPerSecond?: number;
         showNavigator?: boolean;
         navigatorId?: string;
-        navigatorPosition?:
-            | "TOP_LEFT"
-            | "TOP_RIGHT"
-            | "BOTTOM_LEFT"
-            | "BOTTOM_RIGHT"
-            | "ABSOLUTE";
+        navigatorPosition?: 'TOP_LEFT' | 'TOP_RIGHT' | 'BOTTOM_LEFT' | 'BOTTOM_RIGHT' | 'ABSOLUTE';
         navigatorSizeRatio?: number;
         navigatorMaintainSizeRatio?: boolean;
         navigatorTop?: number | string;
@@ -383,10 +363,10 @@ declare namespace OpenSeadragon {
         collectionMode?: boolean;
         collectionRows?: number;
         collectionColumns?: number;
-        collectionLayout?: "horizontal" | "vertical";
+        collectionLayout?: 'horizontal' | 'vertical';
         collectionTileSize?: number;
         collectionTileMargin?: number;
-        crossOriginPolicy?: "Anonymous" | "use-credentials" | false;
+        crossOriginPolicy?: 'Anonymous' | 'use-credentials' | false;
         ajaxWithCredentials?: boolean;
         loadTilesWithAjax?: boolean;
         ajaxHeaders?: object;
@@ -436,28 +416,19 @@ declare namespace OpenSeadragon {
             onBlur?: EventHandler<ButtonEvent>;
         });
 
-        addHandler(
-            eventName: ButtonEventName,
-            handler: EventHandler<ButtonEvent>,
-            userData?: object
-        ): void;
+        addHandler(eventName: ButtonEventName, handler: EventHandler<ButtonEvent>, userData?: object): void;
         addOnceHandler(
             eventName: ButtonEventName,
             handler: EventHandler<ButtonEvent>,
             userData?: object,
-            times?: number
+            times?: number,
         ): void;
         disable(): void;
         enable(): void;
-        getHandler(
-            eventName: ButtonEventName
-        ): (source: ButtonEventName, ...args: any[]) => void;
+        getHandler(eventName: ButtonEventName): (source: ButtonEventName, ...args: any[]) => void;
         raiseEvent(eventName: ButtonEventName, eventArgs: object): void;
         removeAllHandlers(eventName: ButtonEventName): void;
-        removeHandler(
-            eventName: ButtonEventName,
-            handler: EventHandler<ButtonEvent>
-        ): void;
+        removeHandler(eventName: ButtonEventName, handler: EventHandler<ButtonEvent>): void;
     }
 
     class ButtonGroup {
@@ -481,11 +452,7 @@ declare namespace OpenSeadragon {
         element: Element;
         wrapper: Element;
 
-        constructor(
-            element: Element,
-            options: TControlOptions,
-            container: Element
-        );
+        constructor(element: Element, options: TControlOptions, container: Element);
 
         destroy(): void;
         isVisible(): boolean;
@@ -507,14 +474,7 @@ declare namespace OpenSeadragon {
         maxLevel: number;
         minLevel: number;
 
-        constructor(
-            x: number,
-            y: number,
-            width: number,
-            height: number,
-            minLevel: number,
-            maxLevel: number
-        );
+        constructor(x: number, y: number, width: number, height: number, minLevel: number, maxLevel: number);
     }
 
     class Drawer {
@@ -523,12 +483,7 @@ declare namespace OpenSeadragon {
         context: CanvasRenderingContext2D | null;
         // element : Element; // Deprecated
 
-        constructor(options: {
-            viewer: Viewer;
-            viewport: Viewport;
-            element: Element;
-            debugGridColor?: string;
-        });
+        constructor(options: { viewer: Viewer; viewport: Viewport; element: Element; debugGridColor?: string });
 
         blendSketch(options: {
             opacity: number;
@@ -542,14 +497,10 @@ declare namespace OpenSeadragon {
         destroy(): void;
         drawTile(
             tile: Tile,
-            drawingHandler: (
-                context: CanvasRenderingContext2D,
-                tile: any,
-                rendered: any
-            ) => void, // TODO: determine handler parameter types
+            drawingHandler: (context: CanvasRenderingContext2D, tile: any, rendered: any) => void, // TODO: determine handler parameter types
             useSketch: boolean,
             scale?: number,
-            translate?: Point
+            translate?: Point,
         ): void;
         getCanvasSize(sketch: boolean): Point;
         getOpacity(): number;
@@ -570,12 +521,12 @@ declare namespace OpenSeadragon {
             fileFormat: number,
             displayRects: number,
             minLevel: number,
-            maxLevel: number
+            maxLevel: number,
         );
     }
 
     class IIIFTileSource extends TileSource {
-        constructor(options: TileSourceOptions & {tileFormat?: string});
+        constructor(options: TileSourceOptions & { tileFormat?: string });
     }
 
     class ImageLoader {
@@ -609,7 +560,7 @@ declare namespace OpenSeadragon {
                 url: string;
                 width: number;
                 height: number;
-            }>
+            }>,
         );
     }
 
@@ -722,20 +673,10 @@ declare namespace OpenSeadragon {
     }
 
     class OsmTileSource extends TileSource {
-        constructor(
-            width: number,
-            height: number,
-            tileSize: number,
-            tileOverlap: number,
-            tilesUrl: string
-        );
+        constructor(width: number, height: number, tileSize: number, tileOverlap: number, tilesUrl: string);
     }
 
-    type OnDrawCallback = (
-        position: Point,
-        size: Point,
-        element: HTMLElement
-    ) => void;
+    type OnDrawCallback = (position: Point, size: Point, element: HTMLElement) => void;
 
     interface OverlayOptions {
         element: HTMLElement;
@@ -781,13 +722,7 @@ declare namespace OpenSeadragon {
         width: number;
         height: number;
         degrees: number;
-        constructor(
-            x?: number,
-            y?: number,
-            width?: number,
-            height?: number,
-            degrees?: number
-        );
+        constructor(x?: number, y?: number, width?: number, height?: number, degrees?: number);
         clone(): Rect;
         containsPoint(point: Point, epsilon?: number): boolean;
         equals(rectangle: Rect): boolean;
@@ -876,17 +811,13 @@ declare namespace OpenSeadragon {
             context2D: CanvasRenderingContext2D,
             loadWithAjax: boolean,
             ajaxHeaders: object,
-            sourceBounds: Rect
+            sourceBounds: Rect,
         );
         drawCanvas(
             context: CanvasRenderingContext2D,
-            drawingHandler: (
-                context: CanvasRenderingContext2D,
-                tile: any,
-                rendered: any
-            ) => void,
+            drawingHandler: (context: CanvasRenderingContext2D, tile: any, rendered: any) => void,
             scale?: number,
-            translate?: Point
+            translate?: Point,
         ): void;
         drawHTML(container: Element): void;
         getScaleForEdgeSmoothing(): number;
@@ -944,23 +875,11 @@ declare namespace OpenSeadragon {
             ajaxHeaders?: object;
         });
 
-        addHandler(
-            eventName: string,
-            handler: EventHandler<TiledImageEvent>,
-            userData?: object
-        ): void;
-        addOnceHandler(
-            eventName: string,
-            handler: EventHandler<TiledImageEvent>,
-            userData?: object
-        ): void;
+        addHandler(eventName: string, handler: EventHandler<TiledImageEvent>, userData?: object): void;
+        addOnceHandler(eventName: string, handler: EventHandler<TiledImageEvent>, userData?: object): void;
         destroy(): void;
         draw(): void;
-        fitBounds(
-            bounds: Rect,
-            anchor?: Placement,
-            immediately?: boolean
-        ): void;
+        fitBounds(bounds: Rect, anchor?: Placement, immediately?: boolean): void;
         getBounds(current?: boolean): Rect;
         getBoundsNoRotate(current?: boolean): Rect;
         getClip(): Rect | null;
@@ -974,34 +893,22 @@ declare namespace OpenSeadragon {
         getRotation(current?: boolean): number;
         imageToViewerElementCoordinats(pixel: Point): Point;
         imageToViewportCoordinates(position: Point, current?: boolean): Point;
-        imageToViewportCoordinates(
-            imageX: number,
-            imageY: number,
-            current?: boolean
-        ): Point;
+        imageToViewportCoordinates(imageX: number, imageY: number, current?: boolean): Point;
         imageToViewportRectangle(
             imageX: number,
             imageY?: number,
             pixelWidth?: number,
             pixelHeight?: number,
-            current?: boolean
+            current?: boolean,
         ): Rect;
-        imageToViewportRectangle(
-            position: Rect,
-            pixelWidth?: number,
-            pixelHeight?: number,
-            current?: boolean
-        ): Rect;
+        imageToViewportRectangle(position: Rect, pixelWidth?: number, pixelHeight?: number, current?: boolean): Rect;
 
         imageToViewportZoom(imageZoom: number): number;
         imageToWindowCoordinates(pixel: Point): Point;
         needsDraw(): boolean;
         raiseEvent(eventName: string, eventArgs: object): void;
         removeAllHandlers(eventName: string): void;
-        removeHandler(
-            eventName: string,
-            handler: EventHandler<TiledImageEvent>
-        ): void;
+        removeHandler(eventName: string, handler: EventHandler<TiledImageEvent>): void;
         reset(): void;
         resetCroppingPolygons(): void;
         setClip(newClip: Rect | null): void;
@@ -1016,18 +923,14 @@ declare namespace OpenSeadragon {
         update(): boolean;
         viewerElementToImageCoordinates(pixel: Point): Point;
         viewportToImageCoordinates(position: Point, current?: boolean): Point;
-        viewportToImageCoordinates(
-            viewerX: number,
-            viewerY: number,
-            current?: boolean
-        ): Point;
+        viewportToImageCoordinates(viewerX: number, viewerY: number, current?: boolean): Point;
         viewportToImageRectangle(position: Rect): Rect;
         viewportToImageRectangle(
             viewportX: number,
             viewportY: number,
             pixelWidth?: number,
             pixelHeight?: number,
-            current?: boolean
+            current?: boolean,
         ): Rect;
         viewportToImageZoom(viewportZoom: number): number;
         windowToImageCoordinates(pixel: Point): Point;
@@ -1041,16 +944,12 @@ declare namespace OpenSeadragon {
         ready: boolean;
         tileOverlap: number;
         constructor(options: TileSourceOptions);
-        addHandler(
-            eventName: string,
-            handler: EventHandler<TileSourceEvent>,
-            userData?: object
-        ): void;
+        addHandler(eventName: string, handler: EventHandler<TileSourceEvent>, userData?: object): void;
         addOnceHandler(
             eventName: string,
             handler: EventHandler<TileSourceEvent>,
             userData?: object,
-            times?: number
+            times?: number,
         ): void;
         configure(data: string | object | any[] | Document): object;
         getClosestLevel(): number;
@@ -1061,33 +960,19 @@ declare namespace OpenSeadragon {
         getPixelRatio(level: number): number;
         getTileAjaxHeaders(level: number, x: number, y: number): object;
         getTileAtPoint(level: number, point: Point): Tile;
-        getTileBounds(
-            level: number,
-            x: number,
-            y: number,
-            isSource?: boolean
-        ): Rect;
+        getTileBounds(level: number, x: number, y: number, isSource?: boolean): Rect;
         getTileHeight(level: number): number;
         getTileUrl(level: number, x: number, y: number): string;
         getTileWidth(level: number): number;
         raiseEvent(eventName: string, eventArgs: object): void;
         removeAllHandlers(eventName: string): void;
         removeHandler(eventName: string, handler: EventHandler<TileSourceEvent>): void;
-        supports(
-            data: string | object | any[] | Document,
-            url: string
-        ): boolean;
+        supports(data: string | object | any[] | Document, url: string): boolean;
         tileExists(level: number, x: number, y: number): boolean;
     }
 
     class TmsTileSource extends TileSource {
-        constructor(
-            width: number,
-            height: number,
-            tileSize: number,
-            tileOverlap: number,
-            tilesUrl: string
-        );
+        constructor(width: number, height: number, tileSize: number, tileOverlap: number, tilesUrl: string);
     }
 
     interface ImageOptions {
@@ -1135,26 +1020,18 @@ declare namespace OpenSeadragon {
 
         constructor(options: Options);
         _cancelPendingImages(): void;
-        addHandler(
-            eventName: ViewerEventName,
-            callback: EventHandler<ViewerEvent>,
-            userData?: object
-        ): void;
+        addHandler(eventName: ViewerEventName, callback: EventHandler<ViewerEvent>, userData?: object): void;
         addOnceHandler(
             eventName: ViewerEventName,
             callback: EventHandler<ViewerEvent>,
             userData?: object,
-            times?: number
+            times?: number,
         ): void;
         addOverlay(
             element: HTMLElement | string | object,
             location?: Point | Rect,
             placement?: Placement,
-            onDraw?: (
-                element: HTMLElement,
-                location: Location,
-                placement: Placement
-            ) => void
+            onDraw?: (element: HTMLElement, location: Location, placement: Placement) => void,
         ): Viewer;
         addReferenceStrip(): void;
         addSimpleImage(options: SimpleImageOptions): void;
@@ -1174,10 +1051,7 @@ declare namespace OpenSeadragon {
         isMouseNavEnabled(): boolean;
         isOpen(): boolean;
         isVisible(): boolean;
-        open(
-            tileSources: string | object | TileSource[],
-            initialPage?: number
-        ): Viewer;
+        open(tileSources: string | object | TileSource[], initialPage?: number): Viewer;
         raiseEvent(eventName: string, eventArgs?: object): void;
         removeAllHandlers(eventName: string): void;
         removeHandler(eventName: string, handler: EventHandler<ViewerEvent>): void;
@@ -1189,11 +1063,7 @@ declare namespace OpenSeadragon {
         setFullScreen(fullScreen: boolean): Viewer;
         setMouseNavEnabled(enabled: boolean): Viewer;
         setVisible(visible: boolean): Viewer;
-        updateOverlay(
-            element: Element | string,
-            location: Point | Rect,
-            placement?: Placement
-        ): Viewer;
+        updateOverlay(element: Element | string, location: Point | Rect, placement?: Placement): Viewer;
     }
 
     class Viewport {
@@ -1215,15 +1085,9 @@ declare namespace OpenSeadragon {
 
         applyConstraints(immediately?: boolean): Viewport;
         deltaPixelsFromPoints(deltaPoints: Point, current?: boolean): Point;
-        deltaPixelsFromPointsNoRotate(
-            deltaPoints: Point,
-            current?: boolean
-        ): Point;
+        deltaPixelsFromPointsNoRotate(deltaPoints: Point, current?: boolean): Point;
         deltaPointsFromPixels(deltaPoints: Point, current?: boolean): Point;
-        deltaPointsFromPixelsNoRotate(
-            deltaPoints: Point,
-            current?: boolean
-        ): Point;
+        deltaPointsFromPixelsNoRotate(deltaPoints: Point, current?: boolean): Point;
         ensureVisible(immediately?: boolean): Viewport;
         fitBounds(bounds: Rect, immediately?: boolean): Viewport;
         fitBoundsWithConstraints(bounds: Rect, immediately?: boolean): Viewport;
@@ -1250,17 +1114,12 @@ declare namespace OpenSeadragon {
         imageToViewerElementCoordinates(pixel: Point): Point;
         imageToViewportCoordinates(position: Point): Point;
         imageToViewportCoordinates(imageX: number, imageY: number): Point;
-        imageToViewportCoordinates(
-            imageX: number,
-            imageY: number,
-            pixelWidth: number,
-            pixelHeight: number
-        ): Point;
+        imageToViewportCoordinates(imageX: number, imageY: number, pixelWidth: number, pixelHeight: number): Point;
         imageToViewportRectangle(
             imageX: number | Rect,
             imageY?: number,
             pixelWidth?: number,
-            pixelHeight?: number
+            pixelHeight?: number,
         ): Rect;
         imageToViewportZoom(imageZoom: number): number;
         imageToWindowCoordinates(pixel: Point): Point;
@@ -1283,48 +1142,26 @@ declare namespace OpenSeadragon {
         viewportToImageCoordinates(position: Point): Point;
         viewportToImageCoordinates(viewerX: number, viewerY: number): Point;
         viewportToImageRectangle(rectangle: Rect): Rect;
-        viewportToImageRectangle(
-            viewerX: number,
-            viewerY: number,
-            pointWidth: number,
-            pointHeight: number
-        ): Rect;
+        viewportToImageRectangle(viewerX: number, viewerY: number, pointWidth: number, pointHeight: number): Rect;
         viewportToImageZoom(viewportZoom: number): number;
         viewportToViewerElementCoordinates(point: Point): Point;
         viewportToViewerElementRectangle(rectangle: Rect): Rect;
         viewportToWindowCoordinates(point: Point): Point;
         windowToImageCoordinates(pixel: Point): Point;
         windowToViewportCoordinates(pixel: Point): Point;
-        zoomBy(
-            factor: number,
-            refPoint?: Point,
-            immediately?: boolean
-        ): Viewport;
-        zoomTo(
-            factor: number,
-            refPoint?: Point,
-            immediately?: boolean
-        ): Viewport;
+        zoomBy(factor: number, refPoint?: Point, immediately?: boolean): Viewport;
+        zoomTo(factor: number, refPoint?: Point, immediately?: boolean): Viewport;
     }
 
     class World extends EventSource {
         constructor(options: object);
 
-        addHandler(
-            eventName: WorldEventName,
-            callback: EventHandler<WorldEvent>,
-            userData?: object
-        ): void;
+        addHandler(eventName: WorldEventName, callback: EventHandler<WorldEvent>, userData?: object): void;
         addItem(item: TiledImage, options?: { index?: number }): void;
-        addOnceHandler(
-            eventName: string,
-            handler: EventHandler<WorldEvent>,
-            userData?: object,
-            times?: number
-        ): void;
+        addOnceHandler(eventName: string, handler: EventHandler<WorldEvent>, userData?: object, times?: number): void;
         arrange(options: {
             immediately?: boolean;
-            layout?: "horizontal" | "vertical";
+            layout?: 'horizontal' | 'vertical';
             rows?: number;
             columns?: number;
             tileSize?: number;
@@ -1350,93 +1187,77 @@ declare namespace OpenSeadragon {
     }
 
     class ZoomifyTileSource extends TileSource {
-        constructor(
-            width: number,
-            height: number,
-            tileSize: number,
-            tilesUrl: string
-        );
+        constructor(width: number, height: number, tileSize: number, tilesUrl: string);
     }
 
     // TODO: use proper eventName type aliases, and OSDEvent where appropiate
 
     type EventHandler<T extends OSDEvent<any>> = (event: T) => void;
 
-    type ButtonEventName =
-        | "blur"
-        | "click"
-        | "enter"
-        | "exit"
-        | "focus"
-        | "press"
-        | "release";
+    type ButtonEventName = 'blur' | 'click' | 'enter' | 'exit' | 'focus' | 'press' | 'release';
     type TiledImageEventName =
-        | "bounds-change"
-        | "clip-change"
-        | "composite-operation-change"
-        | "fully-loaded-change"
-        | "opacity-change";
-    type TileSourceEventname = "open-failed" | "ready";
+        | 'bounds-change'
+        | 'clip-change'
+        | 'composite-operation-change'
+        | 'fully-loaded-change'
+        | 'opacity-change';
+    type TileSourceEventname = 'open-failed' | 'ready';
     type ViewerEventName =
-        | "add-item-failed"
-        | "add-overlay"
-        | "animation"
-        | "animation-finish"
-        | "animation-start"
-        | "canvas-click"
-        | "canvas-double-click"
-        | "canvas-drag"
-        | "canvas-drag-end"
-        | "canvas-enter"
-        | "canvas-exit"
-        | "canvas-key"
-        | "canvas-nonprimary-press"
-        | "canvas-nonprimary-release"
-        | "canvas-pinch"
-        | "canvas-press"
-        | "canvas-release"
-        | "canvas-scroll"
-        | "clear-overlay"
-        | "close"
-        | "constrain"
-        | "container-enter"
-        | "container-exit"
-        | "controls-enabled"
-        | "flip"
-        | "full-page"
-        | "full-screen"
-        | "home"
-        | "mouse-enabled"
-        | "navigator-click"
-        | "navigator-drag"
-        | "navigator-scroll"
-        | "open"
-        | "open-failed"
-        | "page"
-        | "pan"
-        | "pre-full-page"
-        | "pre-full-screen"
-        | "remove-overlay"
-        | "reset-size"
-        | "resize"
-        | "rotate"
-        | "tile-drawing"
-        | "tile-drawn"
-        | "tile-load-failed"
-        | "tile-loaded"
-        | "tile-unloaded"
-        | "update-level"
-        | "update-overlay"
-        | "update-tile"
-        | "update-viewport"
-        | "viewport-change"
-        | "visible"
-        | "zoom";
-    type WorldEventName =
-        | "add-item"
-        | "item-index-change"
-        | "metrics-change"
-        | "remove-item";
+        | 'add-item-failed'
+        | 'add-overlay'
+        | 'animation'
+        | 'animation-finish'
+        | 'animation-start'
+        | 'canvas-click'
+        | 'canvas-double-click'
+        | 'canvas-drag'
+        | 'canvas-drag-end'
+        | 'canvas-enter'
+        | 'canvas-exit'
+        | 'canvas-key'
+        | 'canvas-nonprimary-press'
+        | 'canvas-nonprimary-release'
+        | 'canvas-pinch'
+        | 'canvas-press'
+        | 'canvas-release'
+        | 'canvas-scroll'
+        | 'clear-overlay'
+        | 'close'
+        | 'constrain'
+        | 'container-enter'
+        | 'container-exit'
+        | 'controls-enabled'
+        | 'flip'
+        | 'full-page'
+        | 'full-screen'
+        | 'home'
+        | 'mouse-enabled'
+        | 'navigator-click'
+        | 'navigator-drag'
+        | 'navigator-scroll'
+        | 'open'
+        | 'open-failed'
+        | 'page'
+        | 'pan'
+        | 'pre-full-page'
+        | 'pre-full-screen'
+        | 'remove-overlay'
+        | 'reset-size'
+        | 'resize'
+        | 'rotate'
+        | 'tile-drawing'
+        | 'tile-drawn'
+        | 'tile-load-failed'
+        | 'tile-loaded'
+        | 'tile-unloaded'
+        | 'update-level'
+        | 'update-overlay'
+        | 'update-tile'
+        | 'update-viewport'
+        | 'viewport-change'
+        | 'visible'
+        | 'zoom';
+    type WorldEventName = 'add-item' | 'item-index-change' | 'metrics-change' | 'remove-item';
 
     interface OSDEvent<T> extends Event {
         eventSource?: T;
@@ -1522,8 +1343,6 @@ declare namespace OpenSeadragon {
 
 export as namespace OpenSeadragon;
 
-declare function OpenSeadragon(
-    options: OpenSeadragon.Options
-): OpenSeadragon.Viewer;
+declare function OpenSeadragon(options: OpenSeadragon.Options): OpenSeadragon.Viewer;
 
 export = OpenSeadragon;

--- a/types/openseadragon/openseadragon-tests.ts
+++ b/types/openseadragon/openseadragon-tests.ts
@@ -10,6 +10,10 @@ viewer.addHandler("full-screen", event => {
     console.log(event.fullScreen);
 });
 
+viewer.addSimpleImage({ url: "2003rosen1799/0001q.jpg" });
+
+viewer.addTiledImage({ tileSource: "2003rosen1799/0001q.jpg" });
+
 const viewport = new Viewport({ margins: {} });
 
 const element = new Element();

--- a/types/openseadragon/openseadragon-tests.ts
+++ b/types/openseadragon/openseadragon-tests.ts
@@ -1,18 +1,18 @@
-import OpenSeadragon, { Viewport, Drawer, MouseTracker, IIIFTileSource } from "openseadragon";
+import OpenSeadragon, { Viewport, Drawer, MouseTracker, IIIFTileSource } from 'openseadragon';
 
-const viewer = OpenSeadragon({ id: "viewerid" });
+const viewer = OpenSeadragon({ id: 'viewerid' });
 
-viewer.addHandler("tile-loaded", event => {
+viewer.addHandler('tile-loaded', event => {
     console.log(event.eventSource);
 });
 
-viewer.addHandler("full-screen", event => {
+viewer.addHandler('full-screen', event => {
     console.log(event.fullScreen);
 });
 
-viewer.addSimpleImage({ url: "2003rosen1799/0001q.jpg" });
+viewer.addSimpleImage({ url: '2003rosen1799/0001q.jpg' });
 
-viewer.addTiledImage({ tileSource: "2003rosen1799/0001q.jpg" });
+viewer.addTiledImage({ tileSource: '2003rosen1799/0001q.jpg' });
 
 const viewport = new Viewport({ margins: {} });
 
@@ -23,21 +23,21 @@ const drawer = new Drawer({ viewer, viewport, element });
 const mouseTracker = new MouseTracker({ element });
 
 const viewer3 = OpenSeadragon({
-    id: "openseadragon",
-    prefixUrl: "openseadragon/images/",
+    id: 'openseadragon',
+    prefixUrl: 'openseadragon/images/',
     showNavigator: false,
     tileSources: {
-        type: "legacy-image-pyramid",
+        type: 'legacy-image-pyramid',
         levels: [
             {
-                url: "2003rosen1799/0001q.jpg",
+                url: '2003rosen1799/0001q.jpg',
                 height: 889,
-                width: 600
+                width: 600,
             },
-        ]
-    }
+        ],
+    },
 });
 
 const iiifTileSource = new IIIFTileSource({
-    tileFormat: 'jpg'
+    tileFormat: 'jpg',
 });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://openseadragon.github.io/docs/OpenSeadragon.Viewer.html#addSimpleImage - specifically, the phrase `The options are the same as the ones in OpenSeadragon.Viewer#addTiledImage except for options.tileSource which is replaced by options.url`
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. `As far as I can tell, addSimpleImage always worked like this`
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


Also - I saw that prettier is in this repo so I ran prettier on the files.  I can take that out if requested.