### PR TITLE
[@types/yup] StringSchema::ensure typing was incorrect

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -129,7 +129,7 @@ export interface StringSchema<T extends string | null | undefined = string | und
     ): StringSchema<T>;
     email(message?: StringLocale['email']): StringSchema<T>;
     url(message?: StringLocale['url']): StringSchema<T>;
-    ensure(): StringSchema<T>;
+    ensure(): StringSchema<Exclude<T, undefined | null>>;
     trim(message?: StringLocale['trim']): StringSchema<T>;
     lowercase(message?: StringLocale['lowercase']): StringSchema<T>;
     uppercase(message?: StringLocale['uppercase']): StringSchema<T>;


### PR DESCRIPTION
Quote from the [documentation](https://github.com/jquense/yup#stringensure-schema):
> Transforms undefined and null values to an empty string along with setting the default to an empty string.

This clearly prevents `null | undefined` from ever being part of the resulting value.
Therefore, the type should be adapted to `Exclude` them.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquense/yup#stringensure-schema

