### PR TITLE
[Passport.socketio] - Changing critical from a string to a boolean for critical arg

### DIFF
--- a/types/passport.socketio/index.d.ts
+++ b/types/passport.socketio/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for passport.socketio 3.7
 // Project: https://github.com/jfromaniello/passport.socketio#readme
 // Definitions by: AhmedMKamal <https://github.com/AhmedMKamal>
+//                 Jack Scotson <https://github.com/Scotsoo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -39,7 +40,7 @@ export interface PassportSocketIoOptions {
     /**
      * callback on fail/error.
      */
-    fail?: (data: any, message: string, critical: string, accept: (err?: any, accepted?: boolean) => void) => void;
+    fail?: (data: any, message: string, critical: boolean, accept: (err?: any, accepted?: boolean) => void) => void;
 }
 
 export function authorize(options: PassportSocketIoOptions): (socket: Socket, fn: (err?: any) => void) => void;

--- a/types/passport.socketio/passport.socketio-tests.ts
+++ b/types/passport.socketio/passport.socketio-tests.ts
@@ -14,7 +14,7 @@ const middleware = passportSocketIo.authorize({
     secret: 'session_secret',
     store: sessionStore,
     success: (data, accept) => accept(),
-    fail: (data, message, error, accept) => {
+    fail: (data, message, error: boolean, accept) => {
         if (error) {
             accept(new Error(message));
         }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/jfromaniello/passport.socketio/blob/master/lib/index.js#L73>> (boolean passed as third arg)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
