### PR TITLE
fix(googlemaps): origins and destinations need not be same type

### DIFF
--- a/types/googlemaps/reference/distance-matrix.d.ts
+++ b/types/googlemaps/reference/distance-matrix.d.ts
@@ -10,10 +10,10 @@ declare namespace google.maps {
         avoidFerries?: boolean;
         avoidHighways?: boolean;
         avoidTolls?: boolean;
-        destinations?: string[] | LatLng[] | LatLngLiteral[] | Place[];
+        destinations?: Array<(string | LatLng | LatLngLiteral | Place)>;
         drivingOptions?: DrivingOptions;
         durationInTraffic?: boolean;
-        origins?: string[] | LatLng[] | LatLngLiteral[] | Place[];
+        origins?: Array<(string | LatLng | LatLngLiteral | Place)>;
         region?: string;
         transitOptions?: TransitOptions;
         travelMode?: TravelMode;


### PR DESCRIPTION
follows on #46263

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
