### PR TITLE
Add type definitions for merge-refs

### DIFF
--- a/types/merge-refs/index.d.ts
+++ b/types/merge-refs/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for merge-refs 1.0
+// Project: https://github.com/wojtekmaj/merge-refs
+// Definitions by: Jakub Skoneczny <https://github.com/Skona27>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as React from 'react';
+
+declare function merge_refs<T>(...refs: Array<React.Ref<T>>): (instance: T) => void;
+export default merge_refs;

--- a/types/merge-refs/merge-refs-tests.ts
+++ b/types/merge-refs/merge-refs-tests.ts
@@ -1,0 +1,8 @@
+import React = require('react');
+import mergeRefs from 'merge-refs';
+
+mergeRefs(React.createRef(), React.createRef());
+mergeRefs(
+    (instance: HTMLDivElement) => {},
+    (instance: HTMLDivElement) => {},
+);

--- a/types/merge-refs/tsconfig.json
+++ b/types/merge-refs/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "allowSyntheticDefaultImports": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "merge-refs-tests.ts"
+    ]
+}

--- a/types/merge-refs/tslint.json
+++ b/types/merge-refs/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`