### PR TITLE
[socket.io]: Made constructor new-able

### DIFF
--- a/types/socket.io/index.d.ts
+++ b/types/socket.io/index.d.ts
@@ -46,6 +46,31 @@ interface SocketIOStatic {
     (opts: SocketIO.ServerOptions): SocketIO.Server;
 
     /**
+     * Default Server constructor
+     */
+    new (): SocketIO.Server;
+
+    /**
+     * Creates a new Server
+     * @param srv The HTTP server that we're going to bind to
+     * @param opts An optional parameters object
+     */
+    new (srv: any, opts?: SocketIO.ServerOptions): SocketIO.Server;
+
+    /**
+     * Creates a new Server
+     * @param port A port to bind to, as a number, or a string
+     * @param An optional parameters object
+     */
+    new (port: string | number, opts?: SocketIO.ServerOptions): SocketIO.Server;
+
+    /**
+     * Creates a new Server
+     * @param A parameters object
+     */
+    new (opts: SocketIO.ServerOptions): SocketIO.Server;
+
+    /**
      * Backwards compatibility
      * @see io().listen()
      */

--- a/types/socket.io/socket.io-tests.ts
+++ b/types/socket.io/socket.io-tests.ts
@@ -1,5 +1,23 @@
 import socketIO = require('socket.io');
 
+function testUsingWithClassConstructor() {
+    var Server = socketIO;
+    var io: socketIO.Server = new Server();
+}
+
+function testUsingWithClassConstructorAndNodeHTTPServer() {
+    var app = require('http').createServer();
+    var Server = socketIO;
+    var io: socketIO.Server = new Server(app);
+}
+
+function testUsingWithWithClassConstructorAndOptions() {
+    var app = require('express')();
+    var httpServer = require('http').Server(app);
+    var Server = socketIO;
+    var io = new Server(httpServer, { wsEngine: 'ws' });
+}
+
 function testUsingWithNodeHTTPServer() {
     var app = require('http').createServer(handler);
     var io: socketIO.Server = socketIO(app);


### PR DESCRIPTION
Socket.io docs states that the `Server` constructor "works with and without new". Updated the interface to reflect this.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://socket.io/docs/server-api/#new-Server-httpServer-options>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
