### PR TITLE
feat(dotenv-defaults): new definition file

### DIFF
--- a/types/dotenv-defaults/OTHER_FILES.txt
+++ b/types/dotenv-defaults/OTHER_FILES.txt
@@ -1,0 +1,1 @@
+config.d.ts

--- a/types/dotenv-defaults/config.d.ts
+++ b/types/dotenv-defaults/config.d.ts
@@ -1,0 +1,3 @@
+import dotenvDefaults = require('./index');
+
+// nothing

--- a/types/dotenv-defaults/dotenv-defaults-tests.ts
+++ b/types/dotenv-defaults/dotenv-defaults-tests.ts
@@ -1,0 +1,17 @@
+import dotenv = require('dotenv-defaults');
+
+// config
+dotenv.config({
+    path: '.env-example',
+    encoding: 'utf8',
+    debug: true,
+    // added via augmentation
+    defaults: '.env.defaults',
+});
+dotenv.parse('HOST=omnionline.us');
+
+// tslint:disable-next-line: no-var-requires this imports is triggering dotenv no import by design
+require('dotenv-defaults/config');
+
+console.log(process.env.HOST);
+console.log(process.env.EMAIL);

--- a/types/dotenv-defaults/index.d.ts
+++ b/types/dotenv-defaults/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for dotenv-defaults 2.0
+// Project: https://github.com/mrsteele/dotenv-defaults#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { DotenvParseOutput, DotenvConfigOutput, DotenvConfigOptions } from 'dotenv';
+
+/**
+ * A dotenv system that supports defaults
+ */
+
+declare module 'dotenv' {
+    interface DotenvConfigOptions {
+        /**
+         * @default '.env.defaults'
+         */
+        defaults?: string;
+    }
+}
+
+/**
+ * Parses objects like before, but with defaults!
+ * @param src - The original src.
+ * @param [defaultSrc] - The new-and-improved default sour
+ */
+export function parse(src: string, defaultSrc?: string): DotenvParseOutput;
+
+/**
+ * Runs the configurations and applies it to process.env.
+ * @param [options] - The options to determnie how this goes
+ */
+export function config(options?: DotenvConfigOptions): DotenvConfigOutput;

--- a/types/dotenv-defaults/package.json
+++ b/types/dotenv-defaults/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "dotenv": "^8.2.0"
+    }
+}

--- a/types/dotenv-defaults/tsconfig.json
+++ b/types/dotenv-defaults/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "dotenv-defaults-tests.ts"
+    ]
+}

--- a/types/dotenv-defaults/tslint.json
+++ b/types/dotenv-defaults/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- definition file
- types

This will fix missing definition types and remove need to use a hack
to import module.

https://github.com/mrsteele/dotenv-defaults#dotenv-defaults

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.