### PR TITLE
Fix require-all filter that should return string or falsy values

### DIFF
--- a/types/require-all/index.d.ts
+++ b/types/require-all/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 interface Options {
     dirname: string;
-    filter?: ((name: string, path: string) => string) | RegExp;
+    filter?: ((name: string, path: string) => string | false) | RegExp;
     excludeDirs?: RegExp;
     map?: (name: string, path: string) => string;
     resolve?: (module: any) => any;

--- a/types/require-all/index.d.ts
+++ b/types/require-all/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 interface Options {
     dirname: string;
-    filter?: ((name: string, path: string) => string | false) | RegExp;
+    filter?: ((name: string, path: string) => string | false | void) | RegExp;
     excludeDirs?: RegExp;
     map?: (name: string, path: string) => string;
     resolve?: (module: any) => any;

--- a/types/require-all/index.d.ts
+++ b/types/require-all/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 interface Options {
     dirname: string;
-    filter?: ((name: string, path: string) => string | false | void) | RegExp;
+    filter?: ((name: string, path: string) => string | false | undefined) | RegExp;
     excludeDirs?: RegExp;
     map?: (name: string, path: string) => string;
     resolve?: (module: any) => any;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/require-all
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
