### PR TITLE
Add types for mudder

### DIFF
--- a/types/mudder/index.d.ts
+++ b/types/mudder/index.d.ts
@@ -1,0 +1,47 @@
+// Type definitions for mudder 1.0
+// Project: https://github.com/fasiha/mudderjs#readme
+// Definitions by: Patrick Gingras <https://github.com/p7g>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export class SymbolTable {
+    num2sym: ReadonlyArray<string>;
+    sym2num: Map<string, number>;
+    maxBase: number;
+    isPrefixCode: boolean;
+
+    constructor(symbols: string | ReadonlyArray<string>, map?: Record<string, number> | Map<string, number>);
+
+    numberToDigits(num: number, base?: number): number[];
+    digitsToString(digits: ReadonlyArray<number>): string;
+    stringToDigits(string: string | ReadonlyArray<string>): number[];
+    digitsToNumber(digits: ReadonlyArray<number>, base?: number): number;
+    numberToString(num: number, base?: number): string;
+    stringToNumber(num: string | ReadonlyArray<string>, base?: number): number;
+    roundFraction(num: number, den: number, base?: number): number[];
+
+    mudder(num: number): string[];
+    mudder(
+        a?: string | ReadonlyArray<string>,
+        b?: string | ReadonlyArray<string>,
+        numStrings?: number,
+        base?: number,
+        numDivisions?: number,
+    ): string[];
+}
+
+export function longLinspace(
+    a: ReadonlyArray<number>,
+    b: ReadonlyArray<number>,
+    base: number,
+    N: number,
+    M: number,
+): Array<{
+    res: number[];
+    carry: boolean;
+    rem: number;
+    den: number;
+}>;
+
+export const base36: SymbolTable;
+export const base62: SymbolTable;
+export const alphabet: SymbolTable;

--- a/types/mudder/mudder-tests.ts
+++ b/types/mudder/mudder-tests.ts
@@ -1,0 +1,10 @@
+import * as mudder from 'mudder';
+
+const abc = new mudder.SymbolTable('abc');
+
+abc.mudder(123); // $ExpectType string[]
+abc.mudder('a', 'c'); // $ExpectType string[]
+abc.mudder('a', 'c', 3, undefined, 100); // $ExpectType string[]
+abc.mudder('a', 'c', 3, 4, 100); // $ExpectType string[]
+
+new mudder.SymbolTable(['def', 'deg'], { def: 0, deg: 1 });

--- a/types/mudder/tsconfig.json
+++ b/types/mudder/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mudder-tests.ts"
+    ]
+}

--- a/types/mudder/tslint.json
+++ b/types/mudder/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
[https://github.com/fasiha/mudderjs](https://github.com/fasiha/mudderjs)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

