### PR TITLE
[react-native] Amend AccessibilityActionInfo to allow custom action names

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -2110,7 +2110,7 @@ export interface AccessibilityProps extends AccessibilityPropsAndroid, Accessibi
 }
 
 export type AccessibilityActionInfo = Readonly<{
-    name: AccessibilityActionName;
+    name: AccessibilityActionName | string;
     label?: string;
 }>;
 

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -1168,3 +1168,31 @@ DevSettings.addMenuItem('alert', () => {
 });
 DevSettings.reload();
 DevSettings.reload('reload with reason');
+
+// Accessibility custom actions
+const AccessibilityCustomActionsTest = () => {
+    return (
+        <View
+            accessible={true}
+            accessibilityActions={[
+                // should support custom defined actions
+                { name: 'cut', label: 'cut' },
+                { name: 'copy', label: 'copy' },
+                { name: 'paste', label: 'paste' },
+            ]}
+            onAccessibilityAction={event => {
+                switch (event.nativeEvent.actionName) {
+                    case 'cut':
+                        Alert.alert('Alert', 'cut action success');
+                        break;
+                    case 'copy':
+                        Alert.alert('Alert', 'copy action success');
+                        break;
+                    case 'paste':
+                        Alert.alert('Alert', 'paste action success');
+                        break;
+                }
+            }}
+        />
+    );
+};


### PR DESCRIPTION
This pull request makes a minor change to the `AccessibilityActionInfo` type in react-native which is used to describe the accessibility 'actions' supplied to `accessibilityActions` prop, previous types defined `name` as the union `AccessibilityActionName` which outlines the 'standard' actions which are supported, but react-native also supports custom named actions.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactnative.dev/docs/accessibility#accessibility-actions