### PR TITLE
mssql: add connect for global connection pool

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -14,26 +14,48 @@
 
 /// <reference types="node" />
 
-
 import events = require('events');
 import tds = require('tedious');
 export interface ISqlType {
-  type: ISqlTypeFactory;
+    type: ISqlTypeFactory;
 }
-export interface ISqlTypeWithNoParams extends ISqlType { type: ISqlTypeFactoryWithNoParams }
-export interface ISqlTypeWithLength extends ISqlType { type: ISqlTypeFactoryWithLength; length: number }
-export interface ISqlTypeWithScale extends ISqlType { type: ISqlTypeFactoryWithScale; scale: number }
-export interface ISqlTypeWithPrecisionScale extends ISqlType { type: ISqlTypeFactoryWithPrecisionScale; precision: number, scale: number }
-export interface ISqlTypeWithTvpType extends ISqlType { type: ISqlTypeFactoryWithTvpType; tvpType: any }
-
-export interface ISqlTypeFactory {
+export interface ISqlTypeWithNoParams extends ISqlType {
+    type: ISqlTypeFactoryWithNoParams;
 }
-export interface ISqlTypeFactoryWithNoParams extends ISqlTypeFactory { (): ISqlTypeWithNoParams; }
-export interface ISqlTypeFactoryWithLength extends ISqlTypeFactory { (length?: number): ISqlTypeWithLength }
-export interface ISqlTypeFactoryWithScale extends ISqlTypeFactory { (scale?: number): ISqlTypeWithScale }
-export interface ISqlTypeFactoryWithPrecisionScale extends ISqlTypeFactory { (precision?: number, scale?: number): ISqlTypeWithPrecisionScale; }
-export interface ISqlTypeFactoryWithTvpType extends ISqlTypeFactory { (tvpType: any): ISqlTypeWithTvpType }
+export interface ISqlTypeWithLength extends ISqlType {
+    type: ISqlTypeFactoryWithLength;
+    length: number;
+}
+export interface ISqlTypeWithScale extends ISqlType {
+    type: ISqlTypeFactoryWithScale;
+    scale: number;
+}
+export interface ISqlTypeWithPrecisionScale extends ISqlType {
+    type: ISqlTypeFactoryWithPrecisionScale;
+    precision: number;
+    scale: number;
+}
+export interface ISqlTypeWithTvpType extends ISqlType {
+    type: ISqlTypeFactoryWithTvpType;
+    tvpType: any;
+}
 
+export interface ISqlTypeFactory {}
+export interface ISqlTypeFactoryWithNoParams extends ISqlTypeFactory {
+    (): ISqlTypeWithNoParams;
+}
+export interface ISqlTypeFactoryWithLength extends ISqlTypeFactory {
+    (length?: number): ISqlTypeWithLength;
+}
+export interface ISqlTypeFactoryWithScale extends ISqlTypeFactory {
+    (scale?: number): ISqlTypeWithScale;
+}
+export interface ISqlTypeFactoryWithPrecisionScale extends ISqlTypeFactory {
+    (precision?: number, scale?: number): ISqlTypeWithPrecisionScale;
+}
+export interface ISqlTypeFactoryWithTvpType extends ISqlTypeFactory {
+    (tvpType: any): ISqlTypeWithTvpType;
+}
 
 export declare var VarChar: ISqlTypeFactoryWithLength;
 export declare var NVarChar: ISqlTypeFactoryWithLength;
@@ -70,166 +92,166 @@ export declare var Geometry: ISqlTypeFactoryWithNoParams;
 export declare var Variant: ISqlTypeFactoryWithNoParams;
 
 export declare var TYPES: {
-  VarChar: ISqlTypeFactoryWithLength;
-  NVarChar: ISqlTypeFactoryWithLength;
-  Text: ISqlTypeFactoryWithNoParams;
-  Int: ISqlTypeFactoryWithNoParams;
-  BigInt: ISqlTypeFactoryWithNoParams;
-  TinyInt: ISqlTypeFactoryWithNoParams;
-  SmallInt: ISqlTypeFactoryWithNoParams;
-  Bit: ISqlTypeFactoryWithNoParams;
-  Float: ISqlTypeFactoryWithNoParams;
-  Numeric: ISqlTypeFactoryWithPrecisionScale;
-  Decimal: ISqlTypeFactoryWithPrecisionScale;
-  Real: ISqlTypeFactoryWithNoParams;
-  Date: ISqlTypeFactoryWithNoParams;
-  DateTime: ISqlTypeFactoryWithNoParams;
-  DateTime2: ISqlTypeFactoryWithScale;
-  DateTimeOffset: ISqlTypeFactoryWithScale;
-  SmallDateTime: ISqlTypeFactoryWithNoParams;
-  Time: ISqlTypeFactoryWithScale;
-  UniqueIdentifier: ISqlTypeFactoryWithNoParams;
-  SmallMoney: ISqlTypeFactoryWithNoParams;
-  Money: ISqlTypeFactoryWithNoParams;
-  Binary: ISqlTypeFactoryWithNoParams;
-  VarBinary: ISqlTypeFactoryWithLength;
-  Image: ISqlTypeFactoryWithNoParams;
-  Xml: ISqlTypeFactoryWithNoParams;
-  Char: ISqlTypeFactoryWithLength;
-  NChar: ISqlTypeFactoryWithLength;
-  NText: ISqlTypeFactoryWithNoParams;
-  TVP: ISqlTypeFactoryWithTvpType;
-  UDT: ISqlTypeFactoryWithNoParams;
-  Geography: ISqlTypeFactoryWithNoParams;
-  Geometry: ISqlTypeFactoryWithNoParams;
-  Variant: ISqlTypeFactoryWithNoParams;
+    VarChar: ISqlTypeFactoryWithLength;
+    NVarChar: ISqlTypeFactoryWithLength;
+    Text: ISqlTypeFactoryWithNoParams;
+    Int: ISqlTypeFactoryWithNoParams;
+    BigInt: ISqlTypeFactoryWithNoParams;
+    TinyInt: ISqlTypeFactoryWithNoParams;
+    SmallInt: ISqlTypeFactoryWithNoParams;
+    Bit: ISqlTypeFactoryWithNoParams;
+    Float: ISqlTypeFactoryWithNoParams;
+    Numeric: ISqlTypeFactoryWithPrecisionScale;
+    Decimal: ISqlTypeFactoryWithPrecisionScale;
+    Real: ISqlTypeFactoryWithNoParams;
+    Date: ISqlTypeFactoryWithNoParams;
+    DateTime: ISqlTypeFactoryWithNoParams;
+    DateTime2: ISqlTypeFactoryWithScale;
+    DateTimeOffset: ISqlTypeFactoryWithScale;
+    SmallDateTime: ISqlTypeFactoryWithNoParams;
+    Time: ISqlTypeFactoryWithScale;
+    UniqueIdentifier: ISqlTypeFactoryWithNoParams;
+    SmallMoney: ISqlTypeFactoryWithNoParams;
+    Money: ISqlTypeFactoryWithNoParams;
+    Binary: ISqlTypeFactoryWithNoParams;
+    VarBinary: ISqlTypeFactoryWithLength;
+    Image: ISqlTypeFactoryWithNoParams;
+    Xml: ISqlTypeFactoryWithNoParams;
+    Char: ISqlTypeFactoryWithLength;
+    NChar: ISqlTypeFactoryWithLength;
+    NText: ISqlTypeFactoryWithNoParams;
+    TVP: ISqlTypeFactoryWithTvpType;
+    UDT: ISqlTypeFactoryWithNoParams;
+    Geography: ISqlTypeFactoryWithNoParams;
+    Geometry: ISqlTypeFactoryWithNoParams;
+    Variant: ISqlTypeFactoryWithNoParams;
 };
 
 export declare var MAX: number;
 export declare var fix: boolean;
 export declare var Promise: any;
 
-interface IMap extends Array<{ js: any, sql: any }> {
-  register(jstype: any, sql: any): void;
+interface IMap extends Array<{ js: any; sql: any }> {
+    register(jstype: any, sql: any): void;
 }
 
 export declare var map: IMap;
 
 export declare var DRIVERS: string[];
 export interface IColumnMetadata {
-  [name: string]: {
-    index: number;
-    name: string;
-    length: number;
-    type: (() => ISqlType) | ISqlType;
-    udt?: any;
-    scale?: number;
-    precision?: number;
-    nullable: boolean;
-    caseSensitive: boolean;
-    identity: boolean;
-    readOnly: boolean;
-  }
+    [name: string]: {
+        index: number;
+        name: string;
+        length: number;
+        type: (() => ISqlType) | ISqlType;
+        udt?: any;
+        scale?: number;
+        precision?: number;
+        nullable: boolean;
+        caseSensitive: boolean;
+        identity: boolean;
+        readOnly: boolean;
+    };
 }
 export interface IResult<T> {
-  recordsets: IRecordSet<T>[];
-  recordset: IRecordSet<T>;
-  rowsAffected: number[],
-  output: { [key: string]: any };
+    recordsets: IRecordSet<T>[];
+    recordset: IRecordSet<T>;
+    rowsAffected: number[];
+    output: { [key: string]: any };
 }
 
 export interface IBulkResult {
-  rowsAffected: number;
+    rowsAffected: number;
 }
 
 export interface IProcedureResult<T> extends IResult<T> {
-  returnValue: any;
+    returnValue: any;
 }
 export interface IRecordSet<T> extends Array<T> {
-  columns: IColumnMetadata;
-  toTable(name?: string): Table;
+    columns: IColumnMetadata;
+    toTable(name?: string): Table;
 }
 
 type IIsolationLevel = number;
 
 export declare var ISOLATION_LEVEL: {
-  READ_UNCOMMITTED: IIsolationLevel
-  READ_COMMITTED: IIsolationLevel
-  REPEATABLE_READ: IIsolationLevel
-  SERIALIZABLE: IIsolationLevel
-  SNAPSHOT: IIsolationLevel
-}
+    READ_UNCOMMITTED: IIsolationLevel;
+    READ_COMMITTED: IIsolationLevel;
+    REPEATABLE_READ: IIsolationLevel;
+    SERIALIZABLE: IIsolationLevel;
+    SNAPSHOT: IIsolationLevel;
+};
 
 export interface IOptions extends tds.ConnectionOptions {
-  beforeConnect?: void;
-  connectionString?: string;
-  enableArithAbort?: boolean;
-  instanceName?: string;
-  trustedConnection?: boolean;
-  useUTC?: boolean;
+    beforeConnect?: void;
+    connectionString?: string;
+    enableArithAbort?: boolean;
+    instanceName?: string;
+    trustedConnection?: boolean;
+    useUTC?: boolean;
 }
 
 export interface IPool {
-  min?: number;
-  max?: number;
-  idleTimeoutMillis?: number;
-  maxWaitingClients?: number;
-  testOnBorrow?: boolean;
-  acquireTimeoutMillis?: number;
-  fifo?: boolean;
-  priorityRange?: number;
-  autostart?: boolean;
-  evictionRunIntervalMillis?: number;
-  numTestsPerRun?: number;
-  softIdleTimeoutMillis?: number;
-  Promise?: any;
+    min?: number;
+    max?: number;
+    idleTimeoutMillis?: number;
+    maxWaitingClients?: number;
+    testOnBorrow?: boolean;
+    acquireTimeoutMillis?: number;
+    fifo?: boolean;
+    priorityRange?: number;
+    autostart?: boolean;
+    evictionRunIntervalMillis?: number;
+    numTestsPerRun?: number;
+    softIdleTimeoutMillis?: number;
+    Promise?: any;
 }
 
 export declare var pool: IPool;
 
 export interface config {
-  driver?: string;
-  user?: string;
-  password?: string;
-  server: string;
-  port?: number;
-  domain?: string;
-  database: string;
-  connectionTimeout?: number;
-  requestTimeout?: number;
-  stream?: boolean;
-  parseJSON?: boolean;
-  options?: IOptions;
-  pool?: IPool;
-  /**
-   * Invoked before opening the connection. The parameter conn is the configured
-   * tedious Connection. It can be used for attaching event handlers.
-   */
-  beforeConnect?: (conn: tds.Connection) => void
+    driver?: string;
+    user?: string;
+    password?: string;
+    server: string;
+    port?: number;
+    domain?: string;
+    database: string;
+    connectionTimeout?: number;
+    requestTimeout?: number;
+    stream?: boolean;
+    parseJSON?: boolean;
+    options?: IOptions;
+    pool?: IPool;
+    /**
+     * Invoked before opening the connection. The parameter conn is the configured
+     * tedious Connection. It can be used for attaching event handlers.
+     */
+    beforeConnect?: (conn: tds.Connection) => void;
 }
 
 export declare class ConnectionPool extends events.EventEmitter {
-  public connected: boolean;
-  public connecting: boolean;
-  public driver: string;
-  public constructor(config: config, callback?: (err?: any) => void);
-  public constructor(connectionString: string, callback?: (err?: any) => void);
-  public query(command: string): Promise<IResult<any>>;
-  public query(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<any>>;
-  public query<Entity>(command: string): Promise<IResult<Entity>>;
-  public query<Entity>(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<Entity>>;
-  public query<Entity>(command: string, callback: (err?: Error, recordset?: IResult<Entity>) => void): void;
-  public batch(batch: string): Promise<IResult<any>>;
-  public batch(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<any>>;
-  public batch(batch: string, callback: (err?: Error, recordset?: IResult<any>) => void): void;
-  public batch<Entity>(batch: string): Promise<IResult<Entity>>;
-  public batch<Entity>(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<Entity>>;
-  public connect(): Promise<ConnectionPool>;
-  public connect(callback: (err: any) => void): void;
-  public close(): Promise<void>;
-  public close(callback: (err: any) => void): void;
-  public request(): Request;
-  public transaction(): Transaction;
+    public connected: boolean;
+    public connecting: boolean;
+    public driver: string;
+    public constructor(config: config, callback?: (err?: any) => void);
+    public constructor(connectionString: string, callback?: (err?: any) => void);
+    public query(command: string): Promise<IResult<any>>;
+    public query(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<any>>;
+    public query<Entity>(command: string): Promise<IResult<Entity>>;
+    public query<Entity>(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<Entity>>;
+    public query<Entity>(command: string, callback: (err?: Error, recordset?: IResult<Entity>) => void): void;
+    public batch(batch: string): Promise<IResult<any>>;
+    public batch(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<any>>;
+    public batch(batch: string, callback: (err?: Error, recordset?: IResult<any>) => void): void;
+    public batch<Entity>(batch: string): Promise<IResult<Entity>>;
+    public batch<Entity>(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<Entity>>;
+    public connect(): Promise<ConnectionPool>;
+    public connect(callback: (err: any) => void): void;
+    public close(): Promise<void>;
+    public close(callback: (err: any) => void): void;
+    public request(): Request;
+    public transaction(): Transaction;
 }
 
 /* utilise the global connection pool */
@@ -237,170 +259,176 @@ export function connect(connection: string): Promise<ConnectionPool>;
 export function connect(config: config): Promise<ConnectionPool>;
 
 export declare class ConnectionError implements Error {
-  constructor(message: string, code?: any)
-  public name: string;
-  public message: string;
-  public code: string;
+    constructor(message: string, code?: any);
+    public name: string;
+    public message: string;
+    public code: string;
 }
 
 export interface IColumnOptions {
-  nullable?: boolean;
-  primary?: boolean;
+    nullable?: boolean;
+    primary?: boolean;
 }
 
 export interface IColumn extends ISqlType {
-  name: string;
-  nullable: boolean;
-  primary: boolean;
+    name: string;
+    nullable: boolean;
+    primary: boolean;
 }
 
 declare class columns extends Array {
-  public add(name: string, type: (() => ISqlType) | ISqlType, options?: IColumnOptions): number;
+    public add(name: string, type: (() => ISqlType) | ISqlType, options?: IColumnOptions): number;
 }
 
 type IRow = (string | number | boolean | Date | Buffer | undefined)[];
 
 declare class rows extends Array {
-  public add(...row: IRow): number;
+    public add(...row: IRow): number;
 }
 
 export declare class Table {
-  public create: boolean;
-  public columns: columns;
-  public rows: rows;
-  public constructor(tableName?: string);
-  public schema?: string;
-  public database?: string;
-  public name?: string;
-  public path?: string;
-  public temporary?: boolean;
+    public create: boolean;
+    public columns: columns;
+    public rows: rows;
+    public constructor(tableName?: string);
+    public schema?: string;
+    public database?: string;
+    public name?: string;
+    public path?: string;
+    public temporary?: boolean;
 }
 
 interface IRequestParameters {
-  [name: string]: {
-    name: string;
-    type: (() => ISqlType) | ISqlType;
-    io: number;
-    value: any;
-    length: number;
-    scale: number;
-    precision: number;
-    tvpType: any;
-  }
+    [name: string]: {
+        name: string;
+        type: (() => ISqlType) | ISqlType;
+        io: number;
+        value: any;
+        length: number;
+        scale: number;
+        precision: number;
+        tvpType: any;
+    };
 }
 
 /**
  * Options object to be passed through to driver (currently tedious only)
  */
 export interface IBulkOptions {
-  /** Honors constraints during bulk load, using T-SQL CHECK_CONSTRAINTS. (default: false) */
-  checkConstraints?: boolean;
-  /** Honors insert triggers during bulk load, using the T-SQL FIRE_TRIGGERS. (default: false) */
-  fireTriggers?: boolean;
-  /** Honors null value passed, ignores the default values set on table, using T-SQL KEEP_NULLS. (default: false) */
-  keepNulls?: boolean;
-  /** Places a bulk update(BU) lock on table while performing bulk load, using T-SQL TABLOCK. (default: false) */
-  tableLock?: boolean;
+    /** Honors constraints during bulk load, using T-SQL CHECK_CONSTRAINTS. (default: false) */
+    checkConstraints?: boolean;
+    /** Honors insert triggers during bulk load, using the T-SQL FIRE_TRIGGERS. (default: false) */
+    fireTriggers?: boolean;
+    /** Honors null value passed, ignores the default values set on table, using T-SQL KEEP_NULLS. (default: false) */
+    keepNulls?: boolean;
+    /** Places a bulk update(BU) lock on table while performing bulk load, using T-SQL TABLOCK. (default: false) */
+    tableLock?: boolean;
 }
 
 export declare class Request extends events.EventEmitter {
-  public transaction: Transaction;
-  public pstatement: PreparedStatement;
-  public parameters: IRequestParameters;
-  public verbose: boolean;
-  public canceled: boolean;
-  public multiple: boolean;
-  public stream: any;
-  public constructor(connection?: ConnectionPool);
-  public constructor(transaction: Transaction);
-  public constructor(preparedStatement: PreparedStatement);
-  public execute(procedure: string): Promise<IProcedureResult<any>>;
-  public execute<Entity>(procedure: string): Promise<IProcedureResult<Entity>>;
-  public execute<Entity>(procedure: string, callback: (err?: any, recordsets?: IProcedureResult<Entity>, returnValue?: any) => void): void;
-  public input(name: string, value: any): Request;
-  public input(name: string, type: (() => ISqlType) | ISqlType, value: any): Request;
-  public output(name: string, type: (() => ISqlType) | ISqlType, value?: any): Request;
-  public pipe(stream: NodeJS.WritableStream): NodeJS.WritableStream;
-  public query(command: string): Promise<IResult<any>>;
-  public query(command: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<any>>;
-  public query<Entity>(command: string): Promise<IResult<Entity>>;
-  public query<Entity>(command: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<Entity>>;
-  public query<Entity>(command: string, callback: (err?: Error, recordset?: IResult<Entity>) => void): void;
-  public batch(batch: string): Promise<IResult<any>>;
-  public batch(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<any>>;
-  public batch(batch: string, callback: (err?: Error, recordset?: IResult<any>) => void): void;
-  public batch<Entity>(batch: string): Promise<IResult<Entity>>;
-  public batch<Entity>(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<Entity>>;
-  public batch<Entity>(batch: string, callback: (err?: any, recordset?: IResult<Entity>) => void): void;
-  public bulk(table: Table): Promise<IBulkResult>;
-  public bulk(table: Table, options: IBulkOptions): Promise<IBulkResult>;
-  public bulk(table: Table, callback: (err: Error, result: IBulkResult) => void): void;
-  public bulk(table: Table, options: IBulkOptions, callback: (err: Error, result: IBulkResult) => void): void;
-  public cancel(): void;
-  public pause(): boolean;
-  public resume(): boolean;
+    public transaction: Transaction;
+    public pstatement: PreparedStatement;
+    public parameters: IRequestParameters;
+    public verbose: boolean;
+    public canceled: boolean;
+    public multiple: boolean;
+    public stream: any;
+    public constructor(connection?: ConnectionPool);
+    public constructor(transaction: Transaction);
+    public constructor(preparedStatement: PreparedStatement);
+    public execute(procedure: string): Promise<IProcedureResult<any>>;
+    public execute<Entity>(procedure: string): Promise<IProcedureResult<Entity>>;
+    public execute<Entity>(
+        procedure: string,
+        callback: (err?: any, recordsets?: IProcedureResult<Entity>, returnValue?: any) => void,
+    ): void;
+    public input(name: string, value: any): Request;
+    public input(name: string, type: (() => ISqlType) | ISqlType, value: any): Request;
+    public output(name: string, type: (() => ISqlType) | ISqlType, value?: any): Request;
+    public pipe(stream: NodeJS.WritableStream): NodeJS.WritableStream;
+    public query(command: string): Promise<IResult<any>>;
+    public query(command: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<any>>;
+    public query<Entity>(command: string): Promise<IResult<Entity>>;
+    public query<Entity>(command: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<Entity>>;
+    public query<Entity>(command: string, callback: (err?: Error, recordset?: IResult<Entity>) => void): void;
+    public batch(batch: string): Promise<IResult<any>>;
+    public batch(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<any>>;
+    public batch(batch: string, callback: (err?: Error, recordset?: IResult<any>) => void): void;
+    public batch<Entity>(batch: string): Promise<IResult<Entity>>;
+    public batch<Entity>(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<Entity>>;
+    public batch<Entity>(batch: string, callback: (err?: any, recordset?: IResult<Entity>) => void): void;
+    public bulk(table: Table): Promise<IBulkResult>;
+    public bulk(table: Table, options: IBulkOptions): Promise<IBulkResult>;
+    public bulk(table: Table, callback: (err: Error, result: IBulkResult) => void): void;
+    public bulk(table: Table, options: IBulkOptions, callback: (err: Error, result: IBulkResult) => void): void;
+    public cancel(): void;
+    public pause(): boolean;
+    public resume(): boolean;
 }
 
 export declare class RequestError implements Error {
-  constructor(message: string, code?: any)
-  public name: string;
-  public message: string;
-  public code: string;
-  public number?: number;
-  public state?: number;
-  public class?: number;
-  public lineNumber?: number;
-  public serverName?: string;
-  public procName?: string;
+    constructor(message: string, code?: any);
+    public name: string;
+    public message: string;
+    public code: string;
+    public number?: number;
+    public state?: number;
+    public class?: number;
+    public lineNumber?: number;
+    public serverName?: string;
+    public procName?: string;
 }
 
 export declare class Transaction extends events.EventEmitter {
-  public isolationLevel: IIsolationLevel;
-  public constructor(connection?: ConnectionPool);
-  /**
-   * Begin a transaction.
-   * @param [isolationLevel] - Controls the locking and row versioning behavior of TSQL statements issued by a connection.
-   * @param [callback] A callback which is called after transaction has began, or an error has occurred. If omited, method returns Promise.
-   */
-  public begin(isolationLevel?: IIsolationLevel): Promise<Transaction>;
-  public begin(isolationLevel?: IIsolationLevel, callback?: (err?: ConnectionError | TransactionError) => void): Transaction;
-  public commit(): Promise<void>;
-  public commit(callback: (err?: any) => void): void;
-  public rollback(): Promise<void>;
-  public rollback(callback: (err?: any) => void): void;
-  public request(): Request;
+    public isolationLevel: IIsolationLevel;
+    public constructor(connection?: ConnectionPool);
+    /**
+     * Begin a transaction.
+     * @param [isolationLevel] - Controls the locking and row versioning behavior of TSQL statements issued by a connection.
+     * @param [callback] A callback which is called after transaction has began, or an error has occurred. If omited, method returns Promise.
+     */
+    public begin(isolationLevel?: IIsolationLevel): Promise<Transaction>;
+    public begin(
+        isolationLevel?: IIsolationLevel,
+        callback?: (err?: ConnectionError | TransactionError) => void,
+    ): Transaction;
+    public commit(): Promise<void>;
+    public commit(callback: (err?: any) => void): void;
+    public rollback(): Promise<void>;
+    public rollback(callback: (err?: any) => void): void;
+    public request(): Request;
 }
 
 export declare class TransactionError implements Error {
-  constructor(message: string, code?: any)
-  public name: string;
-  public message: string;
-  public code: string;
+    constructor(message: string, code?: any);
+    public name: string;
+    public message: string;
+    public code: string;
 }
 
 export declare class PreparedStatement extends events.EventEmitter {
-  public transaction: Transaction;
-  public prepared: boolean;
-  public statement: string;
-  public parameters: IRequestParameters;
-  public stream: any;
-  public constructor(connection?: ConnectionPool);
-  public constructor(transaction: Transaction);
-  public input(name: string, type: (() => ISqlType) | ISqlType): PreparedStatement;
-  public output(name: string, type: (() => ISqlType) | ISqlType): PreparedStatement;
-  public prepare(statement?: string): Promise<void>;
-  public prepare(statement?: string, callback?: (err?: Error) => void): PreparedStatement;
-  public execute(values: Object): Promise<IProcedureResult<any>>;
-  public execute<Entity>(values: Object): Promise<IProcedureResult<Entity>>;
-  public execute(values: Object, callback: (err?: Error, result?: IProcedureResult<any>) => void): Request;
-  public execute<Entity>(values: Object, callback: (err?: Error, result?: IProcedureResult<Entity>) => void): Request;
-  public unprepare(): Promise<void>;
-  public unprepare(callback: (err?: Error) => void): PreparedStatement;
+    public transaction: Transaction;
+    public prepared: boolean;
+    public statement: string;
+    public parameters: IRequestParameters;
+    public stream: any;
+    public constructor(connection?: ConnectionPool);
+    public constructor(transaction: Transaction);
+    public input(name: string, type: (() => ISqlType) | ISqlType): PreparedStatement;
+    public output(name: string, type: (() => ISqlType) | ISqlType): PreparedStatement;
+    public prepare(statement?: string): Promise<void>;
+    public prepare(statement?: string, callback?: (err?: Error) => void): PreparedStatement;
+    public execute(values: Object): Promise<IProcedureResult<any>>;
+    public execute<Entity>(values: Object): Promise<IProcedureResult<Entity>>;
+    public execute(values: Object, callback: (err?: Error, result?: IProcedureResult<any>) => void): Request;
+    public execute<Entity>(values: Object, callback: (err?: Error, result?: IProcedureResult<Entity>) => void): Request;
+    public unprepare(): Promise<void>;
+    public unprepare(callback: (err?: Error) => void): PreparedStatement;
 }
 
 export declare class PreparedStatementError implements Error {
-  constructor(message: string, code?: any)
-  public name: string;
-  public message: string;
-  public code: string;
+    constructor(message: string, code?: any);
+    public name: string;
+    public message: string;
+    public code: string;
 }

--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -18,7 +18,7 @@
 import events = require('events');
 import tds = require('tedious');
 export interface ISqlType {
-    type: ISqlTypeFactory;
+  type: ISqlTypeFactory;
 }
 export interface ISqlTypeWithNoParams extends ISqlType { type: ISqlTypeFactoryWithNoParams }
 export interface ISqlTypeWithLength extends ISqlType { type: ISqlTypeFactoryWithLength; length: number }
@@ -70,39 +70,39 @@ export declare var Geometry: ISqlTypeFactoryWithNoParams;
 export declare var Variant: ISqlTypeFactoryWithNoParams;
 
 export declare var TYPES: {
-    VarChar: ISqlTypeFactoryWithLength;
-    NVarChar: ISqlTypeFactoryWithLength;
-    Text: ISqlTypeFactoryWithNoParams;
-    Int: ISqlTypeFactoryWithNoParams;
-    BigInt: ISqlTypeFactoryWithNoParams;
-    TinyInt: ISqlTypeFactoryWithNoParams;
-    SmallInt: ISqlTypeFactoryWithNoParams;
-    Bit: ISqlTypeFactoryWithNoParams;
-    Float: ISqlTypeFactoryWithNoParams;
-    Numeric: ISqlTypeFactoryWithPrecisionScale;
-    Decimal: ISqlTypeFactoryWithPrecisionScale;
-    Real: ISqlTypeFactoryWithNoParams;
-    Date: ISqlTypeFactoryWithNoParams;
-    DateTime: ISqlTypeFactoryWithNoParams;
-    DateTime2: ISqlTypeFactoryWithScale;
-    DateTimeOffset: ISqlTypeFactoryWithScale;
-    SmallDateTime: ISqlTypeFactoryWithNoParams;
-    Time: ISqlTypeFactoryWithScale;
-    UniqueIdentifier: ISqlTypeFactoryWithNoParams;
-    SmallMoney: ISqlTypeFactoryWithNoParams;
-    Money: ISqlTypeFactoryWithNoParams;
-    Binary: ISqlTypeFactoryWithNoParams;
-    VarBinary: ISqlTypeFactoryWithLength;
-    Image: ISqlTypeFactoryWithNoParams;
-    Xml: ISqlTypeFactoryWithNoParams;
-    Char: ISqlTypeFactoryWithLength;
-    NChar: ISqlTypeFactoryWithLength;
-    NText: ISqlTypeFactoryWithNoParams;
-    TVP: ISqlTypeFactoryWithTvpType;
-    UDT: ISqlTypeFactoryWithNoParams;
-    Geography: ISqlTypeFactoryWithNoParams;
-    Geometry: ISqlTypeFactoryWithNoParams;
-    Variant: ISqlTypeFactoryWithNoParams;
+  VarChar: ISqlTypeFactoryWithLength;
+  NVarChar: ISqlTypeFactoryWithLength;
+  Text: ISqlTypeFactoryWithNoParams;
+  Int: ISqlTypeFactoryWithNoParams;
+  BigInt: ISqlTypeFactoryWithNoParams;
+  TinyInt: ISqlTypeFactoryWithNoParams;
+  SmallInt: ISqlTypeFactoryWithNoParams;
+  Bit: ISqlTypeFactoryWithNoParams;
+  Float: ISqlTypeFactoryWithNoParams;
+  Numeric: ISqlTypeFactoryWithPrecisionScale;
+  Decimal: ISqlTypeFactoryWithPrecisionScale;
+  Real: ISqlTypeFactoryWithNoParams;
+  Date: ISqlTypeFactoryWithNoParams;
+  DateTime: ISqlTypeFactoryWithNoParams;
+  DateTime2: ISqlTypeFactoryWithScale;
+  DateTimeOffset: ISqlTypeFactoryWithScale;
+  SmallDateTime: ISqlTypeFactoryWithNoParams;
+  Time: ISqlTypeFactoryWithScale;
+  UniqueIdentifier: ISqlTypeFactoryWithNoParams;
+  SmallMoney: ISqlTypeFactoryWithNoParams;
+  Money: ISqlTypeFactoryWithNoParams;
+  Binary: ISqlTypeFactoryWithNoParams;
+  VarBinary: ISqlTypeFactoryWithLength;
+  Image: ISqlTypeFactoryWithNoParams;
+  Xml: ISqlTypeFactoryWithNoParams;
+  Char: ISqlTypeFactoryWithLength;
+  NChar: ISqlTypeFactoryWithLength;
+  NText: ISqlTypeFactoryWithNoParams;
+  TVP: ISqlTypeFactoryWithTvpType;
+  UDT: ISqlTypeFactoryWithNoParams;
+  Geography: ISqlTypeFactoryWithNoParams;
+  Geometry: ISqlTypeFactoryWithNoParams;
+  Variant: ISqlTypeFactoryWithNoParams;
 };
 
 export declare var MAX: number;
@@ -110,293 +110,297 @@ export declare var fix: boolean;
 export declare var Promise: any;
 
 interface IMap extends Array<{ js: any, sql: any }> {
-    register(jstype: any, sql: any): void;
+  register(jstype: any, sql: any): void;
 }
 
 export declare var map: IMap;
 
 export declare var DRIVERS: string[];
 export interface IColumnMetadata {
-    [name: string]: {
-        index: number;
-        name: string;
-        length: number;
-        type: (() => ISqlType) | ISqlType;
-        udt?: any;
-        scale?: number;
-        precision?: number;
-        nullable: boolean;
-        caseSensitive: boolean;
-        identity: boolean;
-        readOnly: boolean;
-    }
+  [name: string]: {
+    index: number;
+    name: string;
+    length: number;
+    type: (() => ISqlType) | ISqlType;
+    udt?: any;
+    scale?: number;
+    precision?: number;
+    nullable: boolean;
+    caseSensitive: boolean;
+    identity: boolean;
+    readOnly: boolean;
+  }
 }
 export interface IResult<T> {
-    recordsets: IRecordSet<T>[];
-    recordset: IRecordSet<T>;
-    rowsAffected: number[],
-    output: { [key: string]: any };
+  recordsets: IRecordSet<T>[];
+  recordset: IRecordSet<T>;
+  rowsAffected: number[],
+  output: { [key: string]: any };
 }
 
 export interface IBulkResult {
-    rowsAffected: number;
+  rowsAffected: number;
 }
 
 export interface IProcedureResult<T> extends IResult<T> {
-    returnValue: any;
+  returnValue: any;
 }
 export interface IRecordSet<T> extends Array<T> {
-    columns: IColumnMetadata;
-    toTable(name?: string): Table;
+  columns: IColumnMetadata;
+  toTable(name?: string): Table;
 }
 
 type IIsolationLevel = number;
 
 export declare var ISOLATION_LEVEL: {
-    READ_UNCOMMITTED: IIsolationLevel
-    READ_COMMITTED: IIsolationLevel
-    REPEATABLE_READ: IIsolationLevel
-    SERIALIZABLE: IIsolationLevel
-    SNAPSHOT: IIsolationLevel
+  READ_UNCOMMITTED: IIsolationLevel
+  READ_COMMITTED: IIsolationLevel
+  REPEATABLE_READ: IIsolationLevel
+  SERIALIZABLE: IIsolationLevel
+  SNAPSHOT: IIsolationLevel
 }
 
 export interface IOptions extends tds.ConnectionOptions {
-    beforeConnect?: void;
-    connectionString?: string;
-    enableArithAbort?: boolean;
-    instanceName?: string;
-    trustedConnection?: boolean;
-    useUTC?: boolean;
+  beforeConnect?: void;
+  connectionString?: string;
+  enableArithAbort?: boolean;
+  instanceName?: string;
+  trustedConnection?: boolean;
+  useUTC?: boolean;
 }
 
 export interface IPool {
-    min?: number;
-    max?: number;
-    idleTimeoutMillis?: number;
-    maxWaitingClients?: number;
-    testOnBorrow?: boolean;
-    acquireTimeoutMillis?: number;
-    fifo?: boolean;
-    priorityRange?: number;
-    autostart?: boolean;
-    evictionRunIntervalMillis?: number;
-    numTestsPerRun?: number;
-    softIdleTimeoutMillis?: number;
-    Promise?: any;
+  min?: number;
+  max?: number;
+  idleTimeoutMillis?: number;
+  maxWaitingClients?: number;
+  testOnBorrow?: boolean;
+  acquireTimeoutMillis?: number;
+  fifo?: boolean;
+  priorityRange?: number;
+  autostart?: boolean;
+  evictionRunIntervalMillis?: number;
+  numTestsPerRun?: number;
+  softIdleTimeoutMillis?: number;
+  Promise?: any;
 }
 
 export declare var pool: IPool;
 
 export interface config {
-    driver?: string;
-    user?: string;
-    password?: string;
-    server: string;
-    port?: number;
-    domain?: string;
-    database: string;
-    connectionTimeout?: number;
-    requestTimeout?: number;
-    stream?: boolean;
-    parseJSON?: boolean;
-    options?: IOptions;
-    pool?: IPool;
-    /**
-     * Invoked before opening the connection. The parameter conn is the configured
-     * tedious Connection. It can be used for attaching event handlers.
-     */
-    beforeConnect?: (conn: tds.Connection) => void
+  driver?: string;
+  user?: string;
+  password?: string;
+  server: string;
+  port?: number;
+  domain?: string;
+  database: string;
+  connectionTimeout?: number;
+  requestTimeout?: number;
+  stream?: boolean;
+  parseJSON?: boolean;
+  options?: IOptions;
+  pool?: IPool;
+  /**
+   * Invoked before opening the connection. The parameter conn is the configured
+   * tedious Connection. It can be used for attaching event handlers.
+   */
+  beforeConnect?: (conn: tds.Connection) => void
 }
 
 export declare class ConnectionPool extends events.EventEmitter {
-    public connected: boolean;
-    public connecting: boolean;
-    public driver: string;
-    public constructor(config: config, callback?: (err?: any) => void);
-    public constructor(connectionString: string, callback?: (err?: any) => void);
-    public query(command: string): Promise<IResult<any>>;
-    public query(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<any>>;
-    public query<Entity>(command: string): Promise<IResult<Entity>>;
-    public query<Entity>(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<Entity>>;
-    public query<Entity>(command: string, callback: (err?: Error, recordset?: IResult<Entity>) => void): void;
-    public batch(batch: string): Promise<IResult<any>>;
-    public batch(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<any>>;
-    public batch(batch: string, callback: (err?: Error, recordset?: IResult<any>) => void): void;
-    public batch<Entity>(batch: string): Promise<IResult<Entity>>;
-    public batch<Entity>(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<Entity>>;
-    public connect(): Promise<ConnectionPool>;
-    public connect(callback: (err: any) => void): void;
-    public close(): Promise<void>;
-    public close(callback: (err: any) => void): void;
-    public request(): Request;
-    public transaction(): Transaction;
+  public connected: boolean;
+  public connecting: boolean;
+  public driver: string;
+  public constructor(config: config, callback?: (err?: any) => void);
+  public constructor(connectionString: string, callback?: (err?: any) => void);
+  public query(command: string): Promise<IResult<any>>;
+  public query(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<any>>;
+  public query<Entity>(command: string): Promise<IResult<Entity>>;
+  public query<Entity>(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<Entity>>;
+  public query<Entity>(command: string, callback: (err?: Error, recordset?: IResult<Entity>) => void): void;
+  public batch(batch: string): Promise<IResult<any>>;
+  public batch(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<any>>;
+  public batch(batch: string, callback: (err?: Error, recordset?: IResult<any>) => void): void;
+  public batch<Entity>(batch: string): Promise<IResult<Entity>>;
+  public batch<Entity>(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<Entity>>;
+  public connect(): Promise<ConnectionPool>;
+  public connect(callback: (err: any) => void): void;
+  public close(): Promise<void>;
+  public close(callback: (err: any) => void): void;
+  public request(): Request;
+  public transaction(): Transaction;
 }
 
+/* utilise the global connection pool */
+export function connect(connection: string): Promise<ConnectionPool>;
+export function connect(config: config): Promise<ConnectionPool>;
+
 export declare class ConnectionError implements Error {
-    constructor(message: string, code?: any)
-    public name: string;
-    public message: string;
-    public code: string;
+  constructor(message: string, code?: any)
+  public name: string;
+  public message: string;
+  public code: string;
 }
 
 export interface IColumnOptions {
-    nullable?: boolean;
-    primary?: boolean;
+  nullable?: boolean;
+  primary?: boolean;
 }
 
 export interface IColumn extends ISqlType {
-    name: string;
-    nullable: boolean;
-    primary: boolean;
+  name: string;
+  nullable: boolean;
+  primary: boolean;
 }
 
 declare class columns extends Array {
-    public add(name: string, type: (() => ISqlType) | ISqlType, options?: IColumnOptions): number;
+  public add(name: string, type: (() => ISqlType) | ISqlType, options?: IColumnOptions): number;
 }
 
 type IRow = (string | number | boolean | Date | Buffer | undefined)[];
 
 declare class rows extends Array {
-    public add(...row: IRow): number;
+  public add(...row: IRow): number;
 }
 
 export declare class Table {
-    public create: boolean;
-    public columns: columns;
-    public rows: rows;
-    public constructor(tableName?: string);
-    public schema?: string;
-    public database?: string;
-    public name?: string;
-    public path?: string;
-    public temporary?: boolean;
+  public create: boolean;
+  public columns: columns;
+  public rows: rows;
+  public constructor(tableName?: string);
+  public schema?: string;
+  public database?: string;
+  public name?: string;
+  public path?: string;
+  public temporary?: boolean;
 }
 
 interface IRequestParameters {
-    [name: string]: {
-        name: string;
-        type: (() => ISqlType) | ISqlType;
-        io: number;
-        value: any;
-        length: number;
-        scale: number;
-        precision: number;
-        tvpType: any;
-    }
+  [name: string]: {
+    name: string;
+    type: (() => ISqlType) | ISqlType;
+    io: number;
+    value: any;
+    length: number;
+    scale: number;
+    precision: number;
+    tvpType: any;
+  }
 }
 
 /**
  * Options object to be passed through to driver (currently tedious only)
  */
 export interface IBulkOptions {
-    /** Honors constraints during bulk load, using T-SQL CHECK_CONSTRAINTS. (default: false) */
-    checkConstraints?: boolean;
-    /** Honors insert triggers during bulk load, using the T-SQL FIRE_TRIGGERS. (default: false) */
-    fireTriggers?: boolean;
-    /** Honors null value passed, ignores the default values set on table, using T-SQL KEEP_NULLS. (default: false) */
-    keepNulls?: boolean;
-    /** Places a bulk update(BU) lock on table while performing bulk load, using T-SQL TABLOCK. (default: false) */
-    tableLock?: boolean;
+  /** Honors constraints during bulk load, using T-SQL CHECK_CONSTRAINTS. (default: false) */
+  checkConstraints?: boolean;
+  /** Honors insert triggers during bulk load, using the T-SQL FIRE_TRIGGERS. (default: false) */
+  fireTriggers?: boolean;
+  /** Honors null value passed, ignores the default values set on table, using T-SQL KEEP_NULLS. (default: false) */
+  keepNulls?: boolean;
+  /** Places a bulk update(BU) lock on table while performing bulk load, using T-SQL TABLOCK. (default: false) */
+  tableLock?: boolean;
 }
 
 export declare class Request extends events.EventEmitter {
-    public transaction: Transaction;
-    public pstatement: PreparedStatement;
-    public parameters: IRequestParameters;
-    public verbose: boolean;
-    public canceled: boolean;
-    public multiple: boolean;
-    public stream: any;
-    public constructor(connection?: ConnectionPool);
-    public constructor(transaction: Transaction);
-    public constructor(preparedStatement: PreparedStatement);
-    public execute(procedure: string): Promise<IProcedureResult<any>>;
-    public execute<Entity>(procedure: string): Promise<IProcedureResult<Entity>>;
-    public execute<Entity>(procedure: string, callback: (err?: any, recordsets?: IProcedureResult<Entity>, returnValue?: any) => void): void;
-    public input(name: string, value: any): Request;
-    public input(name: string, type: (() => ISqlType) | ISqlType, value: any): Request;
-    public output(name: string, type: (() => ISqlType) | ISqlType, value?: any): Request;
-    public pipe(stream: NodeJS.WritableStream): NodeJS.WritableStream;
-    public query(command: string): Promise<IResult<any>>;
-    public query(command: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<any>>;
-    public query<Entity>(command: string): Promise<IResult<Entity>>;
-    public query<Entity>(command: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<Entity>>;
-    public query<Entity>(command: string, callback: (err?: Error, recordset?: IResult<Entity>) => void): void;
-    public batch(batch: string): Promise<IResult<any>>;
-    public batch(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<any>>;
-    public batch(batch: string, callback: (err?: Error, recordset?: IResult<any>) => void): void;
-    public batch<Entity>(batch: string): Promise<IResult<Entity>>;
-    public batch<Entity>(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<Entity>>;
-    public batch<Entity>(batch: string, callback: (err?: any, recordset?: IResult<Entity>) => void): void;
-    public bulk(table: Table): Promise<IBulkResult>;
-    public bulk(table: Table, options: IBulkOptions): Promise<IBulkResult>;
-    public bulk(table: Table, callback: (err: Error, result: IBulkResult) => void): void;
-    public bulk(table: Table, options: IBulkOptions, callback: (err: Error, result: IBulkResult) => void): void;
-    public cancel(): void;
-    public pause(): boolean;
-    public resume(): boolean;
+  public transaction: Transaction;
+  public pstatement: PreparedStatement;
+  public parameters: IRequestParameters;
+  public verbose: boolean;
+  public canceled: boolean;
+  public multiple: boolean;
+  public stream: any;
+  public constructor(connection?: ConnectionPool);
+  public constructor(transaction: Transaction);
+  public constructor(preparedStatement: PreparedStatement);
+  public execute(procedure: string): Promise<IProcedureResult<any>>;
+  public execute<Entity>(procedure: string): Promise<IProcedureResult<Entity>>;
+  public execute<Entity>(procedure: string, callback: (err?: any, recordsets?: IProcedureResult<Entity>, returnValue?: any) => void): void;
+  public input(name: string, value: any): Request;
+  public input(name: string, type: (() => ISqlType) | ISqlType, value: any): Request;
+  public output(name: string, type: (() => ISqlType) | ISqlType, value?: any): Request;
+  public pipe(stream: NodeJS.WritableStream): NodeJS.WritableStream;
+  public query(command: string): Promise<IResult<any>>;
+  public query(command: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<any>>;
+  public query<Entity>(command: string): Promise<IResult<Entity>>;
+  public query<Entity>(command: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<Entity>>;
+  public query<Entity>(command: string, callback: (err?: Error, recordset?: IResult<Entity>) => void): void;
+  public batch(batch: string): Promise<IResult<any>>;
+  public batch(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<any>>;
+  public batch(batch: string, callback: (err?: Error, recordset?: IResult<any>) => void): void;
+  public batch<Entity>(batch: string): Promise<IResult<Entity>>;
+  public batch<Entity>(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<Entity>>;
+  public batch<Entity>(batch: string, callback: (err?: any, recordset?: IResult<Entity>) => void): void;
+  public bulk(table: Table): Promise<IBulkResult>;
+  public bulk(table: Table, options: IBulkOptions): Promise<IBulkResult>;
+  public bulk(table: Table, callback: (err: Error, result: IBulkResult) => void): void;
+  public bulk(table: Table, options: IBulkOptions, callback: (err: Error, result: IBulkResult) => void): void;
+  public cancel(): void;
+  public pause(): boolean;
+  public resume(): boolean;
 }
 
 export declare class RequestError implements Error {
-    constructor(message: string, code?: any)
-    public name: string;
-    public message: string;
-    public code: string;
-    public number?: number;
-    public state?: number;
-    public class?: number;
-    public lineNumber?: number;
-    public serverName?: string;
-    public procName?: string;
+  constructor(message: string, code?: any)
+  public name: string;
+  public message: string;
+  public code: string;
+  public number?: number;
+  public state?: number;
+  public class?: number;
+  public lineNumber?: number;
+  public serverName?: string;
+  public procName?: string;
 }
 
 export declare class Transaction extends events.EventEmitter {
-    public isolationLevel: IIsolationLevel;
-    public constructor(connection?: ConnectionPool);
-    /**
-     * Begin a transaction.
-     * @param [isolationLevel] - Controls the locking and row versioning behavior of TSQL statements issued by a connection.
-     * @param [callback] A callback which is called after transaction has began, or an error has occurred. If omited, method returns Promise.
-     */
-    public begin(isolationLevel?: IIsolationLevel): Promise<Transaction>;
-    public begin(isolationLevel?: IIsolationLevel, callback?: (err?: ConnectionError | TransactionError) => void): Transaction;
-    public commit(): Promise<void>;
-    public commit(callback: (err?: any) => void): void;
-    public rollback(): Promise<void>;
-    public rollback(callback: (err?: any) => void): void;
-    public request(): Request;
+  public isolationLevel: IIsolationLevel;
+  public constructor(connection?: ConnectionPool);
+  /**
+   * Begin a transaction.
+   * @param [isolationLevel] - Controls the locking and row versioning behavior of TSQL statements issued by a connection.
+   * @param [callback] A callback which is called after transaction has began, or an error has occurred. If omited, method returns Promise.
+   */
+  public begin(isolationLevel?: IIsolationLevel): Promise<Transaction>;
+  public begin(isolationLevel?: IIsolationLevel, callback?: (err?: ConnectionError | TransactionError) => void): Transaction;
+  public commit(): Promise<void>;
+  public commit(callback: (err?: any) => void): void;
+  public rollback(): Promise<void>;
+  public rollback(callback: (err?: any) => void): void;
+  public request(): Request;
 }
 
 export declare class TransactionError implements Error {
-    constructor(message: string, code?: any)
-    public name: string;
-    public message: string;
-    public code: string;
+  constructor(message: string, code?: any)
+  public name: string;
+  public message: string;
+  public code: string;
 }
 
 export declare class PreparedStatement extends events.EventEmitter {
-    public transaction: Transaction;
-    public prepared: boolean;
-    public statement: string;
-    public parameters: IRequestParameters;
-    public stream: any;
-    public constructor(connection?: ConnectionPool);
-    public constructor(transaction: Transaction);
-    public input(name: string, type: (() => ISqlType) | ISqlType): PreparedStatement;
-    public output(name: string, type: (() => ISqlType) | ISqlType): PreparedStatement;
-    public prepare(statement?: string): Promise<void>;
-    public prepare(statement?: string, callback?: (err?: Error) => void): PreparedStatement;
-    public execute(values: Object): Promise<IProcedureResult<any>>;
-    public execute<Entity>(values: Object): Promise<IProcedureResult<Entity>>;
-    public execute(values: Object, callback: (err?: Error, result?: IProcedureResult<any>) => void): Request;
-    public execute<Entity>(values: Object, callback: (err?: Error, result?: IProcedureResult<Entity>) => void): Request;
-    public unprepare(): Promise<void>;
-    public unprepare(callback: (err?: Error) => void): PreparedStatement;
+  public transaction: Transaction;
+  public prepared: boolean;
+  public statement: string;
+  public parameters: IRequestParameters;
+  public stream: any;
+  public constructor(connection?: ConnectionPool);
+  public constructor(transaction: Transaction);
+  public input(name: string, type: (() => ISqlType) | ISqlType): PreparedStatement;
+  public output(name: string, type: (() => ISqlType) | ISqlType): PreparedStatement;
+  public prepare(statement?: string): Promise<void>;
+  public prepare(statement?: string, callback?: (err?: Error) => void): PreparedStatement;
+  public execute(values: Object): Promise<IProcedureResult<any>>;
+  public execute<Entity>(values: Object): Promise<IProcedureResult<Entity>>;
+  public execute(values: Object, callback: (err?: Error, result?: IProcedureResult<any>) => void): Request;
+  public execute<Entity>(values: Object, callback: (err?: Error, result?: IProcedureResult<Entity>) => void): Request;
+  public unprepare(): Promise<void>;
+  public unprepare(callback: (err?: Error) => void): PreparedStatement;
 }
 
 export declare class PreparedStatementError implements Error {
-    constructor(message: string, code?: any)
-    public name: string;
-    public message: string;
-    public code: string;
+  constructor(message: string, code?: any)
+  public name: string;
+  public message: string;
+  public code: string;
 }

--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -14,48 +14,26 @@
 
 /// <reference types="node" />
 
+
 import events = require('events');
 import tds = require('tedious');
 export interface ISqlType {
     type: ISqlTypeFactory;
 }
-export interface ISqlTypeWithNoParams extends ISqlType {
-    type: ISqlTypeFactoryWithNoParams;
-}
-export interface ISqlTypeWithLength extends ISqlType {
-    type: ISqlTypeFactoryWithLength;
-    length: number;
-}
-export interface ISqlTypeWithScale extends ISqlType {
-    type: ISqlTypeFactoryWithScale;
-    scale: number;
-}
-export interface ISqlTypeWithPrecisionScale extends ISqlType {
-    type: ISqlTypeFactoryWithPrecisionScale;
-    precision: number;
-    scale: number;
-}
-export interface ISqlTypeWithTvpType extends ISqlType {
-    type: ISqlTypeFactoryWithTvpType;
-    tvpType: any;
-}
+export interface ISqlTypeWithNoParams extends ISqlType { type: ISqlTypeFactoryWithNoParams }
+export interface ISqlTypeWithLength extends ISqlType { type: ISqlTypeFactoryWithLength; length: number }
+export interface ISqlTypeWithScale extends ISqlType { type: ISqlTypeFactoryWithScale; scale: number }
+export interface ISqlTypeWithPrecisionScale extends ISqlType { type: ISqlTypeFactoryWithPrecisionScale; precision: number, scale: number }
+export interface ISqlTypeWithTvpType extends ISqlType { type: ISqlTypeFactoryWithTvpType; tvpType: any }
 
-export interface ISqlTypeFactory {}
-export interface ISqlTypeFactoryWithNoParams extends ISqlTypeFactory {
-    (): ISqlTypeWithNoParams;
+export interface ISqlTypeFactory {
 }
-export interface ISqlTypeFactoryWithLength extends ISqlTypeFactory {
-    (length?: number): ISqlTypeWithLength;
-}
-export interface ISqlTypeFactoryWithScale extends ISqlTypeFactory {
-    (scale?: number): ISqlTypeWithScale;
-}
-export interface ISqlTypeFactoryWithPrecisionScale extends ISqlTypeFactory {
-    (precision?: number, scale?: number): ISqlTypeWithPrecisionScale;
-}
-export interface ISqlTypeFactoryWithTvpType extends ISqlTypeFactory {
-    (tvpType: any): ISqlTypeWithTvpType;
-}
+export interface ISqlTypeFactoryWithNoParams extends ISqlTypeFactory { (): ISqlTypeWithNoParams; }
+export interface ISqlTypeFactoryWithLength extends ISqlTypeFactory { (length?: number): ISqlTypeWithLength }
+export interface ISqlTypeFactoryWithScale extends ISqlTypeFactory { (scale?: number): ISqlTypeWithScale }
+export interface ISqlTypeFactoryWithPrecisionScale extends ISqlTypeFactory { (precision?: number, scale?: number): ISqlTypeWithPrecisionScale; }
+export interface ISqlTypeFactoryWithTvpType extends ISqlTypeFactory { (tvpType: any): ISqlTypeWithTvpType }
+
 
 export declare var VarChar: ISqlTypeFactoryWithLength;
 export declare var NVarChar: ISqlTypeFactoryWithLength;
@@ -131,7 +109,7 @@ export declare var MAX: number;
 export declare var fix: boolean;
 export declare var Promise: any;
 
-interface IMap extends Array<{ js: any; sql: any }> {
+interface IMap extends Array<{ js: any, sql: any }> {
     register(jstype: any, sql: any): void;
 }
 
@@ -151,12 +129,12 @@ export interface IColumnMetadata {
         caseSensitive: boolean;
         identity: boolean;
         readOnly: boolean;
-    };
+    }
 }
 export interface IResult<T> {
     recordsets: IRecordSet<T>[];
     recordset: IRecordSet<T>;
-    rowsAffected: number[];
+    rowsAffected: number[],
     output: { [key: string]: any };
 }
 
@@ -175,12 +153,12 @@ export interface IRecordSet<T> extends Array<T> {
 type IIsolationLevel = number;
 
 export declare var ISOLATION_LEVEL: {
-    READ_UNCOMMITTED: IIsolationLevel;
-    READ_COMMITTED: IIsolationLevel;
-    REPEATABLE_READ: IIsolationLevel;
-    SERIALIZABLE: IIsolationLevel;
-    SNAPSHOT: IIsolationLevel;
-};
+    READ_UNCOMMITTED: IIsolationLevel
+    READ_COMMITTED: IIsolationLevel
+    REPEATABLE_READ: IIsolationLevel
+    SERIALIZABLE: IIsolationLevel
+    SNAPSHOT: IIsolationLevel
+}
 
 export interface IOptions extends tds.ConnectionOptions {
     beforeConnect?: void;
@@ -227,7 +205,7 @@ export interface config {
      * Invoked before opening the connection. The parameter conn is the configured
      * tedious Connection. It can be used for attaching event handlers.
      */
-    beforeConnect?: (conn: tds.Connection) => void;
+    beforeConnect?: (conn: tds.Connection) => void
 }
 
 export declare class ConnectionPool extends events.EventEmitter {
@@ -254,12 +232,11 @@ export declare class ConnectionPool extends events.EventEmitter {
     public transaction(): Transaction;
 }
 
-/* utilise the global connection pool */
 export function connect(connection: string): Promise<ConnectionPool>;
 export function connect(config: config): Promise<ConnectionPool>;
 
 export declare class ConnectionError implements Error {
-    constructor(message: string, code?: any);
+    constructor(message: string, code?: any)
     public name: string;
     public message: string;
     public code: string;
@@ -308,7 +285,7 @@ interface IRequestParameters {
         scale: number;
         precision: number;
         tvpType: any;
-    };
+    }
 }
 
 /**
@@ -338,10 +315,7 @@ export declare class Request extends events.EventEmitter {
     public constructor(preparedStatement: PreparedStatement);
     public execute(procedure: string): Promise<IProcedureResult<any>>;
     public execute<Entity>(procedure: string): Promise<IProcedureResult<Entity>>;
-    public execute<Entity>(
-        procedure: string,
-        callback: (err?: any, recordsets?: IProcedureResult<Entity>, returnValue?: any) => void,
-    ): void;
+    public execute<Entity>(procedure: string, callback: (err?: any, recordsets?: IProcedureResult<Entity>, returnValue?: any) => void): void;
     public input(name: string, value: any): Request;
     public input(name: string, type: (() => ISqlType) | ISqlType, value: any): Request;
     public output(name: string, type: (() => ISqlType) | ISqlType, value?: any): Request;
@@ -367,7 +341,7 @@ export declare class Request extends events.EventEmitter {
 }
 
 export declare class RequestError implements Error {
-    constructor(message: string, code?: any);
+    constructor(message: string, code?: any)
     public name: string;
     public message: string;
     public code: string;
@@ -388,10 +362,7 @@ export declare class Transaction extends events.EventEmitter {
      * @param [callback] A callback which is called after transaction has began, or an error has occurred. If omited, method returns Promise.
      */
     public begin(isolationLevel?: IIsolationLevel): Promise<Transaction>;
-    public begin(
-        isolationLevel?: IIsolationLevel,
-        callback?: (err?: ConnectionError | TransactionError) => void,
-    ): Transaction;
+    public begin(isolationLevel?: IIsolationLevel, callback?: (err?: ConnectionError | TransactionError) => void): Transaction;
     public commit(): Promise<void>;
     public commit(callback: (err?: any) => void): void;
     public rollback(): Promise<void>;
@@ -400,7 +371,7 @@ export declare class Transaction extends events.EventEmitter {
 }
 
 export declare class TransactionError implements Error {
-    constructor(message: string, code?: any);
+    constructor(message: string, code?: any)
     public name: string;
     public message: string;
     public code: string;
@@ -427,7 +398,7 @@ export declare class PreparedStatement extends events.EventEmitter {
 }
 
 export declare class PreparedStatementError implements Error {
-    constructor(message: string, code?: any);
+    constructor(message: string, code?: any)
     public name: string;
     public message: string;
     public code: string;


### PR DESCRIPTION
Please fill in this template.

- [Y ] Use a meaningful title for the pull request. Include the name of the package modified.
- [Y] Test the change in your own code. (Compile and run.)
- [N] Add or edit tests to reflect the change. (Run with `npm test`.)
No obvious tests to make
- [Y] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [Y] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [N] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
I did this, and then reversed it, as it looks like it hasn't been done before.  That should be part of a separate PR.

Select one of these and delete the others:

If changing an existing definition:
- [Y] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/mssql#quick-example
Most examples actually work off the global connection pool.
- [N] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [N] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
No obvious tests to make
- [N] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.