### PR TITLE
[yandex-maps]: add shape and geometry.pixel namespaces

### DIFF
--- a/types/yandex-maps/index.d.ts
+++ b/types/yandex-maps/index.d.ts
@@ -752,7 +752,6 @@ declare namespace ymaps {
 
                 fire(type: string, eventobject: object | IEvent): this;
             }
-        }
 
             class Point implements IBasePointGeometry { //tslint:disable-line no-shadowed-variable
                 events: IEventManager;

--- a/types/yandex-maps/index.d.ts
+++ b/types/yandex-maps/index.d.ts
@@ -752,189 +752,7 @@ declare namespace ymaps {
 
                 fire(type: string, eventobject: object | IEvent): this;
             }
-
-            namespace pixel {
-                class Circle implements IPixelCircleGeometry {
-                  constructor(
-                    coordinates: number[] | null,
-                    radius: number,
-                    metaData?: object
-                  );
-
-                  events: IEventManager;
-
-                  equals(geometry: IPixelGeometry): boolean;
-
-                  getBounds(): number[][] | null;
-
-                  getCoordinates(): number[];
-
-                  getMetaData(): object;
-
-                  getRadius(): number;
-
-                  getType(): string;
-
-                  scale(factor: number): IPixelGeometry;
-
-                  shift(offset: number[]): IPixelGeometry;
-                }
-
-                class LineString implements IPixelLineStringGeometry {
-                  constructor(coordinates: number[][], metaData?: object);
-
-                  events: IEventManager;
-
-                  equals(geometry: IPixelGeometry): boolean;
-
-                  getBounds(): number[][] | null;
-
-                  getClosest(anchorPosition: number[]): object;
-
-                  getCoordinates(): number[][];
-
-                  getLength(): number;
-
-                  getMetaData(): object;
-
-                  getType(): string;
-
-                  scale(factor: number): IPixelGeometry;
-
-                  shift(offset: number[]): IPixelGeometry;
-                }
-
-                class MultiLineString implements IPixelMultiLineGeometry {
-                  constructor(coordinates: number[][][], metaData?: object);
-
-                  events: IEventManager;
-
-                  equals(geometry: IPixelGeometry): boolean;
-
-                  getBounds(): number[][] | null;
-
-                  getClosest(anchorPosition: number[]): object;
-
-                  getCoordinates(): number[][][];
-
-                  getLength(): number;
-
-                  getMetaData(): object;
-
-                  getType(): string;
-
-                  scale(factor: number): IPixelGeometry;
-
-                  shift(offset: number[]): IPixelGeometry;
-                }
-
-                class MultiPolygon implements IPixelMultiPolygonGeometry {
-                  constructor(
-                    coordinates: number[][][][],
-                    fillRule: string,
-                    metaData?: object
-                  );
-
-                  events: IEventManager;
-
-                  contains(position: number[]): boolean;
-
-                  equals(geometry: IPixelGeometry): boolean;
-
-                  getBounds(): number[][] | null;
-
-                  getClosest(anchorPosition: number[]): object;
-
-                  getCoordinates(): number[][][][];
-
-                  getFillRule(): string;
-
-                  getLength(): number;
-
-                  getMetaData(): object;;
-
-                  getType(): string;
-
-                  scale(factor: number): IPixelGeometry;
-
-                  shift(offset: number[]): IPixelGeometry;
-                }
-
-                class Point implements IPixelPointGeometry {
-                  constructor(position: number[] | null, metaData?: object);
-
-                  events: IEventManager;
-
-                  equals(geometry: IPixelGeometry): boolean;
-
-                  getBounds(): number[][] | null;
-
-                  getCoordinates(): number[];
-
-                  getMetaData(): object;
-
-                  getType(): string;
-
-                  scale(factor: number): IPixelGeometry;
-
-                  shift(offset: number[]): IPixelGeometry;
-                }
-
-                class Polygon implements IPixelPolygonGeometry {
-                  constructor(
-                    coordinates: number[][][],
-                    fillRule: string,
-                    metaData?: object
-                  );
-
-                  events: IEventManager;
-
-                  contains(position: number[]): boolean;
-
-                  equals(geometry: IPixelGeometry): boolean;
-
-                  getBounds(): number[][] | null;
-
-                  getClosest(anchorPosition: number[]): object;
-
-                  getCoordinates(): number[][][];
-
-                  getFillRule(): string;
-
-                  getLength(): number;
-
-                  getMetaData(): object;
-
-                  getType(): string;
-
-                  scale(factor: number): IPixelGeometry;
-
-                  shift(offset: number[]): IPixelGeometry;
-                }
-
-                class Rectangle implements IPixelRectangleGeometry {
-                  constructor(coordinates: number[][] | null, metaData?: object);
-
-                  events: IEventManager;
-
-                  equals(geometry: IPixelGeometry): boolean;
-
-                  getBounds(): number[][] | null;
-
-                  getClosest(anchorPosition: number[]): object;
-
-                  getCoordinates(): number[][];
-
-                  getMetaData(): object;
-
-                  getType(): string;
-
-                  scale(factor: number): IPixelGeometry;
-
-                  shift(offset: number[]): IPixelGeometry;
-                }
-              }
-            }
+        }
 
             class Point implements IBasePointGeometry { //tslint:disable-line no-shadowed-variable
                 events: IEventManager;
@@ -1139,6 +957,188 @@ declare namespace ymaps {
             splice(index: number, number: number): ILinearRingGeometryAccess[];
 
             unfreeze(): IFreezable;
+        }
+
+        namespace pixel {
+            class Circle implements IPixelCircleGeometry {
+                constructor(
+                    coordinates: number[] | null,
+                    radius: number,
+                    metaData?: object
+                );
+
+                events: IEventManager;
+
+                equals(geometry: IPixelGeometry): boolean;
+
+                getBounds(): number[][] | null;
+
+                getCoordinates(): number[];
+
+                getMetaData(): object;
+
+                getRadius(): number;
+
+                getType(): string;
+
+                scale(factor: number): IPixelGeometry;
+
+                shift(offset: number[]): IPixelGeometry;
+            }
+
+            class LineString implements IPixelLineStringGeometry {
+                constructor(coordinates: number[][], metaData?: object);
+
+                events: IEventManager;
+
+                equals(geometry: IPixelGeometry): boolean;
+
+                getBounds(): number[][] | null;
+
+                getClosest(anchorPosition: number[]): object;
+
+                getCoordinates(): number[][];
+
+                getLength(): number;
+
+                getMetaData(): object;
+
+                getType(): string;
+
+                scale(factor: number): IPixelGeometry;
+
+                shift(offset: number[]): IPixelGeometry;
+            }
+
+            class MultiLineString implements IPixelMultiLineGeometry {
+                constructor(coordinates: number[][][], metaData?: object);
+
+                events: IEventManager;
+
+                equals(geometry: IPixelGeometry): boolean;
+
+                getBounds(): number[][] | null;
+
+                getClosest(anchorPosition: number[]): object;
+
+                getCoordinates(): number[][][];
+
+                getLength(): number;
+
+                getMetaData(): object;
+
+                getType(): string;
+
+                scale(factor: number): IPixelGeometry;
+
+                shift(offset: number[]): IPixelGeometry;
+            }
+
+            class MultiPolygon implements IPixelMultiPolygonGeometry {
+                constructor(
+                    coordinates: number[][][][],
+                    fillRule: string,
+                    metaData?: object
+                );
+
+                events: IEventManager;
+
+                contains(position: number[]): boolean;
+
+                equals(geometry: IPixelGeometry): boolean;
+
+                getBounds(): number[][] | null;
+
+                getClosest(anchorPosition: number[]): object;
+
+                getCoordinates(): number[][][][];
+
+                getFillRule(): string;
+
+                getLength(): number;
+
+                getMetaData(): object;;
+
+                getType(): string;
+
+                scale(factor: number): IPixelGeometry;
+
+                shift(offset: number[]): IPixelGeometry;
+            }
+
+            class Point implements IPixelPointGeometry {
+                constructor(position: number[] | null, metaData?: object);
+
+                events: IEventManager;
+
+                equals(geometry: IPixelGeometry): boolean;
+
+                getBounds(): number[][] | null;
+
+                getCoordinates(): number[];
+
+                getMetaData(): object;
+
+                getType(): string;
+
+                scale(factor: number): IPixelGeometry;
+
+                shift(offset: number[]): IPixelGeometry;
+            }
+
+            class Polygon implements IPixelPolygonGeometry {
+                constructor(
+                    coordinates: number[][][],
+                    fillRule: string,
+                    metaData?: object
+                );
+
+                events: IEventManager;
+
+                contains(position: number[]): boolean;
+
+                equals(geometry: IPixelGeometry): boolean;
+
+                getBounds(): number[][] | null;
+
+                getClosest(anchorPosition: number[]): object;
+
+                getCoordinates(): number[][][];
+
+                getFillRule(): string;
+
+                getLength(): number;
+
+                getMetaData(): object;
+
+                getType(): string;
+
+                scale(factor: number): IPixelGeometry;
+
+                shift(offset: number[]): IPixelGeometry;
+            }
+
+            class Rectangle implements IPixelRectangleGeometry {
+                constructor(coordinates: number[][] | null, metaData?: object);
+
+                events: IEventManager;
+
+                equals(geometry: IPixelGeometry): boolean;
+
+                getBounds(): number[][] | null;
+
+                getClosest(anchorPosition: number[]): object;
+
+                getCoordinates(): number[][];
+
+                getMetaData(): object;
+
+                getType(): string;
+
+                scale(factor: number): IPixelGeometry;
+
+                shift(offset: number[]): IPixelGeometry;
+            }
         }
     }
 

