### PR TITLE
Leaflet.Control.Attribution.setPrefix allows false

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1410,7 +1410,7 @@ export namespace Control {
 
     class Attribution extends Control {
         constructor(options?: AttributionOptions);
-        setPrefix(prefix: string): this;
+        setPrefix(prefix: string | false): this;
         addAttribution(text: string): this;
         removeAttribution(text: string): this;
         options: AttributionOptions;


### PR DESCRIPTION
See https://leafletjs.com/reference-1.6.0.html#control-attribution-prefix
