### PR TITLE
Add type definitions for nanoid-dictionary

### DIFF
--- a/types/nanoid-dictionary/index.d.ts
+++ b/types/nanoid-dictionary/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for nanoid-dictionary 3.0
+// Project: https://github.com/CyberAP/nanoid-dictionary#readme
+// Definitions by: Shengjie Pan <https://github.com/kenelm007>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/* Lowercase English letters */
+export const lowercase: string;
+/* Uppercase English letters */
+export const uppercase: string;
+/* Numbers from 0 to 9 */
+export const numbers: string;
+/* Numbers and english alphabet without lookalikes */
+export const nolookalikes: string;

--- a/types/nanoid-dictionary/index.d.ts
+++ b/types/nanoid-dictionary/index.d.ts
@@ -3,11 +3,7 @@
 // Definitions by: Shengjie Pan <https://github.com/kenelm007>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/* Lowercase English letters */
-export const lowercase: string;
-/* Uppercase English letters */
-export const uppercase: string;
-/* Numbers from 0 to 9 */
-export const numbers: string;
-/* Numbers and english alphabet without lookalikes */
-export const nolookalikes: string;
+export import lowercase = require('./lowercase');
+export import uppercase = require('./uppercase');
+export import numbers = require('./numbers');
+export import nolookalikes = require('./nolookalikes');

--- a/types/nanoid-dictionary/lowercase.d.ts
+++ b/types/nanoid-dictionary/lowercase.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Lowercase English letters
+ */
+declare const lowercase: string;
+
+export = lowercase;

--- a/types/nanoid-dictionary/nanoid-dictionary-tests.ts
+++ b/types/nanoid-dictionary/nanoid-dictionary-tests.ts
@@ -1,0 +1,6 @@
+import { lowercase, uppercase, numbers, nolookalikes } from 'nanoid-dictionary';
+
+lowercase; // $ExpectType string
+uppercase; // $ExpectType string
+numbers; // $ExpectType string
+nolookalikes; // $ExpectType string

--- a/types/nanoid-dictionary/nanoid-dictionary-tests.ts
+++ b/types/nanoid-dictionary/nanoid-dictionary-tests.ts
@@ -1,4 +1,13 @@
-import { lowercase, uppercase, numbers, nolookalikes } from 'nanoid-dictionary';
+import dict = require('nanoid-dictionary');
+import lowercase = require('nanoid-dictionary/lowercase');
+import uppercase = require('nanoid-dictionary/uppercase');
+import numbers = require('nanoid-dictionary/numbers');
+import nolookalikes = require('nanoid-dictionary/nolookalikes');
+
+dict.lowercase; // $ExpectType string
+dict.uppercase; // $ExpectType string
+dict.numbers; // $ExpectType string
+dict.nolookalikes; // $ExpectType string
 
 lowercase; // $ExpectType string
 uppercase; // $ExpectType string

--- a/types/nanoid-dictionary/nolookalikes.d.ts
+++ b/types/nanoid-dictionary/nolookalikes.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Numbers and english alphabet without lookalikes
+ */
+declare const nolookalikes: string;
+
+export = nolookalikes;

--- a/types/nanoid-dictionary/numbers.d.ts
+++ b/types/nanoid-dictionary/numbers.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Numbers from 0 to 9
+ */
+declare const numbers: string;
+
+export = numbers;

--- a/types/nanoid-dictionary/tsconfig.json
+++ b/types/nanoid-dictionary/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "nanoid-dictionary-tests.ts"
+    ]
+}

--- a/types/nanoid-dictionary/tslint.json
+++ b/types/nanoid-dictionary/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/nanoid-dictionary/uppercase.d.ts
+++ b/types/nanoid-dictionary/uppercase.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Uppercase English letters
+ */
+declare const uppercase: string;
+
+export = uppercase;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
