### PR TITLE
[@types/underscore] Collection and Array Tests - Compact and Range

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -791,7 +791,7 @@ declare module _ {
          * @returns An array containing the elements of `list` without falsy
          * values.
          **/
-        compact<V extends List<any>>(list: V): Truthy<TypeOfList<V>>[];
+        compact<V extends List<any> | null | undefined>(list: V): Truthy<TypeOfList<V>>[];
 
         /**
          * Flattens a nested array (the nesting can be to any depth). If you pass shallow, the array will

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -1004,32 +1004,28 @@ declare module _ {
 
         /**
          * A function to create flexibly-numbered lists of integers, handy for
-         * `each` and `map` loops. Returns a list of integers from `start`
-         * (inclusive) to `stop` (exclusive), incremented (or decremented) by
-         * `step`, exclusive. Note that ranges that `stop` before they `start`
-         * are considered to be zero-length instead of negative - if you'd like
-         * a negative range, use a negative `step`.
-         * @param start The number to start at, optional, default = 1.
+         * `each` and `map` loops. Returns a list of integers from
+         * `startOrStop` (inclusive) to `stop` (exclusive), incremented
+         * (or decremented) by `step`. Note that ranges that `stop` before they
+         * `start` are considered to be zero-length instead of negative - if
+         * you'd like a negative range, use a negative `step`.
+         *
+         * If `stop` is not specified, `startOrStop` will be the number to stop
+         * at and the default start of 0 will be used.
+         * @param startOrStop If `stop` is specified, the number to start at.
+         * Otherwise, this is the number to stop at and the default start of 0
+         * will be used.
          * @param stop The number to stop at.
          * @param step The number to count up by each iteration, optional,
          * default = 1.
-         * @returns An array of numbers from `start` to `stop` with increments
+         * @returns An array of numbers from start to `stop` with increments
          * of `step`.
          **/
         range(
-            start: number,
-            stop: number,
+            startOrStop: number,
+            stop?: number,
             step?: number
         ): number[];
-
-        /**
-         * A function to create flexibly-numbered lists of integers, handy for
-         * `each` and `map` loops.  Returns a list of integers from 0
-         * (inclusive) to `stop` (exclusive), incremented by 1.
-         * @param stop The number to stop at.
-         * @returns An array of numbers from 0 to `stop` with increments of 1.
-         **/
-        range(stop: number): number[];
 
         /**
          * Chunks a list into multiple arrays, each containing length or fewer items.
@@ -4558,27 +4554,21 @@ declare module _ {
 
         /**
          * A function to create flexibly-numbered lists of integers, handy for
-         * `each` and `map` loops. Returns a list of integers from the wrapped
-         * value (inclusive) to `stop` (exclusive), incremented (or
-         * decremented) by `step`, exclusive. Note that ranges that `stop`
-         * before they start are considered to be zero-length instead of
-         * negative - if you'd like a negative range, use a negative `step`.
+         * `each` and `map` loops. Returns a list of integers from
+         * the wrapped value (inclusive) to `stop` (exclusive), incremented
+         * (or decremented) by `step`. Note that ranges that `stop` before they
+         * `start` are considered to be zero-length instead of negative - if
+         * you'd like a negative range, use a negative `step`.
+         *
+         * If `stop` is not specified, the wrapped value will be the number to
+         * stop at and the default start of 0 will be used.
          * @param stop The number to stop at.
          * @param step The number to count up by each iteration, optional,
          * default = 1.
-         * @returns An array of numbers from the wrapped value to `stop` with
-         * increments of `step`.
+         * @returns An array of numbers from start to `stop` with increments
+         * of `step`.
          **/
-        range(stop: number, step?: number): number[];
-
-        /**
-         * A function to create flexibly-numbered lists of integers, handy for
-         * `each` and `map` loops.  Returns a list of integers from 0
-         * (inclusive) to the wrapped value (exclusive), incremented by 1.
-         * @returns An array of numbers from 0 to the wrapped value with
-         * increments of 1.
-         **/
-        range(): number[];
+        range(stop?: number, step?: number): number[];
 
         /**
          * Chunks a wrapped list into multiple arrays, each containing length or fewer items.
@@ -5570,27 +5560,21 @@ declare module _ {
 
         /**
          * A function to create flexibly-numbered lists of integers, handy for
-         * `each` and `map` loops. Returns a list of integers from the wrapped
-         * value (inclusive) to `stop` (exclusive), incremented (or
-         * decremented) by `step`, exclusive. Note that ranges that `stop`
-         * before they start are considered to be zero-length instead of
-         * negative - if you'd like a negative range, use a negative `step`.
+         * `each` and `map` loops. Returns a list of integers from
+         * the wrapped value (inclusive) to `stop` (exclusive), incremented
+         * (or decremented) by `step`. Note that ranges that `stop` before they
+         * `start` are considered to be zero-length instead of negative - if
+         * you'd like a negative range, use a negative `step`.
+         *
+         * If `stop` is not specified, the wrapped value will be the number to
+         * stop at and the default start of 0 will be used.
          * @param stop The number to stop at.
          * @param step The number to count up by each iteration, optional,
          * default = 1.
-         * @returns A chain wrapper around an array of numbers from the wrapped
-         * value to `stop` with increments of `step`.
+         * @returns A chain wrapper around an array of numbers from start to
+         * `stop` with increments of `step`.
          **/
-        range(stop: number, step?: number): _Chain<number, number[]>;
-
-        /**
-         * A function to create flexibly-numbered lists of integers, handy for
-         * `each` and `map` loops.  Returns a list of integers from 0
-         * (inclusive) to the wrapped value (exclusive), incremented by 1.
-         * @returns A chain wrapper around nn array of numbers from 0 to the
-         * wrapped value with increments of 1.
-         **/
-        range(): _Chain<number, number[]>;
+        range(stop?: number, step?: number): _Chain<number, number[]>;
 
         /**
          * Chunks a wrapped list into multiple arrays, each containing length or fewer items.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -154,6 +154,10 @@ declare module _ {
         : TItem
         : T;
 
+    type AnyFalsy = undefined | null | false | '' | 0;
+
+    type Truthy<T> = Exclude<T, AnyFalsy>;
+
     type _ChainSingle<V> = _Chain<TypeOfCollection<V>, V>;
 
     interface Cancelable {
@@ -781,12 +785,13 @@ declare module _ {
         drop: UnderscoreStatic['rest'];
 
         /**
-        * Returns a copy of the array with all falsy values removed. In JavaScript, false, null, 0, "",
-        * undefined and NaN are all falsy.
-        * @param array Array to compact.
-        * @return Copy of `array` without false values.
-        **/
-        compact<T>(array: _.List<T | null | undefined | false | "" | 0> | null | undefined): T[]
+         * Returns a copy of `list` with all falsy values removed. In
+         * JavaScript, false, null, 0, "", undefined and NaN are all falsy.
+         * @param list The list to compact.
+         * @returns An array containing the elements of `list` without falsy
+         * values.
+         **/
+        compact<V extends List<any>>(list: V): Truthy<TypeOfList<V>>[];
 
         /**
          * Flattens a nested array (the nesting can be to any depth). If you pass shallow, the array will
@@ -998,26 +1003,32 @@ declare module _ {
         ): number;
 
         /**
-        * A function to create flexibly-numbered lists of integers, handy for each and map loops. start, if omitted,
-        * defaults to 0; step defaults to 1. Returns a list of integers from start to stop, incremented (or decremented)
-        * by step, exclusive.
-        * @param start Start here.
-        * @param stop Stop here.
-        * @param step The number to count up by each iteration, optional, default = 1.
-        * @return Array of numbers from `start` to `stop` with increments of `step`.
-        **/
-
+         * A function to create flexibly-numbered lists of integers, handy for
+         * `each` and `map` loops. Returns a list of integers from `start`
+         * (inclusive) to `stop` (exclusive), incremented (or decremented) by
+         * `step`, exclusive. Note that ranges that `stop` before they `start`
+         * are considered to be zero-length instead of negative - if you'd like
+         * a negative range, use a negative `step`.
+         * @param start The number to start at, optional, default = 1.
+         * @param stop The number to stop at.
+         * @param step The number to count up by each iteration, optional,
+         * default = 1.
+         * @returns An array of numbers from `start` to `stop` with increments
+         * of `step`.
+         **/
         range(
             start: number,
             stop: number,
-            step?: number): number[];
+            step?: number
+        ): number[];
 
         /**
-        * @see _.range
-        * @param stop Stop here.
-        * @return Array of numbers from 0 to `stop` with increments of 1.
-        * @note If start is not specified the implementation will never pull the step (step = arguments[2] || 0)
-        **/
+         * A function to create flexibly-numbered lists of integers, handy for
+         * `each` and `map` loops.  Returns a list of integers from 0
+         * (inclusive) to `stop` (exclusive), incremented by 1.
+         * @param stop The number to stop at.
+         * @returns An array of numbers from 0 to `stop` with increments of 1.
+         **/
         range(stop: number): number[];
 
         /**
@@ -4414,10 +4425,12 @@ declare module _ {
         drop: Underscore<T, V>['rest'];
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.compact
-        **/
-        compact(): T[];
+         * Returns a copy of the wrapped list with all falsy values removed. In
+         * JavaScript, false, null, 0, "", undefined and NaN are all falsy.
+         * @returns An array containing the elements of the wrapped list without
+         * falsy values.
+         **/
+        compact(): Truthy<T>[];
 
         /**
          * Flattens the wrapped nested list (the nesting can be to any depth). If you pass shallow, the list will
@@ -4544,15 +4557,27 @@ declare module _ {
         sortedIndex(value: T, iteratee?: Iteratee<V, any>, context?: any): number;
 
         /**
-        * Wrapped type `number`.
-        * @see _.range
-        **/
+         * A function to create flexibly-numbered lists of integers, handy for
+         * `each` and `map` loops. Returns a list of integers from the wrapped
+         * value (inclusive) to `stop` (exclusive), incremented (or
+         * decremented) by `step`, exclusive. Note that ranges that `stop`
+         * before they start are considered to be zero-length instead of
+         * negative - if you'd like a negative range, use a negative `step`.
+         * @param stop The number to stop at.
+         * @param step The number to count up by each iteration, optional,
+         * default = 1.
+         * @returns An array of numbers from the wrapped value to `stop` with
+         * increments of `step`.
+         **/
         range(stop: number, step?: number): number[];
 
         /**
-        * Wrapped type `number`.
-        * @see _.range
-        **/
+         * A function to create flexibly-numbered lists of integers, handy for
+         * `each` and `map` loops.  Returns a list of integers from 0
+         * (inclusive) to the wrapped value (exclusive), incremented by 1.
+         * @returns An array of numbers from 0 to the wrapped value with
+         * increments of 1.
+         **/
         range(): number[];
 
         /**
@@ -5411,10 +5436,12 @@ declare module _ {
         drop: _Chain<T, V>['rest'];
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.compact
-        **/
-        compact(): _Chain<T>;
+         * Returns a copy of the wrapped list with all falsy values removed. In
+         * JavaScript, false, null, 0, "", undefined and NaN are all falsy.
+         * @returns A chain wrapper around an array containing the elements of
+         * the wrapped list without falsy values.
+         **/
+        compact(): _Chain<Truthy<T>, Truthy<T>[]>;
 
         /**
          * Flattens the wrapped nested list (the nesting can be to any depth). If you pass shallow, the list will
@@ -5542,16 +5569,28 @@ declare module _ {
         sortedIndex(value: T, iteratee?: _ChainIteratee<V, any, T>, context?: any): _ChainSingle<number>;
 
         /**
-        * Wrapped type `number`.
-        * @see _.range
-        **/
-        range(stop: number, step?: number): _Chain<T>;
+         * A function to create flexibly-numbered lists of integers, handy for
+         * `each` and `map` loops. Returns a list of integers from the wrapped
+         * value (inclusive) to `stop` (exclusive), incremented (or
+         * decremented) by `step`, exclusive. Note that ranges that `stop`
+         * before they start are considered to be zero-length instead of
+         * negative - if you'd like a negative range, use a negative `step`.
+         * @param stop The number to stop at.
+         * @param step The number to count up by each iteration, optional,
+         * default = 1.
+         * @returns A chain wrapper around an array of numbers from the wrapped
+         * value to `stop` with increments of `step`.
+         **/
+        range(stop: number, step?: number): _Chain<number, number[]>;
 
         /**
-        * Wrapped type `number`.
-        * @see _.range
-        **/
-        range(): _Chain<T>;
+         * A function to create flexibly-numbered lists of integers, handy for
+         * `each` and `map` loops.  Returns a list of integers from 0
+         * (inclusive) to the wrapped value (exclusive), incremented by 1.
+         * @returns A chain wrapper around nn array of numbers from 0 to the
+         * wrapped value with increments of 1.
+         **/
+        range(): _Chain<number, number[]>;
 
         /**
          * Chunks a wrapped list into multiple arrays, each containing length or fewer items.

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -2026,6 +2026,11 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _(simpleNumber).range(simpleNumber); // $ExpectType number[]
     extractChainTypes(_.chain(simpleNumber).range(simpleNumber)); // $ExpectType ChainType<number[], number>
 
+    // stop and step
+    _.range(simpleNumber, undefined, simpleNumber); // $ExpectType number[]
+    _(simpleNumber).range(undefined, simpleNumber); // $ExpectType number[]
+    extractChainTypes(_.chain(simpleNumber).range(undefined, simpleNumber)); // $ExpectType ChainType<number[], number>
+
     // start, stop, and step
     _.range(simpleNumber, simpleNumber, simpleNumber); // $ExpectType number[]
     _(simpleNumber).range(simpleNumber, simpleNumber); // $ExpectType number[]

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -511,6 +511,27 @@ _.chain([
     .sample()
     .value();
 
+// $ExpectType number
+_.chain([1, 2, 3, 4, 5, 6])
+    .chunk(3)
+    .first()
+    .compact()
+    .reduce((aggregate, n) => aggregate + n, 0)
+    .value();
+
+// $ExpectType number[]
+_.chain([1, 2, 3, 4, 5, 6])
+    .sample()
+    .range(10)
+    .value();
+
+// $ExpectType [number[], number[]]
+_.chain([[1, 2, 3], [4, undefined, 5], [undefined, undefined, 6]])
+    .flatten()
+    .compact()
+    .partition(n => n > 3)
+    .value();
+
 // verify that partial objects can be provided without error to where and findWhere for a union type collection
 // where no types in the union share the same property names
 declare const nonIntersectinglTypeUnion: _.Dictionary<{ one: string; } | { two: number; }>;

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -660,6 +660,7 @@ declare const stringy: StringRecord | string;
 
 type Truthies = string | number | boolean | object | Function | StringRecord | (() => void);
 declare const truthyFalsyList: _.List<Truthies | _.AnyFalsy>;
+declare const maybeTruthyFalsyList: _.List<Truthies | _.AnyFalsy> | null | undefined;
 
 // avoid referencing types under test directly by translating them to other types to avoid needing to make lots of changes if
 // the types under test need to be refactored
@@ -1749,15 +1750,10 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _(truthyFalsyList).compact(); // $ExpectType (string | number | true | object | Function | StringRecord | (() => void))[]
     extractChainTypes(_.chain(truthyFalsyList).compact()); // $ExpectType ChainType<(string | number | true | object | Function | StringRecord | (() => void))[], string | number | true | object | Function | StringRecord | (() => void)>
 
-    // null
-    _.compact(null); // $ExpectType never[]
-    _(null).compact(); // $ExpectType never[]
-    extractChainTypes(_.chain(null).compact()); // $ExpectType ChainType<never[], never>
-
-    // undefined
-    _.compact(undefined); // $ExpectType never[]
-    _(undefined).compact(); // $ExpectType never[]
-    extractChainTypes(_.chain(undefined).compact()); // $ExpectType ChainType<never[], never>
+    // maybe lists
+    _.compact(maybeTruthyFalsyList); // $ExpectType (string | number | true | object | Function | StringRecord | (() => void))[]
+    _(maybeTruthyFalsyList).compact(); // $ExpectType (string | number | true | object | Function | StringRecord | (() => void))[]
+    extractChainTypes(_.chain(maybeTruthyFalsyList).compact()); // $ExpectType ChainType<(string | number | true | object | Function | StringRecord | (() => void))[], string | number | true | object | Function | StringRecord | (() => void)>
 }
 
 // flatten

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1744,9 +1744,15 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
 
 // compact
 {
+    // lists
     _.compact(truthyFalsyList); // $ExpectType (string | number | true | object | Function | StringRecord | (() => void))[]
     _(truthyFalsyList).compact(); // $ExpectType (string | number | true | object | Function | StringRecord | (() => void))[]
     extractChainTypes(_.chain(truthyFalsyList).compact()); // $ExpectType ChainType<(string | number | true | object | Function | StringRecord | (() => void))[], string | number | true | object | Function | StringRecord | (() => void)>
+
+    // undefined
+    _.compact(undefined); // $ExpectType never[]
+    _(undefined).compact(); // $ExpectType never[]
+    extractChainTypes(_.chain(undefined).compact()); // $ExpectType ChainType<never[], never>
 }
 
 // flatten

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -645,6 +645,9 @@ declare const maybeFunction: (() => void) | undefined;
 declare const maybeStringArray: string[] | undefined;
 declare const stringy: StringRecord | string;
 
+type Truthies = string | number | boolean | object | Function | StringRecord | (() => void);
+declare const truthyFalsyList: _.List<Truthies | _.AnyFalsy>;
+
 // avoid referencing types under test directly by translating them to other types to avoid needing to make lots of changes if
 // the types under test need to be refactored
 interface UnderscoreType<TWrappedValue, TItemType> { }
@@ -1726,6 +1729,13 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     extractChainTypes(_.chain(stringRecordList).drop(simpleNumber)); // $ExpectType ChainType<StringRecord[], StringRecord>
 }
 
+// compact
+{
+    _.compact(truthyFalsyList); // $ExpectType (string | number | true | object | Function | StringRecord | (() => void))[]
+    _(truthyFalsyList).compact(); // $ExpectType (string | number | true | object | Function | StringRecord | (() => void))[]
+    extractChainTypes(_.chain(truthyFalsyList).compact()); // $ExpectType ChainType<(string | number | true | object | Function | StringRecord | (() => void))[], string | number | true | object | Function | StringRecord | (() => void)>
+}
+
 // flatten
 {
     // one dimension, deep
@@ -1983,6 +1993,24 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _([{a: 'a'}, {a: 'b'}]).findLastIndex({ a: 'b' }); // $ExpectType number
     _.chain([1, 2, 3, 1, 2, 3]).findLastIndex(num => num % 2 === 0).value(); // $ExpectType number
     _.chain([{a: 'a'}, {a: 'b'}]).findLastIndex({ a: 'b' }).value(); // $ExpectType number
+}
+
+// range
+{
+    // only stop
+    _.range(simpleNumber); // $ExpectType number[]
+    _(simpleNumber).range(); // $ExpectType number[]
+    extractChainTypes(_.chain(simpleNumber).range()); // $ExpectType ChainType<number[], number>
+
+    // start and stop
+    _.range(simpleNumber, simpleNumber); // $ExpectType number[]
+    _(simpleNumber).range(simpleNumber); // $ExpectType number[]
+    extractChainTypes(_.chain(simpleNumber).range(simpleNumber)); // $ExpectType ChainType<number[], number>
+
+    // start, stop, and step
+    _.range(simpleNumber, simpleNumber, simpleNumber); // $ExpectType number[]
+    _(simpleNumber).range(simpleNumber, simpleNumber); // $ExpectType number[]
+    extractChainTypes(_.chain(simpleNumber).range(simpleNumber, simpleNumber)); // $ExpectType ChainType<number[], number>
 }
 
 // Objects

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1749,6 +1749,11 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _(truthyFalsyList).compact(); // $ExpectType (string | number | true | object | Function | StringRecord | (() => void))[]
     extractChainTypes(_.chain(truthyFalsyList).compact()); // $ExpectType ChainType<(string | number | true | object | Function | StringRecord | (() => void))[], string | number | true | object | Function | StringRecord | (() => void)>
 
+    // null
+    _.compact(null); // $ExpectType never[]
+    _(null).compact(); // $ExpectType never[]
+    extractChainTypes(_.chain(null).compact()); // $ExpectType ChainType<never[], never>
+
     // undefined
     _.compact(undefined); // $ExpectType never[]
     _(undefined).compact(); // $ExpectType never[]

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -511,14 +511,6 @@ _.chain([
     .sample()
     .value();
 
-// $ExpectType number
-_.chain([1, 2, 3, 4, 5, 6])
-    .chunk(3)
-    .first()
-    .compact()
-    .reduce((aggregate, n) => aggregate + n, 0)
-    .value();
-
 // $ExpectType number[]
 _.chain([1, 2, 3, 4, 5, 6])
     .sample()


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://underscorejs.org/
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

This PR continues the planned set that will together add up to #45201 and includes the following changes:

- Adds tests for `compact` and `range`.
- Adds a `Truthy` conditional type and updates all `compact` functions to use it.
- Updates the return type of `_Chain.compact` and `_Chain.range` to use the correct wrapped value type `V` to partially fix #36308.