### PR TITLE
semantic-release: Correct type of "prerelease"

### DIFF
--- a/types/semantic-release/index.d.ts
+++ b/types/semantic-release/index.d.ts
@@ -284,7 +284,7 @@ declare namespace SemanticRelease {
          *
          * Required for pre-release branches.
          */
-        prerelease?: string;
+        prerelease?: string | boolean;
     };
 
     /**

--- a/types/semantic-release/semantic-release-tests.ts
+++ b/types/semantic-release/semantic-release-tests.ts
@@ -45,6 +45,10 @@ const options2: lib.Options = {
             prerelease: "beta"
         },
         {
+            name: "rc*",
+            prerelease: true
+        },
+        {
             name: "legacy",
             range: "1.x"
         }


### PR DESCRIPTION
According to the documentation this field can be set to `true` to use the name of the branch as the pre-release identifier. In practice it can also be set to `false` which is equivalent to not setting the field at all.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/semantic-release/semantic-release/blob/master/docs/usage/workflow-configuration.md#prerelease
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.