### PR TITLE
Add types for folder-hash

### DIFF
--- a/types/folder-hash/folder-hash-tests.ts
+++ b/types/folder-hash/folder-hash-tests.ts
@@ -1,0 +1,80 @@
+import { hashElement, HashElementOptions } from 'folder-hash';
+
+const testAsync = async () => {
+    // $ExpectType HashElementNode
+    const result1 = await hashElement('./whatever');
+
+    // $ExpectType string
+    result1.hash;
+    // $ExpectType string
+    result1.name;
+    // $ExpectType HashElementNode[]
+    result1.children;
+    for (const node of result1.children) {
+        // $ExpectType string
+        node.hash;
+        // $ExpectType string
+        node.name;
+        // $ExpectType HashElementNode[]
+        result1.children;
+    }
+
+    // $ExpectType HashElementNode
+    await hashElement('./whatever', {});
+
+    const stringOptions: HashElementOptions = {
+        algo: 'sha1',
+        encoding: 'hex',
+        folders: {
+            exclude: ['1'],
+            include: ['2'],
+            matchBasename: false,
+            matchPath: false,
+            ignoreRootName: true,
+            ignoreBasename: true,
+        },
+        files: {
+            exclude: ['1'],
+            include: ['2'],
+            matchBasename: false,
+            matchPath: false,
+            ignoreRootName: true,
+            ignoreBasename: true,
+        },
+    };
+
+    const functionOptions: HashElementOptions = {
+        algo: 'sha1',
+        encoding: 'binary',
+        folders: {
+            exclude: () => ['1'],
+            include: () => ['2'],
+            matchBasename: false,
+            matchPath: false,
+            ignoreRootName: true,
+            ignoreBasename: true,
+        },
+        files: {
+            exclude: () => ['1'],
+            include: () => ['2'],
+            matchBasename: false,
+            matchPath: false,
+            ignoreRootName: true,
+            ignoreBasename: true,
+        },
+    };
+    // $ExpectType HashElementNode
+    await hashElement('./whatever', stringOptions);
+    // $ExpectType HashElementNode
+    await hashElement('./whatever', functionOptions);
+
+    // $ExpectType HashElementNode
+    await hashElement('./whatever', 'directory', stringOptions);
+    // $ExpectType HashElementNode
+    await hashElement('./whatever', 'directory', functionOptions);
+
+    // $ExpectType HashElementNode
+    await hashElement('./whatever', 'directory', stringOptions, (error, result) => {});
+    // $ExpectType HashElementNode
+    await hashElement('./whatever', 'directory', functionOptions, (error, result) => {});
+};

--- a/types/folder-hash/folder-hash-tests.ts
+++ b/types/folder-hash/folder-hash-tests.ts
@@ -73,8 +73,20 @@ const testAsync = async () => {
     // $ExpectType HashElementNode
     await hashElement('./whatever', 'directory', functionOptions);
 
-    // $ExpectType HashElementNode
-    await hashElement('./whatever', 'directory', stringOptions, (error, result) => {});
-    // $ExpectType HashElementNode
-    await hashElement('./whatever', 'directory', functionOptions, (error, result) => {});
+    // $ExpectType void
+    hashElement('./whatever', 'directory', stringOptions, (error, result) => {
+        // $ExpectType Error | undefined
+        error;
+
+        // $ExpectType HashElementNode | undefined
+        result;
+    });
+    // $ExpectType void
+    hashElement('./whatever', 'directory', functionOptions, (error, result) => {
+        // $ExpectType Error | undefined
+        error;
+
+        // $ExpectType HashElementNode | undefined
+        result;
+    });
 };

--- a/types/folder-hash/index.d.ts
+++ b/types/folder-hash/index.d.ts
@@ -3,38 +3,36 @@
 // Definitions by: Kevin Brown <https://github.com/thekevinbrown>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module 'folder-hash' {
-    type PathGlobFunction = () => string[];
+export type PathGlobFunction = () => string[];
 
