### PR TITLE
fix(jest): remove `require.requireActual` and `require.requireMock`

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -72,8 +72,6 @@ type ExtractEachCallbackArgs<T extends ReadonlyArray<any>> = {
         : 'fallback'
 ];
 
-type MockModuleFactory<T> = () => T extends { default: unknown } ? T & { __esModule: true } : T;
-
 declare namespace jest {
     /**
      * Provides a way to add Jasmine-compatible matchers into your Jest context.

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -74,23 +74,6 @@ type ExtractEachCallbackArgs<T extends ReadonlyArray<any>> = {
 
 type MockModuleFactory<T> = () => T extends { default: unknown } ? T & { __esModule: true } : T;
 
-interface NodeRequire {
-    /**
-     * Returns the actual module instead of a mock, bypassing all checks on
-     * whether the module should receive a mock implementation or not.
-     *
-     * @deprecated Use `jest.requireActual` instead.
-     */
-    requireActual(moduleName: string): any;
-    /**
-     * Returns a mock module instead of the actual module, bypassing all checks
-     * on whether the module should be required normally or not.
-     *
-     * @deprecated Use `jest.requireMock`instead.
-     */
-    requireMock(moduleName: string): any;
-}
-
 declare namespace jest {
     /**
      * Provides a way to add Jasmine-compatible matchers into your Jest context.

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -228,16 +228,6 @@ describe('', () => {
     });
 });
 
-/* NodeRequire interface (require extensions) */
-
-declare const nodeRequire: NodeRequire;
-
-// $ExpectType any
-nodeRequire.requireActual('moduleName');
-
-// $ExpectType any
-nodeRequire.requireMock('moduleName');
-
 /* Top-level jest namespace functions */
 
 interface FakeModule {


### PR DESCRIPTION
`require.requireActual` and `require.requireMock` have been removed by https://github.com/facebook/jest/pull/9854
this pull request remove the type definitions

