### PR TITLE
Add typings for the WICG Native File System API

### DIFF
--- a/types/wicg-native-file-system/index.d.ts
+++ b/types/wicg-native-file-system/index.d.ts
@@ -1,0 +1,155 @@
+// Type definitions for non-npm package Native File System API 2020.06
+// Project: https://github.com/WICG/native-file-system
+// Definitions by: Ingvar Stepanyan <https://github.com/RReverser>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.5
+
+interface FilePickerAcceptType {
+    description?: string;
+    accept: Record<string, string[]>;
+}
+
+interface FilePickerOptions {
+    types?: FilePickerAcceptType[];
+    excludeAcceptAllOption?: boolean;
+}
+
+interface OpenFilePickerOptions extends FilePickerOptions {
+    multiple?: boolean;
+}
+
+// tslint:disable-next-line:no-empty-interface
+interface SaveFilePickerOptions extends FilePickerOptions {}
+
+// tslint:disable-next-line:no-empty-interface
+interface DirectoryPickerOptions {}
+
+interface FileSystemHandlePermissionDescriptor {
+    writable?: boolean;
+}
+
+interface FileSystemCreateWritableOptions {
+    keepExistingData?: boolean;
+}
+
+interface FileSystemGetFileOptions {
+    create?: boolean;
+}
+
+interface FileSystemGetDirectoryOptions {
+    create?: boolean;
+}
+
+interface FileSystemRemoveOptions {
+    recursive?: boolean;
+}
+
+type WriteParams =
+    | { type: 'write'; position?: number; data: BufferSource | Blob | string }
+    | { type: 'seek'; position: number }
+    | { type: 'truncate'; size: number };
+
+type FileSystemWriteChunkType = BufferSource | Blob | string | WriteParams;
+
+// TODO: remove this once https://github.com/microsoft/TSJS-lib-generator/issues/881 is fixed.
+// Native File System API especially needs this method.
+interface WritableStream {
+    close(): Promise<void>;
+}
+
+interface FileSystemWritableFileStream extends WritableStream {
+    write(data: FileSystemWriteChunkType): Promise<void>;
+    seek(position: number): Promise<void>;
+    truncate(size: number): Promise<void>;
+}
+
+interface BaseFileSystemHandle {
+    readonly isFile: boolean;
+    readonly isDirectory: boolean;
+    readonly name: string;
+
+    isSameEntry(other: FileSystemHandle): Promise<boolean>;
+    queryPermission(descriptor?: FileSystemHandlePermissionDescriptor): Promise<PermissionState>;
+    requestPermission(descriptor?: FileSystemHandlePermissionDescriptor): Promise<PermissionState>;
+}
+
+interface FileSystemFileHandle extends BaseFileSystemHandle {
+    readonly isFile: true;
+    readonly isDirectory: false;
+    isSameEntry(other: FileSystemDirectoryHandle): Promise<false>;
+
+    getFile(): Promise<File>;
+    createWritable(options?: FileSystemCreateWritableOptions): Promise<FileSystemWritableFileStream>;
+}
+
+interface FileSystemDirectoryHandle extends BaseFileSystemHandle {
+    readonly isFile: false;
+    readonly isDirectory: true;
+    isSameEntry(other: FileSystemFileHandle): Promise<false>;
+
+    getFile(name: string, options?: FileSystemGetFileOptions): Promise<FileSystemFileHandle>;
+    getDirectory(name: string, options?: FileSystemGetDirectoryOptions): Promise<FileSystemDirectoryHandle>;
+    removeEntry(name: string, options?: FileSystemRemoveOptions): Promise<void>;
+    resolve(possibleDescendant: FileSystemHandle): Promise<string[] | null>;
+
+    // Note: iterables below are not yet implemented in Chrome, use getEntries instead.
+
+    [Symbol.asyncIterator](): AsyncIterable<FileSystemHandle>;
+    keys(): AsyncIterable<string>;
+    values(): AsyncIterable<FileSystemHandle>;
+    entries(): AsyncIterable<[string, FileSystemHandle]>;
+}
+
+type FileSystemHandle = FileSystemFileHandle | FileSystemDirectoryHandle;
+
+declare function showOpenFilePicker(
+    options?: OpenFilePickerOptions & { multiple?: false },
+): Promise<[FileSystemFileHandle]>;
+declare function showOpenFilePicker(options?: OpenFilePickerOptions): Promise<FileSystemFileHandle[]>;
+declare function showSaveFilePicker(options?: SaveFilePickerOptions): Promise<FileSystemFileHandle>;
+declare function showDirectoryPicker(options?: DirectoryPickerOptions): Promise<FileSystemDirectoryHandle>;
+declare function getOriginPrivateDirectory(): Promise<FileSystemDirectoryHandle>;
+
+// Old methods available on stable Chrome instead of the ones above.
+
+interface ChooseFileSystemEntriesOptionsAccepts {
+    description?: string;
+    mimeTypes?: string[];
+    extensions?: string[];
+}
+
+interface ChooseFileSystemEntriesFileOptions {
+    accepts?: ChooseFileSystemEntriesOptionsAccepts[];
+    excludeAcceptAllOption?: boolean;
+}
+
+declare function chooseFileSystemEntries(
+    options?: ChooseFileSystemEntriesFileOptions & {
+        type?: 'open-file';
+        multiple?: false;
+    },
+): Promise<FileSystemFileHandle>;
+declare function chooseFileSystemEntries(
+    options: ChooseFileSystemEntriesFileOptions & {
+        type?: 'open-file';
+        multiple: true;
+    },
+): Promise<FileSystemFileHandle[]>;
+declare function chooseFileSystemEntries(
+    options: ChooseFileSystemEntriesFileOptions & {
+        type: 'save-file';
+    },
+): Promise<FileSystemFileHandle>;
+declare function chooseFileSystemEntries(options: { type: 'open-directory' }): Promise<FileSystemDirectoryHandle>;
+
+interface GetSystemDirectoryOptions {
+    type: 'sandbox';
+}
+
+declare const FileSystemDirectoryHandle: {
+    getSystemDirectory(options: GetSystemDirectoryOptions): Promise<FileSystemDirectoryHandle>;
+};
+
+interface FileSystemDirectoryHandle {
+    getEntries(): AsyncIterable<FileSystemHandle>;
+}

