### PR TITLE
Type updates for frappe-gantt library

### DIFF
--- a/types/frappe-gantt/frappe-gantt-tests.ts
+++ b/types/frappe-gantt/frappe-gantt-tests.ts
@@ -7,24 +7,27 @@ const tasks = [
         start: '2016-12-28',
         end: '2016-12-31',
         progress: 20,
-        dependencies: 'Task 2, Task 3'
-    }
+        dependencies: 'Task 2, Task 3',
+    },
 ];
 const gantt1 = new Gantt('#gantt', tasks);
+
+const gantt2 = new Gantt(new HTMLElement(), tasks);
+const gantt3 = new Gantt(new SVGElement(), tasks);
 
 gantt1.change_view_mode('Week');
 gantt1.refresh(tasks);
 
 new Gantt('#gantt', tasks, {
-    on_click: (task) => { },
-    on_date_change: (task, start, end) => { },
-    on_progress_change: (task, progress) => { },
-    on_view_change: (mode) => { }
+    on_click: task => {},
+    on_date_change: (task, start, end) => {},
+    on_progress_change: (task, progress) => {},
+    on_view_change: mode => {},
 });
 
 new Gantt('#gantt', tasks, {
-    custom_popup_html: (task) => {
-        const end_date = task._end.format('MMM D');
+    custom_popup_html: task => {
+        const end_date = task._end.toDateString();
         return `
         <div class="details-container">
           <h5>${task.name}</h5>
@@ -32,5 +35,5 @@ new Gantt('#gantt', tasks, {
           <p>${task.progress}% completed!</p>
         </div>
       `;
-    }
+    },
 });

--- a/types/frappe-gantt/index.d.ts
+++ b/types/frappe-gantt/index.d.ts
@@ -1,12 +1,12 @@
-// Type definitions for frappe-gantt 0.3
+// Type definitions for frappe-gantt 0.4
 // Project: https://github.com/frappe/gantt
-// Definitions by: Sam Alexander <https://github.com/samalexander>
+// Definitions by: Sam Alexander <https://github.com/samalexander>, Elijah Lucian <https://github.com/eli7vh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = Gantt;
 
 declare class Gantt {
-    constructor(wrapper: string, tasks: Gantt.Task[], options?: Gantt.Options);
+    constructor(wrapper: string | HTMLElement | SVGElement, tasks: Gantt.Task[], options?: Gantt.Options);
 
     change_view_mode(mode: Gantt.viewMode): void;
     refresh(tasks: Gantt.Task[]): void;
@@ -23,6 +23,12 @@ declare namespace Gantt {
         custom_class?: string;
     }
 
+    interface EnrichedTask extends Task {
+        _start: Date;
+        _end: Date;
+        _index: number;
+    }
+
     interface Options {
         header_height?: number;
         column_width?: number;
@@ -34,10 +40,10 @@ declare namespace Gantt {
         padding?: number;
         view_mode?: viewMode;
         date_format?: string;
-        custom_popup_html?: string | ((task: any) => string);
-        on_click?: (task: any) => void;
-        on_date_change?: (task: any, start: string, end: string) => void;
-        on_progress_change?: (task: any, progress: number) => void;
+        custom_popup_html?: string | ((task: EnrichedTask) => string);
+        on_click?: (task: EnrichedTask) => void;
+        on_date_change?: (task: EnrichedTask, start: Date, end: Date) => void;
+        on_progress_change?: (task: EnrichedTask, progress: number) => void;
         on_view_change?: (mode: viewMode) => void;
     }
 

--- a/types/frappe-gantt/tsconfig.json
+++ b/types/frappe-gantt/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
- removed `any`
- added new options to constructor arguments
- added typing of event handlers
- updated tests
- incremented version