### PR TITLE
Improve deprecated reasons for @types/node

### DIFF
--- a/types/node/assert.d.ts
+++ b/types/node/assert.d.ts
@@ -19,16 +19,16 @@ declare module "assert" {
         type AssertPredicate = RegExp | (new() => object) | ((thrown: any) => boolean) | object | Error;
 
         function fail(message?: string | Error): never;
-        /** @deprecated since v10.0.0 - use fail([message]) or other assert functions instead. */
+        /** @deprecated since v10.0.0 - use `fail([message])` or other assert functions instead. */
         function fail(actual: any, expected: any, message?: string | Error, operator?: string, stackStartFn?: Function): never;
         function ok(value: any, message?: string | Error): void;
-        /** @deprecated since v9.9.0 - use strictEqual() instead. */
+        /** @deprecated since v9.9.0 - use `strictEqual()` instead. */
         function equal(actual: any, expected: any, message?: string | Error): void;
-        /** @deprecated since v9.9.0 - use notStrictEqual() instead. */
+        /** @deprecated since v9.9.0 - use `notStrictEqual()` instead. */
         function notEqual(actual: any, expected: any, message?: string | Error): void;
-        /** @deprecated since v9.9.0 - use deepStrictEqual() instead. */
+        /** @deprecated since v9.9.0 - use `deepStrictEqual()` instead. */
         function deepEqual(actual: any, expected: any, message?: string | Error): void;
-        /** @deprecated since v9.9.0 - use notDeepStrictEqual() instead. */
+        /** @deprecated since v9.9.0 - use `notDeepStrictEqual()` instead. */
         function notDeepEqual(actual: any, expected: any, message?: string | Error): void;
         function strictEqual(actual: any, expected: any, message?: string | Error): void;
         function notStrictEqual(actual: any, expected: any, message?: string | Error): void;

--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -13,7 +13,7 @@ declare module "buffer" {
     export function transcode(source: Uint8Array, fromEnc: TranscodeEncoding, toEnc: TranscodeEncoding): Buffer;
 
     export const SlowBuffer: {
-        /** @deprecated since v6.0.0, use Buffer.allocUnsafeSlow() */
+        /** @deprecated since v6.0.0, use `Buffer.allocUnsafeSlow()` */
         new(size: number): Buffer;
         prototype: Buffer;
     };

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -178,11 +178,11 @@ declare module "crypto" {
     interface CipherGCMOptions extends stream.TransformOptions {
         authTagLength?: number;
     }
-    /** @deprecated since v10.0.0 use createCipheriv() */
+    /** @deprecated since v10.0.0 use `createCipheriv()` */
     function createCipher(algorithm: CipherCCMTypes, password: BinaryLike, options: CipherCCMOptions): CipherCCM;
-    /** @deprecated since v10.0.0 use createCipheriv() */
+    /** @deprecated since v10.0.0 use `createCipheriv()` */
     function createCipher(algorithm: CipherGCMTypes, password: BinaryLike, options?: CipherGCMOptions): CipherGCM;
-    /** @deprecated since v10.0.0 use createCipheriv() */
+    /** @deprecated since v10.0.0 use `createCipheriv()` */
     function createCipher(algorithm: string, password: BinaryLike, options?: stream.TransformOptions): Cipher;
 
     function createCipheriv(
@@ -221,11 +221,11 @@ declare module "crypto" {
         setAAD(buffer: Buffer, options?: { plaintextLength: number }): this;
         getAuthTag(): Buffer;
     }
-    /** @deprecated since v10.0.0 use createDecipheriv() */
+    /** @deprecated since v10.0.0 use `createDecipheriv()` */
     function createDecipher(algorithm: CipherCCMTypes, password: BinaryLike, options: CipherCCMOptions): DecipherCCM;
-    /** @deprecated since v10.0.0 use createDecipheriv() */
+    /** @deprecated since v10.0.0 use `createDecipheriv()` */
     function createDecipher(algorithm: CipherGCMTypes, password: BinaryLike, options?: CipherGCMOptions): DecipherGCM;
-    /** @deprecated since v10.0.0 use createDecipheriv() */
+    /** @deprecated since v10.0.0 use `createDecipheriv()` */
     function createDecipher(algorithm: string, password: BinaryLike, options?: stream.TransformOptions): Decipher;
 
     function createDecipheriv(

--- a/types/node/dns.d.ts
+++ b/types/node/dns.d.ts
@@ -60,7 +60,7 @@ declare module "dns" {
         ttl: number;
     }
 
-    /** @deprecated Use AnyARecord or AnyAaaaRecord instead. */
+    /** @deprecated Use `AnyARecord` or `AnyAaaaRecord` instead. */
     type AnyRecordWithTtl = AnyARecord | AnyAaaaRecord;
 
     interface AnyARecord extends RecordWithTtl {

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -1727,7 +1727,7 @@ declare module "fs" {
 
     /**
      * Asynchronously tests whether or not the given path exists by checking with the file system.
-     * @deprecated
+     * @deprecated since v1.0.0 Use `fs.stat()` or `fs.access()` instead
      * @param path A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
      */

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -726,7 +726,7 @@ declare module "tls" {
     function connect(port: number, host?: string, options?: ConnectionOptions, secureConnectListener?: () => void): TLSSocket;
     function connect(port: number, options?: ConnectionOptions, secureConnectListener?: () => void): TLSSocket;
     /**
-     * @deprecated
+     * @deprecated since v0.11.3 Use `tls.TLSSocket` instead.
      */
     function createSecurePair(credentials?: SecureContext, isServer?: boolean, requestCert?: boolean, rejectUnauthorized?: boolean): SecurePair;
     function createSecureContext(details: SecureContextOptions): SecureContext;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/fs.html#fs_fs_exists_path_callback
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.



- Adds a few missing messages on deprecated apis about which alternatives to use

- Marks code references in deprecated messages with markdown backticks

/cc @DanielRosenwasser 
