### PR TITLE
[react-email-editor] Added translation key to unlayer options

### DIFF
--- a/types/react-email-editor/index.d.ts
+++ b/types/react-email-editor/index.d.ts
@@ -73,7 +73,7 @@ export interface Features {
     readonly undoRedo?: boolean;
 }
 
-export type Translations = Record<string, Record<string, string>>
+export type Translations = Record<string, Record<string, string>>;
 
 export type DisplayMode = 'email' | 'web';
 export interface UnlayerOptions {

--- a/types/react-email-editor/index.d.ts
+++ b/types/react-email-editor/index.d.ts
@@ -73,6 +73,8 @@ export interface Features {
     readonly undoRedo?: boolean;
 }
 
+export type Translations = Record<string, Record<string, string>>
+
 export type DisplayMode = 'email' | 'web';
 export interface UnlayerOptions {
     readonly id?: string;
@@ -91,6 +93,7 @@ export interface UnlayerOptions {
     readonly customJS?: string[];
     readonly customCSS?: string[];
     readonly features?: Features;
+    readonly translations?: Translations;
 }
 
 export interface EmailEditorProps {

--- a/types/react-email-editor/react-email-editor-tests.tsx
+++ b/types/react-email-editor/react-email-editor-tests.tsx
@@ -122,6 +122,11 @@ class App extends React.Component {
               imageEditor: false,
               undoRedo: true,
             },
+            translations: {
+              en: {
+                'custom.key': 'Custom translation',
+              },
+            },
           }}
           tools={TOOLS_CONFIG}
           appearance={{


### PR DESCRIPTION
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.unlayer.com/docs/localization#overriding-translations
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
