### PR TITLE
[@types/react-native] Fixed Android Ripple Config for the new Pressable component

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -477,9 +477,9 @@ export type PressableStateCallbackType = Readonly<{
 }>;
 
 export interface PressableAndroidRippleConfig {
-    color?: ColorValue;
-    borderless?: boolean;
-    radius?: number;
+    color?: null | ColorValue;
+    borderless?: null | boolean;
+    radius?: null | number;
 }
 
 export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'style' | 'hitSlop'> {

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -476,6 +476,12 @@ export type PressableStateCallbackType = Readonly<{
     pressed: boolean;
 }>;
 
+export interface PressableAndroidRippleConfig {
+    color?: ColorValue;
+    borderless?: boolean;
+    radius?: number;
+}
+
 export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'style' | 'hitSlop'> {
     /**
      * Called when a single tap gesture is detected.
@@ -532,7 +538,7 @@ export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'sty
     /**
      * Enables the Android ripple effect and configures its color.
      */
-    android_ripple?: null | RippleBackgroundPropType;
+    android_ripple?: null | PressableAndroidRippleConfig;
 
     /**
      * Used only for documentation or testing (e.g. snapshot testing).
@@ -3956,7 +3962,12 @@ declare class ImageComponent extends React.Component<ImageProps> {}
 declare const ImageBase: Constructor<NativeMethodsMixinType> & typeof ImageComponent;
 export class Image extends ImageBase {
     static getSize(uri: string, success: (width: number, height: number) => void, failure?: (error: any) => void): any;
-    static getSizeWithHeaders(uri: string, headers: {[index: string]: string}, success: (width: number, height: number) => void, failure?: (error: any) => void): any;
+    static getSizeWithHeaders(
+        uri: string,
+        headers: { [index: string]: string },
+        success: (width: number, height: number) => void,
+        failure?: (error: any) => void,
+    ): any;
     static prefetch(url: string): any;
     static abortPrefetch?(requestId: number): void;
     static queryCache?(urls: string[]): Promise<{ [url: string]: 'memory' | 'disk' | 'disk/memory' }>;
@@ -5273,7 +5284,7 @@ interface BaseBackgroundPropType {
 
 interface RippleBackgroundPropType extends BaseBackgroundPropType {
     type: 'RippleAndroid';
-    color?: number;
+    color?: ColorValue;
     borderless?: boolean;
     radius?: number;
 }

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -407,6 +407,20 @@ export class PressableTest extends React.Component {
                         )
                     }
                 </Pressable>
+                {/* Android Ripple */}
+                <Pressable
+                    android_ripple={{
+                        borderless: true,
+                        color: 'green',
+                        radius: 20,
+                    }}
+                    onPress={this.onPressButton}
+                    style={{ backgroundColor: 'blue' }}
+                >
+                    <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
+                        <Text style={{ margin: 30 }}>Button</Text>
+                    </View>
+                </Pressable>
             </>
         );
     }


### PR DESCRIPTION
Fixed the type definition for the android ripple config object on the new Pressable component. Removed the requirement for a "type" property to be passed in and used the correct type for the "color" property.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactnative.dev/docs/pressable#rippleconfig
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
