### PR TITLE
[dotenv-safe] Extend DotenvConfigOutput to match dotenv-safe output

### DIFF
--- a/types/dotenv-safe/dotenv-safe-tests.ts
+++ b/types/dotenv-safe/dotenv-safe-tests.ts
@@ -1,7 +1,7 @@
-import env = require("dotenv-safe")
+import env = require('dotenv-safe');
 
 env.config({
-  allowEmptyValues: true,
-  path: "/foo/bar/baz.env",
-  sample: "/foo/bar/qux.env"
-})
+    allowEmptyValues: true,
+    path: '/foo/bar/baz.env',
+    sample: '/foo/bar/qux.env',
+});

--- a/types/dotenv-safe/index.d.ts
+++ b/types/dotenv-safe/index.d.ts
@@ -38,9 +38,16 @@ export interface DotenvSafeOptions extends dotenv.DotenvConfigOptions {
   allowEmptyValues?: boolean,
 }
 
+export interface DotenvSafeConfigOutput extends dotenv.DotenvConfigOutput {
+  /**
+   * key-value pairs required by .env.example
+   */
+  required: dotenv.DotenvParseOutput
+}
+
 /**
  * Loads environment variables file into 'process.env'.
  *
  * @throws MissingEnvVarsError
  */
-export function config(options?: DotenvSafeOptions): dotenv.DotenvConfigOutput
+export function config(options?: DotenvSafeOptions): DotenvSafeConfigOutput

--- a/types/dotenv-safe/index.d.ts
+++ b/types/dotenv-safe/index.d.ts
@@ -4,45 +4,45 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-import dotenv = require("dotenv")
+import dotenv = require('dotenv');
 
 export interface MissingEnvVarsError extends Error {
-  /**
-   * Path to example environment file.
-   */
-  sample: string
+    /**
+     * Path to example environment file.
+     */
+    sample: string;
 
-  /**
-   * Variables which existing in the sample file, but not in the loaded file.
-   */
-  missing: string[]
+    /**
+     * Variables which existing in the sample file, but not in the loaded file.
+     */
+    missing: string[];
 }
 
 export interface DotenvSafeOptions extends dotenv.DotenvConfigOptions {
-  /**
-   * Path to example environment file. (Option 1)
-   * @default ".env.example"
-   */
-  example?: string,
+    /**
+     * Path to example environment file. (Option 1)
+     * @default ".env.example"
+     */
+    example?: string;
 
-  /**
-   * Path to example environment file. (Option 2 -- example takes precedence)
-   * @default ".env.example"
-   */
-  sample?: string,
+    /**
+     * Path to example environment file. (Option 2 -- example takes precedence)
+     * @default ".env.example"
+     */
+    sample?: string;
 
-  /**
-   * Enabling this option will not throw an error after loading.
-   * @default false
-   */
-  allowEmptyValues?: boolean,
+    /**
+     * Enabling this option will not throw an error after loading.
+     * @default false
+     */
+    allowEmptyValues?: boolean;
 }
 
 export interface DotenvSafeConfigOutput extends dotenv.DotenvConfigOutput {
-  /**
-   * key-value pairs required by .env.example
-   */
-  required: dotenv.DotenvParseOutput
+    /**
+     * key-value pairs required by .env.example
+     */
+    required: dotenv.DotenvParseOutput;
 }
 
 /**
@@ -50,4 +50,4 @@ export interface DotenvSafeConfigOutput extends dotenv.DotenvConfigOutput {
  *
  * @throws MissingEnvVarsError
  */
-export function config(options?: DotenvSafeOptions): DotenvSafeConfigOutput
+export function config(options?: DotenvSafeOptions): DotenvSafeConfigOutput;


### PR DESCRIPTION
* The return value of dotenv-safe.config() extends dotenv.config() by adding a `required` property, which is now reflected in the type structure.
* Apply prettier to dotenv-safe to conform to contribution guidelines/common mistakes (second commit).

---

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rolodato/dotenv-safe#usage
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing): (covered by existing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
