### PR TITLE
[@types/undercore] Object Tests - Type Checks

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -3818,7 +3818,7 @@ declare module _ {
          * to determine if they should be considered equal.
          * @param object Compare to `other`.
          * @param other Compare to `object`.
-         * @returns True if `object` is equal to `other`.
+         * @returns True if `object` should be considered equal to `other`.
          **/
         isEqual(object: any, other: any): boolean;
 
@@ -4850,7 +4850,7 @@ declare module _ {
          * Performs an optimized deep comparison between the wrapped object
          * and the provided object to determine if they should be considered equal.
          * @param other Compare to the wrapped object.
-         * @returns True if the wrapped object is equal to `other`.
+         * @returns True if the wrapped object should be considered equal to `other`.
          **/
         isEqual(other: any): boolean;
 
@@ -5815,7 +5815,7 @@ declare module _ {
          * Performs an optimized deep comparison between the wrapped object
          * and the provided object to determine if they should be considered equal.
          * @param other Compare to the wrapped object.
-         * @returns True if the wrapped object is equal to `other`.
+         * @returns True if the wrapped object should be considered equal to `other`.
          * The result will be wrapped in a chain wrapper.
          **/
         isEqual(other: any): _ChainSingle<boolean>;

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -3823,12 +3823,12 @@ declare module _ {
         isEqual(object: any, other: any): boolean;
 
         /**
-         * Returns true if an enumerable object contains no values (no enumerable own-properties).
+         * Returns true if a collection contains no values.
          * For strings and array-like objects checks if the length property is 0.
-         * @param object The object to check.
-         * @returns True if `object` is empty.
+         * @param collection The collection to check.
+         * @returns True if `collection` has no elements.
          **/
-        isEmpty(object: any): boolean;
+        isEmpty(collection: any): boolean;
 
         /**
          * Returns true if the keys and values in `properties` are contained in `object`.
@@ -4855,9 +4855,9 @@ declare module _ {
         isEqual(other: any): boolean;
 
         /**
-         * Returns true if an enumerable object contains no values (no enumerable own-properties).
+         * Returns true if the wrapped collection contains no values.
          * For strings and array-like objects checks if the length property is 0.
-         * @returns True if the wrapped object is empty.
+         * @returns True if the wrapped collection has no elements.
          **/
         isEmpty(): boolean;
 
@@ -5821,9 +5821,9 @@ declare module _ {
         isEqual(other: any): _ChainSingle<boolean>;
 
         /**
-         * Returns true if an enumerable object contains no values (no enumerable own-properties).
+         * Returns true if the wrapped collection contains no values.
          * For strings and array-like objects checks if the length property is 0.
-         * @returns True if the wrapped object is empty.
+         * @returns True if the wrapped collection has no elements.
          * The result will be wrapped in a chain wrapper.
          **/
         isEmpty(): _ChainSingle<boolean>;

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -3814,150 +3814,144 @@ declare module _ {
         propertyOf(object: object): (key: string | number | Array<string | number>) => any;
 
         /**
-        * Performs an optimized deep comparison between the two objects,
-        * to determine if they should be considered equal.
-        * @param object Compare to `other`.
-        * @param other Compare to `object`.
-        * @return True if `object` is equal to `other`.
-        **/
+         * Performs an optimized deep comparison between the two objects
+         * to determine if they should be considered equal.
+         * @param object Compare to `other`.
+         * @param other Compare to `object`.
+         * @returns True if `object` is equal to `other`.
+         **/
         isEqual(object: any, other: any): boolean;
 
         /**
-        * Returns true if object contains no values.
-        * @param object Check if this object has no properties or values.
-        * @return True if `object` is empty.
-        **/
+         * Returns true if an enumerable object contains no values (no enumerable own-properties).
+         * For strings and array-like objects checks if the length property is 0.
+         * @param object The object to check.
+         * @returns True if `object` is empty.
+         **/
         isEmpty(object: any): boolean;
 
         /**
-        * Returns true if the keys and values in `properties` matches with the `object` properties.
-        * @param object Object to be compared with `properties`.
-        * @param properties Properties be compared with `object`
-        * @return True if `object` has matching keys and values, otherwise false.
-        **/
+         * Tells you if the keys and values in properties are contained in object.
+         * @param object The object to check.
+         * @param properties The properties to check for in `object`.
+         * @returns True if all keys and values in `properties` are also in `object`.
+         **/
         isMatch(object: any, properties: any): boolean;
 
         /**
-        * Returns true if object is a DOM element.
-        * @param object Check if this object is a DOM element.
-        * @return True if `object` is a DOM element, otherwise false.
-        **/
+         * Returns true if object is a DOM element.
+         * @param object The object to check.
+         * @returns True if `object` is a DOM element, otherwise false.
+         **/
         isElement(object: any): object is Element;
 
         /**
-        * Returns true if object is an Array.
-        * @param object Check if this object is an Array.
-        * @return True if `object` is an Array, otherwise false.
-        **/
+         * Returns true if object is an Array.
+         * @param object The object to check.
+         * @returns True if `object` is an Array, otherwise false.
+         **/
         isArray(object: any): object is any[];
 
         /**
-        * Returns true if object is an Array.
-        * @param object Check if this object is an Array.
-        * @return True if `object` is an Array, otherwise false.
-        **/
-        isArray<T>(object: any): object is T[];
-
-        /**
          * Returns true if object is a Symbol.
-         * @param object Check if this object is a Symbol.
-         * @return True if `object` is a Symbol, otherwise false.
+         * @param object The object to check.
+         * @returns True if `object` is a Symbol, otherwise false.
          **/
         isSymbol(object: any): object is symbol;
 
         /**
-        * Returns true if value is an Object. Note that JavaScript arrays and functions are objects,
-        * while (normal) strings and numbers are not.
-        * @param object Check if this object is an Object.
-        * @return True of `object` is an Object, otherwise false.
-        **/
-        isObject(object: any): boolean;
+         * Returns true if object is an Object. Note that JavaScript arrays and functions are objects,
+         * while (normal) strings and numbers are not.
+         * @param object The object to check.
+         * @returns True if `object` is an Object, otherwise false.
+         **/
+        isObject(object: any): object is object;
 
         /**
-        * Returns true if object is an Arguments object.
-        * @param object Check if this object is an Arguments object.
-        * @return True if `object` is an Arguments object, otherwise false.
-        **/
+         * Returns true if object is an Arguments object.
+         * @param object The object to check.
+         * @returns True if `object` is an Arguments object, otherwise false.
+         **/
         isArguments(object: any): object is IArguments;
 
         /**
-        * Returns true if object is a Function.
-        * @param object Check if this object is a Function.
-        * @return True if `object` is a Function, otherwise false.
-        **/
+         * Returns true if object is a Function.
+         * @param object The object to check.
+         * @returns True if `object` is a Function, otherwise false.
+         **/
         isFunction(object: any): object is Function;
 
         /**
-        * Returns true if object inherits from an Error.
-        * @param object Check if this object is an Error.
-        * @return True if `object` is a Error, otherwise false.
-        **/
+         * Returns true if object is an Error.
+         * @param object The object to check.
+         * @returns True if `object` is a Error, otherwise false.
+         **/
         isError(object: any): object is Error;
 
         /**
-        * Returns true if object is a String.
-        * @param object Check if this object is a String.
-        * @return True if `object` is a String, otherwise false.
-        **/
+         * Returns true if object is a String.
+         * @param object The object to check.
+         * @returns True if `object` is a String, otherwise false.
+         **/
         isString(object: any): object is string;
 
         /**
-        * Returns true if object is a Number (including NaN).
-        * @param object Check if this object is a Number.
-        * @return True if `object` is a Number, otherwise false.
-        **/
+         * Returns true if object is a Number (including NaN).
+         * @param object The object to check.
+         * @returns True if `object` is a Number, otherwise false.
+         **/
         isNumber(object: any): object is number;
 
         /**
-        * Returns true if object is a finite Number.
-        * @param object Check if this object is a finite Number.
-        * @return True if `object` is a finite Number.
-        **/
+         * Returns true if object is a finite Number.
+         * @param object The object to check.
+         * @returns True if `object` is a finite Number.
+         **/
         isFinite(object: any): boolean;
 
         /**
-        * Returns true if object is either true or false.
-        * @param object Check if this object is a bool.
-        * @return True if `object` is a bool, otherwise false.
-        **/
+         * Returns true if object is a Boolean.
+         * @param object The object to check.
+         * @returns True if `object` is a Boolean, otherwise false.
+         **/
         isBoolean(object: any): object is boolean;
 
         /**
-        * Returns true if object is a Date.
-        * @param object Check if this object is a Date.
-        * @return True if `object` is a Date, otherwise false.
-        **/
+         * Returns true if object is a Date.
+         * @param object The object to check.
+         * @returns True if `object` is a Date, otherwise false.
+         **/
         isDate(object: any): object is Date;
 
         /**
-        * Returns true if object is a RegExp.
-        * @param object Check if this object is a RegExp.
-        * @return True if `object` is a RegExp, otherwise false.
-        **/
+         * Returns true if object is a RegExp.
+         * @param object The object to check.
+         * @returns True if `object` is a RegExp, otherwise false.
+         **/
         isRegExp(object: any): object is RegExp;
 
         /**
-        * Returns true if object is NaN.
-        * Note: this is not the same as the native isNaN function,
-        * which will also return true if the variable is undefined.
-        * @param object Check if this object is NaN.
-        * @return True if `object` is NaN, otherwise false.
-        **/
+         * Returns true if object is NaN.
+         * Note: this is not the same as the native isNaN function,
+         * which will also return true if the variable is undefined.
+         * @param object The object to check.
+         * @returns True if `object` is NaN, otherwise false.
+         **/
         isNaN(object: any): boolean;
 
         /**
-        * Returns true if the value of object is null.
-        * @param object Check if this object is null.
-        * @return True if `object` is null, otherwise false.
-        **/
-        isNull(object: any): boolean;
+         * Returns true if object is null.
+         * @param object The object to check.
+         * @returns True if `object` is null, otherwise false.
+         **/
+        isNull(object: any): object is null;
 
         /**
-        * Returns true if value is undefined.
-        * @param object Check if this object is undefined.
-        * @return True if `object` is undefined, otherwise false.
-        **/
-        isUndefined(value: any): boolean;
+         * Returns true if object is undefined.
+         * @param object The object to check.
+         * @returns True if `object` is undefined, otherwise false.
+         **/
+        isUndefined(object: any): object is undefined;
 
         /* *********
         * Utility *
@@ -4853,117 +4847,124 @@ declare module _ {
         propertyOf(): (key: string) => any;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isEqual
-        **/
+         * Performs an optimized deep comparison between the wrapped object
+         * and the provided object to determine if they should be considered equal.
+         * @param other Compare to the wrapped object.
+         * @returns True if the wrapped object is equal to `other`.
+         **/
         isEqual(other: any): boolean;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isEmpty
-        **/
+         * Returns true if an enumerable object contains no values (no enumerable own-properties).
+         * For strings and array-like objects checks if the length property is 0.
+         * @returns True if the wrapped object is empty.
+         **/
         isEmpty(): boolean;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isMatch
-        **/
-        isMatch(): boolean;
+         * Tells you if the keys and values in properties are contained in the wrapped object.
+         * @param properties The properties to check for in the wrapped object.
+         * @returns True if all keys and values in `properties` are also in the wrapped object.
+         **/
+        isMatch(properties: any): boolean;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isElement
-        **/
+         * Returns true if the wrapped object is a DOM element.
+         * @returns True if the wrapped object is a DOM element, otherwise false.
+         **/
         isElement(): boolean;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isArray
-        **/
+         * Returns true if the wrapped object is an Array.
+         * @returns True if the wrapped object is an Array, otherwise false.
+         **/
         isArray(): boolean;
 
         /**
-         * Wrapped type `object`.
-         * @see _.isSymbol
+         * Returns true if the wrapped object is a Symbol.
+         * @returns True if the wrapped object is a Symbol, otherwise false.
          **/
         isSymbol(): boolean;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isObject
-        **/
+         * Returns true if the wrapped object is an Object. Note that JavaScript arrays
+         * and functions are objects, while (normal) strings and numbers are not.
+         * @returns True if the wrapped object is an Object, otherwise false.
+         **/
         isObject(): boolean;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isArguments
-        **/
+         * Returns true if the wrapped object is an Arguments object.
+         * @returns True if the wrapped object is an Arguments object, otherwise false.
+         **/
         isArguments(): boolean;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isFunction
-        **/
+         * Returns true if the wrapped object is a Function.
+         * @returns True if the wrapped object is a Function, otherwise false.
+         **/
         isFunction(): boolean;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isError
-        **/
+         * Returns true if the wrapped object is a Error.
+         * @returns True if the wrapped object is a Error, otherwise false.
+         **/
         isError(): boolean;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isString
-        **/
+         * Returns true if the wrapped object is a String.
+         * @returns True if the wrapped object is a String, otherwise false.
+         **/
         isString(): boolean;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isNumber
-        **/
+         * Returns true if the wrapped object is a Number (including NaN).
+         * @returns True if the wrapped object is a Number, otherwise false.
+         **/
         isNumber(): boolean;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isFinite
-        **/
+         * Returns true if the wrapped object is a finite Number.
+         * @returns True if the wrapped object is a finite Number.
+         **/
         isFinite(): boolean;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isBoolean
-        **/
+         * Returns true if the wrapped object is a Boolean.
+         * @returns True if the wrapped object is a Boolean, otherwise false.
+         **/
         isBoolean(): boolean;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isDate
-        **/
+         * Returns true if the wrapped object is a Date.
+         * @returns True if the wrapped object is a Date, otherwise false.
+         **/
         isDate(): boolean;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isRegExp
-        **/
+         * Returns true if the wrapped object is a RegExp.
+         * @returns True if the wrapped object is a RegExp, otherwise false.
+         **/
         isRegExp(): boolean;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isNaN
-        **/
+         * Returns true if the wrapped object is NaN.
+         * Note: this is not the same as the native isNaN function,
+         * which will also return true if the variable is undefined.
+         * @returns True if the wrapped object is NaN, otherwise false.
+         **/
         isNaN(): boolean;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isNull
-        **/
+         * Returns true if the wrapped object is null.
+         * @returns True if the wrapped object is null, otherwise false.
+         **/
         isNull(): boolean;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isUndefined
-        **/
+         * Returns true if the wrapped object is undefined.
+         * @returns True if the wrapped object is undefined, otherwise false.
+         **/
         isUndefined(): boolean;
 
         /********* *
@@ -5811,118 +5812,144 @@ declare module _ {
         propertyOf(): _Chain<T>;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isEqual
-        **/
-        isEqual(other: any): _Chain<T>;
+         * Performs an optimized deep comparison between the wrapped object
+         * and the provided object to determine if they should be considered equal.
+         * @param other Compare to the wrapped object.
+         * @returns True if the wrapped object is equal to `other`.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        isEqual(other: any): _ChainSingle<boolean>;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isEmpty
-        **/
-        isEmpty(): _Chain<T>;
+         * Returns true if an enumerable object contains no values (no enumerable own-properties).
+         * For strings and array-like objects checks if the length property is 0.
+         * @returns True if the wrapped object is empty.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        isEmpty(): _ChainSingle<boolean>;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isMatch
-        **/
-        isMatch(): _Chain<T>;
+         * Tells you if the keys and values in properties are contained in the wrapped object.
+         * @param properties The properties to check for in the wrapped object.
+         * @returns True if all keys and values in `properties` are also in the wrapped object.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        isMatch(properties: any): _ChainSingle<boolean>;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isElement
-        **/
-        isElement(): _Chain<T>;
+         * Returns true if the wrapped object is a DOM element.
+         * @returns True if the wrapped object is a DOM element, otherwise false.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        isElement(): _ChainSingle<boolean>;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isArray
-        **/
-        isArray(): _Chain<T>;
+         * Returns true if the wrapped object is an Array.
+         * @returns True if the wrapped object is an Array, otherwise false.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        isArray(): _ChainSingle<boolean>;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isSymbol
-        **/
-        isSymbol(): _Chain<T>;
+         * Returns true if the wrapped object is a Symbol.
+         * @returns True if the wrapped object is a Symbol, otherwise false.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        isSymbol(): _ChainSingle<boolean>;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isObject
-        **/
-        isObject(): _Chain<T>;
+         * Returns true if the wrapped object is an Object. Note that JavaScript arrays
+         * and functions are objects, while (normal) strings and numbers are not.
+         * @returns True if the wrapped object is an Object, otherwise false.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        isObject(): _ChainSingle<boolean>;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isArguments
-        **/
-        isArguments(): _Chain<T>;
+         * Returns true if the wrapped object is an Arguments object.
+         * @returns True if the wrapped object is an Arguments object, otherwise false.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        isArguments(): _ChainSingle<boolean>;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isFunction
-        **/
-        isFunction(): _Chain<T>;
+         * Returns true if the wrapped object is a Function.
+         * @returns True if the wrapped object is a Function, otherwise false.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        isFunction(): _ChainSingle<boolean>;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isError
-        **/
-        isError(): _Chain<T>;
+         * Returns true if the wrapped object is a Error.
+         * @returns True if the wrapped object is a Error, otherwise false.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        isError(): _ChainSingle<boolean>;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isString
-        **/
-        isString(): _Chain<T>;
+         * Returns true if the wrapped object is a String.
+         * @returns True if the wrapped object is a String, otherwise false.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        isString(): _ChainSingle<boolean>;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isNumber
-        **/
-        isNumber(): _Chain<T>;
+         * Returns true if the wrapped object is a Number (including NaN).
+         * @returns True if the wrapped object is a Number, otherwise false.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        isNumber(): _ChainSingle<boolean>;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isFinite
-        **/
-        isFinite(): _Chain<T>;
+         * Returns true if the wrapped object is a finite Number.
+         * @returns True if the wrapped object is a finite Number.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        isFinite(): _ChainSingle<boolean>;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isBoolean
-        **/
-        isBoolean(): _Chain<T>;
+         * Returns true if the wrapped object is a Boolean.
+         * @returns True if the wrapped object is a Boolean, otherwise false.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        isBoolean(): _ChainSingle<boolean>;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isDate
-        **/
-        isDate(): _Chain<T>;
+         * Returns true if the wrapped object is a Date.
+         * @returns True if the wrapped object is a Date, otherwise false.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        isDate(): _ChainSingle<boolean>;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isRegExp
-        **/
-        isRegExp(): _Chain<T>;
+         * Returns true if the wrapped object is a RegExp.
+         * @returns True if the wrapped object is a RegExp, otherwise false.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        isRegExp(): _ChainSingle<boolean>;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isNaN
-        **/
-        isNaN(): _Chain<T>;
+         * Returns true if the wrapped object is NaN.
+         * Note: this is not the same as the native isNaN function,
+         * which will also return true if the variable is undefined.
+         * @returns True if the wrapped object is NaN, otherwise false.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        isNaN(): _ChainSingle<boolean>;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isNull
-        **/
-        isNull(): _Chain<T>;
+         * Returns true if the wrapped object is null.
+         * @returns True if the wrapped object is null, otherwise false.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        isNull(): _ChainSingle<boolean>;
 
         /**
-        * Wrapped type `object`.
-        * @see _.isUndefined
-        **/
-        isUndefined(): _Chain<T>;
+         * Returns true if the wrapped object is undefined.
+         * @returns True if the wrapped object is undefined, otherwise false.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        isUndefined(): _ChainSingle<boolean>;
 
         /********* *
          * Utility *

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -3865,7 +3865,7 @@ declare module _ {
          * @param object The object to check.
          * @returns True if `object` is an Object, otherwise false.
          **/
-        isObject(object: any): object is object;
+        isObject(object: any): boolean;
 
         /**
          * Returns true if `object` is an Arguments object.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -3823,7 +3823,7 @@ declare module _ {
         isEqual(object: any, other: any): boolean;
 
         /**
-         * Returns true if a collection contains no values.
+         * Returns true if `collection` contains no values.
          * For strings and array-like objects checks if the length property is 0.
          * @param collection The collection to check.
          * @returns True if `collection` has no elements.
@@ -3839,28 +3839,28 @@ declare module _ {
         isMatch(object: any, properties: any): boolean;
 
         /**
-         * Returns true if object is a DOM element.
+         * Returns true if `object` is a DOM element.
          * @param object The object to check.
          * @returns True if `object` is a DOM element, otherwise false.
          **/
         isElement(object: any): object is Element;
 
         /**
-         * Returns true if object is an Array.
+         * Returns true if `object` is an Array.
          * @param object The object to check.
          * @returns True if `object` is an Array, otherwise false.
          **/
         isArray(object: any): object is any[];
 
         /**
-         * Returns true if object is a Symbol.
+         * Returns true if `object` is a Symbol.
          * @param object The object to check.
          * @returns True if `object` is a Symbol, otherwise false.
          **/
         isSymbol(object: any): object is symbol;
 
         /**
-         * Returns true if object is an Object. Note that JavaScript arrays and functions are objects,
+         * Returns true if `object` is an Object. Note that JavaScript arrays and functions are objects,
          * while (normal) strings and numbers are not.
          * @param object The object to check.
          * @returns True if `object` is an Object, otherwise false.
@@ -3868,70 +3868,70 @@ declare module _ {
         isObject(object: any): object is object;
 
         /**
-         * Returns true if object is an Arguments object.
+         * Returns true if `object` is an Arguments object.
          * @param object The object to check.
          * @returns True if `object` is an Arguments object, otherwise false.
          **/
         isArguments(object: any): object is IArguments;
 
         /**
-         * Returns true if object is a Function.
+         * Returns true if `object` is a Function.
          * @param object The object to check.
          * @returns True if `object` is a Function, otherwise false.
          **/
         isFunction(object: any): object is Function;
 
         /**
-         * Returns true if object is an Error.
+         * Returns true if `object` is an Error.
          * @param object The object to check.
          * @returns True if `object` is a Error, otherwise false.
          **/
         isError(object: any): object is Error;
 
         /**
-         * Returns true if object is a String.
+         * Returns true if `object` is a String.
          * @param object The object to check.
          * @returns True if `object` is a String, otherwise false.
          **/
         isString(object: any): object is string;
 
         /**
-         * Returns true if object is a Number (including NaN).
+         * Returns true if `object` is a Number (including NaN).
          * @param object The object to check.
          * @returns True if `object` is a Number, otherwise false.
          **/
         isNumber(object: any): object is number;
 
         /**
-         * Returns true if object is a finite Number.
+         * Returns true if `object` is a finite Number.
          * @param object The object to check.
          * @returns True if `object` is a finite Number.
          **/
         isFinite(object: any): boolean;
 
         /**
-         * Returns true if object is a Boolean.
+         * Returns true if `object` is a Boolean.
          * @param object The object to check.
          * @returns True if `object` is a Boolean, otherwise false.
          **/
         isBoolean(object: any): object is boolean;
 
         /**
-         * Returns true if object is a Date.
+         * Returns true if `object` is a Date.
          * @param object The object to check.
          * @returns True if `object` is a Date, otherwise false.
          **/
         isDate(object: any): object is Date;
 
         /**
-         * Returns true if object is a RegExp.
+         * Returns true if `object` is a RegExp.
          * @param object The object to check.
          * @returns True if `object` is a RegExp, otherwise false.
          **/
         isRegExp(object: any): object is RegExp;
 
         /**
-         * Returns true if object is NaN.
+         * Returns true if `object` is NaN.
          * Note: this is not the same as the native isNaN function,
          * which will also return true if the variable is undefined.
          * @param object The object to check.
@@ -3940,14 +3940,14 @@ declare module _ {
         isNaN(object: any): boolean;
 
         /**
-         * Returns true if object is null.
+         * Returns true if `object` is null.
          * @param object The object to check.
          * @returns True if `object` is null, otherwise false.
          **/
         isNull(object: any): object is null;
 
         /**
-         * Returns true if object is undefined.
+         * Returns true if `object` is undefined.
          * @param object The object to check.
          * @returns True if `object` is undefined, otherwise false.
          **/

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -3865,7 +3865,7 @@ declare module _ {
          * @param object The object to check.
          * @returns True if `object` is an Object, otherwise false.
          **/
-        isObject(object: any): boolean;
+        isObject(object: any): object is Dictionary<any> & object;
 
         /**
          * Returns true if `object` is an Arguments object.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -3831,7 +3831,7 @@ declare module _ {
         isEmpty(object: any): boolean;
 
         /**
-         * Tells you if the keys and values in properties are contained in object.
+         * Returns true if the keys and values in `properties` are contained in `object`.
          * @param object The object to check.
          * @param properties The properties to check for in `object`.
          * @returns True if all keys and values in `properties` are also in `object`.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -3814,7 +3814,7 @@ declare module _ {
         propertyOf(object: object): (key: string | number | Array<string | number>) => any;
 
         /**
-         * Performs an optimized deep comparison between the two objects
+         * Performs an optimized deep comparison between `object` and `other`
          * to determine if they should be considered equal.
          * @param object Compare to `other`.
          * @param other Compare to `object`.
@@ -4848,7 +4848,7 @@ declare module _ {
 
         /**
          * Performs an optimized deep comparison between the wrapped object
-         * and the provided object to determine if they should be considered equal.
+         * and `other` to determine if they should be considered equal.
          * @param other Compare to the wrapped object.
          * @returns True if the wrapped object should be considered equal to `other`.
          **/
@@ -4862,7 +4862,7 @@ declare module _ {
         isEmpty(): boolean;
 
         /**
-         * Tells you if the keys and values in properties are contained in the wrapped object.
+         * Returns true if the keys and values in `properties` are contained in the wrapped object.
          * @param properties The properties to check for in the wrapped object.
          * @returns True if all keys and values in `properties` are also in the wrapped object.
          **/
@@ -5813,7 +5813,7 @@ declare module _ {
 
         /**
          * Performs an optimized deep comparison between the wrapped object
-         * and the provided object to determine if they should be considered equal.
+         * and `other` to determine if they should be considered equal.
          * @param other Compare to the wrapped object.
          * @returns True if the wrapped object should be considered equal to `other`.
          * The result will be wrapped in a chain wrapper.
@@ -5829,7 +5829,7 @@ declare module _ {
         isEmpty(): _ChainSingle<boolean>;
 
         /**
-         * Tells you if the keys and values in properties are contained in the wrapped object.
+         * Returns true if the keys and values in `properties` are contained in the wrapped object.
          * @param properties The properties to check for in the wrapped object.
          * @returns True if all keys and values in `properties` are also in the wrapped object.
          * The result will be wrapped in a chain wrapper.

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -685,6 +685,8 @@ declare const mixedIterabilityValue: number | number[];
 declare const anyValue: any;
 declare const neverValue: never;
 declare const maybeFunction: (() => void) | undefined;
+declare const maybeStringArray: string[] | undefined;
+declare const stringy: StringRecord | string;
 
 // avoid referencing types under test directly by translating them to other types to avoid needing to make lots of changes if
 // the types under test need to be refactored
@@ -1093,7 +1095,18 @@ declare const extractChainTypes: ChainTypeExtractor;
 
 // isObject
 {
-    _.isObject(anyValue); // $ExpectType boolean
+    if (_.isObject(anyValue)) {
+        anyValue; // $ExpectType Dictionary<any> & object
+        anyValue.propertyName; // $ExpectType any
+        anyValue[3]; // $ExpectType any
+        _.map(anyValue, i => i); // $ExpectType any[]
+    }
+
+    _.isObject(stringy) ? stringy : neverValue // $ExpectType StringRecord
+    _.isObject(maybeStringArray) ? maybeStringArray : neverValue; // $ExpectType string[]
+    _.isObject(maybeFunction) ? maybeFunction : neverValue; // $ExpectType () => void
+    _.isObject(simpleString) ? simpleString : neverValue; // $ExpectType never
+
     _(anyValue).isObject(); // $ExpectType boolean
     extractChainTypes(_.chain(anyValue).isObject()); // $ExpectType ChainType<boolean, never>
 }

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -683,6 +683,7 @@ const simpleNumber = 7;
 
 declare const mixedIterabilityValue: number | number[];
 declare const anyValue: any;
+declare const neverValue: never;
 declare const maybeFunction: (() => void) | undefined
 
 // avoid referencing types under test directly by translating them to other types to avoid needing to make lots of changes if
@@ -1071,63 +1072,63 @@ declare const extractChainTypes: ChainTypeExtractor;
 
 // isElement
 {
-    _.isElement(anyValue) ? anyValue : undefined; // $ExpectType Element | undefined
+    _.isElement(anyValue) ? anyValue : neverValue; // $ExpectType Element
     _(anyValue).isElement(); // $ExpectType boolean
     extractChainTypes(_.chain(anyValue).isElement()); // $ExpectType ChainType<boolean, never>
 }
 
 // isArray
 {
-    _.isArray(anyValue) ? anyValue : undefined; // $ExpectType any[] | undefined
+    _.isArray(anyValue) ? anyValue : neverValue; // $ExpectType any[]
     _(anyValue).isArray(); // $ExpectType boolean
     extractChainTypes(_.chain(anyValue).isArray()); // $ExpectType ChainType<boolean, never>
 }
 
 // isSymbol
 {
-    _.isSymbol(anyValue) ? anyValue : undefined; // $ExpectType symbol | undefined
+    _.isSymbol(anyValue) ? anyValue : neverValue; // $ExpectType symbol
     _(anyValue).isSymbol(); // $ExpectType boolean
     extractChainTypes(_.chain(anyValue).isSymbol()); // $ExpectType ChainType<boolean, never>
 }
 
 // isObject
 {
-    _.isObject(anyValue) ? anyValue : undefined; // $ExpectType object | undefined
+    _.isObject(anyValue) ? anyValue : neverValue; // $ExpectType object
     _(anyValue).isObject(); // $ExpectType boolean
     extractChainTypes(_.chain(anyValue).isObject()); // $ExpectType ChainType<boolean, never>
 }
 
 // isArguments
 {
-    _.isArguments(anyValue) ? anyValue : undefined; // $ExpectType IArguments | undefined
+    _.isArguments(anyValue) ? anyValue : neverValue; // $ExpectType IArguments
     _(anyValue).isArguments(); // $ExpectType boolean
     extractChainTypes(_.chain(anyValue).isArguments()); // $ExpectType ChainType<boolean, never>
 }
 
 // isFunction
 {
-    _.isFunction(maybeFunction) ? maybeFunction : null; // $ExpectType (() => void) | null
+    _.isFunction(maybeFunction) ? maybeFunction : neverValue; // $ExpectType () => void
     _(anyValue).isFunction(); // $ExpectType boolean
     extractChainTypes(_.chain(anyValue).isFunction()); // $ExpectType ChainType<boolean, never>
 }
 
 // isError
 {
-    _.isError(anyValue) ? anyValue : undefined; // $ExpectType Error | undefined
+    _.isError(anyValue) ? anyValue : neverValue; // $ExpectType Error
     _(anyValue).isError(); // $ExpectType boolean
     extractChainTypes(_.chain(anyValue).isError()); // $ExpectType ChainType<boolean, never>
 }
 
 // isString
 {
-    _.isString(anyValue) ? anyValue : undefined; // $ExpectType string | undefined
+    _.isString(anyValue) ? anyValue : neverValue; // $ExpectType string
     _(anyValue).isString(); // $ExpectType boolean
     extractChainTypes(_.chain(anyValue).isString()); // $ExpectType ChainType<boolean, never>
 }
 
 // isNumber
 {
-    _.isNumber(anyValue) ? anyValue : undefined; // $ExpectType number | undefined
+    _.isNumber(anyValue) ? anyValue : neverValue; // $ExpectType number
     _(anyValue).isNumber(); // $ExpectType boolean
     extractChainTypes(_.chain(anyValue).isNumber()); // $ExpectType ChainType<boolean, never>
 }
@@ -1141,21 +1142,21 @@ declare const extractChainTypes: ChainTypeExtractor;
 
 // isBoolean
 {
-    _.isBoolean(anyValue) ? anyValue : undefined; // $ExpectType boolean | undefined
+    _.isBoolean(anyValue) ? anyValue : neverValue; // $ExpectType boolean
     _(anyValue).isBoolean(); // $ExpectType boolean
     extractChainTypes(_.chain(anyValue).isBoolean()); // $ExpectType ChainType<boolean, never>
 }
 
 // isDate
 {
-    _.isDate(anyValue) ? anyValue : undefined; // $ExpectType Date | undefined
+    _.isDate(anyValue) ? anyValue : neverValue; // $ExpectType Date
     _(anyValue).isDate(); // $ExpectType boolean
     extractChainTypes(_.chain(anyValue).isDate()); // $ExpectType ChainType<boolean, never>
 }
 
 // isRegExp
 {
-    _.isRegExp(anyValue) ? anyValue : undefined; // $ExpectType RegExp | undefined
+    _.isRegExp(anyValue) ? anyValue : neverValue; // $ExpectType RegExp
     _(anyValue).isRegExp(); // $ExpectType boolean
     extractChainTypes(_.chain(anyValue).isRegExp()); // $ExpectType ChainType<boolean, never>
 }
@@ -1169,14 +1170,14 @@ declare const extractChainTypes: ChainTypeExtractor;
 
 // isNull
 {
-    _.isNull(anyValue) ? anyValue : undefined; // $ExpectType null | undefined
+    _.isNull(anyValue) ? anyValue : neverValue; // $ExpectType null
     _(anyValue).isNull(); // $ExpectType boolean
     extractChainTypes(_.chain(anyValue).isNull()); // $ExpectType ChainType<boolean, never>
 }
 
 // isUndefined
 {
-    _.isUndefined(anyValue) ? anyValue : null; // $ExpectType null | undefined
+    _.isUndefined(anyValue) ? anyValue : neverValue; // $ExpectType undefined
     _(anyValue).isUndefined(); // $ExpectType boolean
     extractChainTypes(_.chain(anyValue).isUndefined()); // $ExpectType ChainType<boolean, never>
 }

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1178,6 +1178,7 @@ declare const extractChainTypes: ChainTypeExtractor;
 // isUndefined
 {
     _.isUndefined(anyValue) ? anyValue : neverValue; // $ExpectType undefined
+    _.isUndefined(maybeFunction) ? neverValue : maybeFunction; // $ExpectType () => void
     _(anyValue).isUndefined(); // $ExpectType boolean
     extractChainTypes(_.chain(anyValue).isUndefined()); // $ExpectType ChainType<boolean, never>
 }

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -431,81 +431,10 @@ _.chain([1, 2, 3, 200])
 _.has({ a: 1, b: 2, c: 3 }, "b");
 
 var moe = { name: 'moe', luckyNumbers: [13, 27, 34] };
-var clone = { name: 'moe', luckyNumbers: [13, 27, 34] };
-moe == clone;
-_.isEqual(moe, clone);
-
-_.isEmpty([1, 2, 3]);
-_.isEmpty({});
-
-_.isElement($('body')[0]);
-
-(function () { return _.isArray(arguments); })();
-_.isArray([1, 2, 3]);
-
-_.isObject({});
-_.isObject(1);
 
 _.property('name')(moe);
 _.property(['name'])(moe);
 _.property(['luckyNumbers', 2])(moe)
-
-// (() => { return _.isArguments(arguments); })(1, 2, 3);
-_.isArguments([1, 2, 3]);
-
-_.isFunction(alert);
-
-_.isString("moe");
-
-_.isNumber(8.4 * 5);
-
-_.isFinite(-101);
-
-_.isFinite(-Infinity);
-
-_.isBoolean(null);
-
-_.isDate(new Date());
-
-_.isRegExp(/moe/);
-
-_.isNaN(NaN);
-_.isNaN(undefined);
-
-_.isNull(null);
-_.isNull(undefined);
-
-_.isUndefined((window).missingVariable);
-
-//////////////////////////////////// User Defined Guard tests
-
-function useElement(arg: Element) {};
-function useArguments(arg: IArguments) {};
-function useFunction(arg: Function) {};
-function useError(arg: Error) {};
-function useString(arg: String) {};
-function useNumber(arg: Number) {};
-function useBoolean(arg: Boolean) {};
-function useDate(arg: Date) {};
-function useRegExp(arg: RegExp) {};
-function useArray<T>(arg: T[]) {};
-function useSymbol(arg: symbol) {};
-
-var guardedType: {} = {};
-if(_.isElement(guardedType)) useElement(guardedType);
-if(_.isArray(guardedType)) useArray(guardedType);
-if(_.isArray<String>(guardedType)) useArray(guardedType);
-if(_.isArguments(guardedType)) useArguments(guardedType);
-if(_.isFunction(guardedType)) useFunction(guardedType);
-if(_.isError(guardedType)) useError(guardedType);
-if(_.isString(guardedType)) useString(guardedType);
-if(_.isNumber(guardedType)) useNumber(guardedType);
-if(_.isBoolean(guardedType)) useBoolean(guardedType);
-if(_.isDate(guardedType)) useDate(guardedType);
-if(_.isRegExp(guardedType)) useRegExp(guardedType);
-if(_.isSymbol(guardedType)) useSymbol(guardedType);
-
-///////////////////////////////////////////////////////////////////////////////////////
 
 var UncleMoe = { name: 'moe' };
 _.constant(UncleMoe)();

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1100,6 +1100,7 @@ declare const extractChainTypes: ChainTypeExtractor;
         anyValue.propertyName; // $ExpectType any
         anyValue[3]; // $ExpectType any
         _.map(anyValue, i => i); // $ExpectType any[]
+        _.isFunction(anyValue) ? anyValue : neverValue; // $ExpectType Function
     }
 
     _.isObject(stringy) ? stringy : neverValue // $ExpectType StringRecord

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -754,6 +754,7 @@ const simpleNumber = 7;
 
 declare const mixedIterabilityValue: number | number[];
 declare const anyValue: any;
+declare const maybeFunction: (() => void) | undefined
 
 // avoid referencing types under test directly by translating them to other types to avoid needing to make lots of changes if
 // the types under test need to be refactored
@@ -1114,6 +1115,141 @@ declare const extractChainTypes: ChainTypeExtractor;
     _([{a: 'a'}, {a: 'b'}]).findLastIndex({ a: 'b' }); // $ExpectType number
     _.chain([1, 2, 3, 1, 2, 3]).findLastIndex(num => num % 2 === 0).value(); // $ExpectType number
     _.chain([{a: 'a'}, {a: 'b'}]).findLastIndex({ a: 'b' }).value(); // $ExpectType number
+}
+
+// Objects
+
+// isEqual
+{
+    _.isEqual(anyValue, anyValue); // $ExpectType boolean
+    _(anyValue).isEqual(anyValue); // $ExpectType boolean
+    extractChainTypes(_.chain(anyValue).isEqual(anyValue)); // $ExpectType ChainType<boolean, never>
+}
+
+// isEmpty
+{
+    _.isEmpty(anyValue); // $ExpectType boolean
+    _(anyValue).isEmpty(); // $ExpectType boolean
+    extractChainTypes(_.chain(anyValue).isEmpty()); // $ExpectType ChainType<boolean, never>
+}
+
+// isMatch
+{
+    _.isMatch(anyValue, anyValue); // $ExpectType boolean
+    _(anyValue).isMatch(anyValue); // $ExpectType boolean
+    extractChainTypes(_.chain(anyValue).isMatch(anyValue)); // $ExpectType ChainType<boolean, never>
+}
+
+// isElement
+{
+    _.isElement(anyValue) ? anyValue : undefined; // $ExpectType Element | undefined
+    _(anyValue).isElement(); // $ExpectType boolean
+    extractChainTypes(_.chain(anyValue).isElement()); // $ExpectType ChainType<boolean, never>
+}
+
+// isArray
+{
+    _.isArray(anyValue) ? anyValue : undefined; // $ExpectType any[] | undefined
+    _(anyValue).isArray(); // $ExpectType boolean
+    extractChainTypes(_.chain(anyValue).isArray()); // $ExpectType ChainType<boolean, never>
+}
+
+// isSymbol
+{
+    _.isSymbol(anyValue) ? anyValue : undefined; // $ExpectType symbol | undefined
+    _(anyValue).isSymbol(); // $ExpectType boolean
+    extractChainTypes(_.chain(anyValue).isSymbol()); // $ExpectType ChainType<boolean, never>
+}
+
+// isObject
+{
+    _.isObject(anyValue) ? anyValue : undefined; // $ExpectType object | undefined
+    _(anyValue).isObject(); // $ExpectType boolean
+    extractChainTypes(_.chain(anyValue).isObject()); // $ExpectType ChainType<boolean, never>
+}
+
+// isArguments
+{
+    _.isArguments(anyValue) ? anyValue : undefined; // $ExpectType IArguments | undefined
+    _(anyValue).isArguments(); // $ExpectType boolean
+    extractChainTypes(_.chain(anyValue).isArguments()); // $ExpectType ChainType<boolean, never>
+}
+
+// isFunction
+{
+    _.isFunction(maybeFunction) ? maybeFunction : null; // $ExpectType (() => void) | null
+    _(anyValue).isFunction(); // $ExpectType boolean
+    extractChainTypes(_.chain(anyValue).isFunction()); // $ExpectType ChainType<boolean, never>
+}
+
+// isError
+{
+    _.isError(anyValue) ? anyValue : undefined; // $ExpectType Error | undefined
+    _(anyValue).isError(); // $ExpectType boolean
+    extractChainTypes(_.chain(anyValue).isError()); // $ExpectType ChainType<boolean, never>
+}
+
+// isString
+{
+    _.isString(anyValue) ? anyValue : undefined; // $ExpectType string | undefined
+    _(anyValue).isString(); // $ExpectType boolean
+    extractChainTypes(_.chain(anyValue).isString()); // $ExpectType ChainType<boolean, never>
+}
+
+// isNumber
+{
+    _.isNumber(anyValue) ? anyValue : undefined; // $ExpectType number | undefined
+    _(anyValue).isNumber(); // $ExpectType boolean
+    extractChainTypes(_.chain(anyValue).isNumber()); // $ExpectType ChainType<boolean, never>
+}
+
+// isFinite
+{
+    _.isFinite(anyValue); // $ExpectType boolean
+    _(anyValue).isFinite(); // $ExpectType boolean
+    extractChainTypes(_.chain(anyValue).isFinite()); // $ExpectType ChainType<boolean, never>
+}
+
+// isBoolean
+{
+    _.isBoolean(anyValue) ? anyValue : undefined; // $ExpectType boolean | undefined
+    _(anyValue).isBoolean(); // $ExpectType boolean
+    extractChainTypes(_.chain(anyValue).isBoolean()); // $ExpectType ChainType<boolean, never>
+}
+
+// isDate
+{
+    _.isDate(anyValue) ? anyValue : undefined; // $ExpectType Date | undefined
+    _(anyValue).isDate(); // $ExpectType boolean
+    extractChainTypes(_.chain(anyValue).isDate()); // $ExpectType ChainType<boolean, never>
+}
+
+// isRegExp
+{
+    _.isRegExp(anyValue) ? anyValue : undefined; // $ExpectType RegExp | undefined
+    _(anyValue).isRegExp(); // $ExpectType boolean
+    extractChainTypes(_.chain(anyValue).isRegExp()); // $ExpectType ChainType<boolean, never>
+}
+
+// isNaN
+{
+    _.isNaN(anyValue); // $ExpectType boolean
+    _(anyValue).isNaN(); // $ExpectType boolean
+    extractChainTypes(_.chain(anyValue).isNaN()); // $ExpectType ChainType<boolean, never>
+}
+
+// isNull
+{
+    _.isNull(anyValue) ? anyValue : undefined; // $ExpectType null | undefined
+    _(anyValue).isNull(); // $ExpectType boolean
+    extractChainTypes(_.chain(anyValue).isNull()); // $ExpectType ChainType<boolean, never>
+}
+
+// isUndefined
+{
+    _.isUndefined(anyValue) ? anyValue : null; // $ExpectType null | undefined
+    _(anyValue).isUndefined(); // $ExpectType boolean
+    extractChainTypes(_.chain(anyValue).isUndefined()); // $ExpectType ChainType<boolean, never>
 }
 
 // OOP Style

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -684,7 +684,7 @@ const simpleNumber = 7;
 declare const mixedIterabilityValue: number | number[];
 declare const anyValue: any;
 declare const neverValue: never;
-declare const maybeFunction: (() => void) | undefined
+declare const maybeFunction: (() => void) | undefined;
 
 // avoid referencing types under test directly by translating them to other types to avoid needing to make lots of changes if
 // the types under test need to be refactored

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1093,7 +1093,7 @@ declare const extractChainTypes: ChainTypeExtractor;
 
 // isObject
 {
-    _.isObject(anyValue) ? anyValue : neverValue; // $ExpectType object
+    _.isObject(anyValue); // $ExpectType boolean
     _(anyValue).isObject(); // $ExpectType boolean
     extractChainTypes(_.chain(anyValue).isObject()); // $ExpectType ChainType<boolean, never>
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://underscorejs.org/
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

This PR makes the following changes to the is* family of functions.
* Updates `UnderscoreStatic` `isObject`, `isNull`, and `isUndefined` functions to be type guards.
* Removes `UnderscoreStatic.isArray<T>` because it violates guidelines in [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes) (but I don't feel strongly about this and can add it back if folks would like).
* Updates non-`UnderscoreStatic` `isMatch` functions to take a parameter.
* Updates `_Chain` functions to result in `_ChainSingle<boolean>` instead of `_Chain<T>`.
* Updates a couple of summary comments to be more accurate.

This is a small deviation from the work I'm doing around collections and arrays. I'm making this change because a particular pain point for me is that my coworkers like to use `_.isUndefined` and `_.isNull` and are often puzzled and displeased when TS doesn't seem to understand the implications of using them as compared to other similar Underscore functions (it's worth noting that the negative effects of this are a lot worse in environments like ours that use `strictNullChecks` than they might be in those that don't). While I was in here, I thought it would also be nice to check over the rest of the is* family and make updates as necessary.