### PR TITLE
moc-better-sqlite3: added basic types

### DIFF
--- a/types/moc-better-sqlite3/index.d.ts
+++ b/types/moc-better-sqlite3/index.d.ts
@@ -1,0 +1,142 @@
+// Type definitions for moc-better-sqlite3 6.2
+// Project: http://github.com/vazra/better-sqlite3
+// Definitions by: Ben Davies <https://github.com/Morfent>
+//                 Mathew Rumsey <https://github.com/matrumz>
+//                 Santiago Aguilar <https://github.com/sant123>
+//                 Alessandro Vergani <https://github.com/loghorn>
+//                 Andrew Kaiser <https://github.com/andykais>
+//                 Mark Stewart <https://github.com/mrkstwrt>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.9
+
+import Integer = require('integer');
+
+type VariableArgFunction = (...params: any[]) => any;
+type ArgumentTypes<F extends VariableArgFunction> = F extends (...args: infer A) => any ? A : never;
+
+declare namespace MocBetterSqlite3 {
+    interface Statement<BindParameters extends any[]> {
+        database: Database;
+        source: string;
+        reader: boolean;
+
+        run(...params: BindParameters): Database.RunResult;
+        get(...params: BindParameters): any;
+        all(...params: BindParameters): any[];
+        iterate(...params: BindParameters): IterableIterator<any>;
+        pluck(toggleState?: boolean): this;
+        expand(toggleState?: boolean): this;
+        raw(toggleState?: boolean): this;
+        bind(...params: BindParameters): this;
+        columns(): ColumnDefinition[];
+        safeIntegers(toggleState?: boolean): this;
+    }
+
+    interface ColumnDefinition {
+        name: string;
+        column: string | null;
+        table: string | null;
+        database: string | null;
+        type: string | null;
+    }
+
+    interface Transaction<F extends VariableArgFunction> {
+        (...params: ArgumentTypes<F>): ReturnType<F>;
+        default(...params: ArgumentTypes<F>): ReturnType<F>;
+        deferred(...params: ArgumentTypes<F>): ReturnType<F>;
+        immediate(...params: ArgumentTypes<F>): ReturnType<F>;
+        exclusive(...params: ArgumentTypes<F>): ReturnType<F>;
+    }
+
+    interface Database {
+        memory: boolean;
+        readonly: boolean;
+        name: string;
+        open: boolean;
+        inTransaction: boolean;
+
+        // tslint:disable-next-line no-unnecessary-generics
+        prepare<BindParameters extends any[] | {} = any[]>(
+            source: string,
+        ): BindParameters extends any[] ? Statement<BindParameters> : Statement<[BindParameters]>;
+        transaction<F extends VariableArgFunction>(fn: F): Transaction<F>;
+        exec(source: string): this;
+        pragma(source: string, options?: Database.PragmaOptions): any;
+        checkpoint(databaseName?: string): this;
+        function(name: string, cb: (...params: any[]) => any): this;
+        function(name: string, options: Database.RegistrationOptions, cb: (...params: any[]) => any): this;
+        aggregate(name: string, options: Database.AggregateOptions): this;
+        loadExtension(path: string): this;
+        close(): this;
+        defaultSafeIntegers(toggleState?: boolean): this;
+        backup(destinationFile: string, options?: Database.BackupOptions): Promise<Database.BackupMetadata>;
+    }
+
+    interface DatabaseConstructor {
+        new (filename: string, options?: Database.Options): Database;
+        (filename: string, options?: Database.Options): Database;
+        prototype: Database;
+
+        Integer: typeof Integer;
+        SqliteError: typeof SqliteError;
+    }
+}
+
+declare class SqliteError implements Error {
+    name: string;
+    message: string;
+    code: string;
+    constructor(message: string, code: string);
+}
+
+declare namespace Database {
+    interface RunResult {
+        changes: number;
+        lastInsertRowid: Integer.IntLike;
+    }
+
+    interface Options {
+        memory?: boolean;
+        readonly?: boolean;
+        fileMustExist?: boolean;
+        timeout?: number;
+        verbose?: (message?: any, ...additionalArgs: any[]) => void;
+    }
+
+    interface PragmaOptions {
+        simple?: boolean;
+    }
+
+    interface RegistrationOptions {
+        varargs?: boolean;
+        deterministic?: boolean;
+        safeIntegers?: boolean;
+    }
+
+    interface AggregateOptions extends RegistrationOptions {
+        start?: any;
+        step: (total: any, next: any) => any;
+        inverse?: (total: any, dropped: any) => any;
+        result?: (total: any) => any;
+    }
+
+    interface BackupMetadata {
+        totalPages: number;
+        remainingPages: number;
+    }
+    interface BackupOptions {
+        progress: (info: BackupMetadata) => number;
+    }
+
+    type Integer = typeof Integer;
+    type SqliteError = typeof SqliteError;
+    type Statement<BindParameters extends any[] | {} = any[]> = BindParameters extends any[]
+        ? MocBetterSqlite3.Statement<BindParameters>
+        : MocBetterSqlite3.Statement<[BindParameters]>;
+    type ColumnDefinition = MocBetterSqlite3.ColumnDefinition;
+    type Transaction = MocBetterSqlite3.Transaction<VariableArgFunction>;
+    type Database = MocBetterSqlite3.Database;
+}
+
+declare const Database: MocBetterSqlite3.DatabaseConstructor;
+export = Database;

