### PR TITLE
[dockerode] Add types for exec instances

### DIFF
--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -59,8 +59,8 @@ declare namespace Dockerode {
         unpause(callback: Callback<any>): void;
         unpause(options?: {}): Promise<any>;
 
-        exec(options: {}, callback: Callback<any>): void;
-        exec(options: {}): Promise<any>;
+        exec(options: ExecCreateOptions, callback: Callback<Exec>): void;
+        exec(options: ExecCreateOptions): Promise<Exec>;
 
         commit(options: {}, callback: Callback<any>): void;
         commit(callback: Callback<any>): void;
@@ -300,11 +300,11 @@ declare namespace Dockerode {
         modem: any;
         id: string;
 
-        inspect(callback: Callback<any>): void;
-        inspect(): Promise<any>;
+        inspect(callback: Callback<ExecInspectInfo>): void;
+        inspect(): Promise<ExecInspectInfo>;
 
-        start(options: {}, callback: Callback<any>): void;
-        start(options: {}): Promise<any>;
+        start(options: ExecStartOptions, callback: Callback<stream.Duplex>): void;
+        start(options: ExecStartOptions): Promise<stream.Duplex>;
 
         resize(options: {}, callback: Callback<any>): void;
         resize(options: {}): Promise<any>;
@@ -492,7 +492,7 @@ declare namespace Dockerode {
         MountLabel: string;
         ProcessLabel: string;
         AppArmorProfile: string;
-        ExecIDs?: any;
+        ExecIDs?: string[];
         HostConfig: HostConfig;
         GraphDriver: {
             Name: string;
@@ -875,6 +875,48 @@ declare namespace Dockerode {
 
     interface EndpointsConfig {
         [key: string]: EndpointSettings;
+    }
+
+    interface ExecCreateOptions {
+        AttachStdin?: boolean;
+        AttachStdout?: boolean;
+        AttachStderr?: boolean;
+        DetachKeys?: string;
+        Tty?: boolean;
+        Env?: string[];
+        Cmd?: string[];
+        Privileged?: boolean;
+        User?: string;
+        WorkingDir?: string;
+    }
+
+    interface ExecInspectInfo {
+        CanRemove: boolean;
+        DetachKeys: string;
+        ID: string;
+        Running: boolean;
+        ExitCode: number | null;
+        ProcessConfig: {
+            privileged: boolean;
+            user: string;
+            tty: boolean;
+            entrypoint: string;
+            arguments: string[];
+        };
+        OpenStdin: boolean;
+        OpenStderr: boolean;
+        OpenStdout: boolean;
+        ContainerID: string;
+        Pid: number;
+    }
+
+    interface ExecStartOptions {
+        // hijack and stdin are used by docker-modem
+        hijack?: boolean;
+        stdin?: boolean;
+        // Detach and Tty are used by Docker's API
+        Detach?: boolean;
+        Tty?: boolean;
     }
 
     type MountType = 'bind' | 'volume' | 'tmpfs';


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:

- Docker API: <<https://docs.docker.com/engine/api/v1.40/#tag/Exec>>
- docker-modem: <<https://github.com/apocas/dockerode/blob/master/lib/exec.js#L31>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
