### PR TITLE
Add @snyk/ruby-semver types

### DIFF
--- a/types/snyk__ruby-semver/OTHER_FILES.txt
+++ b/types/snyk__ruby-semver/OTHER_FILES.txt
@@ -1,0 +1,2 @@
+lib/ruby/gem-requirement.d.ts
+lib/ruby/gem-version.d.ts

--- a/types/snyk__ruby-semver/index.d.ts
+++ b/types/snyk__ruby-semver/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for @snyk/ruby-semver 2.2
+// Project: https://github.com/Snyk/ruby-semver#readme
+// Definitions by: Jamie Magee <https://github.com/JamieMagee>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.1
+
+// comparison
+export function gt(v1: string, v2: string): boolean;
+export function gte(v1: string, v2: string): boolean;
+export function lt(v1: string, v2: string): boolean;
+export function lte(v1: string, v2: string): boolean;
+export function eq(v1: string, v2: string): boolean;
+export function neq(v1: string, v2: string): boolean;
+export function cmp(v1: string, comparator: Comparator, v2: string): boolean;
+export function compare(v1: string, v2: string): boolean;
+export function rcompare(v1: string, v2: string): boolean;
+export function diff(v1: string, v2: string): string;
+// functions
+export function valid(v: string): boolean;
+export function prerelease(v: string): string[];
+export function major(v: string): number;
+export function minor(v: string): number;
+export function patch(v: string): number;
+// ranges
+export function validRange(range: string): boolean;
+export function satisfies(version: string, range: string): boolean;
+export function maxSatisfying(versions: string[], range: string): string;
+export function minSatisfying(versions: string[], range: string): string;
+export function intersects(r1: string, r2: string): boolean;
+
+export type Comparator = '>' | '>=' | '<' | '<=' | '==' | '!=' | '===' | '!==';

--- a/types/snyk__ruby-semver/index.d.ts
+++ b/types/snyk__ruby-semver/index.d.ts
@@ -21,11 +21,15 @@ export function prerelease(v: string): string[];
 export function major(v: string): number;
 export function minor(v: string): number;
 export function patch(v: string): number;
+export function inc(): never;
 // ranges
 export function validRange(range: string): boolean;
 export function satisfies(version: string, range: string): boolean;
 export function maxSatisfying(versions: string[], range: string): string;
 export function minSatisfying(versions: string[], range: string): string;
 export function intersects(r1: string, r2: string): boolean;
+export function gtr(): never;
+export function ltr(): never;
+export function outside(): never;
 
 export type Comparator = '>' | '>=' | '<' | '<=' | '==' | '!=' | '===' | '!==';

--- a/types/snyk__ruby-semver/lib/ruby/gem-requirement.d.ts
+++ b/types/snyk__ruby-semver/lib/ruby/gem-requirement.d.ts
@@ -1,0 +1,14 @@
+import GemVersion = require('./gem-version');
+
+declare class GemRequirement {
+    static create(input: string | GemVersion | string[] | GemVersion[]): GemRequirement;
+    static default(): GemRequirement;
+    static parse(obj: string | GemVersion): [Op, GemVersion];
+    constructor(...requirements: string[] | GemVersion[]);
+    asList(): string[];
+    isPrerelease: boolean;
+    satisfiedBy(version: GemVersion): boolean;
+    toString(): string;
+}
+type Op = '=' | '!=' | '>' | '<' | '>=' | '<=' | '~>';
+export = GemRequirement;

--- a/types/snyk__ruby-semver/lib/ruby/gem-version.d.ts
+++ b/types/snyk__ruby-semver/lib/ruby/gem-version.d.ts
@@ -1,0 +1,13 @@
+declare class GemVersion {
+    toString(): string;
+    static isCorrect(version: string): GemVersion;
+    static create(version: string): GemVersion;
+    constructor(version: string);
+    bump(): GemVersion;
+    isIdentical(other: GemVersion): boolean;
+    isPrerelease(): boolean;
+    release(): GemVersion;
+    getSegments(): Array<number | string>;
+    compare(other: GemVersion): -1 | 0 | 1;
+}
+export = GemVersion;

--- a/types/snyk__ruby-semver/snyk__ruby-semver-tests.ts
+++ b/types/snyk__ruby-semver/snyk__ruby-semver-tests.ts
@@ -19,6 +19,10 @@ import {
     maxSatisfying,
     minSatisfying,
     intersects,
+    inc,
+    gtr,
+    ltr,
+    outside,
 } from '@snyk/ruby-semver';
 import GemVersion from '@snyk/ruby-semver/lib/ruby/gem-version';
 import GemRequirement from '@snyk/ruby-semver/lib/ruby/gem-requirement';
@@ -40,12 +44,16 @@ prerelease('1.2.3'); // $ExpectedType string[]
 major('1.2.3'); // $ExpectedType number
 minor('1.2.3'); // $ExpectedType number
 patch('1.2.3'); // $ExpectedType number
