### PR TITLE
Use simplified syntax for repository location in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,7 @@
     "name": "definitely-typed",
     "version": "0.0.3",
     "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/DefinitelyTyped/DefinitelyTyped.git"
-    },
+    "repository": "DefinitelyTyped/DefinitelyTyped",
     "license": "MIT",
     "bugs": {
         "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/issues"


### PR DESCRIPTION
Like mentioned in the npm package.json specification [here](https://docs.npmjs.com/files/package.json): 
`For GitHub, GitHub gist, Bitbucket, or GitLab repositories you can use the same shortcut syntax you use for npm install`

This also resolves a problem when installing via CITGM.