### PR TITLE
Fix type definition for async retry().

### DIFF
--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -239,7 +239,7 @@ export interface RetryOptions {
 export function retry<T, E = Error>(
     opts?: number | RetryOptions,
     task?: (callback: AsyncResultCallback<T, E>, results: any) => void,
-): Promise<void>;
+): Promise<T>;
 export function retry<T, E = Error>(
     opts?: number | RetryOptions,
     task?: (callback: AsyncResultCallback<T, E>, results: any) => void,


### PR DESCRIPTION
**I am not sure how to test the changes here, see details in the template below. I would be happy to help more if someone offer some guidance**.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)

Sorry not sure how to test - any guidance appreciated.
I tested it by running my own client code.

- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://caolan.github.io/async/v3/docs.html#retry
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

The tests now fails as the resulting type is different according to Typescript version.
Any guidance on how to fix those would be appreciated.

- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.\
