### PR TITLE
Add type definitions for cxs-css/cxs

### DIFF
--- a/types/cxs/component/index.d.ts
+++ b/types/cxs/component/index.d.ts
@@ -1,4 +1,3 @@
-// Minimum TypeScript Version: 3.8
 import * as React from 'react';
 import { CSSObject } from '../index';
 

--- a/types/cxs/component/index.d.ts
+++ b/types/cxs/component/index.d.ts
@@ -1,9 +1,5 @@
-// Type definitions for cxs 6.2
-// Project: https://github.com/cxs-css/cxs
-// Definitions by: Daniel Eden <https://github.com/daneden>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-import { CSSObject } from 'cxs';
 import * as React from 'react';
+import { CSSObject } from '../index';
 
 type ApparentComponentProps<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -24,4 +20,4 @@ declare const cxsComponent: {
     ): (arg: CSSObject | ((arg: PropsType) => CSSObject)) => React.JSXElementConstructor<PropsType>;
 };
 
-export default cxsComponent;
+export = cxsComponent;

--- a/types/cxs/component/index.d.ts
+++ b/types/cxs/component/index.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for cxs 6.2
+// Project: https://github.com/cxs-css/cxs
+// Definitions by: Daniel Eden <https://github.com/daneden>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import { CSSObject } from 'cxs';
+import * as React from 'react';
+
+type ApparentComponentProps<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
+> = C extends React.JSXElementConstructor<infer P>
+    ? JSX.LibraryManagedAttributes<C, P>
+    : React.ComponentPropsWithRef<C>;
+
+declare const cxsComponent: {
+    <
+        Component extends
+            | keyof JSX.IntrinsicElements
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            | React.JSXElementConstructor<any>,
+        PropsType extends object & ApparentComponentProps<Component>
+    >(
+        component: Component,
+    ): (arg: CSSObject | ((arg: PropsType) => CSSObject)) => React.JSXElementConstructor<PropsType>;
+};
+
+export default cxsComponent;

--- a/types/cxs/component/index.d.ts
+++ b/types/cxs/component/index.d.ts
@@ -1,3 +1,4 @@
+// Minimum TypeScript Version: 3.8
 import * as React from 'react';
 import { CSSObject } from '../index';
 

--- a/types/cxs/cxs-tests.ts
+++ b/types/cxs/cxs-tests.ts
@@ -24,9 +24,9 @@ cxsComponent(ComponentA)({
 });
 
 /** React composition with props callback */
-type Props = {
+interface Props {
     isActive: boolean;
-};
+}
 
 const ComponentB = (props: Props) => React.createElement('div');
 

--- a/types/cxs/cxs-tests.ts
+++ b/types/cxs/cxs-tests.ts
@@ -11,14 +11,12 @@ cxs({
         color: 'green',
     },
 
-    // @ts-expect-error
     borderWidth: () => {}, // $ExpectError
 });
 
 cxsComponent('div')({
     fontSize: 24,
 
-    // @ts-expect-error
     content: {}, // $ExpectError
 });
 
@@ -29,7 +27,6 @@ cxsComponent(ComponentA)({
     fontSize: 72,
 });
 
-// @ts-expect-error
 cxsComponent(ComponentA)(true); // $ExpectError
 
 /** React composition with props callback */

--- a/types/cxs/cxs-tests.ts
+++ b/types/cxs/cxs-tests.ts
@@ -11,13 +11,15 @@ cxs({
         color: 'green',
     },
 
-    borderWidth: () => {}, // $ExpectError
+    // @ts-expect-error
+    borderWidth: () => {},
 });
 
 cxsComponent('div')({
     fontSize: 24,
 
-    content: {}, // $ExpectError
+    // @ts-expect-error
+    content: {},
 });
 
 /** React component composition */
@@ -27,7 +29,8 @@ cxsComponent(ComponentA)({
     fontSize: 72,
 });
 
