### PR TITLE
fix(carbon-components-react): update DataTableSkeleton props

### DIFF
--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -37,6 +37,7 @@ import {
     ButtonRenderIconRenderProps,
     Modal,
     InlineLoading,
+    DataTableSkeleton,
 } from 'carbon-components-react';
 import Link from 'carbon-components-react/lib/components/UIShell/Link';
 
@@ -630,3 +631,12 @@ const sideNavChildren = (
 const modal = (
     <Modal primaryButtonText={<InlineLoading />} secondaryButtonText={<InlineLoading />} />
 )
+
+// DataTableSkeleton
+const dataTableSkeleton = (
+    <DataTableSkeleton showHeader={true} showToolbar={true} columnCount={5} rowCount={6} compact={false} zebra={false} />
+);
+
+const dataTableSkeletonBasic = (
+    <DataTableSkeleton />
+);

--- a/types/carbon-components-react/lib/components/DataTableSkeleton/DataTableSkeleton.d.ts
+++ b/types/carbon-components-react/lib/components/DataTableSkeleton/DataTableSkeleton.d.ts
@@ -12,6 +12,8 @@ export interface DataTableSkeletonProps extends InheritedProps {
     columnCount?: number;
     // headers?: ReadonlyArray<string> | ReadonlyArray<ShapeOf<HeaderType>>; // doesn't seem to be used anymore but prop type is still there so leaving this commented out.
     rowCount?: number;
+    showHeader?: boolean;
+    showToolbar?: boolean;
     zebra?: boolean;
 }
 


### PR DESCRIPTION
Add show props for header and toolbar per Carbon (https://react.carbondesignsystem.com/?path=/story/datatableskeleton--default)

Please fill in this template.

- [X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [X ] Test the change in your own code. (Compile and run.)
- [X ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://react.carbondesignsystem.com/?path=/story/datatableskeleton--default
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
