### PR TITLE
fix(react-native): mark Animated config option `useNativeDriver` as optional

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8764,7 +8764,7 @@ export namespace Animated {
 
     interface AnimationConfig {
         isInteraction?: boolean;
-        useNativeDriver: boolean;
+        useNativeDriver?: boolean;
     }
 
     /**
@@ -8916,7 +8916,7 @@ export namespace Animated {
     type Mapping = { [key: string]: Mapping } | AnimatedValue;
     interface EventConfig<T> {
         listener?: (event: NativeSyntheticEvent<T>) => void;
-        useNativeDriver: boolean;
+        useNativeDriver?: boolean;
     }
 
     /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

After linting got:
```
error TS2307: Cannot find module 'csstype' or its corresponding type declarations.
```


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactnative.dev/docs/animated#event (indicates option defaults to `false`)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.