### PR TITLE
update(simperium): add missing optional parameters to event listener

### DIFF
--- a/types/simperium/index.d.ts
+++ b/types/simperium/index.d.ts
@@ -179,7 +179,13 @@ interface ChannelEvent<T> extends SimperiumEvent {
     indexingStateChange: (isIndexing: boolean) => void;
     ready: () => void;
     send: (message: string) => void;
-    update: (entityId: EntityId, updatedEntity: T) => void;
+    update: (
+        entityId: EntityId,
+        updatedEntity: T,
+        originalEntity?: T,
+        patch?: JSONDiff<T>,
+        isIndexing?: boolean,
+    ) => void;
     version: (entityId: EntityId, version: number, entity: T) => void;
 }
 


### PR DESCRIPTION
When creating the original types there was an oversight in the event
types for the `Channel` and its `update` event. In some cases the
event fires only with the first two parameters: the entity id and
data. In the normative case however there are additional parameters
available indicating meta information about the update. Those
optional paramters have been added here.

Although it looks like all three of the last parameters are optional
it's actually the case that either you get only the first two or
all five. It would not occur that you only get three or four of them
but I wasn't sure how to type this beyond function overloads and I
believe that it's not the best idea to use function overloads for
optional parameters.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (was a mistake in the original typing for simperium: [first invocation](https://github.com/Simperium/node-simperium/blob/986ce2a7d688dd249c346626dce76d292e01c684/src/simperium/channel.js#L111) | [second invocation](https://github.com/Simperium/node-simperium/blob/986ce2a7d688dd249c346626dce76d292e01c684/src/simperium/channel.js#L111)).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing) - _**hard to do since the library doesn't expose a way to fake or mock the event**_
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