--- a/types/wicg-native-file-system/tsconfig.json
+++ b/types/wicg-native-file-system/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "ES5",
+            "ES2015.Promise",
+            "ESNext.AsyncIterable",
+            "DOM"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "wicg-native-file-system-tests.ts"
+    ]
+}

--- a/types/wicg-native-file-system/tslint.json
+++ b/types/wicg-native-file-system/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/wicg-native-file-system/wicg-native-file-system-tests.ts
+++ b/types/wicg-native-file-system/wicg-native-file-system-tests.ts
@@ -1,0 +1,73 @@
+(async () => {
+    let [fileHandle]: [FileSystemFileHandle] = await showOpenFilePicker();
+    [fileHandle] = await showOpenFilePicker({ multiple: false });
+    const fileHandles: FileSystemFileHandle[] = await showOpenFilePicker({
+        excludeAcceptAllOption: true,
+        multiple: true,
+        types: [{ accept: { 'image/*': ['png', 'gif', 'jpeg', 'jpg'] } }],
+    });
+    let w: FileSystemWritableFileStream = await fileHandle.createWritable();
+    w = await fileHandle.createWritable({ keepExistingData: true });
+    await w.write('abc');
+    await w.write(new Uint8Array([1, 2, 3]));
+    await w.write({ type: 'seek', position: 0 });
+    await w.seek(1);
+    await w.write(new Blob(['xyz']));
+    await w.write({ type: 'write', position: 3, data: new Uint8Array([4, 5, 6]) });
+    await w.write({ type: 'truncate', size: 2 });
+    await w.truncate(1);
+    await w.close();
+
+    let permissionState: PermissionState = await fileHandle.queryPermission();
+    permissionState = await fileHandle.requestPermission({ writable: true });
+
+    fileHandle = await showSaveFilePicker();
+    fileHandle = await showSaveFilePicker({
+        excludeAcceptAllOption: true,
+        types: [{ description: 'SVG images', accept: { 'image/svg': ['svg'] } }],
+    });
+
+    const file: File = await fileHandle.getFile();
+    new ReadableStream().pipeTo(await fileHandle.createWritable());
+
+    let dirHandle: FileSystemDirectoryHandle = await showDirectoryPicker();
+    dirHandle = await showDirectoryPicker({});
+
+    (async function* recursivelyWalkDir(dirHandle: FileSystemDirectoryHandle): AsyncIterable<File> {
+        for await (const handle of dirHandle.getEntries()) {
+            if (handle.isFile) {
+                yield handle.getFile();
+            } else {
+                yield* recursivelyWalkDir(handle);
+            }
+        }
+    })(dirHandle);
+
+    const maybePath = await dirHandle.resolve(fileHandle);
+    if (maybePath) {
+        const pathItems: string[] = maybePath;
+    }
+
+    fileHandle = await dirHandle.getFile('temp.txt');
+    fileHandle = await dirHandle.getFile('temp.txt', { create: true });
+
+    dirHandle = await dirHandle.getDirectory('subdir', { create: false });
+
+    await dirHandle.removeEntry('temp.txt');
+    await dirHandle.removeEntry('nested-dir', { recursive: true });
+
+    dirHandle = await getOriginPrivateDirectory();
+
+    // Testing old / stable Chrome methods, remove when they're removed.
+
+    fileHandle = await chooseFileSystemEntries();
+    fileHandle = await chooseFileSystemEntries({
+        type: 'open-file',
+        accepts: [{ description: 'Images', extensions: ['png', 'jpg'], mimeTypes: ['image/*'] }],
+        excludeAcceptAllOption: false,
+        multiple: false,
+    });
+    fileHandle = await chooseFileSystemEntries({ type: 'save-file' });
+    dirHandle = await chooseFileSystemEntries({ type: 'open-directory' });
+    dirHandle = await FileSystemDirectoryHandle.getSystemDirectory({ type: 'sandbox' });
+})();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.