### PR TITLE
[echarts] Fix Datazoom.Inside disabled attribute

### DIFF
--- a/types/echarts/options/data-zoom.d.ts
+++ b/types/echarts/options/data-zoom.d.ts
@@ -33,7 +33,7 @@ declare namespace echarts {
             interface Inside {
                 type?: string;
                 id?: string;
-                disable?: boolean;
+                disabled?: boolean;
                 xAxisIndex?: number | number[];
                 yAxisIndex?: number | number[];
                 radiusAxisIndex?: number | number[];


### PR DESCRIPTION
There was a typo. The correct attribute name is not disable but disabled: https://echarts.apache.org/en/option.html#dataZoom-inside.disabled

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://echarts.apache.org/en/option.html#dataZoom-inside.disabled
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Didn't add any tests because there are not tests present yet and it is a very minor change.

CC Maintainers @xieisabug @AntiMoron @liveangela @Ovilia @iRON5 @bilalucar @tmtron @dwhitney @ruixuel @robert-wettstaedt @trajnisz