### PR TITLE
[@types/underscore] Collection and Array Tests - Each, ToArray, and Partition

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -83,6 +83,12 @@ declare module _ {
 
     type Collection<T> = List<T> | Dictionary<T>;
 
+    type EnumerableKey = string | number;
+
+    type CollectionKey<V> = V extends List<any> ? number
+        : V extends Dictionary<any> ? string
+        : never;
+
     interface Predicate<T> {
         (value: T): boolean;
     }
@@ -94,12 +100,6 @@ declare module _ {
     interface ObjectIterator<T, TResult, V = Dictionary<T>> {
         (element: T, key: string, object: V): TResult;
     }
-
-    type EnumerableKey = string | number;
-
-    type CollectionKey<V> = V extends List<any> ? number
-        : V extends Dictionary<any> ? string
-        : never;
 
     type CollectionIterator<T, TResult, V> = (element: T, key: CollectionKey<V>, collection: V) => TResult;
 

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -4088,9 +4088,9 @@ declare module _ {
             memo: TResult,
             context?: any
         ): TResult;
-        reduce<TResult = TypeOfCollection<V>>(
-            iteratee: MemoCollectionIterator<T, TResult | TypeOfCollection<V>, V>
-        ): TResult | TypeOfCollection<V> | undefined;
+        reduce<TResult = T>(
+            iteratee: MemoCollectionIterator<T, TResult | T, V>
+        ): TResult | T | undefined;
 
         /**
          * @see reduce
@@ -4116,9 +4116,9 @@ declare module _ {
             memo: TResult,
             context?: any
         ): TResult;
-        reduceRight<TResult = TypeOfCollection<V>>(
-            iteratee: MemoCollectionIterator<T, TResult | TypeOfCollection<V>, V>
-        ): TResult | TypeOfCollection<V> | undefined;
+        reduceRight<TResult = T>(
+            iteratee: MemoCollectionIterator<T, TResult | T, V>
+        ): TResult | T | undefined;
 
         /**
          * @see reduceRight
@@ -5086,9 +5086,9 @@ declare module _ {
             memo: TResult,
             context?: any
         ): _ChainSingle<TResult>;
-        reduce<TResult = TypeOfCollection<V>>(
-            iteratee: MemoCollectionIterator<T, TResult | TypeOfCollection<V>, V>
-        ): _ChainSingle<TResult | TypeOfCollection<V> | undefined>;
+        reduce<TResult = T>(
+            iteratee: MemoCollectionIterator<T, TResult | T, V>
+        ): _ChainSingle<TResult | T | undefined>;
 
         /**
          * @see reduce
@@ -5114,9 +5114,9 @@ declare module _ {
             memo: TResult,
             context?: any
         ): _ChainSingle<TResult>;
-        reduceRight<TResult = TypeOfCollection<V>>(
-            iteratee: MemoCollectionIterator<T, TResult | TypeOfCollection<V>, V>
-        ): _ChainSingle<TResult | TypeOfCollection<V> | undefined>;
+        reduceRight<TResult = T>(
+            iteratee: MemoCollectionIterator<T, TResult | T, V>
+        ): _ChainSingle<TResult | T | undefined>;
 
         /**
          * @see reduceRight

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -93,17 +93,13 @@ declare module _ {
         (value: T): boolean;
     }
 
-    interface ListIterator<T, TResult, V = List<T>> {
-        (value: T, index: number, list: V): TResult;
-    }
-
-    interface ObjectIterator<T, TResult, V = Dictionary<T>> {
-        (element: T, key: string, object: V): TResult;
-    }
-
-    interface CollectionIterator<T, TResult, V> {
+    interface CollectionIterator<T, TResult, V = Collection<T>> {
         (element: T, key: CollectionKey<V>, collection: V): TResult;
     }
+
+    interface ListIterator<T, TResult, V extends List<T> = List<T>> extends CollectionIterator<T, TResult, V> { }
+
+    interface ObjectIterator<T, TResult, V extends Dictionary<T> = Dictionary<T>> extends CollectionIterator<T, TResult, V> { }
 
     type Iteratee<V, R, T extends TypeOfCollection<V> = TypeOfCollection<V>> =
         undefined |
@@ -125,17 +121,13 @@ declare module _ {
 
     type PropertyTypeOrAny<T, K> = K extends keyof T ? T[K] : any;
 
-    interface MemoIterator<T, TResult, V = List<T>> {
-        (prev: TResult, curr: T, index: number, list: V): TResult;
-    }
-
-    interface MemoObjectIterator<T, TResult, V = Dictionary<T>> {
-        (prev: TResult, curr: T, key: string, object: V): TResult;
-    }
-
-    interface MemoCollectionIterator<T, TResult, V> {
+    interface MemoCollectionIterator<T, TResult, V = Collection<T>> {
         (prev: TResult, curr: T, key: CollectionKey<V>, collection: V): TResult;
     }
+
+    interface MemoIterator<T, TResult, V extends List<T> = List<T>> extends MemoCollectionIterator<T, TResult, V> { }
+
+    interface MemoObjectIterator<T, TResult, V extends Dictionary<T> = Dictionary<T>> extends MemoCollectionIterator<T, TResult, V> { }
 
     type TypeOfList<V> = V extends List<infer T> ? T : never;
 

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -125,6 +125,14 @@ declare module _ {
 
     type PropertyTypeOrAny<T, K> = K extends keyof T ? T[K] : any;
 
+    interface MemoIterator<T, TResult, V = List<T>> {
+        (prev: TResult, curr: T, index: number, list: V): TResult;
+    }
+
+    interface MemoObjectIterator<T, TResult, V = Dictionary<T>> {
+        (prev: TResult, curr: T, key: string, object: V): TResult;
+    }
+
     interface MemoCollectionIterator<T, TResult, V> {
         (prev: TResult, curr: T, key: CollectionKey<V>, collection: V): TResult;
     }

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -180,8 +180,8 @@ declare module _ {
         /**
          * Iterates over a collection of elements, yielding each in turn to an
          * iteratee. The iteratee is bound to the context object, if one is
-         * passed. If iteratee is a function, Each invocation is called with
-         * three arguments: (value, key, collection).
+         * passed. Each invocation of `iteratee` is called with three
+         * arguments: (element, key, collection).
          * @param collection The collection of elements to iterate over.
          * @param iteratee The iteratee to call for each element in
          * `collection`.
@@ -4064,8 +4064,8 @@ declare module _ {
         /**
          * Iterates over the wrapped collection of elements, yielding each in
          * turn to an iteratee. The iteratee is bound to the context object, if
-         * one is passed. If iteratee is a function, Each invocation is called
-         * with three arguments: (value, key, collection).
+         * one is passed. Each invocation of `iteratee` is called with three
+         * arguments: (element, key, collection).
          * @param iteratee The iteratee to call for each element in the wrapped
          * collection.
          * @param context 'this' object in `iteratee`, optional.
@@ -5061,8 +5061,8 @@ declare module _ {
         /**
          * Iterates over the wrapped collection of elements, yielding each in
          * turn to an iteratee. The iteratee is bound to the context object, if
-         * one is passed. If iteratee is a function, Each invocation is called
-         * with three arguments: (value, key, collection).
+         * one is passed. Each invocation of `iteratee` is called with three
+         * arguments: (element, key, collection).
          * @param iteratee The iteratee to call for each element in the wrapped
          * collection.
          * @param context 'this' object in `iteratee`, optional.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -236,26 +236,16 @@ declare module _ {
          * @param context `this` object in `iteratee`, optional.
          * @returns The reduced result.
          **/
-        reduce<V extends List<any>, TResult>(
+        reduce<V extends Collection<any>, TResult>(
             collection: V,
-            iteratee: MemoIterator<TypeOfList<V>, TResult, V>,
+            iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult, V>,
             memo: TResult,
             context?: any
         ): TResult;
-        reduce<V extends Dictionary<any>, TResult>(
+        reduce<V extends Collection<any>, TResult = TypeOfCollection<V>>(
             collection: V,
-            iteratee: MemoObjectIterator<TypeOfDictionary<V>, TResult, V>,
-            memo: TResult,
-            context?: any
-        ): TResult;
-        reduce<V extends List<any>, TResult = TypeOfList<V>>(
-            collection: V,
-            iteratee: MemoIterator<TypeOfList<V>, TResult | TypeOfList<V>, V>
-        ): TResult | TypeOfList<V> | undefined;
-        reduce<V extends Dictionary<any>, TResult = TypeOfDictionary<V>>(
-            collection: V,
-            iteratee: MemoObjectIterator<TypeOfDictionary<V>, TResult | TypeOfDictionary<V>, V>
-        ): TResult | TypeOfDictionary<V> | undefined;
+            iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult | TypeOfCollection<V>, V>
+        ): TResult | TypeOfCollection<V> | undefined;
 
         /**
          * @see reduce
@@ -277,26 +267,16 @@ declare module _ {
          * @param context `this` object in `iteratee`, optional.
          * @returns The reduced result.
          **/
-        reduceRight<V extends List<any>, TResult>(
+        reduceRight<V extends Collection<any>, TResult>(
             collection: V,
-            iteratee: MemoIterator<TypeOfList<V>, TResult, V>,
+            iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult, V>,
             memo: TResult,
             context?: any
         ): TResult;
-        reduceRight<V extends Dictionary<any>, TResult>(
+        reduceRight<V extends Collection<any>, TResult = TypeOfCollection<V>>(
             collection: V,
-            iteratee: MemoObjectIterator<TypeOfDictionary<V>, TResult, V>,
-            memo: TResult,
-            context?: any
-        ): TResult;
-        reduceRight<V extends List<any>, TResult = TypeOfList<V>>(
-            collection: V,
-            iteratee: MemoIterator<TypeOfList<V>, TResult | TypeOfList<V>, V>
-        ): TResult | TypeOfList<V> | undefined;
-        reduceRight<V extends Dictionary<any>, TResult = TypeOfDictionary<V>>(
-            collection: V,
-            iteratee: MemoObjectIterator<TypeOfDictionary<V>, TResult | TypeOfDictionary<V>, V>
-        ): TResult | TypeOfDictionary<V> | undefined;
+            iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult | TypeOfCollection<V>, V>
+        ): TResult | TypeOfCollection<V> | undefined;
 
         /**
          * @see reduceRight

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -101,7 +101,9 @@ declare module _ {
         (element: T, key: string, object: V): TResult;
     }
 
-    type CollectionIterator<T, TResult, V> = (element: T, key: CollectionKey<V>, collection: V) => TResult;
+    interface CollectionIterator<T, TResult, V> {
+        (element: T, key: CollectionKey<V>, collection: V): TResult;
+    }
 
     type Iteratee<V, R, T extends TypeOfCollection<V> = TypeOfCollection<V>> =
         undefined |
@@ -131,10 +133,9 @@ declare module _ {
         (prev: TResult, curr: T, key: string, object: V): TResult;
     }
 
-    type MemoCollectionIterator<T, TResult, V> =
-        V extends List<T> ? MemoIterator<T, TResult, V>
-        : V extends Dictionary<T> ? MemoObjectIterator<T, TResult, V>
-        : never;
+    interface MemoCollectionIterator<T, TResult, V> {
+        (prev: TResult, curr: T, key: CollectionKey<V>, collection: V): TResult;
+    }
 
     type TypeOfList<V> = V extends List<infer T> ? T : never;
 

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -109,7 +109,7 @@ declare module _ {
         undefined |
         CollectionIterator<T, R, V> |
         EnumerableKey |
-        Array<EnumerableKey> |
+        EnumerableKey[] |
         Partial<T>;
 
     // temporary iteratee type for _Chain until _Chain return types have been fixed
@@ -119,7 +119,7 @@ declare module _ {
         I extends undefined ? T // default iteratee is _.identity
         : I extends (...args: any[]) => infer R ? R
         : I extends keyof T ? T[I]
-        : I extends EnumerableKey | Array<EnumerableKey> ? any
+        : I extends EnumerableKey |EnumerableKey[] ? any
         : I extends Partial<T> ? boolean
         : never;
 

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -97,10 +97,11 @@ declare module _ {
 
     type EnumerableKey = string | number;
 
-    type CollectionIterator<T, TResult, V> =
-        V extends List<T> ? ListIterator<T, TResult, V>
-        : V extends Dictionary<T> ? ObjectIterator<T, TResult, V>
+    type CollectionKey<V> = V extends List<any> ? number
+        : V extends Dictionary<any> ? string
         : never;
+
+    type CollectionIterator<T, TResult, V> = (element: T, key: CollectionKey<V>, collection: V) => TResult;
 
     type Iteratee<V, R, T extends TypeOfCollection<V> = TypeOfCollection<V>> =
         undefined |

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -125,14 +125,6 @@ declare module _ {
 
     type PropertyTypeOrAny<T, K> = K extends keyof T ? T[K] : any;
 
-    interface MemoIterator<T, TResult, V = List<T>> {
-        (prev: TResult, curr: T, index: number, list: V): TResult;
-    }
-
-    interface MemoObjectIterator<T, TResult, V = Dictionary<T>> {
-        (prev: TResult, curr: T, key: string, object: V): TResult;
-    }
-
     interface MemoCollectionIterator<T, TResult, V> {
         (prev: TResult, curr: T, key: CollectionKey<V>, collection: V): TResult;
     }

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -723,7 +723,7 @@ declare module _ {
          **/
         partition<V extends Collection<any>>(
             list: V,
-            iteratee: Iteratee<V, boolean>,
+            iteratee?: Iteratee<V, boolean>,
             context?: any
         ): [TypeOfCollection<V>[], TypeOfCollection<V>[]];
 
@@ -4387,7 +4387,7 @@ declare module _ {
          * contains the elements in the wrapped collection that satisfied the
          * predicate and the second element contains the elements that did not.
          **/
-        partition(iteratee: Iteratee<V, boolean>, context?: any): [T[], T[]];
+        partition(iteratee?: Iteratee<V, boolean>, context?: any): [T[], T[]];
 
         /*********
         * Arrays *
@@ -5389,7 +5389,7 @@ declare module _ {
          * collection that satisfied the predicate and the second element
          * contains the elements that did not.
          **/
-        partition(iteratee: _ChainIteratee<V, boolean, T>, context?: any): _Chain<T[], [T[], T[]]>;
+        partition(iteratee?: _ChainIteratee<V, boolean, T>, context?: any): _Chain<T[], [T[], T[]]>;
 
         /*********
         * Arrays *

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -102,21 +102,22 @@ declare module _ {
     interface ObjectIterator<T extends TypeOfDictionary<V>, TResult, V = Dictionary<T>> extends CollectionIterator<T, TResult, V> { }
 
     type Iteratee<V, R, T extends TypeOfCollection<V> = TypeOfCollection<V>> =
-        undefined |
         CollectionIterator<T, R, V> |
         EnumerableKey |
         EnumerableKey[] |
-        Partial<T>;
+        Partial<T> |
+        null |
+        undefined;
 
     // temporary iteratee type for _Chain until _Chain return types have been fixed
     type _ChainIteratee<V, R, T> = Iteratee<V extends Collection<T> ? V : T[], R>;
 
     type IterateeResult<I, T> =
-        I extends undefined ? T // default iteratee is _.identity
-        : I extends (...args: any[]) => infer R ? R
+        I extends (...args: any[]) => infer R ? R
         : I extends keyof T ? T[I]
         : I extends EnumerableKey |EnumerableKey[] ? any
         : I extends Partial<T> ? boolean
+        : I extends null | undefined ? T
         : never;
 
     type PropertyTypeOrAny<T, K> = K extends keyof T ? T[K] : any;

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -123,8 +123,6 @@ declare module _ {
 
     type PropertyTypeOrAny<T, K> = K extends keyof T ? T[K] : any;
 
-    type IterateePropertyShorthand = string | number;
-
     interface MemoIterator<T, TResult, V = List<T>> {
         (prev: TResult, curr: T, index: number, list: V): TResult;
     }

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -179,45 +179,26 @@ declare module _ {
         ************* */
 
         /**
-        * Iterates over a list of elements, yielding each in turn to an iterator function. The iterator is
-        * bound to the context object, if one is passed. Each invocation of iterator is called with three
-        * arguments: (element, index, list). If list is a JavaScript object, iterator's arguments will be
-        * (value, key, object). Delegates to the native forEach function if it exists.
-        * @param list Iterates over this list of elements.
-        * @param iterator Iterator function for each element `list`.
-        * @param context 'this' object in `iterator`, optional.
-        **/
-        each<T>(
-            list: _.List<T>,
-            iterator: _.ListIterator<T, void>,
-            context?: any): _.List<T>;
+         * Iterates over a collection of elements, yielding each in turn to an
+         * iteratee. The iteratee is bound to the context object, if one is
+         * passed. If iteratee is a function, Each invocation is called with
+         * three arguments: (value, key, collection).
+         * @param collection The collection of elements to iterate over.
+         * @param iteratee The iteratee to call for each element in
+         * `collection`.
+         * @param context 'this' object in `iteratee`, optional.
+         * @returns The original collection.
+         **/
+        each<V extends Collection<any>>(
+            collection: V,
+            iteratee: CollectionIterator<TypeOfCollection<V>, void, V>,
+            context?: any
+        ): V;
 
         /**
-        * @see _.each
-        * @param object Iterates over properties of this object.
-        * @param iterator Iterator function for each property on `object`.
-        * @param context 'this' object in `iterator`, optional.
-        **/
-        each<T>(
-            object: _.Dictionary<T>,
-            iterator: _.ObjectIterator<T, void>,
-            context?: any): _.Dictionary<T>;
-
-        /**
-        * @see _.each
-        **/
-        forEach<T>(
-            list: _.List<T>,
-            iterator: _.ListIterator<T, void>,
-            context?: any): _.List<T>;
-
-        /**
-        * @see _.each
-        **/
-        forEach<T>(
-            object: _.Dictionary<T>,
-            iterator: _.ObjectIterator<T, void>,
-            context?: any): _.Dictionary<T>;
+         * @see each
+         **/
+        forEach: UnderscoreStatic['each'];
 
         /**
          * Produces a new array of values by mapping each value in the collection through a transformation function
@@ -714,12 +695,12 @@ declare module _ {
         sample<V extends Collection<any>>(collection: V): TypeOfCollection<V> | undefined;
 
         /**
-        * Converts the list (anything that can be iterated over), into a real Array. Useful for transmuting
-        * the arguments object.
-        * @param list object to transform into an array.
-        * @return `list` as an array.
-        **/
-        toArray<T>(list: _.Collection<T>): T[];
+         * Creates a real Array from the collection (anything that can be
+         * iterated over). Useful for transmuting the arguments object.
+         * @param collection The collection to transform into an array.
+         * @returns An array containing the elements of `collection`.
+         **/
+        toArray<V extends Collection<any>>(collection: V): TypeOfCollection<V>[];
 
         /**
         * Return the number of values in the list.
@@ -729,17 +710,21 @@ declare module _ {
         size<T>(list: _.Collection<T>): number;
 
         /**
-        * Split array into two arrays:
-        * one whose elements all satisfy predicate and one whose elements all do not satisfy predicate.
-        * @param array Array to split in two.
-        * @param iterator Filter iterator function for each element in `array`.
-        * @param context `this` object in `iterator`, optional.
-        * @return Array where Array[0] are the elements in `array` that satisfies the predicate, and Array[1] the elements that did not.
-        **/
-        partition<T>(
-            array: Array<T>,
-            iterator: _.ListIterator<T, boolean>,
-            context?: any): T[][];
+         * Splits `collection` into two arrays: one whose elements all satisfy
+         * `iteratee` and one whose elements all do not satisfy `iteratee`.
+         * @param collection The collection to partition.
+         * @param iteratee The iteratee that defines the partitioning scheme
+         * for each element in `collection`.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns An array composed of two elements, where the first element
+         * contains the elements in `collection` that satisfied the predicate
+         * and the second element contains the elements that did not.
+         **/
+        partition<V extends Collection<any>>(
+            list: V,
+            iteratee: Iteratee<V, boolean>,
+            context?: any
+        ): [TypeOfCollection<V>[], TypeOfCollection<V>[]];
 
         /*********
         * Arrays *
@@ -4078,25 +4063,21 @@ declare module _ {
         ************* */
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.each
-        **/
-        each(iterator: _.ListIterator<T, void>, context?: any): _.List<T>;
+         * Iterates over the wrapped collection of elements, yielding each in
+         * turn to an iteratee. The iteratee is bound to the context object, if
+         * one is passed. If iteratee is a function, Each invocation is called
+         * with three arguments: (value, key, collection).
+         * @param iteratee The iteratee to call for each element in the wrapped
+         * collection.
+         * @param context 'this' object in `iteratee`, optional.
+         * @returns The originally wrapped collection.
+         **/
+        each(iteratee: CollectionIterator<T, void, V>, context?: any): V;
 
         /**
-        * @see _.each
-        **/
-        each(iterator: _.ObjectIterator<T, void>, context?: any): _.List<T>;
-
-        /**
-        * @see _.each
-        **/
-        forEach(iterator: _.ListIterator<T, void>, context?: any): _.List<T>;
-
-        /**
-        * @see _.each
-        **/
-        forEach(iterator: _.ObjectIterator<T, void>, context?: any): _.List<T>;
+         * @see each
+         **/
+        forEach: Underscore<T, V>['each'];
 
         /**
          * Produces a new array of values by mapping each value in the wrapped collection through a transformation function
@@ -4382,9 +4363,10 @@ declare module _ {
         sample(): T | undefined;
 
         /**
-        * Wrapped type `any`.
-        * @see _.toArray
-        **/
+         * Creates a real Array from the wrapped collection (anything that can
+         * be iterated over). Useful for transmuting the arguments object.
+         * @returns An array containing the elements of the wrapped collection.
+         **/
         toArray(): T[];
 
         /**
@@ -4392,6 +4374,19 @@ declare module _ {
         * @see _.size
         **/
         size(): number;
+
+        /**
+         * Splits the wrapped collection into two arrays: one whose elements
+         * all satisfy `iteratee` and one whose elements all do not satisfy
+         * `iteratee`.
+         * @param iteratee The iteratee that defines the partitioning scheme
+         * for each element in the wrapped collection.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns An array composed of two elements, where the first element
+         * contains the elements in the wrapped collection that satisfied the
+         * predicate and the second element contains the elements that did not.
+         **/
+        partition(iteratee: Iteratee<V, boolean>, context?: any): [T[], T[]];
 
         /*********
         * Arrays *
@@ -4486,12 +4481,6 @@ declare module _ {
          * except for `values`.
          **/
         without(...values: T[]): T[];
-
-        /**
-        * Wrapped type `any[]`.
-        * @see _.partition
-        **/
-        partition(iterator: _.ListIterator<T, boolean>, context?: any): T[][];
 
         /**
         * Wrapped type `any[][]`.
@@ -5071,25 +5060,21 @@ declare module _ {
         ************* */
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.each
-        **/
-        each(iterator: _.ListIterator<T, void>, context?: any): _Chain<T>;
+         * Iterates over the wrapped collection of elements, yielding each in
+         * turn to an iteratee. The iteratee is bound to the context object, if
+         * one is passed. If iteratee is a function, Each invocation is called
+         * with three arguments: (value, key, collection).
+         * @param iteratee The iteratee to call for each element in the wrapped
+         * collection.
+         * @param context 'this' object in `iteratee`, optional.
+         * @returns A chain wrapper around the originally wrapped collection.
+         **/
+        each(iteratee: CollectionIterator<T, void, V>, context?: any): _Chain<T, V>;
 
         /**
-        * @see _.each
+        * @see each
         **/
-        each(iterator: _.ObjectIterator<T, void>, context?: any): _Chain<T>;
-
-        /**
-        * @see _.each
-        **/
-        forEach(iterator: _.ListIterator<T, void>, context?: any): _Chain<T>;
-
-        /**
-        * @see _.each
-        **/
-        forEach(iterator: _.ObjectIterator<T, void>, context?: any): _Chain<T>;
+        forEach: _Chain<T, V>['each'];
 
         /**
          * Produces a new array of values by mapping each value in the wrapped collection through a transformation function
@@ -5378,16 +5363,32 @@ declare module _ {
         sample(): _ChainSingle<T | undefined>;
 
         /**
-        * Wrapped type `any`.
-        * @see _.toArray
-        **/
-        toArray(): _Chain<T>;
+         * Creates a real Array from the wrapped collection (anything that can
+         * be iterated over). Useful for transmuting the arguments object.
+         * @returns A chain wrapper around an array containing the elements
+         * of the wrapped collection.
+         **/
+        toArray(): _Chain<T, T[]>;
 
         /**
         * Wrapped type `any`.
         * @see _.size
         **/
         size(): _ChainSingle<number>;
+
+        /**
+         * Splits the wrapped collection into two arrays: one whose elements
+         * all satisfy `iteratee` and one whose elements all do not satisfy
+         * `iteratee`.
+         * @param iteratee The iteratee that defines the partitioning scheme
+         * for each element in the wrapped collection.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns A chain wrapper around an array composed of two elements,
+         * where the first element contains the elements in the wrapped
+         * collection that satisfied the predicate and the second element
+         * contains the elements that did not.
+         **/
+        partition(iteratee: _ChainIteratee<V, boolean, T>, context?: any): _Chain<T[], [T[], T[]]>;
 
         /*********
         * Arrays *
@@ -5482,12 +5483,6 @@ declare module _ {
          * of the wrapped list except for `values`.
          **/
         without(...values: T[]): _Chain<T, T[]>;
-
-        /**
-        * Wrapped type `any[]`.
-        * @see _.partition
-        **/
-        partition(iterator: _.ListIterator<T, boolean>, context?: any): _Chain<T[]>;
 
         /**
         * Wrapped type `any[][]`.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -93,13 +93,13 @@ declare module _ {
         (value: T): boolean;
     }
 
-    interface CollectionIterator<T, TResult, V = Collection<T>> {
+    interface CollectionIterator<T extends TypeOfCollection<V>, TResult, V = Collection<T>> {
         (element: T, key: CollectionKey<V>, collection: V): TResult;
     }
 
-    interface ListIterator<T, TResult, V extends List<T> = List<T>> extends CollectionIterator<T, TResult, V> { }
+    interface ListIterator<T extends TypeOfList<V>, TResult, V = List<T>> extends CollectionIterator<T, TResult, V> { }
 
-    interface ObjectIterator<T, TResult, V extends Dictionary<T> = Dictionary<T>> extends CollectionIterator<T, TResult, V> { }
+    interface ObjectIterator<T extends TypeOfDictionary<V>, TResult, V = Dictionary<T>> extends CollectionIterator<T, TResult, V> { }
 
     type Iteratee<V, R, T extends TypeOfCollection<V> = TypeOfCollection<V>> =
         undefined |
@@ -121,23 +121,25 @@ declare module _ {
 
     type PropertyTypeOrAny<T, K> = K extends keyof T ? T[K] : any;
 
-    interface MemoCollectionIterator<T, TResult, V = Collection<T>> {
+    interface MemoCollectionIterator<T extends TypeOfCollection<V>, TResult, V = Collection<T>> {
         (prev: TResult, curr: T, key: CollectionKey<V>, collection: V): TResult;
     }
 
-    interface MemoIterator<T, TResult, V extends List<T> = List<T>> extends MemoCollectionIterator<T, TResult, V> { }
+    interface MemoIterator<T extends TypeOfList<V>, TResult, V = List<T>> extends MemoCollectionIterator<T, TResult, V> { }
 
-    interface MemoObjectIterator<T, TResult, V extends Dictionary<T> = Dictionary<T>> extends MemoCollectionIterator<T, TResult, V> { }
+    interface MemoObjectIterator<T extends TypeOfDictionary<V>, TResult, V = Dictionary<T>> extends MemoCollectionIterator<T, TResult, V> { }
 
-    type TypeOfList<V> = V extends List<infer T> ? T : never;
-
-    type TypeOfDictionary<V> = V extends Dictionary<infer T> ? T : never;
-
-    type TypeOfCollection<V> =
+    type TypeOfList<V> =
         V extends never ? any
         : V extends List<infer T> ? T
+        : never;
+
+    type TypeOfDictionary<V> =
+        V extends never ? any
         : V extends Dictionary<infer T> ? T
         : never;
+
+    type TypeOfCollection<V> = TypeOfList<V> | TypeOfDictionary<V>;
 
     type ListItemOrSelf<T> = T extends List<infer TItem> ? TItem : T;
 
@@ -4044,7 +4046,7 @@ declare module _ {
          * @param context 'this' object in `iteratee`, optional.
          * @returns The originally wrapped collection.
          **/
-        each(iteratee: CollectionIterator<T, void, V>, context?: any): V;
+        each(iteratee: CollectionIterator<TypeOfCollection<V>, void, V>, context?: any): V;
 
         /**
          * @see each
@@ -4084,13 +4086,13 @@ declare module _ {
          * @param context `this` object in `iteratee`, optional.
          * @returns The reduced result.
          **/
-        reduce<TResult>(iteratee: MemoCollectionIterator<T, TResult, V>,
+        reduce<TResult>(iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult, V>,
             memo: TResult,
             context?: any
         ): TResult;
-        reduce<TResult = T>(
-            iteratee: MemoCollectionIterator<T, TResult | T, V>
-        ): TResult | T | undefined;
+        reduce<TResult = TypeOfCollection<V>>(
+            iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult | TypeOfCollection<V>, V>
+        ): TResult | TypeOfCollection<V> | undefined;
 
         /**
          * @see reduce
@@ -4112,13 +4114,13 @@ declare module _ {
          * @returns The reduced result.
          **/
         reduceRight<TResult>(
-            iteratee: MemoCollectionIterator<T, TResult, V>,
+            iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult, V>,
             memo: TResult,
             context?: any
         ): TResult;
-        reduceRight<TResult = T>(
-            iteratee: MemoCollectionIterator<T, TResult | T, V>
-        ): TResult | T | undefined;
+        reduceRight<TResult = TypeOfCollection<V>>(
+            iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult | TypeOfCollection<V>, V>
+        ): TResult | TypeOfCollection<V> | undefined;
 
         /**
          * @see reduceRight
@@ -5041,7 +5043,7 @@ declare module _ {
          * @param context 'this' object in `iteratee`, optional.
          * @returns A chain wrapper around the originally wrapped collection.
          **/
-        each(iteratee: CollectionIterator<T, void, V>, context?: any): _Chain<T, V>;
+        each(iteratee: CollectionIterator<TypeOfCollection<V>, void, V>, context?: any): _Chain<T, V>;
 
         /**
         * @see each
@@ -5082,13 +5084,13 @@ declare module _ {
          * @returns The reduced result in a chain wraper.
          **/
         reduce<TResult>(
-            iteratee: MemoCollectionIterator<T, TResult, V>,
+            iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult, V>,
             memo: TResult,
             context?: any
         ): _ChainSingle<TResult>;
-        reduce<TResult = T>(
-            iteratee: MemoCollectionIterator<T, TResult | T, V>
-        ): _ChainSingle<TResult | T | undefined>;
+        reduce<TResult = TypeOfCollection<V>>(
+            iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult | TypeOfCollection<V>, V>
+        ): _ChainSingle<TResult | TypeOfCollection<V> | undefined>;
 
         /**
          * @see reduce
@@ -5110,13 +5112,13 @@ declare module _ {
          * @returns The reduced result in a chain wrapper.
          **/
         reduceRight<TResult>(
-            iteratee: MemoCollectionIterator<T, TResult, V>,
+            iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult, V>,
             memo: TResult,
             context?: any
         ): _ChainSingle<TResult>;
-        reduceRight<TResult = T>(
-            iteratee: MemoCollectionIterator<T, TResult | T, V>
-        ): _ChainSingle<TResult | T | undefined>;
+        reduceRight<TResult = TypeOfCollection<V>>(
+            iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult | TypeOfCollection<V>, V>
+        ): _ChainSingle<TResult | TypeOfCollection<V> | undefined>;
 
         /**
          * @see reduceRight

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -663,6 +663,139 @@ interface ChainTypeExtractor {
 
 declare const extractChainTypes: ChainTypeExtractor;
 
+// Types
+
+// Iteratee
+{
+    // functions
+    const listFunctionIteratee: _.Iteratee<_.List<StringRecord>, string> = (element, key, collection) => {
+        element; // $ExpectType StringRecord
+        key; // $ExpectType number
+        collection; // $ExpectType List<StringRecord>
+        return element.a;
+    };
+    listFunctionIteratee(stringRecordList[0], 0, stringRecordList);
+
+    const dictionaryFunctionIteratee: _.Iteratee<_.Dictionary<StringRecord>, string> = (element, key, collection) => {
+        element; // $ExpectType StringRecord
+        key; // $ExpectType string
+        collection; // $ExpectType Dictionary<StringRecord>
+        return element.a;
+    };
+    dictionaryFunctionIteratee(stringRecordDictionary['a'], 'a', stringRecordDictionary);
+
+    const unionCollectionItemFunctionIteratee: _.Iteratee<_.List<IntersectingProperties>, string | boolean> = (element, key, collection) => {
+        element; // $ExpectType IntersectingProperties
+        key; // $ExpectType number
+        collection; // $ExpectType List<IntersectingProperties>
+        return element.a;
+    };
+    unionCollectionItemFunctionIteratee(intersectingPropertiesList[0], 0, intersectingPropertiesList); // $ExpectType string | boolean
+
+    const unionCollectionFunctionIteratee: _.Iteratee<_.Dictionary<StringRecord> | StringRecord[], string> = (element, key, collection) => {
+        element; // $ExpectType StringRecord
+        key; // $ExpectType string | number
+        collection; // $ExpectType Dictionary<StringRecord> | StringRecord[]
+        return element.a;
+    };
+    unionCollectionFunctionIteratee(stringRecordDictionary['a'], 'a', stringRecordDictionary); // $ExpectType string
+
+    const anyFunctionIteratee: _.Iteratee<any, string> = (element, key, collection) => {
+        element; // $ExpectType any
+        key; // $ExpectType string | number
+        collection; // $ExpectType any
+        return element.a;
+    };
+    if (_.isFunction(anyFunctionIteratee)) {
+        anyFunctionIteratee(stringRecordDictionary['a'], 'a', stringRecordDictionary); // $ExpectType string
+    }
+
+    // partial objects
+    const listPartialObjectIteratee: _.Iteratee<_.List<StringRecord>, string> = partialStringRecord;
+    listPartialObjectIteratee; // $ExpectType Partial<StringRecord>
+
+    const dictionaryPartialObjectIteratee: _.Iteratee<_.Dictionary<StringRecord>, string> = partialStringRecord;
+    dictionaryPartialObjectIteratee; // $ExpectType Partial<StringRecord>
+
+    const unionCollectionItemPartialObjectIteratee: _.Iteratee<_.List<IntersectingProperties>, string | boolean> = partialStringRecord;
+    unionCollectionItemPartialObjectIteratee; // $ExpectType Partial<StringRecord>
+
+    const unionCollectionPartialObjectIteratee: _.Iteratee<StringRecord[] | _.Dictionary<StringRecord>, string> = partialStringRecord;
+    unionCollectionPartialObjectIteratee; // $ExpectType Partial<StringRecord>
+
+    const anyPartialObjectIteratee: _.Iteratee<any, string> = partialStringRecord;
+    anyPartialObjectIteratee; // $ExpectType Partial<any>
+
+    // property names
+    const listPropertyNameIteratee: _.Iteratee<_.List<StringRecord>, string> = stringRecordProperty;
+    listPropertyNameIteratee; // $ExpectType string
+
+    const dictionaryPropertyNameIteratee: _.Iteratee<_.Dictionary<StringRecord>, string> = stringRecordProperty;
+    dictionaryPropertyNameIteratee; // $ExpectType string
+
+    const unionCollectionItemPropertyNameIteratee: _.Iteratee<_.List<IntersectingProperties>, string | boolean> = stringRecordProperty;
+    unionCollectionItemPropertyNameIteratee; // $ExpectType string
+
+    const unionCollectionPropertyNameIteratee: _.Iteratee<StringRecord[] | _.Dictionary<StringRecord>, string> = stringRecordProperty;
+    unionCollectionPropertyNameIteratee; // $ExpectType string
+
+    const anyPropertyNameteratee: _.Iteratee<any, string> = stringRecordProperty;
+    anyPropertyNameteratee; // $ExpectType string
+
+    // property paths
+    const listPropertyPathIteratee: _.Iteratee<_.List<StringRecord>, string> = stringRecordPropertyPath;
+    listPropertyPathIteratee; // $ExpectType (string | number)[]
+
+    const dictionaryPropertyPathIteratee: _.Iteratee<_.Dictionary<StringRecord>, string> = stringRecordPropertyPath;
+    dictionaryPropertyPathIteratee; // $ExpectType (string | number)[]
+
+    const unionCollectionItemPropertyPathIteratee: _.Iteratee<_.List<IntersectingProperties>, string | boolean> = stringRecordPropertyPath;
+    unionCollectionItemPropertyPathIteratee; // $ExpectType (string | number)[]
+
+    const unionCollectionPropertyPathIteratee: _.Iteratee<StringRecord[] | _.Dictionary<StringRecord>, string> = stringRecordPropertyPath;
+    unionCollectionPropertyPathIteratee; // $ExpectType (string | number)[]
+
+    const anyPropertyPathIteratee: _.Iteratee<any, string> = stringRecordPropertyPath;
+    if (_.isArray(anyPropertyPathIteratee)) {
+        anyPropertyPathIteratee; // $ExpectType (string | number)[]
+    }
+
+    // identity
+    const listIdentityIteratee: _.Iteratee<_.List<StringRecord>, string> = undefined;
+    listIdentityIteratee; // $ExpectType undefined
+
+    const dictionaryIdentityIteratee: _.Iteratee<_.Dictionary<StringRecord>, string> = undefined;
+    dictionaryIdentityIteratee; // $ExpectType undefined
+
+    const unionCollectionItemIdentityIteratee: _.Iteratee<_.List<IntersectingProperties>, string | boolean> = undefined;
+    unionCollectionItemIdentityIteratee; // $ExpectType undefined
+
+    const unionCollectionIdentityIteratee: _.Iteratee<StringRecord[] | _.Dictionary<StringRecord>, string> = undefined;
+    unionCollectionIdentityIteratee; // $ExpectType undefined
+
+    const anyIdentityIteratee: _.Iteratee<any, string> = undefined;
+    anyIdentityIteratee; // $ExpectType undefined
+}
+
+// IterateeResult
+declare const functionIterateeResult: _.IterateeResult<() => string, StringRecord>;
+functionIterateeResult; // $ExpectType string
+
+declare const partialObjectIterateeResult: _.IterateeResult<Partial<StringRecord>, StringRecord>;
+partialObjectIterateeResult; // $ExpectType boolean
+
+declare const knownPropertyNameIterateeResult: _.IterateeResult<typeof stringRecordProperty, IntersectingProperties>;
+knownPropertyNameIterateeResult; // $ExpectType string | boolean
+
+declare const unknownPropertyNameIterateeResult: _.IterateeResult<typeof stringRecordProperty, NonIntersectingProperties>;
+unknownPropertyNameIterateeResult; // $ExpectType any
+
+declare const propertyPathIterateeResult: _.IterateeResult<_.EnumerableKey[], StringRecord>;
+propertyPathIterateeResult; // $ExpectType any
+
+declare const identityIterateeResult: _.IterateeResult<undefined, StringRecord>;
+identityIterateeResult; // $ExpectType StringRecord
+
 // Collections
 
 // each, forEach

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -543,6 +543,15 @@ _.chain(overlappingTypeUnion)
     .findWhere({ same: 'no' })
     .value();
 
+declare const nestedObjectList: { a: { b: boolean; c: string; }; }[];
+
+// $ExpectType [{ a: { b: boolean; c: string; }; }[], { a: { b: boolean; c: string; }; }[]]
+_.chain(nestedObjectList)
+    .uniq(['a', 'c'])
+    .without(nestedObjectList[0], nestedObjectList[2])
+    .partition(['a', 'b'])
+    .value();
+
 // common testing types and objects
 const context = {};
 

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -637,6 +637,7 @@ declare const resultUnionStringListMemoIterator: (prev: string | number, value: 
 declare const anyCollectionVoidIterator: (element: any, index: string | number, collection: any) => void;
 
 const simpleNumber = 7;
+declare const simpleNumberDictionary: _.Dictionary<number>;
 
 declare const mixedIterabilityValue: number | number[];
 declare const neverValue: never;
@@ -1155,14 +1156,14 @@ declare const extractChainTypes: ChainTypeExtractor;
     extractChainTypes(_.chain(stringRecordDictionary).detect(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecordOrUndefined, never>
 
     // identity iteratee - dictionaries - find
-    _.find(stringRecordDictionary); // $ExpectType StringRecordOrUndefined
-    _(stringRecordDictionary).find(); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordDictionary).find()); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.find(simpleNumberDictionary); // $ExpectType number | undefined
+    _(simpleNumberDictionary).find(); // $ExpectType number | undefined
+    extractChainTypes(_.chain(simpleNumberDictionary).find()); // $ExpectType ChainType<number | undefined, never>
 
     // identity iteratee - lists - detect
-    _.detect(stringRecordList); // $ExpectType StringRecordOrUndefined
-    _(stringRecordList).detect(); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordList).detect()); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.detect(simpleStringList); // $ExpectType string | undefined
+    _(simpleStringList).detect(); // $ExpectType string | undefined
+    extractChainTypes(_.chain(simpleStringList).detect()); // $ExpectType ChainType<string | undefined, string>
 }
 
 // filter, select
@@ -1238,14 +1239,14 @@ declare const extractChainTypes: ChainTypeExtractor;
     extractChainTypes(_.chain(stringRecordDictionary).select(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // identity iteratee - dictionaries - filter
-    _.filter(stringRecordDictionary); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).filter(); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).filter()); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.filter(simpleNumberDictionary); // $ExpectType number[]
+    _(simpleNumberDictionary).filter(); // $ExpectType number[]
+    extractChainTypes(_.chain(simpleNumberDictionary).filter()); // $ExpectType ChainType<number[], number>
 
     // identity iteratee - lists - select
-    _.select(stringRecordList); // $ExpectType StringRecord[]
-    _(stringRecordList).select(); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).select()); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.select(simpleStringList); // $ExpectType string[]
+    _(simpleStringList).select(); // $ExpectType string[]
+    extractChainTypes(_.chain(simpleStringList).select()); // $ExpectType ChainType<string[], string>
 }
 
 // where
@@ -1322,9 +1323,9 @@ declare const extractChainTypes: ChainTypeExtractor;
     extractChainTypes(_.chain(stringRecordList).reject(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // identity iteratee - dictionaries
-    _.reject(stringRecordDictionary); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).reject(); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).reject()); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.reject(simpleNumberDictionary); // $ExpectType number[]
+    _(simpleNumberDictionary).reject(); // $ExpectType number[]
+    extractChainTypes(_.chain(simpleNumberDictionary).reject()); // $ExpectType ChainType<number[], number>
 }
 
 // pluck
@@ -1479,16 +1480,6 @@ declare const extractChainTypes: ChainTypeExtractor;
     _(stringRecordList).partition(partialStringRecord); // $ExpectType [StringRecord[], StringRecord[]]
     extractChainTypes(_.chain(stringRecordList).partition(partialStringRecord)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
 
-    // partial object iteratee - dictionaries
-    _.partition(stringRecordDictionary, partialStringRecord); // $ExpectType [StringRecord[], StringRecord[]]
-    _(stringRecordDictionary).partition(partialStringRecord); // $ExpectType [StringRecord[], StringRecord[]]
-    extractChainTypes(_.chain(stringRecordDictionary).partition(partialStringRecord)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
-
-    // property name iteratee - lists
-    _.partition(stringRecordList, stringRecordProperty); // $ExpectType [StringRecord[], StringRecord[]]
-    _(stringRecordList).partition(stringRecordProperty); // $ExpectType [StringRecord[], StringRecord[]]
-    extractChainTypes(_.chain(stringRecordList).partition(stringRecordProperty)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
-
     // property name iteratee - dictionaries
     _.partition(stringRecordDictionary, stringRecordProperty); // $ExpectType [StringRecord[], StringRecord[]]
     _(stringRecordDictionary).partition(stringRecordProperty); // $ExpectType [StringRecord[], StringRecord[]]
@@ -1499,10 +1490,10 @@ declare const extractChainTypes: ChainTypeExtractor;
     _(stringRecordList).partition(stringRecordPropertyPath); // $ExpectType [StringRecord[], StringRecord[]]
     extractChainTypes(_.chain(stringRecordList).partition(stringRecordPropertyPath)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
 
-    // property path iteratee - dictionaries
-    _.partition(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType [StringRecord[], StringRecord[]]
-    _(stringRecordDictionary).partition(stringRecordPropertyPath); // $ExpectType [StringRecord[], StringRecord[]]
-    extractChainTypes(_.chain(stringRecordDictionary).partition(stringRecordPropertyPath)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
+    // identity iteratee - dictionaries
+    _.partition(simpleNumberDictionary); // $ExpectType [number[], number[]]
+    _(simpleNumberDictionary).partition(); // $ExpectType [number[], number[]]
+    extractChainTypes(_.chain(simpleNumberDictionary).partition()); // $ExpectType ChainType<[number[], number[]], number[]>
 }
 
 // Arrays

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -674,7 +674,7 @@ declare const extractChainTypes: ChainTypeExtractor;
         collection; // $ExpectType List<StringRecord>
         return element.a;
     };
-    listFunctionIteratee(stringRecordList[0], 0, stringRecordList);
+    listFunctionIteratee(stringRecordList[0], 0, stringRecordList); // $ExpectType string
 
     const dictionaryFunctionIteratee: _.Iteratee<_.Dictionary<StringRecord>, string> = (element, key, collection) => {
         element; // $ExpectType StringRecord
@@ -682,7 +682,7 @@ declare const extractChainTypes: ChainTypeExtractor;
         collection; // $ExpectType Dictionary<StringRecord>
         return element.a;
     };
-    dictionaryFunctionIteratee(stringRecordDictionary['a'], 'a', stringRecordDictionary);
+    dictionaryFunctionIteratee(stringRecordDictionary['a'], 'a', stringRecordDictionary); // $ExpectType string
 
     const unionCollectionItemFunctionIteratee: _.Iteratee<_.List<IntersectingProperties>, string | boolean> = (element, key, collection) => {
         element; // $ExpectType IntersectingProperties

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -131,7 +131,7 @@ _.shuffle([1, 2, 3, 4, 5, 6]);
 
 _.size({ one: 1, two: 2, three: 3 });
 
-_.partition<number>([0, 1, 2, 3, 4, 5], (num) => {return num % 2 == 0 });
+_.partition<number[]>([0, 1, 2, 3, 4, 5], (num) => {return num % 2 == 0 });
 
 interface Family {
     name: string;
@@ -567,6 +567,7 @@ declare const level4RecordList: _.List<_.List<_.List<_.List<StringRecord>>>>;
 declare const maxLevel2RecordArray: (StringRecord | StringRecord[])[];
 declare const maxLevel3RecordArray: (StringRecord | StringRecord[] | StringRecord[][])[];
 
+const stringRecordListVoidIterator = (value: StringRecord, index: number, list: _.List<StringRecord>) => { value.a += 'b'; };
 const stringRecordListValueIterator = (value: StringRecord, index: number, list: _.List<StringRecord>) => value.a;
 const stringRecordListBooleanIterator = (value: StringRecord, index: number, list: _.List<StringRecord>) => value.a === 'b';
 const stringRecordPartialBooleanIterator = (value: StringRecord) => value.a === 'b';
@@ -583,6 +584,7 @@ interface StringRecordExplicitDictionary extends _.Dictionary<StringRecord> {
 const stringRecordExplicitDictionary: StringRecordExplicitDictionary = { a: { a: 'a', b: 'c' }, b: { a: 'b', b: 'b' }, c: { a: 'c', b: 'a' } };
 const stringRecordDictionary: _.Dictionary<StringRecord> = stringRecordExplicitDictionary;
 
+const stringRecordDictionaryVoidIterator = (element: StringRecord, key: string, dictionary: _.Dictionary<StringRecord>) => { element.a += 'b'; };
 const stringRecordDictionaryValueIterator = (element: StringRecord, key: string, dictionary: _.Dictionary<StringRecord>) => element.a;
 const stringRecordDictionaryBooleanIterator = (element: StringRecord, key: string, list: _.Dictionary<StringRecord>) => element.a === 'b';
 declare const stringRecordDictionaryMemoIterator: (prev: string, element: StringRecord, key: string, dictionary: _.Dictionary<StringRecord>) => string;
@@ -648,6 +650,41 @@ interface ChainTypeExtractor {
 declare const extractChainTypes: ChainTypeExtractor;
 
 // Collections
+
+// each, forEach
+{
+    // lists - each
+    _.each(stringRecordList, stringRecordListVoidIterator); // $ExpectType List<StringRecord>
+    _.each(stringRecordList, stringRecordListVoidIterator, context); // $ExpectType List<StringRecord>
+    _(stringRecordList).each(stringRecordListVoidIterator); // $ExpectType List<StringRecord>
+    _(stringRecordList).each(stringRecordListVoidIterator, context); // $ExpectType List<StringRecord>
+    _.chain(stringRecordList).each(stringRecordListVoidIterator); // // $ExpectType _Chain<StringRecord, List<StringRecord>>
+    _.chain(stringRecordList).each(stringRecordListVoidIterator, context); // // $ExpectType _Chain<StringRecord, List<StringRecord>>
+
+    // lists - forEach
+    _.forEach(stringRecordList, stringRecordListVoidIterator); // $ExpectType List<StringRecord>
+    _.forEach(stringRecordList, stringRecordListVoidIterator, context); // $ExpectType List<StringRecord>
+    _(stringRecordList).forEach(stringRecordListVoidIterator); // $ExpectType List<StringRecord>
+    _(stringRecordList).forEach(stringRecordListVoidIterator, context); // $ExpectType List<StringRecord>
+    _.chain(stringRecordList).forEach(stringRecordListVoidIterator); // // $ExpectType _Chain<StringRecord, List<StringRecord>>
+    _.chain(stringRecordList).forEach(stringRecordListVoidIterator, context); // // $ExpectType _Chain<StringRecord, List<StringRecord>>
+
+    // dictionaries - each
+    _.each(stringRecordDictionary, stringRecordDictionaryVoidIterator); // $ExpectType Dictionary<StringRecord>
+    _.each(stringRecordDictionary, stringRecordDictionaryVoidIterator, context); // $ExpectType Dictionary<StringRecord>
+    _(stringRecordDictionary).each(stringRecordDictionaryVoidIterator); // $ExpectType Dictionary<StringRecord>
+    _(stringRecordDictionary).each(stringRecordDictionaryVoidIterator, context); // $ExpectType Dictionary<StringRecord>
+    _.chain(stringRecordDictionary).each(stringRecordDictionaryVoidIterator); // // $ExpectType _Chain<StringRecord, Dictionary<StringRecord>>
+    _.chain(stringRecordDictionary).each(stringRecordDictionaryVoidIterator, context); // // $ExpectType _Chain<StringRecord, Dictionary<StringRecord>>
+
+    // dictionaries - forEach
+    _.forEach(stringRecordDictionary, stringRecordDictionaryVoidIterator); // $ExpectType Dictionary<StringRecord>
+    _.forEach(stringRecordDictionary, stringRecordDictionaryVoidIterator, context); // $ExpectType Dictionary<StringRecord>
+    _(stringRecordDictionary).forEach(stringRecordDictionaryVoidIterator); // $ExpectType Dictionary<StringRecord>
+    _(stringRecordDictionary).forEach(stringRecordDictionaryVoidIterator, context); // $ExpectType Dictionary<StringRecord>
+    _.chain(stringRecordDictionary).forEach(stringRecordDictionaryVoidIterator); // // $ExpectType _Chain<StringRecord, Dictionary<StringRecord>>
+    _.chain(stringRecordDictionary).forEach(stringRecordDictionaryVoidIterator, context); // // $ExpectType _Chain<StringRecord, Dictionary<StringRecord>>
+}
 
 // map, collect
 {
@@ -1370,6 +1407,81 @@ declare const extractChainTypes: ChainTypeExtractor;
     _.sample(simpleString, simpleNumber); // $ExpectType string[]
     _(simpleString).sample(simpleNumber); // $ExpectType string[]
     extractChainTypes(_.chain(simpleString).sample(simpleNumber)); // $ExpectType ChainType<string[], string>
+}
+
+// toArray
+{
+    // lists
+    _.toArray(stringRecordList); // $ExpectType StringRecord[]
+    _(stringRecordList).toArray(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).toArray()); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // dictionaries
+    _.toArray(stringRecordDictionary); // $ExpectType StringRecord[]
+    _(stringRecordDictionary).toArray(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordDictionary).toArray()); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // strings
+    _.toArray(simpleString); // $ExpectType string[]
+    _(simpleString).toArray(); // $ExpectType string[]
+    extractChainTypes(_.chain(simpleString).toArray()); // $ExpectType ChainType<string[], string>
+}
+
+// partition
+{
+    // function iteratee - lists
+    _.partition(stringRecordList, stringRecordListBooleanIterator); // $ExpectType [StringRecord[], StringRecord[]]
+    _.partition(stringRecordList, stringRecordListBooleanIterator, context); // $ExpectType [StringRecord[], StringRecord[]]
+    _(stringRecordList).partition(stringRecordListBooleanIterator); // $ExpectType [StringRecord[], StringRecord[]]
+    _(stringRecordList).partition(stringRecordListBooleanIterator, context); // $ExpectType [StringRecord[], StringRecord[]]
+    extractChainTypes(_.chain(stringRecordList).partition(stringRecordListBooleanIterator)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
+    extractChainTypes(_.chain(stringRecordList).partition(stringRecordListBooleanIterator, context)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
+
+    // function iteratee - dictionaries
+    _.partition(stringRecordDictionary, stringRecordDictionaryBooleanIterator); // $ExpectType [StringRecord[], StringRecord[]]
+    _.partition(stringRecordDictionary, stringRecordDictionaryBooleanIterator, context); // $ExpectType [StringRecord[], StringRecord[]]
+    _(stringRecordDictionary).partition(stringRecordDictionaryBooleanIterator); // $ExpectType [StringRecord[], StringRecord[]]
+    _(stringRecordDictionary).partition(stringRecordDictionaryBooleanIterator, context); // $ExpectType [StringRecord[], StringRecord[]]
+    extractChainTypes(_.chain(stringRecordDictionary).partition(stringRecordDictionaryBooleanIterator)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
+    extractChainTypes(_.chain(stringRecordDictionary).partition(stringRecordDictionaryBooleanIterator, context)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
+
+    // function iteratee - strings
+    _.partition(simpleString, stringListBooleanIterator); // $ExpectType [string[], string[]]
+    _.partition(simpleString, stringListBooleanIterator, context); // $ExpectType [string[], string[]]
+    _(simpleString).partition(stringListBooleanIterator); // $ExpectType [string[], string[]]
+    _(simpleString).partition(stringListBooleanIterator, context); // $ExpectType [string[], string[]]
+    extractChainTypes(_.chain(simpleString).partition(stringListBooleanIterator)); // $ExpectType ChainType<[string[], string[]], string[]>
+    extractChainTypes(_.chain(simpleString).partition(stringListBooleanIterator, context)); // $ExpectType ChainType<[string[], string[]], string[]>
+
+    // partial object iteratee - lists
+    _.partition(stringRecordList, partialStringRecord); // $ExpectType [StringRecord[], StringRecord[]]
+    _(stringRecordList).partition(partialStringRecord); // $ExpectType [StringRecord[], StringRecord[]]
+    extractChainTypes(_.chain(stringRecordList).partition(partialStringRecord)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
+
+    // partial object iteratee - dictionaries
+    _.partition(stringRecordDictionary, partialStringRecord); // $ExpectType [StringRecord[], StringRecord[]]
+    _(stringRecordDictionary).partition(partialStringRecord); // $ExpectType [StringRecord[], StringRecord[]]
+    extractChainTypes(_.chain(stringRecordDictionary).partition(partialStringRecord)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
+
+    // property name iteratee - lists
+    _.partition(stringRecordList, stringRecordProperty); // $ExpectType [StringRecord[], StringRecord[]]
+    _(stringRecordList).partition(stringRecordProperty); // $ExpectType [StringRecord[], StringRecord[]]
+    extractChainTypes(_.chain(stringRecordList).partition(stringRecordProperty)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
+
+    // property name iteratee - dictionaries
+    _.partition(stringRecordDictionary, stringRecordProperty); // $ExpectType [StringRecord[], StringRecord[]]
+    _(stringRecordDictionary).partition(stringRecordProperty); // $ExpectType [StringRecord[], StringRecord[]]
+    extractChainTypes(_.chain(stringRecordDictionary).partition(stringRecordProperty)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
+
+    // property path iteratee - lists
+    _.partition(stringRecordList, stringRecordPropertyPath); // $ExpectType [StringRecord[], StringRecord[]]
+    _(stringRecordList).partition(stringRecordPropertyPath); // $ExpectType [StringRecord[], StringRecord[]]
+    extractChainTypes(_.chain(stringRecordList).partition(stringRecordPropertyPath)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
+
+    // property path iteratee - dictionaries
+    _.partition(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType [StringRecord[], StringRecord[]]
+    _(stringRecordDictionary).partition(stringRecordPropertyPath); // $ExpectType [StringRecord[], StringRecord[]]
+    extractChainTypes(_.chain(stringRecordDictionary).partition(stringRecordPropertyPath)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
 }
 
 // Arrays

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -570,16 +570,18 @@ interface StringRecordAugmentedList extends _.List<StringRecord> {
 
 const stringRecordAugmentedList: StringRecordAugmentedList = { 0: { a: 'a', b: 'c' }, 1: { a: 'b', b: 'b' }, 2: { a: 'c', b: 'a' }, length: 3, notAListProperty: true };
 const stringRecordList: _.List<StringRecord> = stringRecordAugmentedList;
+declare const stringRecordListUnion: StringRecord[] | _.List<StringRecord>;
 declare const level2RecordList: _.List<_.List<StringRecord>>;
 declare const level3RecordList: _.List<_.List<_.List<StringRecord>>>;
 declare const level4RecordList: _.List<_.List<_.List<_.List<StringRecord>>>>;
 declare const maxLevel2RecordArray: (StringRecord | StringRecord[])[];
 declare const maxLevel3RecordArray: (StringRecord | StringRecord[] | StringRecord[][])[];
 
-const stringRecordListVoidIterator = (value: StringRecord, index: number, list: _.List<StringRecord>) => { value.a += 'b'; };
+const stringRecordAugmentedListVoidIterator = (value: StringRecord, index: number, list: StringRecordAugmentedList) => { value.a += 'b'; };
 const stringRecordListValueIterator = (value: StringRecord, index: number, list: _.List<StringRecord>) => value.a;
 const stringRecordListBooleanIterator = (value: StringRecord, index: number, list: _.List<StringRecord>) => value.a === 'b';
 const stringRecordPartialBooleanIterator = (value: StringRecord) => value.a === 'b';
+declare const stringRecordListUnionVoidIterator: (element: StringRecord, key: number, list: StringRecord[] | _.List<StringRecord>) => void;
 declare const stringRecordPartialMemoIterator: (prev: string, value: StringRecord) => string;
 declare const stringRecordListMemoIterator: (prev: string, value: StringRecord, index: number, list: _.List<StringRecord>) => string;
 declare const resultUnionPartialMemoIterator: (prev: string | StringRecord, value: StringRecord) => string | StringRecord;
@@ -593,7 +595,7 @@ interface StringRecordExplicitDictionary extends _.Dictionary<StringRecord> {
 const stringRecordExplicitDictionary: StringRecordExplicitDictionary = { a: { a: 'a', b: 'c' }, b: { a: 'b', b: 'b' }, c: { a: 'c', b: 'a' } };
 const stringRecordDictionary: _.Dictionary<StringRecord> = stringRecordExplicitDictionary;
 
-const stringRecordDictionaryVoidIterator = (element: StringRecord, key: string, dictionary: _.Dictionary<StringRecord>) => { element.a += 'b'; };
+const stringRecordExplicitDictionaryVoidIterator = (element: StringRecord, key: string, dictionary: StringRecordExplicitDictionary) => { element.a += 'b'; };
 const stringRecordDictionaryValueIterator = (element: StringRecord, key: string, dictionary: _.Dictionary<StringRecord>) => element.a;
 const stringRecordDictionaryBooleanIterator = (element: StringRecord, key: string, list: _.Dictionary<StringRecord>) => element.a === 'b';
 declare const stringRecordDictionaryMemoIterator: (prev: string, element: StringRecord, key: string, dictionary: _.Dictionary<StringRecord>) => string;
@@ -632,6 +634,8 @@ declare const stringListSelfMemoIterator: (prev: string, value: string, index: n
 declare const stringListMemoIterator: (prev: _.Dictionary<number>, value: string, index: number, str: string) => _.Dictionary<number>;
 declare const resultUnionStringListMemoIterator: (prev: string | number, value: string, index: number, str: string) => string | number;
 
+declare const anyCollectionVoidIterator: (element: any, index: string | number, collection: any) => void;
+
 const simpleNumber = 7;
 
 declare const mixedIterabilityValue: number | number[];
@@ -663,36 +667,44 @@ declare const extractChainTypes: ChainTypeExtractor;
 // each, forEach
 {
     // lists - each
-    _.each(stringRecordList, stringRecordListVoidIterator); // $ExpectType List<StringRecord>
-    _.each(stringRecordList, stringRecordListVoidIterator, context); // $ExpectType List<StringRecord>
-    _(stringRecordList).each(stringRecordListVoidIterator); // $ExpectType List<StringRecord>
-    _(stringRecordList).each(stringRecordListVoidIterator, context); // $ExpectType List<StringRecord>
-    _.chain(stringRecordList).each(stringRecordListVoidIterator); // // $ExpectType _Chain<StringRecord, List<StringRecord>>
-    _.chain(stringRecordList).each(stringRecordListVoidIterator, context); // // $ExpectType _Chain<StringRecord, List<StringRecord>>
+    _.each(stringRecordAugmentedList, stringRecordAugmentedListVoidIterator); // $ExpectType StringRecordAugmentedList
+    _(stringRecordAugmentedList).each(stringRecordAugmentedListVoidIterator, context); // $ExpectType StringRecordAugmentedList
+    _.chain(stringRecordAugmentedList).each(stringRecordAugmentedListVoidIterator); // // $ExpectType _Chain<StringRecordAugmentedList, StringRecordAugmentedList>
 
     // lists - forEach
-    _.forEach(stringRecordList, stringRecordListVoidIterator); // $ExpectType List<StringRecord>
-    _.forEach(stringRecordList, stringRecordListVoidIterator, context); // $ExpectType List<StringRecord>
-    _(stringRecordList).forEach(stringRecordListVoidIterator); // $ExpectType List<StringRecord>
-    _(stringRecordList).forEach(stringRecordListVoidIterator, context); // $ExpectType List<StringRecord>
-    _.chain(stringRecordList).forEach(stringRecordListVoidIterator); // // $ExpectType _Chain<StringRecord, List<StringRecord>>
-    _.chain(stringRecordList).forEach(stringRecordListVoidIterator, context); // // $ExpectType _Chain<StringRecord, List<StringRecord>>
+    _.forEach(stringRecordAugmentedList, stringRecordAugmentedListVoidIterator, context); // $ExpectType StringRecordAugmentedList
+    _(stringRecordAugmentedList).forEach(stringRecordAugmentedListVoidIterator); // $ExpectType StringRecordAugmentedList
+    _.chain(stringRecordAugmentedList).forEach(stringRecordAugmentedListVoidIterator, context); // // $ExpectType _Chain<StringRecordAugmentedList, StringRecordAugmentedList>
 
     // dictionaries - each
-    _.each(stringRecordDictionary, stringRecordDictionaryVoidIterator); // $ExpectType Dictionary<StringRecord>
-    _.each(stringRecordDictionary, stringRecordDictionaryVoidIterator, context); // $ExpectType Dictionary<StringRecord>
-    _(stringRecordDictionary).each(stringRecordDictionaryVoidIterator); // $ExpectType Dictionary<StringRecord>
-    _(stringRecordDictionary).each(stringRecordDictionaryVoidIterator, context); // $ExpectType Dictionary<StringRecord>
-    _.chain(stringRecordDictionary).each(stringRecordDictionaryVoidIterator); // // $ExpectType _Chain<StringRecord, Dictionary<StringRecord>>
-    _.chain(stringRecordDictionary).each(stringRecordDictionaryVoidIterator, context); // // $ExpectType _Chain<StringRecord, Dictionary<StringRecord>>
+    _.each(stringRecordExplicitDictionary, stringRecordExplicitDictionaryVoidIterator, context); // $ExpectType StringRecordExplicitDictionary
+    _(stringRecordExplicitDictionary).each(stringRecordExplicitDictionaryVoidIterator); // $ExpectType StringRecordExplicitDictionary
+    _.chain(stringRecordExplicitDictionary).each(stringRecordExplicitDictionaryVoidIterator, context); // // $ExpectType _Chain<StringRecord, StringRecordExplicitDictionary>
 
     // dictionaries - forEach
-    _.forEach(stringRecordDictionary, stringRecordDictionaryVoidIterator); // $ExpectType Dictionary<StringRecord>
-    _.forEach(stringRecordDictionary, stringRecordDictionaryVoidIterator, context); // $ExpectType Dictionary<StringRecord>
-    _(stringRecordDictionary).forEach(stringRecordDictionaryVoidIterator); // $ExpectType Dictionary<StringRecord>
-    _(stringRecordDictionary).forEach(stringRecordDictionaryVoidIterator, context); // $ExpectType Dictionary<StringRecord>
-    _.chain(stringRecordDictionary).forEach(stringRecordDictionaryVoidIterator); // // $ExpectType _Chain<StringRecord, Dictionary<StringRecord>>
-    _.chain(stringRecordDictionary).forEach(stringRecordDictionaryVoidIterator, context); // // $ExpectType _Chain<StringRecord, Dictionary<StringRecord>>
+    _.forEach(stringRecordExplicitDictionary, stringRecordExplicitDictionaryVoidIterator); // $ExpectType StringRecordExplicitDictionary
+    _(stringRecordExplicitDictionary).forEach(stringRecordExplicitDictionaryVoidIterator, context); // $ExpectType StringRecordExplicitDictionary
+    _.chain(stringRecordExplicitDictionary).forEach(stringRecordExplicitDictionaryVoidIterator); // // $ExpectType _Chain<StringRecord, StringRecordExplicitDictionary>
+
+    // unioned list types with similar items - each
+    _.each(stringRecordListUnion, stringRecordListUnionVoidIterator); // $ExpectType List<StringRecord> | StringRecord[]
+    _(stringRecordListUnion).each(stringRecordListUnionVoidIterator); // $ExpectType List<StringRecord> | StringRecord[]
+    _.chain(stringRecordListUnion).each(stringRecordListUnionVoidIterator); // // $ExpectType _Chain<StringRecord, List<StringRecord> | StringRecord[]>
+
+    // unioned list types with similar items - forEach
+    _.forEach(stringRecordListUnion, stringRecordListUnionVoidIterator); // $ExpectType List<StringRecord> | StringRecord[]
+    _(stringRecordListUnion).forEach(stringRecordListUnionVoidIterator); // $ExpectType List<StringRecord> | StringRecord[]
+    _.chain(stringRecordListUnion).forEach(stringRecordListUnionVoidIterator); // // $ExpectType _Chain<StringRecord, List<StringRecord> | StringRecord[]>
+
+    // any - each
+    _.each(anyValue, anyCollectionVoidIterator); // $ExpectType any
+    _(anyValue).each(anyCollectionVoidIterator, context); // $ExpectType any
+    _.chain(anyValue).each(anyCollectionVoidIterator); // // $ExpectType _Chain<any, any>
+
+    // any - forEach
+    _.forEach(anyValue, anyCollectionVoidIterator); // $ExpectType any
+    _(anyValue).forEach(anyCollectionVoidIterator, context); // $ExpectType any
+    _.chain(anyValue).forEach(anyCollectionVoidIterator); // // $ExpectType _Chain<any, any>
 }
 
 // map, collect

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -764,14 +764,14 @@ declare const extractChainTypes: ChainTypeExtractor;
     const listIdentityIteratee: _.Iteratee<_.List<StringRecord>, string> = undefined;
     listIdentityIteratee; // $ExpectType undefined
 
-    const dictionaryIdentityIteratee: _.Iteratee<_.Dictionary<StringRecord>, string> = undefined;
-    dictionaryIdentityIteratee; // $ExpectType undefined
+    const dictionaryIdentityIteratee: _.Iteratee<_.Dictionary<StringRecord>, string> = null;
+    dictionaryIdentityIteratee; // $ExpectType null
 
     const unionCollectionItemIdentityIteratee: _.Iteratee<_.List<IntersectingProperties>, string | boolean> = undefined;
     unionCollectionItemIdentityIteratee; // $ExpectType undefined
 
-    const unionCollectionIdentityIteratee: _.Iteratee<StringRecord[] | _.Dictionary<StringRecord>, string> = undefined;
-    unionCollectionIdentityIteratee; // $ExpectType undefined
+    const unionCollectionIdentityIteratee: _.Iteratee<StringRecord[] | _.Dictionary<StringRecord>, string> = null;
+    unionCollectionIdentityIteratee; // $ExpectType null
 
     const anyIdentityIteratee: _.Iteratee<any, string> = undefined;
     anyIdentityIteratee; // $ExpectType undefined
@@ -793,8 +793,11 @@ unknownPropertyNameIterateeResult; // $ExpectType any
 declare const propertyPathIterateeResult: _.IterateeResult<_.EnumerableKey[], StringRecord>;
 propertyPathIterateeResult; // $ExpectType any
 
-declare const identityIterateeResult: _.IterateeResult<undefined, StringRecord>;
-identityIterateeResult; // $ExpectType StringRecord
+declare const nullIdentityIterateeResult: _.IterateeResult<null, StringRecord>;
+nullIdentityIterateeResult; // $ExpectType StringRecord
+
+declare const undefinedIdentityIterateeResult: _.IterateeResult<undefined, StringRecord>;
+undefinedIdentityIterateeResult; // $ExpectType StringRecord
 
 // Collections
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://underscorejs.org/
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

This PR continues the planned set that will together add up to #45201 and includes the following changes:

- Adds tests for `each`, `toArray`, and `partition`.
- Collapses overloads of `each` by updating it to use `CollectionIterator`.
- Updates the return value of `each` to be the exact original collection type rather than an approximation.
- Updates `partition` to use `Collection` and `Iteratee` to partially fix #20623.
- Updates `partition` to result in a two-item tuple instead of an array.
- Updates the location of `Underscore.partition` and `_Chain.partition` to be in the Collections sections of those interfaces.
- Updates the return type of `_Chain.each`, `_Chain.toArray`, and `_Chain.partition` to use the correct wrapped value type `V` to partially fix #36308.
- Updates the `Underscore` and `_Chain` versions of `reject` to work with both Lists and Dictionaries to partially fix #20623.
- Replaces all `forEach` overloads with a reference to `each` overloads.
- Fixes issues with `CollectionIterator` and `MemoCollectionIterator` around element type inference with collections that are type unions or `any`.