### PR TITLE
d3-dispatch - parameter `that` need not be an `EventTarget`

### DIFF
--- a/types/d3-dispatch/d3-dispatch-tests.ts
+++ b/types/d3-dispatch/d3-dispatch-tests.ts
@@ -15,7 +15,12 @@ interface Datum {
     b: string;
 }
 
+interface ContextObject {
+    about: string;
+}
+
 let dispatch: d3Dispatch.Dispatch<HTMLElement>;
+let dispatch2: d3Dispatch.Dispatch<ContextObject>;
 let callback: (this: HTMLElement, ...args: any[]) => void;
 let callbackOrUndef: ((this: HTMLElement, ...args: any[]) => void) | undefined;
 let undef: undefined;
@@ -24,6 +29,7 @@ let undef: undefined;
 
 // create new dispatch object
 dispatch = d3Dispatch.dispatch('foo', 'bar');
+dispatch2 = d3Dispatch.dispatch('start', 'end');
 
 function cbFn(this: HTMLElement, d: Datum, i: number) {
     console.log(this.baseURI ? this.baseURI : 'nada');
@@ -49,6 +55,8 @@ dispatch.on('bar', dispatch.on('bar')!);
 dispatch.call('foo');
 dispatch.call('foo', document.body);
 dispatch.call('foo', document.body, { a: 3, b: 'test' }, 1);
+
+dispatch2.call('start', {about: 'I am a context object'}, 'I am an argument');
 
 dispatch.apply('bar');
 dispatch.apply('bar', document.body);

--- a/types/d3-dispatch/index.d.ts
+++ b/types/d3-dispatch/index.d.ts
@@ -8,7 +8,7 @@
 
 // Last module patch version validated against: 1.0.3
 
-export interface Dispatch<T extends EventTarget> {
+export interface Dispatch<T> {
     /**
      * Like `function.apply`, invokes each registered callback for the specified type,
      * passing the callback the specified arguments, with `that` as the `this` context.
@@ -71,4 +71,4 @@ export interface Dispatch<T extends EventTarget> {
  * @param types The event types.
  * @throws "illegal type" on empty string or duplicated event types.
  */
-export function dispatch<T extends EventTarget>(...types: string[]): Dispatch<T>;
+export function dispatch<T>(...types: string[]): Dispatch<T>;

--- a/types/d3-dispatch/index.d.ts
+++ b/types/d3-dispatch/index.d.ts
@@ -8,7 +8,7 @@
 
 // Last module patch version validated against: 1.0.3
 
-export interface Dispatch<T> {
+export interface Dispatch<T extends object> {
     /**
      * Like `function.apply`, invokes each registered callback for the specified type,
      * passing the callback the specified arguments, with `that` as the `this` context.
@@ -71,4 +71,4 @@ export interface Dispatch<T> {
  * @param types The event types.
  * @throws "illegal type" on empty string or duplicated event types.
  */
-export function dispatch<T>(...types: string[]): Dispatch<T>;
+export function dispatch<T extends object>(...types: string[]): Dispatch<T>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-dispatch - use example as a test case that fails without this change.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

I am one of the maintainers of https://github.com/dc-js/dc.js. We are converting it to Typescript. I want to get the PR process right so that I can raise additional ones if I come across any other inconsistency.

Many thanks for your great work!
