### PR TITLE
raygun4js Add support for logContentsOfXhrCalls command

### DIFF
--- a/types/raygun4js/index.d.ts
+++ b/types/raygun4js/index.d.ts
@@ -386,6 +386,7 @@ interface RaygunV2 {
             | "attach"
             | "enableCrashReporting"
             | "enablePulse"
+            | "logContentsOfXhrCalls"
             | "noConflict"
             | "saveIfOffline",
         value: boolean


### PR DESCRIPTION
According to the documentation, consumers of the raygun4js package should be able to enable / disable including the body of XHR requests in the breadcrumbs using the logContentsOfXhrCalls command. This change adds support for the logContentsOfXhrCalls command to the official types package.

See https://raygun.com/documentation/language-guides/javascript/crash-reporting/breadcrumbs/#configuration-options for the full documentation of the logContentsOfXhrCalls option.
