### PR TITLE
Add types for npm package dependency-solver

### DIFF
--- a/types/dependency-solver/dependency-solver-tests.ts
+++ b/types/dependency-solver/dependency-solver-tests.ts
@@ -1,0 +1,8 @@
+import { addMissingKeys, getDependedBy, getDependencyLines, getEdges, getInDegree, solve } from 'dependency-solver';
+
+const graph: { [key: string]: string[] } = addMissingKeys({ a: ['b', 'c'], c: ['b'] });
+const dependedBy_1: { [key: string]: number } = getDependedBy({ a: ['b', 'c'], c: ['b'] });
+const dependedBy_2: { [key: string]: number } = getEdges({ a: ['b', 'c'], c: ['b'] });
+const dependencyLines_1: Array<[string, string]> = getDependencyLines({ a: ['b', 'c'], c: ['b'] });
+const dependencyLines_2: Array<[string, string]> = getInDegree({ a: ['b', 'c'], c: ['b'] });
+const solved: string[] = solve({ a: ['b', 'c'], c: ['b'] });

--- a/types/dependency-solver/index.d.ts
+++ b/types/dependency-solver/index.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for dependency-solver 1.0
+// Project: https://github.com/haavistu/dependency-solver#readme
+// Definitions by: Justus Fluegel <https://github.com/Technikkeller>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Solve dependency graph
+ *
+ * @param g dependency graph
+ */
+export function solve(g: { [key: string]: string[] }): string[];
+
+/**
+ * Add missing keys for dependencies of other nodes
+ *
+ * @param g dependency graph
+ */
+export function addMissingKeys(g: { [key: string]: string[] }): { [key: string]: string[] };
+
+/**
+ * Get numbers of dependants for each node
+ *
+ * @param g dependency graph
+ */
+export function getEdges(g: { [key: string]: string[] }): { [key: string]: number };
+
+/**
+ * Get relations between dependencies, eg. the lines in a tree diagramm
+ *
+ * @param g dependency graph
+ */
+export function getInDegree(g: { [key: string]: string[] }): Array<[string, string]>;
+
+export { getEdges as getDependedBy, getInDegree as getDependencyLines };

--- a/types/dependency-solver/tsconfig.json
+++ b/types/dependency-solver/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "dependency-solver-tests.ts"
+    ]
+}

--- a/types/dependency-solver/tslint.json
+++ b/types/dependency-solver/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.