### PR TITLE
feat(docdown): new type definition

### DIFF
--- a/types/docdown/docdown-tests.ts
+++ b/types/docdown/docdown-tests.ts
@@ -1,0 +1,18 @@
+import docdown = require('docdown');
+import { Options } from 'docdown';
+
+const options: Options = {
+    path: './some/path',
+    url: 'https://github.com/username/project/blob/master/my.js',
+};
+const markdown = docdown(options);
+// $ExpectType string
+docdown({
+    path: './some/path',
+    url: 'https://example.com/my.js',
+    lang: 'js',
+    sort: false,
+    style: 'github',
+    title: 'README',
+    toc: 'properties',
+});

--- a/types/docdown/index.d.ts
+++ b/types/docdown/index.d.ts
@@ -1,0 +1,50 @@
+// Type definitions for docdown 0.7
+// Project: https://github.com/jdalton/docdown#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * A simple JSDoc to Markdown documentation generator.
+ * Generates Markdown documentation based on JSDoc comments.
+ */
+declare function docdown(options: docdown.Options): string;
+
+declare namespace docdown {
+    interface Options {
+        /**
+         * the input file pat
+         */
+        path: string;
+        /**
+         * The source URL.
+         */
+        url: string;
+        /**
+         *  The language indicator for code blocks.
+         * @default 'js'
+         */
+        lang?: string;
+        /**
+         * Specify whether entries are sorted.
+         * @default true
+         */
+        sort?: boolean;
+        /**
+         * The hash style for links ('default' or 'github').
+         * @default 'default'
+         */
+        style?: string;
+        /**
+         * The documentation title.
+         * @default '<%= basename(options.path) %> API documentation'
+         */
+        title?: string;
+        /**
+         * The table of contents organization style ('categories' or 'properties').
+         * @default 'properties'
+         */
+        toc?: string;
+    }
+}
+
+export = docdown;

--- a/types/docdown/tsconfig.json
+++ b/types/docdown/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "docdown-tests.ts"
+    ]
+}

--- a/types/docdown/tslint.json
+++ b/types/docdown/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Definition types for 'docdown':
- definitioins files
- tests

https://github.com/jdalton/docdown#readme

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. 
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.