### PR TITLE
[ramda] preparing for breaking change in ts-toolbelt

### DIFF
--- a/types/ramda/tools.d.ts
+++ b/types/ramda/tools.d.ts
@@ -293,9 +293,9 @@ export type Merge<O1 extends object, O2 extends object, Depth extends 'flat' | '
  */
 export type MergeAll<Os extends readonly object[]> =
     O.AssignUp<{}, Os, 1> extends infer M
-    ? {} extends M         // nothing merged => bcs no `as const`
-      ? T.UnionOf<Os>      // so we output the approximate types
-      : T.ObjectOf<M & {}> // otherwise, we can get accurate types
+    ? {} extends M    // nothing merged => bcs no `as const`
+      ? T.UnionOf<Os> // so we output the approximate types
+      : M             // otherwise, we can get accurate types
     : never;
 
 // ---------------------------------------------------------------------------------------

--- a/types/ramda/tools.d.ts
+++ b/types/ramda/tools.d.ts
@@ -280,6 +280,7 @@ export interface Lens {
  * <created by @pirix-gh>
  */
 export type Merge<O1 extends object, O2 extends object, Depth extends 'flat' | 'deep'> =
+    // tslint:disable-next-line:use-default-type-parameter
     O.MergeUp<T.ObjectOf<O1>, T.ObjectOf<O2>, Depth, 1>;
 
 /**
@@ -292,6 +293,7 @@ export type Merge<O1 extends object, O2 extends object, Depth extends 'flat' | '
  * <created by @pirix-gh>
  */
 export type MergeAll<Os extends readonly object[]> =
+    // tslint:disable-next-line:use-default-type-parameter
     O.AssignUp<{}, Os, 'flat', 1> extends infer M
     ? {} extends M    // nothing merged => bcs no `as const`
       ? T.UnionOf<Os> // so we output the approximate types

--- a/types/ramda/tools.d.ts
+++ b/types/ramda/tools.d.ts
@@ -292,7 +292,7 @@ export type Merge<O1 extends object, O2 extends object, Depth extends 'flat' | '
  * <created by @pirix-gh>
  */
 export type MergeAll<Os extends readonly object[]> =
-    O.AssignUp<{}, Os, 1> extends infer M
+    O.AssignUp<{}, Os, 'flat', 1> extends infer M
     ? {} extends M    // nothing merged => bcs no `as const`
       ? T.UnionOf<Os> // so we output the approximate types
       : M             // otherwise, we can get accurate types

--- a/types/ramda/tools.d.ts
+++ b/types/ramda/tools.d.ts
@@ -292,7 +292,7 @@ export type Merge<O1 extends object, O2 extends object, Depth extends 'flat' | '
  * <created by @pirix-gh>
  */
 export type MergeAll<Os extends readonly object[]> =
-    O.AssignUp<{}, Os> extends infer M
+    O.AssignUp<{}, Os, 1> extends infer M
     ? {} extends M         // nothing merged => bcs no `as const`
       ? T.UnionOf<Os>      // so we output the approximate types
       : T.ObjectOf<M & {}> // otherwise, we can get accurate types

--- a/types/ramda/tools.d.ts
+++ b/types/ramda/tools.d.ts
@@ -280,7 +280,7 @@ export interface Lens {
  * <created by @pirix-gh>
  */
 export type Merge<O1 extends object, O2 extends object, Depth extends 'flat' | 'deep'> =
-    O.MergeUp<T.ObjectOf<O1>, T.ObjectOf<O2>, Depth>;
+    O.MergeUp<T.ObjectOf<O1>, T.ObjectOf<O2>, Depth, 1>;
 
 /**
  * Merge multiple objects `Os` with each other


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I am making the lodash merging style the default merging style (which is array-preserving) for all merging utilities on the ts-toolbelt:

```ts
type t0 = Merge<{
    a: number[]
    b: {a: 1}[]
    c: {a: [0]}
}, {
    a: string[]
    b: {b: 2}[]
    c: {a: [0, 1, 2]}
}, 'deep', 0>

// {
//     a: (string | number)[];
//     b: {
//         a: 1;
//         b: 2;
//     }[];
//     c: {
//         a: [0, 1, 2];
//     };
// }
```

ATM, `Merge` uses ramda's merging style by default (which disassembles lists and their methods) but I don't want this any longer as a default. I am not willing to mark this a a breaking feature because I see it as an upgrade or patch of ts-toolbelt's `Merge` utility that never worked properly (ie. we can now merge nested arrays and objects efficiently).