+inc(); // $ExpectedType never
 // ranges
 validRange('>1.2.3'); // $ExpectedType boolean
 satisfies('2.3.4', '>1.2.3'); // $ExpectedType boolean
 maxSatisfying(['2.3.4'], '>1.2.3'); // $ExpectedType string
 minSatisfying(['1.2.3'], '<2.3.4'); // $ExpectedType string
 intersects('>1.2.3', '<2.3.4'); // $ExpectedType boolean
+gtr(); // $ExpectedType never
+ltr(); // $ExpectedType never
+outside(); // $ExpectedType never
 
 // GemVersion
 GemVersion.isCorrect('1.2.3'); // $ExpectedType boolean

--- a/types/snyk__ruby-semver/snyk__ruby-semver-tests.ts
+++ b/types/snyk__ruby-semver/snyk__ruby-semver-tests.ts
@@ -1,0 +1,69 @@
+import {
+    gt,
+    gte,
+    lt,
+    lte,
+    eq,
+    neq,
+    cmp,
+    compare,
+    rcompare,
+    diff,
+    valid,
+    prerelease,
+    major,
+    minor,
+    patch,
+    validRange,
+    satisfies,
+    maxSatisfying,
+    minSatisfying,
+    intersects,
+} from '@snyk/ruby-semver';
+import GemVersion from '@snyk/ruby-semver/lib/ruby/gem-version';
+import GemRequirement from '@snyk/ruby-semver/lib/ruby/gem-requirement';
+
+// comparison
+gt('1.2.3', '2.3.4'); // $ExpectedType boolean
+gte('1.2.3', '2.3.4'); // $ExpectedType boolean
+lt('1.2.3', '2.3.4'); // $ExpectedType boolean
+lte('1.2.3', '2.3.4'); // $ExpectedType boolean
+eq('1.2.3', '2.3.4'); // $ExpectedType boolean
+neq('1.2.3', '2.3.4'); // $ExpectedType boolean
+cmp('1.2.3', '>', '2.3.4'); // $ExpectedType boolean
+compare('1.2.3', '2.3.4'); // $ExpectedType boolean
+rcompare('1.2.3', '2.3.4'); // $ExpectedType boolean
+diff('1.2.3', '2.3.4'); // $ExpectedType string
+// functions
+valid('1.2.3'); // $ExpectedType boolean
+prerelease('1.2.3'); // $ExpectedType string[]
+major('1.2.3'); // $ExpectedType number
+minor('1.2.3'); // $ExpectedType number
+patch('1.2.3'); // $ExpectedType number
+// ranges
+validRange('>1.2.3'); // $ExpectedType boolean
+satisfies('2.3.4', '>1.2.3'); // $ExpectedType boolean
+maxSatisfying(['2.3.4'], '>1.2.3'); // $ExpectedType string
+minSatisfying(['1.2.3'], '<2.3.4'); // $ExpectedType string
+intersects('>1.2.3', '<2.3.4'); // $ExpectedType boolean
+
+// GemVersion
+GemVersion.isCorrect('1.2.3'); // $ExpectedType boolean
+GemVersion.create('1.2.3'); // $ExpectedType GemVersion
+const gemVersion = new GemVersion('1.2.3'); // $ExpectedType GemVersion
+gemVersion.bump(); // $ExpectedType GemVersion
+gemVersion.compare(new GemVersion('2.3.4')); // $ExpectedType -1 | 0 | 1
+gemVersion.getSegments(); // $ExpectedType (string | number)[]
+gemVersion.isIdentical(new GemVersion('1.2.3')); // $ExpectedType boolean
+gemVersion.isPrerelease(); // $ExpectedType boolean
+gemVersion.release(); // $ExpectedType GemVersion
+gemVersion.toString(); // $ExpectedType string
+
+// GemRequirement
+GemRequirement.create('>1.2.3'); // $ExpectedType GemRequirement
+GemRequirement.parse('~>1.2.3'); // $ExpectedType [Op, GemVersion]
+const gemRequirement = new GemRequirement('>1.2.3'); // $ExpectedType GemRequirement
+gemRequirement.asList(); // $ExpectedType string[]
+gemRequirement.isPrerelease; // $ExpectedType boolean
+gemRequirement.satisfiedBy(new GemVersion('1.2.3')); // $ExpectedType boolean
+gemRequirement.toString(); // $ExpectedType string

--- a/types/snyk__ruby-semver/tsconfig.json
+++ b/types/snyk__ruby-semver/tsconfig.json
@@ -1,0 +1,32 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "esModuleInterop": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@snyk/ruby-semver": [
+                "snyk__ruby-semver"
+            ],
+            "@snyk/ruby-semver/*": [
+                "snyk__ruby-semver/*"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "snyk__ruby-semver-tests.ts"
+    ]
+}

--- a/types/snyk__ruby-semver/tslint.json
+++ b/types/snyk__ruby-semver/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.