### PR TITLE
@types/react-input-autosize: Added support for props: extraWidth

### DIFF
--- a/types/react-input-autosize/index.d.ts
+++ b/types/react-input-autosize/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-input-autosize 2.2.2
+// Type definitions for react-input-autosize 2.2
 // Project: https://github.com/JedWatson/react-input-autosize#readme
 // Definitions by: Jason Unger <https://github.com/jsonunger>
 //                 Frank Li <https://github.com/franklixuefei>

--- a/types/react-input-autosize/index.d.ts
+++ b/types/react-input-autosize/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-input-autosize 2.0
+// Type definitions for react-input-autosize 2.2.2
 // Project: https://github.com/JedWatson/react-input-autosize#readme
 // Definitions by: Jason Unger <https://github.com/jsonunger>
 //                 Frank Li <https://github.com/franklixuefei>

--- a/types/react-input-autosize/index.d.ts
+++ b/types/react-input-autosize/index.d.ts
@@ -14,6 +14,7 @@ export interface AutosizeInputProps extends React.InputHTMLAttributes<HTMLInputE
     minWidth?: string | number;
     onAutosize?: (inputWidth: string | number) => void;
     placeholderIsMinWidth?: boolean;
+    extraWidth?: string | number;
 }
 
 declare class AutosizeInput extends React.Component<AutosizeInputProps> {

--- a/types/react-input-autosize/index.d.ts
+++ b/types/react-input-autosize/index.d.ts
@@ -15,6 +15,7 @@ export interface AutosizeInputProps extends React.InputHTMLAttributes<HTMLInputE
     onAutosize?: (inputWidth: string | number) => void;
     placeholderIsMinWidth?: boolean;
     extraWidth?: string | number;
+    injectStyles?: boolean;
 }
 
 declare class AutosizeInput extends React.Component<AutosizeInputProps> {

--- a/types/react-input-autosize/react-input-autosize-tests.tsx
+++ b/types/react-input-autosize/react-input-autosize-tests.tsx
@@ -27,6 +27,8 @@ class Test extends React.Component<AutosizeInputProps> {
                 placeholder="Testing 1, 2, 3"
                 placeholderIsMinWidth
                 onChange={this.onChange}
+                extraWidth={64}
+                injectStyles
             />
         );
     }


### PR DESCRIPTION
Adding the new props :)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JedWatson/react-input-autosize/blob/master/src/AutosizeInput.js#L188
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
