### PR TITLE
[@types/underscore] Collection and Array Tests - Find and Reject

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -358,8 +358,8 @@ declare module _ {
         ): TypeOfCollection<V>[];
 
         /**
-        * @see filter
-        **/
+         * @see filter
+         **/
         select: UnderscoreStatic['filter'];
 
         /**
@@ -4141,13 +4141,13 @@ declare module _ {
         ): TResult | TypeOfCollection<V> | undefined;
 
         /**
-        * @see reduce
-        **/
+         * @see reduce
+         **/
         inject: Underscore<T, V>['reduce'];
 
         /**
-        * @see reduce
-        **/
+         * @see reduce
+         **/
         foldl: Underscore<T, V>['reduce'];
 
         /**
@@ -4169,8 +4169,8 @@ declare module _ {
         ): TResult | TypeOfCollection<V> | undefined;
 
         /**
-        * @see reduceRight
-        **/
+         * @see reduceRight
+         **/
         foldr: Underscore<T, V>['reduceRight'];
 
         /**
@@ -4200,8 +4200,8 @@ declare module _ {
         filter(iteratee: Iteratee<V, boolean>, context?: any): T[];
 
         /**
-        * @see filter
-        **/
+         * @see filter
+         **/
         select: Underscore<T, V>['filter'];
 
         /**
@@ -5118,13 +5118,13 @@ declare module _ {
         ): _ChainSingle<TResult | TypeOfCollection<V> | undefined>;
 
         /**
-        * @see reduce
-        **/
+         * @see reduce
+         **/
         inject: _Chain<T, V>['reduce'];
 
         /**
-        * @see reduce
-        **/
+         * @see reduce
+         **/
         foldl: _Chain<T, V>['reduce'];
 
         /**
@@ -5146,8 +5146,8 @@ declare module _ {
         ): _ChainSingle<TResult | TypeOfCollection<V> | undefined>;
 
         /**
-        * @see reduceRight
-        **/
+         * @see reduceRight
+         **/
         foldr: _Chain<T, V>['reduceRight'];
 
         /**

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -142,9 +142,9 @@ declare module _ {
     type TypeOfDictionary<V> = V extends Dictionary<infer T> ? T : never;
 
     type TypeOfCollection<V> =
-        V extends List<infer T> ? T
+        V extends never ? any
+        : V extends List<infer T> ? T
         : V extends Dictionary<infer T> ? T
-        : V extends never ? any
         : never;
 
     type ListItemOrSelf<T> = T extends List<infer TItem> ? TItem : T;

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -144,6 +144,7 @@ declare module _ {
     type TypeOfCollection<V> =
         V extends List<infer T> ? T
         : V extends Dictionary<infer T> ? T
+        : V extends never ? any
         : never;
 
     type ListItemOrSelf<T> = T extends List<infer TItem> ? TItem : T;

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -322,70 +322,26 @@ declare module _ {
         foldr: UnderscoreStatic['reduceRight'];
 
         /**
-        * Looks through each value in the list, returning the first one that passes a truth
-        * test (iterator). The function returns as soon as it finds an acceptable element,
-        * and doesn't traverse the entire list.
-        * @param list Searches for a value in this list.
-        * @param iterator Search iterator function for each element in `list`.
-        * @param context `this` object in `iterator`, optional.
-        * @return The first acceptable found element in `list`, if nothing is found undefined/null is returned.
-        **/
-        find<T>(
-            list: _.List<T>,
-            iterator: _.ListIterator<T, boolean>,
-            context?: any): T | undefined;
+         * Looks through each value in the collection, returning the first one that passes a
+         * truth test (iteratee), or undefined if no value passes the test. The function
+         * returns as soon as it finds an acceptable element, and doesn't traverse the entire
+         * collection.
+         * @param collection Searches for a value in this collection.
+         * @param iteratee The truth test to apply.
+         * @param context `this` object in `iteratee`, optional.
+         * @return The first element in `collection` that passes the truth test or undefined
+         * if no elements pass.
+         **/
+        find<V extends Collection<any>>(
+            collection: V,
+            iteratee: Iteratee<V, boolean>,
+            context?: any
+        ): TypeOfCollection<V> | undefined;
 
         /**
-        * @see _.find
-        **/
-        find<T>(
-            object: _.Dictionary<T>,
-            iterator: _.ObjectIterator<T, boolean>,
-            context?: any): T | undefined;
-
-        /**
-        * @see _.find
-        **/
-        find<T, U extends {}>(
-            object: _.List<T> | _.Dictionary<T>,
-            iterator: U): T | undefined;
-
-        /**
-        * @see _.find
-        **/
-        find<T>(
-            object: _.List<T> | _.Dictionary<T>,
-            iterator: string): T | undefined;
-
-        /**
-        * @see _.find
-        **/
-        detect<T>(
-            list: _.List<T>,
-            iterator: _.ListIterator<T, boolean>,
-            context?: any): T | undefined;
-
-        /**
-        * @see _.find
-        **/
-        detect<T>(
-            object: _.Dictionary<T>,
-            iterator: _.ObjectIterator<T, boolean>,
-            context?: any): T | undefined;
-
-        /**
-        * @see _.find
-        **/
-        detect<T, U extends {}>(
-            object: _.List<T> | _.Dictionary<T>,
-            iterator: U): T | undefined;
-
-        /**
-        * @see _.find
-        **/
-        detect<T>(
-            object: _.List<T> | _.Dictionary<T>,
-            iterator: string): T | undefined;
+         * @see find
+         **/
+        detect: UnderscoreStatic['find'];
 
         /**
          * Looks through each value in the collection, returning an array of all the values that pass a truth
@@ -393,7 +349,7 @@ declare module _ {
          * @param collection The collection to filter.
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
-         * @returns The filtered set of values.
+         * @returns The set of values for which the truth test passes.
          **/
         filter<V extends Collection<any>>(
             collection: V,
@@ -428,26 +384,18 @@ declare module _ {
             properties: U): T | undefined;
 
         /**
-        * Returns the values in list without the elements that the truth test (iterator) passes.
-        * The opposite of filter.
-        * Return all the elements for which a truth test fails.
-        * @param list Reject elements within this list.
-        * @param iterator Reject iterator function for each element in `list`.
-        * @param context `this` object in `iterator`, optional.
-        * @return The rejected list of elements.
-        **/
-        reject<T>(
-            list: _.List<T>,
-            iterator: _.ListIterator<T, boolean>,
-            context?: any): T[];
-
-        /**
-        * @see _.reject
-        **/
-        reject<T>(
-            object: _.Dictionary<T>,
-            iterator: _.ObjectIterator<T, boolean>,
-            context?: any): T[];
+         * Returns the values in `collection` without the elements that the truth test (iteratee) passes.
+         * The opposite of filter.
+         * @param collection The collection to filter.
+         * @param iteratee The truth test to apply.
+         * @param context `this` object in `iteratee`, optional.
+         * @return The set of values for which the truth test fails.
+         **/
+        reject<V extends Collection<any>>(
+            collection: V,
+            iteratee: Iteratee<V, boolean>,
+            context?: any
+        ): TypeOfCollection<V>[];
 
         /**
         * Returns true if all of the values in the list pass the iterator truth test. Delegates to the
@@ -4226,42 +4174,28 @@ declare module _ {
         foldr: Underscore<T, V>['reduceRight'];
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.find
-        **/
-        find<T>(iterator: _.ListIterator<T, boolean> | _.ObjectIterator<T, boolean>, context?: any): T | undefined;
+         * Looks through each value in the wrapped collection, returning the first one that passes a
+         * truth test (iteratee), or undefined if no value passes the test. The function
+         * returns as soon as it finds an acceptable element, and doesn't traverse the entire
+         * collection.
+         * @param iteratee The truth test to apply.
+         * @param context `this` object in `iteratee`, optional.
+         * @return The first element in the wrapped collection that passes the truth test or undefined
+         * if no elements pass.
+         **/
+        find(iterator: Iteratee<V, boolean>, context?: any): T | undefined;
 
         /**
-        * @see _.find
-        **/
-        find<T, U extends {}>(interator: U): T | undefined;
-
-        /**
-        * @see _.find
-        **/
-        find<T>(interator: string): T | undefined;
-
-        /**
-        * @see _.find
-        **/
-        detect<T>(iterator: _.ListIterator<T, boolean> | _.ObjectIterator<T, boolean>, context?: any): T | undefined;
-
-        /**
-        * @see _.find
-        **/
-        detect<T, U extends {}>(interator?: U): T | undefined;
-
-        /**
-        * @see _.find
-        **/
-        detect<T>(interator?: string): T | undefined;
+         * @see find
+         **/
+        detect: Underscore<T, V>['find'];
 
         /**
          * Looks through each value in the wrapped collection, returning an array of all the values that pass a truth
          * test (iteratee).
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
-         * @returns The filtered set of values.
+         * @returns The set of values for which the truth test passes.
          **/
         filter(iteratee: Iteratee<V, boolean>, context?: any): T[];
 
@@ -4283,10 +4217,13 @@ declare module _ {
         findWhere<U extends {}>(properties: U): T | undefined;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.reject
-        **/
-        reject(iterator: _.ListIterator<T, boolean>, context?: any): T[];
+         * Returns the values in the wrapped collection without the elements that the truth test (iteratee) passes.
+         * The opposite of filter.
+         * @param iteratee The truth test to apply.
+         * @param context `this` object in `iteratee`, optional.
+         * @return The set of values for which the truth test fails.
+         **/
+        reject(iterator: Iteratee<V, boolean>, context?: any): T[];
 
         /**
         * Wrapped type `any[]`.
@@ -5214,42 +5151,28 @@ declare module _ {
         foldr: _Chain<T, V>['reduceRight'];
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.find
-        **/
-        find<T>(iterator: _.ListIterator<T, boolean> | _.ObjectIterator<T, boolean>, context?: any): _ChainSingle<T | undefined>;
+         * Looks through each value in the wrapped collection, returning the first one that passes a
+         * truth test (iteratee), or undefined if no value passes the test. The function
+         * returns as soon as it finds an acceptable element, and doesn't traverse the entire
+         * collection.
+         * @param iteratee The truth test to apply.
+         * @param context `this` object in `iteratee`, optional.
+         * @return A chain wrapper containing the first element in the wrapped collection that passes
+         * the truth test or undefined if no elements pass.
+         **/
+        find(iterator: _ChainIteratee<V, boolean, T>, context?: any): _ChainSingle<T | undefined>;
 
         /**
-        * @see _.find
-        **/
-        find<T, U extends {}>(interator: U): _ChainSingle<T | undefined>;
-
-        /**
-        * @see _.find
-        **/
-        find<T>(interator: string): _ChainSingle<T | undefined>;
-
-        /**
-        * @see _.find
-        **/
-        detect<T>(iterator: _.ListIterator<T, boolean> | _.ObjectIterator<T, boolean>, context?: any): _ChainSingle<T | undefined>;
-
-        /**
-        * @see _.find
-        **/
-        detect<T, U extends {}>(interator: U): _ChainSingle<T | undefined>;
-
-        /**
-        * @see _.find
-        **/
-        detect<T>(interator: string): _ChainSingle<T | undefined>;
+         * @see find
+         **/
+        detect: _Chain<T, V>['find'];
 
         /**
          * Looks through each value in the wrapped collection, returning an array of all the values that pass a truth
          * test (iteratee).
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
-         * @returns The filtered set of values in a chain wrapper.
+         * @returns The set of values for which the truth test passes in a chain wrapper.
          **/
         filter(iteratee: _ChainIteratee<V, any, T>, context?: any): _Chain<T, T[]>;
 
@@ -5271,10 +5194,13 @@ declare module _ {
         findWhere<U extends {}>(properties: U): _ChainSingle<T>;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.reject
-        **/
-        reject(iterator: _.ListIterator<T, boolean>, context?: any): _Chain<T>;
+         * Returns the values in the wrapped collection without the elements that the truth test (iteratee) passes.
+         * The opposite of filter.
+         * @param iteratee The truth test to apply.
+         * @param context `this` object in `iteratee`, optional.
+         * @return The set of values for which the truth test fails in a chain wrapper.
+         **/
+        reject(iterator: _ChainIteratee<V, boolean, T>, context?: any): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any[]`.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -350,7 +350,7 @@ declare module _ {
          * @param collection The collection to filter.
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
-         * @returns The set of values for which the truth test passes.
+         * @returns The set of values that pass the truth test.
          **/
         filter<V extends Collection<any>>(
             collection: V,
@@ -385,12 +385,12 @@ declare module _ {
             properties: U): T | undefined;
 
         /**
-         * Returns the values in `collection` without the elements that the truth test (iteratee) passes.
+         * Returns the values in `collection` without the elements that pass a truth test (iteratee).
          * The opposite of filter.
          * @param collection The collection to filter.
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
-         * @return The set of values for which the truth test fails.
+         * @return The set of values that fail the truth test.
          **/
         reject<V extends Collection<any>>(
             collection: V,
@@ -4196,7 +4196,7 @@ declare module _ {
          * test (iteratee).
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
-         * @returns The set of values for which the truth test passes.
+         * @returns The set of values that pass the truth test.
          **/
         filter(iteratee?: Iteratee<V, boolean>, context?: any): T[];
 
@@ -4218,11 +4218,11 @@ declare module _ {
         findWhere<U extends {}>(properties: U): T | undefined;
 
         /**
-         * Returns the values in the wrapped collection without the elements that the truth test (iteratee) passes.
+         * Returns the values in the wrapped collection without the elements that pass a truth test (iteratee).
          * The opposite of filter.
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
-         * @return The set of values for which the truth test fails.
+         * @return The set of values that fail the truth test.
          **/
         reject(iteratee?: Iteratee<V, boolean>, context?: any): T[];
 
@@ -5173,7 +5173,7 @@ declare module _ {
          * test (iteratee).
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
-         * @returns The set of values for which the truth test passes in a chain wrapper.
+         * @returns The set of values that pass a truth test in a chain wrapper.
          **/
         filter(iteratee?: _ChainIteratee<V, any, T>, context?: any): _Chain<T, T[]>;
 
@@ -5195,11 +5195,11 @@ declare module _ {
         findWhere<U extends {}>(properties: U): _ChainSingle<T>;
 
         /**
-         * Returns the values in the wrapped collection without the elements that the truth test (iteratee) passes.
+         * Returns the values in the wrapped collection without the elements that pass a truth test (iteratee).
          * The opposite of filter.
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
-         * @return The set of values for which the truth test fails in a chain wrapper.
+         * @return The set of values that fail the truth test in a chain wrapper.
          **/
         reject(iteratee?: _ChainIteratee<V, boolean, T>, context?: any): _Chain<T, T[]>;
 

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -335,7 +335,7 @@ declare module _ {
          **/
         find<V extends Collection<any>>(
             collection: V,
-            iteratee: Iteratee<V, boolean>,
+            iteratee?: Iteratee<V, boolean>,
             context?: any
         ): TypeOfCollection<V> | undefined;
 
@@ -354,7 +354,7 @@ declare module _ {
          **/
         filter<V extends Collection<any>>(
             collection: V,
-            iteratee: Iteratee<V, boolean>,
+            iteratee?: Iteratee<V, boolean>,
             context?: any
         ): TypeOfCollection<V>[];
 
@@ -394,7 +394,7 @@ declare module _ {
          **/
         reject<V extends Collection<any>>(
             collection: V,
-            iteratee: Iteratee<V, boolean>,
+            iteratee?: Iteratee<V, boolean>,
             context?: any
         ): TypeOfCollection<V>[];
 
@@ -4184,7 +4184,7 @@ declare module _ {
          * @return The first element in the wrapped collection that passes the truth test or undefined
          * if no elements pass.
          **/
-        find(iterator: Iteratee<V, boolean>, context?: any): T | undefined;
+        find(iteratee?: Iteratee<V, boolean>, context?: any): T | undefined;
 
         /**
          * @see find
@@ -4198,7 +4198,7 @@ declare module _ {
          * @param context `this` object in `iteratee`, optional.
          * @returns The set of values for which the truth test passes.
          **/
-        filter(iteratee: Iteratee<V, boolean>, context?: any): T[];
+        filter(iteratee?: Iteratee<V, boolean>, context?: any): T[];
 
         /**
          * @see filter
@@ -4224,7 +4224,7 @@ declare module _ {
          * @param context `this` object in `iteratee`, optional.
          * @return The set of values for which the truth test fails.
          **/
-        reject(iterator: Iteratee<V, boolean>, context?: any): T[];
+        reject(iteratee?: Iteratee<V, boolean>, context?: any): T[];
 
         /**
         * Wrapped type `any[]`.
@@ -5161,7 +5161,7 @@ declare module _ {
          * @return A chain wrapper containing the first element in the wrapped collection that passes
          * the truth test or undefined if no elements pass.
          **/
-        find(iterator: _ChainIteratee<V, boolean, T>, context?: any): _ChainSingle<T | undefined>;
+        find(iteratee?: _ChainIteratee<V, boolean, T>, context?: any): _ChainSingle<T | undefined>;
 
         /**
          * @see find
@@ -5175,7 +5175,7 @@ declare module _ {
          * @param context `this` object in `iteratee`, optional.
          * @returns The set of values for which the truth test passes in a chain wrapper.
          **/
-        filter(iteratee: _ChainIteratee<V, any, T>, context?: any): _Chain<T, T[]>;
+        filter(iteratee?: _ChainIteratee<V, any, T>, context?: any): _Chain<T, T[]>;
 
         /**
          * @see filter
@@ -5201,7 +5201,7 @@ declare module _ {
          * @param context `this` object in `iteratee`, optional.
          * @return The set of values for which the truth test fails in a chain wrapper.
          **/
-        reject(iterator: _ChainIteratee<V, boolean, T>, context?: any): _Chain<T, T[]>;
+        reject(iteratee?: _ChainIteratee<V, boolean, T>, context?: any): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any[]`.

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1003,60 +1003,40 @@ declare const extractChainTypes: ChainTypeExtractor;
     _(stringRecordList).find(partialStringRecord); // $ExpectType StringRecordOrUndefined
     extractChainTypes(_.chain(stringRecordList).find(partialStringRecord)); // $ExpectType ChainType<StringRecordOrUndefined, never>
 
-    // partial object iteratee - lists - detect
-    _.detect(stringRecordList, partialStringRecord); // $ExpectType StringRecordOrUndefined
-    _(stringRecordList).detect(partialStringRecord); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordList).detect(partialStringRecord)); // $ExpectType ChainType<StringRecordOrUndefined, never>
-
-    // partial object iteratee - dictionaries - find
-    _.find(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecordOrUndefined
-    _(stringRecordDictionary).find(partialStringRecord); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordDictionary).find(partialStringRecord)); // $ExpectType ChainType<StringRecordOrUndefined, never>
-
     // partial object iteratee - dictionaries - detect
     _.detect(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecordOrUndefined
     _(stringRecordDictionary).detect(partialStringRecord); // $ExpectType StringRecordOrUndefined
     extractChainTypes(_.chain(stringRecordDictionary).detect(partialStringRecord)); // $ExpectType ChainType<StringRecordOrUndefined, never>
-
-    // property name iteratee - lists - find
-    _.find(stringRecordList, stringRecordProperty); // $ExpectType StringRecordOrUndefined
-    _(stringRecordList).find(stringRecordProperty); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordList).find(stringRecordProperty)); // $ExpectType ChainType<StringRecordOrUndefined, never>
-
-    // property name iteratee - lists - detect
-    _.detect(stringRecordList, stringRecordProperty); // $ExpectType StringRecordOrUndefined
-    _(stringRecordList).detect(stringRecordProperty); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordList).detect(stringRecordProperty)); // $ExpectType ChainType<StringRecordOrUndefined, never>
 
     // property name iteratee - dictionaries - find
     _.find(stringRecordDictionary, stringRecordProperty); // $ExpectType StringRecordOrUndefined
     _(stringRecordDictionary).find(stringRecordProperty); // $ExpectType StringRecordOrUndefined
     extractChainTypes(_.chain(stringRecordDictionary).find(stringRecordProperty)); // $ExpectType ChainType<StringRecordOrUndefined, never>
 
