### PR TITLE
fix(jest): Fix usage example of `jest.MockedClass`

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1099,7 +1099,7 @@ declare namespace jest {
      *  import { MyClass } from "./libary";
      *  jest.mock("./library");
      *
-     *  const mockedMyClass = MyClass as jest.MockedClass<MyClass>;
+     *  const mockedMyClass = MyClass as jest.MockedClass<typeof MyClass>;
      *
      *  expect(mockedMyClass.mock.calls[0][0]).toBe(42); // Constructor calls
      *  expect(mockedMyClass.prototype.myMethod.mock.calls[0][0]).toBe(42); // Method calls


### PR DESCRIPTION
So it reflects of how it should be done in [reality](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/15fe0696be464ec1f7cc97ed42f1ec35bc4476b5/types/jest/jest-tests.ts#L613).