### PR TITLE
[@types/stripe-v3] hideIcon is no more a variable of ElementsOptions as per Stripe docs

### DIFF
--- a/types/react-stripe-elements/react-stripe-elements-tests.tsx
+++ b/types/react-stripe-elements/react-stripe-elements-tests.tsx
@@ -49,7 +49,7 @@ const cardElementProps: ElementsOptions = {
         invalid: 'is-invalid',
         webkitAutofill: 'webkit-autofill',
     },
-    showIcon: true,
+    hideIcon: true,
 };
 
 const fontElementsProps: ElementsCreateOptions = {

--- a/types/react-stripe-elements/react-stripe-elements-tests.tsx
+++ b/types/react-stripe-elements/react-stripe-elements-tests.tsx
@@ -49,7 +49,7 @@ const cardElementProps: ElementsOptions = {
         invalid: 'is-invalid',
         webkitAutofill: 'webkit-autofill',
     },
-    hideIcon: true,
+    showIcon: true,
 };
 
 const fontElementsProps: ElementsCreateOptions = {

--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -957,7 +957,7 @@ declare namespace stripe {
                 webkitAutofill?: string;
             };
             hidePostalCode?: boolean;
-            hideIcon?: boolean;
+            showIcon?: boolean;
             iconStyle?: 'solid' | 'default';
             placeholder?: string;
             placeholderCountry?: string;

--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -957,6 +957,7 @@ declare namespace stripe {
                 webkitAutofill?: string;
             };
             hidePostalCode?: boolean;
+            hideIcon?: boolean;
             showIcon?: boolean;
             iconStyle?: 'solid' | 'default';
             placeholder?: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://stripe.com/docs/js/elements_object/create_element?type=cardNumber>>
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
