### PR TITLE
fix(rnmu): Change icon type on CheckBox style

### DIFF
--- a/types/react-native-material-ui/index.d.ts
+++ b/types/react-native-material-ui/index.d.ts
@@ -146,7 +146,7 @@ export interface CheckBoxProps {
     uncheckedIcon?: string;
     checkedIcon?: string;
     style?: {
-        icon?: ViewStyle
+        icon?: TextStyle
         container?: ViewStyle
         label?: TextStyle
     };
@@ -156,7 +156,7 @@ export interface CheckBoxProps {
 /**
  * @see https://github.com/xotahal/react-native-material-ui/blob/master/src/Checkbox/Checkbox.react.js
  */
-export class Checkbox extends Component<CheckBoxProps, any> {}
+export class Checkbox extends Component<CheckBoxProps> {}
 
 export interface DialogProps {
     children: JSX.Element | JSX.Element[];

--- a/types/react-native-material-ui/react-native-material-ui-tests.tsx
+++ b/types/react-native-material-ui/react-native-material-ui-tests.tsx
@@ -147,4 +147,4 @@ class ToolbarExample extends React.Component<{}, {search: string}> {
 
 const CheckboxExample = () => (
     <Checkbox value="checked" onCheck={console.log} label="Check Me" style={{ icon: { color: 'pink' }}} />
-)
+);

--- a/types/react-native-material-ui/react-native-material-ui-tests.tsx
+++ b/types/react-native-material-ui/react-native-material-ui-tests.tsx
@@ -144,3 +144,7 @@ class ToolbarExample extends React.Component<{}, {search: string}> {
         );
     }
 }
+
+const CheckboxExample = () => (
+    <Checkbox value="checked" onCheck={console.log} label="Check Me" style={{ icon: { color: 'pink' }}} />
+)


### PR DESCRIPTION
lib: react-native-material-ui

The icon value for the CheckBox style should be a TextStyle.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-native-material-ui/index.d.ts#L149>>
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/45952