### PR TITLE
[@types/braintree-web-drop-in] Typed `off` method added in 1.19

### DIFF
--- a/types/braintree-web-drop-in/index.d.ts
+++ b/types/braintree-web-drop-in/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for braintree-web-drop-in 1.18
+// Type definitions for braintree-web-drop-in 1.22
 // Project: https://github.com/braintree/braintree-web-dropin
 // Definitions by: Saoud Rizwan <https://github.com/saoudrizwan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -87,17 +87,35 @@ export interface venmoCreateOptions {
 
 // Dropin
 
+export interface PaymentMethodRequestablePayload {
+    type: "CreditCard" | "PayPalAccount";
+    paymentMethodIsSelected: boolean;
+}
+
+export interface PaymentOptionSelectedPayload {
+    paymentOption: "card" | "paypal" | "paypalCredit";
+}
+
 export interface Dropin {
     clearSelectedPaymentMethod(): void;
     isPaymentMethodRequestable(): boolean;
     on(event: "noPaymentMethodRequestable", handler: () => void): void;
     on(
         event: "paymentMethodRequestable",
-        handler: (payload: { type: "CreditCard" | "PayPalAccount"; paymentMethodIsSelected: boolean }) => void
+        handler: (payload: PaymentMethodRequestablePayload) => void
     ): void;
     on(
         event: "paymentOptionSelected",
-        handler: (payload: { paymentOption: "card" | "paypal" | "paypalCredit" }) => void
+        handler: (payload: PaymentOptionSelectedPayload) => void
+    ): void;
+    off(event: "noPaymentMethodRequestable", handler: () => void): void;
+    off(
+        event: "paymentMethodRequestable",
+        handler: (payload: PaymentMethodRequestablePayload) => void
+    ): void;
+    off(
+        event: "paymentOptionSelected",
+        handler: (payload: PaymentOptionSelectedPayload) => void
     ): void;
     requestPaymentMethod(callback: (error: object | null, payload: PaymentMethodPayload | undefined) => void): void;
     requestPaymentMethod(): Promise<PaymentMethodPayload>;

--- a/types/braintree-web-drop-in/test/braintree-web-drop-in-global.test.ts
+++ b/types/braintree-web-drop-in/test/braintree-web-drop-in-global.test.ts
@@ -1,3 +1,5 @@
+import { PaymentMethodRequestablePayload, PaymentOptionSelectedPayload } from "braintree-web-drop-in";
+
 braintree.dropin.create({ authorization: "", container: "my-div" }, (error, myDropin) => {
     if (error) {
         return;
@@ -65,16 +67,24 @@ braintree.dropin.create({ authorization: "", container: "my-div" }, (error, myDr
     myDropin.clearSelectedPaymentMethod();
     const myBool: boolean = myDropin.isPaymentMethodRequestable();
 
-    myDropin.on("noPaymentMethodRequestable", () => {
+    function onNoPaymentMethodRequestable() {
         return;
-    });
-    myDropin.on("paymentMethodRequestable", ({ type, paymentMethodIsSelected }) => {
+    }
+    function onPaymentMethodRequestable({ type, paymentMethodIsSelected }: PaymentMethodRequestablePayload) {
         const myType: "CreditCard" | "PayPalAccount" = type;
         const myBool: boolean = paymentMethodIsSelected;
-    });
-    myDropin.on("paymentOptionSelected", ({ paymentOption }) => {
+    }
+    function onPaymentOptionSelected({ paymentOption }: PaymentOptionSelectedPayload) {
         const myPaymentOption: "card" | "paypal" | "paypalCredit" = paymentOption;
-    });
+    }
+
+    myDropin.on("noPaymentMethodRequestable", onNoPaymentMethodRequestable);
+    myDropin.on('paymentMethodRequestable', onPaymentMethodRequestable);
+    myDropin.on("paymentOptionSelected", onPaymentOptionSelected);
+
+    myDropin.off("noPaymentMethodRequestable", onNoPaymentMethodRequestable);
+    myDropin.off("paymentMethodRequestable", onPaymentMethodRequestable);
+    myDropin.off("paymentOptionSelected", onPaymentOptionSelected);
 
     myDropin.requestPaymentMethod((error, payload) => {
         if (error) {

--- a/types/braintree-web-drop-in/test/braintree-web-drop-in-module.test.ts
+++ b/types/braintree-web-drop-in/test/braintree-web-drop-in-module.test.ts
@@ -68,16 +68,24 @@ dropin.create({ authorization: "", container: "my-div" }, (error, myDropin) => {
     myDropin.clearSelectedPaymentMethod();
     const myBool: boolean = myDropin.isPaymentMethodRequestable();
 
-    myDropin.on("noPaymentMethodRequestable", () => {
+    function onNoPaymentMethodRequestable() {
         return;
-    });
-    myDropin.on("paymentMethodRequestable", ({ type, paymentMethodIsSelected }) => {
+    }
+    function onPaymentMethodRequestable({ type, paymentMethodIsSelected }: dropin.PaymentMethodRequestablePayload) {
         const myType: "CreditCard" | "PayPalAccount" = type;
         const myBool: boolean = paymentMethodIsSelected;
-    });
-    myDropin.on("paymentOptionSelected", ({ paymentOption }) => {
+    }
+    function onPaymentOptionSelected({ paymentOption }: dropin.PaymentOptionSelectedPayload) {
         const myPaymentOption: "card" | "paypal" | "paypalCredit" = paymentOption;
-    });
+    }
+
+    myDropin.on("noPaymentMethodRequestable", onNoPaymentMethodRequestable);
+    myDropin.on("paymentMethodRequestable", onPaymentMethodRequestable);
+    myDropin.on("paymentOptionSelected", onPaymentOptionSelected);
+
+    myDropin.off("noPaymentMethodRequestable", onNoPaymentMethodRequestable);
+    myDropin.off("paymentMethodRequestable", onPaymentMethodRequestable);
+    myDropin.off("paymentOptionSelected", onPaymentOptionSelected);
 
     myDropin.requestPaymentMethod((error, payload) => {
         if (error) {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
* https://github.com/braintree/braintree-web-drop-in/blob/bd5a9a997337aaad4f779c201097a2d917f9609e/CHANGELOG.md#1190
* https://braintree.github.io/braintree-web-drop-in/docs/current/Dropin.html#off
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
