### PR TITLE
graphql-fields: Update graphql to 15.3.0

### DIFF
--- a/types/graphql-fields/package.json
+++ b/types/graphql-fields/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "^14.5.3"
+    "graphql": "^15.3.0"
   }
 }


### PR DESCRIPTION
`graphql` version 15.3.0 added breaking changes to the type `GraphQLResolveInfo` so that code like the following:

```
function getChildRequestedFields(info: GraphQLResolveInfo): string[] {
	return Object.keys(
		graphqlFields(info, {}, { excludedFields: ['__typename'] })
	);
}
```

Throws the following error:

```
Type 'GraphQLScalarType' is missing the following properties from type 'GraphQLEnumType': getValues, getValue
```

Bumping the dependent `graphql` version to 15.3.0 fixes this issue.