-    export interface FolderAndFileOptions {
-        exclude?: string[] | PathGlobFunction;
-        include?: string[] | PathGlobFunction;
-        matchBasename?: boolean;
-        matchPath?: boolean;
-        ignoreBasename?: boolean;
-        ignoreRootName?: boolean;
-    }
-    export interface HashElementOptions {
-        // See crypto.getHashes() for options.
-        // Defaults to 'sha1'.
-        algo?: string;
-        // Defaults to 'base64'
-        encoding?: 'base64' | 'hex' | 'binary';
-        folders?: FolderAndFileOptions;
-        files?: FolderAndFileOptions;
-    }
-
-    export interface HashElementNode {
-        name: string;
-        hash: string;
-        children: HashElementNode[];
-    }
-    export function hashElement(path: string, options?: HashElementOptions): Promise<HashElementNode>;
-    export function hashElement(path: string, dir?: string, options?: HashElementOptions): Promise<HashElementNode>;
-    export function hashElement(
-        path: string,
-        dir?: string,
-        options?: HashElementOptions,
-        callback?: (error?: Error, result?: HashElementNode) => any,
-    ): void;
+export interface FolderAndFileOptions {
+    exclude?: string[] | PathGlobFunction;
+    include?: string[] | PathGlobFunction;
+    matchBasename?: boolean;
+    matchPath?: boolean;
+    ignoreBasename?: boolean;
+    ignoreRootName?: boolean;
 }
+export interface HashElementOptions {
+    // See crypto.getHashes() for options.
+    // Defaults to 'sha1'.
+    algo?: string;
+    // Defaults to 'base64'
+    encoding?: 'base64' | 'hex' | 'binary';
+    folders?: FolderAndFileOptions;
+    files?: FolderAndFileOptions;
+}
+
+export interface HashElementNode {
+    name: string;
+    hash: string;
+    children: HashElementNode[];
+}
+export function hashElement(path: string, options?: HashElementOptions): Promise<HashElementNode>;
+export function hashElement(path: string, dir?: string, options?: HashElementOptions): Promise<HashElementNode>;
+export function hashElement(
+    path: string,
+    dir?: string,
+    options?: HashElementOptions,
+    callback?: (error?: Error, result?: HashElementNode) => any,
+): void;

--- a/types/folder-hash/index.d.ts
+++ b/types/folder-hash/index.d.ts
@@ -1,0 +1,40 @@
+// Type definitions for folder-hash 3.3
+// Project: https://github.com/marc136/node-folder-hash#readme
+// Definitions by: Kevin Brown <https://github.com/thekevinbrown>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'folder-hash' {
+    type PathGlobFunction = () => string[];
+
+    export interface FolderAndFileOptions {
+        exclude?: string[] | PathGlobFunction;
+        include?: string[] | PathGlobFunction;
+        matchBasename?: boolean;
+        matchPath?: boolean;
+        ignoreBasename?: boolean;
+        ignoreRootName?: boolean;
+    }
+    export interface HashElementOptions {
+        // See crypto.getHashes() for options.
+        // Defaults to 'sha1'.
+        algo?: string;
+        // Defaults to 'base64'
+        encoding?: 'base64' | 'hex' | 'binary';
+        folders?: FolderAndFileOptions;
+        files?: FolderAndFileOptions;
+    }
+
+    export interface HashElementNode {
+        name: string;
+        hash: string;
+        children: HashElementNode[];
+    }
+    export function hashElement(path: string, options?: HashElementOptions): Promise<HashElementNode>;
+    export function hashElement(path: string, dir?: string, options?: HashElementOptions): Promise<HashElementNode>;
+    export function hashElement(
+        path: string,
+        dir?: string,
+        options?: HashElementOptions,
+        callback?: (error?: Error, result?: HashElementNode) => any,
+    ): void;
+}

--- a/types/folder-hash/tsconfig.json
+++ b/types/folder-hash/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "folder-hash-tests.ts"
+    ]
+}

--- a/types/folder-hash/tslint.json
+++ b/types/folder-hash/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.