### PR TITLE
[socket.io][hapi]: Added type checking for the HTTP server Socket.io binds to

### DIFF
--- a/types/hapi/v16/test/server/listener.ts
+++ b/types/hapi/v16/test/server/listener.ts
@@ -1,4 +1,3 @@
-
 // From https://hapijs.com/api/16.1.1#serverlistener
 
 import * as Hapi from 'hapi';
@@ -8,9 +7,8 @@ const server = new Hapi.Server();
 server.connection({ port: 80 });
 
 // https://socket.io/docs/server-api/#server-attach-httpserver-options
-const io = SocketIO.listen(server.listener);
-io.sockets.on('connection', (socket) => {
-
+const io = SocketIO.listen(server.listener!);
+io.sockets.on('connection', socket => {
     // TODO, FIXME by removing <any>, probably `socket` type given here is
     // a wrapper around socket.io.  Much less likely is either
     // a type error in the TypeScript definitions of socket.io or

--- a/types/socket.io/index.d.ts
+++ b/types/socket.io/index.d.ts
@@ -14,6 +14,8 @@
 
 declare const SocketIO: SocketIOStatic;
 import engine = require('engine.io');
+import { Server as HttpServer } from 'http';
+import { Server as HttpsServer } from 'https';
 import { EventEmitter } from 'events';
 export = SocketIO;
 /** @deprecated Available as a global for backwards-compatibility. */
@@ -30,7 +32,7 @@ interface SocketIOStatic {
      * @param srv The HTTP server that we're going to bind to
      * @param opts An optional parameters object
      */
-    (srv: any, opts?: SocketIO.ServerOptions): SocketIO.Server;
+    (srv: HttpServer | HttpsServer, opts?: SocketIO.ServerOptions): SocketIO.Server;
 
     /**
      * Creates a new Server
@@ -55,7 +57,7 @@ interface SocketIOStatic {
      * @param srv The HTTP server that we're going to bind to
      * @param opts An optional parameters object
      */
-    new (srv: any, opts?: SocketIO.ServerOptions): SocketIO.Server;
+    new (srv: HttpServer | HttpsServer, opts?: SocketIO.ServerOptions): SocketIO.Server;
 
     /**
      * Creates a new Server
@@ -188,7 +190,7 @@ declare namespace SocketIO {
          * @param opts An optional parameters object
          * @return This Server
          */
-        attach(srv: any, opts?: ServerOptions): Server;
+        attach(srv: HttpServer | HttpsServer, opts?: ServerOptions): Server;
 
         /**
          * Attaches socket.io to a port
@@ -201,7 +203,7 @@ declare namespace SocketIO {
         /**
          * @see attach( srv, opts )
          */
-        listen(srv: any, opts?: ServerOptions): Server;
+        listen(srv: HttpServer | HttpsServer, opts?: ServerOptions): Server;
 
         /**
          * @see attach( port, opts )


### PR DESCRIPTION
This PR adds type checking for the HTTP server socket.io binds to instead of using `any`. This required a small change to Hapi's listeners test which uses Socket.io.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://socket.io/docs/server-api/#new-Server-httpServer-options>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
