### PR TITLE
[web-bluetooth] Add writeValueWithResponse and writeValueWithoutResponse

### DIFF
--- a/types/web-bluetooth/index.d.ts
+++ b/types/web-bluetooth/index.d.ts
@@ -102,6 +102,8 @@ interface BluetoothRemoteGATTCharacteristic extends EventTarget, CharacteristicE
     getDescriptors(descriptor?: BluetoothDescriptorUUID): Promise<BluetoothRemoteGATTDescriptor[]>;
     readValue(): Promise<DataView>;
     writeValue(value: BufferSource): Promise<void>;
+    writeValueWithResponse(value: BufferSource): Promise<void>;
+    writeValueWithoutResponse(value: BufferSource): Promise<void>;
     startNotifications(): Promise<BluetoothRemoteGATTCharacteristic>;
     stopNotifications(): Promise<BluetoothRemoteGATTCharacteristic>;
     addEventListener(type: "characteristicvaluechanged", listener: (this: this, ev: Event) => any, useCapture?: boolean): void;

--- a/types/web-bluetooth/web-bluetooth-tests.ts
+++ b/types/web-bluetooth/web-bluetooth-tests.ts
@@ -22,6 +22,13 @@ function handleBodySensorLocationCharacteristic(characteristic: BluetoothRemoteG
         console.log("Unknown sensor location.");
         return Promise.resolve();
     }
+
+    // not from the spec - exercising additional APIs
+    const buffer = new Uint8Array(0);
+    characteristic.writeValue(buffer);
+    characteristic.writeValueWithResponse(buffer);
+    characteristic.writeValueWithoutResponse(buffer);
+
     return characteristic.readValue()
         .then(sensorLocationData => {
             let sensorLocation = sensorLocationData.getUint8(0);


### PR DESCRIPTION
New methods writeValueWithResponse() and writeValueWithoutResponse()
have been added to BluetoothRemoteGATTCharacteristic in Chrome 85.

https://chromestatus.com/feature/5152041850634240

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://chromestatus.com/feature/5152041850634240
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
