### PR TITLE
[@types/react-map-gl] Harmonize signature of queryRenderedFeatures with mapbox-gl

### DIFF
--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -87,9 +87,9 @@ export interface QueryRenderedFeaturesParams {
 export class StaticMap extends React.PureComponent<StaticMapProps> {
     getMap(): MapboxGL.Map;
     queryRenderedFeatures(
-        geometry?: MapboxGL.PointLike | MapboxGL.PointLike[],
+        geometry?: MapboxGL.PointLike | [MapboxGL.PointLike, MapboxGL.PointLike],
         parameters?: QueryRenderedFeaturesParams,
-    ): Array<GeoJSON.Feature<GeoJSON.GeometryObject>>;
+    ): MapboxGL.MapboxGeoJSONFeature[];
 }
 
 export interface ExtraState {
@@ -306,9 +306,9 @@ export interface InteractiveMapProps extends StaticMapProps {
 export class InteractiveMap extends React.PureComponent<InteractiveMapProps> {
     getMap(): MapboxGL.Map;
     queryRenderedFeatures(
-        geometry?: MapboxGL.PointLike | MapboxGL.PointLike[],
+        geometry?: MapboxGL.PointLike | [MapboxGL.PointLike, MapboxGL.PointLike],
         parameters?: QueryRenderedFeaturesParams,
-    ): Array<GeoJSON.Feature<GeoJSON.GeometryObject>>;
+    ): MapboxGL.MapboxGeoJSONFeature[];
 }
 
 export default InteractiveMap;

--- a/types/react-map-gl/react-map-gl-tests.tsx
+++ b/types/react-map-gl/react-map-gl-tests.tsx
@@ -47,7 +47,8 @@ class MyMap extends React.Component<{}, State> {
             minPitch: 0,
         },
     };
-    private map: MapboxGL.Map;
+    private mapboxMap: MapboxGL.Map;
+    private map: InteractiveMap;
 
     render() {
         return (
@@ -59,6 +60,12 @@ class MyMap extends React.Component<{}, State> {
                     ref={this.setRefInteractive}
                     onViewportChange={viewport => this.setState({ viewport })}
                     onViewStateChange={({ viewState }) => this.setState({ viewport: viewState })}
+                    onClick={e => {
+                        const features = this.map.queryRenderedFeatures(e.point);
+                        if (features.length > 0) {
+                            console.log(features[0].source);
+                        }
+                    }}
                     onContextMenu={event => {
                         event.preventDefault();
                     }}
@@ -170,10 +177,11 @@ class MyMap extends React.Component<{}, State> {
     }
 
     private readonly setRefInteractive = (el: InteractiveMap) => {
-        this.map = el.getMap();
+        this.map = el;
+        this.mapboxMap = el.getMap();
     }
 
     private readonly setRefStatic = (el: StaticMap) => {
-        this.map = el.getMap();
+        this.mapboxMap = el.getMap();
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
The linting fails on Typescript 4.0 due to some React external dependency but this is completely out of scope of this pull request.


If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: the method shadows mapbox-gl method as seen [here](https://github.com/visgl/react-map-gl/blob/68aa89d311f32008d49af1403f69fbabd07adec7/src/components/interactive-map.js#L271) but the current function signature does not match (notably, Mapbox injects properties as the root of each feature such as `source`, `layer` or `state` that can be useful). Check the mapbox Gl definition [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/94804c828501efe1c327672926082d955d7cf9f5/types/mapbox-gl/index.d.ts#L252)
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

Adds the additional information that Mapbox injects into the Feature through `queryRenderedFeatures` into the function signature of the react-map-gl equivalent.
