### PR TITLE
[@types/underscore] Collection and Array Tests - Where, FindWhere, Shuffle, and Sample

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -364,25 +364,30 @@ declare module _ {
         select: UnderscoreStatic['filter'];
 
         /**
-        * Looks through each value in the list, returning an array of all the values that contain all
-        * of the key-value pairs listed in properties.
-        * @param list List to match elements again `properties`.
-        * @param properties The properties to check for on each element within `list`.
-        * @return The elements within `list` that contain the required `properties`.
-        **/
-        where<T, U extends {}>(
-            list: _.List<T>,
-            properties: U): T[];
+         * Looks through each value in the collection, returning an array of all the values that matches the
+         * key-value pairs listed in `properties`.
+         * @param collection The collection in which to find elements that match `properties`.
+         * @param properties The properties to check for on the elements within `collection`.
+         * @return The elements in `collection` that match `properties`.
+         **/
+        where<V extends Collection<any>>(
+            collection: V,
+            properties: Partial<TypeOfCollection<V>>
+        ): TypeOfCollection<V>[];
 
         /**
-        * Looks through the list and returns the first value that matches all of the key-value pairs listed in properties.
-        * @param list Search through this list's elements for the first object with all `properties`.
-        * @param properties Properties to look for on the elements within `list`.
-        * @return The first element in `list` that has all `properties`.
-        **/
-        findWhere<T, U extends {}>(
-            list: _.List<T>,
-            properties: U): T | undefined;
+         * Looks through the collection and returns the first value that matches all of the key-value
+         * pairs listed in `properties`.
+         * If no match is found, or if list is empty, undefined will be returned.
+         * @param collection The collection in which to find an element that matches `properties`.
+         * @param properties The properties to check for on the elements within `collection`.
+         * @return The first element in `collection` that matches `properties` or undefined if
+         * no match is found.
+         **/
+        findWhere<V extends Collection<any>>(
+            collection: V,
+            properties: Partial<TypeOfCollection<V>>
+        ): TypeOfCollection<V> | undefined;
 
         /**
          * Returns the values in `collection` without the elements that pass a truth test (iteratee).
@@ -692,23 +697,21 @@ declare module _ {
             context?: any): _.Dictionary<number>;
 
         /**
-        * Returns a shuffled copy of the list, using a version of the Fisher-Yates shuffle.
-        * @param list List to shuffle.
-        * @return Shuffled copy of `list`.
-        **/
-        shuffle<T>(list: _.Collection<T>): T[];
+         * Returns a shuffled copy of the collection, using a version of the Fisher-Yates shuffle.
+         * @param collection The collection to shuffle.
+         * @return A shuffled copy of `collection`.
+         **/
+        shuffle<V extends Collection<any>>(collection: V): TypeOfCollection<V>[];
 
         /**
-        * Produce a random sample from the `list`.  Pass a number to return `n` random elements from the list.  Otherwise a single random item will be returned.
-        * @param list List to sample.
-        * @return Random sample of `n` elements in `list`.
-        **/
-        sample<T>(list: _.Collection<T>, n: number): T[];
-
-        /**
-        * @see _.sample
-        **/
-        sample<T>(list: _.Collection<T>): T;
+         * Produce a random sample from the collection. Pass a number to return `n` random elements from the collection.
+         * Otherwise a single random item will be returned.
+         * @param collection The collection to sample.
+         * @param n The number of elements to sample from the collection.
+         * @return A random sample of `n` elements from `collection` or a single element if `n` is not specified.
+         **/
+        sample<V extends Collection<any>>(collection: V, n: number): TypeOfCollection<V>[];
+        sample<V extends Collection<any>>(collection: V): TypeOfCollection<V> | undefined;
 
         /**
         * Converts the list (anything that can be iterated over), into a real Array. Useful for transmuting
@@ -4206,16 +4209,22 @@ declare module _ {
         select: Underscore<T, V>['filter'];
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.where
-        **/
-        where<U extends {}>(properties: U): T[];
+         * Looks through each value in the wrapped collection, returning an array of all the values that matches the
+         * key-value pairs listed in `properties`.
+         * @param properties The properties to check for on the elements within the wrapped collection.
+         * @return The elements in the wrapped collection that match `properties`.
+         **/
+        where(properties: Partial<T>): T[];
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.findWhere
-        **/
-        findWhere<U extends {}>(properties: U): T | undefined;
+         * Looks through the wrapped collection and returns the first value that matches all of the key-value
+         * pairs listed in `properties`.
+         * If no match is found, or if list is empty, undefined will be returned.
+         * @param properties The properties to check for on the elements within the wrapped collection.
+         * @return The first element in the wrapped collection that matches `properties` or undefined if
+         * no match is found.
+         **/
+        findWhere(properties: Partial<T>): T | undefined;
 
         /**
          * Returns the values in the wrapped collection without the elements that pass a truth test (iteratee).
@@ -4363,21 +4372,19 @@ declare module _ {
         countBy(iterator: string, context?: any): _.Dictionary<number>;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.shuffle
-        **/
+         * Returns a shuffled copy of the wrapped collection, using a version of the Fisher-Yates shuffle.
+         * @return A shuffled copy of the wrapped collection.
+         **/
         shuffle(): T[];
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.sample
-        **/
-        sample<T>(n: number): T[];
-
-        /**
-        * @see _.sample
-        **/
-        sample<T>(): T;
+         * Produce a random sample from the wrapped collection. Pass a number to return `n` random elements from the
+         * wrapped collection. Otherwise a single random item will be returned.
+         * @param n The number of elements to sample from the wrapped collection.
+         * @return A random sample of `n` elements from the wrapped collection or a single element if `n` is not specified.
+         **/
+        sample(n: number): T[];
+        sample(): T | undefined;
 
         /**
         * Wrapped type `any`.
@@ -5183,16 +5190,22 @@ declare module _ {
         select: _Chain<T, V>['filter'];
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.where
-        **/
-        where<U extends {}>(properties: U): _Chain<T>;
+         * Looks through each value in the wrapped collection, returning an array of all the values that matches the
+         * key-value pairs listed in `properties`.
+         * @param properties The properties to check for on the elements within the wrapped collection.
+         * @return The elements in the wrapped collection that match `properties` in a chain wrapper.
+         **/
+        where(properties: Partial<T>): _Chain<T, T[]>;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.findWhere
-        **/
-        findWhere<U extends {}>(properties: U): _ChainSingle<T>;
+         * Looks through the wrapped collection and returns the first value that matches all of the key-value
+         * pairs listed in `properties`.
+         * If no match is found, or if list is empty, undefined will be returned.
+         * @param properties The properties to check for on the elements within the wrapped collection.
+         * @return The first element in the wrapped collection that matches `properties` or undefined if
+         * no match is found. The result will be wrapped in a chain wrapper.
+         **/
+        findWhere(properties: Partial<T>): _ChainSingle<T | undefined>;
 
         /**
          * Returns the values in the wrapped collection without the elements that pass a truth test (iteratee).
@@ -5347,15 +5360,20 @@ declare module _ {
         shuffle(): _Chain<T>;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.sample
-        **/
-        sample<T>(n: number): _Chain<T>;
+         * Returns a shuffled copy of the wrapped collection, using a version of the Fisher-Yates shuffle.
+         * @return A shuffled copy of the wrapped collection in a chain wrapper.
+         **/
+        shuffle(): _Chain<T, T[]>;
 
         /**
-        * @see _.sample
-        **/
-        sample<T>(): _Chain<T>;
+         * Produce a random sample from the wrapped collection. Pass a number to return `n` random elements from the
+         * wrapped collection. Otherwise a single random item will be returned.
+         * @param n The number of elements to sample from the wrapped collection.
+         * @return A random sample of `n` elements from the wrapped collection or a single element if `n` is not specified.
+         * The result will be wrapped in a chain wrapper.
+         **/
+        sample(n: number): _Chain<T, T[]>;
+        sample(): _ChainSingle<T | undefined>;
 
         /**
         * Wrapped type `any`.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -5354,12 +5354,6 @@ declare module _ {
         countBy(iterator: string, context?: any): _Chain<T>;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.shuffle
-        **/
-        shuffle(): _Chain<T>;
-
-        /**
          * Returns a shuffled copy of the wrapped collection, using a version of the Fisher-Yates shuffle.
          * @return A shuffled copy of the wrapped collection in a chain wrapper.
          **/

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -486,6 +486,30 @@ _.chain(anyValue)
     .find(i => i.findBooleanFunction())
     .value();
 
+// $ExpectType { valueProperty: string }[]
+_.chain([
+    {
+        group: 'a',
+        subGroup: 1,
+        value: { valueProperty: 'first' }
+    },
+    {
+        group: 'b',
+        subGroup: 2,
+        value: { valueProperty: 'second' }
+    },
+    {
+        group: 'b',
+        subGroup: 3,
+        value: { valueProperty: 'third' }
+    }])
+    .groupBy(i => i.group)
+    .filter(i => i.length >= 2)
+    .flatten()
+    .where({ subGroup: 2 })
+    .map(i => i.value)
+    .value();
+
 // verify that partial objects can be provided without error to where and findWhere for a union type collection
 // where no types in the union share the same property names
 declare const nonIntersectinglTypeUnion: _.Dictionary<{ one: string; } | { two: number; }>;

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -503,8 +503,8 @@ _.chain([
         subGroup: 3,
         value: { valueProperty: 'third' }
     }])
