### PR TITLE
Update date-and-time types to 0.13 version

### DIFF
--- a/types/date-and-time/date-and-time-tests.ts
+++ b/types/date-and-time/date-and-time-tests.ts
@@ -1,26 +1,27 @@
-import * as date from "date-and-time";
+import * as date from 'date-and-time';
+import 'date-and-time/plugin/meridiem';
 
 const now = new Date();
 // $ExpectType string
-date.format(now, "YYYY/MM/DD HH:mm:ss"); // => '2015/01/02 23:14:05'
+date.format(now, 'YYYY/MM/DD HH:mm:ss'); // => '2015/01/02 23:14:05'
 // $ExpectType string
-date.format(now, "ddd MMM DD YYYY"); // => 'Fri Jan 02 2015'
+date.format(now, 'ddd MMM DD YYYY'); // => 'Fri Jan 02 2015'
 // $ExpectType string
-date.format(now, "hh:mm A [GMT]Z"); // => '11:14 p.m. GMT-0800'
+date.format(now, 'hh:mm A [GMT]Z'); // => '11:14 p.m. GMT-0800'
 // $ExpectType string
-date.format(now, "hh:mm A [GMT]Z", true); // => '07:14 a.m. GMT+0000'
+date.format(now, 'hh:mm A [GMT]Z', true); // => '07:14 a.m. GMT+0000'
 
-// $ExpectType number | Date
-date.parse("2015/01/02 23:14:05", "YYYY/MM/DD HH:mm:ss"); // => date object
-// $ExpectType number | Date
-date.parse("02-01-2015", "DD-MM-YYYY"); // => date object
-// $ExpectType number | Date
-date.parse("Jam 1 2017", "MMM D YYYY"); // => NaN
+// $ExpectType Date
+date.parse('2015/01/02 23:14:05', 'YYYY/MM/DD HH:mm:ss'); // => date object
+// $ExpectType Date
+date.parse('02-01-2015', 'DD-MM-YYYY'); // => date object
+// $ExpectType Date
+date.parse('Jam 1 2017', 'MMM D YYYY'); // => NaN
 
 // $ExpectType boolean
-date.isValid("2015/01/02 23:14:05", "YYYY/MM/DD HH:mm:ss"); // => true
+date.isValid('2015/01/02 23:14:05', 'YYYY/MM/DD HH:mm:ss'); // => true
 // $ExpectType boolean
-date.isValid("29-02-2015", "DD-MM-YYYY"); // => false
+date.isValid('29-02-2015', 'DD-MM-YYYY'); // => false
 
 // $ExpectType Date
 date.addYears(now, 1); // => Date object
@@ -46,7 +47,7 @@ date.addMilliseconds(now, 1); // => Date object
 const today = new Date(2015, 0, 2);
 const yesterday = new Date(2015, 0, 1);
 
-// $ExpectType Subtract
+// $ExpectType SubtractResult
 date.subtract(today, yesterday);
 // $ExpectType number
 date.subtract(today, yesterday).toDays(); // => 1 = today - yesterday
@@ -59,12 +60,10 @@ date.subtract(today, yesterday).toSeconds(); // => 86400
 // $ExpectType number
 date.subtract(today, yesterday).toMilliseconds(); // => 86400000
 
-const date1 = new Date(2015, 0, 2);
-const date2 = new Date(2012, 0, 2);
 // $ExpectType boolean
-date.isLeapYear(date1); // => false
+date.isLeapYear(2015); // => false
 // $ExpectType boolean
-date.isLeapYear(date2); // => true
+date.isLeapYear(2012); // => true
 
 const date1_ = new Date(2017, 0, 2, 0); // Jan 2 2017 00:00:00
 const date2_ = new Date(2017, 0, 2, 23, 59); // Jan 2 2017 23:59:00
@@ -77,10 +76,14 @@ date.isSameDay(date1_, date3); // => false
 // $ExpectType string
 date.locale();
 
-// $ExpectType any
-date.getLocales();
+// $ExpectType PreparseResult
+date.preparse('0000', 'YYYY');
+
+// $ExpectType string[]
+date.compile('YYYY');
 
 // $ExpectType void
