### PR TITLE
prosemirror-commands: Add types Command and Keymap

### DIFF
--- a/types/prosemirror-commands/index.d.ts
+++ b/types/prosemirror-commands/index.d.ts
@@ -4,12 +4,25 @@
 //                 David Hahn <https://github.com/davidka>
 //                 Tim Baumann <https://github.com/timjb>
 //                 Patrick Simmelbauer <https://github.com/patsimm>
+//                 Mike Morearty <https://github.com/mmorearty>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.0
 
 import { MarkType, Node as ProsemirrorNode, NodeType, Schema } from 'prosemirror-model';
 import { EditorState, Transaction } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
+
+export interface Command<S extends Schema = any> {
+  (
+    state: EditorState<S>,
+    dispatch: (tr: Transaction<S>) => void,
+    view: EditorView<S>
+  ): boolean;
+}
+
+export interface Keymap<S extends Schema = any> {
+  [key: string]: Command<S>;
+}
 
 /**
  * Delete the selection, if there is one.
@@ -222,17 +235,17 @@ export function chainCommands<S extends Schema = any>(
  * * **Mod-Delete** to `deleteSelection`, `joinForward`, `selectNodeForward`
  * * **Mod-a** to `selectAll`
  */
-export let pcBaseKeymap: { [key: string]: any };
+export let pcBaseKeymap: Keymap;
 /**
  * A copy of `pcBaseKeymap` that also binds **Ctrl-h** like Backspace,
  * **Ctrl-d** like Delete, **Alt-Backspace** like Ctrl-Backspace, and
  * **Ctrl-Alt-Backspace**, **Alt-Delete**, and **Alt-d** like
  * Ctrl-Delete.
  */
-export let macBaseKeymap: { [key: string]: any };
+export let macBaseKeymap: Keymap;
 /**
  * Depending on the detected platform, this will hold
  * [`pcBasekeymap`](#commands.pcBaseKeymap) or
  * [`macBaseKeymap`](#commands.macBaseKeymap).
  */
-export let baseKeymap: { [key: string]: any };
+export let baseKeymap: Keymap;

--- a/types/prosemirror-commands/prosemirror-commands-tests.ts
+++ b/types/prosemirror-commands/prosemirror-commands-tests.ts
@@ -9,3 +9,13 @@ commands.deleteSelection(state);
 
 commands.baseKeymap["Ctrl-h"];
 commands.wrapIn(nodeType, { attr: 'value' });
+
+const c1: commands.Command = commands.deleteSelection;
+const c2: commands.Command = commands.joinBackward;
+
+const keymap: commands.Keymap = {
+    ArrowUp: () => true,  // takes no args
+    ArrowDown: commands.deleteSelection,  // takes two args
+    ArrowLeft: commands.joinBackward,  // takes three args
+    ArrowRight: (state, dispatch, view) => true,  // arg types inferred
+};

--- a/types/prosemirror-keymap/index.d.ts
+++ b/types/prosemirror-keymap/index.d.ts
@@ -6,10 +6,11 @@
 //                 Patrick Simmelbauer <https://github.com/patsimm>
 //                 Mike Morearty <https://github.com/mmorearty>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
+import { Keymap } from 'prosemirror-commands';
 import { Schema } from 'prosemirror-model';
-import { EditorState, Plugin, Transaction } from 'prosemirror-state';
+import { Plugin } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 
 /**
@@ -43,23 +44,13 @@ import { EditorView } from 'prosemirror-view';
  * which they appear determines their precedence (the ones early in
  * the array get to dispatch first).
  */
-export function keymap<S extends Schema = any>(bindings: {
-  [key: string]: (
-    state: EditorState<S>,
-    dispatch: (tr: Transaction<S>) => void,
-    view: EditorView<S>
-  ) => boolean;
-}): Plugin;
+export function keymap<S extends Schema = any>(bindings: Keymap<S>): Plugin;
 
 /**
  * Given a set of bindings (using the same format as
  * [`keymap`](#keymap.keymap), return a [keydown
  * handler](#view.EditorProps.handleKeyDown) handles them.
  */
-export function keydownHandler<S extends Schema = any>(bindings: {
-  [key: string]: (
-      state: EditorState<S>,
-      dispatch: (tr: Transaction<S>) => void,
-      view: EditorView<S>
-    ) => boolean;
-}): (view: EditorView, event: KeyboardEvent) => boolean;
+export function keydownHandler<S extends Schema = any>(
+  bindings: Keymap<S>,
+): (view: EditorView, event: KeyboardEvent) => boolean;


### PR DESCRIPTION
Previously, no types were specified for a Command or for a Keymap. This
meant that (a) in prosemirror-commands, the types for pcBaseKeymap,
macBaseKeymap, and baseKeymap were not very well specified, and (b) in
prosemirror-keymap, there was some duplication of types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://prosemirror.net/docs/ref/#commands and https://prosemirror.net/docs/ref/#keymap
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
