### PR TITLE
[@types/testing-library__react-hooks] Derive the props type into the wrapper prop

### DIFF
--- a/types/testing-library__react-hooks/index.d.ts
+++ b/types/testing-library__react-hooks/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @testing-library/react-hooks 3.2
+// Type definitions for @testing-library/react-hooks 3.3
 // Project: https://github.com/testing-library/react-hooks-testing-library
 // Definitions by: Michael Peyper <https://github.com/mpeyper>
 //                 Sarah Dayan <https://github.com/sarahdayan>
@@ -10,7 +10,7 @@ export { act } from 'react-test-renderer';
 
 export interface RenderHookOptions<P> {
     initialProps?: P;
-    wrapper?: React.ComponentType;
+    wrapper?: React.ComponentType<P>;
 }
 
 export interface HookResult<R> {
@@ -27,7 +27,7 @@ export interface RenderHookResult<P, R> {
     readonly result: HookResult<R>;
     readonly waitForNextUpdate: (options?: WaitOptions) => Promise<void>;
     readonly waitForValueToChange: (selector: () => any, options?: WaitOptions) => Promise<void>;
-    readonly wait: (callback: () => boolean|void, options?: WaitOptions) => Promise<void>;
+    readonly wait: (callback: () => boolean | void, options?: WaitOptions) => Promise<void>;
     readonly unmount: () => boolean;
     readonly rerender: (newProps?: P) => void;
 }

--- a/types/testing-library__react-hooks/testing-library__react-hooks-tests.tsx
+++ b/types/testing-library__react-hooks/testing-library__react-hooks-tests.tsx
@@ -1,5 +1,7 @@
-import { useState } from 'react';
+import * as React from 'react';
 import { renderHook, act, cleanup } from '@testing-library/react-hooks';
+
+const { useState, createContext, useContext } = React;
 
 const useHook = (initialValue: number) => {
     const [value, setValue] = useState(initialValue);
@@ -31,6 +33,46 @@ function checkTypesWithInitialProps() {
             value: number;
             setValue: (_: number) => void;
         };
+    } = result;
+    const _unmount: () => boolean = unmount;
+    const _rerender: (_?: { value: number }) => void = rerender;
+}
+
+function checkTypesWithWrapper() {
+    const TestContext = createContext<number>(10);
+
+    const wrapper: React.FC = ({ children }) => <div>{children}</div>;
+
+    const { result, unmount, rerender } = renderHook(() => useContext(TestContext), {
+        wrapper,
+    });
+
+    // check types
+    const _result: {
+        current: number;
+    } = result;
+    const _unmount: () => boolean = unmount;
+    const _rerender: (_?: { value: number }) => void = rerender;
+}
+
+function checkTypesWithInitialPropsAndWrapper() {
+    const TestContext = createContext<number>(10);
+
+    interface WrapperProps {
+        value: number;
+    }
+
+    const wrapper: React.FC<WrapperProps> = ({ children, value }) => (
+        <TestContext.Provider value={value}>{children}</TestContext.Provider>
+    );
+
+    const { result, unmount, rerender } = renderHook(() => useContext(TestContext), {
+        wrapper,
+    });
+
+    // check types
+    const _result: {
+        current: number;
     } = result;
     const _unmount: () => boolean = unmount;
     const _rerender: (_?: { value: number }) => void = rerender;

--- a/types/testing-library__react-hooks/tsconfig.json
+++ b/types/testing-library__react-hooks/tsconfig.json
@@ -14,7 +14,8 @@
         "forceConsistentCasingInFileNames": true,
         "paths": {
             "@testing-library/react-hooks": ["testing-library__react-hooks"]
-        }
+        },
+        "jsx": "react"
     },
-    "files": ["index.d.ts", "testing-library__react-hooks-tests.ts"]
+    "files": ["index.d.ts", "testing-library__react-hooks-tests.tsx"]
 }


### PR DESCRIPTION
- Derive the props type into the "wrapper" prop of RenderHookOptions
- Rename testing file to a ".tsx" file
- Add tests for the "wrapper" prop of RenderHookOptions

## Check List

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

---

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [react-hooks-testing-library/src/pure.js:61](https://github.com/testing-library/react-hooks-testing-library/blob/master/src/pure.js#L61)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.