### PR TITLE
Add 'inline' to the type definition of SourceMapOptions.content

### DIFF
--- a/types/uglify-js/index.d.ts
+++ b/types/uglify-js/index.d.ts
@@ -433,7 +433,7 @@ export interface SourceMapOptions {
     names?: boolean;
     url?: string | 'inline';
     root?: string;
-    content?: RawSourceMap;
+    content?: RawSourceMap | 'inline';
 }
 
 export function minify(files: string | string[] | { [file: string]: string }, options?: MinifyOptions): MinifyOutput;

--- a/types/uglify-js/uglify-js-tests.ts
+++ b/types/uglify-js/uglify-js-tests.ts
@@ -11,7 +11,7 @@ code = {
 
 minify(code);
 
-code = "function add(first, second) { return first + second; }";
+code = 'function add(first, second) { return first + second; }';
 minify(code, { toplevel: true });
 
 minify(code, {
@@ -27,7 +27,7 @@ const output = minify(code, {
     warnings: 'verbose',
     mangle: {
         properties: {
-            regex: /reg/
+            regex: /reg/,
         },
         toplevel: true,
     },
@@ -38,12 +38,15 @@ const output = minify(code, {
     compress: {
         arguments: true,
         global_defs: {
-            "@console.log": "alert"
+            '@console.log': 'alert',
         },
         passes: 2,
     },
     nameCache: {},
 });
+if (output.warnings) {
+    output.warnings.filter(x => x === 'Dropping unused variable');
+}
 
 const compressOptions = {
     booleans: true,
@@ -63,6 +66,8 @@ minify(code, {
     compress: compressOptions,
 });
 
-if (output.warnings) {
-    output.warnings.filter(x => x === 'Dropping unused variable');
-}
+minify(code, {
+    sourceMap: {
+        content: 'inline',
+    },
+});


### PR DESCRIPTION
UglifyJS's [source code](https://github.com/mishoo/UglifyJS/blob/484d3fd8c77d8d144c97b312cc2be17586fce995/lib/minify.js#L161) as well as its `--source-map` [document](https://github.com/mishoo/UglifyJS#command-line-options) saying `content` accepts 'inline' string. This is to fix type definitions that are present in UglifyJS version 3.9.

- Added 'inline' to the type definition of SourceMapOptions.content
- Added a new test.
- Moved mis-placed checking output.warnings closer to its corresponding test body.
- Run prettier on the test file.
