### PR TITLE
KJUR.jws.JWS.sign signature should accept string based header

### DIFF
--- a/types/jsrsasign/modules/KJUR/jws/JWS.d.ts
+++ b/types/jsrsasign/modules/KJUR/jws/JWS.d.ts
@@ -170,7 +170,7 @@ declare namespace jsrsasign.KJUR.jws {
          * // header and payload can be passed by both string and object
          * sJWS = KJUR.jws.JWS.sign(null, '{alg:"HS256",cty:"JWT"}', '{age:21}', "aaa");
          */
-        function sign(alg: string | null, spHead: { alg: string }, spPayload: string | object, pass?: string): string;
+        function sign(alg: string | null, spHead: string | { alg: string }, spPayload: string | object, pass?: string): string;
 
         /**
          * verify JWS signature by specified key or certificate


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>> The [JSDoc itself](https://kjur.github.io/jsrsasign/api/symbols/KJUR.jws.JWS.html#.sign) says that the header field accepts a string 