-date.setLocales("en", {
-    A: ["AM", "PM"]
-});
+date.plugin('meridiem');
+
+// $ExpectType void
+date.extend({ res: { A: ['am', 'pm'] } });

--- a/types/date-and-time/index.d.ts
+++ b/types/date-and-time/index.d.ts
@@ -1,57 +1,97 @@
-// Type definitions for date-and-time 0.6
+// Type definitions for date-and-time 0.13
 // Project: https://github.com/knowledgecode/date-and-time
 // Definitions by: Daniel Plisetsky <https://github.com/danplisetsky>
+//                 Justin Grant <https://github.com/justingrant>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+export interface PreparseResult {
+    /** Year */
+    Y: number;
+    /** Month */
+    M: number;
+    /** Day */
+    D: number;
+    /** 24-hour */
+    H: number;
+    /** Meridiem */
+    A: number;
+    /** 12-hour */
+    h: number;
+    /** Minute */
+    m: number;
+    /** Second */
+    s: number;
+    /** Millisecond */
+    S: number;
+    /** Timezone offset */
+    Z: number;
+    /** Pointer offset */
+    _index: number;
+    /** Length of the date string */
+    _length: number;
+    /** Token matching count */
+    _match: number;
+}
+
+/** @deprecated */
 export type getDelta = () => number;
 
