### PR TITLE
Export the `Options` interface for @types/cssbeautify

### DIFF
--- a/types/cssbeautify/index.d.ts
+++ b/types/cssbeautify/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: rictic <https://github.com/rictic>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-interface Options {
+export interface Options {
   /**
    * A string used for the indentation of the declaration (default is 4
    * spaces).
@@ -22,4 +22,4 @@ interface Options {
 }
 declare function beautify(cssText: string, options?: Options): string;
 
-export = beautify;
+export default beautify;


### PR DESCRIPTION
Hi sorry I didn't use the template but it's a two word change that I've tested locally by editing the file in node_modules and I think it's pretty straight forward.

Currently you have to use `type CSSBeautifyOptions = Parameters<typeof cssBeautify>[1]`.

The usecase for importing an interface is to use it as options for some other options interface like:

```ts
import type { Options as CSSBeautifyOptions } from 'cssbeautify'

type MyProgramOpts = {
  quite: boolean,
  cssOutFile: string,
  cssBeautifyOpts: CSSBeautifyOptions,
}
```