### PR TITLE
[draft-js] Add formatPastedText prop

### DIFF
--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -142,6 +142,10 @@ declare namespace Draft {
                  * that you set this to `true`.
                  */
                 stripPastedStyles?: boolean;
+                formatPastedText?: (
+                    text: string,
+                    html?: string,
+                ) => { text: string, html: string | undefined },
 
                 tabIndex?: number;
 


### PR DESCRIPTION
We just added a new `formatPastedText` prop – it is typed in the included flow definitions but needs to be synced with TS. Besides the linter I tested this manually by calling the function from the test and seeing that the signature matched the same expectations we had from flow. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/draft-js/issues/2496