### PR TITLE
[react-map-gl] Fix missing auto prop from GeolocateControl props interface

### DIFF
--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -396,6 +396,7 @@ export interface GeolocateControlProps extends BaseControlProps {
     onViewportChange?: ViewportChangeHandler;
     onGeolocate?: (options: PositionOptions) => void;
     style?: React.CSSProperties;
+    auto?: boolean;
 }
 
 export class GeolocateControl extends BaseControl<GeolocateControlProps, HTMLDivElement> {}

--- a/types/react-map-gl/react-map-gl-tests.tsx
+++ b/types/react-map-gl/react-map-gl-tests.tsx
@@ -65,6 +65,7 @@ class MyMap extends React.Component<{}, State> {
                 >
                     <FullscreenControl className="test-class" container={document.querySelector('body')} />
                     <GeolocateControl
+                        auto={false}
                         className="test-class"
                         style={{ marginTop: '8px' }}
                         onGeolocate={options => {


### PR DESCRIPTION
Fixed missing `auto` prop from `GeolocateControl` props interface. Related: https://github.com/visgl/react-map-gl/issues/1148

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://visgl.github.io/react-map-gl/docs/api-reference/geolocate-control#auto
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
