### PR TITLE
[codemirror] Add Doc#lineSeparator (move from Editor#lineSeparator)

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -460,9 +460,6 @@ declare namespace CodeMirror {
         /** Tells you whether the editor's content can be edited by the user. */
         isReadOnly(): boolean;
 
-        /** Returns the preferred line separator string for this document, as per the option by the same name. When that option is null, the string "\n" is returned. */
-        lineSeparator(): string;
-
         /** Switches between overwrite and normal insert mode (when not given an argument),
         or sets the overwrite mode to a specific state (when given an argument). */
         toggleOverwrite(value?: boolean): void;
@@ -889,6 +886,9 @@ declare namespace CodeMirror {
         /** Gets the mode object for the editor. Note that this is distinct from getOption("mode"), which gives you the mode specification,
         rather than the resolved, instantiated mode object. */
         getMode(): any;
+
+        /** Returns the preferred line separator string for this document, as per the option by the same name. When that option is null, the string "\n" is returned. */
+        lineSeparator(): string;
 
         /** Calculates and returns a { line , ch } object for a zero-based index whose value is relative to the start of the editor's text.
         If the index is out of range of the text then the returned object is clipped to start or end of the text respectively. */

--- a/types/codemirror/test/index.ts
+++ b/types/codemirror/test/index.ts
@@ -41,6 +41,7 @@ const myCodeMirror3: CodeMirror.Editor = CodeMirror(
 const myCodeMirror4: CodeMirror.Editor = CodeMirror.fromTextArea(myTextArea);
 
 const doc: CodeMirror.Doc = new CodeMirror.Doc('text');
+doc.lineSeparator();
 const doc2: CodeMirror.Doc = CodeMirror(document.body).getDoc();
 
 const lintStateOptions: CodeMirror.LintStateOptions = {


### PR DESCRIPTION
function `lineSeparator` can be called from Doc.
https://codemirror.net/doc/manual.html#lineSeparator
https://github.com/codemirror/CodeMirror/blob/5.55.0/src/model/Doc.js#L421

```js
new CodeMirror.Doc("xxxx", "", 1, "foo").lineSeparator();
// => "foo"
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://codemirror.net/doc/manual.html#lineSeparator
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.