### PR TITLE
Fixes stream-json types with esModuleInterop: true

### DIFF
--- a/types/stream-json/filters/Filter.d.ts
+++ b/types/stream-json/filters/Filter.d.ts
@@ -1,5 +1,5 @@
-import * as Chain from 'stream-chain';
-import * as FilterBase from './FilterBase';
+import Chain = require('stream-chain');
+import FilterBase = require('./FilterBase');
 
 export = Filter;
 

--- a/types/stream-json/filters/Ignore.d.ts
+++ b/types/stream-json/filters/Ignore.d.ts
@@ -1,5 +1,5 @@
-import * as Chain from 'stream-chain';
-import * as FilterBase from './FilterBase';
+import Chain = require('stream-chain');
+import FilterBase = require('./FilterBase');
 
 export = Ignore;
 

--- a/types/stream-json/filters/Pick.d.ts
+++ b/types/stream-json/filters/Pick.d.ts
@@ -1,5 +1,5 @@
-import * as Chain from 'stream-chain';
-import * as FilterBase from './FilterBase';
+import Chain = require('stream-chain');
+import FilterBase = require('./FilterBase');
 
 export = Pick;
 

--- a/types/stream-json/filters/Replace.d.ts
+++ b/types/stream-json/filters/Replace.d.ts
@@ -1,5 +1,5 @@
-import * as Chain from 'stream-chain';
-import * as FilterBase from './FilterBase';
+import Chain = require('stream-chain');
+import FilterBase = require('./FilterBase');
 
 export = Replace;
 

--- a/types/stream-json/index.d.ts
+++ b/types/stream-json/index.d.ts
@@ -5,26 +5,7 @@
 
 /// <reference types="node" />
 
-import * as Assembler from './Assembler';
-import * as Disassembler from './Disassembler';
-import * as Emitter from './Emitter';
-import * as Parser from './Parser';
-import * as Stringer from './Stringer';
-
-import * as FilterBase from './filters/FilterBase';
-import * as Pick from './filters/Pick';
-import * as Replace from './filters/Replace';
-import * as Ignore from './filters/Ignore';
-import * as Filter from './filters/Filter';
-
-import * as StreamArray from './streamers/StreamArray';
-import * as StreamObject from './streamers/StreamObject';
-import * as StreamValues from './streamers/StreamValues';
-
-import * as Batch from "./utils/Batch";
-import * as Verifier from "./utils/Verifier";
-import * as emit from './utils/emit';
-import * as withParser from './utils/withParser';
+import Parser = require('./Parser');
 
 export = make;
 

--- a/types/stream-json/streamers/StreamArray.d.ts
+++ b/types/stream-json/streamers/StreamArray.d.ts
@@ -1,5 +1,5 @@
-import * as Chain from 'stream-chain';
-import * as StreamBase from './StreamBase';
+import Chain = require('stream-chain');
+import StreamBase = require('./StreamBase');
 
 export = StreamArray;
 

--- a/types/stream-json/streamers/StreamBase.d.ts
+++ b/types/stream-json/streamers/StreamBase.d.ts
@@ -1,5 +1,5 @@
 import { Transform, TransformOptions } from 'stream';
-import * as Assembler from '../Assembler';
+import Assembler = require('../Assembler');
 
 export = StreamBase;
 

--- a/types/stream-json/streamers/StreamObject.d.ts
+++ b/types/stream-json/streamers/StreamObject.d.ts
@@ -1,5 +1,5 @@
-import * as Chain from 'stream-chain';
-import * as StreamBase from './StreamBase';
+import Chain = require('stream-chain');
+import StreamBase = require('./StreamBase');
 
 export = StreamObject;
 

--- a/types/stream-json/streamers/StreamValues.d.ts
+++ b/types/stream-json/streamers/StreamValues.d.ts
@@ -1,5 +1,5 @@
-import * as Chain from 'stream-chain';
-import * as StreamBase from './StreamBase';
+import Chain = require('stream-chain');
+import StreamBase = require('./StreamBase');
 
 export = StreamValues;
 

--- a/types/stream-json/utils/Batch.d.ts
+++ b/types/stream-json/utils/Batch.d.ts
@@ -1,4 +1,4 @@
-import * as Chain from 'stream-chain';
+import Chain = require('stream-chain');
 import { Transform, TransformOptions } from 'stream';
 
 export = Batch;

--- a/types/stream-json/utils/withParser.d.ts
+++ b/types/stream-json/utils/withParser.d.ts
@@ -1,9 +1,8 @@
 import { Writable, WritableOptions, Duplex, DuplexOptions, Transform, TransformOptions } from 'stream';
-import * as Chain from 'stream-chain';
-import * as Parser from '../Parser';
-import * as FilterBase from '../filters/FilterBase';
-import * as StreamBase from '../streamers/StreamBase';
-
+import FilterBase = require('../filters/FilterBase');
+import Parser = require('../Parser');
+import StreamBase = require('../streamers/StreamBase');
+import Chain = require('stream-chain');
 export = withParser;
 
 declare function withParser(


### PR DESCRIPTION
When using `esModuleInterop: true` then imports are failing when using `stream-json`. A thread on patch to fix this issue can be found here: https://github.com/uhop/stream-json/issues/69.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/uhop/stream-json/issues/69