-cxsComponent(ComponentA)(true); // $ExpectError
+// @ts-expect-error
+cxsComponent(ComponentA)(true);
 
 /** React composition with props callback */
 type Props = {

--- a/types/cxs/cxs-tests.ts
+++ b/types/cxs/cxs-tests.ts
@@ -10,16 +10,10 @@ cxs({
     ':hover': {
         color: 'green',
     },
-
-    // @ts-expect-error
-    borderWidth: () => {},
 });
 
 cxsComponent('div')({
     fontSize: 24,
-
-    // @ts-expect-error
-    content: {},
 });
 
 /** React component composition */
@@ -28,9 +22,6 @@ const ComponentA = () => React.createElement('div');
 cxsComponent(ComponentA)({
     fontSize: 72,
 });
-
-// @ts-expect-error
-cxsComponent(ComponentA)(true);
 
 /** React composition with props callback */
 type Props = {

--- a/types/cxs/cxs-tests.ts
+++ b/types/cxs/cxs-tests.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-const cxsComponent = require('./component');
-const cxs = require('./index');
+import cxsComponent = require('./component');
+import cxs = require('./index');
 
 /**
  * Standard calls to cxs to generate classNames
@@ -11,12 +11,14 @@ cxs({
         color: 'green',
     },
 
+    // @ts-expect-error
     borderWidth: () => {}, // $ExpectError
 });
 
 cxsComponent('div')({
     fontSize: 24,
 
+    // @ts-expect-error
     content: {}, // $ExpectError
 });
 
@@ -27,6 +29,7 @@ cxsComponent(ComponentA)({
     fontSize: 72,
 });
 
+// @ts-expect-error
 cxsComponent(ComponentA)(true); // $ExpectError
 
 /** React composition with props callback */

--- a/types/cxs/cxs-tests.ts
+++ b/types/cxs/cxs-tests.ts
@@ -1,6 +1,6 @@
-import cxs from 'cxs';
-import cxsComponent from 'cxs/component';
 import * as React from 'react';
+const cxsComponent = require('./component');
+const cxs = require('./index');
 
 /**
  * Standard calls to cxs to generate classNames
@@ -11,15 +11,13 @@ cxs({
         color: 'green',
     },
 
-    // @ts-expect-error
-    borderWidth: () => {},
+    borderWidth: () => {}, // $ExpectError
 });
 
 cxsComponent('div')({
     fontSize: 24,
 
-    // @ts-expect-error
-    content: {},
+    content: {}, // $ExpectError
 });
 
 /** React component composition */
@@ -29,8 +27,7 @@ cxsComponent(ComponentA)({
     fontSize: 72,
 });
 
-// @ts-expect-error
-cxsComponent(ComponentA)(true);
+cxsComponent(ComponentA)(true); // $ExpectError
 
 /** React composition with props callback */
 type Props = {
@@ -39,6 +36,6 @@ type Props = {
 
 const ComponentB = (props: Props) => React.createElement('div');
 
-cxsComponent(ComponentB)(props => ({
+cxsComponent(ComponentB)((props: Props) => ({
     color: props.isActive ? 'blue' : 'purple',
 }));

--- a/types/cxs/cxs-tests.ts
+++ b/types/cxs/cxs-tests.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import cxsComponent = require('./component');
-import cxs = require('./index');
+import cxsComponent = require('cxs/component');
+import cxs = require('cxs');
 
 /**
  * Standard calls to cxs to generate classNames

--- a/types/cxs/cxs-tests.ts
+++ b/types/cxs/cxs-tests.ts
@@ -1,0 +1,44 @@
+import cxs from 'cxs';
+import cxsComponent from 'cxs/component';
+import * as React from 'react';
+
+/**
+ * Standard calls to cxs to generate classNames
+ */
+cxs({
+    color: 'red',
+    ':hover': {
+        color: 'green',
+    },
+
+    // @ts-expect-error
+    borderWidth: () => {},
+});
+
+cxsComponent('div')({
+    fontSize: 24,
+
+    // @ts-expect-error
+    content: {},
+});
+
+/** React component composition */
+const ComponentA = () => React.createElement('div');
+
+cxsComponent(ComponentA)({
+    fontSize: 72,
+});
+
+// @ts-expect-error
+cxsComponent(ComponentA)(true);
+
+/** React composition with props callback */
+type Props = {
+    isActive: boolean;
+};
+
+const ComponentB = (props: Props) => React.createElement('div');
+
+cxsComponent(ComponentB)(props => ({
+    color: props.isActive ? 'blue' : 'purple',
+}));

--- a/types/cxs/index.d.ts
+++ b/types/cxs/index.d.ts
@@ -2,19 +2,20 @@
 // Project: https://github.com/cxs-css/cxs
 // Definitions by: Daniel Eden <https://github.com/daneden>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version 3.9
 import * as CSS from 'csstype';
 
-export type CSSProperties = CSS.Properties<string | number>;
-export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject };
+declare namespace cxs {
+    type CSSProperties = CSS.Properties<string | number>;
+    type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject };
 
-export interface CSSObject extends CSSProperties, CSSPseudos {
-    [key: string]: CSSObject | string | number | undefined;
+    export interface CSSObject extends CSSProperties, CSSPseudos {
+        [key: string]: CSSObject | string | number | undefined;
+    }
 }
 
-export type CSSKeyframes = object & { [key: string]: CSSObject };
-
 declare const cxs: {
-    (styles: CSSObject): string;
+    (styles: cxs.CSSObject): string;
     /** Returns cached CSS as a string for server-side rendering */
     css: () => string;
     /** Resets the CSS cache for future renders */
@@ -22,4 +23,5 @@ declare const cxs: {
     /** Sets a custom className prefix */
     prefix: (val: string) => void;
 };
-export default cxs;
+
+export = cxs;

--- a/types/cxs/index.d.ts
+++ b/types/cxs/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for cxs 6.2
+// Project: https://github.com/cxs-css/cxs
+// Definitions by: Daniel Eden <https://github.com/daneden>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import * as CSS from 'csstype';
+
+export type CSSProperties = CSS.Properties<string | number>;
+export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject };
+
+export interface CSSObject extends CSSProperties, CSSPseudos {
+    [key: string]: CSSObject | string | number | undefined;
+}
+
+export type CSSKeyframes = object & { [key: string]: CSSObject };
+
+declare const cxs: {
+    (styles: CSSObject): string;
+    /** Returns cached CSS as a string for server-side rendering */
+    css: () => string;
+    /** Resets the CSS cache for future renders */
+    reset: () => void;
+    /** Sets a custom className prefix */
+    prefix: (val: string) => void;
+};
+export default cxs;

--- a/types/cxs/index.d.ts
+++ b/types/cxs/index.d.ts
@@ -9,7 +9,7 @@ declare namespace cxs {
     type CSSProperties = CSS.Properties<string | number>;
     type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject };
 
-    export interface CSSObject extends CSSProperties, CSSPseudos {
+    interface CSSObject extends CSSProperties, CSSPseudos {
         [key: string]: CSSObject | string | number | undefined;
     }
 }

--- a/types/cxs/package.json
+++ b/types/cxs/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "csstype": "^2.2.0"
+    }
+}

--- a/types/cxs/tsconfig.json
+++ b/types/cxs/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "jsx": "react",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "cxs-tests.ts"]
+}

--- a/types/cxs/tsconfig.json
+++ b/types/cxs/tsconfig.json
@@ -9,7 +9,7 @@
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": ["../"],
-        "types": ["node"],
+        "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/cxs/tsconfig.json
+++ b/types/cxs/tsconfig.json
@@ -9,7 +9,7 @@
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": ["../"],
-        "types": [],
+        "types": ["node"],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/cxs/tslint.json
+++ b/types/cxs/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). **(NB: for some reason this is failing on the `react` types package on my machine, hoping that CI can give me some more clues)**

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.