### PR TITLE
[pg] Move application_name field from PoolConfig to ClientConfig

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -10,7 +10,7 @@ import events = require('events');
 import stream = require('stream');
 import pgTypes = require('pg-types');
 
-import { ConnectionOptions } from "tls";
+import { ConnectionOptions } from 'tls';
 
 export interface ClientConfig {
     user?: string;
@@ -27,6 +27,7 @@ export interface ClientConfig {
     query_timeout?: number;
     keepAliveInitialDelayMillis?: number;
     idle_in_transaction_session_timeout?: number;
+    application_name?: string;
 }
 
 export type ConnectionConfig = ClientConfig;
@@ -46,8 +47,6 @@ export interface PoolConfig extends ClientConfig {
     connectionTimeoutMillis?: number;
     idleTimeoutMillis?: number;
     log?: (...messages: any[]) => void;
-
-    application_name?: string;
     Promise?: PromiseConstructorLike;
 }
 

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -9,6 +9,7 @@ const client = new Client({
     port: 5334,
     user: 'database-user',
     password: 'secretpassword!!',
+    application_name: 'DefinitelyTyped',
     keepAlive: true,
 });
 client.connect(err => {


### PR DESCRIPTION
The `application_name` field was added in #14735 but was placed under `PoolConfig` instead of `ClientConfig`. The field is actually valid in both contexts.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/brianc/node-postgres/blob/master/packages/pg/lib/connection-parameters.js#L87
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be 