### PR TITLE
Change lodash .split() signature to be nil safe

### DIFF
--- a/types/lodash/common/string.d.ts
+++ b/types/lodash/common/string.d.ts
@@ -534,14 +534,14 @@ declare module "../index" {
          *
          * Note: This method is based on String#split.
          *
-         * @param string The string to trim.
+         * @param string The string to split.
          * @param separator The separator pattern to split by.
          * @param limit The length to truncate results to.
          * @return Returns the new array of string segments.
          */
         split(
-            string: string,
-            separator?: RegExp|string,
+            string: string | null | undefined,
+            separator?: RegExp | string,
             limit?: number
         ): string[];
 
@@ -556,7 +556,7 @@ declare module "../index" {
          * @return Returns the new array of string segments.
          */
         split(
-            string: string,
+            string: string | null | undefined,
             index: string | number,
             guard: object
         ): string[];

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -4039,12 +4039,12 @@ declare namespace _ {
     type LodashSortedUniqBy1x1<T> = (array: lodash.List<T> | null | undefined) => T[];
     type LodashSortedUniqBy1x2<T> = (iteratee: lodash.ValueIteratee<T>) => T[];
     interface LodashSplit extends LodashConvertible {
-        (separator: RegExp|string): LodashSplit1x1;
-        (separator: lodash.__, string: string): LodashSplit1x2;
-        (separator: RegExp|string, string: string): string[];
+        (separator: RegExp | string): LodashSplit1x1;
+        (separator: lodash.__, string: string | null | undefined): LodashSplit1x2;
+        (separator: RegExp | string, string: string | null | undefined): string[];
     }
-    type LodashSplit1x1 = (string: string) => string[];
-    type LodashSplit1x2 = (separator: RegExp|string) => string[];
+    type LodashSplit1x1 = (string: string | null | undefined) => string[];
+    type LodashSplit1x2 = (separator: RegExp | string) => string[];
     type LodashSpread = <TResult>(func: (...args: any[]) => TResult) => (...args: any[]) => TResult;
     interface LodashSpreadFrom extends LodashConvertible {
         (start: number): LodashSpreadFrom1x1;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -6412,16 +6412,29 @@ fp.now(); // $ExpectType number
 
 // _.split
 {
+    _.split(undefined); // $ExpectType string[]
+    _.split(null); // $ExpectType string[]
     _.split("a-b-c"); // $ExpectType string[]
+    _.split(null, "-"); // $ExpectType string[]
     _.split("a-b-c", "-"); // $ExpectType string[]
+    _.split(null, "-", 2); // $ExpectType string[]
     _.split("a-b-c", "-", 2); // $ExpectType string[]
+    _(null).split();  // $ExpectType LoDashImplicitWrapper<string[]>
     _("a-b-c").split(); // $ExpectType LoDashImplicitWrapper<string[]>
+    _(null).split("-");  // $ExpectType LoDashImplicitWrapper<string[]>
     _("a-b-c").split("-"); // $ExpectType LoDashImplicitWrapper<string[]>
+    _(null).split("-", 2);  // $ExpectType LoDashImplicitWrapper<string[]>
     _("a-b-c").split("-", 2); // $ExpectType LoDashImplicitWrapper<string[]>
+    _.chain(null).split(); // $ExpectType LoDashExplicitWrapper<string[]>
     _.chain("a-b-c").split(); // $ExpectType LoDashExplicitWrapper<string[]>
+    _.chain(null).split("-"); // $ExpectType LoDashExplicitWrapper<string[]>
     _.chain("a-b-c").split("-"); // $ExpectType LoDashExplicitWrapper<string[]>
+    _.chain(null).split("-", 2); // $ExpectType LoDashExplicitWrapper<string[]>
     _.chain("a-b-c").split("-", 2); // $ExpectType LoDashExplicitWrapper<string[]>
+    fp.split("-", undefined); // $ExpectType string[]
+    fp.split("-", null); // $ExpectType string[]
     fp.split("-", "a-b-c"); // $ExpectType string[]
+    fp.split("-")(null); // $ExpectType string[]
     fp.split("-")("a-b-c"); // $ExpectType string[]
 
     _.map(["abc", "def"], _.split); // $ExpectType string[][]

--- a/types/lodash/ts3.1/common/string.d.ts
+++ b/types/lodash/ts3.1/common/string.d.ts
@@ -401,16 +401,16 @@ declare module "../index" {
          *
          * Note: This method is based on String#split.
          *
-         * @param string The string to trim.
+         * @param string The string to split.
          * @param separator The separator pattern to split by.
          * @param limit The length to truncate results to.
          * @return Returns the new array of string segments.
          */
-        split(string: string, separator?: RegExp | string, limit?: number): string[];
+        split(string: string | null | undefined, separator?: RegExp | string, limit?: number): string[];
         /**
          * @see _.split
          */
-        split(string: string, index: string | number, guard: object): string[];
+        split(string: string | null | undefined, index: string | number, guard: object): string[];
     }
     interface LoDashImplicitWrapper<TValue> {
         /**

--- a/types/lodash/ts3.1/fp.d.ts
+++ b/types/lodash/ts3.1/fp.d.ts
@@ -4020,10 +4020,10 @@ declare namespace _ {
     type LodashSortedUniqBy1x2<T> = (iteratee: lodash.ValueIteratee<T>) => T[];
     interface LodashSplit {
         (separator: RegExp | string): LodashSplit1x1;
-        (separator: lodash.__, string: string): LodashSplit1x2;
-        (separator: RegExp | string, string: string): string[];
+        (separator: lodash.__, string: string | null | undefined): LodashSplit1x2;
+        (separator: RegExp | string, string: string | null | undefined): string[];
     }
-    type LodashSplit1x1 = (string: string) => string[];
+    type LodashSplit1x1 = (string: string | null | undefined) => string[];
     type LodashSplit1x2 = (separator: RegExp | string) => string[];
     type LodashSpread = <TResult>(func: (...args: any[]) => TResult) => (...args: any[]) => TResult;
     interface LodashSpreadFrom {

--- a/types/lodash/ts3.1/lodash-tests.ts
+++ b/types/lodash/ts3.1/lodash-tests.ts
@@ -6427,16 +6427,29 @@ fp.now(); // $ExpectType number
 
 // _.split
 {
+    _.split(undefined); // $ExpectType string[]
+    _.split(null); // $ExpectType string[]
     _.split("a-b-c"); // $ExpectType string[]
+    _.split(null, "-"); // $ExpectType string[]
     _.split("a-b-c", "-"); // $ExpectType string[]
+    _.split(null, "-", 2); // $ExpectType string[]
     _.split("a-b-c", "-", 2); // $ExpectType string[]
+    _(null).split();  // $ExpectType Collection<string>
     _("a-b-c").split(); // $ExpectType Collection<string>
+    _(null).split("-");  // $ExpectType Collection<string>
     _("a-b-c").split("-"); // $ExpectType Collection<string>
+    _(null).split("-", 2);  // $ExpectType Collection<string>
     _("a-b-c").split("-", 2); // $ExpectType Collection<string>
+    _.chain(null).split(); // $ExpectType CollectionChain<string>
     _.chain("a-b-c").split(); // $ExpectType CollectionChain<string>
+    _.chain(null).split("-"); // $ExpectType CollectionChain<string>
     _.chain("a-b-c").split("-"); // $ExpectType CollectionChain<string>
+    _.chain(null).split("-", 2); // $ExpectType CollectionChain<string>
     _.chain("a-b-c").split("-", 2); // $ExpectType CollectionChain<string>
+    fp.split("-", undefined); // $ExpectType string[]
+    fp.split("-", null); // $ExpectType string[]
     fp.split("-", "a-b-c"); // $ExpectType string[]
+    fp.split("-")(null); // $ExpectType string[]
     fp.split("-")("a-b-c"); // $ExpectType string[]
 
     _.map(["abc", "def"], _.split); // $ExpectType string[][]


### PR DESCRIPTION
Generally speaking, all of lodash's functions are nil safe, and return
something reasonable when `null` or `undefined` are given as an
argument. For `.split()`, `_.split(null)` returns `[""]`.

This commit changes the type signature to allow the string given to
`.split()` to be optional or `null`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://lodash.com/docs/4.17.15#split
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.