### PR TITLE
[@types/daterangepicker] property 'drops' could accept 'auto' value (update to 3.1)

### DIFF
--- a/types/daterangepicker/daterangepicker-tests.ts
+++ b/types/daterangepicker/daterangepicker-tests.ts
@@ -3,6 +3,9 @@ import daterangepicker = require('daterangepicker');
 
 function tests_simple() {
     $('#daterange').daterangepicker();
+    $('#daterange').daterangepicker({
+        drops: 'auto'
+    });
     $('input[name="daterange"]')
         .daterangepicker({
             timePicker: true,

--- a/types/daterangepicker/index.d.ts
+++ b/types/daterangepicker/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Date Range Picker 3.0
+// Type definitions for Date Range Picker 3.1
 // Project: http://www.daterangepicker.com/, https://github.com/dangrossman/daterangepicker
 // Definitions by: SirMartin <https://github.com/SirMartin>
 //                 Steven Masala <https://github.com/smasala>

--- a/types/daterangepicker/index.d.ts
+++ b/types/daterangepicker/index.d.ts
@@ -127,7 +127,7 @@ declare namespace daterangepicker {
         /**
          * Whether the picker appears below (default) or above the HTML element it's attached to
          */
-        drops?: 'down' | 'up';
+        drops?: 'down' | 'up' | 'auto';
         /**
          * CSS class names that will be added to all buttons in the picker
          */


### PR DESCRIPTION
Property ``drops`` accepts 'down'/'up'/'auto' options ('auto' added)

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://www.daterangepicker.com/#options
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)