-    .groupBy(i => i.group)
-    .filter(i => i.length >= 2)
+    .groupBy(v => v.group)
+    .filter(g => g.length >= 2)
     .flatten()
     .where({ subGroup: 2 })
     .pluck('value')

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -486,7 +486,7 @@ _.chain(anyValue)
     .find(i => i.findBooleanFunction())
     .value();
 
-// $ExpectType { valueProperty: string }[]
+// $ExpectType { valueProperty: string; } | undefined
 _.chain([
     {
         group: 'a',
@@ -507,7 +507,8 @@ _.chain([
     .filter(i => i.length >= 2)
     .flatten()
     .where({ subGroup: 2 })
-    .map(i => i.value)
+    .pluck('value')
+    .sample()
     .value();
 
 // verify that partial objects can be provided without error to where and findWhere for a union type collection

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -486,7 +486,7 @@ _.chain(anyValue)
     .find(i => i.findBooleanFunction())
     .value();
 
-// verify that inline partial objects can be provided without error to where and findWhere for a union type collection
+// verify that partial objects can be provided without error to where and findWhere for a union type collection
 // where no types in the union share the same property names
 declare const nonIntersectinglTypeUnion: _.Dictionary<{ one: string; } | { two: number; }>;
 

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -531,7 +531,7 @@ _.chain(nonIntersectinglTypeUnion)
 // two properties in the union have different types
 declare const overlappingTypeUnion: _.Dictionary<{ same: string; } | { same: number; }>;
 
-// $ExpectType ({ one: string; } | { two: number; })[]
+// $ExpectType ({ same: string; } | { same: number; })[]
 _.chain(overlappingTypeUnion)
     .where({ same: 0 })
     .shuffle()

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -486,6 +486,28 @@ _.chain(anyValue)
     .find(i => i.findBooleanFunction())
     .value();
 
+// verify that inline partial objects can be provided without error to where and findWhere for a union type collection
+// where no types in the union share the same property names
+declare const nonIntersectinglTypeUnion: _.Dictionary<{ one: string; } | { two: number; }>;
+
+// $ExpectType { one: string; } | { two: number; } | undefined
+_.chain(nonIntersectinglTypeUnion)
+    .sample(5)
+    .where({ one: 'one' })
+    .findWhere({ two: 2 })
+    .value();
+
+// verify that both types can be provided without error to where and findWhere for a union type collection where
+// two properties in the union have different types
+declare const overlappingTypeUnion: _.Dictionary<{ same: string; } | { same: number; }>;
+
+// $ExpectType { same: string; } | { same: number; } | undefined
+_.chain(overlappingTypeUnion)
+    .where({ same: 0 })
+    .shuffle()
+    .findWhere({ same: 'no' })
+    .value();
+
 // common testing types and objects
 const context = {};
 

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1136,9 +1136,9 @@ declare const extractChainTypes: ChainTypeExtractor;
 // where
 {
     // non-intersecting type union - lists
-    _.where(nonIntersectingPropertiesList, partialStringRecord); // $ExpectType StringRecord[]
-    _(nonIntersectingPropertiesList).where(partialStringRecord); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(nonIntersectingPropertiesList).where(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.where(nonIntersectingPropertiesList, partialStringRecord); // $ExpectType NonIntersectingProperties[]
+    _(nonIntersectingPropertiesList).where(partialStringRecord); // $ExpectType NonIntersectingProperties[]
+    extractChainTypes(_.chain(nonIntersectingPropertiesList).where(partialStringRecord)); // $ExpectType ChainType<NonIntersectingProperties[], NonIntersectingProperties>
 
     // simple type - dictionaries
     _.where(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecord[]
@@ -1154,14 +1154,14 @@ declare const extractChainTypes: ChainTypeExtractor;
 // findWhere
 {
     // non-intersecting type union - lists
-    _.findWhere(nonIntersectingPropertiesList, partialStringRecord); // $ExpectType StringRecord | undefined
-    _(nonIntersectingPropertiesList).findWhere(partialStringRecord); // $ExpectType StringRecord | undefined
-    extractChainTypes(_.chain(nonIntersectingPropertiesList).findWhere(partialStringRecord)); // $ExpectType ChainType<StringRecord | undefined, never>
+    _.findWhere(nonIntersectingPropertiesList, partialStringRecord); // $ExpectType StringRecord | NonIntersectingStringRecord | undefined
+    _(nonIntersectingPropertiesList).findWhere(partialStringRecord); // $ExpectType StringRecord | NonIntersectingStringRecord | undefined
+    extractChainTypes(_.chain(nonIntersectingPropertiesList).findWhere(partialStringRecord)); // $ExpectType ChainType<StringRecord | NonIntersectingStringRecord | undefined, never>
 
     // simple type - dictionaries
-    _.findWhere(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecord | undefined
-    _(stringRecordDictionary).findWhere(partialStringRecord); // $ExpectType StringRecord | undefined
-    extractChainTypes(_.chain(stringRecordDictionary).findWhere(partialStringRecord)); // $ExpectType ChainType<StringRecord | undefined, never>
+    _.findWhere(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecordOrUndefined
+    _(stringRecordDictionary).findWhere(partialStringRecord); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordDictionary).findWhere(partialStringRecord)); // $ExpectType ChainType<StringRecordOrUndefined, never>
 
     // any
     _.findWhere(anyValue, partialStringRecord); // $ExpectType any
@@ -1285,14 +1285,14 @@ declare const extractChainTypes: ChainTypeExtractor;
 // sample
 {
     // without n - lists
-    _.sample(stringRecordList); // $ExpectType StringRecord | undefined
-    _(stringRecordList).sample(); // $ExpectType StringRecord | undefined
-    extractChainTypes(_.chain(stringRecordList).sample()); // $ExpectType ChainType<StringRecord | undefined, never>
+    _.sample(stringRecordList); // $ExpectType StringRecordOrUndefined
+    _(stringRecordList).sample(); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordList).sample()); // $ExpectType ChainType<StringRecordOrUndefined, never>
 
     // without n - dictionaries
-    _.sample(stringRecordDictionary); // $ExpectType StringRecord | undefined
-    _(stringRecordDictionary).sample(); // $ExpectType StringRecord | undefined
-    extractChainTypes(_.chain(stringRecordDictionary).sample()); // $ExpectType ChainType<StringRecord | undefined, never>
+    _.sample(stringRecordDictionary); // $ExpectType StringRecordOrUndefined
+    _(stringRecordDictionary).sample(); // $ExpectType StringRecordOrUndefined
+    extractChainTypes(_.chain(stringRecordDictionary).sample()); // $ExpectType ChainType<StringRecordOrUndefined, never>
 
     // without n - strings
     _.sample(simpleString); // $ExpectType string | undefined

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1144,6 +1144,11 @@ declare const extractChainTypes: ChainTypeExtractor;
     _.where(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecord[]
     _(stringRecordDictionary).where(partialStringRecord); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordDictionary).where(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // any
+    _.where(anyValue, partialStringRecord); // $ExpectType any[]
+    _(anyValue).where(partialStringRecord); // $ExpectType any[]
+    extractChainTypes(_.chain(anyValue).where(partialStringRecord)); // $ExpectType ChainType<any[], any>
 }
 
 // findWhere
@@ -1157,6 +1162,11 @@ declare const extractChainTypes: ChainTypeExtractor;
     _.findWhere(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecord | undefined
     _(stringRecordDictionary).findWhere(partialStringRecord); // $ExpectType StringRecord | undefined
     extractChainTypes(_.chain(stringRecordDictionary).findWhere(partialStringRecord)); // $ExpectType ChainType<StringRecord | undefined, never>
+
+    // any
+    _.findWhere(anyValue, partialStringRecord); // $ExpectType any
+    _(anyValue).findWhere(partialStringRecord); // $ExpectType any
+    extractChainTypes(_.chain(anyValue).findWhere(partialStringRecord)); // $ExpectType ChainType<any, any>
 }
 
 // reject

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -490,10 +490,15 @@ _.chain(anyValue)
 // where no types in the union share the same property names
 declare const nonIntersectinglTypeUnion: _.Dictionary<{ one: string; } | { two: number; }>;
 
+// $ExpectType ({ one: string; } | { two: number; })[]
+_.chain(nonIntersectinglTypeUnion)
+    .where({ one: 'one' })
+    .sample(5)
+    .value();
+
 // $ExpectType { one: string; } | { two: number; } | undefined
 _.chain(nonIntersectinglTypeUnion)
     .sample(5)
-    .where({ one: 'one' })
     .findWhere({ two: 2 })
     .value();
 
@@ -501,9 +506,14 @@ _.chain(nonIntersectinglTypeUnion)
 // two properties in the union have different types
 declare const overlappingTypeUnion: _.Dictionary<{ same: string; } | { same: number; }>;
 
-// $ExpectType { same: string; } | { same: number; } | undefined
+// $ExpectType ({ one: string; } | { two: number; })[]
 _.chain(overlappingTypeUnion)
     .where({ same: 0 })
+    .shuffle()
+    .value();
+
+// $ExpectType { same: string; } | { same: number; } | undefined
+_.chain(overlappingTypeUnion)
     .shuffle()
     .findWhere({ same: 'no' })
     .value();

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1133,6 +1133,32 @@ declare const extractChainTypes: ChainTypeExtractor;
     extractChainTypes(_.chain(stringRecordList).select()); // $ExpectType ChainType<StringRecord[], StringRecord>
 }
 
+// where
+{
+    // non-intersecting type union - lists
+    _.where(nonIntersectingPropertiesList, partialStringRecord); // $ExpectType StringRecord[]
+    _(nonIntersectingPropertiesList).where(partialStringRecord); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(nonIntersectingPropertiesList).where(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // simple type - dictionaries
+    _.where(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecord[]
+    _(stringRecordDictionary).where(partialStringRecord); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordDictionary).where(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+}
+
+// findWhere
+{
+    // non-intersecting type union - lists
+    _.findWhere(nonIntersectingPropertiesList, partialStringRecord); // $ExpectType StringRecord | undefined
+    _(nonIntersectingPropertiesList).findWhere(partialStringRecord); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(nonIntersectingPropertiesList).findWhere(partialStringRecord)); // $ExpectType ChainType<StringRecord | undefined, never>
+
+    // simple type - dictionaries
+    _.findWhere(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecord | undefined
+    _(stringRecordDictionary).findWhere(partialStringRecord); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(stringRecordDictionary).findWhere(partialStringRecord)); // $ExpectType ChainType<StringRecord | undefined, never>
+}
+
 // reject
 {
     // function iteratee - lists
@@ -1226,6 +1252,57 @@ declare const extractChainTypes: ChainTypeExtractor;
     _.groupBy(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord[]>
     _(stringRecordDictionary).groupBy(stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord[]>
     _.chain(stringRecordDictionary).groupBy(stringRecordPropertyPath); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
+}
+
+// shuffle
+{
+    // lists
+    _.shuffle(stringRecordList); // $ExpectType StringRecord[]
+    _(stringRecordList).shuffle(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).shuffle()); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // dictionaries
+    _.shuffle(stringRecordDictionary); // $ExpectType StringRecord[]
+    _(stringRecordDictionary).shuffle(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordDictionary).shuffle()); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // strings
+    _.shuffle(simpleString); // $ExpectType string[]
+    _(simpleString).shuffle(); // $ExpectType string[]
+    extractChainTypes(_.chain(simpleString).shuffle()); // $ExpectType ChainType<string[], string>
+}
+
+// sample
+{
+    // without n - lists
+    _.sample(stringRecordList); // $ExpectType StringRecord | undefined
+    _(stringRecordList).sample(); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(stringRecordList).sample()); // $ExpectType ChainType<StringRecord | undefined, never>
+
+    // without n - dictionaries
+    _.sample(stringRecordDictionary); // $ExpectType StringRecord | undefined
+    _(stringRecordDictionary).sample(); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(stringRecordDictionary).sample()); // $ExpectType ChainType<StringRecord | undefined, never>
+
+    // without n - strings
+    _.sample(simpleString); // $ExpectType string | undefined
+    _(simpleString).sample(); // $ExpectType string | undefined
+    extractChainTypes(_.chain(simpleString).sample()); // $ExpectType ChainType<string | undefined, string>
+
+    // with n - lists
+    _.sample(stringRecordList, simpleNumber); // $ExpectType StringRecord[]
+    _(stringRecordList).sample(simpleNumber); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).sample(simpleNumber)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // with n - dictionaries
+    _.sample(stringRecordDictionary, simpleNumber); // $ExpectType StringRecord[]
+    _(stringRecordDictionary).sample(simpleNumber); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordDictionary).sample(simpleNumber)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // with n - strings
+    _.sample(simpleString, simpleNumber); // $ExpectType string[]
+    _(simpleString).sample(simpleNumber); // $ExpectType string[]
+    extractChainTypes(_.chain(simpleString).sample(simpleNumber)); // $ExpectType ChainType<string[], string>
 }
 
 // Arrays

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -619,7 +619,7 @@ declare const extractChainTypes: ChainTypeExtractor;
     _(simpleString).map(stringListValueIterator, context); // $ExpectType number[]
     extractChainTypes(_.chain(simpleString).map(stringListValueIterator, context)); // $ExpectType ChainType<number[], number>
 
-    // function iteratee - collect
+    // function iteratee - strings - collect
     _.collect(simpleString, stringListValueIterator, context); // $ExpectType number[]
     _(simpleString).collect(stringListValueIterator, context); // $ExpectType number[]
     extractChainTypes(_.chain(simpleString).collect(stringListValueIterator, context)); // $ExpectType ChainType<number[], number>


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://underscorejs.org/
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

This PR continues the planned set that will together add up to #45201 and includes the following changes:

- Adds tests for `where`, `findWhere`, `shuffle`, and `sample`.
- Updates `where` and `findWhere` to take a `Partial<T>` instead of an object to provide better autocomplete support where available and provide an error for inline object declarations with no matching properties.
- Updates the overload of `sample` in which `n` is not provided to include `undefined` as a possible result (for the case where an empty collection is provided).
- Updates the return type for `_Chain.findWhere` to include undefined.
- Removes the redeclaration of the `T` generic in `Underscore.sample` and `_Chain.sample` which will fix #20440 for those functions.
- Updates the return type of `_Chain.where`, `_Chain.shuffle`, and `_Chain.sample` to use the correct wrapped value type `V` to partially fix #36308.
- Updates `UnderscoreStatic.where` and `UnderscoreStatic.findWhere` to work with both Lists and Dictionaries to partially fix #20623.