### PR TITLE
google-libphonenumer - Update PhoneNumberUtil with getLengthOfGeographicalAreaCode()

### DIFF
--- a/types/google-libphonenumber/index.d.ts
+++ b/types/google-libphonenumber/index.d.ts
@@ -145,6 +145,7 @@ declare namespace libphonenumber {
         parseAndKeepRawInput(number: string, regionCode?: string): PhoneNumber;
         truncateTooLongNumber(number: PhoneNumber): boolean;
         isNumberMatch(firstNumber: string | PhoneNumber, secondNumber: string | PhoneNumber): PhoneNumberUtil.MatchType;
+        getLengthOfGeographicalAreaCode(number: PhoneNumber): number;
     }
 
     export class AsYouTypeFormatter {


### PR DESCRIPTION
Add missing function getLengthOfGeographicalAreaCode in the PhoneNumberUtil class.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/google/libphonenumber/blob/2b227b6df706cb3a3aafd544b9dece8e28263b3f/javascript/i18n/phonenumbers/phonenumberutil.js#L1196>
