### PR TITLE
improve http-assert type annotation with 'asserts'

### DIFF
--- a/types/http-assert/http-assert-tests.ts
+++ b/types/http-assert/http-assert-tests.ts
@@ -25,13 +25,16 @@ try {
     console.log((err as HttpError).expose);
 }
 
+/**
+ * Test `asserts` annotation
+ */
 interface Resource {
-    id: string
+    id: string;
 }
+function getResource(): Resource | undefined { return undefined; }
 
-let resource: Resource | undefined;
-
+const resource: Resource | undefined = getResource();
 httpAssert(resource);
 
 // TS knows resource is not undefined and it can be safely used
-resource.id;
+console.log(resource.id);

--- a/types/http-assert/http-assert-tests.ts
+++ b/types/http-assert/http-assert-tests.ts
@@ -24,3 +24,14 @@ try {
     console.log((err as HttpError).message);
     console.log((err as HttpError).expose);
 }
+
+interface Resource {
+    id: string
+}
+
+let resource: Resource | undefined;
+
+httpAssert(resource);
+
+// TS knows resource is not undefined and it can be safely used
+resource.id;

--- a/types/http-assert/index.d.ts
+++ b/types/http-assert/index.d.ts
@@ -6,13 +6,15 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
+type Truthy<T> = T extends null | undefined | false | '' | 0 ? never : T;
+
 /**
  * @param status the status code
  * @param msg the message of the error, defaulting to node's text for that status code
  * @param opts custom properties to attach to the error object
  */
-declare function assert(value: any, status?: number, msg?: string, opts?: {}): void;
-declare function assert(value: any, status?: number, opts?: {}): void;
+declare function assert<T>(value: T, status?: number, msg?: string, opts?: {}): asserts value is Truthy<T>;
+declare function assert<T>(value: T, status?: number, opts?: {}): asserts value is Truthy<T>;
 
 declare namespace assert {
     /**

--- a/types/http-assert/index.d.ts
+++ b/types/http-assert/index.d.ts
@@ -4,7 +4,8 @@
 //                 Peter Squicciarini <https://github.com/stripedpajamas>
 //                 Alex Bulanov <https://github.com/sapfear>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.7
+// Minimum TypeScript Version: 3.7
 
 type Truthy<T> = T extends null | undefined | false | '' | 0 ? never : T;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/koajs/koa/issues/1467
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
