### PR TITLE
Add type definitions for @ottomated/passport-twitch

### DIFF
--- a/types/ottomated__passport-twitch/index.d.ts
+++ b/types/ottomated__passport-twitch/index.d.ts
@@ -1,0 +1,64 @@
+// Type definitions for @ottomated/passport-twitch 1.0
+// Project: https://github.com/ottomated/passport-twitch
+// Definitions by: Ottomated <https://github.com/ottomated>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as passport from 'passport';
+import * as express from 'express';
+import * as oauth2 from 'passport-oauth2';
+import { OutgoingHttpHeaders } from 'http';
+
+import twitch = Strategy;
+
+declare class Strategy extends oauth2.Strategy {
+    constructor(options: twitch.StrategyOptions, verify: (accessToken: string, refreshToken: string, profile: twitch.Profile, done: oauth2.VerifyCallback) => void);
+    // NOTE: A union of function types prevents contextual typing of arguments.
+    // tslint:disable-next-line:unified-signatures
+    constructor(options: twitch.StrategyOptions, verify: (accessToken: string, refreshToken: string, params: any, profile: twitch.Profile, done: oauth2.VerifyCallback) => void);
+    constructor(options: twitch.StrategyOptionsWithRequest, verify: (req: express.Request, accessToken: string, refreshToken: string, profile: twitch.Profile, done: oauth2.VerifyCallback) => void);
+    // NOTE: A union of function types prevents contextual typing of arguments.
+    // tslint:disable-next-line:unified-signatures max-line-length
+    constructor(options: twitch.StrategyOptionsWithRequest, verify: (req: express.Request, accessToken: string, params: any, refreshToken: string, profile: twitch.Profile, done: oauth2.VerifyCallback) => void);
+    checkScope(scope: string, accessToken: string, cb: (err?: Error | null, value?: any) => void): void;
+}
+
+declare namespace Strategy {
+    // NOTE: not true for `export import` statements
+    // tslint:disable-next-line:strict-export-declare-modifiers
+    export import Strategy = twitch;
+
+    interface _StrategyOptionsBase {
+        authorizationURL?: string;
+        tokenURL?: string;
+        clientID: string;
+        clientSecret: string;
+        callbackURL?: string;
+        customHeaders?: OutgoingHttpHeaders;
+        scope?: string | string[];
+        scopeSeparator?: string;
+        sessionKey?: string;
+        store?: oauth2.StateStore;
+        state?: any;
+    }
+
+    interface StrategyOptions extends _StrategyOptionsBase {
+        passReqToCallback?: false;
+    }
+
+    interface StrategyOptionsWithRequest extends _StrategyOptionsBase {
+        passReqToCallback: true;
+    }
+
+    interface Profile extends passport.Profile {
+        provider: "twitch";
+        id: string;
+        userName: string;
+        displayName: string;
+        profileImageUrl: string;
+        viewCount: number;
+        _raw: string;
+        _json: object;
+    }
+}
+
+export = Strategy;

--- a/types/ottomated__passport-twitch/ottomated__passport-twitch-tests.ts
+++ b/types/ottomated__passport-twitch/ottomated__passport-twitch-tests.ts
@@ -1,0 +1,34 @@
+import passport = require('passport');
+import twitch = require('ottomated__passport-twitch');
+import { Request } from 'express';
+
+// just some test model
+
+declare const User: { findOrCreate(twitchId: any, callback: (err: any, user: any) => void): void; };
+
+passport.use(new twitch.Strategy(
+    {
+        clientID: 'clientID',
+        clientSecret: 'clientSecret',
+        callbackURL: 'callbackURL'
+    },
+    (accessToken: string, refreshToken: string, profile, cb) => {
+        profile; // $ExpectType Profile
+        cb; // $ExpectType VerifyCallback
+        User.findOrCreate({ twitchId: profile.id }, cb);
+    }
+));
+
+passport.use(new twitch.Strategy(
+    {
+        clientID: 'clientID',
+        clientSecret: 'clientSecret',
+        callbackURL: 'callbackURL',
+        passReqToCallback: true
+    },
+    (req: Request, accessToken: string, refreshToken: string, profile, cb) => {
+        profile; // $ExpectType Profile
+        cb; // $ExpectType VerifyCallback
+        User.findOrCreate({ twitchId: profile.id }, cb);
+    }
+));

--- a/types/ottomated__passport-twitch/tsconfig.json
+++ b/types/ottomated__passport-twitch/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ottomated__passport-twitch-tests.ts"
+    ]
+}

--- a/types/ottomated__passport-twitch/tslint.json
+++ b/types/ottomated__passport-twitch/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.