### PR TITLE
[poker-evaluator] Fix for number input

### DIFF
--- a/types/poker-evaluator/index.d.ts
+++ b/types/poker-evaluator/index.d.ts
@@ -9,8 +9,7 @@ export const HANDTYPES: HandName[];
 export const CARDS: Deck;
 export const ranks: Buffer;
 
-export function evalHand(cards: string[]): EvaluatedHand;
-export function evalCard(card: string): number;
+export function evalHand(cards: string[] | number[]): EvaluatedHand;
 
 export type HandName =
     'invalid hand' |

--- a/types/poker-evaluator/poker-evaluator-tests.ts
+++ b/types/poker-evaluator/poker-evaluator-tests.ts
@@ -1,17 +1,16 @@
-import { Deck, evalCard, evalHand, EvaluatedHand, HandName, HANDTYPES, ranks } from 'poker-evaluator';
+import { Deck, evalHand, EvaluatedHand, HandName, HANDTYPES, ranks } from 'poker-evaluator';
 
 HANDTYPES; // $ExpectType HandName[]
 ranks; // $ExpectType Buffer
 
 evalHand(['as', 'ks', 'qs', 'js', 'ts', '3c', '5h']); // $ExpectType EvaluatedHand
+evalHand([52, 48, 44, 40, 36, 5, 15]); // $ExpectType EvaluatedHand
 const result: EvaluatedHand = {
     handType: 9,
     handRank: 10,
     value: 36874,
     handName: 'straight flush',
 };
-
-evalCard('as'); // $ExpectType number
 
 const highCardName: HandName = 'high card';
 const deck: Deck = {


### PR DESCRIPTION
Update for number input. Remove evalCard typing as is for internal usage

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chenosaurus/poker-evaluator/issues/28
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
