### PR TITLE
`@babel/traverse`: add `visitors.merge`

### DIFF
--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -261,3 +261,5 @@ const VisitorAliasTest: Visitor = {
 const hub = new Hub('file', { options: '' });
 // $ExpectType string | undefined
 hub.getCode();
+
+traverse.visitors.merge([{ Expression(path) { } }, { Expression(path) { } }]);

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -13,20 +13,28 @@ import * as t from '@babel/types';
 
 export type Node = t.Node;
 
-export default function traverse<S>(
-    parent: Node | Node[],
-    opts: TraverseOptions<S>,
-    scope: Scope | undefined,
-    state: S,
-    parentPath?: NodePath,
-): void;
-export default function traverse(
-    parent: Node | Node[],
-    opts: TraverseOptions,
-    scope?: Scope,
-    state?: any,
-    parentPath?: NodePath,
-): void;
+declare const traverse: {
+    <S>(
+        parent: Node | Node[],
+        opts: TraverseOptions<S>,
+        scope: Scope | undefined,
+        state: S,
+        parentPath?: NodePath,
+    ): void;
+    (
+        parent: Node | Node[],
+        opts: TraverseOptions,
+        scope?: Scope,
+        state?: any,
+        parentPath?: NodePath,
+    ): void;
+
+    visitors: {
+        merge: (visitors: Visitor[]) => Visitor
+    }
+};
+
+export default traverse;
 
 export interface TraverseOptions<S = Node> extends Visitor<S> {
     scope?: Scope;


### PR DESCRIPTION
Related: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44527

Example usage: https://github.com/babel/babel/blob/eea156b2cb8deecfcf82d52aa1b71ba4995c7d68/packages/babel-core/src/transformation/index.js#L107

Unfortunately I couldn't find any docs.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see links/notes above
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.