### PR TITLE
[react-vis] Update HighlightProps to have optional fields, and its callback fields to be typed

### DIFF
--- a/types/react-vis/index.d.ts
+++ b/types/react-vis/index.d.ts
@@ -426,19 +426,26 @@ export class LineMarkSeries extends AbstractSeries<LineMarkSeriesProps> {}
 export interface LineMarkSeriesCanvasProps extends AbstractSeriesProps<LineMarkSeriesPoint> {}
 export class LineMarkSeriesCanvas extends AbstractSeries<LineMarkSeriesCanvasProps> {}
 
+export interface HighlightArea {
+    bottom?: number;
+    left?: number;
+    right?: number;
+    top?: number;
+}
 export interface HighlightProps extends AbstractSeriesProps<LineMarkSeriesPoint> {
     enableX?: boolean;
     enableY?: boolean;
-    highlightHeight: number;
-    highlightWidth: number;
-    highlightX: string | number;
-    highlightY: string | number;
-    onBrushStart: (row: any) => any;
-    onDragStart: (row: any) => any;
-    onBrush: (row: any) => any;
-    onDrag: (row: any) => any;
-    onBrushEnd: (row: any) => any;
-    onDragEnd: (row: any) => any;
+    highlightHeight?: number;
+    highlightWidth?: number;
+    highlightX?: string | number;
+    highlightY?: string | number;
+    drag?: boolean;
+    onBrushStart?: (area: HighlightArea | null) => void;
+    onDragStart?: (area: HighlightArea | null) => void;
+    onBrush?: (area: HighlightArea | null) => void;
+    onDrag?: (area: HighlightArea | null) => void;
+    onBrushEnd?: (area: HighlightArea | null) => void;
+    onDragEnd?: (area: HighlightArea | null) => void;
 }
 export class Highlight extends AbstractSeries<HighlightProps> {}
 

--- a/types/react-vis/react-vis-tests.tsx
+++ b/types/react-vis/react-vis-tests.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, useState } from 'react';
 
 import {
     XYPlot,
@@ -9,7 +9,11 @@ import {
     LineMarkSeries,
     HexbinSeries,
     ChartLabel,
-    VerticalBarSeries
+    VerticalBarSeries,
+    LineSeries,
+    Highlight,
+    HighlightArea,
+    VerticalRectSeries,
 } from 'react-vis';
 
 export function Example() {
@@ -127,9 +131,10 @@ export class BarSeriesExample extends Component {
                     xType="ordinal"
                     width={250}
                     height={250}
-                    colorType={"literal"}
-                    style={{ fill: "#ffffff", height: "300px" }}
-                    margin={{ left: 0, top: 25 }} >
+                    colorType={'literal'}
+                    style={{ fill: '#ffffff', height: '300px' }}
+                    margin={{ left: 0, top: 25 }}
+                >
                     <XAxis />
                     <VerticalBarSeries data={data} stroke={0} barWidth={1.0} />
                 </XYPlot>
@@ -137,3 +142,72 @@ export class BarSeriesExample extends Component {
         );
     }
 }
+
+export class HighlightExample extends Component {
+    render() {
+        const data = [
+            { x: 0, y: 8 },
+            { x: 1, y: 5 },
+            { x: 2, y: 4 },
+            { x: 3, y: 9 },
+            { x: 4, y: 1 },
+        ];
+        return (
+            <div className="highlight-example">
+                <XYPlot height={300} width={300}>
+                    <LineSeries data={data} />
+                    <Highlight />
+                </XYPlot>
+            </div>
+        );
+    }
+}
+
+export const HighlightDragExample: React.FC = () => {
+    const data = [
+        { x0: 0, x: 1, y0: 0, y: 1 },
+        { x0: 1, x: 2, y0: 0, y: 2 },
+        { x0: 2, x: 3, y0: 0, y: 10 },
+        { x0: 3, x: 4, y0: 0, y: 6 },
+        { x0: 4, x: 5, y0: 0, y: 5 },
+        { x0: 5, x: 6, y0: 0, y: 3 },
+        { x0: 6, x: 7, y0: 0, y: 1 },
+    ];
+
+    const [selection, setSelection] = useState<{
+        start: number;
+        end: number;
+    } | null>(null);
+
+    const updateDragState = (area: HighlightArea | null) => {
+        if (!area || area.left === undefined || area.right === undefined) {
+            setSelection(null);
+        } else {
+            setSelection({ start: area.left, end: area.right });
+        }
+    };
+    return (
+        <XYPlot width={500} height={300}>
+            <XAxis />
+            <YAxis />
+            <VerticalRectSeries
+                className="highlight-drag-example"
+                data={data}
+                stroke="white"
+                colorType="literal"
+                getColor={d => {
+                    if (!selection) {
+                        return '#1E96BE';
+                    }
+                    const inX = d.x >= selection.start && d.x <= selection.end;
+                    const inX0 = d.x0 >= selection.start && d.x0 <= selection.end;
+                    const inStart = selection.start >= d.x0 && selection.start <= d.x;
+                    const inEnd = selection.end >= d.x0 && selection.end <= d.x;
+
+                    return inStart || inEnd || inX || inX0 ? '#12939A' : '#1E96BE';
+                }}
+            />
+            <Highlight color="#829AE3" drag enableY={false} onDrag={updateDragState} onDragEnd={updateDragState} />
+        </XYPlot>
+    );
+};


### PR DESCRIPTION
Motivation:
As I migrated some react-vis code to use Typescript, the `Highlight` elements started requiring to have all the props explicitly declared, bloating the code. Taking a look at the docs, most of them are actually optional, so I decided to update the definitions.

PR template:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] URL to documentation which provides context for the suggested changes: properties taken from https://github.com/uber/react-vis/blob/master/docs/highlight.md, and callback signature from https://github.com/uber/react-vis/blob/master/packages/react-vis/src/plot/highlight.js
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing). The test is a port from https://github.com/uber/react-vis/blob/premodern/showcase/misc/dragable-chart-example.js 
