### PR TITLE
[@types/underscore] Collection and Array Tests - Every, Some, and Contains

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -412,7 +412,7 @@ declare module _ {
          **/
         contains<V extends Collection<any>>(
             collection: V,
-            value: TypeOfCollection<V>,
+            value: any,
             fromIndex?: number
         ): boolean;
 
@@ -4166,7 +4166,7 @@ declare module _ {
          * @returns True if `value` is present in the wrapped collection after
          * `fromIndex`, otherwise false.
          **/
-        contains(value: T, fromIndex?: number): boolean;
+        contains(value: any, fromIndex?: number): boolean;
 
         /**
          * @see contains
@@ -5178,7 +5178,7 @@ declare module _ {
          * @returns A chain wrapper around true if `value` is present in the
          * wrapped collection after `fromIndex`, otherwise around false.
          **/
-        contains(value: T, fromIndex?: number): _ChainSingle<boolean>;
+        contains(value: any, fromIndex?: number): _ChainSingle<boolean>;
 
         /**
          * @see contains

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -360,131 +360,71 @@ declare module _ {
         ): TypeOfCollection<V>[];
 
         /**
-        * Returns true if all of the values in the list pass the iterator truth test. Delegates to the
-        * native method every, if present.
-        * @param list Truth test against all elements within this list.
-        * @param iterator Trust test iterator function for each element in `list`.
-        * @param context `this` object in `iterator`, optional.
-        * @return True if all elements passed the truth test, otherwise false.
-        **/
-        every<T>(
-            list: _.List<T>,
-            iterator?: _.ListIterator<T, boolean>,
-            context?: any): boolean;
+         * Returns true if all of the values in `collection` pass the `iteratee`
+         * truth test. Short-circuits and stops traversing `collection` if a false
+         * element is found.
+         * @param collection The collection to evaluate.
+         * @param iteratee The truth test to apply.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns True if all elements pass the truth test, otherwise false.
+         **/
+        every<V extends Collection<any>>(
+            collection: V,
+            iteratee?: Iteratee<V, boolean>,
+            context?: any
+        ): boolean;
 
         /**
-        * @see _.every
-        **/
-        every<T>(
-            list: _.Dictionary<T>,
-            iterator?: _.ObjectIterator<T, boolean>,
-            context?: any): boolean;
+         * @see every
+         **/
+        all: UnderscoreStatic['every'];
 
         /**
-        * @see _.every
-        **/
-        all<T>(
-            list: _.List<T>,
-            iterator?: _.ListIterator<T, boolean>,
-            context?: any): boolean;
+         * Returns true if any of the values in `collection` pass the `iteratee`
+         * truth test. Short-circuits and stops traversing `collection` if a
+         * true element is found.
+         * @param collection The collection to evaluate.
+         * @param iteratee The truth test to apply.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns True if any element passed the truth test, otherwise false.
+         **/
+        some<V extends Collection<any>>(
+            collection: V,
+            iteratee?: Iteratee<V, boolean>,
+            context?: any
+        ): boolean;
 
         /**
-        * @see _.every
-        **/
-        all<T>(
-            list: _.Dictionary<T>,
-            iterator?: _.ObjectIterator<T, boolean>,
-            context?: any): boolean;
+         * @see some
+         **/
+        any: UnderscoreStatic['some'];
 
         /**
-        * Returns true if any of the values in the list pass the iterator truth test. Short-circuits and
-        * stops traversing the list if a true element is found. Delegates to the native method some, if present.
-        * @param list Truth test against all elements within this list.
-        * @param iterator Trust test iterator function for each element in `list`.
-        * @param context `this` object in `iterator`, optional.
-        * @return True if any elements passed the truth test, otherwise false.
-        **/
-        some<T>(
-            list: _.List<T>,
-            iterator?: _.ListIterator<T, boolean>,
-            context?: any): boolean;
+         * Returns true if the value is present in `collection`. Uses indexOf
+         * internally, if `collection` is a List. Use `fromIndex` to start your
+         * search at a given index.
+         * @param collection The collection to check for `value`.
+         * @param value The value to check `collection` for.
+         * @param fromIndex The index to start searching from, optional,
+         * default = 0, only used when `collection` is a List.
+         * @returns True if `value` is present in `collection` after
+         * `fromIndex`, otherwise false.
+         **/
+        contains<V extends Collection<any>>(
+            collection: V,
+            value: TypeOfCollection<V>,
+            fromIndex?: number
+        ): boolean;
 
         /**
-        * @see _.some
-        **/
-        some<T>(
-            object: _.Dictionary<T>,
-            iterator?: _.ObjectIterator<T, boolean>,
-            context?: any): boolean;
+         * @see contains
+         **/
+        include: UnderscoreStatic['contains'];
 
         /**
-        * @see _.some
-        **/
-        any<T>(
-            list: _.List<T>,
-            iterator?: _.ListIterator<T, boolean>,
-            context?: any): boolean;
-
-        /**
-        * @see _.some
-        **/
-        any<T>(
-            object: _.Dictionary<T>,
-            iterator?: _.ObjectIterator<T, boolean>,
-            context?: any): boolean;
-
-        any<T>(
-            list: _.List<T>,
-            value: T): boolean;
-
-        /**
-        * Returns true if the value is present in the list. Uses indexOf internally,
-        * if list is an Array.
-        * @param list Checks each element to see if `value` is present.
-        * @param value The value to check for within `list`.
-        * @return True if `value` is present in `list`, otherwise false.
-        **/
-        contains<T>(
-            list: _.List<T>,
-            value: T,
-            fromIndex?: number): boolean;
-
-        /**
-        * @see _.contains
-        **/
-        contains<T>(
-            object: _.Dictionary<T>,
-            value: T): boolean;
-
-        /**
-        * @see _.contains
-        **/
-        include<T>(
-            list: _.Collection<T>,
-            value: T,
-            fromIndex?: number): boolean;
-
-        /**
-        * @see _.contains
-        **/
-        include<T>(
-            object: _.Dictionary<T>,
-            value: T): boolean;
-
-        /**
-        * @see _.contains
-        **/
-        includes<T>(
-            list: _.Collection<T>,
-            value: T,
-            fromIndex?: number): boolean;
-
-        /**
-        * @see _.contains
-        **/
-        includes<T>(
-            object: _.Dictionary<T>,
-            value: T): boolean;
+         * @see contains
+         **/
+        includes: UnderscoreStatic['contains'];
 
         /**
         * Calls the method named by methodName on each value in the list. Any extra arguments passed to
@@ -4187,44 +4127,56 @@ declare module _ {
         reject(iteratee?: Iteratee<V, boolean>, context?: any): T[];
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.all
-        **/
-        all(iterator?: _.ListIterator<T, boolean>, context?: any): boolean;
+         * Returns true if all of the values in the wrapped collection pass the
+         * `iteratee` truth test. Short-circuits and stops traversing the
+         * wrapped collection if a false element is found.
+         * @param iteratee The truth test to apply.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns True if all elements pass the truth test, otherwise false.
+         **/
+        every(iteratee?: Iteratee<V, boolean>, context?: any): boolean;
 
         /**
-        * @see _.all
-        **/
-        every(iterator?: _.ListIterator<T, boolean>, context?: any): boolean;
+         * @see every
+         **/
+        all: Underscore<T, V>['every'];
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.any
-        **/
-        any(iterator?: _.ListIterator<T, boolean>, context?: any): boolean;
+         * Returns true if any of the values in the wrapped collection pass the
+         * `iteratee` truth test. Short-circuits and stops traversing the
+         * wrapped collection if a true element is found.
+         * @param iteratee The truth test to apply.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns True if any element passed the truth test, otherwise false.
+         **/
+        some(iteratee?: Iteratee<V, boolean>, context?: any): boolean;
 
         /**
-        * @see _.any
-        **/
-        some(iterator?: _.ListIterator<T, boolean>, context?: any): boolean;
+         * @see some
+         **/
+        any: Underscore<T, V>['some'];
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.contains
-        **/
+         * Returns true if the value is present in the wrapped collection. Uses
+         * indexOf internally, if the wrapped collection is a List. Use
+         * `fromIndex` to start your search at a given index.
+         * @param value The value to check the wrapped collection for.
+         * @param fromIndex The index to start searching from, optional,
+         * default = 0, only used when the wrapped collection is a List.
+         * @returns True if `value` is present in the wrapped collection after
+         * `fromIndex`, otherwise false.
+         **/
         contains(value: T, fromIndex?: number): boolean;
 
         /**
-        * Alias for 'contains'.
-        * @see contains
-        **/
-        include(value: T, fromIndex?: number): boolean;
-
-        /**
-         * Alias for 'contains'.
          * @see contains
          **/
-        includes(value: T, fromIndex?: number): boolean;
+        include: Underscore<T, V>['contains'];
+
+        /**
+         * @see contains
+         **/
+        includes: Underscore<T, V>['contains'];
 
         /**
         * Wrapped type `any[]`.
@@ -5185,44 +5137,58 @@ declare module _ {
         reject(iteratee?: _ChainIteratee<V, boolean, T>, context?: any): _Chain<T, T[]>;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.all
-        **/
-        all(iterator?: _.ListIterator<T, boolean>, context?: any): _ChainSingle<boolean>;
+         * Returns true if all of the values in the wrapped collection pass the
+         * `iteratee` truth test. Short-circuits and stops traversing the
+         * wrapped collection if a false element is found.
+         * @param iteratee The truth test to apply.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns A chain wrapper around true if all elements pass the truth
+         * test, otherwise around false.
+         **/
+        every(iterator?: _ChainIteratee<V, boolean, T>, context?: any): _ChainSingle<boolean>;
 
         /**
-        * @see _.all
-        **/
-        every(iterator?: _.ListIterator<T, boolean>, context?: any): _ChainSingle<boolean>;
+         * @see every
+         **/
+        all: _Chain<T, V>['every'];
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.any
-        **/
-        any(iterator?: _.ListIterator<T, boolean>, context?: any): _ChainSingle<boolean>;
+         * Returns true if any of the values in the wrapped collection pass the
+         * `iteratee` truth test. Short-circuits and stops traversing the
+         * wrapped collection if a true element is found.
+         * @param iteratee The truth test to apply.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns A chain wrapper around true if any element passed the truth
+         * test, otherwise around false.
+         **/
+        some(iterator?: _ChainIteratee<V, boolean, T>, context?: any): _ChainSingle<boolean>;
 
         /**
-        * @see _.any
-        **/
-        some(iterator?: _.ListIterator<T, boolean>, context?: any): _ChainSingle<boolean>;
+         * @see some
+         **/
+        any: _Chain<T, V>['some'];
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.contains
-        **/
+         * Returns true if the value is present in the wrapped collection. Uses
+         * indexOf internally, if the wrapped collection is a List. Use
+         * `fromIndex` to start your search at a given index.
+         * @param value The value to check the wrapped collection for.
+         * @param fromIndex The index to start searching from, optional,
+         * default = 0, only used when the wrapped collection is a List.
+         * @returns A chain wrapper around true if `value` is present in the
+         * wrapped collection after `fromIndex`, otherwise around false.
+         **/
         contains(value: T, fromIndex?: number): _ChainSingle<boolean>;
 
         /**
-        * Alias for 'contains'.
-        * @see contains
-        **/
-        include(value: T, fromIndex?: number): _ChainSingle<boolean>;
-
-        /**
-         * Alias for 'contains'.
          * @see contains
          **/
-        includes(value: T, fromIndex?: number): _ChainSingle<boolean>;
+        include: _Chain<T, V>['contains'];
+
+        /**
+         * @see contains
+         **/
+        includes: _Chain<T, V>['contains'];
 
         /**
         * Wrapped type `any[]`.

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -639,6 +639,9 @@ declare const anyCollectionVoidIterator: (element: any, index: string | number, 
 const simpleNumber = 7;
 declare const simpleNumberDictionary: _.Dictionary<number>;
 
+declare const simpleBooleanList: _.List<boolean>;
+declare const simpleBooleanDictionary: _.Dictionary<boolean>;
+
 declare const mixedIterabilityValue: number | number[];
 declare const neverValue: never;
 declare const maybeFunction: (() => void) | undefined;
@@ -1462,6 +1465,260 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _.reject(simpleNumberDictionary); // $ExpectType number[]
     _(simpleNumberDictionary).reject(); // $ExpectType number[]
     extractChainTypes(_.chain(simpleNumberDictionary).reject()); // $ExpectType ChainType<number[], number>
+}
+
+// every, all
+{
+    // function iteratee - lists - every
+    _.every(stringRecordList, stringRecordListBooleanIterator); // $ExpectType boolean
+    _(stringRecordList).every(stringRecordListBooleanIterator, context); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).every(stringRecordListBooleanIterator)); // $ExpectType ChainType<boolean, never>
+
+    // function iteratee - lists - all
+    _.all(stringRecordList, stringRecordListBooleanIterator, context); // $ExpectType boolean
+    _(stringRecordList).all(stringRecordListBooleanIterator); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).all(stringRecordListBooleanIterator, context)); // $ExpectType ChainType<boolean, never>
+
+    // function iteratee - dictionaries - every
+    _.every(stringRecordDictionary, stringRecordDictionaryBooleanIterator, context); // $ExpectType boolean
+    _(stringRecordDictionary).every(stringRecordDictionaryBooleanIterator); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordDictionary).every(stringRecordDictionaryBooleanIterator, context)); // $ExpectType ChainType<boolean, never>
+
+    // function iteratee - dictionaries - all
+    _.all(stringRecordDictionary, stringRecordDictionaryBooleanIterator); // $ExpectType boolean
+    _(stringRecordDictionary).all(stringRecordDictionaryBooleanIterator, context); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordDictionary).all(stringRecordDictionaryBooleanIterator)); // $ExpectType ChainType<boolean, never>
+
+    // partial object iteratee - lists - every
+    _.every(stringRecordList, partialStringRecord); // $ExpectType boolean
+    _(stringRecordList).every(partialStringRecord); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).every(partialStringRecord)); // $ExpectType ChainType<boolean, never>
+
+    // partial object iteratee - lists - all
+    _.all(stringRecordList, partialStringRecord); // $ExpectType boolean
+    _(stringRecordList).all(partialStringRecord); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).all(partialStringRecord)); // $ExpectType ChainType<boolean, never>
+
+    // partial object iteratee - dictionaries - every
+    _.every(stringRecordDictionary, partialStringRecord); // $ExpectType boolean
+    _(stringRecordDictionary).every(partialStringRecord); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordDictionary).every(partialStringRecord)); // $ExpectType ChainType<boolean, never>
+
+    // partial object iteratee - dictionaries - all
+    _.all(stringRecordDictionary, partialStringRecord); // $ExpectType boolean
+    _(stringRecordDictionary).all(partialStringRecord); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordDictionary).all(partialStringRecord)); // $ExpectType ChainType<boolean, never>
+
+    // property name iterator - lists - every
+    _.every(stringRecordList, stringRecordProperty); // $ExpectType boolean
+    _(stringRecordList).every(stringRecordProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).every(stringRecordProperty)); // $ExpectType ChainType<boolean, never>
+
+    // property name iterator - lists - all
+    _.all(stringRecordList, stringRecordProperty); // $ExpectType boolean
+    _(stringRecordList).all(stringRecordProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).all(stringRecordProperty)); // $ExpectType ChainType<boolean, never>
+
+    // property name iterator - dictionaries - every
+    _.every(stringRecordDictionary, stringRecordProperty); // $ExpectType boolean
+    _(stringRecordDictionary).every(stringRecordProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordDictionary).every(stringRecordProperty)); // $ExpectType ChainType<boolean, never>
+
+    // property name iterator - dictionaries - all
+    _.all(stringRecordDictionary, stringRecordProperty); // $ExpectType boolean
+    _(stringRecordDictionary).all(stringRecordProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordDictionary).all(stringRecordProperty)); // $ExpectType ChainType<boolean, never>
+
+    // property path iterator - lists - every
+    _.every(stringRecordList, stringRecordPropertyPath); // $ExpectType boolean
+    _(stringRecordList).every(stringRecordPropertyPath); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).every(stringRecordPropertyPath)); // $ExpectType ChainType<boolean, never>
+
+    // property path iterator - lists - all
+    _.all(stringRecordList, stringRecordPropertyPath); // $ExpectType boolean
+    _(stringRecordList).all(stringRecordPropertyPath); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).all(stringRecordPropertyPath)); // $ExpectType ChainType<boolean, never>
+
+    // property path iterator - dictionaries - every
+    _.every(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType boolean
+    _(stringRecordDictionary).every(stringRecordPropertyPath); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordDictionary).every(stringRecordPropertyPath)); // $ExpectType ChainType<boolean, never>
+
+    // property path iterator - dictionaries - all
+    _.all(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType boolean
+    _(stringRecordDictionary).all(stringRecordPropertyPath); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordDictionary).all(stringRecordPropertyPath)); // $ExpectType ChainType<boolean, never>
+
+    // identity iterator - lists - every
+    _.every(simpleBooleanList); // $ExpectType boolean
+    _(simpleBooleanList).every(); // $ExpectType boolean
+    extractChainTypes(_.chain(simpleBooleanList).every()); // $ExpectType ChainType<boolean, never>
+
+    // identity iterator - lists - all
+    _.all(simpleBooleanList); // $ExpectType boolean
+    _(simpleBooleanList).all(); // $ExpectType boolean
+    extractChainTypes(_.chain(simpleBooleanList).all()); // $ExpectType ChainType<boolean, never>
+
+    // identity iterator - dictionaries - every
+    _.every(simpleBooleanDictionary); // $ExpectType boolean
+    _(simpleBooleanDictionary).every(); // $ExpectType boolean
+    extractChainTypes(_.chain(simpleBooleanDictionary).every()); // $ExpectType ChainType<boolean, never>
+
+    // identity iterator - dictionaries - all
+    _.all(simpleBooleanDictionary); // $ExpectType boolean
+    _(simpleBooleanDictionary).all(); // $ExpectType boolean
+    extractChainTypes(_.chain(simpleBooleanDictionary).all()); // $ExpectType ChainType<boolean, never>
+}
+
+// some, any
+{
+    // function iteratee - lists - some
+    _.some(stringRecordList, stringRecordListBooleanIterator); // $ExpectType boolean
+    _(stringRecordList).some(stringRecordListBooleanIterator, context); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).some(stringRecordListBooleanIterator)); // $ExpectType ChainType<boolean, never>
+
+    // function iteratee - lists - any
+    _.any(stringRecordList, stringRecordListBooleanIterator, context); // $ExpectType boolean
+    _(stringRecordList).any(stringRecordListBooleanIterator); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).any(stringRecordListBooleanIterator, context)); // $ExpectType ChainType<boolean, never>
+
+    // function iteratee - dictionaries - some
+    _.some(stringRecordDictionary, stringRecordDictionaryBooleanIterator, context); // $ExpectType boolean
+    _(stringRecordDictionary).some(stringRecordDictionaryBooleanIterator); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordDictionary).some(stringRecordDictionaryBooleanIterator, context)); // $ExpectType ChainType<boolean, never>
+
+    // function iteratee - dictionaries - any
+    _.any(stringRecordDictionary, stringRecordDictionaryBooleanIterator); // $ExpectType boolean
+    _(stringRecordDictionary).any(stringRecordDictionaryBooleanIterator, context); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordDictionary).any(stringRecordDictionaryBooleanIterator)); // $ExpectType ChainType<boolean, never>
+
+    // partial object iteratee - lists - some
+    _.some(stringRecordList, partialStringRecord); // $ExpectType boolean
+    _(stringRecordList).some(partialStringRecord); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).some(partialStringRecord)); // $ExpectType ChainType<boolean, never>
+
+    // partial object iteratee - lists - any
+    _.any(stringRecordList, partialStringRecord); // $ExpectType boolean
+    _(stringRecordList).any(partialStringRecord); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).any(partialStringRecord)); // $ExpectType ChainType<boolean, never>
+
+    // partial object iteratee - dictionaries - some
+    _.some(stringRecordDictionary, partialStringRecord); // $ExpectType boolean
+    _(stringRecordDictionary).some(partialStringRecord); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordDictionary).some(partialStringRecord)); // $ExpectType ChainType<boolean, never>
+
+    // partial object iteratee - dictionaries - any
+    _.any(stringRecordDictionary, partialStringRecord); // $ExpectType boolean
+    _(stringRecordDictionary).any(partialStringRecord); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordDictionary).any(partialStringRecord)); // $ExpectType ChainType<boolean, never>
+
+    // property name iterator - lists - some
+    _.some(stringRecordList, stringRecordProperty); // $ExpectType boolean
+    _(stringRecordList).some(stringRecordProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).some(stringRecordProperty)); // $ExpectType ChainType<boolean, never>
+
+    // property name iterator - lists - any
+    _.any(stringRecordList, stringRecordProperty); // $ExpectType boolean
+    _(stringRecordList).any(stringRecordProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).any(stringRecordProperty)); // $ExpectType ChainType<boolean, never>
+
+    // property name iterator - dictionaries - some
+    _.some(stringRecordDictionary, stringRecordProperty); // $ExpectType boolean
+    _(stringRecordDictionary).some(stringRecordProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordDictionary).some(stringRecordProperty)); // $ExpectType ChainType<boolean, never>
+
+    // property name iterator - dictionaries - any
+    _.any(stringRecordDictionary, stringRecordProperty); // $ExpectType boolean
+    _(stringRecordDictionary).any(stringRecordProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordDictionary).any(stringRecordProperty)); // $ExpectType ChainType<boolean, never>
+
+    // property path iterator - lists - some
+    _.some(stringRecordList, stringRecordPropertyPath); // $ExpectType boolean
+    _(stringRecordList).some(stringRecordPropertyPath); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).some(stringRecordPropertyPath)); // $ExpectType ChainType<boolean, never>
+
+    // property path iterator - lists - any
+    _.any(stringRecordList, stringRecordPropertyPath); // $ExpectType boolean
+    _(stringRecordList).any(stringRecordPropertyPath); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).any(stringRecordPropertyPath)); // $ExpectType ChainType<boolean, never>
+
+    // property path iterator - dictionaries - some
+    _.some(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType boolean
+    _(stringRecordDictionary).some(stringRecordPropertyPath); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordDictionary).some(stringRecordPropertyPath)); // $ExpectType ChainType<boolean, never>
+
+    // property path iterator - dictionaries - any
+    _.any(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType boolean
+    _(stringRecordDictionary).any(stringRecordPropertyPath); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordDictionary).any(stringRecordPropertyPath)); // $ExpectType ChainType<boolean, never>
+
+    // identity iterator - lists - some
+    _.some(simpleBooleanList); // $ExpectType boolean
+    _(simpleBooleanList).some(); // $ExpectType boolean
+    extractChainTypes(_.chain(simpleBooleanList).some()); // $ExpectType ChainType<boolean, never>
+
+    // identity iterator - lists - any
+    _.any(simpleBooleanList); // $ExpectType boolean
+    _(simpleBooleanList).any(); // $ExpectType boolean
+    extractChainTypes(_.chain(simpleBooleanList).any()); // $ExpectType ChainType<boolean, never>
+
+    // identity iterator - dictionaries - some
+    _.some(simpleBooleanDictionary); // $ExpectType boolean
+    _(simpleBooleanDictionary).some(); // $ExpectType boolean
+    extractChainTypes(_.chain(simpleBooleanDictionary).some()); // $ExpectType ChainType<boolean, never>
+
+    // identity iterator - dictionaries - any
+    _.any(simpleBooleanDictionary); // $ExpectType boolean
+    _(simpleBooleanDictionary).any(); // $ExpectType boolean
+    extractChainTypes(_.chain(simpleBooleanDictionary).any()); // $ExpectType ChainType<boolean, never>
+}
+
+// contains, include, includes
+{
+    // no index - lists - contains
+    _.contains(stringRecordList, stringRecordList[0]); // $ExpectType boolean
+    _(stringRecordList).contains(stringRecordList[0]); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).contains(stringRecordList[0])); // $ExpectType ChainType<boolean, never>
+
+    // no index - lists - include
+    _.include(stringRecordList, stringRecordList[0]); // $ExpectType boolean
+    _(stringRecordList).include(stringRecordList[0]); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).include(stringRecordList[0])); // $ExpectType ChainType<boolean, never>
+
+    // no index - lists - includes
+    _.includes(stringRecordList, stringRecordList[0]); // $ExpectType boolean
+    _(stringRecordList).includes(stringRecordList[0]); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).includes(stringRecordList[0])); // $ExpectType ChainType<boolean, never>
+
+    // no index - dictionaries - contains
+    _.contains(stringRecordDictionary, stringRecordList[0]); // $ExpectType boolean
+    _(stringRecordDictionary).contains(stringRecordList[0]); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordDictionary).contains(stringRecordList[0])); // $ExpectType ChainType<boolean, never>
+
+    // no index - dictionaries - include
+    _.include(stringRecordDictionary, stringRecordList[0]); // $ExpectType boolean
+    _(stringRecordDictionary).include(stringRecordList[0]); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordDictionary).include(stringRecordList[0])); // $ExpectType ChainType<boolean, never>
+
+    // no index - dictionaries - includes
+    _.includes(stringRecordDictionary, stringRecordList[0]); // $ExpectType boolean
+    _(stringRecordDictionary).includes(stringRecordList[0]); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordDictionary).includes(stringRecordList[0])); // $ExpectType ChainType<boolean, never>
+
+    // with index - contains - lists
+    _.contains(stringRecordList, stringRecordList[0], simpleNumber); // $ExpectType boolean
+    _(stringRecordList).contains(stringRecordList[0], simpleNumber); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).contains(stringRecordList[0], simpleNumber)); // $ExpectType ChainType<boolean, never>
+
+    // with index - contains - include
+    _.include(stringRecordList, stringRecordList[0], simpleNumber); // $ExpectType boolean
+    _(stringRecordList).include(stringRecordList[0], simpleNumber); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).include(stringRecordList[0], simpleNumber)); // $ExpectType ChainType<boolean, never>
+
+    // with index - contains - includes
+    _.includes(stringRecordList, stringRecordList[0], simpleNumber); // $ExpectType boolean
+    _(stringRecordList).includes(stringRecordList[0], simpleNumber); // $ExpectType boolean
+    extractChainTypes(_.chain(stringRecordList).includes(stringRecordList[0], simpleNumber)); // $ExpectType ChainType<boolean, never>
 }
 
 // pluck

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -486,6 +486,12 @@ _.chain(anyValue)
     .find(i => i.findBooleanFunction())
     .value();
 
+// $ExpectType boolean
+_.chain([{ a: 1 }, { a: 2 }, { a: 3 }, { b: 4 }])
+    .map('a')
+    .contains(3)
+    .value();
+
 // $ExpectType { valueProperty: string; } | undefined
 _.chain([
     {

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1711,17 +1711,17 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _(stringRecordDictionary).includes(stringRecordList[0]); // $ExpectType boolean
     extractChainTypes(_.chain(stringRecordDictionary).includes(stringRecordList[0])); // $ExpectType ChainType<boolean, never>
 
-    // with index - contains - lists
+    // with index - contains
     _.contains(stringRecordList, stringRecordList[0], simpleNumber); // $ExpectType boolean
     _(stringRecordList).contains(stringRecordList[0], simpleNumber); // $ExpectType boolean
     extractChainTypes(_.chain(stringRecordList).contains(stringRecordList[0], simpleNumber)); // $ExpectType ChainType<boolean, never>
 
-    // with index - contains - include
+    // with index - include
     _.include(stringRecordList, stringRecordList[0], simpleNumber); // $ExpectType boolean
     _(stringRecordList).include(stringRecordList[0], simpleNumber); // $ExpectType boolean
     extractChainTypes(_.chain(stringRecordList).include(stringRecordList[0], simpleNumber)); // $ExpectType ChainType<boolean, never>
 
-    // with index - contains - includes
+    // with index - includes
     _.includes(stringRecordList, stringRecordList[0], simpleNumber); // $ExpectType boolean
     _(stringRecordList).includes(stringRecordList[0], simpleNumber); // $ExpectType boolean
     extractChainTypes(_.chain(stringRecordList).includes(stringRecordList[0], simpleNumber)); // $ExpectType ChainType<boolean, never>


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://underscorejs.org/
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

This PR continues the planned set that will together add up to #45201 and includes the following changes:

- Adds tests for `every`, `some`, and `contains`.
- Collapses overloads of `UnderscoreStatic.every` and `UnderscoreStatic.some` by updating them to use `CollectionIterator`.
- Updates the `Underscore` and `_Chain` versions of `every` and `some` to work with both Lists and Dictionaries to partially fix #20623.
- Replaces all `all` overloads with a reference to `every` overloads, all `any` overloads with a reference to `some` overloads, and all `include` and `includes` overloads with a reference to `contains` overloads.