### PR TITLE
[node-polyglot] fixed type for version 2.4.0 (added pluralRules)

### DIFF
--- a/types/node-polyglot/index.d.ts
+++ b/types/node-polyglot/index.d.ts
@@ -18,6 +18,11 @@ declare namespace Polyglot {
         suffix?: string;
     }
 
+    interface PluralRules {
+        pluralTypes: {[lang: string]: (n: number) => void};
+        pluralTypeToLanguages: {[lang: string]: string[]};
+    }
+
     interface PolyglotOptions {
         phrases?: any;
         locale?: string;
@@ -25,6 +30,7 @@ declare namespace Polyglot {
         onMissingKey?: (key: string, options: Polyglot.InterpolationOptions, locale: string) => string;
         warn?: (message: string) => void;
         interpolation?: InterpolationTokenOptions;
+        pluralRules?: PluralRules;
     }
 
     function transformPhrase(phrase: string, options?: number | Polyglot.InterpolationOptions, locale?: string): string;

--- a/types/node-polyglot/index.d.ts
+++ b/types/node-polyglot/index.d.ts
@@ -19,7 +19,7 @@ declare namespace Polyglot {
     }
 
     interface PluralRules {
-        pluralTypes: {[lang: string]: (n: number) => void};
+        pluralTypes: {[lang: string]: (n: number) => number};
         pluralTypeToLanguages: {[lang: string]: string[]};
     }
 

--- a/types/node-polyglot/node-polyglot-tests.ts
+++ b/types/node-polyglot/node-polyglot-tests.ts
@@ -29,6 +29,16 @@ function instantiatePolyglot(): void {
         interpolation: { prefix: '$[' },
     });
     var interpolationSuffixPolyglot = new Polyglot({ interpolation: { suffix: ']' } });
+    var pluralRulesPolyglot = new Polyglot({
+        pluralRules: {
+            pluralTypes: {
+                french: (n) => n > 1 ? 2 : n,
+            },
+            pluralTypeToLanguages: {
+                french: ['fr'],
+            }
+        }
+    });
 }
 
 function translate(): void {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [here](https://github.com/airbnb/polyglot.js/blob/v2.4.0/index.js#L216)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
