### PR TITLE
[webpack] Argument "env" passed to configuration factories can be undefined

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -151,12 +151,12 @@ declare namespace webpack {
     }
 
     type ConfigurationFactory = ((
-        env: string | Record<string, boolean | number | string>,
+        env: string | Record<string, boolean | number | string> | undefined,
         args: CliConfigOptions,
     ) => Configuration | Promise<Configuration>);
 
     type MultiConfigurationFactory = ((
-        env: string | Record<string, boolean | number | string>,
+        env: string | Record<string, boolean | number | string> | undefined,
         args: CliConfigOptions,
     ) => Configuration[] | Promise<Configuration[]>);
 

--- a/types/webpack/test/index.ts
+++ b/types/webpack/test/index.ts
@@ -1234,3 +1234,13 @@ compiler.hooks.compilation.tap('SomePlugin', compilation => {
     stats.normalizeFieldKey('field'); // $ExpectType string
     stats.sortOrderRegular('!field'); // $ExpectType boolean
 });
+
+const config1: webpack.ConfigurationFactory = (env) => {
+    env; // $ExpectType string | Record<string, string | number | boolean> | undefined
+    return {};
+};
+
+const config2: webpack.MultiConfigurationFactory = (env) => {
+    env; // $ExpectType string | Record<string, string | number | boolean> | undefined
+    return [];
+};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (see below)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

Using this `webpack.config.js`:

```js
module.exports = (env, argv) => {
    console.log(typeof env);

    return {};
}
```

Running: `npx webpack` -> `undefined` logged.
Running: `npx webpack --env.x` -> `object` logged.

- Let me know if there is a better way of writing the tests.
- Linting may fail because of https://github.com/microsoft/dtslint/issues/299.