### PR TITLE
Update types for "nuclear-js" package to add additional Reactor options

### DIFF
--- a/types/nuclear-js/index.d.ts
+++ b/types/nuclear-js/index.d.ts
@@ -14,6 +14,30 @@ export import Immutable = _Immutable;
 interface ReactorConfig {
     /** If true it will log the entire app state for every dispatch. */
     debug?: boolean;
+
+    /** Additional options for customizing Reactor behavior. */
+    options?: {
+        /** Log information for each dispatch. */
+        logDispatches?: boolean;
+
+        /** log the entire app state after each dispatch. */
+        logAppState?: boolean;
+
+        /** Log what stores changed after a dispatch. */
+        logDirtyStores?: boolean;
+
+        /** Throw an error when dispatching an `undefined` actionType. */
+        throwOnUndefinedActionType?: boolean;
+
+        /** Throw an error if a store returns undefined. */
+        throwOnUndefinedStoreReturnValue?: boolean;
+
+        /** Throw an error if a store.getInitialState() returns a non immutable value. */
+        throwOnNonImmutableStore?: boolean;
+
+        /** Throw when dispatching in dispatch. */
+        throwOnDispatchInDispatch?: boolean;
+    };
 }
 
 // Getters have a really complex, recursive type that can't be represented

--- a/types/nuclear-js/nuclear-js-tests.ts
+++ b/types/nuclear-js/nuclear-js-tests.ts
@@ -17,6 +17,19 @@ Immutable.fromJS([5]);
 new Reactor();
 Reactor();
 new Reactor({ debug: true });
+new Reactor({ options: {} });
+new Reactor({
+    options: {
+        logDispatches: true,
+        logAppState: true,
+        logDirtyStores: true,
+        throwOnUndefinedActionType: true,
+        throwOnUndefinedStoreReturnValue: true,
+        throwOnNonImmutableStore: true,
+        throwOnDispatchInDispatch: true,
+    },
+});
+
 Reactor({ debug: undefined });
 // Make sure that type checking succeeds with or without `new`.
 const r1: Reactor = new Reactor();


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/optimizely/nuclear-js/blob/1e53154b78b31be9dd85605ae49e4a690523c140/src/reactor/records.js
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (N/A)
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.