### PR TITLE
[@types/underscore] Collection and Array Tests - Max, Min, and Size

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -451,70 +451,42 @@ declare module _ {
         ): PropertyTypeOrAny<TypeOfCollection<V>, K>[];
 
         /**
-        * Returns the maximum value in list.
-        * @param list Finds the maximum value in this list.
-        * @return Maximum value in `list`.
-        **/
-        max(list: _.List<number>): number;
+         * Returns the maximum value in `collection`. If an `iteratee` is
+         * provided, it will be used on each element to generate the criterion
+         * by which the element is ranked. -Infinity is returned if list is
+         * empty. Non-numerical values returned by `iteratee` will be ignored.
+         * @param collection The collection in which to find the maximum value.
+         * @param iteratee The iteratee that provides the criterion by which
+         * each element is ranked, optional if evaluating a collection of
+         * numbers.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns The maximum element within `collection` or -Infinity if
+         * `collection` is empty.
+         **/
+        max<V extends Collection<any>>(
+            collection: V,
+            iteratee?: Iteratee<V, number>,
+            context?: any
+        ): TypeOfCollection<V> | number;
 
         /**
-        * @see _.max
-        */
-        max(object: _.Dictionary<number>): number;
-
-        /**
-        * Returns the maximum value in list. If iterator is passed, it will be used on each value to generate
-        * the criterion by which the value is ranked.
-        * @param list Finds the maximum value in this list.
-        * @param iterator Compares each element in `list` to find the maximum value.
-        * @param context `this` object in `iterator`, optional.
-        * @return The maximum element within `list`.
-        **/
-        max<T>(
-            list: _.List<T>,
-            iterator?: _.ListIterator<T, any>,
-            context?: any): T;
-
-        /**
-        * @see _.max
-        */
-        max<T>(
-            list: _.Dictionary<T>,
-            iterator?: _.ObjectIterator<T, any>,
-            context?: any): T;
-
-        /**
-        * Returns the minimum value in list.
-        * @param list Finds the minimum value in this list.
-        * @return Minimum value in `list`.
-        **/
-        min(list: _.List<number>): number;
-
-        /**
-         * @see _.min
-         */
-        min(o: _.Dictionary<number>): number;
-
-        /**
-        * Returns the minimum value in list. If iterator is passed, it will be used on each value to generate
-        * the criterion by which the value is ranked.
-        * @param list Finds the minimum value in this list.
-        * @param iterator Compares each element in `list` to find the minimum value.
-        * @param context `this` object in `iterator`, optional.
-        * @return The minimum element within `list`.
-        **/
-        min<T>(
-            list: _.List<T>,
-            iterator?: _.ListIterator<T, any>,
-            context?: any): T;
-
-        /**
-        * @see _.min
-        */
-        min<T>(
-            list: _.Dictionary<T>,
-            iterator?: _.ObjectIterator<T, any>,
-            context?: any): T;
+         * Returns the minimum value in `collection`. If an `iteratee` is
+         * provided, it will be used on each element to generate the criterion
+         * by which the element is ranked. Infinity is returned if list is
+         * empty. Non-numerical values returned by `iteratee` will be ignored.
+         * @param collection The collection in which to find the minimum value.
+         * @param iteratee The iteratee that provides the criterion by which
+         * each element is ranked, optional if evaluating a collection of
+         * numbers.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns The minimum element within `collection` or Infinity if
+         * `collection` is empty.
+         **/
+        min<V extends Collection<any>>(
+            list: V,
+            iteratee?: Iteratee<V, number>,
+            context?: any
+        ): TypeOfCollection<V> | number;
 
         /**
         * Returns a sorted copy of list, ranked in ascending order by the results of running each value
@@ -618,11 +590,11 @@ declare module _ {
         toArray<V extends Collection<any>>(collection: V): TypeOfCollection<V>[];
 
         /**
-        * Return the number of values in the list.
-        * @param list Count the number of values/elements in this list.
-        * @return Number of values in `list`.
-        **/
-        size<T>(list: _.Collection<T>): number;
+         * Determines the number of values in `collection`.
+         * @param collection The collection to determine the number of values for.
+         * @returns The number of values in `collection`.
+         **/
+        size(collection: Collection<any>): number;
 
         /**
          * Splits `collection` into two arrays: one whose elements all satisfy
@@ -4180,40 +4152,34 @@ declare module _ {
         ): PropertyTypeOrAny<T, K>[];
 
         /**
-        * Wrapped type `number[]`.
-        * @see _.max
-        **/
-        max(): number;
+         * Returns the maximum value in the wrapped collection. If an
+         * `iteratee` is provided, it will be used on each element to generate
+         * the criterion by which the element is ranked. -Infinity is returned
+         * if list is empty. Non-numerical values returned by `iteratee` will
+         * be ignored.
+         * @param iteratee The iteratee that provides the criterion by which
+         * each element is ranked, optional if evaluating a collection of
+         * numbers.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns The maximum element within the wrapped collection or
+         * -Infinity if the wrapped collection is empty.
+         **/
+        max(iteratee?: Iteratee<V, number>, context?: any): T | number;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.max
-        **/
-        max(iterator: _.ListIterator<T, number>, context?: any): T;
-
-        /**
-        * Wrapped type `any[]`.
-        * @see _.max
-        **/
-        max(iterator?: _.ListIterator<T, any>, context?: any): T;
-
-        /**
-        * Wrapped type `number[]`.
-        * @see _.min
-        **/
-        min(): number;
-
-        /**
-        * Wrapped type `any[]`.
-        * @see _.min
-        **/
-        min(iterator: _.ListIterator<T, number>, context?: any): T;
-
-        /**
-        * Wrapped type `any[]`.
-        * @see _.min
-        **/
-        min(iterator?: _.ListIterator<T, any>, context?: any): T;
+         * Returns the minimum value in the wrapped collection. If an
+         * `iteratee` is provided, it will be used on each element to generate
+         * the criterion by which the element is ranked. Infinity is returned
+         * if list is empty. Non-numerical values returned by `iteratee` will
+         * be ignored.
+         * @param iteratee The iteratee that provides the criterion by which
+         * each element is ranked, optional if evaluating a collection of
+         * numbers.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns The minimum element within the wrapped collection or
+         * Infinity if the wrapped collection is empty.
+         **/
+        min(iteratee?: Iteratee<V, number>, context?: any): T | number;
 
         /**
         * Wrapped type `any[]`.
@@ -4282,9 +4248,9 @@ declare module _ {
         toArray(): T[];
 
         /**
-        * Wrapped type `any`.
-        * @see _.size
-        **/
+         * Determines the number of values in the wrapped collection.
+         * @returns The number of values in the wrapped collection.
+         **/
         size(): number;
 
         /**
@@ -5187,40 +5153,36 @@ declare module _ {
         ): _Chain<PropertyTypeOrAny<T, K>, PropertyTypeOrAny<T, K>[]>;
 
         /**
-        * Wrapped type `number[]`.
-        * @see _.max
-        **/
-        max(): _ChainSingle<T>;
+         * Returns the maximum value in the wrapped collection. If an
+         * `iteratee` is provided, it will be used on each element to generate
+         * the criterion by which the element is ranked. -Infinity is returned
+         * if list is empty. Non-numerical values returned by `iteratee` will
+         * be ignored.
+         * @param iteratee The iteratee that provides the criterion by which
+         * each element is ranked, optional if evaluating a collection of
+         * numbers.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns A chain wrapper around the maximum element within the
+         * wrapped collection or around -Infinity if the wrapped collection is
+         * empty.
+         **/
+        max(iteratee?: _ChainIteratee<V, number, T>, context?: any): _ChainSingle<T | number>;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.max
-        **/
-        max(iterator: _.ListIterator<T, number>, context?: any): _ChainSingle<T>;
-
-        /**
-        * Wrapped type `any[]`.
-        * @see _.max
-        **/
-        max(iterator?: _.ListIterator<T, any>, context?: any): _ChainSingle<T>;
-
-        /**
-        * Wrapped type `number[]`.
-        * @see _.min
-        **/
-        min(): _ChainSingle<T>;
-
-        /**
-        * Wrapped type `any[]`.
-        * @see _.min
-        **/
-        min(iterator: _.ListIterator<T, number>, context?: any): _ChainSingle<T>;
-
-        /**
-        * Wrapped type `any[]`.
-        * @see _.min
-        **/
-        min(iterator?: _.ListIterator<T, any>, context?: any): _ChainSingle<T>;
+         * Returns the minimum value in the wrapped collection. If an
+         * `iteratee` is provided, it will be used on each element to generate
+         * the criterion by which the element is ranked. Infinity is returned
+         * if list is empty. Non-numerical values returned by `iteratee` will
+         * be ignored.
+         * @param iteratee The iteratee that provides the criterion by which
+         * each element is ranked, optional if evaluating a collection of
+         * numbers.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns A chain wrapper around the minimum element within the
+         * wrapped collection or around Infinity if the wrapped collection is
+         * empty.
+         **/
+        min(iteratee?: _ChainIteratee<V, number, T>, context?: any): _ChainSingle<T | number>;
 
         /**
         * Wrapped type `any[]`.
@@ -5292,9 +5254,10 @@ declare module _ {
         toArray(): _Chain<T, T[]>;
 
         /**
-        * Wrapped type `any`.
-        * @see _.size
-        **/
+         * Determines the number of values in the wrapped collection.
+         * @returns A chain wrapper around the number of values in the wrapped
+         * collection.
+         **/
         size(): _ChainSingle<number>;
 
         /**

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -465,7 +465,7 @@ declare module _ {
          **/
         max<V extends Collection<any>>(
             collection: V,
-            iteratee?: Iteratee<V, number>,
+            iteratee?: Iteratee<V, any>,
             context?: any
         ): TypeOfCollection<V> | number;
 
