### PR TITLE
Add Credentials type to react-native-auth0

### DIFF
--- a/types/react-native-auth0/index.d.ts
+++ b/types/react-native-auth0/index.d.ts
@@ -4,6 +4,7 @@
 //                 Mark Nelissen <https://github.com/marknelissen>
 //                 Leo Farias <https://github.com/leoafarias>
 //                 Will Dady <https://github.com/willdady>
+//                 Bogdan Vitoc <https://github.com/bogidon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -188,8 +189,16 @@ export interface ClearSessionParams {
     federated: boolean;
 }
 
+export interface Credentials {
+    accessToken: string;
+    idToken: string;
+    expiresIn: number;
+    scope: string;
+    tokenType: string;
+}
+
 export class WebAuth {
-    authorize(parameters: AuthorizeParams, options?: AuthorizeOptions): Promise<any>;
+    authorize(parameters: AuthorizeParams, options?: AuthorizeOptions): Promise<Credentials>;
     clearSession(parameters?: ClearSessionParams): Promise<any>;
 }
 

--- a/types/react-native-auth0/react-native-auth0-tests.ts
+++ b/types/react-native-auth0/react-native-auth0-tests.ts
@@ -98,6 +98,22 @@ auth0.webAuth.authorize(
     },
 );
 
+auth0.webAuth.authorize({
+    state: 'state',
+    nonce: 'nonce',
+    scope: 'openid',
+    language: 'en',
+    prompt: 'login',
+}).then(credentials => credentials.accessToken);
+
+auth0.webAuth.authorize({
+    state: 'state',
+    nonce: 'nonce',
+    scope: 'openid',
+    language: 'en',
+    prompt: 'login',
+}).then(credentials => credentials.doesNotExist); // $ExpectError
+
 auth0.webAuth.clearSession({ federated: false });
 auth0.webAuth.clearSession();
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/auth0/react-native-auth0/blob/master/src/webauth/index.js#L114 and https://auth0.com/docs/api/authentication#authenticate-user
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
