### PR TITLE
react-test-renderer: add array return types for fragment components

### DIFF
--- a/types/react-test-renderer/index.d.ts
+++ b/types/react-test-renderer/index.d.ts
@@ -24,7 +24,7 @@ export type ReactTestRendererNode = ReactTestRendererJSON | string;
 export interface ReactTestRendererTree extends ReactTestRendererJSON {
     nodeType: 'component' | 'host';
     instance: any;
-    rendered: null | ReactTestRendererTree;
+    rendered: null | ReactTestRendererTree | ReactTestRendererTree[];
 }
 export interface ReactTestInstance {
     instance: any;
@@ -42,7 +42,7 @@ export interface ReactTestInstance {
     findAllByProps(props: { [propName: string]: any }, options?: { deep: boolean }): ReactTestInstance[];
 }
 export interface ReactTestRenderer {
-    toJSON(): null | ReactTestRendererJSON;
+    toJSON(): null | ReactTestRendererJSON | ReactTestRendererJSON[];
     toTree(): null | ReactTestRendererTree;
     unmount(nextElement?: ReactElement): void;
     update(nextElement: ReactElement): void;

--- a/types/react-test-renderer/react-test-renderer-tests.ts
+++ b/types/react-test-renderer/react-test-renderer-tests.ts
@@ -11,12 +11,20 @@ const renderer = create(React.createElement("div"), {
 });
 
 const json = renderer.toJSON();
-if (json) {
+if (json && !Array.isArray(json)) {
     json.type = "t";
     json.props = {
         prop1: "p",
     };
     json.children = [json];
+}
+
+if (json && Array.isArray(json)) {
+    json[json.length - 1].type = "t";
+    json[json.length - 1].props = {
+        prop1: "p",
+    };
+    json[json.length - 1].children = [json[json.length - 1]];
 }
 
 const tree = renderer.toTree();
@@ -27,6 +35,7 @@ if (tree) {
     };
     tree.children = [tree];
     tree.rendered = tree;
+    tree.rendered = [tree];
     tree.nodeType = "component";
     tree.nodeType = "host";
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://codesandbox.io/s/jovial-dhawan-qddtb?file=/src/App.test.tsx>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.