### PR TITLE
[passport-apple]: New definition

### DIFF
--- a/types/passport-apple/index.d.ts
+++ b/types/passport-apple/index.d.ts
@@ -1,0 +1,74 @@
+// Type definitions for passport-apple 1.1
+// Project: https://github.com/ananay/passport-apple
+// Definitions by: Atom Yuen <https://github.com/atomyyyy>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import { Request } from 'express';
+import { Strategy } from 'passport';
+import passportOAuth2 = require('passport-oauth2');
+
+declare namespace AppleStrategy {
+    interface AuthenticateOptionsBase extends Partial<passportOAuth2._StrategyOptionsBase> {
+        authorizationURL?: string;
+        tokenURL?: string;
+        clientID: string;
+        teamID: string;
+        keyID: string;
+        privateKeyLocation?: string;
+        privateKeyString?: string;
+    }
+
+    interface AuthenticateOptions extends AuthenticateOptionsBase {
+        passReqToCallback?: false;
+    }
+
+    interface AuthenticateOptionsWithRequest extends AuthenticateOptionsBase {
+        passReqToCallback: true;
+    }
+
+    type AppleAuthorizationParams = object & {
+        response_mode: "form_post";
+        scope: "name email";
+        response_type: "name email";
+        state: string | undefined;
+    };
+
+    interface DecodedIdToken {
+        sub: string;
+        [key: string]: any;
+    }
+
+    interface Profile {
+        [key: string]: any;
+    }
+
+    type VerifyCallback = (err?: Error | null, user?: object, info?: object) => void;
+
+    type VerifyFunction = (
+        accessToken: string,
+        refreshToken: string,
+        decodedIdToken: DecodedIdToken,
+        profile: Profile,
+        verified: VerifyCallback
+    ) => void;
+
+    type VerifyFunctionWithRequest = (
+        req: Request,
+        accessToken: string,
+        refreshToken: string,
+        decodedIdToken: DecodedIdToken,
+        profile: Profile,
+        verified: VerifyCallback
+    ) => void;
+}
+
+declare class AppleStrategy extends passportOAuth2 {
+    constructor(options: AppleStrategy.AuthenticateOptions, verify: AppleStrategy.VerifyFunction);
+    constructor(options: AppleStrategy.AuthenticateOptionsWithRequest, verify: AppleStrategy.VerifyFunctionWithRequest);
+
+    authorizationParams(options: object): AppleStrategy.AppleAuthorizationParams;
+    name: "apple";
+}
+
+export = AppleStrategy;

--- a/types/passport-apple/index.d.ts
+++ b/types/passport-apple/index.d.ts
@@ -1,8 +1,7 @@
 // Type definitions for passport-apple 1.1
-// Project: https://github.com/ananay/passport-apple
-// Definitions by: Atom Yuen <https://github.com/atomyyyy>
+// Project: https://github.com/ananay/passport-apple#readme
+// Definitions by: ytkalan <https://github.com/atomyyyy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 import { Request } from 'express';
 import { Strategy } from 'passport';

--- a/types/passport-apple/passport-apple-tests.ts
+++ b/types/passport-apple/passport-apple-tests.ts
@@ -1,0 +1,77 @@
+import AppleStrategy, {
+    AuthenticateOptions,
+    AuthenticateOptionsWithRequest,
+    AppleAuthorizationParams,
+    DecodedIdToken,
+    Profile,
+    VerifyCallback,
+    VerifyFunction,
+    VerifyFunctionWithRequest,
+} from 'passport-apple';
+import { Request } from 'express';
+
+const authenticateOptions: AuthenticateOptions = {
+    clientID: "",
+    teamID: "",
+    callbackURL: "",
+    keyID: "",
+    privateKeyString: "",
+    privateKeyLocation: "",
+};
+
+const authenticateOptionsWithRequest: AuthenticateOptionsWithRequest = {
+    clientID: "",
+    teamID: "",
+    callbackURL: "",
+    keyID: "",
+    privateKeyString: "",
+    privateKeyLocation: "",
+    passReqToCallback: true
+};
+
+const decodedIdToken: DecodedIdToken = { sub: '1' };
+
+const verifyFunction: VerifyFunction = (
+    accessToken: string,
+    refreshToken: string,
+    decodedIdToken: DecodedIdToken,
+    profile: Profile,
+    verifyCallback: VerifyCallback
+) => {
+    verifyCallback(new Error('unimplemented'));
+};
+
+const VerifyFunctionWithRequest: VerifyFunctionWithRequest = (
+    req: Request,
+    accessToken: string,
+    refreshToken: string,
+    decodedIdToken: DecodedIdToken,
+    profile: Profile,
+    verifyCallback: VerifyCallback) => {
+    verifyCallback(new Error('unimplemented'));
+};
+
+const appleStrategy = new AppleStrategy({
+    clientID: "",
+    teamID: "",
+    callbackURL: "",
+    keyID: "",
+    privateKeyString: "",
+    privateKeyLocation: "",
+}, (accessToken, refreshToken, decodedIdToken, profile, cb) => {
+    cb(null, decodedIdToken);
+});
+
+const appleStrategyWithRequest = new AppleStrategy({
+    clientID: "",
+    teamID: "",
+    callbackURL: "",
+    keyID: "",
+    privateKeyString: "",
+    privateKeyLocation: "",
+    passReqToCallback: true,
+}, (req, accessToken, refreshToken, decodedIdToken, profile, cb) => {
+    cb(null, decodedIdToken);
+});
+
+const AppleAuthorizationParams: AppleAuthorizationParams = appleStrategy.authorizationParams({});

--- a/types/passport-apple/tsconfig.json
+++ b/types/passport-apple/tsconfig.json
@@ -6,9 +6,9 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": true,
-        "strictFunctionTypes": true,
         "esModuleInterop": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/passport-apple/tsconfig.json
+++ b/types/passport-apple/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "esModuleInterop": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "passport-apple-tests.ts"
+    ]
+}

--- a/types/passport-apple/tslint.json
+++ b/types/passport-apple/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
