### PR TITLE
[@types/relay-runtime]: added fetchQueryInternal

### DIFF
--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -192,6 +192,17 @@ export { RelayFeatureFlags } from './lib/util/RelayFeatureFlags';
 export { default as deepFreeze } from './lib/util/deepFreeze';
 export { default as isPromise } from './lib/util/isPromise';
 
+import * as fetchQueryInternal from './lib/query/fetchQueryInternal';
+
+interface Internal {
+    fetchQuery: typeof fetchQueryInternal.fetchQuery;
+    fetchQueryDeduped: typeof fetchQueryInternal.fetchQueryDeduped;
+    getPromiseForActiveRequest: typeof fetchQueryInternal.getPromiseForActiveRequest;
+    getObservableForActiveRequest: typeof fetchQueryInternal.getObservableForActiveRequest;
+}
+
+export const __internal: Internal;
+
 /**
  * relay-compiler-language-typescript support for fragment references
  */

--- a/types/relay-runtime/lib/query/fetchQueryInternal.d.ts
+++ b/types/relay-runtime/lib/query/fetchQueryInternal.d.ts
@@ -1,0 +1,25 @@
+import { CacheConfig } from '../util/RelayRuntimeTypes';
+import { Environment, OperationDescriptor, RequestDescriptor } from '../store/RelayStoreTypes';
+import { GraphQLResponse } from '../network/RelayNetworkTypes';
+import { RelayObservable as Observable } from '../network/RelayObservable';
+
+export function fetchQuery(
+    environment: Environment,
+    operation: OperationDescriptor,
+    options?: {
+        networkCacheConfig?: CacheConfig;
+    },
+): Observable<GraphQLResponse>;
+
+export function fetchQueryDeduped(
+    environment: Environment,
+    request: RequestDescriptor,
+    fetchFn: () => Observable<GraphQLResponse>,
+): Observable<GraphQLResponse>;
+
+export function getPromiseForActiveRequest(environment: Environment, request: RequestDescriptor): Promise<void> | null;
+
+export function getObservableForActiveRequest(
+    environment: Environment,
+    request: RequestDescriptor,
+): Observable<void> | null;

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -14,6 +14,7 @@ import {
     commitLocalUpdate,
     ReaderFragment,
     isPromise,
+    __internal,
 } from 'relay-runtime';
 
 const source = new RecordSource();


### PR DESCRIPTION
Hi @alloy,
in this PR I added fetchQueryInternal and __internal in order to use the relay-runtime types in relay-hooks and fix https://github.com/relay-tools/relay-hooks/issues/99

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
[__internal](https://github.com/facebook/relay/blob/v9.1.0/packages/relay-runtime/index.js#L304)
[fetchQueryInternal](https://github.com/facebook/relay/blob/v9.1.0/packages/relay-runtime/query/fetchQueryInternal.js)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


