### PR TITLE
Update ALBResult in aws-lambda

### DIFF
--- a/types/aws-lambda/trigger/alb.d.ts
+++ b/types/aws-lambda/trigger/alb.d.ts
@@ -24,9 +24,9 @@ export interface ALBEvent {
 
 export interface ALBResult {
     statusCode: number;
-    statusDescription: string;
+    statusDescription?: string;
     headers?: { [header: string]: boolean | number | string };
     multiValueHeaders?: { [header: string]: Array<boolean | number | string> };
     body?: string;
-    isBase64Encoded: boolean;
+    isBase64Encoded?: boolean;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

As far as I can tell `statusDescription` and `isBase64Encoded` are optional. E.g. `statusDescription` is also not a part of this official example: https://github.com/aws/elastic-load-balancing-tools/blob/master/application-load-balancer-serverless-app/whatismyip/whatismyip.py#L14

But I'm not super familiar with the API. There are several old blog post which says that those fields are required, but my tests can't verify this. Same results for me if I drop those fields? Maybe ALB changed it's behavior? 
