### PR TITLE
[webpack-deadcode-plugin]: New definition

### DIFF
--- a/types/webpack-deadcode-plugin/index.d.ts
+++ b/types/webpack-deadcode-plugin/index.d.ts
@@ -1,0 +1,38 @@
+// Type definitions for webpack-deadcode-plugin 0.1
+// Project: https://github.com/MQuy/webpack-deadcode-plugin#readme
+// Definitions by: Ciarán Ingle <https://github.com/inglec-arista>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { compilation, Plugin } from 'webpack';
+
+interface Options {
+    /** Current working directoy for patterns above. If you don't set explicitly, your webpack context will be used. */
+    context?: string;
+    /** Whether to run unsed export detection or not. */
+    detectUnusedExport?: boolean;
+    /** Whether to run unused files detection or not. */
+    detectUnusedFiles?: boolean;
+    /** The array of patterns to not look at. */
+    exclude?: string[];
+    /**
+     * Deadcode does not interrupt the compilation by default.
+     * If you want to cancel the compilation, set it `true`, it throws a fatal error and stops the compilation.
+     */
+    failOnHint?: boolean;
+    outputFile?: string;
+    /**
+     * The array of patterns to look for unused files and unused export in used files.
+     * Directly passed to [`fast-glob`](https://github.com/mrmlnc/fast-glob).
+     */
+    patterns?: string[];
+}
+
+declare class WebpackDeadcodePlugin extends Plugin {
+    options: Options;
+
+    constructor(options?: Options);
+
+    handleAfterEmit(options: Required<Options>, compilation: compilation.Compilation, callback: () => void): void;
+}
+
+export = WebpackDeadcodePlugin;

--- a/types/webpack-deadcode-plugin/tsconfig.json
+++ b/types/webpack-deadcode-plugin/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "baseUrl": "../",
+        "forceConsistentCasingInFileNames": true,
+        "lib": ["es6"],
+        "module": "commonjs",
+        "noEmit": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "typeRoots": ["../"],
+        "types": []
+    },
+    "files": [
+        "index.d.ts",
+        "webpack-deadcode-plugin-tests.ts"
+    ]
+}

--- a/types/webpack-deadcode-plugin/tslint.json
+++ b/types/webpack-deadcode-plugin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/webpack-deadcode-plugin/webpack-deadcode-plugin-tests.ts
+++ b/types/webpack-deadcode-plugin/webpack-deadcode-plugin-tests.ts
@@ -1,0 +1,22 @@
+import { Configuration, Plugin } from 'webpack';
+import DeadCodePlugin = require('webpack-deadcode-plugin');
+
+const webpackConfig: Configuration = {
+    plugins: [
+        new DeadCodePlugin({
+            patterns: ['src/**/*.(js|jsx|css)'],
+            exclude: ['**/*.(stories|spec).(js|jsx)'],
+        }),
+    ],
+};
+
+const plugin1: Plugin = new DeadCodePlugin();
+const plugin2: Plugin = new DeadCodePlugin({});
+const plugin3: Plugin = new DeadCodePlugin({
+    patterns: ['src/**/*.(js|jsx|css)'],
+    exclude: ['**/*.(stories|spec).(js|jsx)'],
+    context: '~/foo/bar',
+    detectUnusedExport: false,
+    detectUnusedFiles: false,
+    failOnHint: true,
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
