### PR TITLE
Bittorrent protocol add dynamic property key for extensions

### DIFF
--- a/types/bittorrent-protocol/bittorrent-protocol-tests.ts
+++ b/types/bittorrent-protocol/bittorrent-protocol-tests.ts
@@ -27,4 +27,7 @@ net.createServer(socket => {
 
     // Extend wire using the test extension
     wire.extended('extname', {});
+
+    // Confirm extension has been added to Wire instance.
+    console.log(wire.extname.name);
 }).listen(6881);

--- a/types/bittorrent-protocol/index.d.ts
+++ b/types/bittorrent-protocol/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Feross Aboukhadijeh <https://github.com/feross>,
 //                 Tomasz Łaziuk <https://github.com/tlaziuk>,
 //                 H1b9b <https://github.com/h1b9b>
+//                 Ronald Zielaznicki <https://github.com/RonaldZielaznicki>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -55,6 +56,8 @@ declare namespace BittorrentProtocol {
         destroy(): void;
 
         use(ext: ExtensionConstructor): void;
+
+        [key: string]: any;
 
         handshake(infoHash: string | Buffer, peerId: string | Buffer, extensions?: any): void;
 

--- a/types/bittorrent-protocol/index.d.ts
+++ b/types/bittorrent-protocol/index.d.ts
@@ -3,7 +3,6 @@
 // Definitions by: Feross Aboukhadijeh <https://github.com/feross>,
 //                 Tomasz Łaziuk <https://github.com/tlaziuk>,
 //                 H1b9b <https://github.com/h1b9b>
-//                 Ronald Zielaznicki <https://github.com/RonaldZielaznicki>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />


### PR DESCRIPTION
When calling Wire.use for an extension, the wire adds the extension directly to the wire instance. And when utilizing the functionality of the extension you're expected to call directly off the wire. This can be seen in [this](https://github.com/webtorrent/bittorrent-protocol#extension-api) example of the ut_metadata extension.

As the interface currently is, Typescript will complain that the extension doesn't exist when it does. Thus I submit the following change. I'm not sure if there is a better way to go about this than using [key: string]: any though. If there is, please let me know and I will implement it post haste.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/webtorrent/bittorrent-protocol/blob/0e3b0ec27f1a5ac39b69a12e933b7de3dc8e5f2f/index.js#L162>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
