### PR TITLE
Fix types for npm package `death`

### DIFF
--- a/types/death/death-tests.ts
+++ b/types/death/death-tests.ts
@@ -1,19 +1,13 @@
-import ON_DEATH = require("death");
+import ON_DEATH = require('death');
 
-const unsub1: () => void = ON_DEATH(
-    (value: "SIGINT" | "SIGTERM" | "SIGQUIT") => {}
-);
+const unsub1: () => void = ON_DEATH((value: 'SIGINT' | 'SIGTERM' | 'SIGQUIT') => {});
 
 const unsub2: () => void = ON_DEATH({
     debug: true,
     SIGINT: true,
     SIGTERM: true,
     SIGQUIT: true,
-})(
-    (
-        value: "SIGINT" | "SIGTERM" | "SIGQUIT"
-    ) => {}
-);
+})((value: 'SIGINT' | 'SIGTERM' | 'SIGQUIT') => {});
 
 const unsub3: () => void = ON_DEATH({
     debug: true,
@@ -21,23 +15,14 @@ const unsub3: () => void = ON_DEATH({
     SIGINT: true,
     SIGTERM: true,
     SIGQUIT: true,
-})(
-    (
-        value: "SIGINT" | "SIGTERM" | "SIGQUIT" | Error
-    ) => {}
-);
+})((value: 'SIGINT' | 'SIGTERM' | 'SIGQUIT' | Error) => {});
 
 const unsub4: () => void = ON_DEATH({
     debug: true,
     SIGINT: true,
     SIGTERM: true,
     SIGQUIT: true,
-})(
-    (
-        value: "SIGINT" | "SIGTERM" | "SIGQUIT"
-    ) => {
-    }
-);
+})((value: 'SIGINT' | 'SIGTERM' | 'SIGQUIT') => {});
 
 const unsub5: () => void = ON_DEATH({
     debug: true,
@@ -47,8 +32,5 @@ const unsub5: () => void = ON_DEATH({
     SIGQUIT: true,
 })(
     // $ExpectError
-    (
-        value: "SIGINT" | "SIGTERM" | "SIGQUIT"
-    ) => {
-    }
+    (value: 'SIGINT' | 'SIGTERM' | 'SIGQUIT') => {},
 );

--- a/types/death/death-tests.ts
+++ b/types/death/death-tests.ts
@@ -1,18 +1,54 @@
 import ON_DEATH = require("death");
 
-const unsub: () => void = ON_DEATH(
+const unsub1: () => void = ON_DEATH(
     (value: "SIGINT" | "SIGTERM" | "SIGQUIT") => {}
 );
 
-const otherUnsub: () => void = ON_DEATH({
+const unsub2: () => void = ON_DEATH({
+    debug: true,
+    SIGINT: true,
+    SIGTERM: true,
+    SIGQUIT: true,
+})(
+    (
+        value: "SIGINT" | "SIGTERM" | "SIGQUIT"
+    ) => {}
+);
+
+const unsub3: () => void = ON_DEATH({
     debug: true,
     uncaughtException: true,
     SIGINT: true,
     SIGTERM: true,
     SIGQUIT: true,
-    SIGHUP: true
 })(
     (
-        value: "uncaughtException" | "SIGINT" | "SIGTERM" | "SIGQUIT" | "SIGHUP"
+        value: "SIGINT" | "SIGTERM" | "SIGQUIT" | Error
     ) => {}
+);
+
+const unsub4: () => void = ON_DEATH({
+    debug: true,
+    SIGINT: true,
+    SIGTERM: true,
+    SIGQUIT: true,
+})(
+    (
+        value: "SIGINT" | "SIGTERM" | "SIGQUIT"
+    ) => {
+    }
+);
+
+const unsub5: () => void = ON_DEATH({
+    debug: true,
+    uncaughtException: true,
+    SIGINT: true,
+    SIGTERM: true,
+    SIGQUIT: true,
+})(
+    // $ExpectError
+    (
+        value: "SIGINT" | "SIGTERM" | "SIGQUIT"
+    ) => {
+    }
 );

--- a/types/death/index.d.ts
+++ b/types/death/index.d.ts
@@ -4,6 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
+type Signal = "SIGINT" | "SIGTERM" | "SIGQUIT";
+
 /**
  * Invokes a callback when a SIGINT, SIGTERM, or SIGQUIT is detected
  * on the current node process.
@@ -21,8 +23,42 @@
  *  OFF_DEATH();
  */
 declare function ON_DEATH(
-    callback: (signal: "SIGINT" | "SIGTERM" | "SIGQUIT") => void
+    callback: (arg: Signal) => void
 ): () => void;
+
+/**
+ * Invokes a callback when a SIGINT, SIGTERM, or SIGQUIT is detected
+ * on the current node process. Configurable by the provided options.
+ *
+ * @param options
+ * @returns A function to subscribe to the configured death detection
+ * @example
+ *  ON_DEATH({
+ *    debug: true,
+ *  })((signal) => {
+ *    console.log('Oh no!');
+ *  });
+ * @example
+ *  const OFF_DEATH = ON_DEATH({
+ *    debug: true,
+ *  })((signal) => {
+ *    console.log('Oh no!');
+ *  });
+ *  // later
+ *  OFF_DEATH();
+ */
+declare function ON_DEATH(options: {
+    debug?: boolean;
+    SIGINT?: boolean;
+    SIGTERM?: boolean;
+    SIGQUIT?: boolean;
+    uncaughtException?: false;
+}): (
+    callback: (
+        signal: Signal
+    ) => void
+) => () => void;
+
 /**
  * Invokes a callback when a SIGINT, SIGTERM, or SIGQUIT is detected
  * on the current node process. Configurable by the provided options.
@@ -51,16 +87,12 @@ declare function ON_DEATH(options: {
     SIGINT?: boolean;
     SIGTERM?: boolean;
     SIGQUIT?: boolean;
-    SIGHUP?: boolean;
-    uncaughtException?: boolean;
+    uncaughtException: true;
 }): (
     callback: (
-        signal:
-            | "SIGINT"
-            | "SIGTERM"
-            | "SIGQUIT"
-            | "SIGHUP"
-            | "uncaughtException"
+        signalOrErr: Signal | Error,
+        origin?: string
     ) => void
 ) => () => void;
+
 export = ON_DEATH;

--- a/types/death/index.d.ts
+++ b/types/death/index.d.ts
@@ -5,7 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-type Signal = "SIGINT" | "SIGTERM" | "SIGQUIT";
+type Signal = 'SIGINT' | 'SIGTERM' | 'SIGQUIT';
 
 /**
  * Invokes a callback when a SIGINT, SIGTERM, or SIGQUIT is detected
@@ -23,9 +23,7 @@ type Signal = "SIGINT" | "SIGTERM" | "SIGQUIT";
  *  // later
  *  OFF_DEATH();
  */
-declare function ON_DEATH(
-    callback: (arg: Signal) => void
-): () => void;
+declare function ON_DEATH(callback: (arg: Signal) => void): () => void;
 
 /**
  * Invokes a callback when a SIGINT, SIGTERM, or SIGQUIT is detected
@@ -54,11 +52,7 @@ declare function ON_DEATH(options: {
     SIGTERM?: boolean;
     SIGQUIT?: boolean;
     uncaughtException?: false;
-}): (
-    callback: (
-        signal: Signal
-    ) => void
-) => () => void;
+}): (callback: (signal: Signal) => void) => () => void;
 
 /**
  * Invokes a callback when a SIGINT, SIGTERM, or SIGQUIT is detected
@@ -89,11 +83,6 @@ declare function ON_DEATH(options: {
     SIGTERM?: boolean;
     SIGQUIT?: boolean;
     uncaughtException: true;
-}): (
-    callback: (
-        signalOrErr: Signal | Error,
-        origin?: string
-    ) => void
-) => () => void;
+}): (callback: (signalOrErr: Signal | Error, origin?: string) => void) => () => void;
 
 export = ON_DEATH;

--- a/types/death/index.d.ts
+++ b/types/death/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for death 1.1
 // Project: https://github.com/jprichardson/node-death
 // Definitions by: Cameron Knight <https://github.com/ckknight>
+//                 Pranay Prakash <https://github.com/pranaygp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 


### PR DESCRIPTION
When using `uncaughtException: true`, the handler actually receives an `Error` and an `origin` instead of a signal. 

furhtermore, SIGHUP is not supported:

see:
https://github.com/jprichardson/node-death/blob/f9453b68b8168def79fa8350f294e2b757f64d75/lib/death.js#L2-L7
https://github.com/jprichardson/node-death/blob/f9453b68b8168def79fa8350f294e2b757f64d75/lib/death.js#L31
https://nodejs.org/api/process.html#process_event_uncaughtexception

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
