### PR TITLE
[react-native] Add onTextInput prop to TextInput

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -1455,13 +1455,13 @@ export interface TextInputProps extends ViewProps, TextInputIOSProps, TextInputA
     onSubmitEditing?: (e: NativeSyntheticEvent<TextInputSubmitEditingEventData>) => void;
 
     /**
-     * Callback that is called on new text input with the argument 
+     * Callback that is called on new text input with the argument
      *  `{ nativeEvent: { text, previousText, range: { start, end } } }`.
      *
      * This prop requires multiline={true} to be set.
      */
     onTextInput?: (e: NativeSyntheticEvent<TextInputTextInputEventData>) => void;
-    
+
     /**
      * Invoked on content scroll with
      *  `{ nativeEvent: { contentOffset: { x, y } } }`.

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -1319,6 +1319,15 @@ export interface TextInputSubmitEditingEventData {
 }
 
 /**
+ * @see TextInputProps.onTextInput
+ */
+export interface TextInputTextInputEventData {
+    text: string;
+    previousText: string;
+    range: { start: number, end: number };
+}
+
+/**
  * @see https://facebook.github.io/react-native/docs/textinput.html#props
  */
 export interface TextInputProps extends ViewProps, TextInputIOSProps, TextInputAndroidProps, AccessibilityProps {
@@ -1445,6 +1454,14 @@ export interface TextInputProps extends ViewProps, TextInputIOSProps, TextInputA
      */
     onSubmitEditing?: (e: NativeSyntheticEvent<TextInputSubmitEditingEventData>) => void;
 
+    /**
+     * Callback that is called on new text input with the argument 
+     *  `{ nativeEvent: { text, previousText, range: { start, end } } }`.
+     *
+     * This prop requires multiline={true} to be set.
+     */
+    onTextInput?: (e: NativeSyntheticEvent<TextInputTextInputEventData>) => void;
+    
     /**
      * Invoked on content scroll with
      *  `{ nativeEvent: { contentOffset: { x, y } } }`.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://reactnative.dev/docs/textinput#ontextinput
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
