### PR TITLE
[node] Add missing properties to ReadableStream on Node >= v10

### DIFF
--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -28,6 +28,7 @@ declare module "stream" {
             readable: boolean;
             readonly readableEncoding: BufferEncoding | null;
             readonly readableEnded: boolean;
+            readonly readableFlowing: boolean | null;
             readonly readableHighWaterMark: number;
             readonly readableLength: number;
             readonly readableObjectMode: boolean;

--- a/types/node/v10/globals.d.ts
+++ b/types/node/v10/globals.d.ts
@@ -692,6 +692,7 @@ declare namespace NodeJS {
         destroy(error?: Error): void;
     }
     interface ReadStream extends Socket {
+        readonly readableFlowing: boolean | null;
         readonly readableHighWaterMark: number;
         readonly readableLength: number;
         isRaw?: boolean;

--- a/types/node/v10/stream.d.ts
+++ b/types/node/v10/stream.d.ts
@@ -18,6 +18,7 @@ declare module "stream" {
 
         class Readable extends Stream implements NodeJS.ReadableStream {
             readable: boolean;
+            readonly readableFlowing: boolean | null;
             readonly readableHighWaterMark: number;
             readonly readableLength: number;
             constructor(opts?: ReadableOptions);

--- a/types/node/v11/globals.d.ts
+++ b/types/node/v11/globals.d.ts
@@ -731,6 +731,7 @@ declare namespace NodeJS {
         destroy(error?: Error): void;
     }
     interface ReadStream extends Socket {
+        readonly readableFlowing: boolean | null;
         readonly readableHighWaterMark: number;
         readonly readableLength: number;
         isRaw?: boolean;

--- a/types/node/v11/stream.d.ts
+++ b/types/node/v11/stream.d.ts
@@ -19,6 +19,7 @@ declare module "stream" {
 
         class Readable extends Stream implements NodeJS.ReadableStream {
             readable: boolean;
+            readonly readableFlowing: boolean | null;
             readonly readableHighWaterMark: number;
             readonly readableLength: number;
             constructor(opts?: ReadableOptions);

--- a/types/node/v12/stream.d.ts
+++ b/types/node/v12/stream.d.ts
@@ -26,6 +26,7 @@ declare module "stream" {
             readable: boolean;
             readonly readableEncoding: BufferEncoding | null;
             readonly readableEnded: boolean;
+            readonly readableFlowing: boolean | null;
             readonly readableHighWaterMark: number;
             readonly readableLength: number;
             readonly readableObjectMode: boolean;

--- a/types/node/v13/stream.d.ts
+++ b/types/node/v13/stream.d.ts
@@ -28,6 +28,7 @@ declare module "stream" {
             readable: boolean;
             readonly readableEncoding: BufferEncoding | null;
             readonly readableEnded: boolean;
+            readonly readableFlowing: boolean | null;
             readonly readableHighWaterMark: number;
             readonly readableLength: number;
             readonly readableObjectMode: boolean;

--- a/types/readable-stream/index.d.ts
+++ b/types/readable-stream/index.d.ts
@@ -71,6 +71,7 @@ declare namespace _Readable {
         readable: boolean;
         readonly readableEncoding: BufferEncoding | null;
         readonly readableEnded: boolean;
+        readonly readableFlowing: boolean | null;
         readonly readableHighWaterMark: number;
         readonly readableLength: number;
         readonly readableObjectMode: boolean;


### PR DESCRIPTION
This change adds the missing properties `readableFlowing`, which has been present since v9.2.0.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://nodejs.org/api/stream.html#stream_readable_readableflowing>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
