### PR TITLE
@types/ioredis - Add ClusterOptions and status to Cluster interface

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -1400,6 +1400,8 @@ declare namespace IORedis {
     type Ok = 'OK';
 
     interface Cluster extends EventEmitter, Commander, Commands {
+        options: ClusterOptions;
+        status: string;
         connect(): Promise<void>;
         disconnect(): void;
         nodes(role?: NodeRole): Redis[];

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -921,8 +921,8 @@ declare namespace IORedis {
 
     interface Redis extends EventEmitter, Commander, Commands {
         Promise: typeof Promise;
-        options: RedisOptions;
-        status: string;
+        readonly options: RedisOptions;
+        readonly status: string;
         connect(callback?: () => void): Promise<void>;
         disconnect(): void;
         duplicate(): Redis;
@@ -1400,8 +1400,8 @@ declare namespace IORedis {
     type Ok = 'OK';
 
     interface Cluster extends EventEmitter, Commander, Commands {
-        options: ClusterOptions;
-        status: string;
+        readonly options: ClusterOptions;
+        readonly status: string;
         connect(): Promise<void>;
         disconnect(): void;
         nodes(role?: NodeRole): Redis[];

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -661,4 +661,7 @@ redis.pipeline()
         // do something with res or err
     });
 
-const { port, host } =  redis.options;
+redis.options.host;
+redis.status;
+cluster.options.maxRedirections;
+cluster.status;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/luin/ioredis/blob/master/lib/redis/index.ts
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
