### PR TITLE
[@types/underscore] Collection and Array Tests - Without, Uniq, and SortedIndex

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -851,14 +851,15 @@ declare module _ {
         flatten<V extends List<any>>(list: V, shallow: true): ListItemOrSelf<TypeOfList<V>>[];
 
         /**
-        * Returns a copy of the array with all instances of the values removed.
-        * @param array The array to remove `values` from.
-        * @param values The values to remove from `array`.
-        * @return Copy of `array` without `values`.
-        **/
-        without<T>(
-            array: _.List<T>,
-            ...values: T[]): T[];
+         * Returns a copy of `list` with all instances of `values` removed.
+         * @param list The list to exclude `values` from.
+         * @param values The values to exclude from `list`.
+         * @return An array that contains all elements of `list` except for `values`.
+         **/
+        without<V extends List<any>>(
+            list: V,
+            ...values: TypeOfList<V>[]
+        ): TypeOfList<V>[];
 
         /**
         * Computes the union of the passed-in arrays: the list of unique items, in order, that are
@@ -887,45 +888,31 @@ declare module _ {
             ...others: _.List<T>[]): T[];
 
         /**
-        * Produces a duplicate-free version of the array, using === to test object equality. If you know in
-        * advance that the array is sorted, passing true for isSorted will run a much faster algorithm. If
-        * you want to compute unique items based on a transformation, pass an iterator function.
-        * @param array Array to remove duplicates from.
-        * @param isSorted True if `array` is already sorted, optional, default = false.
-        * @param iterator Transform the elements of `array` before comparisons for uniqueness.
-        * @param context 'this' object in `iterator`, optional.
-        * @return Copy of `array` where all elements are unique.
-        **/
-        uniq<T, TSort>(
-            array: _.List<T>,
+         * Produces a duplicate-free version of `list`, using === to test object equality. If you know in
+         * advance that `list` is sorted, passing true for isSorted will run a much faster algorithm. If
+         * you want to compute unique items based on a transformation, pass an iteratee function.
+         * @param list The list to remove duplicates from.
+         * @param isSorted True if `list` is already sorted, optional, default = false.
+         * @param iteratee Transform the elements of `list` before comparisons for uniqueness.
+         * @param context 'this' object in `iteratee`, optional.
+         * @return An array containing only the unique elements in `list`.
+         **/
+        uniq<V extends List<any>>(
+            list: V,
             isSorted?: boolean,
-            iterator?: _.ListIterator<T, TSort> | _.IterateePropertyShorthand,
-            context?: any): T[];
+            iteratee?: Iteratee<V, any>,
+            context?: any
+        ): TypeOfList<V>[];
+        uniq<V extends List<any>>(
+            list: V,
+            iteratee?: Iteratee<V, any>,
+            context?: any
+        ): TypeOfList<V>[];
 
         /**
-        * @see _.uniq
-        **/
-        uniq<T, TSort>(
-            array: _.List<T>,
-            iterator?: _.ListIterator<T, TSort> | _.IterateePropertyShorthand,
-            context?: any): T[];
-
-        /**
-        * @see _.uniq
-        **/
-        unique<T, TSort>(
-            array: _.List<T>,
-            iterator?: _.ListIterator<T, TSort> | _.IterateePropertyShorthand,
-            context?: any): T[];
-
-        /**
-        * @see _.uniq
-        **/
-        unique<T, TSort>(
-            array: _.List<T>,
-            isSorted?: boolean,
-            iterator?: _.ListIterator<T, TSort>  | _.IterateePropertyShorthand,
-            context?: any): T[];
+         * @see uniq
+         **/
+        unique: UnderscoreStatic['uniq'];
 
         /**
         * Merges together the values of each of the arrays with the values at the corresponding position.
@@ -1038,19 +1025,19 @@ declare module _ {
             context?: any): number;
 
         /**
-        * Uses a binary search to determine the index at which the value should be inserted into the list in order
-        * to maintain the list's sorted order. If an iterator is passed, it will be used to compute the sort ranking
-        * of each value, including the value you pass.
-        * @param list The sorted list.
-        * @param value The value to determine its index within `list`.
-        * @param iterator Iterator to compute the sort ranking of each value, optional.
-        * @param context `this` object in `iterator`, optional.
-        * @return The index where `value` should be inserted into `list`.
-        **/
-        sortedIndex<T, TSort>(
-            list: _.List<T>,
-            value: T,
-            iterator?: ((x: T) => TSort) | string,
+         * Uses a binary search to determine the index at which the value should be inserted into `list` in order
+         * to maintain `list`'s sorted order. If an iteratee is provided, it will be used to compute the sort ranking
+         * of each value, including the value you pass.
+         * @param list A sorted list.
+         * @param value The value to determine an insert index for to mainain the sorting in `list`.
+         * @param iteratee Iteratee to compute the sort ranking of each element including `value`, optional.
+         * @param context `this` object in `iteratee`, optional.
+         * @return The index where `value` should be inserted into `list`.
+         **/
+        sortedIndex<V extends List<any>>(
+            list: V,
+            value: TypeOfList<V>,
+            iteratee?: Iteratee<V, any>,
             context?: any
         ): number;
 
@@ -4477,9 +4464,10 @@ declare module _ {
         flatten(shallow: true): ListItemOrSelf<T>[];
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.without
-        **/
+         * Returns a copy of the wrapped list with all instances of `values` removed.
+         * @param values The values to exclude from the wrapped list.
+         * @return An array that contains all elements of the wrapped list except for `values`.
+         **/
         without(...values: T[]): T[];
 
         /**
@@ -4507,26 +4495,21 @@ declare module _ {
         difference(...others: _.List<T>[]): T[];
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.uniq
-        **/
-        uniq(isSorted?: boolean, iterator?: _.ListIterator<T, any> |  _.IterateePropertyShorthand): T[];
+         * Produces a duplicate-free version of the wrapped list, using === to test object equality. If you know in
+         * advance that the wrapped list is sorted, passing true for isSorted will run a much faster algorithm. If
+         * you want to compute unique items based on a transformation, pass an iteratee function.
+         * @param isSorted True if the wrapped list is already sorted, optional, default = false.
+         * @param iteratee Transform the elements of the wrapped list before comparisons for uniqueness.
+         * @param context 'this' object in `iteratee`, optional.
+         * @return An array containing only the unique elements in the wrapped list.
+         **/
+        uniq(isSorted?: boolean, iteratee?: Iteratee<V, any>, cotext?: any): T[];
+        uniq(iteratee?: Iteratee<V, any>, context?: any): T[];
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.uniq
+        * @see uniq
         **/
-        uniq<TSort>(iterator?: _.ListIterator<T, TSort>, context?: any): T[];
-
-        /**
-        * @see _.uniq
-        **/
-        unique<TSort>(isSorted?: boolean, iterator?: _.ListIterator<T, TSort>): T[];
-
-        /**
-        * @see _.uniq
-        **/
-        unique<TSort>(iterator?: _.ListIterator<T, TSort>, context?: any): T[];
+        unique: Underscore<T, V>['uniq'];
 
         /**
         * Wrapped type `any[][]`.
@@ -4579,10 +4562,15 @@ declare module _ {
         findLastIndex(predicate: _.ListIterator<T, boolean> | {}, context?: any): number;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.sortedIndex
-        **/
-        sortedIndex(value: T, iterator?: (x: T) => any, context?: any): number;
+         * Uses a binary search to determine the index at which the value should be inserted into the wrapped list in order
+         * to maintain the wrapped list's sorted order. If an iteratee is provided, it will be used to compute the sort ranking
+         * of each value, including the value you pass.
+         * @param value The value to determine an insert index for to mainain the sorting in the wrapped list.
+         * @param iteratee Iteratee to compute the sort ranking of each element including `value`, optional.
+         * @param context `this` object in `iteratee`, optional.
+         * @return The index where `value` should be inserted into the wrapped list.
+         **/
+        sortedIndex(value: T, iteratee?: Iteratee<V, any>, context?: any): number;
 
         /**
         * Wrapped type `number`.
@@ -5455,9 +5443,10 @@ declare module _ {
         flatten(shallow: true): _Chain<ListItemOrSelf<T>, ListItemOrSelf<T>[]>;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.without
-        **/
+         * Returns a copy of the wrapped list with all instances of `values` removed.
+         * @param values The values to exclude from the wrapped list.
+         * @return A chain wrapper around an array that contains all elements of the wrapped list except for `values`.
+         **/
         without(...values: T[]): _Chain<T, T[]>;
 
         /**
@@ -5485,26 +5474,27 @@ declare module _ {
         difference(...others: _.List<T>[]): _Chain<T>;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.uniq
-        **/
-        uniq(isSorted?: boolean, iterator?: _.ListIterator<T, any> | _.IterateePropertyShorthand): _Chain<T>;
+         * Produces a duplicate-free version of the wrapped list, using === to test object equality. If you know in
+         * advance that the wrapped list is sorted, passing true for isSorted will run a much faster algorithm. If
+         * you want to compute unique items based on a transformation, pass an iteratee function.
+         * @param isSorted True if the wrapped list is already sorted, optional, default = false.
+         * @param iteratee Transform the elements of the wrapped list before comparisons for uniqueness.
+         * @param context 'this' object in `iteratee`, optional.
+         * @return A chain wrapper around an array containing only the unique elements in the wrapped list.
+         **/
+        uniq(isSorted?: boolean, iteratee?: _ChainIteratee<V, any, T>, context?: any): _Chain<T, T[]>;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.uniq
+        * Wrapped type List<T>.
+        * @see uniq
         **/
-        uniq<TSort>(iterator?: _.ListIterator<T, TSort> | _.IterateePropertyShorthand, context?: any): _Chain<T>;
+        uniq(iteratee?: _ChainIteratee<V, any, T>, context?: any): _Chain<T, T[]>;
 
         /**
-        * @see _.uniq
+        * Wrapped type List<T>.
+        * @see uniq
         **/
-        unique<TSort>(isSorted?: boolean, iterator?: _.ListIterator<T, TSort> | _.IterateePropertyShorthand): _Chain<T>;
-
-        /**
-        * @see _.uniq
-        **/
-        unique<TSort>(iterator?: _.ListIterator<T, TSort> | _.IterateePropertyShorthand, context?: any): _Chain<T>;
+        unique: _Chain<T, V>['uniq'];
 
         /**
         * Wrapped type `any[][]`.
@@ -5557,10 +5547,15 @@ declare module _ {
         findLastIndex(predicate: _.ListIterator<T, boolean> | {}, context?: any): _ChainSingle<number>;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.sortedIndex
-        **/
-        sortedIndex(value: T, iterator?: (x: T) => any, context?: any): _ChainSingle<number>;
+         * Uses a binary search to determine the index at which the value should be inserted into the wrapped list in order
+         * to maintain the wrapped list's sorted order. If an iteratee is provided, it will be used to compute the sort ranking
+         * of each value, including the value you pass.
+         * @param value The value to determine an insert index for to mainain the sorting in the wrapped list.
+         * @param iteratee Iteratee to compute the sort ranking of each element including `value`, optional.
+         * @param context `this` object in `iteratee`, optional.
+         * @return A chain wrapper around the index where `value` should be inserted into the wrapped list.
+         **/
+        sortedIndex(value: T, iteratee?: _ChainIteratee<V, any, T>, context?: any): _ChainSingle<number>;
 
         /**
         * Wrapped type `number`.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -854,7 +854,8 @@ declare module _ {
          * Returns a copy of `list` with all instances of `values` removed.
          * @param list The list to exclude `values` from.
          * @param values The values to exclude from `list`.
-         * @return An array that contains all elements of `list` except for `values`.
+         * @return An array that contains all elements of `list` except for
+         * `values`.
          **/
         without<V extends List<any>>(
             list: V,
@@ -888,12 +889,16 @@ declare module _ {
             ...others: _.List<T>[]): T[];
 
         /**
-         * Produces a duplicate-free version of `list`, using === to test object equality. If you know in
-         * advance that `list` is sorted, passing true for isSorted will run a much faster algorithm. If
-         * you want to compute unique items based on a transformation, pass an iteratee function.
+         * Produces a duplicate-free version of `list`, using === to test
+         * object equality. If you know in advance that `list` is sorted,
+         * passing true for isSorted will run a much faster algorithm. If you
+         * want to compute unique items based on a transformation, pass an
+         * iteratee function.
          * @param list The list to remove duplicates from.
-         * @param isSorted True if `list` is already sorted, optional, default = false.
-         * @param iteratee Transform the elements of `list` before comparisons for uniqueness.
+         * @param isSorted True if `list` is already sorted, optional,
+         * default = false.
+         * @param iteratee Transform the elements of `list` before comparisons
+         * for uniqueness.
          * @param context 'this' object in `iteratee`, optional.
          * @return An array containing only the unique elements in `list`.
          **/
@@ -1025,12 +1030,15 @@ declare module _ {
             context?: any): number;
 
         /**
-         * Uses a binary search to determine the index at which the value should be inserted into `list` in order
-         * to maintain `list`'s sorted order. If an iteratee is provided, it will be used to compute the sort ranking
-         * of each value, including the value you pass.
+         * Uses a binary search to determine the lowest index at which the
+         * value should be inserted into `list` in order to maintain `list`'s
+         * sorted order. If an iteratee is provided, it will be used to compute
+         * the sort ranking of each value, including the value you pass.
          * @param list A sorted list.
-         * @param value The value to determine an insert index for to mainain the sorting in `list`.
-         * @param iteratee Iteratee to compute the sort ranking of each element including `value`, optional.
+         * @param value The value to determine an insert index for to mainain
+         * the sorting in `list`.
+         * @param iteratee Iteratee to compute the sort ranking of each
+         * element including `value`, optional.
          * @param context `this` object in `iteratee`, optional.
          * @return The index where `value` should be inserted into `list`.
          **/
@@ -4464,9 +4472,11 @@ declare module _ {
         flatten(shallow: true): ListItemOrSelf<T>[];
 
         /**
-         * Returns a copy of the wrapped list with all instances of `values` removed.
+         * Returns a copy of the wrapped list with all instances of `values`
+         * removed.
          * @param values The values to exclude from the wrapped list.
-         * @return An array that contains all elements of the wrapped list except for `values`.
+         * @return An array that contains all elements of the wrapped list
+         * except for `values`.
          **/
         without(...values: T[]): T[];
 
@@ -4495,13 +4505,18 @@ declare module _ {
         difference(...others: _.List<T>[]): T[];
 
         /**
-         * Produces a duplicate-free version of the wrapped list, using === to test object equality. If you know in
-         * advance that the wrapped list is sorted, passing true for isSorted will run a much faster algorithm. If
-         * you want to compute unique items based on a transformation, pass an iteratee function.
-         * @param isSorted True if the wrapped list is already sorted, optional, default = false.
-         * @param iteratee Transform the elements of the wrapped list before comparisons for uniqueness.
+         * Produces a duplicate-free version of the wrapped list, using === to
+         * test object equality. If you know in advance that the wrapped list
+         * is sorted, passing true for isSorted will run a much faster
+         * algorithm. If you want to compute unique items based on a
+         * transformation, pass an iteratee function.
+         * @param isSorted True if the wrapped list is already sorted,
+         * optional, default = false.
+         * @param iteratee Transform the elements of the wrapped list before
+         * comparisons for uniqueness.
          * @param context 'this' object in `iteratee`, optional.
-         * @return An array containing only the unique elements in the wrapped list.
+         * @return An array containing only the unique elements in the wrapped
+         * list.
          **/
         uniq(isSorted?: boolean, iteratee?: Iteratee<V, any>, cotext?: any): T[];
         uniq(iteratee?: Iteratee<V, any>, context?: any): T[];
@@ -4562,13 +4577,18 @@ declare module _ {
         findLastIndex(predicate: _.ListIterator<T, boolean> | {}, context?: any): number;
 
         /**
-         * Uses a binary search to determine the index at which the value should be inserted into the wrapped list in order
-         * to maintain the wrapped list's sorted order. If an iteratee is provided, it will be used to compute the sort ranking
-         * of each value, including the value you pass.
-         * @param value The value to determine an insert index for to mainain the sorting in the wrapped list.
-         * @param iteratee Iteratee to compute the sort ranking of each element including `value`, optional.
+         * Uses a binary search to determine the lowest index at which the
+         * value should be inserted into the wrapped list in order to maintain
+         * the wrapped list's sorted order. If an iteratee is provided, it will
+         * be used to compute the sort ranking of each value, including the
+         * value you pass.
+         * @param value The value to determine an insert index for to mainain
+         * the sorting in the wrapped list.
+         * @param iteratee Iteratee to compute the sort ranking of each
+         * element including `value`, optional.
          * @param context `this` object in `iteratee`, optional.
-         * @return The index where `value` should be inserted into the wrapped list.
+         * @return The index where `value` should be inserted into the wrapped
+         * list.
          **/
         sortedIndex(value: T, iteratee?: Iteratee<V, any>, context?: any): number;
 
@@ -5443,9 +5463,11 @@ declare module _ {
         flatten(shallow: true): _Chain<ListItemOrSelf<T>, ListItemOrSelf<T>[]>;
 
         /**
-         * Returns a copy of the wrapped list with all instances of `values` removed.
+         * Returns a copy of the wrapped list with all instances of `values`
+         * removed.
          * @param values The values to exclude from the wrapped list.
-         * @return A chain wrapper around an array that contains all elements of the wrapped list except for `values`.
+         * @return A chain wrapper around an array that contains all elements
+         * of the wrapped list except for `values`.
          **/
         without(...values: T[]): _Chain<T, T[]>;
 
@@ -5474,20 +5496,20 @@ declare module _ {
         difference(...others: _.List<T>[]): _Chain<T>;
 
         /**
-         * Produces a duplicate-free version of the wrapped list, using === to test object equality. If you know in
-         * advance that the wrapped list is sorted, passing true for isSorted will run a much faster algorithm. If
-         * you want to compute unique items based on a transformation, pass an iteratee function.
-         * @param isSorted True if the wrapped list is already sorted, optional, default = false.
-         * @param iteratee Transform the elements of the wrapped list before comparisons for uniqueness.
+         * Produces a duplicate-free version of the wrapped list, using === to
+         * test object equality. If you know in advance that the wrapped list
+         * is sorted, passing true for isSorted will run a much faster
+         * algorithm. If you want to compute unique items based on a
+         * transformation, pass an iteratee function.
+         * @param isSorted True if the wrapped list is already sorted,
+         * optional, default = false.
+         * @param iteratee Transform the elements of the wrapped list before
+         * comparisons for uniqueness.
          * @param context 'this' object in `iteratee`, optional.
-         * @return A chain wrapper around an array containing only the unique elements in the wrapped list.
+         * @return A chain wrapper around an array containing only the unique
+         * elements in the wrapped list.
          **/
         uniq(isSorted?: boolean, iteratee?: _ChainIteratee<V, any, T>, context?: any): _Chain<T, T[]>;
-
-        /**
-        * Wrapped type List<T>.
-        * @see uniq
-        **/
         uniq(iteratee?: _ChainIteratee<V, any, T>, context?: any): _Chain<T, T[]>;
 
         /**
@@ -5547,13 +5569,18 @@ declare module _ {
         findLastIndex(predicate: _.ListIterator<T, boolean> | {}, context?: any): _ChainSingle<number>;
 
         /**
-         * Uses a binary search to determine the index at which the value should be inserted into the wrapped list in order
-         * to maintain the wrapped list's sorted order. If an iteratee is provided, it will be used to compute the sort ranking
-         * of each value, including the value you pass.
-         * @param value The value to determine an insert index for to mainain the sorting in the wrapped list.
-         * @param iteratee Iteratee to compute the sort ranking of each element including `value`, optional.
+         * Uses a binary search to determine the lowest index at which the
+         * value should be inserted into the wrapped list in order to maintain
+         * the wrapped list's sorted order. If an iteratee is provided, it
+         * will be used to compute the sort ranking of each value, including
+         * the value you pass.
+         * @param value The value to determine an insert index for to mainain
+         * the sorting in the wrapped list.
+         * @param iteratee Iteratee to compute the sort ranking of each element
+         * including `value`, optional.
          * @param context `this` object in `iteratee`, optional.
-         * @return A chain wrapper around the index where `value` should be inserted into the wrapped list.
+         * @return A chain wrapper around the index where `value` should be
+         * inserted into the wrapped list.
          **/
         sortedIndex(value: T, iteratee?: _ChainIteratee<V, any, T>, context?: any): _ChainSingle<number>;
 

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1302,6 +1302,114 @@ declare const extractChainTypes: ChainTypeExtractor;
     extractChainTypes(_.chain(level2NonIntersectingPropertiesList).flatten(true)); // $ExpectType ChainType<NonIntersectingProperties[], NonIntersectingProperties>
 }
 
+// without
+{
+    // lists
+    _.without(stringRecordList, stringRecordList[0], stringRecordList[1]); // $ExpectType StringRecord[]
+    _(stringRecordList).without(stringRecordList[0], stringRecordList[1]); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).without(stringRecordList[0], stringRecordList[1])); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // strings
+    _.without(simpleString, simpleString[0], simpleString[1]); // $ExpectType string[]
+    _(simpleString).without(simpleString[0], simpleString[1]); // $ExpectType string[]
+    extractChainTypes(_.chain(simpleString).without(simpleString[0], simpleString[1])); // $ExpectType ChainType<string[], string>
+}
+
+// uniq, unique
+{
+    // not sorted - identity iteratee - uniq
+    _.uniq(stringRecordList); // $ExpectType StringRecord[]
+    _(stringRecordList).uniq(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).uniq()); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // not sorted - identity iteratee - unique
+    _.unique(stringRecordList); // $ExpectType StringRecord[]
+    _(stringRecordList).unique(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).unique()); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // not sorted - function iteratee - uniq
+    _.uniq(stringRecordList, stringRecordListValueIterator); // $ExpectType StringRecord[]
+    _.uniq(stringRecordList, stringRecordListValueIterator, context); // $ExpectType StringRecord[]
+    _(stringRecordList).uniq(stringRecordListValueIterator); // $ExpectType StringRecord[]
+    _(stringRecordList).uniq(stringRecordListValueIterator, context); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).uniq(stringRecordListValueIterator)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    extractChainTypes(_.chain(stringRecordList).uniq(stringRecordListValueIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // not sorted - function iteratee - unique
+    _.unique(stringRecordList, stringRecordListValueIterator); // $ExpectType StringRecord[]
+    _.unique(stringRecordList, stringRecordListValueIterator, context); // $ExpectType StringRecord[]
+    _(stringRecordList).unique(stringRecordListValueIterator); // $ExpectType StringRecord[]
+    _(stringRecordList).unique(stringRecordListValueIterator, context); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).unique(stringRecordListValueIterator)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    extractChainTypes(_.chain(stringRecordList).unique(stringRecordListValueIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // not sorted - property name iteratee - uniq
+    _.uniq(stringRecordList, stringRecordProperty); // $ExpectType StringRecord[]
+    _(stringRecordList).uniq(stringRecordProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).uniq(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // not sorted - property name iteratee - unique
+    _.unique(stringRecordList, stringRecordProperty); // $ExpectType StringRecord[]
+    _(stringRecordList).unique(stringRecordProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).unique(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // not sorted - property path iteratee - uniq
+    _.uniq(stringRecordList, stringRecordPropertyPath); // $ExpectType StringRecord[]
+    _(stringRecordList).uniq(stringRecordPropertyPath); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).uniq(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // not sorted - property path iteratee - unique
+    _.unique(stringRecordList, stringRecordPropertyPath); // $ExpectType StringRecord[]
+    _(stringRecordList).unique(stringRecordPropertyPath); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).unique(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // sorted - identity iteratee - uniq
+    _.uniq(stringRecordList, true); // $ExpectType StringRecord[]
+    _(stringRecordList).uniq(true); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).uniq(true)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // sorted - identity iteratee - unique
+    _.unique(stringRecordList, true); // $ExpectType StringRecord[]
+    _(stringRecordList).unique(true); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).unique(true)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // sorted - function iteratee - uniq
+    _.uniq(stringRecordList, true, stringRecordListValueIterator); // $ExpectType StringRecord[]
+    _.uniq(stringRecordList, true, stringRecordListValueIterator, context); // $ExpectType StringRecord[]
+    _(stringRecordList).uniq(true, stringRecordListValueIterator); // $ExpectType StringRecord[]
+    _(stringRecordList).uniq(true, stringRecordListValueIterator, context); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).uniq(true, stringRecordListValueIterator)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    extractChainTypes(_.chain(stringRecordList).uniq(true, stringRecordListValueIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // sorted - function iteratee - unique
+    _.unique(stringRecordList, true, stringRecordListValueIterator); // $ExpectType StringRecord[]
+    _.unique(stringRecordList, true, stringRecordListValueIterator, context); // $ExpectType StringRecord[]
+    _(stringRecordList).unique(true, stringRecordListValueIterator); // $ExpectType StringRecord[]
+    _(stringRecordList).unique(true, stringRecordListValueIterator, context); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).unique(true, stringRecordListValueIterator)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    extractChainTypes(_.chain(stringRecordList).unique(true, stringRecordListValueIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // sorted - property name iteratee - uniq
+    _.uniq(stringRecordList, true, stringRecordProperty); // $ExpectType StringRecord[]
+    _(stringRecordList).uniq(true, stringRecordProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).uniq(true, stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // sorted - property name iteratee - unique
+    _.unique(stringRecordList, true, stringRecordProperty); // $ExpectType StringRecord[]
+    _(stringRecordList).unique(true, stringRecordProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).unique(true, stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // sorted - property path iteratee - uniq
+    _.uniq(stringRecordList, true, stringRecordPropertyPath); // $ExpectType StringRecord[]
+    _(stringRecordList).uniq(true, stringRecordPropertyPath); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).uniq(true, stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // sorted - property path iteratee - unique
+    _.unique(stringRecordList, true, stringRecordPropertyPath); // $ExpectType StringRecord[]
+    _(stringRecordList).unique(true, stringRecordPropertyPath); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).unique(true, stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+}
+
 // chunk
 {
     const length = 2;
@@ -1315,6 +1423,32 @@ declare const extractChainTypes: ChainTypeExtractor;
     _.chunk(simpleString, length); // $ExpectType string[][]
     _(simpleString).chunk(length); // $ExpectType string[][]
     extractChainTypes(_.chain(simpleString).chunk(length)); // $ExpectType ChainType<string[][], string[]>
+}
+
+// sortedIndex
+{
+    // identity iteratee
+    _.sortedIndex(simpleStringList, simpleString); // $ExpectType number
+    _(simpleStringList).sortedIndex(simpleString); // $ExpectType number
+    extractChainTypes(_.chain(simpleStringList).sortedIndex(simpleString)); // $ExpectType ChainType<number, never>
+
+    // function iteratee
+    _.sortedIndex(stringRecordList, stringRecordList[0], stringRecordListValueIterator); // $ExpectType number
+    _.sortedIndex(stringRecordList, stringRecordList[0], stringRecordListValueIterator, context); // $ExpectType number
+    _(stringRecordList).sortedIndex(stringRecordList[0], stringRecordListValueIterator); // $ExpectType number
+    _(stringRecordList).sortedIndex(stringRecordList[0], stringRecordListValueIterator, context); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).sortedIndex(stringRecordList[0], stringRecordListValueIterator)); // $ExpectType ChainType<number, never>
+    extractChainTypes(_.chain(stringRecordList).sortedIndex(stringRecordList[0], stringRecordListValueIterator, context)); // $ExpectType ChainType<number, never>
+
+    // property name iteratee
+    _.sortedIndex(stringRecordList, stringRecordList[0], stringRecordProperty); // $ExpectType number
+    _(stringRecordList).sortedIndex(stringRecordList[0], stringRecordProperty); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).sortedIndex(stringRecordList[0], stringRecordProperty)); // $ExpectType ChainType<number, never>
+
+    // property path iteratee
+    _.sortedIndex(stringRecordList, stringRecordList[0], stringRecordPropertyPath); // $ExpectType number
+    _(stringRecordList).sortedIndex(stringRecordList[0], stringRecordPropertyPath); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).sortedIndex(stringRecordList[0], stringRecordPropertyPath)); // $ExpectType ChainType<number, never>
 }
 
 // findIndex and findLastIndex

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1343,6 +1343,16 @@ declare const extractChainTypes: ChainTypeExtractor;
     extractChainTypes(_.chain(stringRecordList).unique(stringRecordListValueIterator)); // $ExpectType ChainType<StringRecord[], StringRecord>
     extractChainTypes(_.chain(stringRecordList).unique(stringRecordListValueIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
+    // not sorted - partial object iteratee - uniq
+    _.uniq(stringRecordList, partialStringRecord); // $ExpectType StringRecord[]
+    _(stringRecordList).uniq(partialStringRecord); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).uniq(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // not sorted - partial object iteratee - unique
+    _.unique(stringRecordList, partialStringRecord); // $ExpectType StringRecord[]
+    _(stringRecordList).unique(partialStringRecord); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).unique(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
     // not sorted - property name iteratee - uniq
     _.uniq(stringRecordList, stringRecordProperty); // $ExpectType StringRecord[]
     _(stringRecordList).uniq(stringRecordProperty); // $ExpectType StringRecord[]
@@ -1388,6 +1398,16 @@ declare const extractChainTypes: ChainTypeExtractor;
     _(stringRecordList).unique(true, stringRecordListValueIterator, context); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordList).unique(true, stringRecordListValueIterator)); // $ExpectType ChainType<StringRecord[], StringRecord>
     extractChainTypes(_.chain(stringRecordList).unique(true, stringRecordListValueIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // sorted - partial object iteratee - uniq
+    _.uniq(stringRecordList, true, partialStringRecord); // $ExpectType StringRecord[]
+    _(stringRecordList).uniq(true, partialStringRecord); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).uniq(true, partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // sorted - partial object iteratee - unique
+    _.unique(stringRecordList, true, partialStringRecord); // $ExpectType StringRecord[]
+    _(stringRecordList).unique(true, partialStringRecord); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).unique(true, partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // sorted - property name iteratee - uniq
     _.uniq(stringRecordList, true, stringRecordProperty); // $ExpectType StringRecord[]
@@ -1439,6 +1459,11 @@ declare const extractChainTypes: ChainTypeExtractor;
     _(stringRecordList).sortedIndex(stringRecordList[0], stringRecordListValueIterator, context); // $ExpectType number
     extractChainTypes(_.chain(stringRecordList).sortedIndex(stringRecordList[0], stringRecordListValueIterator)); // $ExpectType ChainType<number, never>
     extractChainTypes(_.chain(stringRecordList).sortedIndex(stringRecordList[0], stringRecordListValueIterator, context)); // $ExpectType ChainType<number, never>
+
+    // partial object iteratee
+    _.sortedIndex(stringRecordList, stringRecordList[0], partialStringRecord); // $ExpectType number
+    _(stringRecordList).sortedIndex(stringRecordList[0], partialStringRecord); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).sortedIndex(stringRecordList[0], partialStringRecord)); // $ExpectType ChainType<number, never>
 
     // property name iteratee
     _.sortedIndex(stringRecordList, stringRecordList[0], stringRecordProperty); // $ExpectType number


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://underscorejs.org/
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

This PR continues the planned set that will together add up to #45201 and includes the following changes:

- Adds tests for `without`, `uniq`, and `sortedIndex`.
- Updates `uniq` and `sortedIndex` to use `Iteratee`.
- Replaces all `unique` overloads with a reference to `uniq` overloads.
- Updates the return type of `_Chain.uniq` to use the correct wrapped value type `V` to partially fix #36308.