### PR TITLE
feat(preview-email): new definition

### DIFF
--- a/types/preview-email/index.d.ts
+++ b/types/preview-email/index.d.ts
@@ -52,7 +52,7 @@ declare namespace previewEmail {
     /**
      * a function to build preview url from file path
      */
-    interface UlrTransform {
+    interface UrlTransform {
         (path: string): string;
     }
 }

--- a/types/preview-email/index.d.ts
+++ b/types/preview-email/index.d.ts
@@ -41,7 +41,7 @@ declare namespace previewEmail {
          * - this is where you can customize the opened path to handle WSL to Windows transformation or build a http url if dir is served.
          * @default (path) => 'file://[file path]'
          */
-        urlTransform?: UlrTransform;
+        urlTransform?: UrlTransform;
     }
 
     interface OpenOptions {

--- a/types/preview-email/index.d.ts
+++ b/types/preview-email/index.d.ts
@@ -1,0 +1,60 @@
+// Type definitions for preview-email 2.0
+// Project: https://github.com/niftylettuce/preview-email
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.3
+
+import { Options as NodeMailerOptions } from 'nodemailer/lib/mailer';
+
+/**
+ * Automatically opens your browser to preview Node.js email messages sent with Nodemailer. Made for Lad!
+ *
+ * The function `previewEmail` returns a `Promise` which resolves with a URL.
+ * We automatically open the browser to this URL unless you specify options.open as false
+ */
+declare function previewEmail(message: NodeMailerOptions, options?: previewEmail.Options): Promise<string>;
+
+declare namespace previewEmail {
+    interface Options {
+        /**
+         * a unique ID for the file name created for the preview in dir (defaults to `uuid.v4()` from `uuid`)
+         */
+        id?: string;
+        /**
+         *  a path to a directory for saving the generated email previews (defaults to `os.tmpdir()`)
+         */
+        dir?: string;
+        /**
+         * an options object that is passed to open (defaults to `{ wait: false }`).
+         * If set to `false` then it will not open the email automatically in the browser using open,
+         * and if set to true then it will default to `{ wait: false }`
+         * @default { wait: false }
+         */
+        open?: OpenOptions | boolean;
+        /**
+         *  file path to a pug template file (defaults to preview-email's `template.pug` by default)
+         * - this is where you can pass a custom template for rendering email previews, e.g. your own stylesheet
+         */
+        template?: string;
+        /**
+         * a function to build preview url from file path
+         * - this is where you can customize the opened path to handle WSL to Windows transformation or build a http url if dir is served.
+         * @default (path) => 'file://[file path]'
+         */
+        urlTransform?: UlrTransform;
+    }
+
+    interface OpenOptions {
+        /** @default false */
+        wait?: boolean;
+    }
+
+    /**
+     * a function to build preview url from file path
+     */
+    interface UlrTransform {
+        (path: string): string;
+    }
+}
+
+export = previewEmail;

--- a/types/preview-email/preview-email-tests.ts
+++ b/types/preview-email/preview-email-tests.ts
@@ -1,0 +1,46 @@
+import previewEmail = require('preview-email');
+import { Options } from 'preview-email';
+import nodemailer = require('nodemailer');
+import { Options as NodeMailerOptions } from 'nodemailer/lib/mailer';
+
+// tests for `README Driven Development`
+const transport = nodemailer.createTransport({
+    jsonTransport: true,
+});
+
+const message: NodeMailerOptions = {
+    from: 'niftylettuce+from@gmail.com',
+    to: 'niftylettuce+to@gmail.com',
+    subject: 'Hello world',
+    html: '<p>Hello world</p>',
+    text: 'Hello world',
+    attachments: [{ filename: 'hello-world.txt', content: 'Hello world' }],
+};
+
+// note that `attachments` will not be parsed unless you use
+// `previewEmail` with the results of `transport.sendMail`
+// e.g. `previewEmail(JSON.parse(res.message));` where `res`
+// is `const res = await transport.sendMail(message);`
+previewEmail(message).then(console.log).catch(console.error);
+transport.sendMail(message).then(console.log).catch(console.error);
+
+// tests
+
+const options: Options = {
+    dir: './dir',
+    id: 'some-id',
+    open: true,
+    template: './dir/template.pug',
+    urlTransform: path => `./dir/${path}`,
+};
+
+// async/await
+(async () => {
+    try {
+        await previewEmail(message); // $ExpectType string
+        await previewEmail(message, {}); // $ExpectType string
+        await previewEmail(message, options); // $ExpectType string
+    } catch (error) {
+        //
+    }
+})();

--- a/types/preview-email/tsconfig.json
+++ b/types/preview-email/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "preview-email-tests.ts"
+    ]
+}

--- a/types/preview-email/tslint.json
+++ b/types/preview-email/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- definition type for `preview-email)
- tests

https://github.com/forwardemail/preview-email#usage

Thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. 
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.