### PR TITLE
Give PropsWithChildren a default type parameter

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -812,7 +812,7 @@ declare namespace React {
                 : P
             : P;
 
-    type PropsWithChildren<P> = P & { children?: ReactNode };
+    type PropsWithChildren<P = {}> = P & { children?: ReactNode };
 
     /**
      * NOTE: prefer ComponentPropsWithRef, if the ref is forwarded,


### PR DESCRIPTION
It's convenient to be able to use this auxiliary type in one's own code like so:

```ts
function MyComponent({ children }: PropsWithChildren) {
  return ...
}
```

without having to append `<{}>` to `PropsWithChildren`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
