### PR TITLE
Add types for `openapi-sampler`

### DIFF
--- a/types/openapi-sampler/index.d.ts
+++ b/types/openapi-sampler/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for openapi-sampler 1.0
+// Project: https://github.com/APIs-guru/openapi-sampler/
+// Definitions by: Marcell Toth <https://github.com/marcelltoth>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.0
+
+export type OpenApiSchema = any;
+
+export type OpenApiSpec = any;
+
+export interface Options {
+    /**
+     * Don't include non-required object properties not specified in `required` property of the schema object
+     */
+    readonly skipNonRequired?: boolean;
+
+    /**
+     * Don't include readOnly object properties
+     */
+    readonly skipReadOnly?: boolean;
+
+    /**
+     * Don't include writeOnly object properties
+     */
+    readonly skipWriteOnly?: boolean;
+
+    /**
+     * Don't log console warning messages
+     */
+    readonly quiet?: boolean;
+}
+
+/**
+ * Generates samples based on OpenAPI payload/response schema
+ * @param schema A OpenAPI Schema Object
+ * @param options Options
+ * @param spec whole specification where the schema is taken from. Required only when schema may contain `$ref`. `spec` must not contain any external references.
+ */
+export function sample(schema: OpenApiSchema, options?: Options, spec?: OpenApiSpec): unknown;

--- a/types/openapi-sampler/openapi-sampler-tests.ts
+++ b/types/openapi-sampler/openapi-sampler-tests.ts
@@ -1,0 +1,12 @@
+import { sample } from 'openapi-sampler';
+
+const schema = { type: 'string'};
+const spec = { openapi: '3.0.0'};
+
+sample(schema, { quiet: true }, spec);
+
+sample(schema);
+
+sample(schema, undefined, spec);
+
+sample(schema, {}, spec);

--- a/types/openapi-sampler/tsconfig.json
+++ b/types/openapi-sampler/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "openapi-sampler-tests.ts"
+    ]
+}

--- a/types/openapi-sampler/tslint.json
+++ b/types/openapi-sampler/tslint.json
@@ -1,0 +1,17 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [
+            true,
+            {
+                "mode": "code",
+                "errors": [
+                    [
+                        "NeedsExportEquals",
+                        false
+                    ]
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

Adds typings for the package [`openapi-sampler`](https://github.com/Redocly/openapi-sampler)

## Template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html) **see footnote about this**
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

## Notes

### Shape

This library is an interesting beast. The [`main` entry](https://github.com/Redocly/openapi-sampler/blob/master/package.json#L5) points to an UMD bundle. (Build step [here](https://github.com/Redocly/openapi-sampler/blob/master/gulp-tasks/build.js).) 

But the `package.json` also has a [`jsnext:main` entry](https://github.com/Redocly/openapi-sampler/blob/master/package.json#L6) that points to the original source ES2015 module. While obsolete (in favor of `module`) webpack, rollup and similar tools still recognize `jsnext:main` and will prefer it against the UMD.

This is why the module is typed as an ES module and why the warning needs to be disabled. I'm assuming that the linter would recognize it as such if it had the `module` property, for which I opened a PR: https://github.com/Redocly/openapi-sampler/pull/112

Let me know if there is a better way to handle this situation. I tested it locally both in a node env (jest) and in the browser with Webpack.

