### PR TITLE
[@types/mailgun-js] Fix mailgun-js type to add multiple data to mailing list

### DIFF
--- a/types/mailgun-js/index.d.ts
+++ b/types/mailgun-js/index.d.ts
@@ -142,11 +142,11 @@ declare namespace Mailgun {
         }
 
         interface MemberAddMultipleData {
-            members: {
+            members: Array<{
                 name?: string;
                 address: string;
                 subscribed?: boolean;
-            }[];
+            }>;
             upsert?: boolean;
         }
 

--- a/types/mailgun-js/index.d.ts
+++ b/types/mailgun-js/index.d.ts
@@ -141,6 +141,15 @@ declare namespace Mailgun {
             vars?: object;
         }
 
+        interface MemberAddMultipleData {
+            members: {
+                name?: string;
+                address: string;
+                subscribed?: boolean;
+            }[];
+            upsert?: boolean;
+        }
+
         interface MemberUpdateData {
             subscribed: boolean;
             name: string;
@@ -150,7 +159,7 @@ declare namespace Mailgun {
         interface Members {
             create(data: MemberCreateData, callback?: (err: Error, data: any) => void): Promise<any>;
 
-            add(data: MemberCreateData[], callback?: (err: Error, data: any) => void): Promise<any>;
+            add(data: MemberAddMultipleData, callback?: (err: Error, data: any) => void): Promise<any>;
 
             list(callback?: (err: Error, data: any) => void): Promise<any>;
         }


### PR DESCRIPTION
Type definition to `add` multiple members to mailing lists was wrong.

Source:
https://www.npmjs.com/package/mailgun-js#creating-mailing-list-members

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://www.npmjs.com/package/mailgun-js#creating-mailing-list-members>>