### PR TITLE
fix(jest): add `createMockFromModule` to replace `genMockFromModule`

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -186,9 +186,8 @@ declare namespace jest {
      */
     function fn<T, Y extends any[]>(implementation?: (...args: Y) => T): Mock<T, Y>;
     /**
+     * (renamed to `createMockFromModule` in Jest 26.0.0+)
      * Use the automatic mocking system to generate a mocked version of the given module.
-     *
-     * @deprecated Use `jest.createMockFromModule` instead.
      */
     // tslint:disable-next-line: no-unnecessary-generics
     function genMockFromModule<T>(moduleName: string): T;

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -189,7 +189,7 @@ declare namespace jest {
     function fn<T, Y extends any[]>(implementation?: (...args: Y) => T): Mock<T, Y>;
     /**
      * Use the automatic mocking system to generate a mocked version of the given module.
-     * 
+     *
      * @deprecated Use `jest.createMockFromModule` instead.
      */
     // tslint:disable-next-line: no-unnecessary-generics

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -188,8 +188,9 @@ declare namespace jest {
      */
     function fn<T, Y extends any[]>(implementation?: (...args: Y) => T): Mock<T, Y>;
     /**
-     * (renamed to `createMockFromModule` in Jest 26.0.0+)
      * Use the automatic mocking system to generate a mocked version of the given module.
+     *
+     * @deprecated Use `jest.createMockFromModule` instead.
      */
     // tslint:disable-next-line: no-unnecessary-generics
     function genMockFromModule<T>(moduleName: string): T;

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -110,6 +110,11 @@ declare namespace jest {
      */
     function clearAllMocks(): typeof jest;
     /**
+     * Use the automatic mocking system to generate a mocked version of the given module.
+     */
+    // tslint:disable-next-line: no-unnecessary-generics
+    function createMockFromModule<T>(moduleName: string): T;
+    /**
      * Resets the state of all mocks.
      * Equivalent to calling .mockReset() on every mocked function.
      */
@@ -184,6 +189,8 @@ declare namespace jest {
     function fn<T, Y extends any[]>(implementation?: (...args: Y) => T): Mock<T, Y>;
     /**
      * Use the automatic mocking system to generate a mocked version of the given module.
+     * 
+     * @deprecated Use `jest.createMockFromModule` instead.
      */
     // tslint:disable-next-line: no-unnecessary-generics
     function genMockFromModule<T>(moduleName: string): T;

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -188,9 +188,8 @@ declare namespace jest {
      */
     function fn<T, Y extends any[]>(implementation?: (...args: Y) => T): Mock<T, Y>;
     /**
+     * (renamed to `createMockFromModule` in Jest 26.0.0+)
      * Use the automatic mocking system to generate a mocked version of the given module.
-     *
-     * @deprecated Use `jest.createMockFromModule` instead.
      */
     // tslint:disable-next-line: no-unnecessary-generics
     function genMockFromModule<T>(moduleName: string): T;

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -409,6 +409,9 @@ mock8.mockImplementation((arg: string) => 1);
 // mockImplementation not required to declare all arguments
 mock9.mockImplementation((a: number) => Promise.resolve(a === 0));
 
+const createMockFromModule1: {} = jest.createMockFromModule('moduleName');
+const createMockFromModule2: { a: 'b' } = jest.createMockFromModule<{ a: 'b' }>('moduleName');
+
 const genMockModule1: {} = jest.genMockFromModule('moduleName');
 const genMockModule2: { a: 'b' } = jest.genMockFromModule<{ a: 'b' }>('moduleName');
 


### PR DESCRIPTION
https://github.com/facebook/jest/pull/9962 adds `createMockFromModule` to replace `genMockFromModule`. This pull request adds `createMockFromModule`.

~CI not passing due to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46271#issuecomment-662684282~