### PR TITLE
ioredis: Allow null return from `set`

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -208,10 +208,10 @@ declare namespace IORedis {
             expiryMode?: string | any[],
             time?: number | string,
             setMode?: number | string,
-        ): Promise<Ok>;
+        ): Promise<Ok | null>;
 
         set(key: KeyType, value: ValueType, callback: Callback<Ok>): void;
-        set(key: KeyType, value: ValueType, setMode: string | any[], callback: Callback<Ok>): void;
+        set(key: KeyType, value: ValueType, setMode: string | any[], callback: Callback<Ok | null>): void;
         set(key: KeyType, value: ValueType, expiryMode: string, time: number | string, callback: Callback<Ok>): void;
         set(
             key: KeyType,
@@ -219,7 +219,7 @@ declare namespace IORedis {
             expiryMode: string,
             time: number | string,
             setMode: number | string,
-            callback: Callback<Ok>,
+            callback: Callback<Ok | null>,
         ): void;
 
         setBuffer(


### PR DESCRIPTION
When used with the `NX` or `XX` option, the `set` command may return `null` instead of `'OK'` to indicate that the key was not set.

See https://redis.io/commands/set

Example:

> r.set('x', '123', 'EX', 1000, 'NX').then(console.log)
> OK
> r.set('x', '123', 'EX', 1000, 'NX').then(console.log)
> null

