### PR TITLE
[inquirer] Fix `Question.filter()` declaration

### DIFF
--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for inquirer 7.3.1
+// Type definitions for inquirer 7.3
 // Project: https://github.com/SBoudrias/Inquirer.js
 // Definitions by: Qubo <https://github.com/tkQubo>
 //                 Parvez <https://github.com/ppathan>

--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -15,11 +15,10 @@
 // TypeScript Version: 3.3
 import { Interface as ReadlineInterface } from "readline";
 import { Observable } from "rxjs";
-import { ThroughStream } from "through";
 import Choice = require("./lib/objects/choice");
 import Choices = require("./lib/objects/choices");
 import Separator = require("./lib/objects/separator");
-import Prompt = require("./lib/prompts/base");
+import "./lib/prompts/base";
 import "./lib/prompts/checkbox";
 import "./lib/prompts/confirm";
 import "./lib/prompts/editor";
@@ -32,9 +31,9 @@ import "./lib/prompts/rawlist";
 import BottomBar = require("./lib/ui/bottom-bar");
 import PromptUI = require("./lib/ui/prompt");
 import "./lib/utils/events";
-import Paginator = require("./lib/utils/paginator");
+import "./lib/utils/paginator";
 import "./lib/utils/readline";
-import ScreenManager = require("./lib/utils/screen-manager");
+import "./lib/utils/screen-manager";
 import "./lib/utils/utils";
 
 /**

--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -564,7 +564,12 @@ declare namespace inquirer {
      * @template T
      * The type of the answers.
      */
-    interface ListQuestionOptions<T extends Answers = Answers> extends ListQuestionOptionsBase<T, ListChoiceMap<T>> { }
+    interface ListQuestionOptions<T extends Answers = Answers> extends ListQuestionOptionsBase<T, ListChoiceMap<T>> {
+        /**
+         * A value indicating whether choices in a list should be looped.
+         */
+        loop?: boolean;
+    }
 
     /**
      * Provides options for a question for the `ListPrompt`.

--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -746,6 +746,11 @@ declare namespace inquirer {
     type DistinctQuestion<T extends Answers = Answers> = QuestionMap<T>[keyof QuestionMap<T>];
 
     /**
+     * Indicates the type of a question
+     */
+    type QuestionTypeName = DistinctQuestion["type"];
+
+    /**
      * Represents a collection of questions.
      *
      * @template T

--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -598,7 +598,7 @@ declare namespace inquirer {
      * @template T
      * The type of the answers.
      */
-    interface RawListQuestion<T extends Answers = Answers> extends ListQuestionOptionsBase<T, ListChoiceMap<T>> {
+    interface RawListQuestion<T extends Answers = Answers> extends RawListQuestionOptions<T> {
         /**
          * @inheritdoc
          */

--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -28,13 +28,13 @@ import "./lib/prompts/list";
 import "./lib/prompts/number";
 import "./lib/prompts/password";
 import "./lib/prompts/rawlist";
-import BottomBar = require("./lib/ui/bottom-bar");
-import PromptUI = require("./lib/ui/prompt");
 import "./lib/utils/events";
 import "./lib/utils/paginator";
 import "./lib/utils/readline";
 import "./lib/utils/screen-manager";
 import "./lib/utils/utils";
+import BottomBar = require("./lib/ui/bottom-bar");
+import PromptUI = require("./lib/ui/prompt");
 
 /**
  * Represents a union which preserves autocompletion.

--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for inquirer 6.5
+// Type definitions for inquirer 7.3.1
 // Project: https://github.com/SBoudrias/Inquirer.js
 // Definitions by: Qubo <https://github.com/tkQubo>
 //                 Parvez <https://github.com/ppathan>

--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -279,8 +279,11 @@ declare namespace inquirer {
          *
          * @param input
          * The answer provided by the user.
+         *
+         * @param answers
+         * The answers provided by the user.
          */
-        filter?(input: any): any;
+        filter?(input: any, answers: T): any;
 
         /**
          * A value indicating whether the question should be prompted.

--- a/types/inquirer/inquirer-tests.ts
+++ b/types/inquirer/inquirer-tests.ts
@@ -20,6 +20,32 @@ import InputPrompt = require("inquirer/lib/prompts/input");
     new inquirer.ui.BottomBar();
     new inquirer.ui.Prompt(inquirer.prompt.prompts);
 }
+{
+    const checkBoxQuestion: inquirer.CheckboxQuestion = {
+        type: "checkbox"
+    };
+
+    const listQuestion: inquirer.ListQuestion = {
+        type: "list"
+    };
+
+    // $ExpectError
+    checkBoxQuestion.loop;
+    // $ExpectType boolean
+    listQuestion.loop!;
+}
+{
+    inquirer.prompt<Partial<any>>([
+        {
+            filter(input, answers) {
+                // $ExpectType any
+                input;
+                // $ExpectType Partial<any>
+                answers;
+            }
+        }
+    ]);
+}
 
 interface ChalkQuestionOptions<T extends inquirer.Answers = inquirer.Answers> extends inquirer.InputQuestionOptions<T> {
     previewColors: boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/SBoudrias/Inquirer.js/blob/master/README.md#question>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The `lint`-task might fail as seen in microsoft/dtslint#299 because this type-declaration contains `@derecated` tags.
