### PR TITLE
@types/jwplayer updated VolumeParam.volume to type number fixes #46078

### DIFF
--- a/types/jwplayer/index.d.ts
+++ b/types/jwplayer/index.d.ts
@@ -177,7 +177,7 @@ declare namespace jwplayer {
     }
 
     interface VolumeParam {
-        volume: boolean;
+        volume: number;
     }
 
     interface PlayParam {


### PR DESCRIPTION
Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.jwplayer.com/jwplayer/docs/jw8-javascript-api-reference#section-jwplayer-on-volume