--- a/types/yandex-maps/index.d.ts
+++ b/types/yandex-maps/index.d.ts
@@ -788,7 +788,7 @@ declare namespace ymaps {
 
                 getCoordinates(): number[] | null;
 
-                getFillRule(): string;
+                getFillRule(): 'evenOdd' | 'nonZero';
 
                 getLength(): number;
 
@@ -804,7 +804,7 @@ declare namespace ymaps {
 
                 setCoordinates(coordinates: number[] | null): this;
 
-                setFillRule(fillRule: string): IPolygonGeometryAccess;
+                setFillRule(fillRule: 'evenOdd' | 'nonZero'): IPolygonGeometryAccess;
 
                 splice(index: number, number: number): ILinearRingGeometryAccess[];
 
@@ -924,7 +924,7 @@ declare namespace ymaps {
 
             getCoordinates(): number[][][];
 
-            getFillRule(): string;
+            getFillRule(): 'evenOdd' | 'nonZero';
 
             getLength(): number;
 
@@ -948,7 +948,7 @@ declare namespace ymaps {
 
             setCoordinates(coordinates: number[][][]): IPolygonGeometryAccess;
 
-            setFillRule(fillRule: string): IPolygonGeometryAccess;
+            setFillRule(fillRule: 'evenOdd' | 'nonZero'): IPolygonGeometryAccess;
 
             setMap(map: Map): void;
 
@@ -1037,7 +1037,7 @@ declare namespace ymaps {
             class MultiPolygon implements IPixelMultiPolygonGeometry {
                 constructor(
                     coordinates: number[][][][],
-                    fillRule: string,
+                    fillRule: 'evenOdd' | 'nonZero',
                     metaData?: object
                 );
 
@@ -1053,7 +1053,7 @@ declare namespace ymaps {
 
                 getCoordinates(): number[][][][];
 
-                getFillRule(): string;
+                getFillRule(): 'evenOdd' | 'nonZero';
 
                 getLength(): number;
 
@@ -1089,7 +1089,7 @@ declare namespace ymaps {
             class Polygon implements IPixelPolygonGeometry {
                 constructor(
                     coordinates: number[][][],
-                    fillRule: string,
+                    fillRule: 'evenOdd' | 'nonZero',
                     metaData?: object
                 );
 
@@ -1105,7 +1105,7 @@ declare namespace ymaps {
 
                 getCoordinates(): number[][][];
 
-                getFillRule(): string;
+                getFillRule(): 'evenOdd' | 'nonZero';
 
                 getLength(): number;
 
@@ -3752,7 +3752,7 @@ declare namespace ymaps {
 
         getCoordinates(): number[][][][];
 
-        getFillRule(): string;
+        getFillRule(): 'evenOdd' | 'nonZero';
 
         getLength(): number;
     }
@@ -3764,7 +3764,7 @@ declare namespace ymaps {
 
         getCoordinates(): number[][][];
 
-        getFillRule(): string;
+        getFillRule(): 'evenOdd' | 'nonZero';
 
         getLength(): number;
     }

--- a/types/yandex-maps/index.d.ts
+++ b/types/yandex-maps/index.d.ts
@@ -1056,7 +1056,7 @@ declare namespace ymaps {
 
                 getLength(): number;
 
-                getMetaData(): object;;
+                getMetaData(): object;
 
                 getType(): string;
 

--- a/types/yandex-maps/index.d.ts
+++ b/types/yandex-maps/index.d.ts
@@ -753,6 +753,189 @@ declare namespace ymaps {
                 fire(type: string, eventobject: object | IEvent): this;
             }
 
+            namespace pixel {
+                class Circle implements IPixelCircleGeometry {
+                  constructor(
+                    coordinates: number[] | null,
+                    radius: number,
+                    metaData?: object
+                  );
+
+                  events: IEventManager;
+
+                  equals(geometry: IPixelGeometry): boolean;
+
+                  getBounds(): number[][] | null;
+
+                  getCoordinates(): number[];
+
+                  getMetaData(): object;
+
+                  getRadius(): number;
+
+                  getType(): string;
+
+                  scale(factor: number): IPixelGeometry;
+
+                  shift(offset: number[]): IPixelGeometry;
+                }
+
+                class LineString implements IPixelLineStringGeometry {
+                  constructor(coordinates: number[][], metaData?: object);
+
+                  events: IEventManager;
+
+                  equals(geometry: IPixelGeometry): boolean;
+
+                  getBounds(): number[][] | null;
+
+                  getClosest(anchorPosition: number[]): object;
+
+                  getCoordinates(): number[][];
+
+                  getLength(): number;
+
+                  getMetaData(): object;
+
+                  getType(): string;
+
+                  scale(factor: number): IPixelGeometry;
+
+                  shift(offset: number[]): IPixelGeometry;
+                }
+
+                class MultiLineString implements IPixelMultiLineGeometry {
+                  constructor(coordinates: number[][][], metaData?: object);
+
+                  events: IEventManager;
+
+                  equals(geometry: IPixelGeometry): boolean;
+
+                  getBounds(): number[][] | null;
+
+                  getClosest(anchorPosition: number[]): object;
+
+                  getCoordinates(): number[][][];
+
+                  getLength(): number;
+
+                  getMetaData(): object;
+
+                  getType(): string;
+
+                  scale(factor: number): IPixelGeometry;
+
+                  shift(offset: number[]): IPixelGeometry;
+                }
+
+                class MultiPolygon implements IPixelMultiPolygonGeometry {
+                  constructor(
+                    coordinates: number[][][][],
+                    fillRule: string,
+                    metaData?: object
+                  );
+
+                  events: IEventManager;
+
+                  contains(position: number[]): boolean;
+
+                  equals(geometry: IPixelGeometry): boolean;
+
+                  getBounds(): number[][] | null;
+
+                  getClosest(anchorPosition: number[]): object;
+
+                  getCoordinates(): number[][][][];
+
+                  getFillRule(): string;
+
+                  getLength(): number;
+
+                  getMetaData(): object;;
+
+                  getType(): string;
+
+                  scale(factor: number): IPixelGeometry;
+
+                  shift(offset: number[]): IPixelGeometry;
+                }
+
+                class Point implements IPixelPointGeometry {
+                  constructor(position: number[] | null, metaData?: object);
+
+                  events: IEventManager;
+
+                  equals(geometry: IPixelGeometry): boolean;
+
+                  getBounds(): number[][] | null;
+
+                  getCoordinates(): number[];
+
+                  getMetaData(): object;
+
+                  getType(): string;
+
+                  scale(factor: number): IPixelGeometry;
+
+                  shift(offset: number[]): IPixelGeometry;
+                }
+
+                class Polygon implements IPixelPolygonGeometry {
+                  constructor(
+                    coordinates: number[][][],
+                    fillRule: string,
+                    metaData?: object
+                  );
+
+                  events: IEventManager;
+
+                  contains(position: number[]): boolean;
+
+                  equals(geometry: IPixelGeometry): boolean;
+
+                  getBounds(): number[][] | null;
+
+                  getClosest(anchorPosition: number[]): object;
+
+                  getCoordinates(): number[][][];
+
+                  getFillRule(): string;
+
+                  getLength(): number;
+
+                  getMetaData(): object;
+
+                  getType(): string;
+
+                  scale(factor: number): IPixelGeometry;
+
+                  shift(offset: number[]): IPixelGeometry;
+                }
+
+                class Rectangle implements IPixelRectangleGeometry {
+                  constructor(coordinates: number[][] | null, metaData?: object);
+
+                  events: IEventManager;
+
+                  equals(geometry: IPixelGeometry): boolean;
+
+                  getBounds(): number[][] | null;
+
+                  getClosest(anchorPosition: number[]): object;
+
+                  getCoordinates(): number[][];
+
+                  getMetaData(): object;
+
+                  getType(): string;
+
+                  scale(factor: number): IPixelGeometry;
+
+                  shift(offset: number[]): IPixelGeometry;
+                }
+              }
+            }
+
             class Point implements IBasePointGeometry { //tslint:disable-line no-shadowed-variable
                 events: IEventManager;
 
@@ -3423,6 +3606,48 @@ declare namespace ymaps {
         getCoordinates(): number[][];
 
         getLength(): number;
+    }
+
+    interface IPixelPointGeometry extends IPixelGeometry {
+        getCoordinates(): number[];
+      }
+
+    interface IPixelMultiLineGeometry extends IPixelGeometry {
+        getClosest(anchorPosition: number[]): object;
+
+        getCoordinates(): number[][][];
+
+        getLength(): number;
+    }
+
+    interface IPixelMultiPolygonGeometry extends IPixelGeometry {
+        contains(position: number[]): boolean;
+
+        getClosest(anchorPosition: number[]): object;
+
+        getCoordinates(): number[][][][];
+
+        getFillRule(): string;
+
+        getLength(): number;
+    }
+
+    interface IPixelPolygonGeometry extends IPixelGeometry {
+        contains(position: number[]): boolean;
+
+        getClosest(anchorPosition: number[]): object;
+
+        getCoordinates(): number[][][];
+
+        getFillRule(): string;
+
+        getLength(): number;
+    }
+
+    interface IPixelRectangleGeometry extends IPixelGeometry {
+        getClosest(anchorPosition: number[]): object;
+
+        getCoordinates(): number[][];
     }
 
     interface IPixelGeometry extends IBaseGeometry {

--- a/types/yandex-maps/index.d.ts
+++ b/types/yandex-maps/index.d.ts
@@ -2369,6 +2369,131 @@ declare namespace ymaps {
         }
     }
 
+    namespace shape {
+        class Circle implements IShape {
+            constructor(
+                pixelGeometry: IPixelCircleGeometry,
+                params?: {
+                    fill?: boolean;
+                    outline?: boolean;
+                    strokeWidth?: number;
+                }
+            );
+
+            contains(position: number[]): boolean;
+
+            equals(shape: IShape): boolean;
+
+            getBounds(): number[][] | null;
+
+            getGeometry(): IPixelGeometry;
+
+            getType(): string;
+
+            scale(factor: number): IShape;
+
+            shift(offset: number[]): IShape;
+        }
+
+        class LineString implements IShape {
+            constructor(
+                pixelGeometry: IPixelLineStringGeometry,
+                params?: {
+                    strokeWidth?: number;
+                }
+            );
+
+            contains(position: number[]): boolean;
+
+            equals(shape: IShape): boolean;
+
+            getBounds(): number[][] | null;
+
+            getGeometry(): IPixelGeometry;
+
+            getType(): string;
+
+            scale(factor: number): IShape;
+
+            shift(offset: number[]): IShape;
+        }
+
+        class MultiPolygon implements IShape {
+            constructor(
+                pixelGeometry: IPixelMultiPolygonGeometry,
+                params?: {
+                    fill?: boolean;
+                    outline?: boolean;
+                    strokeWidth?: number;
+                }
+            );
+
+            contains(position: number[]): boolean;
+
+            equals(shape: IShape): boolean;
+
+            getBounds(): number[][] | null;
+
+            getGeometry(): IPixelGeometry;
+
+            getType(): string;
+
+            scale(factor: number): IShape;
+
+            shift(offset: number[]): IShape;
+        }
+
+        class Polygon implements IShape {
+            constructor(
+                pixelGeometry: IPixelPolygonGeometry,
+                params?: {
+                    fill?: boolean;
+                    outline?: boolean;
+                    strokeWidth?: number;
+                }
+            );
+
+            contains(position: number[]): boolean;
+
+            equals(shape: IShape): boolean;
+
+            getBounds(): number[][] | null;
+
+            getGeometry(): IPixelGeometry;
+
+            getType(): string;
+
+            scale(factor: number): IShape;
+
+            shift(offset: number[]): IShape;
+        }
+
+        class Rectangle implements IShape {
+            constructor(
+                geometry: IPixelRectangleGeometry,
+                params?: {
+                    fill?: boolean;
+                    outline?: boolean;
+                    strokeWidth?: number;
+                }
+            );
+
+            contains(position: number[]): boolean;
+
+            equals(shape: IShape): boolean;
+
+            getBounds(): number[][] | null;
+
+            getGeometry(): IPixelGeometry;
+
+            getType(): string;
+
+            scale(factor: number): IShape;
+
+            shift(offset: number[]): IShape;
+        }
+    }
+
     class Balloon extends Popup<Balloon> implements IBaloon<Balloon> {
         constructor(map: Map, options?: IBalloonOptions);
 

--- a/types/yandex-maps/yandex-maps-tests.ts
+++ b/types/yandex-maps/yandex-maps-tests.ts
@@ -61,3 +61,9 @@ map.layers.each((layer) => {
 });
 
 map.setZoom(13);
+
+const shapeCircle = new ymaps.shape.Circle(
+    new ymaps.geometry.pixel.Circle([0, 0], 10)
+);
+
+shapeCircle.getGeometry();


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
geometry.pixel:
https://tech.yandex.com/maps/jsapi/doc/2.1-dev/ref/reference/geometry.pixel.Circle-docpage/
https://tech.yandex.com/maps/jsapi/doc/2.1-dev/ref/reference/geometry.pixel.LineString-docpage/
https://tech.yandex.com/maps/jsapi/doc/2.1-dev/ref/reference/geometry.pixel.MultiLineString-docpage/
https://tech.yandex.com/maps/jsapi/doc/2.1-dev/ref/reference/geometry.pixel.MultiPolygon-docpage/
https://tech.yandex.com/maps/jsapi/doc/2.1-dev/ref/reference/geometry.pixel.Point-docpage/
https://tech.yandex.com/maps/jsapi/doc/2.1-dev/ref/reference/geometry.pixel.Polygon-docpage/
https://tech.yandex.com/maps/jsapi/doc/2.1-dev/ref/reference/geometry.pixel.Rectangle-docpage/
shape:
https://tech.yandex.com/maps/jsapi/doc/2.1-dev/ref/reference/shape.Circle-docpage/
https://tech.yandex.com/maps/jsapi/doc/2.1-dev/ref/reference/shape.LineString-docpage/
https://tech.yandex.com/maps/jsapi/doc/2.1-dev/ref/reference/shape.MultiPolygon-docpage/
https://tech.yandex.com/maps/jsapi/doc/2.1-dev/ref/reference/shape.Polygon-docpage/
https://tech.yandex.com/maps/jsapi/doc/2.1-dev/ref/reference/shape.Rectangle-docpage/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
