### PR TITLE
[office-js, office-js-preview] Remove SVG size limitation note

### DIFF
--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -4062,15 +4062,6 @@ declare namespace Office {
          *   </tr>
          * </table>
          *
-         * **Type-specific behaviors**
-         *
-         * <table>
-         *   <tr>
-         *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>(Excel only): In Excel builds between 16.0.11526.10000 and 16.0.12309.10000, there is a 64KB size limitation for SVG insertions.</td>
-         *   </tr>
-         * </table>
-         *
          * **Hosts**
          *
          * The possible values for the {@link Office.CoercionType} parameter vary by the host.
@@ -4257,16 +4248,6 @@ declare namespace Office {
          *     <td>PowerPoint</td>
          *     <td>Insert image</td>
          *     <td>Inserted images are floating. The position imageLeft and imageTop parameters are optional but if provided, both should be present. If a single value is provided, it will be ignored. Negative imageLeft and imageTop values are allowed and can position an image outside of a slide. If no optional parameter is given and slide has a placeholder, the image will replace the placeholder in the slide. Image aspect ratio will be locked unless both imageWidth and imageHeight parameters are provided. If only one of the imageWidth and imageHeight parameter is given, the other value will be automatically scaled to keep the original aspect ratio.</td>
-         *   </tr>
-         * </table>
-         *
-         *
-         * **Type-specific behaviors**
-         *
-         * <table>
-         *   <tr>
-         *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>(Excel only): There is a 64KB size limitation for SVG insertions as of build 16.0.11526.10000.</td>
          *   </tr>
          * </table>
          *

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -3797,15 +3797,6 @@ declare namespace Office {
          *   </tr>
          * </table>
          * 
-         * **Type-specific behaviors**
-         * 
-         * <table>
-         *   <tr>
-         *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>(Excel only): In Excel builds between 16.0.11526.10000 and 16.0.12309.10000, there is a 64KB size limitation for SVG insertions.</td>
-         *   </tr>
-         * </table>
-         * 
          * **Hosts**
          * 
          * The possible values for the {@link Office.CoercionType} parameter vary by the host. 
@@ -3992,15 +3983,6 @@ declare namespace Office {
          *     <td>PowerPoint</td>
          *     <td>Insert image</td>
          *     <td>Inserted images are floating. The position imageLeft and imageTop parameters are optional but if provided, both should be present. If a single value is provided, it will be ignored. Negative imageLeft and imageTop values are allowed and can position an image outside of a slide. If no optional parameter is given and slide has a placeholder, the image will replace the placeholder in the slide. Image aspect ratio will be locked unless both imageWidth and imageHeight parameters are provided. If only one of the imageWidth and imageHeight parameter is given, the other value will be automatically scaled to keep the original aspect ratio.</td>
-         *   </tr>
-         * </table>
-         * 
-         * **Type-specific behaviors**
-         * 
-         * <table>
-         *   <tr>
-         *     <td>`Office.CoercionType.XmlSvg`</td>
-         *     <td>(Excel only): There is a 64KB size limitation for SVG insertions as of build 16.0.11526.10000.</td>
          *   </tr>
          * </table>
          * 


### PR DESCRIPTION
The current SAC build of Excel has been updated, so there shouldn't be users in the previously specified build range.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.microsoft.com/en-us/officeupdates/semi-annual-enterprise-channel
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.