### PR TITLE
[@types/dynamodb-lock-client] Add types for dynamodb-lock-client

### DIFF
--- a/types/dynamodb-lock-client/dynamodb-lock-client-tests.ts
+++ b/types/dynamodb-lock-client/dynamodb-lock-client-tests.ts
@@ -1,0 +1,21 @@
+import * as AWS from 'aws-sdk';
+import { FailClosed, FailOpen } from 'dynamodb-lock-client';
+
+const failClosedLock = new FailClosed(); // $ExpectError
+const failOpenLock = new FailOpen(); // $ExpectError
+
+// $ExpectType FailClosed
+new FailClosed({
+    dynamodb: new AWS.DynamoDB.DocumentClient(),
+    lockTable: 'test',
+    partitionKey: 'test',
+    acquirePeriodMs: 100,
+});
+
+// $ExpectType FailOpen
+new FailOpen({
+    dynamodb: new AWS.DynamoDB.DocumentClient(),
+    lockTable: 'test',
+    partitionKey: 'test',
+    leaseDurationMs: 100,
+});

--- a/types/dynamodb-lock-client/index.d.ts
+++ b/types/dynamodb-lock-client/index.d.ts
@@ -1,0 +1,45 @@
+// Type definitions for dynamodb-lock-client 0.7
+// Project: https://github.com/tristanls/dynamodb-lock-client
+// Definitions by: Vadym Abramchuk <https://github.com/devbranch-vadym>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+import * as AWS from 'aws-sdk';
+import * as events from 'events';
+
+export interface FailClosedConfig {
+    owner?: string;
+    dynamodb: AWS.DynamoDB.DocumentClient;
+    lockTable: string;
+    partitionKey: string;
+    retryCount?: number;
+    acquirePeriodMs: number;
+}
+
+export interface FailOpenConfig {
+    owner?: string;
+    dynamodb: AWS.DynamoDB.DocumentClient;
+    lockTable: string;
+    partitionKey: string;
+    retryCount?: number;
+    sortKey?: string;
+    heartbeatPeriodMs?: number;
+    leaseDurationMs: number;
+    trustLocalTime?: boolean;
+}
+
+export type LockAcquiredCallback = (error: Error | undefined, lock: Lock) => void;
+
+export class FailClosed {
+    constructor(config: FailClosedConfig);
+    acquireLock(id: string, callback: LockAcquiredCallback): void;
+}
+
+export class FailOpen {
+    constructor(config: FailOpenConfig);
+    acquireLock(id: string, callback: LockAcquiredCallback): void;
+}
+
+export class Lock extends events.EventEmitter {
+    release(callback: (error?: Error) => void): void;
+}

--- a/types/dynamodb-lock-client/package.json
+++ b/types/dynamodb-lock-client/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "aws-sdk": "^2.325.0"
+    }
+}

--- a/types/dynamodb-lock-client/tsconfig.json
+++ b/types/dynamodb-lock-client/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "dynamodb-lock-client-tests.ts"
+    ]
+}

--- a/types/dynamodb-lock-client/tslint.json
+++ b/types/dynamodb-lock-client/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
