### PR TITLE
fix(@types/styled-system__css): build performance issues with `css` function

### DIFF
--- a/types/styled-system__css/index.d.ts
+++ b/types/styled-system__css/index.d.ts
@@ -589,7 +589,8 @@ export interface ScaleThemeProperties {
  * If you're using variants in your theme, you can access them by using the `variant`
  * property. The value of the property has to correspond to a path of your `Theme`.
  */
-export function css(input?: SystemStyleObject): (props?: Theme | { theme: Theme }) => CSSObject;
+export type CssFunctionReturnType = (props?: Theme | { theme: Theme }) => CSSObject;
+export function css(input?: SystemStyleObject): CssFunctionReturnType;
 export default css;
 
 /**

--- a/types/styled-system__css/styled-system__css-tests.ts
+++ b/types/styled-system__css/styled-system__css-tests.ts
@@ -1,4 +1,4 @@
-import css, {CssFunctionReturnType, Theme} from '@styled-system/css';
+import css, { CssFunctionReturnType, Theme } from '@styled-system/css';
 
 const theme = {
     colors: {

--- a/types/styled-system__css/styled-system__css-tests.ts
+++ b/types/styled-system__css/styled-system__css-tests.ts
@@ -1,4 +1,4 @@
-import css, { Theme } from '@styled-system/css';
+import css, {CssFunctionReturnType, Theme} from '@styled-system/css';
 
 const theme = {
     colors: {
@@ -260,3 +260,5 @@ css({
         label: 'baz',
     },
 });
+
+const result: CssFunctionReturnType = css({});


### PR DESCRIPTION
When we intensively use the function `css`, typescript declaration files are really slow to compile and generated files are huge.

This is due to `css` return type being inlined for every usage of the function.

To fix the issue, we just export the return type, so it can be reused

Here is a reproduction https://github.com/ardeois/style-components-slow-compilation

|                   | Before |  After  |
| :---------: | :-----: | :-----: |
| Build time |  19s     | 3s |
| File size    |   1.2MB      | 9.1KB  |


> Note on an internal project using  `styled-system/css` our build takes 4 minutes, and is down to 30 seconds with this fix.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] ~Add or edit tests to reflect the change. (Run with `npm test`.)~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ardeois/style-components-slow-compilation
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [x] ~Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)~
- [x] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~