### PR TITLE
[jest] Add generic support to jest.mock and jest.doMock

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -72,7 +72,7 @@ type ExtractEachCallbackArgs<T extends ReadonlyArray<any>> = {
         : 'fallback'
 ];
 
-type MockModuleFactory<T> = () => T extends { default: any } ? Partial<T> & { __esModule: boolean } : Partial<T>;
+type MockModuleFactory<T> = () => T extends { default: unknown } ? T & { __esModule: true } : T;
 
 interface NodeRequire {
     /**
@@ -164,11 +164,7 @@ declare namespace jest {
     /**
      * Mocks a module with an auto-mocked version when it is being required.
      */
-    function doMock(moduleName: string, factory?: () => unknown, options?: MockOptions): typeof jest;
-    /**
-     * Mocks a module with a provided version when it is being required.
-     */
-    function doMock<T extends any>(moduleName: string, factory: MockModuleFactory<T>, options?: MockOptions): typeof jest;
+    function doMock<T>(moduleName: string, factory?: MockModuleFactory<T>, options?: MockOptions): typeof jest;
     /**
      * Indicates that the module system should never return a mocked version
      * of the specified module from require() (e.g. that it should always return the real module).
@@ -197,11 +193,7 @@ declare namespace jest {
     /**
      * Mocks a module with an auto-mocked version when it is being required.
      */
-    function mock(moduleName: string, factory?: () => unknown, options?: MockOptions): typeof jest;
-    /**
-     * Mocks a module with a provided version when it is being required.
-     */
-    function mock<T extends any>(moduleName: string, factory: MockModuleFactory<T>, options?: MockOptions): typeof jest;
+    function mock<T>(moduleName: string, factory?: MockModuleFactory<T>, options?: MockOptions): typeof jest;
     /**
      * Returns the actual module instead of a mock, bypassing all checks on
      * whether the module should receive a mock implementation or not.

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -72,6 +72,8 @@ type ExtractEachCallbackArgs<T extends ReadonlyArray<any>> = {
         : 'fallback'
 ];
 
+type MockModuleFactory<T> = () => T extends { default: any } ? Partial<T> & { __esModule: boolean } : Partial<T>;
+
 interface NodeRequire {
     /**
      * Returns the actual module instead of a mock, bypassing all checks on
@@ -164,6 +166,10 @@ declare namespace jest {
      */
     function doMock(moduleName: string, factory?: () => unknown, options?: MockOptions): typeof jest;
     /**
+     * Mocks a module with a provided version when it is being required.
+     */
+    function doMock<T extends any>(moduleName: string, factory: MockModuleFactory<T>, options?: MockOptions): typeof jest;
+    /**
      * Indicates that the module system should never return a mocked version
      * of the specified module from require() (e.g. that it should always return the real module).
      */
@@ -192,6 +198,10 @@ declare namespace jest {
      * Mocks a module with an auto-mocked version when it is being required.
      */
     function mock(moduleName: string, factory?: () => unknown, options?: MockOptions): typeof jest;
+    /**
+     * Mocks a module with a provided version when it is being required.
+     */
+    function mock<T extends any>(moduleName: string, factory: MockModuleFactory<T>, options?: MockOptions): typeof jest;
     /**
      * Returns the actual module instead of a mock, bypassing all checks on
      * whether the module should receive a mock implementation or not.

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -240,7 +240,35 @@ nodeRequire.requireMock('moduleName');
 
 /* Top-level jest namespace functions */
 
+interface FakeModule {
+    import1: { property: string };
+    import2: { method(): void };
+}
+
+interface FakeModuleWithDefault {
+    default: { property: number };
+    import1: { property: string };
+}
+
+type FakeRequiredFunction = () => string;
+
 const customMatcherFactories: jasmine.CustomMatcherFactories = {};
+
+const fakeImportModuleTypePartial = {
+    import1: { property: 'Hello World' },
+};
+
+const fakeImportModuleWithDefault = {
+    __esModule: true,
+    default: { property: 42 },
+};
+
+const fakeImportModuleNoDefaultProvided = {
+    __esModule: false,
+    import2: { method() {} }
+};
+
+const fakeFunction = jest.fn<ReturnType<FakeRequiredFunction>, Parameters<FakeRequiredFunction>>();
 
 jest.addMatchers(customMatcherFactories)
     .addMatchers({})
@@ -258,12 +286,22 @@ jest.addMatchers(customMatcherFactories)
     .doMock('moduleName', jest.fn())
     .doMock('moduleName', jest.fn(), {})
     .doMock('moduleName', jest.fn(), { virtual: true })
+    .doMock<FakeRequiredFunction>('moduleName', () => fakeFunction)
+    .doMock<FakeModule>('moduleName', () => fakeImportModuleTypePartial)
+    .doMock<FakeModule>('moduleName', () => fakeImportModuleTypePartial, { virtual: true })
+    .doMock<FakeModuleWithDefault>('moduleName', () => fakeImportModuleWithDefault)
+    .doMock<FakeModuleWithDefault>('moduleName', () => fakeImportModuleNoDefaultProvided)
     .dontMock('moduleName')
     .enableAutomock()
     .mock('moduleName')
     .mock('moduleName', jest.fn())
     .mock('moduleName', jest.fn(), {})
     .mock('moduleName', jest.fn(), { virtual: true })
+    .mock<FakeRequiredFunction>('moduleName', () => fakeFunction)
+    .mock<FakeModule>('moduleName', () => fakeImportModuleTypePartial)
+    .mock<FakeModule>('moduleName', () => fakeImportModuleTypePartial, { virtual: true })
+    .mock<FakeModuleWithDefault>('moduleName', () => fakeImportModuleWithDefault)
+    .mock<FakeModuleWithDefault>('moduleName', () => fakeImportModuleNoDefaultProvided)
     .resetModuleRegistry()
     .resetModules()
     .isolateModules(() => {})

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -253,21 +253,9 @@ interface FakeModuleWithDefault {
 type FakeRequiredFunction = () => string;
 
 const customMatcherFactories: jasmine.CustomMatcherFactories = {};
-
-const fakeImportModuleTypePartial = {
-    import1: { property: 'Hello World' },
-};
-
-const fakeImportModuleWithDefault = {
-    __esModule: true,
-    default: { property: 42 },
-};
-
-const fakeImportModuleNoDefaultProvided = {
-    __esModule: false,
-    import2: { method() {} }
-};
-
+const fakeDefault = { property: 42 };
+const fakeImport1 = { property: 'Hello World' };
+const fakeImport2 = { method() {} };
 const fakeFunction = jest.fn<ReturnType<FakeRequiredFunction>, Parameters<FakeRequiredFunction>>();
 
 jest.addMatchers(customMatcherFactories)
@@ -287,10 +275,9 @@ jest.addMatchers(customMatcherFactories)
     .doMock('moduleName', jest.fn(), {})
     .doMock('moduleName', jest.fn(), { virtual: true })
     .doMock<FakeRequiredFunction>('moduleName', () => fakeFunction)
-    .doMock<FakeModule>('moduleName', () => fakeImportModuleTypePartial)
-    .doMock<FakeModule>('moduleName', () => fakeImportModuleTypePartial, { virtual: true })
-    .doMock<FakeModuleWithDefault>('moduleName', () => fakeImportModuleWithDefault)
-    .doMock<FakeModuleWithDefault>('moduleName', () => fakeImportModuleNoDefaultProvided)
+    .doMock<FakeModule>('moduleName', () => ({ import1: fakeImport1, import2: fakeImport2 }))
+    .doMock<FakeModule>('moduleName', () => ({ import1: fakeImport1, import2: fakeImport2 }), { virtual: true })
+    .doMock<FakeModuleWithDefault>('moduleName', () => ({ __esModule: true, default: fakeDefault, import1: fakeImport1 }))
     .dontMock('moduleName')
     .enableAutomock()
     .mock('moduleName')
@@ -298,10 +285,9 @@ jest.addMatchers(customMatcherFactories)
     .mock('moduleName', jest.fn(), {})
     .mock('moduleName', jest.fn(), { virtual: true })
     .mock<FakeRequiredFunction>('moduleName', () => fakeFunction)
-    .mock<FakeModule>('moduleName', () => fakeImportModuleTypePartial)
-    .mock<FakeModule>('moduleName', () => fakeImportModuleTypePartial, { virtual: true })
-    .mock<FakeModuleWithDefault>('moduleName', () => fakeImportModuleWithDefault)
-    .mock<FakeModuleWithDefault>('moduleName', () => fakeImportModuleNoDefaultProvided)
+    .mock<FakeModule>('moduleName', () => ({ import1: fakeImport1, import2: fakeImport2 }))
+    .mock<FakeModule>('moduleName', () => ({ import1: fakeImport1, import2: fakeImport2 }), { virtual: true })
+    .mock<FakeModuleWithDefault>('moduleName', () => ({ __esModule: true, default: fakeDefault, import1: fakeImport1 }))
     .resetModuleRegistry()
     .resetModules()
     .isolateModules(() => {})
@@ -319,6 +305,23 @@ jest.addMatchers(customMatcherFactories)
     .unmock('moduleName')
     .useFakeTimers()
     .useRealTimers();
+
+// $ExpectError
+jest.doMock<FakeModuleWithDefault>('moduleName', () => ({ default: fakeDefault, import1: fakeImport1 }));
+// $ExpectError
+jest.doMock<FakeModuleWithDefault>('moduleName', () => ({ __esModue: false, default: fakeDefault, import1: fakeImport1 }));
+// $ExpectError
+jest.doMock<FakeModuleWithDefault>('moduleName', () => ({ __esModule: true, import1: fakeImport1 }));
+// $ExpectError
+jest.doMock<FakeModule>('moduleName', () => ({ import1: fakeImport1 }));
+// $ExpectError
+jest.mock<FakeModuleWithDefault>('moduleName', () => ({ default: fakeDefault, import1: fakeImport1 }));
+// $ExpectError
+jest.mock<FakeModuleWithDefault>('moduleName', () => ({ __esModue: false, default: fakeDefault, import1: fakeImport1 }));
+// $ExpectError
+jest.mock<FakeModuleWithDefault>('moduleName', () => ({ __esModule: true, import1: fakeImport1 }));
+// $ExpectError
+jest.mock<FakeModule>('moduleName', () => ({ import1: fakeImport1 }));
 
 jest.advanceTimersToNextTimer();
 jest.advanceTimersToNextTimer(2);


### PR DESCRIPTION
**Changes**
Allow `jest.mock` and `jest.doMock` to support generics which apply a measure of type-safety to the factory function which can be provided.

**Rationale**
When dealing with `jest.mock` / `jest.doMock` factories, currently there is no type-safety to ensure that the replacement values you provide are of the correct types. If you try to make use of existing stubs and mocks in a codebase or custom replacements with non-jest Mock functions, you do not get the benefit of knowing that the module replacements are of the correct types.
By adding an overload type def for `jest.mock` and `jest.doMock` which accepts a generic, we can make sure that the factory function provided returns replacements of the correct types. An overload also ensures that all existing usages in projects will remain in a working condition (no breaking change in typings).

A `Parital` is used to give the freedom to provide as much or as little as devs like.

A check for `default` is in place to encourage devs to remember to set the required `__esModule` flag when a `default` value in a module exists.

For example usages see the test file (`jest-tests.ts`).

-----

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://jestjs.io/docs/en/jest-object#jestmockmodulename-factory-options
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header~~. No new version of the library.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
