### PR TITLE
[node][qs][history] PoorMansUnknown -> UnknownFacade

### DIFF
--- a/types/history/history-tests.ts
+++ b/types/history/history-tests.ts
@@ -153,5 +153,5 @@ let input = { value: '' };
 {
     const anything: any = {};
     const history: History = anything;
-    history.location.state; // $ExpectType PoorMansUnknown
+    history.location.state; // $ExpectType UnknownFacade
 }

--- a/types/history/index.d.ts
+++ b/types/history/index.d.ts
@@ -49,7 +49,7 @@ export namespace History {
     // Now that TypeScript's DT support is  3.0+, we can look into replacing this with `unknown`.
     type UnknownFacade = {} | null | undefined;
 
-    /** @deprecated - UnknownFacade is more clear about what's going on */
+    /** @deprecated - Use `UnknownFacade` instead. It is a better classifier for the type */
     type PoorMansUnknown = UnknownFacade
 
     export type LocationState = UnknownFacade;

--- a/types/history/index.d.ts
+++ b/types/history/index.d.ts
@@ -44,10 +44,15 @@ export namespace History {
     export type LocationDescriptor<S = LocationState> = Path | LocationDescriptorObject<S>;
     export type LocationKey = string;
     export type LocationListener<S = LocationState> = (location: Location<S>, action: Action) => void;
-    // The value type here is a "poor man's `unknown`". When these types support TypeScript
-    // 3.0+, we can replace this with `unknown`.
-    type PoorMansUnknown = {} | null | undefined;
-    export type LocationState = PoorMansUnknown;
+
+    // TODO: The value type here is a version of `unknown` with an acceptably lossy amount of accuracy.
+    // Now that TypeScript's DT support is  3.0+, we can look into replacing this with `unknown`.
+    type UnknownFacade = {} | null | undefined;
+
+    /** @deprecated - UnknownFacade is more clear about what's going on */
+    type PoorMansUnknown = UnknownFacade
+
+    export type LocationState = UnknownFacade;
     export type Path = string;
     export type Pathname = string;
     export type Search = string;

--- a/types/node/v11/globals.d.ts
+++ b/types/node/v11/globals.d.ts
@@ -1137,7 +1137,10 @@ declare namespace NodeJS {
 
     type TypedArray = Uint8Array | Uint8ClampedArray | Uint16Array | Uint32Array | Int8Array | Int16Array | Int32Array | Float32Array | Float64Array;
 
-    // The value type here is a "poor man's `unknown`". When these types support TypeScript
-    // 3.0+, we can replace this with `unknown`.
-    type PoorMansUnknown = {} | null | undefined;
+    // TODO: The value type here is a version of `unknown` with an acceptably lossy amount of accuracy.
+    // Now that TypeScript's DT support is  3.0+, we can look into replacing this with `unknown`.
+    type UnknownFacade = {} | null | undefined;
+
+    /** @deprecated - UnknownFacade is more clear about what's going on */
+    type PoorMansUnknown = UnknownFacade
 }

--- a/types/node/v11/globals.d.ts
+++ b/types/node/v11/globals.d.ts
@@ -1142,5 +1142,5 @@ declare namespace NodeJS {
     type UnknownFacade = {} | null | undefined;
 
     /** @deprecated - Use `UnknownFacade` instead. It is a better classifier for the type */
-    type PoorMansUnknown = UnknownFacade
+    type PoorMansUnknown = UnknownFacade;
 }

--- a/types/node/v11/globals.d.ts
+++ b/types/node/v11/globals.d.ts
@@ -1141,6 +1141,6 @@ declare namespace NodeJS {
     // Now that TypeScript's DT support is  3.0+, we can look into replacing this with `unknown`.
     type UnknownFacade = {} | null | undefined;
 
-    /** @deprecated - UnknownFacade is more clear about what's going on */
+    /** @deprecated - Use `UnknownFacade` instead. It is a better classifier for the type */
     type PoorMansUnknown = UnknownFacade
 }

--- a/types/node/v11/querystring.d.ts
+++ b/types/node/v11/querystring.d.ts
@@ -11,7 +11,7 @@ declare module "querystring" {
     interface ParsedUrlQuery { [key: string]: string | string[]; }
 
     interface ParsedUrlQueryInput {
-        [key: string]: NodeJS.PoorMansUnknown;
+        [key: string]: NodeJS.UnknownFacade;
     }
 
     function stringify(obj?: ParsedUrlQueryInput, sep?: string, eq?: string, options?: StringifyOptions): string;

--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -1176,7 +1176,10 @@ declare namespace NodeJS {
     type TypedArray = Uint8Array | Uint8ClampedArray | Uint16Array | Uint32Array | Int8Array | Int16Array | Int32Array | Float32Array | Float64Array;
     type ArrayBufferView = TypedArray | DataView;
 
-    // The value type here is a "poor man's `unknown`". When these types support TypeScript
-    // 3.0+, we can replace this with `unknown`.
-    type PoorMansUnknown = {} | null | undefined;
+    // TODO: The value type here is a version of `unknown` with an acceptably lossy amount of accuracy.
+    // Now that TypeScript's DT support is  3.0+, we can look into replacing this with `unknown`.
+    type UnknownFacade = {} | null | undefined;
+
+    /** @deprecated - UnknownFacade is more clear about what's going on */
+    type PoorMansUnknown = UnknownFacade
 }

--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -1181,5 +1181,5 @@ declare namespace NodeJS {
     type UnknownFacade = {} | null | undefined;
 
     /** @deprecated - Use `UnknownFacade` instead. It is a better classifier for the type */
-    type PoorMansUnknown = UnknownFacade
+    type PoorMansUnknown = UnknownFacade;
 }

--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -1180,6 +1180,6 @@ declare namespace NodeJS {
     // Now that TypeScript's DT support is  3.0+, we can look into replacing this with `unknown`.
     type UnknownFacade = {} | null | undefined;
 
-    /** @deprecated - UnknownFacade is more clear about what's going on */
+    /** @deprecated - Use `UnknownFacade` instead. It is a better classifier for the type */
     type PoorMansUnknown = UnknownFacade
 }

--- a/types/node/v12/test/util.ts
+++ b/types/node/v12/test/util.ts
@@ -120,7 +120,7 @@ import { readFile } from 'fs';
     const arg0: () => Promise<number> = util.promisify((cb: (err: Error | null, result: number) => void): void => { });
     const arg0NoResult: () => Promise<any> = util.promisify((cb: (err: Error | null) => void): void => { });
     const arg1: (arg: string) => Promise<number> = util.promisify((arg: string, cb: (err: Error | null, result: number) => void): void => { });
-    const arg1UnknownError: (arg: string) => Promise<number> = util.promisify((arg: string, cb: (err: NodeJS.PoorMansUnknown, result: number) => void): void => { });
+    const arg1UnknownError: (arg: string) => Promise<number> = util.promisify((arg: string, cb: (err: NodeJS.UnknownFacade, result: number) => void): void => { });
     const arg1NoResult: (arg: string) => Promise<any> = util.promisify((arg: string, cb: (err: Error | null) => void): void => { });
     const cbOptionalError: () => Promise<void | {}> = util.promisify((cb: (err?: Error | null) => void): void => { cb(); }); // tslint:disable-line void-return
     assert(typeof util.promisify.custom === 'symbol');

--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -61,7 +61,7 @@ declare namespace QueryString {
     // When these types support TypeScript 3.0+, we can replace this with `unknown`.
     type UnknownFacade = {} | null | undefined;
 
-    /** @deprecated - UnknownFacade is more clear about what's going on */
+    /** @deprecated - Use `UnknownFacade` instead. It is a better classifier for the type */
     type PoorMansUnknown = UnknownFacade
 
     function stringify(obj: any, options?: IStringifyOptions): string;

--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -10,8 +10,6 @@
 //                 Hunter Perrin <https://github.com/hperrin>
 //                 Jordan Harband <https://github.com/ljharb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
-//
 export = QueryString;
 export as namespace qs;
 

--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -57,11 +57,14 @@ declare namespace QueryString {
 
     interface ParsedQs { [key: string]: undefined | string | string[] | ParsedQs | ParsedQs[] }
 
-    // TODO: The value type here is a "poor man's `unknown`". When these types support TypeScript
-    // 3.0+, we can replace this with `unknown`.
-    type PoorMansUnknown = {} | null | undefined;
+    // TODO: The value type here is a version of `unknown` which replicates with an acceptably lossy amount of accuracy.
+    // When these types support TypeScript 3.0+, we can replace this with `unknown`.
+    type UnknownFacade = {} | null | undefined;
+
+    /** @deprecated - UnknownFacade is more clear about what's going on */
+    type PoorMansUnknown = UnknownFacade
 
     function stringify(obj: any, options?: IStringifyOptions): string;
     function parse(str: string, options?: IParseOptions & { decoder?: never }): ParsedQs;
-    function parse(str: string, options?: IParseOptions): { [key: string]: PoorMansUnknown };
+    function parse(str: string, options?: IParseOptions): { [key: string]: UnknownFacade };
 }

--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for qs 6.9
+// Type definitions for qs 7.0
 // Project: https://github.com/ljharb/qs
 // Definitions by: Roman Korneev <https://github.com/RWander>
 //                 Leon Yu <https://github.com/leonyu>
@@ -10,7 +10,8 @@
 //                 Hunter Perrin <https://github.com/hperrin>
 //                 Jordan Harband <https://github.com/ljharb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
+// TypeScript Version: 3.0
+//
 export = QueryString;
 export as namespace qs;
 
@@ -57,14 +58,7 @@ declare namespace QueryString {
 
     interface ParsedQs { [key: string]: undefined | string | string[] | ParsedQs | ParsedQs[] }
 
-    // TODO: The value type here is a version of `unknown` which replicates with an acceptably lossy amount of accuracy.
-    // When these types support TypeScript 3.0+, we can replace this with `unknown`.
-    type UnknownFacade = {} | null | undefined;
-
-    /** @deprecated - UnknownFacade is more clear about what's going on */
-    type PoorMansUnknown = UnknownFacade
-
     function stringify(obj: any, options?: IStringifyOptions): string;
     function parse(str: string, options?: IParseOptions & { decoder?: never }): ParsedQs;
-    function parse(str: string, options?: IParseOptions): { [key: string]: UnknownFacade };
+    function parse(str: string, options?: IParseOptions): { [key: string]: unknown };
 }

--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for qs 7.0
+// Type definitions for qs 6.9
 // Project: https://github.com/ljharb/qs
 // Definitions by: Roman Korneev <https://github.com/RWander>
 //                 Leon Yu <https://github.com/leonyu>
@@ -56,9 +56,16 @@ declare namespace QueryString {
         interpretNumericEntities?: boolean;
     }
 
+    // TODO: The value type here is a version of `unknown` which replicates with an acceptably lossy amount of accuracy.
+    // When these types support TypeScript 3.0+, we can replace this with `unknown`.
+    type UnknownFacade = {} | null | undefined;
+
+    /** @deprecated - UnknownFacade is more clear about what's going on */
+    type PoorMansUnknown = UnknownFacade
+
     interface ParsedQs { [key: string]: undefined | string | string[] | ParsedQs | ParsedQs[] }
 
     function stringify(obj: any, options?: IStringifyOptions): string;
     function parse(str: string, options?: IParseOptions & { decoder?: never }): ParsedQs;
-    function parse(str: string, options?: IParseOptions): { [key: string]: unknown };
+    function parse(str: string, options?: IParseOptions): { [key: string]: UnknownFacade };
 }

--- a/types/qs/qs-tests.ts
+++ b/types/qs/qs-tests.ts
@@ -26,8 +26,8 @@ qs.parse('a=b&c=d', { delimiter: '&' });
             }
         },
     });
-    obj; // $ExpectType { [key: string]: PoorMansUnknown; }
-    obj.a; // $ExpectType PoorMansUnknown
+    obj; // $ExpectType { [key: string]: UnknownFacade; }
+    obj.a; // $ExpectType UnknownFacade
 }
 
 {
@@ -40,8 +40,8 @@ qs.parse('a=b&c=d', { delimiter: '&' });
         },
     };
     let obj = qs.parse('a=c', options);
-    obj; // $ExpectType { [key: string]: PoorMansUnknown; }
-    obj.a; // $ExpectType PoorMansUnknown
+    obj; // $ExpectType { [key: string]: UnknownFacade; }
+    obj.a; // $ExpectType UnknownFacade
 }
 
 () => {


### PR DESCRIPTION
Switches out the term "poor mans unknown" with "unknown facade" - I'm totally open to what the name could be but that seemed reasonable enough. As removing the type change would be a breaking change, I kept the original around but classed it as deprecated which should show up for people's IDEs in 4.0 builds.

Given that we've also dropped 2.9 support in DT as of May, this could also be switched out to an unknown but I'd rather let module owners do that. 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
