### PR TITLE
[papaparse]: Correctly show `meta.fields` as optional

### DIFF
--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -156,7 +156,7 @@ export interface ParseMeta {
     delimiter: string; // Delimiter used
     linebreak: string; // Line break sequence used
     aborted: boolean; // Whether process was aborted
-    fields: string[]; // Array of field names
+    fields?: string[]; // Array of field names
     truncated: boolean; // Whether preview consumed all input
     cursor: number;
 }

--- a/types/papaparse/papaparse-tests.ts
+++ b/types/papaparse/papaparse-tests.ts
@@ -53,10 +53,7 @@ Papa.parse(file, {
         return header;
     },
     complete(a, b) {
-        // This should be string[] | undefined, however the assertion is not
-        // working correctly.
-        // https://github.com/microsoft/dtslint/issues/238
-        // $ExpectType string[]
+        // $ExpectType string[] | undefined
         a.meta.fields;
         if (b) b.name;
     },

--- a/types/papaparse/papaparse-tests.ts
+++ b/types/papaparse/papaparse-tests.ts
@@ -53,6 +53,10 @@ Papa.parse(file, {
         return header;
     },
     complete(a, b) {
+        // This should be string[] | undefined, however the assertion is not
+        // working correctly.
+        // https://github.com/microsoft/dtslint/issues/238
+        // $ExpectType string[]
         a.meta.fields;
         if (b) b.name;
     },


### PR DESCRIPTION
See https://www.papaparse.com/docs#meta, and confirmed experimentally.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.papaparse.com/docs#meta
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.