### PR TITLE
[@types/pouchdb-find]: Accept string in selector `_id`

### DIFF
--- a/types/pouchdb-find/index.d.ts
+++ b/types/pouchdb-find/index.d.ts
@@ -77,7 +77,7 @@ declare namespace PouchDB {
         interface Selector extends CombinationOperators {
             [field: string]: Selector | Selector[] | ConditionOperators | any;
 
-            _id?: ConditionOperators;
+            _id?: string | ConditionOperators;
         }
 
         interface FindRequest<Content extends {}> {

--- a/types/pouchdb-find/pouchdb-find-tests.ts
+++ b/types/pouchdb-find/pouchdb-find-tests.ts
@@ -20,6 +20,10 @@ function testFind() {
         sort: [{fieldName: 'asc'}]
     });
 
+    db.find({
+        selector: {_id: 'toto'}
+    });
+
     // test combinations of selectors
     db.find({
         selector: {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] ~~Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).~~
Failing with unrelated error:
```
Error: Errors in typescript@4.0 for external dependencies:
../node-fetch/index.d.ts(19,27): error TS7016: Could not find a declaration file for module 'form-data'. '/home/hoel/Bordel/DefinitelyTyped/node_modules/form-data/lib/form_data.js' implicitly has an 'any' type.
  Try `npm install @types/form-data` if it exists or add a new declaration (.d.ts) file containing `declare module 'form-data';`
```

If changing an existing definition:
- [ ] ~~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~~ No URL that shows it, but concrete examples.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

--- 

### Commit message:

#### [@types/pouchdb-find]: Accept string in selector `_id`

Because the following example works well:
```html
<html>
  <script src="pouchdb.js"></script>
  <script src="pouchdb.find.js"></script>
  <script>
    async function main() {
        let db = new PouchDB('local_database');
        await db.put({_id: 'document', data: 'toto'});
        await db.put({_id: 'other_document', data: 'other_toto'});
        console.warn(await db.find({
          selector: {_id: 'document'}
        })); // return {data: "toto", _id: "document", _rev: "..."}
    }
    main().catch(err => console.warn(err));
  </script>
</html>
```
As well as the following CouchDB API:
```bash
curl -sSf -X POST "localhost:5984/database/_find" \
     -H 'Content-Type: application/json' -d '{"selector": {"_id": "document"}}'
```

Maybe it's not usefull for `pouchdb-find`, but `pouchdb-core` reuses the
`Selector` interface for replication and it block the following code:
```ts
this.db.replicate.from(this.remoteDb, {'selector': {'_id': 'document'}})
```
See here:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/650cddc/types/pouchdb-core/index.d.ts#L443

