### PR TITLE
[jest] Revert Breaking #46072

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -72,8 +72,6 @@ type ExtractEachCallbackArgs<T extends ReadonlyArray<any>> = {
         : 'fallback'
 ];
 
-type MockModuleFactory<T> = () => T extends { default: unknown } ? T & { __esModule: true } : T;
-
 interface NodeRequire {
     /**
      * Returns the actual module instead of a mock, bypassing all checks on
@@ -164,7 +162,7 @@ declare namespace jest {
     /**
      * Mocks a module with an auto-mocked version when it is being required.
      */
-    function doMock<T>(moduleName: string, factory?: MockModuleFactory<T>, options?: MockOptions): typeof jest;
+    function doMock(moduleName: string, factory?: () => unknown, options?: MockOptions): typeof jest;
     /**
      * Indicates that the module system should never return a mocked version
      * of the specified module from require() (e.g. that it should always return the real module).
@@ -194,7 +192,7 @@ declare namespace jest {
     /**
      * Mocks a module with an auto-mocked version when it is being required.
      */
-    function mock<T>(moduleName: string, factory?: MockModuleFactory<T>, options?: MockOptions): typeof jest;
+    function mock(moduleName: string, factory?: () => unknown, options?: MockOptions): typeof jest;
     /**
      * Returns the actual module instead of a mock, bypassing all checks on
      * whether the module should receive a mock implementation or not.

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -240,23 +240,7 @@ nodeRequire.requireMock('moduleName');
 
 /* Top-level jest namespace functions */
 
-interface FakeModule {
-    import1: { property: string };
-    import2: { method(): void };
-}
-
-interface FakeModuleWithDefault {
-    default: { property: number };
-    import1: { property: string };
-}
-
-type FakeRequiredFunction = () => string;
-
 const customMatcherFactories: jasmine.CustomMatcherFactories = {};
-const fakeDefault = { property: 42 };
-const fakeImport1 = { property: 'Hello World' };
-const fakeImport2 = { method() {} };
-const fakeFunction = jest.fn<ReturnType<FakeRequiredFunction>, Parameters<FakeRequiredFunction>>();
 
 jest.addMatchers(customMatcherFactories)
     .addMatchers({})
@@ -274,20 +258,12 @@ jest.addMatchers(customMatcherFactories)
     .doMock('moduleName', jest.fn())
     .doMock('moduleName', jest.fn(), {})
     .doMock('moduleName', jest.fn(), { virtual: true })
-    .doMock<FakeRequiredFunction>('moduleName', () => fakeFunction)
-    .doMock<FakeModule>('moduleName', () => ({ import1: fakeImport1, import2: fakeImport2 }))
-    .doMock<FakeModule>('moduleName', () => ({ import1: fakeImport1, import2: fakeImport2 }), { virtual: true })
-    .doMock<FakeModuleWithDefault>('moduleName', () => ({ __esModule: true, default: fakeDefault, import1: fakeImport1 }))
     .dontMock('moduleName')
     .enableAutomock()
     .mock('moduleName')
     .mock('moduleName', jest.fn())
     .mock('moduleName', jest.fn(), {})
     .mock('moduleName', jest.fn(), { virtual: true })
-    .mock<FakeRequiredFunction>('moduleName', () => fakeFunction)
-    .mock<FakeModule>('moduleName', () => ({ import1: fakeImport1, import2: fakeImport2 }))
-    .mock<FakeModule>('moduleName', () => ({ import1: fakeImport1, import2: fakeImport2 }), { virtual: true })
-    .mock<FakeModuleWithDefault>('moduleName', () => ({ __esModule: true, default: fakeDefault, import1: fakeImport1 }))
     .resetModuleRegistry()
     .resetModules()
     .isolateModules(() => {})
@@ -305,23 +281,6 @@ jest.addMatchers(customMatcherFactories)
     .unmock('moduleName')
     .useFakeTimers()
     .useRealTimers();
-
-// $ExpectError
-jest.doMock<FakeModuleWithDefault>('moduleName', () => ({ default: fakeDefault, import1: fakeImport1 }));
-// $ExpectError
-jest.doMock<FakeModuleWithDefault>('moduleName', () => ({ __esModue: false, default: fakeDefault, import1: fakeImport1 }));
-// $ExpectError
-jest.doMock<FakeModuleWithDefault>('moduleName', () => ({ __esModule: true, import1: fakeImport1 }));
-// $ExpectError
-jest.doMock<FakeModule>('moduleName', () => ({ import1: fakeImport1 }));
-// $ExpectError
-jest.mock<FakeModuleWithDefault>('moduleName', () => ({ default: fakeDefault, import1: fakeImport1 }));
-// $ExpectError
-jest.mock<FakeModuleWithDefault>('moduleName', () => ({ __esModue: false, default: fakeDefault, import1: fakeImport1 }));
-// $ExpectError
-jest.mock<FakeModuleWithDefault>('moduleName', () => ({ __esModule: true, import1: fakeImport1 }));
-// $ExpectError
-jest.mock<FakeModule>('moduleName', () => ({ import1: fakeImport1 }));
 
 jest.advanceTimersToNextTimer();
 jest.advanceTimersToNextTimer(2);


### PR DESCRIPTION
#46072 caused a [breaking change](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/46283#issue-664303850) so reverting. Will be nice if this is merged and published asap.

Fixes #46283

cc @sandersn

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: -
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
