### PR TITLE
[rascal] Fix callback based Broker and PublicationSession

### DIFF
--- a/types/rascal/index.d.ts
+++ b/types/rascal/index.d.ts
@@ -497,7 +497,12 @@ export class Vhost extends EventEmitter {
     isPaused(): boolean;
 }
 
-declare function createBroker(config: BrokerConfig, components: any, next: any, ...args: any[]): any;
+declare function createBroker(config: BrokerConfig, next: (err: Error | null, broker: Broker) => void): void;
+declare function createBroker(
+    config: BrokerConfig,
+    components: unknown,
+    next: (err: Error | null, broker: Broker) => void,
+): void;
 
 declare function createBrokerAsPromised(config: BrokerConfig, components?: unknown): Promise<BrokerAsPromised>;
 

--- a/types/rascal/index.d.ts
+++ b/types/rascal/index.d.ts
@@ -408,10 +408,10 @@ declare const testConfig: {
 
 type AckOrNack = (err?: Error, recovery?: Recovery | Recovery[]) => void;
 
-export class SubscriptionSession extends EventEmitter {
+export class SubscriberSessionAsPromised extends EventEmitter {
     name: string;
-    isCancelled(): boolean;
     cancel(): Promise<void>;
+
     on(event: 'message', listener: (message: Message, content: any, ackOrNackFn: AckOrNack) => void): this;
     on(event: 'error' | 'cancelled', listener: (err: Error) => void): this;
     on(
@@ -432,8 +432,21 @@ declare class BrokerAsPromised extends EventEmitter {
     publish(name: string, message: any, overrides?: PublicationConfig | string): Promise<PublicationSession>;
     forward(name: string, message: any, overrides?: PublicationConfig | string): Promise<PublicationSession>;
     unsubscribeAll(): Promise<void>;
-    subscribe(name: string, overrides?: SubscriptionConfig): Promise<SubscriptionSession>;
-    subscribeAll(filter?: (config: SubscriptionConfig) => boolean): Promise<SubscriptionSession[]>;
+    subscribe(name: string, overrides?: SubscriptionConfig): Promise<SubscriberSessionAsPromised>;
+    subscribeAll(filter?: (config: SubscriptionConfig) => boolean): Promise<SubscriberSessionAsPromised[]>;
+}
+
+export class SubscriptionSession extends EventEmitter {
+    name: string;
+    isCancelled(): boolean;
+    cancel(next: ErrorCb): void;
+
+    on(event: 'message', listener: (message: Message, content: any, ackOrNackFn: AckOrNack) => void): this;
+    on(event: 'error' | 'cancelled', listener: (err: Error) => void): this;
+    on(
+        event: 'invalid_content' | 'redeliveries_exceeded' | 'redeliveries_error',
+        listener: (err: Error, message: Message, ackOrNackFn: AckOrNack) => void,
+    ): this;
 }
 
 type Cb<E, A> = (...x: [E, never] | [null, A]) => void;

--- a/types/rascal/index.d.ts
+++ b/types/rascal/index.d.ts
@@ -433,7 +433,7 @@ declare class BrokerAsPromised extends EventEmitter {
     forward(name: string, message: any, overrides?: PublicationConfig | string): Promise<PublicationSession>;
     unsubscribeAll(): Promise<void>;
     subscribe(name: string, overrides?: SubscriptionConfig): Promise<SubscriptionSession>;
-    subscribeAll(filter?: string): Promise<SubscriptionSession[]>;
+    subscribeAll(filter?: (config: SubscriptionConfig) => boolean): Promise<SubscriptionSession[]>;
 }
 
 declare class Broker extends EventEmitter {
@@ -466,7 +466,10 @@ declare class Broker extends EventEmitter {
         next: (err: Error, subscription: SubscriptionSession) => void,
     ): void;
     subscribeAll(next: (err: Error, results: SubscriptionSession[]) => void): void;
-    subscribeAll(filter: string, next?: (err: Error, results: SubscriptionSession[]) => void): void;
+    subscribeAll(
+        filter: (config: SubscriptionConfig) => boolean,
+        next: (err: Error, results: SubscriptionSession[]) => void,
+    ): void;
     unsubscribeAll(next: (err?: Error) => void): void;
 }
 

--- a/types/rascal/index.d.ts
+++ b/types/rascal/index.d.ts
@@ -415,7 +415,7 @@ export class SubscriptionSession extends EventEmitter {
     on(event: 'message', listener: (message: Message, content: any, ackOrNackFn: AckOrNack) => void): this;
     on(event: 'error' | 'cancelled', listener: (err: Error) => void): this;
     on(
-        event: 'invalid_content' | 'redeliveries_exceeded' | 'redeliveries_error' | 'redeliveries_error',
+        event: 'invalid_content' | 'redeliveries_exceeded' | 'redeliveries_error',
         listener: (err: Error, message: Message, ackOrNackFn: AckOrNack) => void,
     ): this;
 }

--- a/types/rascal/index.d.ts
+++ b/types/rascal/index.d.ts
@@ -438,8 +438,8 @@ declare class BrokerAsPromised extends EventEmitter {
 
 declare class Broker extends EventEmitter {
     readonly config: BrokerConfig;
-    static create(config: BrokerConfig, next: (err: Error, broker: Broker) => void): void;
-    static create(config: BrokerConfig, components: any, next: (err?: Error, broker?: Broker) => void): void;
+    static create(config: BrokerConfig, next: (err: Error | null, broker: Broker) => void): void;
+    static create(config: BrokerConfig, components: unknown, next: (err: Error | null, broker: Broker) => void): void;
     connect(name: string, next: (err?: Error, connection?: Connection) => void): void;
     nuke(next: (err?: Error) => void): void;
     purge(next: (err?: Error) => void): void;

--- a/types/rascal/index.d.ts
+++ b/types/rascal/index.d.ts
@@ -4,7 +4,7 @@
 //                 MartinTechy <https://github.com/MartinTechy>
 //                 Nikita Volodin <https://github.com/qlonik>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.2
+// TypeScript Version: 3.4
 
 /// <reference types="node" />
 

--- a/types/rascal/index.d.ts
+++ b/types/rascal/index.d.ts
@@ -476,6 +476,10 @@ export class PublicationSession extends EventEmitter {
     abort(): void;
     isAborted(): boolean;
     emitPaused(): void;
+
+    on(event: 'error', cb: (err: Error, messageId: string) => void): this;
+    on(event: 'success', cb: (messageId: string) => void): this;
+    on(event: 'return', cb: (message: Message) => void): this;
 }
 
 export class Vhost extends EventEmitter {

--- a/types/rascal/index.d.ts
+++ b/types/rascal/index.d.ts
@@ -438,8 +438,8 @@ declare class BrokerAsPromised extends EventEmitter {
 
 declare class Broker extends EventEmitter {
     readonly config: BrokerConfig;
-    static create(config: BrokerConfig, next: (err: Error, broker: Broker) => void): any;
-    static create(config: BrokerConfig, components: any, next: (err?: Error, broker?: Broker) => void): any;
+    static create(config: BrokerConfig, next: (err: Error, broker: Broker) => void): void;
+    static create(config: BrokerConfig, components: any, next: (err?: Error, broker?: Broker) => void): void;
     connect(name: string, next: (err?: Error, connection?: Connection) => void): void;
     nuke(next: (err?: Error) => void): void;
     purge(next: (err?: Error) => void): void;

--- a/types/rascal/index.d.ts
+++ b/types/rascal/index.d.ts
@@ -499,7 +499,7 @@ export class Vhost extends EventEmitter {
 
 declare function createBroker(config: BrokerConfig, components: any, next: any, ...args: any[]): any;
 
-declare function createBrokerAsPromised(config: BrokerConfig, components: any): Promise<BrokerAsPromised>;
+declare function createBrokerAsPromised(config: BrokerConfig, components?: unknown): Promise<BrokerAsPromised>;
 
 declare function withDefaultConfig(config: BrokerConfig): BrokerConfig;
 

--- a/types/rascal/index.d.ts
+++ b/types/rascal/index.d.ts
@@ -436,41 +436,39 @@ declare class BrokerAsPromised extends EventEmitter {
     subscribeAll(filter?: (config: SubscriptionConfig) => boolean): Promise<SubscriptionSession[]>;
 }
 
+type Cb<E, A> = (...x: [E, never] | [null, A]) => void;
+type ErrorCb = (x: Error | null) => void;
+type CreateCb = (...x: [Error, Broker] | [null, Broker]) => void;
+type ConnectCb = (...x: [Error, null] | [Error, Connection] | [null, Connection]) => void;
+
 declare class Broker extends EventEmitter {
     readonly config: BrokerConfig;
-    static create(config: BrokerConfig, next: (err: Error | null, broker: Broker) => void): void;
-    static create(config: BrokerConfig, components: unknown, next: (err: Error | null, broker: Broker) => void): void;
-    connect(name: string, next: (err?: Error, connection?: Connection) => void): void;
-    nuke(next: (err?: Error) => void): void;
-    purge(next: (err?: Error) => void): void;
-    shutdown(next: (err?: Error) => void): void;
-    bounce(next: (err?: Error) => void): void;
-    publish(name: string, message: any, next: (err: Error, publication: PublicationSession) => void): void;
+    static create(config: BrokerConfig, next: CreateCb): void;
+    static create(config: BrokerConfig, components: unknown, next: CreateCb): void;
+    connect(name: string, next: ConnectCb): void;
+    nuke(next: ErrorCb): void;
+    purge(next: ErrorCb): void;
+    shutdown(next: ErrorCb): void;
+    bounce(next: ErrorCb): void;
+    publish(name: string, message: any, next: Cb<Error, PublicationSession>): void;
     publish(
         name: string,
         message: any,
         overrides: PublicationConfig | string,
-        next: (err: Error, publication: PublicationSession) => void,
+        next: Cb<Error, PublicationSession>,
     ): void;
-    forward(name: string, message: any, next: (err: Error, publication: PublicationSession) => void): void;
+    forward(name: string, message: any, next: Cb<Error, PublicationSession>): void;
     forward(
         name: string,
         message: any,
         overrides: PublicationConfig | string,
-        next: (err: Error, publication: PublicationSession) => void,
+        next: Cb<Error, PublicationSession>,
     ): void;
-    subscribe(name: string, next: (err: Error, subscription: SubscriptionSession) => void): void;
-    subscribe(
-        name: string,
-        overrides: SubscriptionConfig | string,
-        next: (err: Error, subscription: SubscriptionSession) => void,
-    ): void;
-    subscribeAll(next: (err: Error, results: SubscriptionSession[]) => void): void;
-    subscribeAll(
-        filter: (config: SubscriptionConfig) => boolean,
-        next: (err: Error, results: SubscriptionSession[]) => void,
-    ): void;
-    unsubscribeAll(next: (err?: Error) => void): void;
+    subscribe(name: string, next: Cb<Error, SubscriptionSession>): void;
+    subscribe(name: string, overrides: SubscriptionConfig | string, next: Cb<Error, SubscriptionSession>): void;
+    subscribeAll(next: Cb<Error, SubscriptionSession[]>): void;
+    subscribeAll(filter: (config: SubscriptionConfig) => boolean, next: Cb<Error, SubscriptionSession[]>): void;
+    unsubscribeAll(next: ErrorCb): void;
 }
 
 export class PublicationSession extends EventEmitter {
@@ -500,12 +498,8 @@ export class Vhost extends EventEmitter {
     isPaused(): boolean;
 }
 
-declare function createBroker(config: BrokerConfig, next: (err: Error | null, broker: Broker) => void): void;
-declare function createBroker(
-    config: BrokerConfig,
-    components: unknown,
-    next: (err: Error | null, broker: Broker) => void,
-): void;
+declare function createBroker(config: BrokerConfig, next: CreateCb): void;
+declare function createBroker(config: BrokerConfig, components: unknown, next: CreateCb): void;
 
 declare function createBrokerAsPromised(config: BrokerConfig, components?: unknown): Promise<BrokerAsPromised>;
 

--- a/types/rascal/rascal-tests.ts
+++ b/types/rascal/rascal-tests.ts
@@ -141,7 +141,7 @@ Broker.create(config, (err, broker) => {
 {
     Broker.create(config, (err, broker) => {
         broker.subscribeAll((err, res) => {
-            err; // $ExpectType Error
+            err; // $ExpectType Error | null
             res; // $ExpectType SubscriptionSession[]
         });
         broker.subscribeAll(
@@ -150,7 +150,7 @@ Broker.create(config, (err, broker) => {
                 return true;
             },
             (err, res) => {
-                err; // $ExpectType Error
+                err; // $ExpectType Error | null
                 res; // $ExpectType SubscriptionSession[]
             },
         );
@@ -164,4 +164,29 @@ Broker.create(config, (err, broker) => {
             return true;
         });
     })();
+}
+
+{
+    Broker.create(config, (err, broker) => {
+        if (err !== null) {
+            err; // $ExpectType Error
+            return;
+        }
+
+        err; // $ExpectType null
+        broker; // $ExpectType Broker
+
+        broker.connect('/', (err, conn) => {
+            err; // $ExpectType Error | null
+            conn; // $ExpectType Connection | null
+        });
+
+        broker.connect('/', (...x) => {
+            if (x[0] === null) {
+                const y = x[1]; // $ExpectType Connection
+            } else {
+                const y = x[1]; // $ExpectType Connection | null
+            }
+        });
+    });
 }

--- a/types/rascal/rascal-tests.ts
+++ b/types/rascal/rascal-tests.ts
@@ -190,3 +190,21 @@ Broker.create(config, (err, broker) => {
         });
     });
 }
+
+{
+    Broker.create(config, (err, broker) => {
+        broker.publish('demo_publication', 'Hello World!', (err, publication) => {
+            publication
+                .on('error', (err, msgId) => {
+                    err; // $ExpectType Error
+                    msgId; // $ExpectType string
+                })
+                .on('return', msg => {
+                    msg; // $ExpectType Message
+                })
+                .on('success', msgId => {
+                    msgId; // $ExpectType string
+                });
+        });
+    });
+}

--- a/types/rascal/rascal-tests.ts
+++ b/types/rascal/rascal-tests.ts
@@ -123,3 +123,17 @@ Broker.create(config, (err, broker) => {
         broker; // $ExpectType Broker
     });
 }
+
+{
+    // $ExpectType void
+    Broker.create(config, (err, broker) => {
+        err; // $ExpectType Error | null
+        broker; // $ExpectType Broker
+    });
+
+    // $ExpectType void
+    Broker.create(config, {}, (err, broker) => {
+        err; // $ExpectType Error | null
+        broker; // $ExpectType Broker
+    });
+}

--- a/types/rascal/rascal-tests.ts
+++ b/types/rascal/rascal-tests.ts
@@ -7,6 +7,7 @@ import {
     PublicationSession,
     SubscriptionSession,
     createBrokerAsPromised,
+    createBroker,
 } from 'rascal';
 import { Message } from 'amqplib';
 
@@ -107,4 +108,18 @@ Broker.create(config, (err, broker) => {
     const b1 = createBrokerAsPromised(config);
     // $ExpectType Promise<BrokerAsPromised>
     const b2 = createBrokerAsPromised(config, {});
+}
+
+{
+    // $ExpectType void
+    createBroker(config, (err, broker) => {
+        err; // $ExpectType Error | null
+        broker; // $ExpectType Broker
+    });
+
+    // $ExpectType void
+    createBroker(config, {}, (err, broker) => {
+        err; // $ExpectType Error | null
+        broker; // $ExpectType Broker
+    });
 }

--- a/types/rascal/rascal-tests.ts
+++ b/types/rascal/rascal-tests.ts
@@ -55,7 +55,6 @@ const config: BrokerConfig = {
         const subscription = await broker.subscribe('demo_subscription');
         await broker.subscribe('s1', { prefetch: 10, retry: false });
         await subscription.cancel();
-        subscription.isCancelled();
         subscription
             .on('message', (message, content, ackOrNack) => {
                 ackOrNack();
@@ -158,7 +157,7 @@ Broker.create(config, (err, broker) => {
 
     (async () => {
         const b = await BrokerAsPromised.create(config);
-        // $ExpectType SubscriptionSession[]
+        // $ExpectType SubscriberSessionAsPromised[]
         const res = await b.subscribeAll(x => {
             x; // $ExpectType SubscriptionConfig
             return true;

--- a/types/rascal/rascal-tests.ts
+++ b/types/rascal/rascal-tests.ts
@@ -69,6 +69,7 @@ const config: BrokerConfig = {
     }
 })();
 
+// $ExpectType void
 Broker.create(config, (err, broker) => {
     if (err) throw err;
 

--- a/types/rascal/rascal-tests.ts
+++ b/types/rascal/rascal-tests.ts
@@ -137,3 +137,31 @@ Broker.create(config, (err, broker) => {
         broker; // $ExpectType Broker
     });
 }
+
+{
+    Broker.create(config, (err, broker) => {
+        broker.subscribeAll((err, res) => {
+            err; // $ExpectType Error
+            res; // $ExpectType SubscriptionSession[]
+        });
+        broker.subscribeAll(
+            x => {
+                x; // $ExpectType SubscriptionConfig
+                return true;
+            },
+            (err, res) => {
+                err; // $ExpectType Error
+                res; // $ExpectType SubscriptionSession[]
+            },
+        );
+    });
+
+    (async () => {
+        const b = await BrokerAsPromised.create(config);
+        // $ExpectType SubscriptionSession[]
+        const res = await b.subscribeAll(x => {
+            x; // $ExpectType SubscriptionConfig
+            return true;
+        });
+    })();
+}

--- a/types/rascal/rascal-tests.ts
+++ b/types/rascal/rascal-tests.ts
@@ -1,4 +1,13 @@
-import { Broker, BrokerAsPromised, BrokerConfig, AckOrNack, withDefaultConfig, PublicationSession, SubscriptionSession } from 'rascal';
+import {
+    Broker,
+    BrokerAsPromised,
+    BrokerConfig,
+    AckOrNack,
+    withDefaultConfig,
+    PublicationSession,
+    SubscriptionSession,
+    createBrokerAsPromised,
+} from 'rascal';
 import { Message } from 'amqplib';
 
 const config: BrokerConfig = {
@@ -92,3 +101,10 @@ Broker.create(config, (err, broker) => {
             .on('error', console.error);
     });
 });
+
+{
+    // $ExpectType Promise<BrokerAsPromised>
+    const b1 = createBrokerAsPromised(config);
+    // $ExpectType Promise<BrokerAsPromised>
+    const b2 = createBrokerAsPromised(config, {});
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - There is no `isCancelled` on `SubscriberSessionAsPromised`: https://github.com/guidesmiths/rascal/blob/master/lib/amqp/SubscriberSessionAsPromised.js
    - I spent some amount of time looking at source code to identify how errors and data are produced in callbacks, that is the reason for tuples in callbacks with few different options. In the default case, tuples just fallback to normal callback definitions (e.g. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46064/files#diff-731af77436c2743a87af3608dbe121e6R178), and in best case, there is a way to discriminate between two or three different cases (e.g. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46064/files#diff-731af77436c2743a87af3608dbe121e6R183)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
