### PR TITLE
fix(sortablejs): missing `version` static property

### DIFF
--- a/types/sortablejs/index.d.ts
+++ b/types/sortablejs/index.d.ts
@@ -62,6 +62,9 @@ declare class Sortable {
     /** Get the Sortable instance on an element. */
     static get(element: HTMLElement): Sortable | undefined;
 
+    /** Get the Sortable version */
+    static readonly version: string;
+
     /**
      * Options getter/setter
      * @param name a Sortable.Options property.

--- a/types/sortablejs/sortablejs-tests.ts
+++ b/types/sortablejs/sortablejs-tests.ts
@@ -77,6 +77,8 @@ simpleList.innerHTML = Array.apply(null, new Array(10))
 
 Sortable.create(simpleList, {});
 
+Sortable.version; // $ExpectType string
+
 simpleList.innerHTML = Array.apply(null, new Array(100))
     .map(function(value: any, iterator: number) {
         return '<div class="list-group-item">item ' + (iterator + 1) + '</div>';


### PR DESCRIPTION
This adds `version` property that DT CI scripts complaints about.

https://github.com/SortableJS/Sortable/blob/master/src/Sortable.js#L1968
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45684#issuecomment-648745109

Thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)