### PR TITLE
Fix issues in chrome/chrome-cast typings

### DIFF
--- a/types/chrome/chrome-cast/index.d.ts
+++ b/types/chrome/chrome-cast/index.d.ts
@@ -225,7 +225,7 @@ declare namespace chrome.cast {
         sessionRequest: chrome.cast.SessionRequest;
         sessionListener: (session: chrome.cast.Session) => void;
         receiverListener: (receiverAvailability: chrome.cast.ReceiverAvailability) => void;
-        autoJoinPolicy?: chrome.cast.AutoJoinPolicy;
+        autoJoinPolicy: chrome.cast.AutoJoinPolicy;
         defaultActionPolicy: chrome.cast.DefaultActionPolicy;
     }
 
@@ -244,8 +244,8 @@ declare namespace chrome.cast {
         );
 
         code: chrome.cast.ErrorCode;
-        description?: string;
-        details?: string;
+        description: string|null;
+        details: object;
 
     }
 
@@ -258,8 +258,8 @@ declare namespace chrome.cast {
         constructor(url: string);
 
         url: string;
-        height?: number;
-        width?: number;
+        height: number|null;
+        width: number|null;
     }
 
     export class SenderApplication {
@@ -273,8 +273,8 @@ declare namespace chrome.cast {
         );
 
         platform: chrome.cast.SenderPlatform;
-        url?: string;
-        packageId?: string;
+        url: string|null;
+        packageId: string|null;
     }
 
     export class SessionRequest {
@@ -294,7 +294,7 @@ declare namespace chrome.cast {
         appId: string;
         capabilities: Array<chrome.cast.Capability>;
         requestSessionTimeout: number;
-        language?: string;
+        language: string|null;
     }
 
     export class Session {
@@ -323,7 +323,9 @@ declare namespace chrome.cast {
         senderApps: Array<chrome.cast.SenderApplication>;
         namespaces: Array<{ name: string }>;
         media: Array<chrome.cast.media.Media>;
-        status: chrome.cast.SessionStatus
+        status: chrome.cast.SessionStatus;
+        statusText: string|null;
+        transportId: string;
 
         /**
          * @param {number} newLevel
@@ -499,8 +501,8 @@ declare namespace chrome.cast {
             muted?: boolean
         );
 
-        level?: number;
-        muted?: boolean;
+        level: number|null;
+        muted: boolean|null;
     }
 }
 
@@ -988,7 +990,7 @@ declare namespace chrome.cast.media {
         activeTrackIds: Array<number>;
         currentItemId: number;
         customData: Object;
-        idleReason: chrome.cast.media.IdleReason;
+        idleReason: chrome.cast.media.IdleReason|null;
         items: Array<chrome.cast.media.QueueItem>;
         liveSeekableRange?: chrome.cast.media.LiveSeekableRange;
         loadingItemId: number;


### PR DESCRIPTION
- Fixed some deviations from official documentation (https://developers.google.com/cast/docs/reference/chrome):
    - chrome.cast.ApiConfig: autojoinPolicy field is non-optional and non-nullable.
    - chrome.cast.Error: description field is non-optional and nullable.
    - chrome.cast.Error: details field is an non-optional and non-nullable Object.
    - chrome.cast.Image: height and width fields are non-optional and nullable.
    - chrome.cast.SenderApplication: url and packageId fields are non-optional and nullable.
    - chrome.cast.SessionRequest: language field is a non-optional and nullable.
    - chrome.cast.Session: Added statusText and transportId fields.
    - chrome.cast.Volume: level and muted fields are non-optional and nullable.
    - chrome.cast.media.Media: idleReason field is nullable.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/cast/docs/reference/chrome
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
