### PR TITLE
Update statsd-client to export config types use by the main StatsdClient export.

### DIFF
--- a/types/statsd-client/index.d.ts
+++ b/types/statsd-client/index.d.ts
@@ -5,128 +5,130 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import * as express from "express";
+import * as express from 'express';
 
-interface Tags {
-    [key: string]: string | number;
-}
+declare namespace StatsdClient {
+    interface Tags {
+        [key: string]: string | number;
+    }
 
-interface CommonOptions {
-    /**
-     * Prefix all stats with this value (default "").
-     */
-    prefix?: string;
+    interface CommonOptions {
+        /**
+         * Prefix all stats with this value (default "").
+         */
+        prefix?: string;
 
-    /**
-     * Print what is being sent to stderr (default false).
-     */
-    debug?: boolean;
+        /**
+         * Print what is being sent to stderr (default false).
+         */
+        debug?: boolean;
 
-    /**
-     * Object of string key/value pairs which will be appended on 
-     * to all StatsD payloads (excluding raw payloads)
-     * (default {})
-     */
-    tags?: Tags;
+        /**
+         * Object of string key/value pairs which will be appended on
+         * to all StatsD payloads (excluding raw payloads)
+         * (default {})
+         */
+        tags?: Tags;
 
-    /**
-     * User specifically wants to use tcp (default false)
-     */
-    tcp?: boolean;
+        /**
+         * User specifically wants to use tcp (default false)
+         */
+        tcp?: boolean;
 
-    /**
-     * Dual-use timer. Will flush metrics every interval. For UDP, 
-     * it auto-closes the socket after this long without activity 
-     * (default 1000 ms; 0 disables this). For TCP, it auto-closes 
-     * the socket after socketTimeoutsToClose number of timeouts 
-     * have elapsed without activity.
-     */
-    socketTimeout?: number;
-}
+        /**
+         * Dual-use timer. Will flush metrics every interval. For UDP,
+         * it auto-closes the socket after this long without activity
+         * (default 1000 ms; 0 disables this). For TCP, it auto-closes
+         * the socket after socketTimeoutsToClose number of timeouts
+         * have elapsed without activity.
+         */
+        socketTimeout?: number;
+    }
 
-interface TcpOptions extends CommonOptions {
-    /**
-     * Where to send the stats (default localhost).
-     */
-    host?: string;
+    interface TcpOptions extends CommonOptions {
+        /**
+         * Where to send the stats (default localhost).
+         */
+        host?: string;
 
-    /**
-     * Port to contact the statsd-daemon on (default 8125).
-     */
-    port?: number;
+        /**
+         * Port to contact the statsd-daemon on (default 8125).
+         */
+        port?: number;
 
-    /**
-     * Number of timeouts in which the socket auto-closes if it 
-     * has been inactive. (default 10; 1 to auto-close after a 
-     * single timeout).
-     */
-    socketTimeoutsToClose: number;
-}
+        /**
+         * Number of timeouts in which the socket auto-closes if it
+         * has been inactive. (default 10; 1 to auto-close after a
+         * single timeout).
+         */
+        socketTimeoutsToClose: number;
+    }
 
-interface UdpOptions extends CommonOptions {
-    /**
-     * Where to send the stats (default localhost).
-     */
-    host?: string;
+    interface UdpOptions extends CommonOptions {
+        /**
+         * Where to send the stats (default localhost).
+         */
+        host?: string;
 
-    /**
-     * Port to contact the statsd-daemon on (default 8125).
-     */
-    port?: number;
-}
+        /**
+         * Port to contact the statsd-daemon on (default 8125).
+         */
+        port?: number;
+    }
 
-interface HttpOptions extends CommonOptions {
-    /**
-     * Where to send the stats (default localhost).
-     */
-    host?: string;
+    interface HttpOptions extends CommonOptions {
+        /**
+         * Where to send the stats (default localhost).
+         */
+        host?: string;
 
-    /**
-     * Additional headers to send (default {}).
-     */
-    headers?: { [index: string]: string };
+        /**
+         * Additional headers to send (default {}).
+         */
+        headers?: { [index: string]: string };
 
-    /**
-     * What HTTP method to use (default "PUT").
-     */
-    method?: string;
-}
+        /**
+         * What HTTP method to use (default "PUT").
+         */
+        method?: string;
+    }
 
-interface ExpressMiddlewareOptions {
-    /**
-     * Metric name to use for reporting if a matching route is not
-     * found (default "unknown_express_route").
-     */
-    notFoundRouteName?: string;
+    interface ExpressMiddlewareOptions {
+        /**
+         * Metric name to use for reporting if a matching route is not
+         * found (default "unknown_express_route").
+         */
+        notFoundRouteName?: string;
 
-    /**
-     * Optional callback called after reporting metrics for an
-     * express route.
-     */
-    onResponseEnd?: (client: StatsdClient, startTime: Date, req: express.Request, res: express.Response) => void;
+        /**
+         * Optional callback called after reporting metrics for an
+         * express route.
+         */
+        onResponseEnd?: (client: StatsdClient, startTime: Date, req: express.Request, res: express.Response) => void;
 
-    /**
-     * Enables inclusion of per-URL response code and timing
-     * metrics (default false).
-     */
-    timeByUrl?: boolean;
+        /**
+         * Enables inclusion of per-URL response code and timing
+         * metrics (default false).
+         */
+        timeByUrl?: boolean;
+    }
 }
 
 declare class StatsdClient {
-    constructor(options: TcpOptions | UdpOptions | HttpOptions);
+    constructor(options: StatsdClient.TcpOptions | StatsdClient.UdpOptions | StatsdClient.HttpOptions);
 
-    counter(metric: string, delta: number, tags?: Tags): this;
-    increment(metric: string, delta?: number, tags?: Tags): this;
-    decrement(metric: string, delta?: number, tags?: Tags): this;
+    counter(metric: string, delta: number, tags?: StatsdClient.Tags): this;
+    increment(metric: string, delta?: number, tags?: StatsdClient.Tags): this;
+    decrement(metric: string, delta?: number, tags?: StatsdClient.Tags): this;
 
-    gauge(name: string, value: number, tags?: Tags): this;
-    gaugeDelta(name: string, delta: number, tags?: Tags): this;
+    gauge(name: string, value: number, tags?: StatsdClient.Tags): this;
+    gaugeDelta(name: string, delta: number, tags?: StatsdClient.Tags): this;
 
-    set(name: string, value: number, tags?: Tags): this;
+    set(name: string, value: number, tags?: StatsdClient.Tags): this;
 
-    timing(name: string, startOrDuration: Date | number, tags?: Tags): this;    
+    timing(name: string, startOrDuration: Date | number, tags?: StatsdClient.Tags): this;
 
-    histogram(name: string, value: number, tags?: Tags): this;
+    histogram(name: string, value: number, tags?: StatsdClient.Tags): this;
 
     raw(rawData: string): this;
 
@@ -134,12 +136,11 @@ declare class StatsdClient {
 
     getChildClient(name: string): StatsdClient;
 
-    formatTags(tags?: Tags): string;
+    formatTags(tags?: StatsdClient.Tags): string;
 
     helpers: {
-        getExpressMiddleware(prefix?: string, options?: ExpressMiddlewareOptions): express.RequestHandler;
+        getExpressMiddleware(prefix?: string, options?: StatsdClient.ExpressMiddlewareOptions): express.RequestHandler;
     };
 }
 
-declare namespace StatsdClient {}
 export = StatsdClient;

--- a/types/statsd-client/statsd-client-tests.ts
+++ b/types/statsd-client/statsd-client-tests.ts
@@ -1,4 +1,4 @@
-import SDC, { Tags, TcpOptions, UdpOptions, HttpOptions } from 'statsd-client';
+import SDC = require('statsd-client');
 
 let sdc = new SDC({ host: 'statsd.example.com' });
 
@@ -10,10 +10,10 @@ sdc.timing('some.timer', timer); // Calculates time diff
 sdc.close(); // Optional - stop NOW
 
 // Initialization
-const tags: Tags = { foo: 'bar' };
-const udpOptions: UdpOptions = { host: 'statsd.example.com', port: 8124, debug: true, tags };
-const tcpOptions: TcpOptions = { host: 'statsd.example.com', port: 8124, debug: true, tags, socketTimeoutsToClose: 1 };
-const httpOptions: HttpOptions = {
+const tags: SDC.Tags = { foo: 'bar' };
+const udpOptions: SDC.UdpOptions = { host: 'statsd.example.com', port: 8124, debug: true, tags };
+const tcpOptions: SDC.TcpOptions = { host: 'statsd.example.com', port: 8124, debug: true, tags, socketTimeoutsToClose: 1 };
+const httpOptions: SDC.HttpOptions = {
     host: 'statsd.example.com',
     headers: { 'x-foo': 'bar' },
     method: 'get',

--- a/types/statsd-client/statsd-client-tests.ts
+++ b/types/statsd-client/statsd-client-tests.ts
@@ -1,7 +1,6 @@
+import SDC, { Tags, TcpOptions, UdpOptions, HttpOptions } from 'statsd-client';
 
-import SDC = require("statsd-client");
-
-let sdc = new SDC( { host: 'statsd.example.com' });
+let sdc = new SDC({ host: 'statsd.example.com' });
 
 const timer = new Date();
 sdc.increment('some.counter'); // Increment by one.
@@ -11,31 +10,42 @@ sdc.timing('some.timer', timer); // Calculates time diff
 sdc.close(); // Optional - stop NOW
 
 // Initialization
-sdc = new SDC({host: 'statsd.example.com', port: 8124, debug: true, tags: {foo: 'bar'}});
+const tags: Tags = { foo: 'bar' };
+const udpOptions: UdpOptions = { host: 'statsd.example.com', port: 8124, debug: true, tags };
+const tcpOptions: TcpOptions = { host: 'statsd.example.com', port: 8124, debug: true, tags, socketTimeoutsToClose: 1 };
+const httpOptions: HttpOptions = {
+    host: 'statsd.example.com',
+    headers: { 'x-foo': 'bar' },
+    method: 'get',
+    debug: true,
+    tags,
+};
+sdc = new SDC(udpOptions);
+sdc = new SDC(tcpOptions);
+sdc = new SDC(httpOptions);
 
 // Counting stuff
 sdc.increment('systemname.subsystem.value'); // Increment by one
 sdc.decrement('systemname.subsystem.value', -10); // Decrement by 10
 sdc.counter('systemname.subsystem.value', 100); // Increment by 100
-sdc.increment('systemname.subsystem.value.tagged', 1, {biz: 'baz'}); // Increment tagged metric by one
-sdc.decrement('systemname.subsystem.value.tagged', -10, {biz: 'baz'}); // Decrement tagged metric  by 10
-sdc.counter('systemname.subsystem.value.tagged', 100, {biz: 'baz'}); // Increment tagged metric  by 100
-
+sdc.increment('systemname.subsystem.value.tagged', 1, { biz: 'baz' }); // Increment tagged metric by one
+sdc.decrement('systemname.subsystem.value.tagged', -10, { biz: 'baz' }); // Decrement tagged metric  by 10
+sdc.counter('systemname.subsystem.value.tagged', 100, { biz: 'baz' }); // Increment tagged metric  by 100
 
 // Gauges
 sdc.gauge('what.you.gauge', 100);
-sdc.gaugeDelta('what.you.gauge', 20);  // Will now count 120
+sdc.gaugeDelta('what.you.gauge', 20); // Will now count 120
 sdc.gaugeDelta('what.you.gauge', -70); // Will now count 50
-sdc.gauge('what.you.gauge', 10);       // Will now count 10
+sdc.gauge('what.you.gauge', 10); // Will now count 10
 
-sdc.gauge('what.you.gauge.tagged', 100, {biz: 'baz'});
-sdc.gaugeDelta('what.you.gauge.tagged', 20, {biz: 'baz'});  // Will now count 120
-sdc.gaugeDelta('what.you.gauge.tagged', -70, {biz: 'baz'}); // Will now count 50
-sdc.gauge('what.you.gauge.tagged', 10, {biz: 'baz'});       // Will now count 10
+sdc.gauge('what.you.gauge.tagged', 100, { biz: 'baz' });
+sdc.gaugeDelta('what.you.gauge.tagged', 20, { biz: 'baz' }); // Will now count 120
+sdc.gaugeDelta('what.you.gauge.tagged', -70, { biz: 'baz' }); // Will now count 50
+sdc.gauge('what.you.gauge.tagged', 10, { biz: 'baz' }); // Will now count 10
 
 // Set
 sdc.set('your.set', 200);
-sdc.set('your.set.tagged', 200, {biz: 'baz'});
+sdc.set('your.set.tagged', 200, { biz: 'baz' });
 
 // Timeouts
 let start = new Date();
@@ -44,18 +54,18 @@ setTimeout(function () {
 }, 100 * Math.random());
 
 setTimeout(function () {
-    sdc.timing('random.timeout.tagged', start, {biz: 'baz'});
+    sdc.timing('random.timeout.tagged', start, { biz: 'baz' });
 }, 100 * Math.random());
 
 // Histogram
 sdc.histogram('histogram.stuff', 40);
-sdc.histogram('histogram.stuff', 44, {biz: 'baz'});
+sdc.histogram('histogram.stuff', 44, { biz: 'baz' });
 
 // Raw string output
 sdc.raw('my.metric:123|g');
 
 // Internal tags formatting
-sdc.formatTags({biz: 'baz'});
+sdc.formatTags({ biz: 'baz' });
 
 // Stopping gracefully
 start = new Date();
@@ -67,7 +77,7 @@ sdc.close(); // 1 - Closes socket early.
 
 // Prefix magic
 // Create generic client
-sdc = new SDC({host: 'statsd.example.com', prefix: 'systemname'});
+sdc = new SDC({ host: 'statsd.example.com', prefix: 'systemname' });
 sdc.increment('foo'); // Increments 'systemname.foo'
 // ... do great stuff ...
 
@@ -80,4 +90,4 @@ const sdcB = sdc.getChildClient('b');
 sdcB.increment('foo'); // Increments 'systemname.b.foo'
 
 // Express middleware helper
-sdc.helpers.getExpressMiddleware('express.metrics', {timeByUrl: true}); // Returns an express handler
+sdc.helpers.getExpressMiddleware('express.metrics', { timeByUrl: true }); // Returns an express handler

--- a/types/statsd-client/tsconfig.json
+++ b/types/statsd-client/tsconfig.json
@@ -5,6 +5,7 @@
             "es6",
             "dom"
         ],
+        "esModuleInterop": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,

--- a/types/statsd-client/tsconfig.json
+++ b/types/statsd-client/tsconfig.json
@@ -5,7 +5,6 @@
             "es6",
             "dom"
         ],
-        "esModuleInterop": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,


### PR DESCRIPTION
Update statsd-client to export config types use by the main StatsdClient export.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: The current source code for statsd-client types does not expose the configuration item types. This means in order to extend or wrap the default export `StatsdClient`, we would need to reimplement the config item types or use `any`. [Here](https://gist.github.com/JCass45/249e7c9c85a57ca9455a84d2aff6b4d7) is a gist with an example.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
