### PR TITLE
Add customdata field to Plotly's PlotDatum.

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -49,6 +49,7 @@ export interface PlotScatterDataPoint {
 export interface PlotDatum {
     curveNumber: number;
     data: PlotData;
+    customdata: Datum;
     pointIndex: number;
     pointNumber: number;
     x: Datum;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see below
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The [documentation about this](https://plotly.com/javascript/plotlyjs-events/) doesn't mention customdata, so [I wrote a fiddle to demonstrate that it exists](https://jsfiddle.net/42yLu1xt/1/).

If you run that fiddle, open the (in-page) console, and box/lasso select a point, you'll see it'll print out the (singular) customdata available on the point itself.