### PR TITLE
update webpack-node-externals

### DIFF
--- a/types/webpack-node-externals/index.d.ts
+++ b/types/webpack-node-externals/index.d.ts
@@ -4,7 +4,6 @@
 //                 Manuel Pogge <https://github.com/MrSpoocy>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 import { ExternalsFunctionElement } from 'webpack';
 
@@ -48,6 +47,10 @@ declare namespace webpackNodeExternals {
          * @default 'node_modules'
          */
         modulesDir?: string;
+        /**
+         * Additional folders to look for node modules.
+         */
+        additionalModuleDirs?: string[],
         /**
          * Read the modules from the package.json file instead of the node_modules folder.
          * @default false

--- a/types/webpack-node-externals/index.d.ts
+++ b/types/webpack-node-externals/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for webpack-node-externals 1.7
+// Type definitions for webpack-node-externals 2.5
 // Project: https://github.com/liady/webpack-node-externals
 // Definitions by: Matt Traynham <https://github.com/mtraynham>
 //                 Manuel Pogge <https://github.com/MrSpoocy>
@@ -13,10 +13,10 @@ export = webpackNodeExternals;
 declare function webpackNodeExternals(options?: webpackNodeExternals.Options): ExternalsFunctionElement;
 
 declare namespace webpackNodeExternals {
-    type WhitelistOption = string | RegExp | WhitelistFunctionType;
+    type AllowlistOption = string | RegExp | AllowlistFunctionType;
     type ImportTypeCallback = (moduleName: string) => string;
     /** a function that accepts the module name and returns whether it should be included */
-    type WhitelistFunctionType = (moduleName: string) => boolean;
+    type AllowlistFunctionType = (moduleName: string) => boolean;
     interface ModulesFromFileType {
         exclude?: string | string[];
         include?: string | string[];
@@ -24,15 +24,15 @@ declare namespace webpackNodeExternals {
 
     interface Options {
         /**
-         * An array for the externals to whitelist, so they will be included in the bundle.
+         * An array for the externals to allow, so they will be included in the bundle.
          * Can accept exact strings ('module_name'), regex patterns (/^module_name/), or a
          * function that accepts the module name and returns whether it should be included.
          * Important - if you have set aliases in your webpack config with the exact
-         * same names as modules in node_modules, you need to whitelist them so Webpack will know
+         * same names as modules in node_modules, you need to allowlist them so Webpack will know
          * they should be bundled.
          * @default []
          */
-        whitelist?: WhitelistOption[] | WhitelistOption;
+        allowlist?: AllowlistOption[] | AllowlistOption;
         /**
          * @default ['.bin']
          */

--- a/types/webpack-node-externals/index.d.ts
+++ b/types/webpack-node-externals/index.d.ts
@@ -50,7 +50,7 @@ declare namespace webpackNodeExternals {
         /**
          * Additional folders to look for node modules.
          */
-        additionalModuleDirs?: string[],
+        additionalModuleDirs?: string[];
         /**
          * Read the modules from the package.json file instead of the node_modules folder.
          * @default false

--- a/types/webpack-node-externals/webpack-node-externals-tests.ts
+++ b/types/webpack-node-externals/webpack-node-externals-tests.ts
@@ -15,7 +15,7 @@ const c: webpack.Configuration = {
     entry: 'test.js',
     externals: [
         webpackNodeExternals({
-            whitelist: [
+            allowList: [
                 'jquery',
                 'webpack/hot/dev-server',
                 /^lodash/,

--- a/types/webpack-node-externals/webpack-node-externals-tests.ts
+++ b/types/webpack-node-externals/webpack-node-externals-tests.ts
@@ -15,7 +15,7 @@ const c: webpack.Configuration = {
     entry: 'test.js',
     externals: [
         webpackNodeExternals({
-            allowList: [
+            allowlist: [
                 'jquery',
                 'webpack/hot/dev-server',
                 /^lodash/,


### PR DESCRIPTION
The library was updated to use a more inclusive language
See. https://github.com/liady/webpack-node-externals/pull/75


