### PR TITLE
[yoga-layout] Allow string as value of setMargin

### DIFF
--- a/types/yoga-layout/index.d.ts
+++ b/types/yoga-layout/index.d.ts
@@ -303,7 +303,7 @@ declare namespace Yoga {
         setHeightAuto(): void;
         setHeightPercent(height: number): void;
         setJustifyContent(justifyContent: YogaJustifyContent): void;
-        setMargin(edge: YogaEdge, margin: number): void;
+        setMargin(edge: YogaEdge, margin: number | string): void;
         setMarginAuto(edge: YogaEdge): void;
         setMarginPercent(edge: YogaEdge, margin: number): void;
         setMaxHeight(maxHeight: number | string): void;


### PR DESCRIPTION
I just tested `setMargin(Yoga.EDGE_BOTTOM, '10%')` and it worked as expected, I believe this type needs to be updated to match one of `setPadding` and allow string values.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.