### PR TITLE
redis - clarify callback argument types for hget and hgetall

### DIFF
--- a/types/redis/index.d.ts
+++ b/types/redis/index.d.ts
@@ -482,14 +482,14 @@ export interface Commands<R> {
     /**
      * Get the value of a hash field.
      */
-    hget(key: string, field: string, cb?: Callback<string>): R;
-    HGET(key: string, field: string, cb?: Callback<string>): R;
+    hget(key: string, field: string, cb?: Callback<string | null>): R;
+    HGET(key: string, field: string, cb?: Callback<string | null>): R;
 
     /**
      * Get all fields and values in a hash.
      */
-    hgetall(key: string, cb?: Callback<{ [key: string]: string }>): R;
-    HGETALL(key: string, cb?: Callback<{ [key: string]: string }>): R;
+    hgetall(key: string, cb?: Callback<{ [key: string]: string } | null>): R;
+    HGETALL(key: string, cb?: Callback<{ [key: string]: string } | null>): R;
 
     /**
      * Increment the integer value of a hash field by the given number.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/NodeRedis/node-redis/blob/27bb93ac19157bdc7b7958bef012e4b266d156ae/lib/utils.js#L3
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.