### PR TITLE
[ember-qunit] Add this type for module hooks

### DIFF
--- a/types/ember-qunit/ember-qunit-tests.ts
+++ b/types/ember-qunit/ember-qunit-tests.ts
@@ -146,4 +146,44 @@ module('engine foo component', function(hooks) {
     });
 });
 
+module('all the hooks', function(hooks) {
+  setupTest(hooks);
+
+  hooks.after(function() {
+    this.owner.lookup('service:store');
+  });
+
+  hooks.afterEach(function() {
+    this.owner.lookup('service:store');
+  });
+
+  hooks.before(function() {
+    this.owner.lookup('service:store');
+  });
+
+  hooks.beforeEach(function() {
+    this.owner.lookup('service:store');
+  });
+});
+
+module.only('exclusive module with hooks', function(hooks) {
+  setupTest(hooks);
+
+  hooks.after(function() {
+    this.owner.lookup('service:store');
+  });
+
+  hooks.afterEach(function() {
+    this.owner.lookup('service:store');
+  });
+
+  hooks.before(function() {
+    this.owner.lookup('service:store');
+  });
+
+  hooks.beforeEach(function() {
+    this.owner.lookup('service:store');
+  });
+});
+
 start();

--- a/types/ember-qunit/index.d.ts
+++ b/types/ember-qunit/index.d.ts
@@ -156,7 +156,34 @@ declare module 'ember-qunit' {
 declare module 'qunit' {
     import { TestContext } from "ember-test-helpers";
 
-    export const module: typeof QUnit.module;
+    type moduleFunc1 = (name: string, hooks?: Hooks, nested?: (hooks: NestedHooks) => void) => void;
+    type moduleFunc2 = (name: string, nested?: (hooks: NestedHooks) => void) => void;
+    interface ModuleOnly { only: moduleFunc1 & moduleFunc2; }
+
+    export const module: moduleFunc1 & moduleFunc2 & ModuleOnly;
+
+    export interface NestedHooks {
+      /**
+       * Runs after the last test. If additional tests are defined after the
+       * module's queue has emptied, it will not run this hook again.
+       */
+      after: (fn: (this: TestContext, assert: Assert) => void) => void;
+
+      /**
+       * Runs after each test.
+       */
+      afterEach: (fn: (this: TestContext, assert: Assert) => void) => void;
+
+      /**
+       * Runs before the first test.
+       */
+      before: (fn: (this: TestContext, assert: Assert) => void) => void;
+
+      /**
+       * Runs before each test.
+       */
+      beforeEach: (fn: (this: TestContext, assert: Assert) => void) => void;
+    }
 
     /**
      * Add a test to run.


### PR DESCRIPTION
Module hooks have access to the test context via `this`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emberjs/ember-qunit#setup-tests
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~
