### PR TITLE
react-native-text-input-mask : add refInput def

### DIFF
--- a/types/react-native-text-input-mask/index.d.ts
+++ b/types/react-native-text-input-mask/index.d.ts
@@ -10,6 +10,7 @@ import * as ReactNative from "react-native";
 export type onChangeTextCallback = (formatted: string, extracted?: string) => void;
 
 export interface TextInputMaskProps extends ReactNative.ViewProps, ReactNative.TextInputIOSProps, ReactNative.TextInputAndroidProps, ReactNative.AccessibilityProps {
+    refInput?: React.RefObject<ReactNative.TextInput>;
     maskDefaultValue?: boolean;
     mask?: string;
     onChangeText: onChangeTextCallback;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/react-native-community/react-native-text-input-mask#usage

There is currently no type def for the `refInput` prop which causes compile error when trying to use that prop. In the example in the README of the project, there is use of the `refInput` prop, so this is just making the props sync up properly.