-export interface Subtract {
-    toMilliseconds: getDelta;
-    toSeconds: getDelta;
-    toMinutes: getDelta;
-    toHours: getDelta;
-    toDays: getDelta;
+export interface SubtractResult {
+    toMilliseconds: () => number;
+    toSeconds: () => number;
+    toMinutes: () => number;
+    toHours: () => number;
+    toDays: () => number;
 }
+/** @deprecated Use `SubtractResult` instead */
+export type Subtract = SubtractResult;
+
+/**
+ * Compiling a format string
+ * @param formatString - Format string
+ * @returns The compiled object
+ */
+export function compile(formatString: string): string[];
+
+/**
+ * Pre-parsing a date string
+ * @param dateString - Date string
+ * @param formatter - Format string or a compiled object
+ * @returns The date structure
+ */
+export function preparse(dateString: string, formatString: string | string[]): PreparseResult;
 
 /**
  * Formatting a date
  * @param dateObj - Date object
- * @param formatString - Format string
- * @param [utc] - Output as UTC
+ * @param formatter - Format string or a compiled object
+ * @param utc - Output as UTC?
  * @returns The formatted string
  *
  */
-export function format(
-    dateObj: Date,
-    formatString: string,
-    utc?: boolean
-): string;
+export function format(dateObj: Date, formatString: string | string[], utc?: boolean): string;
 
 /**
  * Parsing a date string
- * @param dateString - date string
- * @param formatString - format string
- * @param [utc] - input as UTC
- * @returns the constructed date or NaN
+ * @param dateString - Date string
+ * @param formatter - Format string or a compiled object
+ * @param [utc] - Input as UTC
+ * @returns The constructed date
  */
-export function parse(
-    dateString: string,
-    formatString: string,
-    utc?: boolean
-): Date | number;
+export function parse(dateString: string, formatter: string | string[], utc?: boolean): Date;
 
 /**
  * Validation
- * @param dateString - Date string
- * @param formatString - Format string
+ * @param dateValue - Date string or preparsed date structure
+ * @param formatter - Format string or a compiled object
  * @returns Whether the date string is a valid date
  */
-export function isValid(dateString: string, formatString: string): boolean;
+export function isValid(dateValue: string | PreparseResult, formatter?: string | string[]): boolean;
 
 /**
  * Adding years
  * @param dateObj - Date object
- * @param years - Adding year
+ * @param years - Number of years to add
  * @returns The date after adding the value
  */
 export function addYears(dateObj: Date, years: number): Date;
@@ -59,7 +99,7 @@ export function addYears(dateObj: Date, years: number): Date;
 /**
  * Adding months
  * @param dateObj - Date object
- * @param months - Adding month
+ * @param months - Number of months to add
  * @returns The date after adding the value
  */
 export function addMonths(dateObj: Date, months: number): Date;
@@ -67,7 +107,7 @@ export function addMonths(dateObj: Date, months: number): Date;
 /**
  * Adding days
  * @param dateObj - Date object
- * @param days - Adding day
+ * @param days - Number of days to add
  * @returns The date after adding the value
  */
 export function addDays(dateObj: Date, days: number): Date;
@@ -75,7 +115,7 @@ export function addDays(dateObj: Date, days: number): Date;
 /**
  * Adding hours
  * @param dateObj - Date object
- * @param hours - Adding hour
+ * @param hours - Number of hours to add
  * @returns The date after adding the value
  */
 export function addHours(dateObj: Date, hours: number): Date;
@@ -83,15 +123,15 @@ export function addHours(dateObj: Date, hours: number): Date;
 /**
  * Adding minutes
  * @param dateObj - Date object
- * @param minutes - Adding minute
+ * @param minutes - Number of minutes to add
  * @returns The date after adding the value
  */
 export function addMinutes(dateObj: Date, minutes: number): Date;
 
 /**
  * Adding seconds
- * @param dateObj - date object
- * @param seconds - adding second
+ * @param dateObj - Date object
+ * @param seconds - Number of seconds to add
  * @returns The date after adding the value
  */
 export function addSeconds(dateObj: Date, seconds: number): Date;
@@ -99,7 +139,7 @@ export function addSeconds(dateObj: Date, seconds: number): Date;
 /**
  * Adding milliseconds
  * @param dateObj - Date object
- * @param milliseconds - Adding millisecond
+ * @param milliseconds - Number of milliseconds to add
  * @returns The date after adding the value
  */
 export function addMilliseconds(dateObj: Date, milliseconds: number): Date;
@@ -108,43 +148,42 @@ export function addMilliseconds(dateObj: Date, milliseconds: number): Date;
  * Subtracting
  * @param date1 - Date object
  * @param date2 - Date object
- * @returns The result object after subtracting the date
+ * @returns The result object subtracting date2 from date1
  */
-export function subtract(date1: Date, date2: Date): Subtract;
+export function subtract(date1: Date, date2: Date): SubtractResult;
 
 /**
  * Leap year
- * @param dateObj - Date object
+ * @param y - Year as a number
  * @returns Whether the year is a leap year
  */
-export function isLeapYear(dateObj: Date): boolean;
+export function isLeapYear(y: number): boolean;
 
 /**
  * Comparison of dates
- * @param date1 - Target for comparison
- * @param date2 - Target for comparison
+ * @param date1 - Date object
+ * @param date2 - Date object
  * @returns Whether the dates are the same day (times are ignored)
  */
 export function isSameDay(date1: Date, date2: Date): boolean;
 
 /**
- * Setting a locale
+ * Change locale or setting a new locale definition
  * @param [code] - Language code
+ * @param [locale] - locale definition
  * @returns Current language code
  */
-export function locale(code?: string): string;
+export function locale(code?: string, locale?: Record<string, unknown>): string;
 
 /**
- * Getting a definition of locale
- * @param [code] - Language code
- * @returns Definition of locale
+ * Locale extension
+ * @param extension - Locale extension
  */
-export function getLocales(code?: string): any;
+export function extend(extension: Record<string, unknown>): void;
 
 /**
- * Adding a new definition of locale
- * @param code - Language code
- * @param options - Definition of locale
- * @returns
+ * Plugin import or definition
+ * @param name - Plugin name
+ * @param extension - Locale extension
  */
-export function setLocales(code: string, options: any): void;
+export function plugin(name: string, extension?: Record<string, unknown>): void;


### PR DESCRIPTION
The date-and-time package has evolved a bit since the 0.6 release.  This PR catches up on these changes, and makes some 
cleanup changes to the types. Summary of changes: 

- Adds types for new functions `compile`, `preparse`, `extend`, `plugin`
- Adds `PreparseResult` type
- Deprecates `getDelta` type that made intellisense worse (and that didn't have a PascalCased name)
- Deprecates `Subtract` in favor of `SubtractResult` alias
- Adapts to breaking changes in the library:
  - `parse` no longer returns NaN (it will return Invalid Date object)
  - `isLeapYear` accepts a `number`, not a `Date`
  - `getLocales` and `setLocales` functions are removed
- Adds various non-breaking updates, e.g. new optional parameters
- Clarifies some JSDoc comments & parameter names
- Makes minor grammar and capitalization updates

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/knowledgecode/date-and-time
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
