### PR TITLE
[vexflow] feat: add optional Formatter constructor options

### DIFF
--- a/types/vexflow/index.d.ts
+++ b/types/vexflow/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for VexFlow v1.2.88
+// Type definitions for VexFlow v3.0.9
 // Project: http://vexflow.com
 // Definitions by: Roman Quiring <https://github.com/rquiring>
 //                 Sebastian Haas <https://github.com/sebastianhaas>
@@ -570,6 +570,10 @@ declare namespace Vex {
 
         class Formatter {
             static DEBUG: boolean;
+            constructor(options?: {
+                softmaxFactor?: number,
+                maxIterations?: number
+            });
             static FormatAndDraw(
                 ctx: IRenderContext,
                 stave: Stave,

--- a/types/vexflow/vexflow-tests.ts
+++ b/types/vexflow/vexflow-tests.ts
@@ -46,7 +46,8 @@ var voice2 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).addTickables([
 ]);
 
 // Format and justify the notes to 550 pixels
-var formatter = new Vex.Flow.Formatter().joinVoices([voice1, voice2]).format([voice1, voice2], 550);
+var formatter = new Vex.Flow.Formatter({softmaxFactor: null, maxIterations: 2})
+    .joinVoices([voice1, voice2]).format([voice1, voice2], 550);
 
 // Render stave
 stave.draw();


### PR DESCRIPTION
Added two new optional arguments to the formatter constructor.

no breaking changes, because the argument is optional.
updated the test to use the options.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [vexflow/src/formatter.js](https://github.com/0xfe/vexflow/blob/3.0.9/src/formatter.js#L322)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
