### PR TITLE
#45975 fix AutocompletePrediction typings

### DIFF
--- a/types/googlemaps/reference/places-autocomplete-service.d.ts
+++ b/types/googlemaps/reference/places-autocomplete-service.d.ts
@@ -52,7 +52,7 @@ declare namespace google.maps.places {
          */
         distance_meters?: number;
 
-        id: string;
+        id?: string;
         matched_substrings: PredictionSubstring[];
         place_id: string;
         reference: string;


### PR DESCRIPTION
Please fill in this template.
Closes #45975.
Package: @types/googlemaps.
