### PR TITLE
Fix redux-pack success typo

### DIFF
--- a/types/redux-pack/index.d.ts
+++ b/types/redux-pack/index.d.ts
@@ -23,7 +23,7 @@ export const LIFECYCLE: {
     readonly FAILURE: 'failure';
 };
 
-export type LIFECYCLEValues = 'start' | 'succes' | 'failure';
+export type LIFECYCLEValues = 'start' | 'success' | 'failure';
 
 export const middleware: Middleware;
 

--- a/types/redux-pack/redux-pack-tests.ts
+++ b/types/redux-pack/redux-pack-tests.ts
@@ -1,4 +1,4 @@
-import { handle, Action, GetState } from 'redux-pack';
+import { handle, Action, MetaPayload, LIFECYCLE } from 'redux-pack';
 
 interface Foo {
   id: string;
@@ -112,3 +112,8 @@ function userDoesFoo(): Action<FooState, Foo> {
     }
   };
 }
+
+// It should work fine with the success lifecycle
+const payloadMeta: MetaPayload<{}> = {
+  'redux-pack/LIFECYCLE': LIFECYCLE.SUCCESS
+};


### PR DESCRIPTION
Fix typo in the redux-pack package.

```typescript
// 'succes' --> 'success'
```

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [example](https://gist.github.com/leandrotk/b2470638929a62d04aeadb1c0b8dfadd)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.