-    // property name iteratee - dictionaries - detect
-    _.detect(stringRecordDictionary, stringRecordProperty); // $ExpectType StringRecordOrUndefined
-    _(stringRecordDictionary).detect(stringRecordProperty); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordDictionary).detect(stringRecordProperty)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    // property name iteratee - lists - detect
+    _.detect(stringRecordList, stringRecordProperty); // $ExpectType StringRecordOrUndefined
+    _(stringRecordList).detect(stringRecordProperty); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordList).detect(stringRecordProperty)); // $ExpectType ChainType<StringRecordOrUndefined, never>
 
     // property path iteratee - lists - find
     _.find(stringRecordList, stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
     _(stringRecordList).find(stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
     extractChainTypes(_.chain(stringRecordList).find(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecordOrUndefined, never>
 
-    // property path iteratee - lists - detect
-    _.detect(stringRecordList, stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
-    _(stringRecordList).detect(stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordList).detect(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecordOrUndefined, never>
-
-    // property path iteratee - dictionaries - find
-    _.find(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
-    _(stringRecordDictionary).find(stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordDictionary).find(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecordOrUndefined, never>
-
     // property path iteratee - dictionaries - detect
     _.detect(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
     _(stringRecordDictionary).detect(stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
     extractChainTypes(_.chain(stringRecordDictionary).detect(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+
+    // identity iteratee - dictionaries - find
+    _.find(stringRecordDictionary, stringRecordProperty); // $ExpectType StringRecordOrUndefined
+    _(stringRecordDictionary).find(stringRecordProperty); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordDictionary).find(stringRecordProperty)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+
+    // identity iteratee - lists - detect
+    _.detect(stringRecordList); // $ExpectType StringRecordOrUndefined
+    _(stringRecordList).detect(); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordList).detect()); // $ExpectType ChainType<StringRecordOrUndefined, never>
 }
 
 // filter, select
@@ -1096,60 +1076,40 @@ declare const extractChainTypes: ChainTypeExtractor;
     _(stringRecordList).filter(partialStringRecord); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordList).filter(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
-    // partial object iteratee - lists - select
-    _.select(stringRecordList, partialStringRecord); // $ExpectType StringRecord[]
-    _(stringRecordList).select(partialStringRecord); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).select(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
-
-    // partial object iteratee - dictionaries - filter
-    _.filter(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).filter(partialStringRecord); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).filter(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
-
     // partial object iteratee - dictionaries - select
     _.select(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecord[]
     _(stringRecordDictionary).select(partialStringRecord); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordDictionary).select(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
-
-    // property name iteratee - lists - filter
-    _.filter(stringRecordList, stringRecordProperty); // $ExpectType StringRecord[]
-    _(stringRecordList).filter(stringRecordProperty); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).filter(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
-
-    // property name iteratee - lists - select
-    _.select(stringRecordList, stringRecordProperty); // $ExpectType StringRecord[]
-    _(stringRecordList).select(stringRecordProperty); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).select(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // property name iteratee - dictionaries - filter
     _.filter(stringRecordDictionary, stringRecordProperty); // $ExpectType StringRecord[]
     _(stringRecordDictionary).filter(stringRecordProperty); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordDictionary).filter(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
-    // property name iteratee - dictionaries - select
-    _.select(stringRecordDictionary, stringRecordProperty); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).select(stringRecordProperty); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).select(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    // property name iteratee - lists - select
+    _.select(stringRecordList, stringRecordProperty); // $ExpectType StringRecord[]
+    _(stringRecordList).select(stringRecordProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).select(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // property path iteratee - lists - filter
     _.filter(stringRecordList, stringRecordPropertyPath); // $ExpectType StringRecord[]
     _(stringRecordList).filter(stringRecordPropertyPath); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordList).filter(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
-    // property path iteratee - lists - select
-    _.select(stringRecordList, stringRecordPropertyPath); // $ExpectType StringRecord[]
-    _(stringRecordList).select(stringRecordPropertyPath); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).select(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
-
-    // property path iteratee - dictionaries - filter
-    _.filter(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).filter(stringRecordPropertyPath); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).filter(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
-
     // property path iteratee - dictionaries - select
     _.select(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType StringRecord[]
     _(stringRecordDictionary).select(stringRecordPropertyPath); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordDictionary).select(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // identity iteratee - dictionaries - filter
+    _.filter(stringRecordDictionary, stringRecordProperty); // $ExpectType StringRecord[]
+    _(stringRecordDictionary).filter(stringRecordProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordDictionary).filter(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // identity iteratee - lists - select
+    _.select(stringRecordList); // $ExpectType StringRecord[]
+    _(stringRecordList).select(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).select()); // $ExpectType ChainType<StringRecord[], StringRecord>
 }
 
 // reject
@@ -1174,16 +1134,6 @@ declare const extractChainTypes: ChainTypeExtractor;
     _(stringRecordList).reject(partialStringRecord); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordList).reject(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
-    // partial object iteratee - dictionaries
-    _.reject(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).reject(partialStringRecord); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).reject(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
-
-    // property name iteratee - lists
-    _.reject(stringRecordList, stringRecordProperty); // $ExpectType StringRecord[]
-    _(stringRecordList).reject(stringRecordProperty); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).reject(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
-
     // property name iteratee - dictionaries
     _.reject(stringRecordDictionary, stringRecordProperty); // $ExpectType StringRecord[]
     _(stringRecordDictionary).reject(stringRecordProperty); // $ExpectType StringRecord[]
@@ -1194,10 +1144,10 @@ declare const extractChainTypes: ChainTypeExtractor;
     _(stringRecordList).reject(stringRecordPropertyPath); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordList).reject(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
-    // property path iteratee - dictionaries
-    _.reject(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).reject(stringRecordPropertyPath); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).reject(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    // identity iteratee - dictionaries
+    _.reject(stringRecordDictionary); // $ExpectType StringRecord[]
+    _(stringRecordDictionary).reject(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordDictionary).reject()); // $ExpectType ChainType<StringRecord[], StringRecord>
 }
 
 // pluck

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1040,9 +1040,9 @@ declare const extractChainTypes: ChainTypeExtractor;
     extractChainTypes(_.chain(stringRecordDictionary).detect(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecordOrUndefined, never>
 
     // identity iteratee - dictionaries - find
-    _.find(stringRecordDictionary, stringRecordProperty); // $ExpectType StringRecordOrUndefined
-    _(stringRecordDictionary).find(stringRecordProperty); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordDictionary).find(stringRecordProperty)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.find(stringRecordDictionary); // $ExpectType StringRecordOrUndefined
+    _(stringRecordDictionary).find(); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordDictionary).find()); // $ExpectType ChainType<StringRecordOrUndefined, never>
 
     // identity iteratee - lists - detect
     _.detect(stringRecordList); // $ExpectType StringRecordOrUndefined
@@ -1123,9 +1123,9 @@ declare const extractChainTypes: ChainTypeExtractor;
     extractChainTypes(_.chain(stringRecordDictionary).select(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // identity iteratee - dictionaries - filter
-    _.filter(stringRecordDictionary, stringRecordProperty); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).filter(stringRecordProperty); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).filter(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.filter(stringRecordDictionary); // $ExpectType StringRecord[]
+    _(stringRecordDictionary).filter(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordDictionary).filter()); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // identity iteratee - lists - select
     _.select(stringRecordList); // $ExpectType StringRecord[]

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -23,140 +23,6 @@ var list = [[0, 1], [2, 3], [4, 5]];
 //var flat = _.reduceRight(list, (a, b) => a.concat(b), []);    // https://typescript.codeplex.com/workitem/1960
 var flat = _.reduceRight(list, (a, b) => a.concat(b), [] as number[]);
 
-namespace TestFind {
-    let array: {a: string}[] = [{a: 'a'}, {a: 'b'}];
-    let list: _.List<{a: string}> = {0: {a: 'a'}, 1: {a: 'b'}, length: 2};
-    let dict: _.Dictionary<{a: string}> = {a: {a: 'a'}, b: {a: 'b'}};
-    let context = {};
-
-    {
-        let iterator = (value: {a: string}, index: number, list: _.List<{a: string}>) => value.a === 'b';
-        let result: {a: string} | undefined;
-
-        result = _.find<{a: string}>(array, iterator);
-        result = _.find<{a: string}>(array, iterator, context);
-        result = _.find<{a: string}, {a: string}>(array, {a: 'b'});
-        result = _.find<{a: string}>(array, 'a');
-
-        result = _(array).find<{a: string}>(iterator);
-        result = _(array).find<{a: string}>(iterator, context);
-        result = _(array).find<{a: string}, {a: string}>({a: 'b'});
-        result = _(array).find<{a: string}>('a');
-
-        result = _(array).chain().find<{a: string}>(iterator).value();
-        result = _(array).chain().find<{a: string}>(iterator, context).value();
-        result = _(array).chain().find<{a: string}, {a: string}>({a: 'b'}).value();
-        result = _(array).chain().find<{a: string}>('a').value();
-
-        result = _.find<{a: string}>(list, iterator);
-        result = _.find<{a: string}>(list, iterator, context);
-        result = _.find<{a: string}, {a: string}>(list, {a: 'b'});
-        result = _.find<{a: string}>(list, 'a');
-
-        result = _(list).find<{a: string}>(iterator);
-        result = _(list).find<{a: string}>(iterator, context);
-        result = _(list).find<{a: string}, {a: string}>({a: 'b'});
-        result = _(list).find<{a: string}>('a');
-
-        result = _(list).chain().find<{a: string}>(iterator).value();
-        result = _(list).chain().find<{a: string}>(iterator, context).value();
-        result = _(list).chain().find<{a: string}, {a: string}>({a: 'b'}).value();
-        result = _(list).chain().find<{a: string}>('a').value();
-
-        result = _.detect<{a: string}>(array, iterator);
-        result = _.detect<{a: string}>(array, iterator, context);
-        result = _.detect<{a: string}, {a: string}>(array, {a: 'b'});
-        result = _.detect<{a: string}>(array, 'a');
-
-        result = _(array).detect<{a: string}>(iterator);
-        result = _(array).detect<{a: string}>(iterator, context);
-        result = _(array).detect<{a: string}, {a: string}>({a: 'b'});
-        result = _(array).detect<{a: string}>('a');
-
-        result = _(array).chain().detect<{a: string}>(iterator).value();
-        result = _(array).chain().detect<{a: string}>(iterator, context).value();
-        result = _(array).chain().detect<{a: string}, {a: string}>({a: 'b'}).value();
-        result = _(array).chain().detect<{a: string}>('a').value();
-
-        result = _.detect<{a: string}>(list, iterator);
-        result = _.detect<{a: string}>(list, iterator, context);
-        result = _.detect<{a: string}, {a: string}>(list, {a: 'b'});
-        result = _.detect<{a: string}>(list, 'a');
-
-        result = _(list).detect<{a: string}>(iterator);
-        result = _(list).detect<{a: string}>(iterator, context);
-        result = _(list).detect<{a: string}, {a: string}>({a: 'b'});
-        result = _(list).detect<{a: string}>('a');
-
-        result = _(list).chain().detect<{a: string}>(iterator).value();
-        result = _(list).chain().detect<{a: string}>(iterator, context).value();
-        result = _(list).chain().detect<{a: string}, {a: string}>({a: 'b'}).value();
-        result = _(list).chain().detect<{a: string}>('a').value();
-    }
-
-    {
-        let iterator = (element: {a: string}, key: string, list: _.Dictionary<{a: string}>) => element.a === 'b';
-        let result: {a: string} | undefined;
-
-        result = _.find<{a: string}>(dict, iterator);
-        result = _.find<{a: string}>(dict, iterator, context);
-        result = _.find<{a: string}, {a: string}>(dict, {a: 'b'});
-        result = _.find<{a: string}>(dict, 'a');
-
-        result = _(dict).find<{a: string}>(iterator);
-        result = _(dict).find<{a: string}>(iterator, context);
-        result = _(dict).find<{a: string}, {a: string}>({a: 'b'});
-        result = _(dict).find<{a: string}>('a');
-
-        result = _(dict).chain().find<{a: string}>(iterator).value();
-        result = _(dict).chain().find<{a: string}>(iterator, context).value();
-        result = _(dict).chain().find<{a: string}, {a: string}>({a: 'b'}).value();
-        result = _(dict).chain().find<{a: string}>('a').value();
-
-        result = _.detect<{a: string}>(dict, iterator);
-        result = _.detect<{a: string}>(dict, iterator, context);
-        result = _.detect<{a: string}, {a: string}>(dict, {a: 'b'});
-        result = _.detect<{a: string}>(dict, 'a');
-
-        result = _(dict).detect<{a: string}>(iterator);
-        result = _(dict).detect<{a: string}>(iterator, context);
-        result = _(dict).detect<{a: string}, {a: string}>({a: 'b'});
-        result = _(dict).detect<{a: string}>('a');
-
-        result = _(dict).chain().detect<{a: string}>(iterator).value();
-        result = _(dict).chain().detect<{a: string}>(iterator, context).value();
-        result = _(dict).chain().detect<{a: string}, {a: string}>({a: 'b'}).value();
-        result = _(dict).chain().detect<{a: string}>('a').value();
-    }
-
-    {
-        let iterator = (value: string, index: number, list: _.List<string>) => value === 'b';
-        let result: string | undefined;
-
-        result = _.find<string>('abc', iterator);
-        result = _.find<string>('abc', iterator, context);
-
-        result = _('abc').find<string>(iterator);
-        result = _('abc').find<string>(iterator, context);
-
-        result = _('abc').chain().find<string>(iterator).value();
-        result = _('abc').chain().find<string>(iterator, context).value();
-
-        result = _.detect<string>('abc', iterator);
-        result = _.detect<string>('abc', iterator, context);
-
-        result = _('abc').detect<string>(iterator);
-        result = _('abc').detect<string>(iterator, context);
-
-        result = _('abc').chain().detect<string>(iterator).value();
-        result = _('abc').chain().detect<string>(iterator, context).value();
-    }
-
-    {
-        _(list).map(x => x.a);
-    }
-}
-
 var evens = _.filter([1, 2, 3, 4, 5, 6], (num) => num % 2 == 0);
 
 var capitalLetters = _.filter({ a: 'a', b: 'B', c: 'C', d: 'd' }, l => l === l.toUpperCase());
@@ -1093,6 +959,99 @@ declare const extractChainTypes: ChainTypeExtractor;
     extractChainTypes(_.chain(simpleString).foldr(resultUnionStringListMemoIterator)); // $ExpectType ChainType<string | number | undefined, string>
 }
 
+// find, detect
+{
+    // function iteratee - lists - find
+    _.find(stringRecordList, stringRecordListBooleanIterator, context); // $ExpectType StringRecordOrUndefined
+    _(stringRecordList).find(stringRecordListBooleanIterator, context); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordList).find(stringRecordListBooleanIterator, context)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+
+    // function iteratee - lists - detect
+    _.detect(stringRecordList, stringRecordListBooleanIterator, context); // $ExpectType StringRecordOrUndefined
+    _(stringRecordList).detect(stringRecordListBooleanIterator, context); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordList).detect(stringRecordListBooleanIterator, context)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+
+    // function iteratee - dictionaries - find
+    _.find(stringRecordDictionary, stringRecordDictionaryBooleanIterator, context); // $ExpectType StringRecordOrUndefined
+    _(stringRecordDictionary).find(stringRecordDictionaryBooleanIterator, context); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordDictionary).find(stringRecordDictionaryBooleanIterator, context)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+
+    // function iteratee - dictionaries - detect
+    _.detect(stringRecordDictionary, stringRecordDictionaryBooleanIterator, context); // $ExpectType StringRecordOrUndefined
+    _(stringRecordDictionary).detect(stringRecordDictionaryBooleanIterator, context); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordDictionary).detect(stringRecordDictionaryBooleanIterator, context)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+
+    // function iteratee - strings - find
+    _.find(simpleString, stringListBooleanIterator, context); // $ExpectType string | undefined
+    _(simpleString).find(stringListBooleanIterator, context); // $ExpectType string | undefined
+    extractChainTypes(_.chain(simpleString).find(stringListBooleanIterator, context)); // $ExpectType ChainType<string | undefined, string>
+
+    // function iteratee - strings - detect
+    _.detect(simpleString, stringListBooleanIterator, context); // $ExpectType string | undefined
+    _(simpleString).detect(stringListBooleanIterator, context); // $ExpectType string | undefined
+    extractChainTypes(_.chain(simpleString).detect(stringListBooleanIterator, context)); // $ExpectType ChainType<string | undefined, string>
+
+    // partial object iteratee - lists - find
+    _.find(stringRecordList, partialStringRecord); // $ExpectType StringRecordOrUndefined
+    _(stringRecordList).find(partialStringRecord); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordList).find(partialStringRecord)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+
+    // partial object iteratee - lists - detect
+    _.detect(stringRecordList, partialStringRecord); // $ExpectType StringRecordOrUndefined
+    _(stringRecordList).detect(partialStringRecord); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordList).detect(partialStringRecord)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+
+    // partial object iteratee - dictionaries - find
+    _.find(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecordOrUndefined
+    _(stringRecordDictionary).find(partialStringRecord); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordDictionary).find(partialStringRecord)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+
+    // partial object iteratee - dictionaries - detect
+    _.detect(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecordOrUndefined
+    _(stringRecordDictionary).detect(partialStringRecord); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordDictionary).detect(partialStringRecord)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+
+    // property name iteratee - lists - find
+    _.find(stringRecordList, stringRecordProperty); // $ExpectType StringRecordOrUndefined
+    _(stringRecordList).find(stringRecordProperty); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordList).find(stringRecordProperty)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+
+    // property name iteratee - lists - detect
+    _.detect(stringRecordList, stringRecordProperty); // $ExpectType StringRecordOrUndefined
+    _(stringRecordList).detect(stringRecordProperty); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordList).detect(stringRecordProperty)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+
+    // property name iteratee - dictionaries - find
+    _.find(stringRecordDictionary, stringRecordProperty); // $ExpectType StringRecordOrUndefined
+    _(stringRecordDictionary).find(stringRecordProperty); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordDictionary).find(stringRecordProperty)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+
+    // property name iteratee - dictionaries - detect
+    _.detect(stringRecordDictionary, stringRecordProperty); // $ExpectType StringRecordOrUndefined
+    _(stringRecordDictionary).detect(stringRecordProperty); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordDictionary).detect(stringRecordProperty)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+
+    // property path iteratee - lists - find
+    _.find(stringRecordList, stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
+    _(stringRecordList).find(stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordList).find(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+
+    // property path iteratee - lists - detect
+    _.detect(stringRecordList, stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
+    _(stringRecordList).detect(stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordList).detect(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+
+    // property path iteratee - dictionaries - find
+    _.find(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
+    _(stringRecordDictionary).find(stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordDictionary).find(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+
+    // property path iteratee - dictionaries - detect
+    _.detect(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
+    _(stringRecordDictionary).detect(stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordDictionary).detect(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+}
+
 // filter, select
 {
     // function iteratee - lists - filter
@@ -1184,6 +1143,54 @@ declare const extractChainTypes: ChainTypeExtractor;
     _.select(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType StringRecord[]
     _(stringRecordDictionary).select(stringRecordPropertyPath); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordDictionary).select(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+}
+
+// reject
+{
+    // function iteratee - lists
+    _.reject(stringRecordList, stringRecordListBooleanIterator, context); // $ExpectType StringRecord[]
+    _(stringRecordList).reject(stringRecordListBooleanIterator, context); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).reject(stringRecordListBooleanIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // function iteratee - dictionaries
+    _.reject(stringRecordDictionary, stringRecordDictionaryBooleanIterator, context); // $ExpectType StringRecord[]
+    _(stringRecordDictionary).reject(stringRecordDictionaryBooleanIterator, context); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordDictionary).reject(stringRecordDictionaryBooleanIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // function iteratee - strings
+    _.reject(simpleString, stringListBooleanIterator, context); // $ExpectType string[]
+    _(simpleString).reject(stringListBooleanIterator, context); // $ExpectType string[]
+    extractChainTypes(_.chain(simpleString).reject(stringListBooleanIterator, context)); // $ExpectType ChainType<string[], string>
+
+    // partial object iteratee - lists
+    _.reject(stringRecordList, partialStringRecord); // $ExpectType StringRecord[]
+    _(stringRecordList).reject(partialStringRecord); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).reject(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // partial object iteratee - dictionaries
+    _.reject(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecord[]
+    _(stringRecordDictionary).reject(partialStringRecord); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordDictionary).reject(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // property name iteratee - lists
+    _.reject(stringRecordList, stringRecordProperty); // $ExpectType StringRecord[]
+    _(stringRecordList).reject(stringRecordProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).reject(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // property name iteratee - dictionaries
+    _.reject(stringRecordDictionary, stringRecordProperty); // $ExpectType StringRecord[]
+    _(stringRecordDictionary).reject(stringRecordProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordDictionary).reject(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // property path iteratee - lists
+    _.reject(stringRecordList, stringRecordPropertyPath); // $ExpectType StringRecord[]
+    _(stringRecordList).reject(stringRecordPropertyPath); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).reject(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // property path iteratee - dictionaries
+    _.reject(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType StringRecord[]
+    _(stringRecordDictionary).reject(stringRecordPropertyPath); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordDictionary).reject(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
 }
 
 // pluck

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1472,6 +1472,12 @@ declare const extractChainTypes: ChainTypeExtractor;
 
     // mixed non-collections and collections
     extractUnderscoreTypes(_(mixedIterabilityValue)); // $ExpectType UnderscoreType<number | number[], number>
+
+    // any
+    extractUnderscoreTypes(_(anyValue)); // $ExpectType UnderscoreType<any, any>
+
+    // never
+    extractUnderscoreTypes(_(neverValue)); // $ExpectType UnderscoreType<never, never>
 }
 
 // value
@@ -1493,6 +1499,12 @@ declare const extractChainTypes: ChainTypeExtractor;
 
     // mixed non-collections and collections
     _(mixedIterabilityValue).value(); // $ExpectType number | number[]
+
+    // any
+    _(anyValue).value(); // $ExpectType any
+
+    // never
+    _(neverValue).value(); // $ExpectType never
 }
 
 // Chaining
@@ -1524,6 +1536,14 @@ declare const extractChainTypes: ChainTypeExtractor;
     // mixed non-collections and collections
     extractChainTypes(_.chain(mixedIterabilityValue)); // $ExpectType ChainType<number | number[], number>
     extractChainTypes(_(mixedIterabilityValue).chain()); // $ExpectType ChainType<number | number[], number>
+
+    // any
+    extractChainTypes(_.chain(anyValue)); // $ExpectType ChainType<any, any>
+    extractChainTypes(_(anyValue).chain()); // $ExpectType ChainType<any, any>
+
+    // never
+    extractChainTypes(_.chain(neverValue)); // $ExpectType ChainType<never, never>
+    extractChainTypes(_(neverValue).chain()); // $ExpectType ChainType<never, never>
 }
 
 // value
@@ -1545,4 +1565,10 @@ declare const extractChainTypes: ChainTypeExtractor;
 
     // mixed non-collections and collections
     _.chain(mixedIterabilityValue).value(); // $ExpectType number | number[]
+
+    // any
+    _.chain(anyValue).value(); // $ExpectType any
+
+    // never
+    _.chain(neverValue).value(); // $ExpectType never
 }

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -2,6 +2,7 @@ declare const $: any;
 declare const window: any;
 declare const alert: (msg: string) => any;
 declare const console: {log: any};
+declare const anyValue: any;
 
 _.VERSION; // $ExpectType string
 _.each([1, 2, 3], (num) => alert(num.toString()));
@@ -478,6 +479,13 @@ _.chain([1, 2, 3, 4, 5, 6])
     .reduce((aggregate, n) => aggregate + n, 0)
     .value();
 
+// $ExpectType any
+_.chain(anyValue)
+    .filter(i => i.filterBoolean)
+    .reject(i => i.rejectBoolean)
+    .find(i => i.findBooleanFunction())
+    .value();
+
 // common testing types and objects
 const context = {};
 
@@ -558,7 +566,6 @@ declare const resultUnionStringListMemoIterator: (prev: string | number, value: 
 const simpleNumber = 7;
 
 declare const mixedIterabilityValue: number | number[];
-declare const anyValue: any;
 declare const neverValue: never;
 declare const maybeFunction: (() => void) | undefined;
 declare const maybeStringArray: string[] | undefined;

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -512,6 +512,7 @@ declare const maxLevel3RecordArray: (StringRecord | StringRecord[] | StringRecor
 
 const stringRecordListValueIterator = (value: StringRecord, index: number, list: _.List<StringRecord>) => value.a;
 const stringRecordListBooleanIterator = (value: StringRecord, index: number, list: _.List<StringRecord>) => value.a === 'b';
+const stringRecordPartialBooleanIterator = (value: StringRecord) => value.a === 'b';
 declare const stringRecordPartialMemoIterator: (prev: string, value: StringRecord) => string;
 declare const stringRecordListMemoIterator: (prev: string, value: StringRecord, index: number, list: _.List<StringRecord>) => string;
 declare const resultUnionPartialMemoIterator: (prev: string | StringRecord, value: StringRecord) => string | StringRecord;
@@ -998,6 +999,16 @@ declare const extractChainTypes: ChainTypeExtractor;
     _(simpleString).detect(stringListBooleanIterator, context); // $ExpectType string | undefined
     extractChainTypes(_.chain(simpleString).detect(stringListBooleanIterator, context)); // $ExpectType ChainType<string | undefined, string>
 
+    // function iteratee - any - find
+    _.find(anyValue, stringRecordPartialBooleanIterator, context); // $ExpectType any
+    _(anyValue).find(stringRecordPartialBooleanIterator, context); // $ExpectType any
+    extractChainTypes(_.chain(anyValue).find(stringRecordPartialBooleanIterator, context)); // $ExpectType ChainType<any, any>
+
+    // function iteratee - any - detect
+    _.detect(anyValue, stringRecordPartialBooleanIterator, context); // $ExpectType any
+    _(anyValue).detect(stringRecordPartialBooleanIterator, context); // $ExpectType any
+    extractChainTypes(_.chain(anyValue).detect(stringRecordPartialBooleanIterator, context)); // $ExpectType ChainType<any, any>
+
     // partial object iteratee - lists - find
     _.find(stringRecordList, partialStringRecord); // $ExpectType StringRecordOrUndefined
     _(stringRecordList).find(partialStringRecord); // $ExpectType StringRecordOrUndefined
@@ -1071,6 +1082,16 @@ declare const extractChainTypes: ChainTypeExtractor;
     _(simpleString).select(stringListBooleanIterator, context); // $ExpectType string[]
     extractChainTypes(_.chain(simpleString).select(stringListBooleanIterator, context)); // $ExpectType ChainType<string[], string>
 
+    // function iteratee - any - filter
+    _.filter(anyValue, stringRecordPartialBooleanIterator, context); // $ExpectType any[]
+    _(anyValue).filter(stringRecordPartialBooleanIterator, context); // $ExpectType any[]
+    extractChainTypes(_.chain(anyValue).filter(stringRecordPartialBooleanIterator, context)); // $ExpectType ChainType<any[], any>
+
+    // function iteratee - any - select
+    _.select(anyValue, stringRecordPartialBooleanIterator, context); // $ExpectType any[]
+    _(anyValue).select(stringRecordPartialBooleanIterator, context); // $ExpectType any[]
+    extractChainTypes(_.chain(anyValue).select(stringRecordPartialBooleanIterator, context)); // $ExpectType ChainType<any[], any>
+
     // partial object iteratee - lists - filter
     _.filter(stringRecordList, partialStringRecord); // $ExpectType StringRecord[]
     _(stringRecordList).filter(partialStringRecord); // $ExpectType StringRecord[]
@@ -1128,6 +1149,11 @@ declare const extractChainTypes: ChainTypeExtractor;
     _.reject(simpleString, stringListBooleanIterator, context); // $ExpectType string[]
     _(simpleString).reject(stringListBooleanIterator, context); // $ExpectType string[]
     extractChainTypes(_.chain(simpleString).reject(stringListBooleanIterator, context)); // $ExpectType ChainType<string[], string>
+
+    // function iteratee - any - filter
+    _.reject(anyValue, stringRecordPartialBooleanIterator, context); // $ExpectType any[]
+    _(anyValue).reject(stringRecordPartialBooleanIterator, context); // $ExpectType any[]
+    extractChainTypes(_.chain(anyValue).reject(stringRecordPartialBooleanIterator, context)); // $ExpectType ChainType<any[], any>
 
     // partial object iteratee - lists
     _.reject(stringRecordList, partialStringRecord); // $ExpectType StringRecord[]

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1150,7 +1150,7 @@ declare const extractChainTypes: ChainTypeExtractor;
     _(simpleString).reject(stringListBooleanIterator, context); // $ExpectType string[]
     extractChainTypes(_.chain(simpleString).reject(stringListBooleanIterator, context)); // $ExpectType ChainType<string[], string>
 
-    // function iteratee - any - filter
+    // function iteratee - any
     _.reject(anyValue, stringRecordPartialBooleanIterator, context); // $ExpectType any[]
     _(anyValue).reject(stringRecordPartialBooleanIterator, context); // $ExpectType any[]
     extractChainTypes(_.chain(anyValue).reject(stringRecordPartialBooleanIterator, context)); // $ExpectType ChainType<any[], any>


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://underscorejs.org/
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

This PR continues the planned set that will together add up to #45201 and includes the following changes:

- Adds tests for `find` and `reject`.
- Updates `find` and `reject` to use `Iteratee`.
- Removes the redeclaration of the `T` generic in `Underscore.find` and `_Chain.find`.
- Updates the return type of `_Chain.reject` to use the correct wrapped value type `V` to partially fix #36308.
- Updates the `Underscore` and `_Chain` versions of `reject` to work with both Lists and Dictionaries to partially fix #20623.
- Replaces all `detect` overloads with a reference to `find` overloads.
- Updates `TypeOfCollection` to extract `any` instead of `unknown` as the collection item type for `any` for better backwards compatibility.
- Updates `filter` to support an identity iteratee.
- Fixes a bit of summary comment indentation that I missed in previous PRs and updates the `@returns` for `filter` to better match the one for `reject`.