### PR TITLE
fix(45927): fix missing `path` for Module in v12

### DIFF
--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -1162,6 +1162,12 @@ declare namespace NodeJS {
         loaded: boolean;
         parent: Module | null;
         children: Module[];
+        /**
+         * @since 11.14.0
+         *
+         * The directory name of the module. This is usually the same as the path.dirname() of the module.id.
+         */
+        path: string;
         paths: string[];
 
         constructor(id: string, parent?: Module);

--- a/types/node/v12/node-tests.ts
+++ b/types/node/v12/node-tests.ts
@@ -764,7 +764,7 @@ import moduleModule = require('module');
     const m2: Module = new Module.Module("moduleId");
     const b: string[] = Module.builtinModules;
     let paths: string[] = module.paths;
-    const path = module.path;
+    const path: string = module.path;
     paths = m1.paths;
 
     const customRequire1 = moduleModule.createRequireFromPath('./test');

--- a/types/node/v12/node-tests.ts
+++ b/types/node/v12/node-tests.ts
@@ -764,6 +764,7 @@ import moduleModule = require('module');
     const m2: Module = new Module.Module("moduleId");
     const b: string[] = Module.builtinModules;
     let paths: string[] = module.paths;
+    const path = module.path;
     paths = m1.paths;
 
     const customRequire1 = moduleModule.createRequireFromPath('./test');


### PR DESCRIPTION
This is an attempt to fix a problem reported in #45927

/cc @tk-1io

Thanks!

Fixes #45927

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)