### PR TITLE
[pdfjs-dist] Add missing renderInteractiveForms param

### DIFF
--- a/types/pdfjs-dist/index.d.ts
+++ b/types/pdfjs-dist/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for PDF.js v2.1
 // Project: https://github.com/mozilla/pdf.js
-// Definitions by: Josh Baldwin <https://github.com/jbaldwin>, Dmitrii Sorin <https://github.com/1999>
+// Definitions by: Josh Baldwin <https://github.com/jbaldwin>
+//                 Dmitrii Sorin <https://github.com/1999>
+//                 Kamil Socha <https://github.com/ksocha>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -11,7 +13,7 @@ declare const version: string;
 declare const GlobalWorkerOptions: GlobalWorkerOptions;
 
 interface GlobalWorkerOptions {
-  workerSrc: string;
+    workerSrc: string;
 }
 
 interface PDFPromise<T> {
@@ -35,7 +37,7 @@ interface PDFInfo {
     PDFFormatVersion: string;
     IsAcroFormPresent: boolean;
     IsXFAPresent: boolean;
-    [key: string]: any;    // return type is string, typescript chokes
+    [key: string]: any; // return type is string, typescript chokes
 }
 
 interface PDFMetadata {
@@ -45,58 +47,60 @@ interface PDFMetadata {
 }
 
 interface PDFDataRangeTransportListener {
-    (loaded: number, total: number): void
+    (loaded: number, total: number): void;
 }
 
 declare enum VerbosityLevel {
     ERRORS = 0,
-    WARNINGS= 1,
-    INFOS= 5,
+    WARNINGS = 1,
+    INFOS = 5,
 }
 
 declare class PDFDataRangeTransport {
-    constructor(length: number, initialData: Uint8Array|BufferSource, progressiveDone?: boolean);
-    addRangeListener(listener: PDFDataRangeTransportListener):void
-    addProgressListener(listener: PDFDataRangeTransportListener): void
-    addProgressiveReadListener(listener: PDFDataRangeTransportListener): void
-    addProgressiveDoneListener(listener: PDFDataRangeTransportListener): void
-    onDataRange(begin: number, chunk: unknown): void
-    onDataProgress(loaded: number, total: number): void
-    onDataProgressiveRead(chunk: unknown): void
-    onDataProgressiveDone(): void
-    transportReady() : void
-    requestDataRange(begin: number, end: number): void
-    abort(): void
+    constructor(length: number, initialData: Uint8Array | BufferSource, progressiveDone?: boolean);
+    addRangeListener(listener: PDFDataRangeTransportListener): void;
+    addProgressListener(listener: PDFDataRangeTransportListener): void;
+    addProgressiveReadListener(listener: PDFDataRangeTransportListener): void;
+    addProgressiveDoneListener(listener: PDFDataRangeTransportListener): void;
+    onDataRange(begin: number, chunk: unknown): void;
+    onDataProgress(loaded: number, total: number): void;
+    onDataProgressiveRead(chunk: unknown): void;
+    onDataProgressiveDone(): void;
+    transportReady(): void;
+    requestDataRange(begin: number, end: number): void;
+    abort(): void;
 }
 
 interface PDFWorkerParameters {
-    name?: string
-    port?: any
-    verbosity?: VerbosityLevel
+    name?: string;
+    port?: any;
+    verbosity?: VerbosityLevel;
 }
 
 declare class PDFWorker {
-    constructor(params?: PDFWorkerParameters)
-    readonly promise: Promise<unknown>
-    readonly port: any |null
-    readonly messageHandler: unknown | null
-    destroy(): void
-    static fromPort(params?: PDFWorkerParameters): PDFWorker
-    static getWorkerSrc(): string
+    constructor(params?: PDFWorkerParameters);
+    readonly promise: Promise<unknown>;
+    readonly port: any | null;
+    readonly messageHandler: unknown | null;
+    destroy(): void;
+    static fromPort(params?: PDFWorkerParameters): PDFWorker;
+    static getWorkerSrc(): string;
 }
-declare enum  CMapCompressionType {
+declare enum CMapCompressionType {
     NONE = 0,
-    BINARY= 1,
-    STREAM= 2,
-  }
+    BINARY = 1,
+    STREAM = 2,
+}
 interface CMapReaderFactory {
-    new (params: {baseUrl: string, isCompressed: boolean}): CMapReader
+    new (params: { baseUrl: string; isCompressed: boolean }): CMapReader;
 }
 interface CMapReader {
-    fetch(params: {name: string}): Promise<{
-        cMapData: any,
-        compressionType: CMapCompressionType
-    }>
+    fetch(params: {
+        name: string;
+    }): Promise<{
+        cMapData: any;
+        compressionType: CMapCompressionType;
+    }>;
 }
 interface PDFSource {
     /** The URL of the PDF. */
@@ -111,27 +115,27 @@ interface PDFSource {
      * Basic authentication headers.
      */
     httpHeaders?: {
-        [key: string]: string
+        [key: string]: string;
     };
     /**
      * For decrypting password-protected PDFs.
      */
     password?: string;
     /**
-    * Indicates whether or not cross-site
-    * Access-Control requests should be made using credentials such as cookies
-    * or authorization headers. The default is false.
-    */
+     * Indicates whether or not cross-site
+     * Access-Control requests should be made using credentials such as cookies
+     * or authorization headers. The default is false.
+     */
     withCredentials?: boolean;
     /*
-    * A typed array with the first portion or
-    * all of the pdf data. Used by the extension since some data is already
-    * loaded before the switch to range requests.  */
+     * A typed array with the first portion or
+     * all of the pdf data. Used by the extension since some data is already
+     * loaded before the switch to range requests.  */
     initialData?: Uint8Array | BufferSource;
     /*
-    * The PDF file length. It's used for progress
-    * reports and range requests operations.
-    */
+     * The PDF file length. It's used for progress
+     * reports and range requests operations.
+     */
     length?: number;
     /** range */
     range?: PDFDataRangeTransport;
@@ -139,7 +143,7 @@ interface PDFSource {
      * Optional parameter to specify
      * maximum number of bytes fetched per range request. The default value is
      * 2^16 = 65536. */
-    rangeChunkSize?: number
+    rangeChunkSize?: number;
     /**
      * The worker that will be used for
      * the loading and parsing of the PDF data.
@@ -157,70 +161,70 @@ interface PDFSource {
      */
     docBaseUrl?: string;
     /**
-    * Strategy for
-    * decoding certain (simple) JPEG images in the browser. This is useful for
-    * environments without DOM image and canvas support, such as e.g. Node.js.
-    * Valid values are 'decode', 'display' or 'none'; where 'decode' is intended
-    * for browsers with full image/canvas support, 'display' for environments
-    * with limited image support through stubs (useful for SVG conversion),
-    * and 'none' where JPEG images will be decoded entirely by PDF.js.
-    * The default value is 'decode'.
-    */
-    nativeImageDecoderSupport?: "decode"|"display"|"none"
+     * Strategy for
+     * decoding certain (simple) JPEG images in the browser. This is useful for
+     * environments without DOM image and canvas support, such as e.g. Node.js.
+     * Valid values are 'decode', 'display' or 'none'; where 'decode' is intended
+     * for browsers with full image/canvas support, 'display' for environments
+     * with limited image support through stubs (useful for SVG conversion),
+     * and 'none' where JPEG images will be decoded entirely by PDF.js.
+     * The default value is 'decode'.
+     */
+    nativeImageDecoderSupport?: 'decode' | 'display' | 'none';
     /**
      * The URL where the predefined
      * Adobe CMaps are located. Include trailing slash. */
-    cMapUrl?: string
+    cMapUrl?: string;
     /**
      * Specifies if the Adobe CMaps are
      * binary packed. */
-    cMapPacked?: boolean
+    cMapPacked?: boolean;
     /**
      * The factory that will be
      * used when reading built-in CMap files. Providing a custom factory is useful
      * for environments without `XMLHttpRequest` support, such as e.g. Node.js.
      * The default value is {DOMCMapReaderFactory}.
      */
-    CMapReaderFactory?: any
+    CMapReaderFactory?: any;
     /**
      * Reject certain promises, e.g.
      * `getOperatorList`, `getTextContent`, and `RenderTask`, when the associated
      * PDF data cannot be successfully parsed, instead of attempting to recover
      * whatever possible of the data. The default value is `false`.
      */
-    stopAtErrors?: boolean
+    stopAtErrors?: boolean;
     /**
      * The maximum allowed image size
      * in total pixels, i.e. width * height. Images above this value will not be
      * rendered. Use -1 for no limit, which is also the default value.
      */
-    maxImageSize?: number
+    maxImageSize?: number;
     /**
      * Determines if we can eval
      * strings as JS. Primarily used to improve performance of font rendering,
      * and when parsing PDF functions. The default value is `true`.
      */
-    isEvalSupported?: boolean
+    isEvalSupported?: boolean;
     /**
      * By default fonts are
      *   converted to OpenType fonts and loaded via font face rules. If disabled,
      *   fonts will be rendered using a built-in font renderer that constructs the
      *   glyphs with primitive path commands. The default value is `false`.
      */
-    disableFontFace?: boolean
+    disableFontFace?: boolean;
     /**
      * Disable range request loading
      *   of PDF files. When enabled, and if the server supports partial content
      *   requests, then the PDF will be fetched in chunks.
      *   The default value is `false`.
      */
-    disableRange?: boolean
+    disableRange?: boolean;
     /**
      * Disable streaming of PDF file
      *   data. By default PDF.js attempts to load PDFs in chunks.
      *   The default value is `false`.
      */
-    disableStream?: boolean
+    disableStream?: boolean;
     /**
      * Disable pre-fetching of PDF
      *   file data. When range requests are enabled PDF.js will automatically keep
@@ -229,18 +233,18 @@ interface PDFSource {
      *   NOTE: It is also necessary to disable streaming, see above,
      *         in order for disabling of pre-fetching to work correctly.
      */
-    disableAutoFetch?: boolean
+    disableAutoFetch?: boolean;
     /**
      * Disable the use of
      *   `URL.createObjectURL`, for compatibility with older browsers.
      *   The default value is `false`.
      */
-    disableCreateObjectURL?: boolean
+    disableCreateObjectURL?: boolean;
     /**
      * Enables special hooks for debugging
      * PDF.js (see `web/debugger.js`). The default value is `false`.
      */
-    pdfBug?: boolean
+    pdfBug?: boolean;
 }
 
 interface PDFProgressData {
@@ -249,7 +253,6 @@ interface PDFProgressData {
 }
 
 interface PDFDocumentProxy {
-
     /**
      * Total number of pages the PDF contains.
      **/
@@ -382,6 +385,7 @@ interface PDFRenderParams {
     viewport?: PDFPageViewport;
     textLayer?: PDFRenderTextLayer;
     imageLayer?: PDFRenderImageLayer;
+    renderInteractiveForms?: boolean;
     continueCallback?: (_continue: () => void) => void;
 }
 
@@ -394,7 +398,6 @@ interface PDFViewerParams {
  * RenderTask is basically a promise but adds a cancel function to termiate it.
  **/
 interface PDFRenderTask extends PDFLoadingTask<PDFPageProxy> {
-
     /**
      * Cancel the rendering task.  If the task is currently rendering it will not be cancelled until graphics pauses with a timeout.  The promise that this object extends will resolve when cancelled.
      **/
@@ -402,7 +405,6 @@ interface PDFRenderTask extends PDFLoadingTask<PDFPageProxy> {
 }
 
 interface PDFPageProxy {
-
     /**
      * Page index of the page.  First page is 0.
      */
@@ -497,7 +499,7 @@ interface PDFJSUtilStatic {
      * means normalization to (BL,TR) ordering. For systems with origin in the
      * top-left, this means (TL,BR) ordering.
      **/
-    normalizeRect(rect:number[]): number[];
+    normalizeRect(rect: number[]): number[];
 }
 
 export const PDFJS: PDFJSStatic;
@@ -633,10 +635,10 @@ interface PDFJSStatic {
 
     PDFViewer(params: PDFViewerParams): void;
     /**
-    * yet another viewer, this will render only one page at the time, reducing rendering time
-    * very important for mobile development
-    * @params {PDFViewerParams}
-    */
+     * yet another viewer, this will render only one page at the time, reducing rendering time
+     * very important for mobile development
+     * @params {PDFViewerParams}
+     */
     PDFSinglePageViewer(params: PDFViewerParams): void;
 }
 
@@ -661,19 +663,19 @@ declare function getDocument(
     url: string,
     pdfDataRangeTransport?: PDFDataRangeTransport,
     passwordCallback?: (fn: (password: string) => void, reason: string) => string,
-    progressCallback?: (progressData: PDFProgressData) => void
+    progressCallback?: (progressData: PDFProgressData) => void,
 ): PDFLoadingTask<PDFDocumentProxy>;
 
 declare function getDocument(
     data: Uint8Array | BufferSource,
     pdfDataRangeTransport?: PDFDataRangeTransport,
     passwordCallback?: (fn: (password: string) => void, reason: string) => string,
-    progressCallback?: (progressData: PDFProgressData) => void
+    progressCallback?: (progressData: PDFProgressData) => void,
 ): PDFLoadingTask<PDFDocumentProxy>;
 
 declare function getDocument(
     source: PDFSource,
     pdfDataRangeTransport?: PDFDataRangeTransport,
     passwordCallback?: (fn: (password: string) => void, reason: string) => string,
-    progressCallback?: (progressData: PDFProgressData) => void
+    progressCallback?: (progressData: PDFProgressData) => void,
 ): PDFLoadingTask<PDFDocumentProxy>;

--- a/types/pdfjs-dist/pdfjs-dist-tests.ts
+++ b/types/pdfjs-dist/pdfjs-dist-tests.ts
@@ -16,7 +16,7 @@ getDocument('helloworld.pdf').promise.then(function (pdf) {
 function renderPage(pageNum: number) {
     pdfDoc.getPage(pageNum).then(function (page) {
         var scale = 1.5;
-        var viewport = page.getViewport({scale: scale});
+        var viewport = page.getViewport({ scale: scale });
 
         //
         // Prepare canvas using PDF page dimensions
@@ -31,7 +31,7 @@ function renderPage(pageNum: number) {
         // convertToViewportRectangle and normalizeRect are used in the acroforms example:
         // https://github.com/mozilla/pdf.js/blob/master/examples/acroforms/forms.js
         //
-        const rect = viewport.convertToViewportRectangle([100,100,0,0]);
+        const rect = viewport.convertToViewportRectangle([100, 100, 0, 0]);
         const normalizedRect = Util.normalizeRect(rect);
         const point = viewport.convertToViewportPoint(100, 100);
         const pdfPoint = viewport.convertToPdfPoint(100, 100);
@@ -39,11 +39,11 @@ function renderPage(pageNum: number) {
         //
         // Render PDF page into canvas context
         //
-        var renderContext = {
+        page.render({
             canvasContext: context,
-            viewport: viewport
-        };
-        page.render(renderContext);
+            viewport: viewport,
+            renderInteractiveForms: false,
+        });
     });
 }
 
@@ -58,5 +58,5 @@ function goNext() {
 // Test PDFPromise allows return value mutation
 //
 var promise: PDFPromise<string> = getDocument('helloworld.pdf').promise.then(pdf => {
-    return "arbitrary string";
+    return 'arbitrary string';
 });


### PR DESCRIPTION
Added missing [param](https://github.com/mozilla/pdf.js/blob/master/src/display/api.js#L870).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [api](https://github.com/mozilla/pdf.js/blob/master/src/display/api.js#L870)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
