### PR TITLE
[chai]: fix return type of inspect()

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -4,6 +4,7 @@ import * as chai from 'chai';
 const expect = chai.expect;
 const assert = chai.assert;
 const should = chai.should();
+const util = chai.util;
 
 function chaiVersion(): string {
     return chai.version;
@@ -1307,6 +1308,11 @@ function oneOf() {
     expect('z').to.not.be.oneOf(['w', 'x', 'y']);
     expect('z').to.not.be.oneOf(['x', 'y', ['z']]);
     expect(obj).to.not.be.oneOf([{z: 3}]);
+}
+
+function testInspectType() {
+    const x: string = util.inspect([1, 2, 3], false, 4, false);
+    expect(x).to.be.equal('[ 1, 2, 3 ]');
 }
 
 // tdd

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -67,7 +67,7 @@ declare namespace Chai {
         getOwnEnumerableProperties(obj: object): Array<string | symbol>;
         getMessage(errorLike: Error | string): string;
         getMessage(obj: any, args: AssertionArgs): string;
-        inspect(obj: any, showHidden?: boolean, depth?: number, colors?: boolean): void;
+        inspect(obj: any, showHidden?: boolean, depth?: number, colors?: boolean): string;
         isProxyEnabled(): boolean;
         objDisplay(obj: object): void;
         proxify(obj: object, nonChainableMethodName: string): object;


### PR DESCRIPTION
`chai.util.inspect` in Chai 4.2.0 is not void, it returns a string. Confirmed by checking the [implementation](https://github.com/chaijs/chai/blob/23764f340d6d3796eafdb7a9869b423bc45e0c8b/lib/chai/utils/inspect.js#L32) and [tests](https://github.com/chaijs/chai/blob/23764f340d6d3796eafdb7a9869b423bc45e0c8b/test/utilities.js#L744) in Chai, as well as by importing and executing the function in a separate repo.

[JSDoc comment](https://github.com/chaijs/chai/blob/23764f340d6d3796eafdb7a9869b423bc45e0c8b/lib/chai/utils/inspect.js#L14) for `inspect` incorrectly states that it 'echoes the value of a value'.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.