### PR TITLE
[n3] Add 'blankNodePrefix' and fix 'prefixes' properties in ParserOptions

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -4,12 +4,12 @@
 //                 Ruben Taelman <https://github.com/rubensworks>
 //                 Laurens Rietveld <https://github.com/LaurensRietveld>
 //                 Joachim Van Herwegen <https://github.com/joachimvh>
+//                 Alexey Morozov <https://github.com/AlexeyMz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
 /// <reference types="node" />
 
-import * as fs from "fs";
 import * as stream from "stream";
 import * as RDF from "rdf-js";
 import { EventEmitter } from "events";
@@ -130,9 +130,9 @@ export interface BlankTriple<Q extends RDF.BaseQuad = RDF.Quad> {
 
 export interface ParserOptions {
     format?: string;
-    prefixes?: string[];
     factory?: RDF.DataFactory;
     baseIRI?: string;
+    blankNodePrefix?: string;
 }
 
 export type ParseCallback<Q extends BaseQuad = Quad> = (error: Error, quad: Q, prefixes: Prefixes) => void;

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -263,3 +263,12 @@ function test_doc_utility() {
     const namedNode2: RDF.NamedNode = N3Util.prefixes(prefixes)('rdfs')('label');
     const namedNode3: N3.NamedNode = N3Util.prefixes(prefixes)('rdfs')('label');
 }
+
+function test_parser_options() {
+    const parser = new N3.Parser({
+        baseIRI: 'http://example.org/',
+        factory: N3.DataFactory,
+        format: 'N-Triples',
+        blankNodePrefix: '',
+    });
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/rdfjs/N3.js#from-an-rdf-document-to-quads (see `blankNodePrefix` note at the end of the section)
  - https://github.com/rdfjs/N3.js#from-quads-to-a-string (`prefixes` argument change from array to object)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
