### PR TITLE
Add namedCodesToUnicode and disableParsingRawHTML props to markdown-to-jsx

### DIFF
--- a/types/markdown-to-jsx/index.d.ts
+++ b/types/markdown-to-jsx/index.d.ts
@@ -82,6 +82,12 @@ export interface MarkdownOptions {
 
     /** Custom function to generate an HTML id from headings. */
     slugify?: (text: string) => string;
+
+    /** List of html codes are converted to unicode characters */
+    namedCodesToUnicode?: { [key: string]: string };
+
+    /** By default, raw HTML is parsed to JSX. This behavior can be disabled with this option. */
+    disableParsingRawHTML?: boolean;
 }
 
 export function compiler(markdown: string, options?: MarkdownOptions): JSX.Element;

--- a/types/markdown-to-jsx/markdown-to-jsx-tests.tsx
+++ b/types/markdown-to-jsx/markdown-to-jsx-tests.tsx
@@ -9,6 +9,21 @@ compiler('Hello there old chap!', { forceBlock: true });
 
 <Markdown options={{ forceInline: true }}># You got it babe!</Markdown>;
 
+<Markdown
+    options={{
+        namedCodesToUnicode: {
+            le: '\u2264',
+            ge: '\u2265',
+        },
+    }}
+>
+    This text is &le; than this text.
+</Markdown>;
+
+<Markdown options={{ disableParsingRawHTML: true }}>
+    This text has <span>html</span> in it but it won't be rendered
+</Markdown>;
+
 const MyParagraph: React.SFC = ({ children, ...props }) => <div {...props}>{children}</div>;
 
 interface MySquareImageProps {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/probablyup/markdown-to-jsx#optionsnamedcodestounicode
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
