### PR TITLE
[Leaflet] GeoJSON.resetStyle() can be called without an argument

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1290,7 +1290,7 @@ export class GeoJSON<P = any> extends FeatureGroup<P> {
      * Resets the given vector layer's style to the original GeoJSON style,
      * useful for resetting style after hover events.
      */
-    resetStyle(layer: Layer): Layer;
+    resetStyle(layer?: Layer): Layer;
 
     /**
      * Same as FeatureGroup's setStyle method, but style-functions are also

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -509,6 +509,9 @@ const styler: L.StyleFunction<MyProperties> = () => style;
 geojson.setStyle(style);
 geojson.setStyle(styler);
 
+geojson.resetStyle();
+geojson.resetStyle(layer);
+
 class MyMarker extends L.Marker {
     constructor() {
         super([12, 13]);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Leaflet/Leaflet/pull/6663
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

The Leaflet GeoJSON.resetStyle() methods can be invoked without argument since https://github.com/Leaflet/Leaflet/pull/6663/files. The definitions didn't reflected that yet, this PR is solving the issue (I think!)
