### PR TITLE
mysql: When configured Pool.config has different structure from what's expected at createPool()

### DIFF
--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -189,7 +189,7 @@ export interface PoolConnection extends Connection {
 }
 
 export interface Pool extends EscapeFunctions {
-    config: PoolConfig;
+    config: PoolActualConfig;
 
     getConnection(callback: (err: MysqlError, connection: PoolConnection) => void): void;
 
@@ -583,7 +583,7 @@ export interface ConnectionConfig extends ConnectionOptions {
     ssl?: string | (tls.SecureContextOptions & { rejectUnauthorized?: boolean });
 }
 
-export interface PoolConfig extends ConnectionConfig {
+export interface PoolSpecificConfig {
     /**
      * The milliseconds before a timeout occurs during the connection acquisition. This is slightly different from connectTimeout,
      * because acquiring a pool connection does not always involve making a connection. (Default: 10 seconds)
@@ -607,6 +607,13 @@ export interface PoolConfig extends ConnectionConfig {
      * is no limit to the number of queued connection requests. (Default: 0)
      */
     queueLimit?: number;
+}
+
+export interface PoolConfig extends PoolSpecificConfig, ConnectionConfig {
+}
+
+export interface PoolActualConfig extends PoolSpecificConfig {
+    connectionConfig: ConnectionConfig;
 }
 
 export interface PoolClusterConfig {

--- a/types/mysql/mysql-tests.ts
+++ b/types/mysql/mysql-tests.ts
@@ -184,6 +184,8 @@ const poolConfig = {
 
 let pool = mysql.createPool(poolConfig);
 
+console.log('Connection timezone config:', pool.config.connectionConfig.timezone);
+
 pool.query('SELECT 1 + 1 AS solution', (err, rows, fields) => {
     if (err) throw err;
 


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Related issue](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44115)

