### PR TITLE
style(jest): fix linting error

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -164,6 +164,7 @@ declare namespace jest {
     /**
      * Mocks a module with an auto-mocked version when it is being required.
      */
+    // tslint:disable-next-line: no-unnecessary-generics
     function doMock<T>(moduleName: string, factory?: MockModuleFactory<T>, options?: MockOptions): typeof jest;
     /**
      * Indicates that the module system should never return a mocked version
@@ -194,6 +195,7 @@ declare namespace jest {
     /**
      * Mocks a module with an auto-mocked version when it is being required.
      */
+    // tslint:disable-next-line: no-unnecessary-generics
     function mock<T>(moduleName: string, factory?: MockModuleFactory<T>, options?: MockOptions): typeof jest;
     /**
      * Returns the actual module instead of a mock, bypassing all checks on


### PR DESCRIPTION
While working on https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46271, I noticed that https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46072 and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46073 are merged at the same time without rebasing, one added a linting rule the other one violates. This pull request fixes that.