### PR TITLE
[@types/fail-on-errors-webpack-plugin]: New definition

### DIFF
--- a/types/fail-on-errors-webpack-plugin/fail-on-errors-webpack-plugin-tests.ts
+++ b/types/fail-on-errors-webpack-plugin/fail-on-errors-webpack-plugin-tests.ts
@@ -1,0 +1,10 @@
+import FailOnErrorsPlugin = require('fail-on-errors-webpack-plugin');
+import { Plugin } from 'webpack';
+
+// Test if constructors are assignable to `Webpack.Plugin`
+const plugin1: Plugin = new FailOnErrorsPlugin();
+const plugin2: Plugin = new FailOnErrorsPlugin({});
+const plugin3: Plugin = new FailOnErrorsPlugin({
+    failOnErrors: true,
+    failOnWarnings: true,
+});

--- a/types/fail-on-errors-webpack-plugin/index.d.ts
+++ b/types/fail-on-errors-webpack-plugin/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for fail-on-errors-webpack-plugin 3.0
+// Project: https://github.com/AustinMatherne/fail-on-errors-webpack-plugin
+// Definitions by: Ciarán Ingle <https://github.com/inglec-arista>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Plugin } from 'webpack';
+
+declare class FailOnErrorsWebpackPlugin extends Plugin {
+    constructor(options?: { failOnErrors?: boolean; failOnWarnings?: boolean });
+}
+
+export = FailOnErrorsWebpackPlugin;

--- a/types/fail-on-errors-webpack-plugin/tsconfig.json
+++ b/types/fail-on-errors-webpack-plugin/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "baseUrl": "../",
+        "forceConsistentCasingInFileNames": true,
+        "lib": ["es6"],
+        "module": "commonjs",
+        "noEmit": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "typeRoots": ["../"],
+        "types": []
+    },
+    "files": [
+        "fail-on-errors-webpack-plugin-tests.ts",
+        "index.d.ts"
+    ]
+}

--- a/types/fail-on-errors-webpack-plugin/tslint.json
+++ b/types/fail-on-errors-webpack-plugin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.