### PR TITLE
ssh2-sftp-client add posixRename and retry connect opts

### DIFF
--- a/types/ssh2-sftp-client/index.d.ts
+++ b/types/ssh2-sftp-client/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ssh2-sftp-client 5.1
+// Type definitions for ssh2-sftp-client 5.2
 // Project: https://github.com/theophilusx/ssh2-sftp-client
 // Definitions by: igrayson <https://github.com/igrayson>
 //                 Ascari Andrea <https://github.com/ascariandrea>
@@ -17,7 +17,7 @@ import * as ssh2Stream from 'ssh2-streams';
 export = sftp;
 
 declare class sftp {
-    connect(options: ssh2.ConnectConfig): Promise<ssh2.SFTPWrapper>;
+    connect(options: sftp.ConnectOptions): Promise<ssh2.SFTPWrapper>;
 
     list(remoteFilePath: string, pattern?: string | RegExp): Promise<sftp.FileInfo[]>;
 
@@ -70,9 +70,17 @@ declare class sftp {
     on(event: string, callback: (...args: any[]) => void): void;
 
     removeListener(event: string, callback: (...args: any[]) => void): void;
+
+    posixRename(fromPath: string, toPath: string): Promise<string>;
 }
 
 declare namespace sftp {
+    interface ConnectOptions extends ssh2.ConnectConfig {
+        retries?: number;
+        retry_factor?: number;
+        retry_minTimeout?: number;
+    }
+
     interface FileInfo {
         type: string;
         name: string;

--- a/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
+++ b/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
@@ -10,6 +10,16 @@ client.connect({
     readyTimeout: 1000,
 }).then(() => null);
 
+client.connect({
+    host: 'asdb',
+    port: 1234,
+    privateKey: 'my private key rsa in openssh format',
+    readyTimeout: 1000,
+    retries: 2,
+    retry_factor: 2,
+    retry_minTimeout: 2000,
+}).then(() => null);
+
 client.list('/remote/path').then(() => null);
 
 client.exists('/remote/path').then(() => null);
@@ -42,3 +52,5 @@ client.chmod('/remote/path', 777).then(() => null);
 client.end().then(() => null);
 
 client.on('event', () => null);
+
+client.posixRename('remote/path/from', 'remote/path/to').then(() => null);


### PR DESCRIPTION
Add `posixRename` that was added in version 5.2. Also add the optional retry parameters to the connect call that are currently missing, as they're not part of the ssh2 definition.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://www.npmjs.com/package/ssh2-sftp-client#sec-5-2-1
https://www.npmjs.com/package/ssh2-sftp-client#sec-5-2-15
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.