### PR TITLE
[@types/formdata]: New definition

### DIFF
--- a/types/formdata/formdata-tests.ts
+++ b/types/formdata/formdata-tests.ts
@@ -1,0 +1,20 @@
+/// <reference lib="dom" />
+
+import FormData = require('formdata');
+
+const formData = new FormData();
+
+const error = formData.append('username', 'Chris');
+if (error) {
+    throw error;
+}
+
+const contentType = formData.getContentType();
+contentType.toUpperCase();
+
+const emitter = formData.serialize('multipart/form-data');
+if (emitter) {
+    emitter.addListener('data', data => console.log(data));
+}
+
+formData.setNodeChunkedEncoding(true);

--- a/types/formdata/index.d.ts
+++ b/types/formdata/index.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for formdata 0.10
+// Project: https://github.com/node-file-api/FormData
+// Definitions by: Ciarán Ingle <https://github.com/inglec-arista>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { EventEmitter } from 'events';
+
+declare class FormData {
+    nodeChunkedEncoding: boolean;
+
+    boundary?: string;
+    type?: string;
+
+    append(key: keyof any, value: unknown): Error | undefined;
+    getContentType(): string;
+    serialize(intendedType?: string): EventEmitter | undefined;
+    setNodeChunkedEncoding(val: boolean): void;
+}
+
+export = FormData;

--- a/types/formdata/tsconfig.json
+++ b/types/formdata/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "baseUrl": "../",
+        "forceConsistentCasingInFileNames": true,
+        "lib": ["es6"],
+        "module": "commonjs",
+        "noEmit": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "typeRoots": ["../"],
+        "types": []
+    },
+    "files": [
+        "formdata-tests.ts",
+        "index.d.ts"
+    ]
+}

--- a/types/formdata/tslint.json
+++ b/types/formdata/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.