### PR TITLE
Add types for 'react-nepal-map' module

### DIFF
--- a/types/react-nepal-map/index.d.ts
+++ b/types/react-nepal-map/index.d.ts
@@ -1,0 +1,78 @@
+// Type definitions for react-nepal-map 1.0
+// Project: https://github.com/keyrunpay/react-nepal-map#readme
+// Definitions by: Ashish Yadav <https://github.com/ashiishme>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as React from 'react';
+
+export as namespace ReactNepalMap;
+
+/**
+ * Returns random color string
+ */
+export function getRandomColor(): string;
+
+/**
+ * Metadata types for Map
+ */
+export interface MapMetaDataTypes {
+    name: string;
+    shape: string;
+}
+
+export interface DistrictMapTypes extends MapMetaDataTypes {
+    zip: number;
+    province: number;
+}
+
+export interface ProvinceMapTypes extends MapMetaDataTypes {
+    zip: number;
+}
+
+export interface ZonalMapTypes extends MapMetaDataTypes {
+    code: string;
+}
+
+/**
+ * Map data
+ */
+export const districtMapData: DistrictMapTypes[];
+
+export const provinceMapData: ProvinceMapTypes[];
+
+export const zonalMapData: ZonalMapTypes[];
+
+/**
+ * Items props for onMapClick method
+ */
+
+export interface itemProps {
+    name: string;
+    zip: number;
+    province: number;
+    code: string;
+}
+
+/**
+ * Map component props
+ */
+
+export interface MapPropsTypes {
+    onMapClick?: (item: itemProps) => void;
+    randomSectorColor?: boolean;
+    sectorClassName?: string;
+    containerClassName?: string;
+    color?: string;
+    hoverColor?: string;
+    stroke?: string;
+    strokeWidth?: number;
+}
+
+export interface ProvinceMapPropsTypes extends MapPropsTypes {
+    provinceColor?: string[];
+}
+
+// Components
+export const DistrictMap: React.FC<MapPropsTypes>;
+export const ProvinceMap: React.FC<ProvinceMapPropsTypes>;
+export const ZonalMap: React.FC<MapPropsTypes>;

--- a/types/react-nepal-map/react-nepal-map-tests.tsx
+++ b/types/react-nepal-map/react-nepal-map-tests.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import {
+    ProvinceMap,
+    getRandomColor,
+    DistrictMap,
+    ZonalMap,
+    itemProps,
+    DistrictMapTypes,
+    ProvinceMapTypes,
+    ZonalMapTypes,
+} from 'react-nepal-map';
+
+export const provinceFC = () => {
+    return <ProvinceMap provinceColor={['red', 'green', 'blue']} />;
+};
+
+export const provinceFCWithProps = () => {
+    return (
+        <ProvinceMap
+            onMapClick={({ name, zip, province }: itemProps) => {
+                // do something
+            }}
+            randomSectorColor={true}
+            sectorClassName="some-class"
+            containerClassName="string"
+            color={getRandomColor()}
+            hoverColor={getRandomColor()}
+            stroke="2"
+            strokeWidth={2}
+            provinceColor={['red', 'blue', 'white']}
+        />
+    );
+};
+
+export const districtFC = () => {
+    return <DistrictMap />;
+};
+
+export const districtFCWithProps = () => {
+    return (
+        <DistrictMap
+            onMapClick={({ name, zip, province }: itemProps) => {
+                // do something
+            }}
+            randomSectorColor={true}
+            sectorClassName="district-sector"
+            containerClassName="district-wrapper"
+            color={getRandomColor()}
+            hoverColor="#000"
+            stroke={getRandomColor()}
+            strokeWidth={2}
+        />
+    );
+};
+
+export const zonalFC = () => {
+    return <ZonalMap />;
+};
+
+export const zonalFCWithProps = () => {
+    return <ZonalMap stroke={getRandomColor()} strokeWidth={2} />;
+};
+
+const zonalMapData: ZonalMapTypes[] = [
+    {
+        name: 'Gandaki',
+        code: 'GA',
+        shape: 'Zonal map data, cannot add the svg data for test because of maximum line length issue.',
+    },
+    {
+        name: 'LU',
+        code: 'Lumbini',
+        shape: 'Zonal map data, cannot add the svg data for test because of maximum line length issue.',
+    },
+];
+
+const districtMapData: DistrictMapTypes[] = [
+    {
+        name: 'Nawalparasi_W',
+        zip: 33010,
+        province: 5,
+        shape: 'District map data, cannot add the svg data for test because of maximum line length issue.',
+    },
+    {
+        name: 'Rupendehi',
+        zip: 32900,
+        province: 5,
+        shape: 'District map data, cannot add the svg data for test because of maximum line length issue.',
+    },
+];
+
+const provinceMapData: ProvinceMapTypes[] = [
+    {
+        name: 'Province 4',
+        zip: 33700,
+        shape: 'Province map data, cannot add the svg data for test because of maximum line length issue.',
+    },
+    {
+        name: 'Province 5',
+        zip: 32907,
+        shape: 'Province map data, cannot add the svg data for test because of maximum line length issue.',
+    },
+];

--- a/types/react-nepal-map/tsconfig.json
+++ b/types/react-nepal-map/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "jsx": "react",
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "react-nepal-map-tests.tsx"]
+}

--- a/types/react-nepal-map/tslint.json
+++ b/types/react-nepal-map/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