@@ -484,7 +484,7 @@ declare module _ {
          **/
         min<V extends Collection<any>>(
             list: V,
-            iteratee?: Iteratee<V, number>,
+            iteratee?: Iteratee<V, any>,
             context?: any
         ): TypeOfCollection<V> | number;
 
@@ -4164,7 +4164,7 @@ declare module _ {
          * @returns The maximum element within the wrapped collection or
          * -Infinity if the wrapped collection is empty.
          **/
-        max(iteratee?: Iteratee<V, number>, context?: any): T | number;
+        max(iteratee?: Iteratee<V, any>, context?: any): T | number;
 
         /**
          * Returns the minimum value in the wrapped collection. If an
@@ -4179,7 +4179,7 @@ declare module _ {
          * @returns The minimum element within the wrapped collection or
          * Infinity if the wrapped collection is empty.
          **/
-        min(iteratee?: Iteratee<V, number>, context?: any): T | number;
+        min(iteratee?: Iteratee<V, any>, context?: any): T | number;
 
         /**
         * Wrapped type `any[]`.
@@ -5166,7 +5166,7 @@ declare module _ {
          * wrapped collection or around -Infinity if the wrapped collection is
          * empty.
          **/
-        max(iteratee?: _ChainIteratee<V, number, T>, context?: any): _ChainSingle<T | number>;
+        max(iteratee?: _ChainIteratee<V, any, T>, context?: any): _ChainSingle<T | number>;
 
         /**
          * Returns the minimum value in the wrapped collection. If an
@@ -5182,7 +5182,7 @@ declare module _ {
          * wrapped collection or around Infinity if the wrapped collection is
          * empty.
          **/
-        min(iteratee?: _ChainIteratee<V, number, T>, context?: any): _ChainSingle<T | number>;
+        min(iteratee?: _ChainIteratee<V, any, T>, context?: any): _ChainSingle<T | number>;
 
         /**
         * Wrapped type `any[]`.

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -628,6 +628,19 @@ type NonIntersectingProperties = StringRecord | NonIntersectingStringRecord;
 const nonIntersectingPropertiesList: _.List<NonIntersectingProperties> = { 0: { a: 'a', b: 'c' }, 1: { onlyNonIntersectingStringRecord: 'b' }, length: 2 };
 declare const level2NonIntersectingPropertiesList: _.List<_.List<NonIntersectingProperties>>;
 
+interface NumberRecord {
+    a: number;
+}
+
+declare const numberRecordList: _.List<NumberRecord>;
+declare const numberRecordListValueIterator: (value: NumberRecord, index: number, collection: _.List<NumberRecord>) => number;
+
+declare const numberRecordDictionary: _.Dictionary<NumberRecord>;
+declare const numberRecordDictionaryValueIterator: (element: NumberRecord, key: string, collection: _.Dictionary<NumberRecord>) => number;
+
+const numberList: _.List<number> = { 0: 0, 1: 1, length: 2 };
+const numberDictionary: _.Dictionary<number> = { a: 0, b: 1 };
+
 const simpleString = 'abc';
 
 const simpleStringArray: string[] = ['a', 'c'];
@@ -1746,6 +1759,104 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _.pluck(anyValue, stringRecordProperty); // $ExpectType any[]
 }
 
+// max
+{
+    // function iterator - lists
+    _.max(numberRecordList, numberRecordListValueIterator); // $ExpectType number | NumberRecord
+    _.max(numberRecordList, numberRecordListValueIterator, context); // $ExpectType number | NumberRecord
+    _(numberRecordList).max(numberRecordListValueIterator); // $ExpectType number | NumberRecord
+    _(numberRecordList).max(numberRecordListValueIterator, context); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordList).max(numberRecordListValueIterator)); // $ExpectType ChainType<number | NumberRecord, never>
+    extractChainTypes(_.chain(numberRecordList).max(numberRecordListValueIterator, context)); // $ExpectType ChainType<number | NumberRecord, never>
+
+    // function iterator - dictionaries
+    _.max(numberRecordDictionary, numberRecordDictionaryValueIterator); // $ExpectType number | NumberRecord
+    _.max(numberRecordDictionary, numberRecordDictionaryValueIterator, context); // $ExpectType number | NumberRecord
+    _(numberRecordDictionary).max(numberRecordDictionaryValueIterator); // $ExpectType number | NumberRecord
+    _(numberRecordDictionary).max(numberRecordDictionaryValueIterator, context); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordDictionary).max(numberRecordDictionaryValueIterator)); // $ExpectType ChainType<number | NumberRecord, never>
+    extractChainTypes(_.chain(numberRecordDictionary).max(numberRecordDictionaryValueIterator, context)); // $ExpectType ChainType<number | NumberRecord, never>
+
+    // property name iterator - lists
+    _.max(numberRecordList, stringRecordProperty); // $ExpectType number | NumberRecord
+    _(numberRecordList).max(stringRecordProperty); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordList).max(stringRecordProperty)); // $ExpectType ChainType<number | NumberRecord, never>
+
+    // property name iterator - dictionaries
+    _.max(numberRecordDictionary, stringRecordProperty); // $ExpectType number | NumberRecord
+    _(numberRecordDictionary).max(stringRecordProperty); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordDictionary).max(stringRecordProperty)); // $ExpectType ChainType<number | NumberRecord, never>
+
+    // property path iterator - lists
+    _.max(numberRecordList, stringRecordPropertyPath); // $ExpectType number | NumberRecord
+    _(numberRecordList).max(stringRecordPropertyPath); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordList).max(stringRecordPropertyPath)); // $ExpectType ChainType<number | NumberRecord, never>
+
+    // property path iterator - dictionaries
+    _.max(numberRecordDictionary, stringRecordPropertyPath); // $ExpectType number | NumberRecord
+    _(numberRecordDictionary).max(stringRecordPropertyPath); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordDictionary).max(stringRecordPropertyPath)); // $ExpectType ChainType<number | NumberRecord, never>
+
+    // identity iterator - lists
+    _.max(numberList); // $ExpectType number
+    _(numberList).max(); // $ExpectType number
+    extractChainTypes(_.chain(numberList).max()); // $ExpectType ChainType<number, never>
+
+    // identity iterator - dictionaries
+    _.max(numberDictionary); // $ExpectType number
+    _(numberDictionary).max(); // $ExpectType number
+    extractChainTypes(_.chain(numberDictionary).max()); // $ExpectType ChainType<number, never>
+}
+
+// min
+{
+    // function iterator - lists
+    _.min(numberRecordList, numberRecordListValueIterator); // $ExpectType number | NumberRecord
+    _.min(numberRecordList, numberRecordListValueIterator, context); // $ExpectType number | NumberRecord
+    _(numberRecordList).min(numberRecordListValueIterator); // $ExpectType number | NumberRecord
+    _(numberRecordList).min(numberRecordListValueIterator, context); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordList).min(numberRecordListValueIterator)); // $ExpectType ChainType<number | NumberRecord, never>
+    extractChainTypes(_.chain(numberRecordList).min(numberRecordListValueIterator, context)); // $ExpectType ChainType<number | NumberRecord, never>
+
+    // function iterator - dictionaries
+    _.min(numberRecordDictionary, numberRecordDictionaryValueIterator); // $ExpectType number | NumberRecord
+    _.min(numberRecordDictionary, numberRecordDictionaryValueIterator, context); // $ExpectType number | NumberRecord
+    _(numberRecordDictionary).min(numberRecordDictionaryValueIterator); // $ExpectType number | NumberRecord
+    _(numberRecordDictionary).min(numberRecordDictionaryValueIterator, context); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordDictionary).min(numberRecordDictionaryValueIterator)); // $ExpectType ChainType<number | NumberRecord, never>
+    extractChainTypes(_.chain(numberRecordDictionary).min(numberRecordDictionaryValueIterator, context)); // $ExpectType ChainType<number | NumberRecord, never>
+
+    // property name iterator - lists
+    _.min(numberRecordList, stringRecordProperty); // $ExpectType number | NumberRecord
+    _(numberRecordList).min(stringRecordProperty); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordList).min(stringRecordProperty)); // $ExpectType ChainType<number | NumberRecord, never>
+
+    // property name iterator - dictionaries
+    _.min(numberRecordDictionary, stringRecordProperty); // $ExpectType number | NumberRecord
+    _(numberRecordDictionary).min(stringRecordProperty); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordDictionary).min(stringRecordProperty)); // $ExpectType ChainType<number | NumberRecord, never>
+
+    // property path iterator - lists
+    _.min(numberRecordList, stringRecordPropertyPath); // $ExpectType number | NumberRecord
+    _(numberRecordList).min(stringRecordPropertyPath); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordList).min(stringRecordPropertyPath)); // $ExpectType ChainType<number | NumberRecord, never>
+
+    // property path iterator - dictionaries
+    _.min(numberRecordDictionary, stringRecordPropertyPath); // $ExpectType number | NumberRecord
+    _(numberRecordDictionary).min(stringRecordPropertyPath); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordDictionary).min(stringRecordPropertyPath)); // $ExpectType ChainType<number | NumberRecord, never>
+
+    // identity iterator - lists
+    _.min(numberList); // $ExpectType number
+    _(numberList).min(); // $ExpectType number
+    extractChainTypes(_.chain(numberList).min()); // $ExpectType ChainType<number, never>
+
+    // identity iterator - dictionaries
+    _.min(numberDictionary); // $ExpectType number
+    _(numberDictionary).min(); // $ExpectType number
+    extractChainTypes(_.chain(numberDictionary).min()); // $ExpectType ChainType<number, never>
+}
+
 // groupBy
 {
     // function iteratee - lists
@@ -1846,6 +1957,24 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _.toArray(simpleString); // $ExpectType string[]
     _(simpleString).toArray(); // $ExpectType string[]
     extractChainTypes(_.chain(simpleString).toArray()); // $ExpectType ChainType<string[], string>
+}
+
+// size
+{
+    // lists
+    _.size(stringRecordList); // $ExpectType number
+    _(stringRecordList).size(); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).size()); // $ExpectType ChainType<number, never>
+
+    // dictionaries
+    _.size(stringRecordDictionary); // $ExpectType number
+    _(stringRecordDictionary).size(); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordDictionary).size()); // $ExpectType ChainType<number, never>
+
+    // strings
+    _.size(simpleString); // $ExpectType number
+    _(simpleString).size(); // $ExpectType number
+    extractChainTypes(_.chain(simpleString).size()); // $ExpectType ChainType<number, never>
 }
 
 // partition


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://underscorejs.org/
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

This PR continues the planned set that will together add up to #45201 and includes the following changes:

- Adds tests for `min`, `max`, and `size`.
- Collapses overloads of `min` and `max` by updating them to use `Iteratee`.
- Updates the return values of `max` and `min` to always include `number` to cover the possibilities of +/-Infinity for empty collections.
- Drops the unnecessary `T` generic from `UnderscoreStatic.size`.
- Updates the `Underscore` and `_Chain` versions of `max` and `min` to work with both Lists and Dictionaries to partially fix #20623.