### PR TITLE
[tabulator-tables] findTable returns Tabulator[] instead of single Ta…

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -2212,8 +2212,8 @@ declare class Tabulator {
     The function takes three arguments, the name of the module, the name of the property you want to extend, and an object containing the elements you want to add in your module. In the example below we extend the format module to add two new default formatters: */
     extendModule: (name: string, property: string, values: {}) => void;
 
-    /** Lookup the table object for any existing table using the element they were created on. */
-    findTable: (query: string) => Tabulator;
+    /** Lookup table objects for any existing table using the element they were created on. */
+    findTable: (query: string) => Tabulator[];
 
     /**The getInvalidCells method returns an array of Cell Components for all cells flagged as invalid after a user edit. */
     getInvalidCells: () => Tabulator.CellComponent[];

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -594,7 +594,7 @@ table = new Tabulator('#test', {});
 table.blockRedraw();
 table.restoreRedraw();
 
-table = Tabulator.prototype.findTable('#example-table');
+table = Tabulator.prototype.findTable('#example-table')[0];
 
 table.getRows('visible');
 table.deleteRow([15, 7, 9]);


### PR DESCRIPTION
…bulator object

In Tabulator 4.7 findTable returns Tabulator[] instead of single Tabulator object.

'The findTable function will return an array of matching tables.'

Ref:  http://tabulator.info/docs/4.7/options#find-table