### PR TITLE
Add types for 'html-docx-js' package

### DIFF
--- a/types/html-docx-js/html-docx-js-tests.ts
+++ b/types/html-docx-js/html-docx-js-tests.ts
@@ -1,0 +1,48 @@
+import { asBlob } from 'html-docx-js';
+
+const html = `
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <!-- page content -->
+  </body>
+</html>
+`;
+
+// Invalid ways to call
+asBlob(); // $ExpectError
+asBlob(1234); // $ExpectError
+asBlob(html, null); // $ExpectError
+asBlob(html, { orientation: 'invalid' }); // $ExpectError
+asBlob(html, { foo: ['bar'] }); // $ExpectError
+
+// Valid ways to call
+asBlob(html); // $ExpectType Blob | Buffer
+asBlob(html, {}); // $ExpectType Blob | Buffer
+
+const result1 = asBlob(html, {
+    orientation: 'landscape',
+    margins: {
+        top: 100,
+        right: 100,
+        bottom: 100,
+        left: 100,
+        header: 100,
+        footer: 100,
+        gutter: 100,
+    },
+});
+result1; // $ExpectType Blob | Buffer
+
+const result2 = asBlob(html, {
+    margins: {
+        top: 75,
+        right: 75,
+        bottom: 75,
+        left: 75,
+    },
+});
+result2; // $ExpectType Blob | Buffer

--- a/types/html-docx-js/index.d.ts
+++ b/types/html-docx-js/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for html-docx-js 0.3
 // Project: https://github.com/evidenceprime/html-docx-js#readme
-// Definitions by: Jacob Fischer <https://github.com/me>
+// Definitions by: Jacob Fischer <https://github.com/JacobFischer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/html-docx-js/index.d.ts
+++ b/types/html-docx-js/index.d.ts
@@ -1,0 +1,48 @@
+// Type definitions for html-docx-js 0.3
+// Project: https://github.com/evidenceprime/html-docx-js#readme
+// Definitions by: Jacob Fischer <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+/**
+ * To generate DOCX, simply pass a HTML document (as string) to this method
+ * to receive `Blob` (or `Buffer`) containing the output file.
+ */
+export function asBlob(
+    /**
+     * An HTML formatted string. It should be a complete, valid HTML
+     * (including DOCTYPE, `html` and `body` tags).
+     * This may be less convenient, but gives you possibility of including
+     * CSS rules in `style` tags.
+     */
+    html: string,
+    /** Additional options for controlling page setup for the document. */
+    options?: {
+        /**
+         * Page orientation. Must be `landscape` or `portrait` (default).
+         */
+        orientation?: 'landscape' | 'portrait';
+        /**
+         * A map of margin sizes (expressed in twentieths of point, see
+         * [WordprocessingML documentation](http://officeopenxml.com/WPsectionPgMar.php)
+         * for details).
+         */
+        margins?: {
+            /** The top page margin (default: 1440, i.e. 2.54 cm). */
+            top?: number;
+            /** The right page margin (default: 1440). */
+            right?: number;
+            /** The bottom page margin (default: 1440). */
+            bottom?: number;
+            /** The left page margin (default: 1440). */
+            left?: number;
+            /** The margin for the header (default: 720). */
+            header?: number;
+            /** The margin for the footer (default: 720). */
+            footer?: number;
+            /** The margin for the gutter (default: 0). */
+            gutter?: number;
+        };
+    },
+): Blob | Buffer;

--- a/types/html-docx-js/tsconfig.json
+++ b/types/html-docx-js/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "html-docx-js-tests.ts"
+    ]
+}

--- a/types/html-docx-js/tslint.json
+++ b/types/html-docx-js/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR adds type definitions for the [`html-docx-js`](https://www.npmjs.com/package/html-docx-js) package, which previously had none.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
