### PR TITLE
[sort-json] Add sort-json

### DIFF
--- a/types/sort-json/index.d.ts
+++ b/types/sort-json/index.d.ts
@@ -1,0 +1,52 @@
+// Type definitions for sort-json 2.0
+// Project: https://github.com/kesla/sort-json
+// Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace visit {
+    interface VisitOptions {
+        /**
+         * Depth's level sorting keys on a multidimensional object
+         * (default: `Infinity`)
+         */
+        depth?: number;
+        /**
+         * When sorting keys, converts all keys to lowercase so that
+         * capitalization doesn't interfere with sort order (default: `false`)
+         */
+        ignoreCase?: boolean;
+        /** Default: `1` */
+        level?: number;
+        /** Reverse the ordering z -> a (default: `false`) */
+        reverse?: boolean;
+    }
+
+    interface OverwriteOptions extends VisitOptions {
+        /**
+         * Formats the file content with an indentation of spaces. Use a number
+         * greater then 0 for the value (default: detects the used indentation
+         * of the file)
+         */
+        indentSize?: number;
+        /** Default: `false` */
+        noFinalNewLine?: boolean;
+    }
+
+    /**
+     * Sorts the JSON files with the `visit()` function and then overwrites the
+     * file with sorted JSON
+     * @param absolutePaths
+     * * String: Absolute path to JSON file to sort and overwrite
+     * * Array: Absolute paths to JSON files to sort and overwrite
+     */
+    function overwrite(absolutePaths: string | string[], options?: OverwriteOptions): any;
+}
+
+/**
+ * Sorts the keys on objects
+ * @param old An object to sort the keys of, if not object just returns whatever
+ * was given
+ */
+declare function visit<T>(old: T, options?: visit.VisitOptions): T;
+
+export = visit;

--- a/types/sort-json/sort-json-tests.ts
+++ b/types/sort-json/sort-json-tests.ts
@@ -1,0 +1,7 @@
+import sortJson = require('sort-json');
+
+const options: sortJson.VisitOptions = { ignoreCase: true, reverse: true, depth: 1 };
+sortJson({ AA: 123, a: 1, b: 21 }, options);
+
+sortJson.overwrite('some/absolute/path.json', options);
+sortJson.overwrite(['some/absolute/path1.json', 'some/absolute/path2.json'], options);

--- a/types/sort-json/tsconfig.json
+++ b/types/sort-json/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "sort-json-tests.ts"
+    ]
+}

--- a/types/sort-json/tslint.json
+++ b/types/sort-json/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
