### PR TITLE
Add types for greek-utils npm library

### DIFF
--- a/types/greek-utils/greek-utils-tests.ts
+++ b/types/greek-utils/greek-utils-tests.ts
@@ -1,0 +1,7 @@
+import * as greekUtils from 'greek-utils';
+
+greekUtils.toGreek('pame re Paokara');
+greekUtils.toGreeklish('πάμε ρε Παοκάρα');
+greekUtils.toPhoneticLatin('PAOK');
+greekUtils.toTransliteratedLatin('ksana');
+greekUtils.sanitizeDiacritics('oxi');

--- a/types/greek-utils/index.d.ts
+++ b/types/greek-utils/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/vbarzokas/greek-utils
 // Definitions by: Dimitris Kirtsios <https://github.com/dimkirt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version 3.9
 
 export function sanitizeDiacritics(text: string, ignore?: string): string;
 

--- a/types/greek-utils/index.d.ts
+++ b/types/greek-utils/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for greek-utils 1.2
+// Project: https://github.com/vbarzokas/greek-utils
+// Definitions by: Dimitris Kirtsios <https://github.com/dimkirt>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version 3.9
+
+export function sanitizeDiacritics(text: string, ignore?: string): string;
+
+export function toGreek(text: string, ignore?: string): string;
+
+export function toGreeklish(text: string, ignore?: string): string;
+
+export function toPhoneticLatin(text: string, ignore?: string): string;
+
+export function toTransliteratedLatin(text: string, ignore?: string): string;

--- a/types/greek-utils/tsconfig.json
+++ b/types/greek-utils/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "module": "commonjs",
+        "lib": ["es5"],
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": []
+    },
+    "files": [
+        "index.d.ts",
+        "greek-utils-tests.ts"
+    ]
+}

--- a/types/greek-utils/tslint.json
+++ b/types/greek-utils/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
