### PR TITLE
[luxon] Changed typings for some datetime and duration functions to return string or null

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -271,25 +271,25 @@ export class DateTime {
     toBSON(): Date;
     toFormat(format: string, options?: DateTimeFormatOptions): string;
     toHTTP(): string;
-    toISO(options?: ToISOTimeOptions): string;
+    toISO(options?: ToISOTimeOptions): string | null;
     /** Returns an ISO 8601-compliant string representation of this DateTime's date component */
-    toISODate(options?: ToISODateOptions): string;
-    toISOTime(options?: ToISOTimeOptions): string;
-    toISOWeekDate(): string;
+    toISODate(options?: ToISODateOptions): string | null;
+    toISOTime(options?: ToISOTimeOptions): string | null;
+    toISOWeekDate(): string | null;
     toJSDate(): Date;
-    toJSON(): string;
+    toJSON(): string | null;
     toLocal(): DateTime;
     toLocaleParts(options?: LocaleOptions & DateTimeFormatOptions): any[];
-    toLocaleString(options?: LocaleOptions & DateTimeFormatOptions): string;
+    toLocaleString(options?: LocaleOptions & DateTimeFormatOptions): string | null;
     toMillis(): number;
     toObject(options?: { includeConfig?: boolean }): DateObject;
     toRelative(options?: ToRelativeOptions): string | null;
     toRelativeCalendar(options?: ToRelativeCalendarOptions): string | null;
-    toRFC2822(): string;
+    toRFC2822(): string | null;
     toSeconds(): number;
-    toSQL(options?: ToSQLOptions): string;
-    toSQLDate(): string;
-    toSQLTime(options?: ToSQLOptions): string;
+    toSQL(options?: ToSQLOptions): string | null;
+    toSQLDate(): string | null;
+    toSQLTime(options?: ToSQLOptions): string | null;
     toString(): string;
     toUTC(offset?: number, options?: ZoneOptions): DateTime;
     until(other: DateTime): Interval;
@@ -364,10 +364,10 @@ export class Duration {
     shiftTo(...units: DurationUnit[]): Duration;
     mapUnits(fn: (x: number, u: DurationUnit) => number): Duration;
     toFormat(format: string, options?: DurationToFormatOptions): string;
-    toISO(): string;
-    toJSON(): string;
+    toISO(): string | null;
+    toJSON(): string | null;
     toObject(options?: { includeConfig?: boolean }): DurationObject;
-    toString(): string;
+    toString(): string | null;
     valueOf(): number;
 }
 

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -68,29 +68,29 @@ getters.isInLeapYear;
 
 dt.toBSON(); // $ExpectType Date
 dt.toHTTP(); // $ExpectType string
-dt.toISO(); // $ExpectType string
-dt.toISO({ includeOffset: true, format: 'extended' }); // $ExpectType string
-dt.toISODate(); // $ExpectType string
-dt.toISODate({ format: 'basic'}); // $ExpectType string
-dt.toISOTime(); // $ExpectType string
-dt.toISOTime({ format: 'basic' }); // $ExpectType string
-dt.toISOWeekDate(); // $ExpectType string
+dt.toISO(); // $ExpectType string | null
+dt.toISO({ includeOffset: true, format: 'extended' }); // $ExpectType string | null
+dt.toISODate(); // $ExpectType string | null
+dt.toISODate({ format: 'basic'}); // $ExpectType string | null
+dt.toISOTime(); // $ExpectType string | null
+dt.toISOTime({ format: 'basic' }); // $ExpectType string | null
+dt.toISOWeekDate(); // $ExpectType string | null
 dt.toJSDate(); // $ExpectType Date
-dt.toJSON(); // $ExpectType string
-dt.toLocaleString(); // $ExpectType string
-dt.toLocaleString({ month: 'long', day: 'numeric' }); // $ExpectType string
-dt.toLocaleString(DateTime.DATE_MED); // $ExpectType string
+dt.toJSON(); // $ExpectType string | null
+dt.toLocaleString(); // $ExpectType string | null
+dt.toLocaleString({ month: 'long', day: 'numeric' }); // $ExpectType string | null
+dt.toLocaleString(DateTime.DATE_MED); // $ExpectType string | null
 dt.toMillis(); // $ExpectType number
 dt.toMillis(); // $ExpectType number
 dt.toRelative(); // $ExpectType string | null
 dt.toRelativeCalendar(); // $ExpectType string | null
-dt.toRFC2822(); // $ExpectType string
+dt.toRFC2822(); // $ExpectType string | null
 dt.toSeconds(); // $ExpectType number
-dt.toSQL(); // $ExpectType string
-dt.toSQL({ includeOffset: false, includeZone: true }); // $ExpectType string
-dt.toSQLDate(); // $ExpectType string
-dt.toSQLTime(); // $ExpectType string
-dt.toSQLTime({ includeOffset: false, includeZone: true }); // $ExpectType string
+dt.toSQL(); // $ExpectType string | null
+dt.toSQL({ includeOffset: false, includeZone: true }); // $ExpectType string | null
+dt.toSQLDate(); // $ExpectType string | null
+dt.toSQLTime(); // $ExpectType string | null
+dt.toSQLTime({ includeOffset: false, includeZone: true }); // $ExpectType string | null
 dt.valueOf(); // $ExpectType number
 
 // $ExpectType string | null
@@ -158,7 +158,7 @@ dur.seconds; // $ExpectType number
 
 dur.as('seconds'); // $ExpectType number
 dur.toObject();
-dur.toISO(); // $ExpectType string
+dur.toISO(); // $ExpectType string | null
 dur.normalize(); // $ExpectType Duration
 dur.mapUnits((x, u) => u === 'hours' ? x * 2 : x); // $ExpectType Duration
 
@@ -216,7 +216,7 @@ Settings.defaultZone = Settings.defaultZone;
 
 /* Intl */
 // prettier-ignore
-DateTime.local().setLocale('el').toLocaleString(DateTime.DATE_FULL); // $ExpectType string
+DateTime.local().setLocale('el').toLocaleString(DateTime.DATE_FULL); // $ExpectType string | null
 dt.locale; // $ExpectType string
 DateTime.local().setLocale('fr').locale; // $ExpectType string
 DateTime.local().reconfigure({ locale: 'fr' }).locale; // $ExpectType string
@@ -226,8 +226,8 @@ DateTime.local().locale; // $ExpectType string
 
 Settings.defaultLocale = DateTime.local().resolvedLocaleOpts().locale;
 
-dt.setLocale('fr').toLocaleString(DateTime.DATE_FULL); // $ExpectType string
-dt.toLocaleString({ locale: 'es', ...DateTime.DATE_FULL }); // $ExpectType string
+dt.setLocale('fr').toLocaleString(DateTime.DATE_FULL); // $ExpectType string | null
+dt.toLocaleString({ locale: 'es', ...DateTime.DATE_FULL }); // $ExpectType string | null
 dt.setLocale('fr').toFormat('MMMM dd, yyyy GG'); // $ExpectType string
 
 DateTime.fromFormat('septembre 25, 2017 après Jésus-Christ', 'MMMM dd, yyyy GG', { locale: 'fr' });
@@ -264,11 +264,11 @@ Settings.defaultZoneName = 'Asia/Tokyo';
 
 /* Calendars */
 // prettier-ignore
-DateTime.fromISO('2017-W23-3').plus({ weeks: 1, days: 2 }).toISOWeekDate(); // $ExpectType string
+DateTime.fromISO('2017-W23-3').plus({ weeks: 1, days: 2 }).toISOWeekDate(); // $ExpectType string | null
 
 const dtHebrew = DateTime.local().reconfigure({ outputCalendar: 'hebrew' });
 dtHebrew.outputCalendar; // $ExpectType string
-dtHebrew.toLocaleString(); // $ExpectType string
+dtHebrew.toLocaleString(); // $ExpectType string | null
 
 DateTime.fromObject({ outputCalendar: 'buddhist' }).toLocaleString(DateTime.DATE_FULL);
 Settings.defaultOutputCalendar = 'persian';
@@ -310,7 +310,7 @@ dur.toObject().days; // $ExpectType number | undefined
 dur.as('minutes'); // $ExpectType number
 dur.shiftTo('minutes').toObject().minutes; // $ExpectType number | undefined
 // prettier-ignore
-DateTime.fromISO('2017-05-15').plus(dur).toISO(); // $ExpectType string
+DateTime.fromISO('2017-05-15').plus(dur).toISO(); // $ExpectType string | null
 
 const end = DateTime.fromISO('2017-03-13');
 const start = DateTime.fromISO('2017-02-13');


### PR DESCRIPTION
The luxon docs claim that certain function will return a string but instead they may return a string OR null (when the DateTime object is invalid). https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html#instance-method-toISO

Examples include:
- `luxon.DateTime.fromISO("").toISO()`
- `luxon.DateTime.fromISO("").toISODate()`
- `luxon.DateTime.fromISO("").toISOTime()`
- `luxon.DateTime.fromISO("").toISOWeekDate()`
- `luxon.DateTime.fromISO("").toJSON()`
- `luxon.DateTime.fromISO("").toLocaleString()`
- `luxon.DateTime.fromISO("").toRFC2822()`
- `luxon.DateTime.fromISO("").toSQL()`
- `luxon.DateTime.fromISO("").toSQLDate()`
- `luxon.DateTime.fromISO("").toSQLTime()`
- `luxon.Duration.fromISO("").toISO()`
- `luxon.Duration.fromISO("").toJSON()`
- `luxon.Duration.fromISO("").toString()`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html#instance-method-toISO (claims it will always return string, but actually the function can return null)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
