### PR TITLE
Add generics to type definitions for Sinon Fakes

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1499,17 +1499,17 @@ declare namespace Sinon {
         /**
          * Creates a basic fake, with no behavior
          */
-        (): SinonSpy;
+        (): SinonSpy<any[], void>;
         /**
          * Wraps an existing Function to record all interactions, while leaving it up to the func to provide the behavior.
          * This is useful when complex behavior not covered by the sinon.fake.* methods is required or when wrapping an existing function or method.
          */
-        (fn: Function): SinonSpy;
+        <TArgs extends any[], TReturn>(fn: (...args: TArgs) => TReturn): SinonSpy<TArgs, TReturn>;
         /**
          * Creates a fake that returns the val argument
          * @param val Returned value
          */
-        returns(val: any): SinonSpy;
+        returns<T>(val: T): SinonSpy<any[], T>;
         /**
          * Creates a fake that throws an Error with the provided value as the message property.
          * If an Error is passed as the val argument, then that will be the thrown value. If any other value is passed, then that will be used for the message property of the thrown Error.
@@ -1520,7 +1520,7 @@ declare namespace Sinon {
          * Creates a fake that returns a resolved Promise for the passed value.
          * @param val Resolved promise
          */
-        resolves(val: any): SinonSpy;
+        resolves<T>(val: T): SinonSpy<any[], Promise<T>>;
         /**
          * Creates a fake that returns a rejected Promise for the passed value.
          * If an Error is passed as the value argument, then that will be the value of the promise.

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -250,16 +250,16 @@ function testMatch() {
 
 function testFake() {
     const fn = () => { };
-    let fake = sinon.fake();
+    const fake = sinon.fake();
 
-    fake = sinon.fake(() => true);
-    fake = sinon.fake.returns(5);
-    fake = sinon.fake.throws('foo');
-    fake = sinon.fake.throws(new Error('foo'));
-    fake = sinon.fake.resolves('foo');
-    fake = sinon.fake.rejects('foo');
-    fake = sinon.fake.yields(1, 2, fn);
-    fake = sinon.fake.yieldsAsync(1, 2, fn);
+    const fakeFn = sinon.fake(() => true);
+    const fakeReturns = sinon.fake.returns(5);
+    const fakeThrows = sinon.fake.throws('foo');
+    const fakeThrowsError = sinon.fake.throws(new Error('foo'));
+    const fakeResolves = sinon.fake.resolves('foo');
+    const fakeRejects = sinon.fake.rejects('foo');
+    const fakeYields = sinon.fake.yields(1, 2, fn);
+    const fakeYieldsAsync = sinon.fake.yieldsAsync(1, 2, fn);
 
     fake.calledWith('foo');
 }


### PR DESCRIPTION
Please fill in this template.

- [✅] Use a meaningful title for the pull request. Include the name of the package modified.
- [✅] Test the change in your own code. (Compile and run.)
- [✅] Add or edit tests to reflect the change. (Run with `npm test`.)
- [✅] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [✅] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [✅] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [✅] Provide a URL to documentation or source code which provides context for the suggested changes: https://sinonjs.org/releases/v9.0.2/fakes/
- [N/A] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [✅] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.