### PR TITLE
[@types/relay-runtime]: drop unused type field and add invalidation method to RecordProxy

### DIFF
--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -358,6 +358,7 @@ export interface RecordProxy<T = {}> {
     ): RecordProxy<T>;
     setValue<K extends keyof T>(value: T[K], name: K, args?: Variables | null): RecordProxy<T>;
     setValue(value: Primitive | Primitive[], name: string, args?: Variables | null): RecordProxy;
+    invalidateRecord(): void;
 }
 
 export interface ReadOnlyRecordProxy {

--- a/types/relay-runtime/lib/util/ReaderNode.d.ts
+++ b/types/relay-runtime/lib/util/ReaderNode.d.ts
@@ -131,7 +131,6 @@ export interface ReaderLocalArgument {
 export interface ReaderRootArgument {
     readonly kind: string; // 'RootArgument';
     readonly name: string;
-    readonly type: string | null | undefined;
 }
 
 export interface ReaderRefetchMetadata {

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -139,6 +139,7 @@ function handlerProvider(handle: any) {
 }
 
 function storeUpdater(store: RecordSourceSelectorProxy) {
+    store.invalidateStore();
     const mutationPayload = store.getRootField('sendConversationMessage');
     const newMessageEdge = mutationPayload!.getLinkedRecord('messageEdge');
     const conversationStore = store.get('a-conversation-id');
@@ -170,6 +171,7 @@ function passToHelper(edge: RecordProxy<MessageEdge>) {
 }
 
 function storeUpdaterWithTypes(store: RecordSourceSelectorProxy<SendConversationMessageMutationResponse>) {
+    store.invalidateStore();
     const mutationPayload = store.getRootField('sendConversationMessage');
     const newMessageEdge = mutationPayload.getLinkedRecord('messageEdge');
     const id = newMessageEdge.getValue('id');

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -298,13 +298,11 @@ const nodeFragment: ReaderFragment = {
             defaultValue: null,
             kind: 'LocalArgument',
             name: 'latArg',
-            type: 'String',
         },
         {
             defaultValue: null,
             kind: 'LocalArgument',
             name: 'lonArg',
-            type: 'String',
         },
     ],
     kind: 'Fragment',

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -142,6 +142,7 @@ function storeUpdater(store: RecordSourceSelectorProxy) {
     const mutationPayload = store.getRootField('sendConversationMessage');
     const newMessageEdge = mutationPayload!.getLinkedRecord('messageEdge');
     const conversationStore = store.get('a-conversation-id');
+    conversationStore!.invalidateRecord();
     const connection = ConnectionHandler.getConnection(conversationStore!, 'Messages_messages');
     if (connection) {
         ConnectionHandler.insertEdgeBefore(connection, newMessageEdge!);
@@ -173,6 +174,7 @@ function storeUpdaterWithTypes(store: RecordSourceSelectorProxy<SendConversation
     const newMessageEdge = mutationPayload.getLinkedRecord('messageEdge');
     const id = newMessageEdge.getValue('id');
     const conversationStore = store.get<TConversation>(id);
+    conversationStore!.invalidateRecord();
     const connection = ConnectionHandler.getConnection(conversationStore!, 'Messages_messages');
     if (connection) {
         ConnectionHandler.insertEdgeBefore(connection, newMessageEdge);


### PR DESCRIPTION
Update types to mirror the latest [Relay v10.0.0](https://github.com/facebook/relay/releases/tag/v10.0.0) update.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/facebook/relay/commit/812e0f466a6b9d203f6f786d275b590905a999f5#diff-bbe7372d54825bade531d0762390bccaL116>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
