### PR TITLE
@types/antlr4 - Fix InputStream.LA() and InputStream.LT() declarations

### DIFF
--- a/types/antlr4/InputStream.d.ts
+++ b/types/antlr4/InputStream.d.ts
@@ -8,9 +8,9 @@ export class InputStream {
 
     consume(): void;
 
-    LA(offset: number): string;
+    LA(offset: number): number;
 
-    LT(offset: number): string;
+    LT(offset: number): number;
 
     mark(): number;
 

--- a/types/antlr4/antlr4-tests.ts
+++ b/types/antlr4/antlr4-tests.ts
@@ -2165,3 +2165,11 @@ function getOriginalText(ctx: ParserRuleContext): string {
     const text = ctx.start.getInputStream().getText(a, b);
     return text;
 }
+
+// fix InputStream.d.ts
+function LA(code: string, offset: number): number {
+    return new InputStream(code).LA(offset);
+}
+function LT(code: string, offset: number): number {
+    return new InputStream(code).LT(offset);
+}

--- a/types/antlr4/index.d.ts
+++ b/types/antlr4/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/antlr/antlr4
 // Definitions by: Marlon Chatman <https://github.com/mcchatman8009>
 //                 Matteo Mortari <https://github.com/tarilabs>
+//                 Jon Gellin <https://github.com/jgellin-sf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 export * from './Lexer';
 export * from './Parser';


### PR DESCRIPTION
Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [ x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/antlr/antlr4/blob/master/runtime/JavaScript/src/antlr4/InputStream.js

InputStream.LA() and InputStream.LT() return a char code or code point, which is a number and not a string.