### PR TITLE
Add missing typings to guacamole-client 1.0 and tests for them

### DIFF
--- a/types/guacamole-client/index.d.ts
+++ b/types/guacamole-client/index.d.ts
@@ -34,3 +34,5 @@ export * from './lib/RawAudioPlayer';
 export * from './lib/StringReader';
 export * from './lib/StringWriter';
 export * from './lib/IntegerPool';
+export * from './lib/OutputStream';
+export * from './lib/VideoPlayer';

--- a/types/guacamole-client/lib/Status.d.ts
+++ b/types/guacamole-client/lib/Status.d.ts
@@ -143,6 +143,23 @@ export class Status {
      */
     constructor(code: Status.Code, message?: string);
 
-    readonly code: Status.Code;
-    readonly message?: string;
+    /**
+     * The Guacamole status code.
+     * @see Guacamole.Status.Code
+     */
+    code: Status.Code;
+
+    /**
+     * An arbitrary human-readable message associated with this status, if any.
+     * The human-readable message is not required, and is generally provided
+     * for debugging purposes only. For user feedback, it is better to translate
+     * the Guacamole status code into a message.
+     */
+    message?: string;
+
+    /**
+     * Returns whether this status represents an error.
+     * @returns true if this status represents an error, false otherwise.
+     */
+    isError(): boolean;
 }


### PR DESCRIPTION
In my previous PR I've forgot to export the [VideoPlayer](http://guacamole.apache.org/doc/guacamole-common-js/Guacamole.VideoPlayer.html) and [OutputStream](http://guacamole.apache.org/doc/guacamole-common-js/Guacamole.OutputStream.html) modules. Also added a missing [method](http://guacamole.apache.org/doc/guacamole-common-js/Status.js.html#line64).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