--- a/types/moc-better-sqlite3/moc-better-sqlite3-tests.ts
+++ b/types/moc-better-sqlite3/moc-better-sqlite3-tests.ts
@@ -1,0 +1,107 @@
+import Sqlite = require('moc-better-sqlite3');
+
+const integer = Sqlite.Integer(1);
+const err = new Sqlite.SqliteError('ok', 'ok');
+const result: Sqlite.RunResult = { changes: 1, lastInsertRowid: 1 };
+const options: Sqlite.Options = { fileMustExist: true, memory: true, readonly: true };
+const registrationOptions: Sqlite.RegistrationOptions = {
+    deterministic: true,
+    safeIntegers: true,
+    varargs: true,
+};
+
+let db: Sqlite.Database = Sqlite('.');
+db = new Sqlite('.', { memory: true, verbose: () => {} });
+db.exec('CREATE TABLE test (id INTEGER PRIMARY KEY NOT NULL, name TEXT NOT NULL);');
+db.exec('INSERT INTO test(name) VALUES("name");');
+db.pragma('data_version', { simple: true });
+db.checkpoint();
+db.checkpoint('main');
+db.function('noop', () => {});
+db.function('noop', { deterministic: true, varargs: true }, () => {});
+db.aggregate('add', {
+    start: 0,
+    step: (t, n) => t + n,
+    deterministic: true,
+    varargs: true,
+});
+db.aggregate('getAverage', {
+    start: () => [],
+    step: (array, nextValue) => {
+        array.push(nextValue);
+    },
+    result: array => array.reduce((t: any, v: any) => t + v) / array.length,
+});
+db.aggregate('addAll', {
+    start: 0,
+    step: (total, nextValue) => total + nextValue,
+    inverse: (total, droppedValue) => total - droppedValue,
+    result: total => Math.round(total),
+});
+db.defaultSafeIntegers();
+db.defaultSafeIntegers(true);
+
+const stmt: Sqlite.Statement = db.prepare('SELECT * FROM test WHERE name == ?;');
+stmt.get(['name']);
+stmt.all({ name: 'name' });
+for (const row of stmt.iterate('name')) {
+}
+stmt.pluck();
+stmt.pluck(true);
+stmt.expand();
+stmt.expand(true);
+stmt.bind('name');
+stmt.safeIntegers();
+stmt.safeIntegers(true);
+stmt.raw();
+stmt.raw(true);
+stmt.raw(false);
+let col: Sqlite.ColumnDefinition;
+for (col of stmt.columns()) {
+    col.name;
+    col.column;
+    col.type;
+}
+type BindParameters = [string, number];
+const stmtWithBindTyped = db.prepare<BindParameters>('SELECT * FROM test WHERE name == ? and age = ?');
+stmtWithBindTyped.run('alice', 20);
+// note the following is technically legal according to the docs, but we do not have a way to express both typed args
+// and variable tuples in typescript. If you want to group tuples, you must specify it that way in the prepare function
+// https://github.com/vazra/better-sqlite3/blob/master/docs/api.md#binding-parameters
+// $ExpectError
+stmtWithBindTyped.run(['alice', 20]);
+interface NamedBindParameters {
+    name: string;
+    age: number;
+}
+const stmtWithNamedBind = db.prepare<NamedBindParameters>('INSERT INTO test VALUES (@name, @age)');
+stmtWithNamedBind.run({ name: 'bob', age: 20 });
+
+const trans: Sqlite.Transaction = db.transaction(param => stmt.all(param));
+trans('name');
+trans(1);
+trans.default('name');
+trans.deferred('name');
+trans.immediate('name');
+trans.exclusive('name');
+
+const transTyped = db.transaction((param: number) => stmt.all(param));
+transTyped(1);
+trans.default(1);
+trans.deferred(1);
+trans.immediate(1);
+trans.exclusive(1);
+// $ExpectError
+transTyped('name');
+
+const transReturn = db.transaction(() => 1);
+// $ExpectType number
+transReturn();
+
+db.backup('backup-today.db').then(({ totalPages, remainingPages }) => {});
+const paused = false;
+db.backup('backup-today.db', {
+    progress({ totalPages: t, remainingPages: r }) {
+        return paused ? 0 : 200;
+    },
+});

--- a/types/moc-better-sqlite3/tsconfig.json
+++ b/types/moc-better-sqlite3/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "moc-better-sqlite3-tests.ts"]
+}

--- a/types/moc-better-sqlite3/tslint.json
+++ b/types/moc-better-sqlite3/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

