### PR TITLE
prosemirror-commands: Fix Command type

### DIFF
--- a/types/prosemirror-commands/index.d.ts
+++ b/types/prosemirror-commands/index.d.ts
@@ -12,11 +12,19 @@ import { MarkType, Node as ProsemirrorNode, NodeType, Schema } from 'prosemirror
 import { EditorState, Transaction } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 
+/**
+ * A command function takes an editor state, *optionally* a `dispatch`
+ * function that it can use to dispatch a transaction and optionally
+ * an `EditorView` instance. It should return a boolean that indicates
+ * whether it could perform any action. When no `dispatch` callback is
+ * passed, the command should do a 'dry run', determining whether it is
+ * applicable, but not actually doing anything.
+ */
 export interface Command<S extends Schema = any> {
   (
     state: EditorState<S>,
-    dispatch: (tr: Transaction<S>) => void,
-    view: EditorView<S>
+    dispatch?: (tr: Transaction<S>) => void,
+    view?: EditorView<S>
   ): boolean;
 }
 
@@ -218,11 +226,7 @@ export function autoJoin<S extends Schema = any>(
  * Combine a number of command functions into a single function (which
  * calls them one by one until one returns true).
  */
-export function chainCommands<S extends Schema = any>(
-  ...commands: Array<
-    (p1: EditorState<S>, p2?: (tr: Transaction<S>) => void, p3?: EditorView<S>) => boolean
-    >
-): (p1: EditorState<S>, p2?: (tr: Transaction<S>) => void, p3?: EditorView<S>) => boolean;
+export function chainCommands<S extends Schema = any>(...commands: Array<Command<S>>): Command<S>;
 /**
  * A basic keymap containing bindings not specific to any schema.
  * Binds the following keys (when multiple commands are listed, they

--- a/types/prosemirror-commands/prosemirror-commands-tests.ts
+++ b/types/prosemirror-commands/prosemirror-commands-tests.ts
@@ -19,3 +19,7 @@ const keymap: commands.Keymap = {
     ArrowLeft: commands.joinBackward,  // takes three args
     ArrowRight: (state, dispatch, view) => true,  // arg types inferred
 };
+
+Object.keys(commands.baseKeymap).forEach(key => {
+    keymap[key] = keymap[key] ? commands.chainCommands(keymap[key], commands.baseKeymap[key]) : commands.baseKeymap[key];
+});

--- a/types/prosemirror-keymap/prosemirror-keymap-tests.ts
+++ b/types/prosemirror-keymap/prosemirror-keymap-tests.ts
@@ -4,7 +4,9 @@ import { Plugin } from 'prosemirror-state';
 const plugin1: Plugin = keymap.keymap({
     // Test that the argument types are correctly inferred
     Enter: (state, dispatch, view) => {
-        dispatch(state.tr.insertText("hello"));
+        if (dispatch) {
+            dispatch(state.tr.insertText("hello"));
+        }
         return true;
     },
 });
@@ -14,7 +16,9 @@ const plugin2 = new Plugin({
         handleKeyDown: keymap.keydownHandler({
             // Test that the argument types are correctly inferred
             Enter: (state, dispatch, view) => {
-                dispatch(state.tr.insertText("hello"));
+                if (dispatch) {
+                    dispatch(state.tr.insertText("hello"));
+                }
                 return true;
             }
         }),


### PR DESCRIPTION
The 'dispatch' and 'view' arguments must be optional to support
'dry runs'.

Also add doc comment for 'Command' type by copying relevant the part
from the ProseMirror documentation.

Also simplify type definition of 'chainCommands' using 'Command'.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [ProseMirror docs](https://prosemirror.net/docs/ref/#commands), [discussion in PR which added the `Command` interface](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45836#discussion_r452077254)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
