### PR TITLE
webpack: add missing MultiStats methods

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1305,6 +1305,14 @@ declare namespace webpack {
         interface MultiStats {
             stats: Stats[];
             hash: string;
+            /** Returns true if there were errors while compiling. */
+            hasErrors(): boolean;
+            /** Returns true if there were warnings while compiling. */
+            hasWarnings(): boolean;
+            /** Returns compilation information as a JSON object. */
+            toJson(options?: Stats.ToJsonOptions): Stats.ToJsonOutput;
+            /** Returns a formatted string of the compilation information (similar to CLI output). */
+            toString(options?: Stats.ToStringOptions): string;
         }
 
         interface MultiCompilerHooks {

--- a/types/webpack/test/index.ts
+++ b/types/webpack/test/index.ts
@@ -1102,14 +1102,19 @@ compiler.hooks.done.tap('foo', stats => {
 
 const multiCompiler = webpack([{}, {}]);
 
-multiCompiler.hooks.done.tap('foo', ({ stats: multiStats, hash }) => {
-    const stats = multiStats[0];
+multiCompiler.hooks.done.tap('foo', (multiStats) => {
+    const [firstStat] = multiStats.stats;
 
-    if (stats.startTime === undefined || stats.endTime === undefined) {
+    if (multiStats.hasWarnings() || multiStats.hasErrors()) {
+        throw new Error(multiStats.toString('errors-warnings'));
+    }
+    multiStats.toJson(); // $ExpectType ToJsonOutput
+
+    if (firstStat.startTime === undefined || firstStat.endTime === undefined) {
         throw new Error('Well, this is odd');
     }
 
-    console.log(`Compiled in ${stats.endTime - stats.startTime}ms`, hash);
+    console.log(`Compiled in ${firstStat.endTime - firstStat.startTime}ms`, multiStats.hash);
 });
 
 webpack.Template.getFunctionContent(() => undefined).trimLeft();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/webpack/blob/v4.43.0/lib/MultiStats.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
