### PR TITLE
@testing-library/vue: Fix ConfigurationCallback type

### DIFF
--- a/types/testing-library__vue/index.d.ts
+++ b/types/testing-library__vue/index.d.ts
@@ -6,8 +6,8 @@
 import { ThisTypedMountOptions, VueClass } from '@vue/test-utils';
 import Vue from 'vue';
 import { Store, StoreOptions } from 'vuex';
-import Router, { RouterOptions, RouteConfig } from 'vue-router';
-import { getQueriesForElement, BoundFunctions, queries, EventType, FireFunction } from '@testing-library/dom';
+import Router, { RouteConfig } from 'vue-router';
+import { BoundFunctions, queries, EventType } from '@testing-library/dom';
 
 // NOTE: fireEvent is overridden below
 export * from '@testing-library/dom';

--- a/types/testing-library__vue/index.d.ts
+++ b/types/testing-library__vue/index.d.ts
@@ -24,7 +24,7 @@ export interface RenderOptions<V extends Vue, S = {}> extends
 }
 
 export type ConfigurationCallback<V extends Vue> =
-  (vue: V, store: Store<any>, router: Router) => Partial<ThisTypedMountOptions<V>> | void;
+  (localVue: typeof Vue, store: Store<any>, router: Router) => Partial<ThisTypedMountOptions<V>> | void;
 
 export interface ComponentHarness extends BoundFunctions<typeof queries> {
   container: HTMLElement;

--- a/types/testing-library__vue/testing-library__vue-tests.ts
+++ b/types/testing-library__vue/testing-library__vue-tests.ts
@@ -50,6 +50,13 @@ const component = lib.render(SomeComponent, {
     ],
 });
 
+const ExamplePlugin: Vue.PluginFunction<never> = () => {};
+const componentWithConfigCallback = lib.render(SomeComponent, {}, (localVue, store, router) => {
+    localVue.use(ExamplePlugin);
+    store.replaceState({foo: 'bar'});
+    router.onError((error) => console.log(error.message));
+});
+
 component.container; // $ExpectType HTMLElement
 component.baseElement; // $ExpectType HTMLBodyElement
 component.debug(); // $ExpectType void


### PR DESCRIPTION
The first parameter to ConfigurationCallback is the Vue *constructor* (or rather a localVue constructor as returned by [createLocalVue()](https://vue-test-utils.vuejs.org/api/createLocalVue.html#createlocalvue)), not a Vue instance. Also removed some unused imports.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [relevant line in source](https://github.com/testing-library/vue-testing-library/blob/af30961a9a633f7362abc7d6cc56c9d4d36a4232/src/vue-testing-library.js#L51)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.