### PR TITLE
[yargs] Fix parse() doesn't recognize (argv, callback)

### DIFF
--- a/types/yargs/v10/index.d.ts
+++ b/types/yargs/v10/index.d.ts
@@ -154,8 +154,7 @@ declare namespace yargs {
 
         parse(arg?: string | ReadonlyArray<string>): Arguments;
         parse(arg: string | ReadonlyArray<string>, parseCallback: ParseCallback): Arguments;
-        parse(arg: string | ReadonlyArray<string>, context: object): Arguments;
-        parse(arg: string | ReadonlyArray<string>, context: object, parseCallback: ParseCallback): Arguments;
+        parse(arg: string | ReadonlyArray<string>, context: object, parseCallback?: ParseCallback): Arguments;
 
         pkgConf(key: string | string[], cwd?: string): Argv;
 

--- a/types/yargs/v10/index.d.ts
+++ b/types/yargs/v10/index.d.ts
@@ -152,8 +152,10 @@ declare namespace yargs {
         options(key: string, options: Options): Argv;
         options(options: { [key: string]: Options }): Argv;
 
-        parse(): Arguments;
-        parse(arg: string | string[], context?: object, parseCallback?: ParseCallback): Arguments;
+        parse(arg?: string | ReadonlyArray<string>): Arguments;
+        parse(arg: string | ReadonlyArray<string>, parseCallback: ParseCallback): Arguments;
+        parse(arg: string | ReadonlyArray<string>, context: object): Arguments;
+        parse(arg: string | ReadonlyArray<string>, context: object, parseCallback: ParseCallback): Arguments;
 
         pkgConf(key: string | string[], cwd?: string): Argv;
 

--- a/types/yargs/v11/index.d.ts
+++ b/types/yargs/v11/index.d.ts
@@ -156,8 +156,7 @@ declare namespace yargs {
 
         parse(arg?: string | ReadonlyArray<string>): Arguments;
         parse(arg: string | ReadonlyArray<string>, parseCallback: ParseCallback): Arguments;
-        parse(arg: string | ReadonlyArray<string>, context: object): Arguments;
-        parse(arg: string | ReadonlyArray<string>, context: object, parseCallback: ParseCallback): Arguments;
+        parse(arg: string | ReadonlyArray<string>, context: object, parseCallback?: ParseCallback): Arguments;
 
         pkgConf(key: string | string[], cwd?: string): Argv;
 

--- a/types/yargs/v11/index.d.ts
+++ b/types/yargs/v11/index.d.ts
@@ -154,8 +154,10 @@ declare namespace yargs {
         options(key: string, options: Options): Argv;
         options(options: { [key: string]: Options }): Argv;
 
-        parse(): Arguments;
-        parse(arg: string | string[], context?: object, parseCallback?: ParseCallback): Arguments;
+        parse(arg?: string | ReadonlyArray<string>): Arguments;
+        parse(arg: string | ReadonlyArray<string>, parseCallback: ParseCallback): Arguments;
+        parse(arg: string | ReadonlyArray<string>, context: object): Arguments;
+        parse(arg: string | ReadonlyArray<string>, context: object, parseCallback: ParseCallback): Arguments;
 
         pkgConf(key: string | string[], cwd?: string): Argv;
 

--- a/types/yargs/v12/index.d.ts
+++ b/types/yargs/v12/index.d.ts
@@ -187,8 +187,7 @@ declare namespace yargs {
 
         parse(arg?: string | ReadonlyArray<string>): { [key in keyof Arguments<T>]: Arguments<T>[key] };
         parse(arg: string | ReadonlyArray<string>, parseCallback: ParseCallback<T>): { [key in keyof Arguments<T>]: Arguments<T>[key] };
-        parse(arg: string | ReadonlyArray<string>, context: object): { [key in keyof Arguments<T>]: Arguments<T>[key] };
-        parse(arg: string | ReadonlyArray<string>, context: object, parseCallback: ParseCallback<T>): { [key in keyof Arguments<T>]: Arguments<T>[key] };
+        parse(arg: string | ReadonlyArray<string>, context: object, parseCallback?: ParseCallback<T>): { [key in keyof Arguments<T>]: Arguments<T>[key] };
 
         parsed: DetailedArguments | false;
 

--- a/types/yargs/v12/index.d.ts
+++ b/types/yargs/v12/index.d.ts
@@ -185,8 +185,10 @@ declare namespace yargs {
         options<K extends string, O extends Options>(key: K, options: O): Argv<T & { [key in K]: InferredOptionType<O> }>;
         options<O extends { [key: string]: Options }>(options: O): Argv<Omit<T, keyof O> & InferredOptionTypes<O>>;
 
-        parse(): { [key in keyof Arguments<T>]: Arguments<T>[key] };
-        parse(arg: string | ReadonlyArray<string>, context?: object, parseCallback?: ParseCallback<T>): { [key in keyof Arguments<T>]: Arguments<T>[key] };
+        parse(arg?: string | ReadonlyArray<string>): { [key in keyof Arguments<T>]: Arguments<T>[key] };
+        parse(arg: string | ReadonlyArray<string>, parseCallback: ParseCallback<T>): { [key in keyof Arguments<T>]: Arguments<T>[key] };
+        parse(arg: string | ReadonlyArray<string>, context: object): { [key in keyof Arguments<T>]: Arguments<T>[key] };
+        parse(arg: string | ReadonlyArray<string>, context: object, parseCallback: ParseCallback<T>): { [key in keyof Arguments<T>]: Arguments<T>[key] };
 
         parsed: DetailedArguments | false;
 

--- a/types/yargs/v12/yargs-tests.ts
+++ b/types/yargs/v12/yargs-tests.ts
@@ -151,7 +151,7 @@ function Argv$parsing() {
     yargs.parse([], (err, argv, msg) => {
         // $ExpectType Error | undefined
         err;
-        // $ExpectType { [x: string]: unknown; _: string[]; $0: string; }
+        // $ExpectType { [argName: string]: unknown; _: string[]; $0: string; }
         argv;
         // $ExpectType string
         msg;
@@ -160,7 +160,7 @@ function Argv$parsing() {
     yargs.parse([], {}, (err, argv, msg) => {
         // $ExpectType Error | undefined
         err;
-        // $ExpectType { [x: string]: unknown; _: string[]; $0: string; }
+        // $ExpectType { [argName: string]: unknown; _: string[]; $0: string; }
         argv;
         // $ExpectType string
         msg;

--- a/types/yargs/v12/yargs-tests.ts
+++ b/types/yargs/v12/yargs-tests.ts
@@ -147,6 +147,24 @@ function Argv$parsing() {
         .boolean('update')
         .boolean('extern')
         .argv;
+
+    yargs.parse([], (err, argv, msg) => {
+        // $ExpectType Error | undefined
+        err;
+        // $ExpectType { [x: string]: unknown; _: string[]; $0: string; }
+        argv;
+        // $ExpectType string
+        msg;
+    });
+
+    yargs.parse([], {}, (err, argv, msg) => {
+        // $ExpectType Error | undefined
+        err;
+        // $ExpectType { [x: string]: unknown; _: string[]; $0: string; }
+        argv;
+        // $ExpectType string
+        msg;
+    });
 }
 
 function Argv$options() {

--- a/types/yargs/v13/index.d.ts
+++ b/types/yargs/v13/index.d.ts
@@ -415,8 +415,10 @@ declare namespace yargs {
          * Note: Providing a callback to parse() disables the `exitProcess` setting until after the callback is invoked.
          * @param [context]  Provides a useful mechanism for passing state information to commands
          */
-        parse(): { [key in keyof Arguments<T>]: Arguments<T>[key] };
-        parse(arg: string | ReadonlyArray<string>, context?: object, parseCallback?: ParseCallback<T>): { [key in keyof Arguments<T>]: Arguments<T>[key] };
+        parse(arg?: string | ReadonlyArray<string>): { [key in keyof Arguments<T>]: Arguments<T>[key] };
+        parse(arg: string | ReadonlyArray<string>, parseCallback: ParseCallback<T>): { [key in keyof Arguments<T>]: Arguments<T>[key] };
+        parse(arg: string | ReadonlyArray<string>, context: object): { [key in keyof Arguments<T>]: Arguments<T>[key] };
+        parse(arg: string | ReadonlyArray<string>, context: object, parseCallback: ParseCallback<T>): { [key in keyof Arguments<T>]: Arguments<T>[key] };
 
         /**
          * If the arguments have not been parsed, this property is `false`.

--- a/types/yargs/v13/index.d.ts
+++ b/types/yargs/v13/index.d.ts
@@ -417,8 +417,7 @@ declare namespace yargs {
          */
         parse(arg?: string | ReadonlyArray<string>): { [key in keyof Arguments<T>]: Arguments<T>[key] };
         parse(arg: string | ReadonlyArray<string>, parseCallback: ParseCallback<T>): { [key in keyof Arguments<T>]: Arguments<T>[key] };
-        parse(arg: string | ReadonlyArray<string>, context: object): { [key in keyof Arguments<T>]: Arguments<T>[key] };
-        parse(arg: string | ReadonlyArray<string>, context: object, parseCallback: ParseCallback<T>): { [key in keyof Arguments<T>]: Arguments<T>[key] };
+        parse(arg: string | ReadonlyArray<string>, context: object, parseCallback?: ParseCallback<T>): { [key in keyof Arguments<T>]: Arguments<T>[key] };
 
         /**
          * If the arguments have not been parsed, this property is `false`.

--- a/types/yargs/v13/yargs-tests.ts
+++ b/types/yargs/v13/yargs-tests.ts
@@ -148,6 +148,24 @@ function Argv$parsing() {
         .boolean('update')
         .boolean('extern')
         .argv;
+
+    yargs.parse([], (err, argv, msg) => {
+        // $ExpectType Error | undefined
+        err;
+        // $ExpectType { [x: string]: unknown; _: string[]; $0: string; }
+        argv;
+        // $ExpectType string
+        msg;
+    });
+
+    yargs.parse([], {}, (err, argv, msg) => {
+        // $ExpectType Error | undefined
+        err;
+        // $ExpectType { [x: string]: unknown; _: string[]; $0: string; }
+        argv;
+        // $ExpectType string
+        msg;
+    });
 }
 
 function Argv$options() {

--- a/types/yargs/v13/yargs-tests.ts
+++ b/types/yargs/v13/yargs-tests.ts
@@ -152,7 +152,7 @@ function Argv$parsing() {
     yargs.parse([], (err, argv, msg) => {
         // $ExpectType Error | undefined
         err;
-        // $ExpectType { [x: string]: unknown; _: string[]; $0: string; }
+        // $ExpectType { [argName: string]: unknown; _: string[]; $0: string; }
         argv;
         // $ExpectType string
         msg;
@@ -161,7 +161,7 @@ function Argv$parsing() {
     yargs.parse([], {}, (err, argv, msg) => {
         // $ExpectType Error | undefined
         err;
-        // $ExpectType { [x: string]: unknown; _: string[]; $0: string; }
+        // $ExpectType { [argName: string]: unknown; _: string[]; $0: string; }
         argv;
         // $ExpectType string
         msg;

--- a/types/yargs/v8/index.d.ts
+++ b/types/yargs/v8/index.d.ts
@@ -16,8 +16,7 @@ declare namespace yargs {
         (args?: string[], cwd?: string): Arguments;
         parse(arg: string | ReadonlyArray<string>): Arguments;
         parse(arg: string | ReadonlyArray<string>, parseCallback: ParseCallback): Arguments;
-        parse(arg: string | ReadonlyArray<string>, context: object): Arguments;
-        parse(arg: string | ReadonlyArray<string>, context: object, parseCallback: ParseCallback): Arguments;
+        parse(arg: string | ReadonlyArray<string>, context: object, parseCallback?: ParseCallback): Arguments;
 
         reset(): Argv;
 

--- a/types/yargs/v8/index.d.ts
+++ b/types/yargs/v8/index.d.ts
@@ -14,7 +14,10 @@ declare namespace yargs {
     interface Argv {
         argv: Arguments;
         (args?: string[], cwd?: string): Arguments;
-        parse(args: string | string[], context?: object, parseCallback?: ParseCallback): Arguments;
+        parse(arg: string | ReadonlyArray<string>): Arguments;
+        parse(arg: string | ReadonlyArray<string>, parseCallback: ParseCallback): Arguments;
+        parse(arg: string | ReadonlyArray<string>, context: object): Arguments;
+        parse(arg: string | ReadonlyArray<string>, context: object, parseCallback: ParseCallback): Arguments;
 
         reset(): Argv;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [yargs API Reference](https://yargs.js.org/docs/#api-reference-parseargs-context-parsecallback)
  - [parse() in yargs@v8.0.2](https://github.com/yargs/yargs/blob/v8.0.2/yargs.js#L508)
  - [parse() in yargs@v10.1.2](https://github.com/yargs/yargs/blob/v10.1.2/yargs.js#L517)
  - [parse() in yargs@v11.1.0](https://github.com/yargs/yargs/blob/v11.1.0/yargs.js#L526)
  - [parse() in yargs@v12.0.5](https://github.com/yargs/yargs/blob/v12.0.5/yargs.js#L539)
  - [parse() in yargs@v13.3.0](https://github.com/yargs/yargs/blob/v13.3.0/yargs.js#L539)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
