### PR TITLE
[ember__debug] Fix args in registerWarnHandler

### DIFF
--- a/types/ember/test/debug.ts
+++ b/types/ember/test/debug.ts
@@ -39,7 +39,17 @@ registerWarnHandler(() => {}); // $ExpectType void
 registerWarnHandler((message, { id }, next) => { // $ExpectType void
     message; // $ExpectType string
     id; // $ExpectType string
-    next; // $ExpectType () => void
+    next; // $ExpectType (message?: string | undefined, options?: { id: string; } | undefined) => void
+});
+registerWarnHandler((message, { id }, next) => { // $ExpectType void
+  message; // $ExpectType string
+  id; // $ExpectType string
+  next(); // $ExpectType void
+});
+registerWarnHandler((message, { id }, next) => { // $ExpectType void
+  message; // $ExpectType string
+  id; // $ExpectType string
+  next(message, { id }); // $ExpectType void
 });
 
 // next is not called, so no warnings get the default behavior

--- a/types/ember__debug/ember__debug-tests.ts
+++ b/types/ember__debug/ember__debug-tests.ts
@@ -49,7 +49,17 @@ registerWarnHandler(() => {}); // $ExpectType void
 registerWarnHandler((message, { id }, next) => { // $ExpectType void
     message; // $ExpectType string
     id; // $ExpectType string
-    next; // $ExpectType () => void
+    next; // $ExpectType (message?: string | undefined, options?: { id: string; } | undefined) => void
+});
+registerWarnHandler((message, { id }, next) => { // $ExpectType void
+    message; // $ExpectType string
+    id; // $ExpectType string
+    next(); // $ExpectType void
+});
+registerWarnHandler((message, { id }, next) => { // $ExpectType void
+    message; // $ExpectType string
+    id; // $ExpectType string
+    next(message, { id }); // $ExpectType void
 });
 
 // next is not called, so no warnings get the default behavior

--- a/types/ember__debug/index.d.ts
+++ b/types/ember__debug/index.d.ts
@@ -34,7 +34,7 @@ export function registerDeprecationHandler(handler: (message: string, options: {
  * The following example demonstrates its usage by registering a handler that does nothing overriding Ember's
  * default warning behavior.
  */
-export function registerWarnHandler(handler: (message: string, options: { id: string }, next: () => void) => void): void;
+export function registerWarnHandler(handler: (message: string, options: { id: string }, next: (message?: string, options?: { id: string }) => void) => void): void;
 
 /**
  * Run a function meant for debugging.


### PR DESCRIPTION
The `next` callback in `registerWarnHandler` actually takes several arguments.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    * [documentation](https://api.emberjs.com/ember/release/functions/@ember%2Fdebug/registerWarnHandler)
    * [source code](https://github.com/emberjs/ember.js/blob/cafbae485d2459b95fcca4301f7a63ad395701d3/packages/%40ember/debug/lib/handlers.ts#L23-L25)
- ~[ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- ~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~