### PR TITLE
Added type definitions for mpesa-node

### DIFF
--- a/types/mpesa-node/index.d.ts
+++ b/types/mpesa-node/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Peter Munyao <https://github.com/petekmunz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export class Mpesa {
+declare class Mpesa {
     constructor(config: ConfigOptions);
 
     accountBalance(shortCode: string, idType: string, queueUrl: string, resultUrl: string, remarks?: string, initiator?: string, commandId?: string): Promise<void>;
@@ -32,7 +32,7 @@ export class Mpesa {
         occasion?: string, initiator?: string, receiverIdType?: string, commandId?: string): Promise<void>;
 }
 
-export interface ConfigOptions {
+interface ConfigOptions {
     consumerKey: string;
     consumerSecret: string;
     enviroment?: string;
@@ -43,3 +43,5 @@ export interface ConfigOptions {
     securityCredential?: string;
     certPath?: string;
 }
+
+export = Mpesa;

--- a/types/mpesa-node/index.d.ts
+++ b/types/mpesa-node/index.d.ts
@@ -1,0 +1,45 @@
+// Type definitions for mpesa-node 0.1
+// Project: https://github.com/safaricom/mpesa-node-library
+// Definitions by: Peter Munyao <https://github.com/petekmunz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export class Mpesa {
+    constructor(config: ConfigOptions);
+
+    accountBalance(shortCode: string, idType: string, queueUrl: string, resultUrl: string, remarks?: string, initiator?: string, commandId?: string): Promise<void>;
+
+    b2b(senderParty: string, receiverParty: string, amount: number, queueUrl: string, resultUrl: string, senderType?: number, receiverType?: number, initiator?: string,
+        commandId?: string, accountRef?: string, remarks?: string): Promise<void>;
+
+    b2c(senderParty: string, receiverParty: string, amount: number, queueUrl: string, resultUrl: string, commandId?: string, initiatorName?: string,
+        remarks?: string, occasion?: string): Promise<void>;
+
+    c2bRegister(confirmationUrl: string, validationUrl: string, shortCode?: string, responseType?: string): Promise<void>;
+
+    c2bSimulate(msisdn: string, amount: number, billRefNumber: string, commandId?: string, shortCode?: string): Promise<void>;
+
+    lipaNaMpesaOnline(senderMsisdn: string, amount: number, callbackUrl: string, accountRef: string, transactionDesc?: string,
+        transactionType?: string, shortCode?: string, passKey?: string): Promise<void>;
+
+    lipaNaMpesaQuery(checkoutRequestId: string, shortCode?: string, passKey?: string): Promise<void>;
+
+    oAuth(consumerKey: string, consumerSecret: string, baseURL?: string): Promise<void>;
+
+    reversal(transactionId: string, amount: number, queueUrl: string, resultUrl: string,
+        shortCode?: string, remarks?: string, occasion?: string, initiator?: string, receiverIdType?: string, commandId?: string): Promise<void>;
+
+    transactionStatus(transactionId: string, amount: number, queueUrl: string, resultUrl: string, shortCode?: string, remarks?: string,
+        occasion?: string, initiator?: string, receiverIdType?: string, commandId?: string): Promise<void>;
+}
+
+export interface ConfigOptions {
+    consumerKey: string;
+    consumerSecret: string;
+    enviroment?: string;
+    shortCode?: string;
+    initiatorName?: string;
+    lipaNaMpesaShortCode?: string;
+    lipaNaMpesaShortPass?: string;
+    securityCredential?: string;
+    certPath?: string;
+}

--- a/types/mpesa-node/mpesa-node-tests.ts
+++ b/types/mpesa-node/mpesa-node-tests.ts
@@ -1,4 +1,4 @@
-import { Mpesa } from 'mpesa-node';
+import Mpesa = require('mpesa-node');
 
 const mpesaClient = new Mpesa({ consumerKey: 'test', consumerSecret: 'test' });
 

--- a/types/mpesa-node/mpesa-node-tests.ts
+++ b/types/mpesa-node/mpesa-node-tests.ts
@@ -1,0 +1,23 @@
+import { Mpesa } from 'mpesa-node';
+
+const mpesaClient = new Mpesa({ consumerKey: 'test', consumerSecret: 'test' });
+
+mpesaClient.accountBalance('600111', '4', 'someurl/queue', 'someurl/result'); // Returns value should match type of promise
+
+mpesaClient.b2b('600100', '600000', 500, 'someurl/queue', 'someurl/result'); // Return value should match type of Promise
+
+mpesaClient.b2c('600100', '254722123456', 56, 'someurl/queue', 'someurl/result'); // Return value should match type of Promise
+
+mpesaClient.c2bRegister('someurl/confirmation', 'someurl/validation'); // Return value should match type of Promise
+
+mpesaClient.c2bSimulate('254722123456', 98, '123456'); // Return value should match type of Promise
+
+mpesaClient.lipaNaMpesaOnline('254722123456', 45, 'someurl/callback', 'accountref'); // Return value should match type of Promise
+
+mpesaClient.lipaNaMpesaQuery('wsyhjk6455opp'); // Return value should match type of Promise
+
+mpesaClient.oAuth('consumerkey', 'consumersecret'); // Return value should match type of Promise
+
+mpesaClient.reversal('WSDFR578', 456, 'someurl/queue', 'someurl/result'); // Return value should match type of Promise
+
+mpesaClient.transactionStatus('WSDFR578', 578, 'someurl/queue', 'someurl/result'); // Return value should match type of Promise

--- a/types/mpesa-node/tsconfig.json
+++ b/types/mpesa-node/tsconfig.json
@@ -1,0 +1,23 @@
+  {
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mpesa-node-tests.ts"
+    ]
+}

--- a/types/mpesa-node/tslint.json
+++ b/types/mpesa-node/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

