### PR TITLE
Add type definitions for "nuclear-js-react-addons-chefsplate" module

### DIFF
--- a/types/nuclear-js-react-addons-chefsplate/index.d.ts
+++ b/types/nuclear-js-react-addons-chefsplate/index.d.ts
@@ -28,13 +28,13 @@ interface MapStateToProps<TInjectedPropNames extends string | number | symbol> {
 // Injects props and removes them from the prop requirements.
 // Will not pass through the injected props if they are passed in during
 // render. Also adds new prop requirements from TNeedsProps.
-interface ComponentConnector<TNeedsProps, TInjectedPropNames extends string | number | symbol> {
+interface ComponentConnector<TInjectedPropNames extends string | number | symbol> {
     // Use "= any" so that if component prop type cannot be inferred (e.g.
     // if using "createReactClass", then we'll end up with
     // ComponentClass<any>, instead of ComponentClass<{}>.
     <P extends { [keyName in TInjectedPropNames]?: any } = any>(
         component: React.ComponentType<P>,
-    ): React.ComponentClass<StrictOmit<P, TInjectedPropNames> & TNeedsProps>;
+    ): React.ComponentClass<StrictOmit<P, TInjectedPropNames>>;
 }
 
 /**
@@ -48,13 +48,11 @@ interface ComponentConnector<TNeedsProps, TInjectedPropNames extends string | nu
  * returns a new, connected component class that wraps the component you
  * passed in.
  *
- * @template TNeedsProps Prop types of component being connected
  * @template TInjectedPropNames Names of props injected by `mapStateToProps`.
  */
-declare function connect<TNeedsProps, TInjectedPropNames extends string | number | symbol>(
+declare function connect<TInjectedPropNames extends string | number | symbol>(
     mapStateToProps: MapStateToProps<TInjectedPropNames>,
-    // tslint:disable-next-line no-unnecessary-generics
-): ComponentConnector<TNeedsProps, TInjectedPropNames>;
+): ComponentConnector<TInjectedPropNames>;
 
 /**
  * Container component allowing a reactor to be exposed via context.

--- a/types/nuclear-js-react-addons-chefsplate/index.d.ts
+++ b/types/nuclear-js-react-addons-chefsplate/index.d.ts
@@ -1,0 +1,125 @@
+// Type definitions for nuclear-js-react-addons-chefsplate 1.0
+// Project: https://github.com/chefsplate/nuclear-js-react-addons
+// Definitions by: Pat Lillis <https://github.com/patlillis>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.9
+
+import * as React from 'react';
+
+// Disable automatic exports.
+export {};
+
+/**
+ * The built-in Omit doesn't error out if omitted key doesn't exist on the main type.
+ */
+type StrictOmit<T, K extends keyof T> = T extends any ? Pick<T, Exclude<keyof T, K>> : never;
+
+// Function that returns getters, which are turned into injected props.
+interface MapStateToProps<TInjectedPropNames extends string | number | symbol> {
+    (props?: any): {
+        // mapStateToProps doesn't actually return the injected props.
+        // Instead, it returns the Nuclear.js getter. So the type
+        // definition here maps the prop key/name to "any" (since getters
+        // can't be statically typed).
+        [propName in TInjectedPropNames]: any;
+    };
+}
+
+// Injects props and removes them from the prop requirements.
+// Will not pass through the injected props if they are passed in during
+// render. Also adds new prop requirements from TNeedsProps.
+interface ComponentConnector<TNeedsProps, TInjectedPropNames extends string | number | symbol> {
+    // Use "= any" so that if component prop type cannot be inferred (e.g.
+    // if using "createReactClass", then we'll end up with
+    // ComponentClass<any>, instead of ComponentClass<{}>.
+    <P extends { [keyName in TInjectedPropNames]?: any } = any>(
+        component: React.ComponentType<P>,
+    ): React.ComponentClass<StrictOmit<P, TInjectedPropNames> & TNeedsProps>;
+}
+
+/**
+ * Connects a React component to a Nuclear.js store.
+ *
+ * `connect()` provides its connected component with the pieces of the data
+ * it needs from the store. This data is supplied via props, which are
+ * configured in the passed-in `mapStateToProps` function.
+ *
+ * `connect()` does not modify the component passed to it; instead, it
+ * returns a new, connected component class that wraps the component you
+ * passed in.
+ *
+ * @template TNeedsProps Prop types of component being connected
+ * @template TInjectedPropNames Names of props injected by `mapStateToProps`.
+ */
+declare function connect<TNeedsProps, TInjectedPropNames extends string | number | symbol>(
+    mapStateToProps: MapStateToProps<TInjectedPropNames>,
+): ComponentConnector<TNeedsProps, TInjectedPropNames>;
+
+/**
+ * Container component allowing a reactor to be exposed via context.
+ */
+declare const Provider: any;
+
+/**
+ * Mixin expecting a context.reactor on the component
+ *
+ * Should be used if a higher level component has been
+ * wrapped with provideReactor
+ */
+declare const nuclearMixin: any;
+
+/**
+ * Provides reactor prop to all children as React context
+ *
+ * Example:
+ *   var WrappedComponent = provideReactor(Component, {
+ *     foo: React.PropTypes.string
+ *   });
+ *
+ * Also supports the decorator pattern:
+ *   @provideReactor({
+ *     foo: React.PropTypes.string
+ *   })
+ *   class BaseComponent extends React.Component {
+ *     render() {
+ *       return <div/>;
+ *     }
+ *   }
+ *
+ * @param [Component] Component to wrap
+ * @param [additionalContextTypes] Additional contextTypes to add
+ * @returns Returns function if using decorator pattern
+ */
+declare const provideReactor: any;
+
+/**
+ * Provides dataBindings + reactor as props to wrapped component.
+ *
+ * Example:
+ * ```
+ * var WrappedComponent = nuclearComponent(Component, function(props) {
+ *   return { counter: 'counter' };
+ * );
+ * ```
+ *
+ * Also supports the decorator pattern:
+ *
+ * ```js
+ * @nuclearComponent((props) => {
+ *   return { counter: 'counter' }
+ * })
+ * class BaseComponent extends React.Component {
+ *   render() {
+ *     const { counter, reactor } = this.props;
+ *     return <div/>;
+ *   }
+ * }
+ * ```
+ *
+ * @param [Component] Component to wrap
+ * @param [getDataBindings] Function which returns dataBindings to listen for data change
+ * @returns Returns function if using decorator pattern
+ */
+declare const nuclearComponent: any;
+
+export { connect, Provider, nuclearMixin, provideReactor, nuclearComponent };

--- a/types/nuclear-js-react-addons-chefsplate/index.d.ts
+++ b/types/nuclear-js-react-addons-chefsplate/index.d.ts
@@ -53,6 +53,7 @@ interface ComponentConnector<TNeedsProps, TInjectedPropNames extends string | nu
  */
 declare function connect<TNeedsProps, TInjectedPropNames extends string | number | symbol>(
     mapStateToProps: MapStateToProps<TInjectedPropNames>,
+    // tslint:disable-next-line no-unnecessary-generics
 ): ComponentConnector<TNeedsProps, TInjectedPropNames>;
 
 /**

--- a/types/nuclear-js-react-addons-chefsplate/nuclear-js-react-addons-chefsplate-tests.tsx
+++ b/types/nuclear-js-react-addons-chefsplate/nuclear-js-react-addons-chefsplate-tests.tsx
@@ -103,13 +103,3 @@ class CCWithAProp extends React.Component<{ a: string }> {}
 connect(badMapStateToProps)(CCWithAProp);
 // Doesn't actually check types, just prop names.
 connect(okayMapStateToProps)(CCWithAProp);
-
-// Check typing on parameter of "mapStateToProps"
-const mapStateToProps1 = () => ({});
-connect(mapStateToProps1);
-const mapStateToProps2 = (props: {}) => ({});
-connect(mapStateToProps2);
-const mapStateToProps3 = (props: { extra: string }) => ({});
-connect(mapStateToProps3);
-const mapStateToProps4 = (props: { extra: string }) => ({ extra: 5 });
-connect(mapStateToProps4);

--- a/types/nuclear-js-react-addons-chefsplate/nuclear-js-react-addons-chefsplate-tests.tsx
+++ b/types/nuclear-js-react-addons-chefsplate/nuclear-js-react-addons-chefsplate-tests.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react';
+
+// Make sure all exports are defined, even though "connect" is the only one with
+// actual types.
+import { connect, Provider, nuclearMixin, provideReactor, nuclearComponent } from 'nuclear-js-react-addons-chefsplate';
+
+/******************** FUNCTION COMPONENT TESTS ********************************/
+
+// Make sure that connect passes through basic props requirement.
+const FC = (props: {}) => <p />;
+const ConnectedFC = connect(() => ({}))(FC);
+// $ExpectError
+<ConnectedFC extra="" />;
+
+const FCWithProp = (props: { extra: string }) => <p />;
+const ConnectedFCWithProps = connect(() => ({}))(FCWithProp);
+<ConnectedFCWithProps extra="" />;
+// $ExpectError
+<ConnectedFCWithProps extra={5} />;
+
+// Make sure it works with untyped function components.
+const UntypedFC: any = (props: { extra: string }) => <p />;
+const ConnectedUntypedFC = connect(() => ({ extra: null, superExtra: null }))(UntypedFC);
+<ConnectedUntypedFC />;
+
+// Make sure that injected props are NOT available in connected component.
+const ConnectedFCWithoutProps = connect(() => ({ extra: null }))(FCWithProp);
+// $ExpectError
+<ConnectedFCWithoutProps extra="" />;
+
+// Check optional props.
+const FCWithOptionalProp = (props: { optional?: string }) => <p />;
+const ConnectedFCWithOptionalProp = connect(() => ({}))(FCWithOptionalProp);
+<ConnectedFCWithOptionalProp />;
+<ConnectedFCWithOptionalProp optional="" />;
+// $ExpectError
+<ConnectedFCWithOptionalProp optional={5} />;
+
+// Any props injeted in mapStateToProps should NOT be available on the connected
+// component.
+const ConnectedFCWithoutOptionalProp = connect(() => ({ optional: null }))(FCWithOptionalProp);
+<ConnectedFCWithoutOptionalProp />;
+// $ExpectError
+<ConnectedFCWithoutOptionalProp optional="" />;
+// $ExpectError
+<ConnectedFCWithoutOptionalProp optional={5} />;
+
+// Check that it's an error to even call connect() with mismatched mapStateToProps
+// and component.
+const FCWithAProp = (props: { a: string }) => <p />;
+const badMapStateToProps = () => ({ b: null });
+const okayMapStateToProps = () => ({ a: 15 });
+// $ExpectError
+connect(badMapStateToProps)(FCWithAProp);
+// Doesn't actually check types, just prop names.
+connect(okayMapStateToProps)(FCWithAProp);
+
+/*********************** CLASS COMPONENT TESTS ********************************/
+
+// Make sure that connect passes through basic props requirement.
+class CC extends React.Component {}
+const ConnectedCC = connect(() => ({}))(CC);
+// $ExpectError
+<ConnectedCC extra="" />;
+
+class CCWithProp extends React.Component<{ extra: string }> {}
+const ConnectedCCWithProps = connect(() => ({}))(CCWithProp);
+<ConnectedCCWithProps extra="" />;
+// $ExpectError
+<ConnectedCCWithProps extra={5} />;
+
+// Make sure it works with untyped class components.
+const UntypedCC: any = CCWithProp;
+const ConnectedUntypedCC = connect(() => ({ extra: null, superExtra: null }))(UntypedCC);
+<ConnectedUntypedCC />;
+
+// Make sure that injected props are NOT available in connected component.
+const ConnectedCCWithoutProps = connect(() => ({ extra: null }))(CCWithProp);
+// $ExpectError
+<ConnectedCCWithoutProps extra="" />;
+
+// Check optional props.
+class CCWithOptionalProp extends React.Component<{ optional?: string }> {}
+const ConnectedCCWithOptionalProp = connect(() => ({}))(CCWithOptionalProp);
+<ConnectedCCWithOptionalProp />;
+<ConnectedCCWithOptionalProp optional="" />;
+// $ExpectError
+<ConnectedCCWithOptionalProp optional={5} />;
+
+// Any props injeted in mapStateToProps should NOT be available on the connected
+// component.
+const ConnectedCCWithoutOptionalProp = connect(() => ({ optional: null }))(CCWithOptionalProp);
+<ConnectedCCWithoutOptionalProp />;
+// $ExpectError
+<ConnectedCCWithoutOptionalProp optional="" />;
+// $ExpectError
+<ConnectedCCWithoutOptionalProp optional={5} />;
+
+// Check that it's an error to even call connect() with mismatched mapStateToProps
+// and component.
+class CCWithAProp extends React.Component<{ a: string }> {}
+// $ExpectError
+connect(badMapStateToProps)(CCWithAProp);
+// Doesn't actually check types, just prop names.
+connect(okayMapStateToProps)(CCWithAProp);
+
+// Check typing on parameter of "mapStateToProps"
+const mapStateToProps1 = () => ({});
+connect(mapStateToProps1);
+const mapStateToProps2 = (props: {}) => ({});
+connect(mapStateToProps2);
+const mapStateToProps3 = (props: { extra: string }) => ({});
+connect(mapStateToProps3);
+const mapStateToProps4 = (props: { extra: string }) => ({ extra: 5 });
+connect(mapStateToProps4);

--- a/types/nuclear-js-react-addons-chefsplate/tsconfig.json
+++ b/types/nuclear-js-react-addons-chefsplate/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react"
+    },
+    "files": [
+        "index.d.ts",
+        "nuclear-js-react-addons-chefsplate-tests.tsx"
+    ]
+}

--- a/types/nuclear-js-react-addons-chefsplate/tslint.json
+++ b/types/nuclear-js-react-addons-chefsplate/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-unnecessary-generics": false
+    }
+}

--- a/types/nuclear-js-react-addons-chefsplate/tslint.json
+++ b/types/nuclear-js-react-addons-chefsplate/tslint.json
@@ -1,6 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "no-unnecessary-generics": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
NOTE: I only added types for `connect()`, and left the other exports as `any`. I only use `connect()` in my own code, so that's the only one I care about having types for.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.