### PR TITLE
Add type definitions for import-all.macro

### DIFF
--- a/types/import-all.macro/import-all.macro-tests.ts
+++ b/types/import-all.macro/import-all.macro-tests.ts
@@ -1,0 +1,11 @@
+import importAll from 'import-all.macro';
+
+const asy = importAll<string>('./files/*.ts').then((modules: { [k: string]: string; }) => {
+    modules['./files/a.ts'].includes('foo');
+});
+
+const syn1: { [k: string]: unknown } = importAll.sync('./files/*.ts');
+
+const syn2: { [k: string]: Date } = importAll.sync<Date>('./files/*.ts');
+
+const def: { [k: string]: () => Promise<object>; } = importAll.deferred<object>('./files/*.ts');

--- a/types/import-all.macro/index.d.ts
+++ b/types/import-all.macro/index.d.ts
@@ -1,0 +1,76 @@
+// Type definitions for import-all.macro 3.0
+// Project: https://github.com/kentcdodds/import-all.macro#readme
+// Definitions by: Jakub Jirutka <https://github.com/jirutka>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.0
+
+interface ImportAll {
+    /**
+     * Generates dynamic `import()` for each file that matches the given glob
+     * and returns a Promise of an object with the imported modules indexed by
+     * the module file name.
+     *
+     * @example
+     * // this statement
+     * const routes = importAll('./routes/*.ts').then(all => {
+     *     console.log(all)
+     * })
+     *
+     * // will generate
+     * Promise.all([
+     *   import('./routes/a.ts'),
+     *   import('./routes/b.ts'),
+     * ]).then(function importAllHandler(importVals) {
+     *   return {
+     *     './routes/a.ts': importVals[0],
+     *     './routes/b.ts': importVals[1],
+     *   }
+     * }).then(all => {
+     *   console.log(all)
+     * })
+     */
+    <T = unknown>(glob: string): Promise<{ [filename: string]: T }>;
+
+    /**
+     * Generates static `import` for each file that matches the given glob
+     * and returns an object with the imported modules indexed by the module
+     * file name.
+     *
+     * @example
+     * // this statement
+     * const routes = importAll.sync('./routes/*.ts')
+     *
+     * // will generate
+     * import * as _routesATs from './routes/a.ts'
+     * import * as _routesBTs from './routes/b.ts'
+     * const routes = {
+     *   './routes/a.ts': _routesATs,
+     *   './routes/b.ts': _routesBTs,
+     * }
+     */
+    sync<T = unknown>(glob: string): { [filename: string]: T };
+
+    /**
+     * Generates and returns an object with a function returning a Promise of
+     * dynamic `import()` for each file that matches the given glob.
+     *
+     * @example
+     * // this statement
+     * const routes = importAll.deferred('./routes/*.ts')
+     *
+     * // will generate
+     * const routes = {
+     *   './routes/a.ts': function() {
+     *     return import('./routes/a.ts')
+     *   },
+     *   './routes/b.ts': function() {
+     *     return import('./routes/b.ts')
+     *   },
+     * }
+     */
+    deferred<T = unknown>(glob: string): { [filename: string]: () => Promise<T> };
+}
+
+declare const importAll: ImportAll;
+
+export default importAll;

--- a/types/import-all.macro/tsconfig.json
+++ b/types/import-all.macro/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "import-all.macro-tests.ts"
+    ]
+}

--- a/types/import-all.macro/tslint.json
+++ b/types/import-all.macro/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.