### PR TITLE
[@types/underscore] Collection and Array Tests - Zip, Unzip, and Object

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -154,12 +154,20 @@ declare module _ {
         : TItem
         : T;
 
-    type PairValue<TPair, TValueList extends List<any> | undefined> =
-        TValueList extends undefined                            // if separate values are not supplied
-        ? (TPair extends [EnumerableKey, infer TValue] ? TValue     // if the pairs are pairs, the value type for the pair
-            : TPair extends List<any> ? any                         // if the pairs are a list, they're probably pairs but the exact type isn't inferrable, so any
-            : never)                                                // if the pairs aren't a list, there's no way that they're pairs, so never
-        : TypeOfList<TValueList> | undefined;                   // if separate values are supplied, the type of values + undefined since there may be more keys than values
+    // if T is an inferrable pair, the value type for the pair
+    // if T is a list, assume that it contains pairs of some type, so any
+    // if T isn't a list, there's no way that it can provide pairs, so never
+    type PairValue<T> =
+        T extends [EnumerableKey, infer TValue, ...any[]] ? TValue
+        : T extends List<any> ? any
+        : never;
+
+    // if separate values are not supplied, the result is the pair type of the possible pair
+    // if separate values are supplied, then the result is the type of the values + undefined since more keys may be supplied than values
+    type ObjectValue<TMaybePair, TValueList extends List<any> | undefined> =
+        TValueList extends undefined
+        ? PairValue<TMaybePair>
+        : TypeOfList<TValueList> | undefined;
 
     type AnyFalsy = undefined | null | false | '' | 0;
 
@@ -853,7 +861,7 @@ declare module _ {
         object<V extends List<any>, TValueList extends List<any> | undefined = undefined>(
             list: V,
             values?: TValueList
-        ): Dictionary<PairValue<TypeOfList<V>, TValueList>>;
+        ): Dictionary<ObjectValue<TypeOfList<V>, TValueList>>;
 
         /**
         * Returns the index at which value can be found in the array, or -1 if value is not present in the array.
@@ -4461,7 +4469,7 @@ declare module _ {
          **/
         object<TValueList extends List<any> | undefined = undefined>(
             values?: TValueList
-        ): Dictionary<PairValue<T, TValueList>>;
+        ): Dictionary<ObjectValue<T, TValueList>>;
 
         /**
         * Wrapped type `any[]`.
@@ -5493,7 +5501,7 @@ declare module _ {
          **/
         object<TValueList extends List<any> | undefined = undefined>(
             values?: TValueList
-        ): _Chain<PairValue<T, TValueList>, Dictionary<PairValue<T, TValueList>>>;
+        ): _Chain<ObjectValue<T, TValueList>, Dictionary<ObjectValue<T, TValueList>>>;
 
         /**
         * Wrapped type `any[]`.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -159,7 +159,7 @@ declare module _ {
     // if T isn't a list, there's no way that it can provide pairs, so never
     type PairValue<T> =
         T extends [EnumerableKey, infer TValue, ...any[]] ? TValue
-        : T extends List<any> ? any
+        : T extends List<infer E> ? E
         : never;
 
     // if separate values are not supplied, the result is the pair type of the possible pair

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -154,7 +154,12 @@ declare module _ {
         : TItem
         : T;
 
-    type PairValueOrAny<T> = T extends [EnumerableKey, infer TValue] ? TValue : any;
+    type PairValue<TPair, TValueList extends List<any> | undefined> =
+        TValueList extends undefined
+        ? (TPair extends [EnumerableKey, infer TValue] ? TValue
+            : TPair extends List<any> ? any
+            : never)
+        : TypeOfList<TValueList> | undefined;
 
     type AnyFalsy = undefined | null | false | '' | 0;
 
@@ -845,10 +850,10 @@ declare module _ {
          * corresponding to those keys.
          * @retursn An object comprised of the provided keys and values.
          **/
-        object<V extends List<any>, TValue extends PairValueOrAny<TypeOfList<V>> = PairValueOrAny<TypeOfList<V>>>(
+        object<V extends List<any>, TValueList extends List<any> | undefined = undefined>(
             list: V,
-            values?: List<TValue>
-        ): Dictionary<TValue>;
+            values?: TValueList
+        ): Dictionary<PairValue<TypeOfList<V>, TValueList>>;
 
         /**
         * Returns the index at which value can be found in the array, or -1 if value is not present in the array.
@@ -4454,9 +4459,9 @@ declare module _ {
          * values corresponding to those keys.
          * @returns An object comprised of the provided keys and values.
          **/
-        object<TValue extends PairValueOrAny<T> = PairValueOrAny<T>>(
-            values?: List<TValue>
-        ): Dictionary<TValue>;
+        object<TValueList extends List<any> | undefined = undefined>(
+            values?: TValueList
+        ): Dictionary<PairValue<T, TValueList>>;
 
         /**
         * Wrapped type `any[]`.
@@ -5486,9 +5491,9 @@ declare module _ {
          * @returns A chain wrapper around an object comprised of the provided
          * keys and values.
          **/
-        object<TValue extends PairValueOrAny<T> = PairValueOrAny<T>>(
-            values?: List<TValue>
-        ): _Chain<TValue, Dictionary<TValue>>;
+        object<TValueList extends List<any> | undefined = undefined>(
+            values?: TValueList
+        ): _Chain<PairValue<T, TValueList>, Dictionary<PairValue<T, TValueList>>>;
 
         /**
         * Wrapped type `any[]`.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -155,11 +155,11 @@ declare module _ {
         : T;
 
     type PairValue<TPair, TValueList extends List<any> | undefined> =
-        TValueList extends undefined
-        ? (TPair extends [EnumerableKey, infer TValue] ? TValue
-            : TPair extends List<any> ? any
-            : never)
-        : TypeOfList<TValueList> | undefined;
+        TValueList extends undefined                            // if separate values are not supplied
+        ? (TPair extends [EnumerableKey, infer TValue] ? TValue     // if the pairs are pairs, the value type for the pair
+            : TPair extends List<any> ? any                         // if the pairs are a list, they're probably pairs but the exact type isn't inferrable, so any
+            : never)                                                // if the pairs aren't a list, there's no way that they're pairs, so never
+        : TypeOfList<TValueList> | undefined;                   // if separate values are supplied, the type of values + undefined since there may be more keys than values
 
     type AnyFalsy = undefined | null | false | '' | 0;
 

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -164,7 +164,7 @@ declare module _ {
 
     // if separate values are not supplied, the result is the pair type of the possible pair
     // if separate values are supplied, then the result is the type of the values + undefined since more keys may be supplied than values
-    type ObjectValue<TMaybePair, TValueList extends List<any> | undefined> =
+    type _ObjectValue<TMaybePair, TValueList extends List<any> | undefined> =
         TValueList extends undefined
         ? PairValue<TMaybePair>
         : TypeOfList<TValueList> | undefined;
@@ -861,7 +861,7 @@ declare module _ {
         object<V extends List<any>, TValueList extends List<any> | undefined = undefined>(
             list: V,
             values?: TValueList
-        ): Dictionary<ObjectValue<TypeOfList<V>, TValueList>>;
+        ): Dictionary<_ObjectValue<TypeOfList<V>, TValueList>>;
 
         /**
         * Returns the index at which value can be found in the array, or -1 if value is not present in the array.
@@ -4469,7 +4469,7 @@ declare module _ {
          **/
         object<TValueList extends List<any> | undefined = undefined>(
             values?: TValueList
-        ): Dictionary<ObjectValue<T, TValueList>>;
+        ): Dictionary<_ObjectValue<T, TValueList>>;
 
         /**
         * Wrapped type `any[]`.
@@ -5501,7 +5501,7 @@ declare module _ {
          **/
         object<TValueList extends List<any> | undefined = undefined>(
             values?: TValueList
-        ): _Chain<ObjectValue<T, TValueList>, Dictionary<ObjectValue<T, TValueList>>>;
+        ): _Chain<_ObjectValue<T, TValueList>, Dictionary<_ObjectValue<T, TValueList>>>;
 
         /**
         * Wrapped type `any[]`.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -849,7 +849,7 @@ declare module _ {
          * corresponding to those keys.
          * @retursn An object comprised of the provided keys and values.
          **/
-        object<TList extends List<any>, TValue>(
+        object<TList extends List<EnumerableKey>, TValue>(
             list: TList,
             values: List<TValue>
         ): Dictionary<TValue | undefined>;

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -830,9 +830,7 @@ declare module _ {
         /**
          * Merges together the values of each of the `lists` with the values at
          * the corresponding position. Useful when you have separate data
-         * sources that are coordinated through matching list indexes. If
-         * you're working with a matrix of nested lists, this can be used to
-         * transpose the matrix.
+         * sources that are coordinated through matching list indexes.
          * @param lists The lists to zip.
          * @returns The zipped version of `lists`.
          **/
@@ -4443,8 +4441,7 @@ declare module _ {
          * Merges together the values of each of the `lists` (including the
          * wrapped list) with the values at the corresponding position. Useful
          * when you have separate data sources that are coordinated through
-         * matching list indexes. If you're working with a matrix of nested
-         * lists, this can be used to transpose the matrix.
+         * matching list indexes.
          * @returns The zipped version of the wrapped list and `lists`.
          **/
         zip(...lists: List<any>[]): any[][];
@@ -5472,8 +5469,7 @@ declare module _ {
          * Merges together the values of each of the `lists` (including the
          * wrapped list) with the values at the corresponding position. Useful
          * when you have separate data sources that are coordinated through
-         * matching list indexes. If you're working with a matrix of nested
-         * lists, this can be used to transpose the matrix.
+         * matching list indexes.
          * @returns A chain wrapper around the zipped version of the wrapped
          * list and `lists`.
          **/

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -154,6 +154,8 @@ declare module _ {
         : TItem
         : T;
 
+    type PairValueOrAny<T> = T extends [EnumerableKey, infer TValue] ? TValue : any;
+
     type AnyFalsy = undefined | null | false | '' | 0;
 
     type Truthy<T> = Exclude<T, AnyFalsy>;
@@ -813,54 +815,40 @@ declare module _ {
         unique: UnderscoreStatic['uniq'];
 
         /**
-        * Merges together the values of each of the arrays with the values at the corresponding position.
-        * Useful when you have separate data sources that are coordinated through matching array indexes.
-        * If you're working with a matrix of nested arrays, zip.apply can transpose the matrix in a similar fashion.
-        * @param arrays The arrays to merge/zip.
-        * @return Zipped version of `arrays`.
-        **/
-        zip(...arrays: any[][]): any[][];
+         * Merges together the values of each of the `lists` with the values at
+         * the corresponding position. Useful when you have separate data
+         * sources that are coordinated through matching list indexes. If
+         * you're working with a matrix of nested lists, this can be used to
+         * transpose the matrix.
+         * @param lists The lists to zip.
+         * @returns The zipped version of `lists`.
+         **/
+        zip(...lists: List<any>[]): any[][];
 
         /**
-        * @see _.zip
-        **/
-        zip(...arrays: any[]): any[];
+         * The opposite of zip. Given a list of lists, returns a series of new
+         * arrays, the first of which contains all of the first elements in the
+         * input lists, the second of which contains all of the second
+         * elements, and so on.
+         * @param lists The lists to unzip.
+         * @returns The unzipped version of `lists`.
+         **/
+        unzip(lists: List<List<any>>): any[][];
 
         /**
-        * The opposite of zip. Given a number of arrays, returns a series of new arrays, the first
-        * of which contains all of the first elements in the input arrays, the second of which
-        * contains all of the second elements, and so on. Use with apply to pass in an array
-        * of arrays
-        * @param arrays The arrays to unzip.
-        * @return Unzipped version of `arrays`.
-        **/
-        unzip(...arrays: any[][]): any[][];
-
-        /**
-        * Converts arrays into objects. Pass either a single list of [key, value] pairs, or a
-        * list of keys, and a list of values.
-        * @param keys Key array.
-        * @param values Value array.
-        * @return An object containing the `keys` as properties and `values` as the property values.
-        **/
-        object<TResult extends {}>(
-            keys: _.List<string>,
-            values: _.List<any>): TResult;
-
-        /**
-        * Converts arrays into objects. Pass either a single list of [key, value] pairs, or a
-        * list of keys, and a list of values.
-        * @param keyValuePairs Array of [key, value] pairs.
-        * @return An object containing the `keys` as properties and `values` as the property values.
-        **/
-        object<TResult extends {}>(...keyValuePairs: any[][]): TResult;
-
-        /**
-        * @see _.object
-        **/
-        object<TResult extends {}>(
-            list: _.List<any>,
-            values?: any): TResult;
+         * Converts lists into objects. Pass either a single `list` of
+         * [key, value] pairs, or a `list` of keys and a list of `values`.
+         * Passing by pairs is the reverse of pairs. If duplicate keys exist,
+         * the last value wins.
+         * @param list A list of [key, value] pairs or a list of keys.
+         * @param values If `list` is a list of keys, a list of values
+         * corresponding to those keys.
+         * @retursn An object comprised of the provided keys and values.
+         **/
+        object<V extends List<any>, TValue extends PairValueOrAny<TypeOfList<V>> = PairValueOrAny<TypeOfList<V>>>(
+            list: V,
+            values?: List<TValue>
+        ): Dictionary<TValue>;
 
         /**
         * Returns the index at which value can be found in the array, or -1 if value is not present in the array.
@@ -4439,27 +4427,36 @@ declare module _ {
         unique: Underscore<T, V>['uniq'];
 
         /**
-        * Wrapped type `any[][]`.
-        * @see _.zip
-        **/
-        zip(...arrays: any[][]): any[][];
+         * Merges together the values of each of the `lists` (including the
+         * wrapped list) with the values at the corresponding position. Useful
+         * when you have separate data sources that are coordinated through
+         * matching list indexes. If you're working with a matrix of nested
+         * lists, this can be used to transpose the matrix.
+         * @returns The zipped version of the wrapped list and `lists`.
+         **/
+        zip(...lists: List<any>[]): any[][];
 
         /**
-        * Wrapped type `any[][]`.
-        * @see _.unzip
-        **/
-        unzip(...arrays: any[][]): any[][];
+         * The opposite of zip. Given the wrapped list of lists, returns a
+         * series of new arrays, the first of which contains all of the first
+         * elements in the wrapped lists, the second of which contains all of
+         * the second elements, and so on.
+         * @returns The unzipped version of the wrapped lists.
+         **/
+        unzip(): any[][];
 
         /**
-        * Wrapped type `any[][]`.
-        * @see _.object
-        **/
-        object(...keyValuePairs: any[][]): any;
-
-        /**
-        * @see _.object
-        **/
-        object(values?: any): any;
+         * Converts lists into objects. Call on either a wrapped list of
+         * [key, value] pairs, or a wrapped list of keys and a list of
+         * `values`. Passing by pairs is the reverse of pairs. If duplicate
+         * keys exist, the last value wins.
+         * @param values If the wrapped list is a list of keys, a list of
+         * values corresponding to those keys.
+         * @returns An object comprised of the provided keys and values.
+         **/
+        object<TValue extends PairValueOrAny<T> = PairValueOrAny<T>>(
+            values?: List<TValue>
+        ): Dictionary<TValue>;
 
         /**
         * Wrapped type `any[]`.
@@ -5459,27 +5456,39 @@ declare module _ {
         unique: _Chain<T, V>['uniq'];
 
         /**
-        * Wrapped type `any[][]`.
-        * @see _.zip
-        **/
-        zip(...arrays: any[][]): _Chain<T>;
+         * Merges together the values of each of the `lists` (including the
+         * wrapped list) with the values at the corresponding position. Useful
+         * when you have separate data sources that are coordinated through
+         * matching list indexes. If you're working with a matrix of nested
+         * lists, this can be used to transpose the matrix.
+         * @returns A chain wrapper around the zipped version of the wrapped
+         * list and `lists`.
+         **/
+        zip(...arrays: List<any>[]): _Chain<any[], any[][]>;
 
         /**
-        * Wrapped type `any[][]`.
-        * @see _.unzip
-        **/
-        unzip(...arrays: any[][]): _Chain<T>;
+         * The opposite of zip. Given the wrapped list of lists, returns a
+         * series of new arrays, the first of which contains all of the first
+         * elements in the wrapped lists, the second of which contains all of
+         * the second elements, and so on.
+         * @returns A chain wrapper aoround the unzipped version of the wrapped
+         * lists.
+         **/
+        unzip(): _Chain<any[], any[][]>;
 
         /**
-        * Wrapped type `any[][]`.
-        * @see _.object
-        **/
-        object(...keyValuePairs: any[][]): _Chain<T>;
-
-        /**
-        * @see _.object
-        **/
-        object(values?: any): _Chain<T>;
+         * Converts lists into objects. Call on either a wrapped list of
+         * [key, value] pairs, or a wrapped list of keys and a list of
+         * `values`. Passing by pairs is the reverse of pairs. If duplicate
+         * keys exist, the last value wins.
+         * @param values If the wrapped list is a list of keys, a list of
+         * values corresponding to those keys.
+         * @returns A chain wrapper around an object comprised of the provided
+         * keys and values.
+         **/
+        object<TValue extends PairValueOrAny<T> = PairValueOrAny<T>>(
+            values?: List<TValue>
+        ): _Chain<TValue, Dictionary<TValue>>;
 
         /**
         * Wrapped type `any[]`.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -158,16 +158,9 @@ declare module _ {
     // if T is a list, assume that it contains pairs of some type, so any
     // if T isn't a list, there's no way that it can provide pairs, so never
     type PairValue<T> =
-        T extends [EnumerableKey, infer TValue, ...any[]] ? TValue
-        : T extends List<infer E> ? E
+        T extends [EnumerableKey, infer TValue] ? TValue
+        : T extends List<infer TValue> ? TValue
         : never;
-
-    // if separate values are not supplied, the result is the pair type of the possible pair
-    // if separate values are supplied, then the result is the type of the values + undefined since more keys may be supplied than values
-    type _ObjectValue<TMaybePair, TValueList extends List<any> | undefined> =
-        TValueList extends undefined
-        ? PairValue<TMaybePair>
-        : TypeOfList<TValueList> | undefined;
 
     type AnyFalsy = undefined | null | false | '' | 0;
 
@@ -856,10 +849,13 @@ declare module _ {
          * corresponding to those keys.
          * @retursn An object comprised of the provided keys and values.
          **/
-        object<V extends List<any>, TValueList extends List<any> | undefined = undefined>(
-            list: V,
-            values?: TValueList
-        ): Dictionary<_ObjectValue<TypeOfList<V>, TValueList>>;
+        object<TList extends List<any>, TValue>(
+            list: TList,
+            values: List<TValue>
+        ): Dictionary<TValue | undefined>;
+        object<TList extends List<List<any>>>(
+            list: TList
+        ): Dictionary<PairValue<TypeOfList<TList>>>;
 
         /**
         * Returns the index at which value can be found in the array, or -1 if value is not present in the array.
@@ -4464,9 +4460,8 @@ declare module _ {
          * values corresponding to those keys.
          * @returns An object comprised of the provided keys and values.
          **/
-        object<TValueList extends List<any> | undefined = undefined>(
-            values?: TValueList
-        ): Dictionary<_ObjectValue<T, TValueList>>;
+        object<TValue>(values: List<TValue>): Dictionary<TValue | undefined>;
+        object(): Dictionary<PairValue<T>>;
 
         /**
         * Wrapped type `any[]`.
@@ -5495,9 +5490,8 @@ declare module _ {
          * @returns A chain wrapper around an object comprised of the provided
          * keys and values.
          **/
-        object<TValueList extends List<any> | undefined = undefined>(
-            values?: TValueList
-        ): _Chain<_ObjectValue<T, TValueList>, Dictionary<_ObjectValue<T, TValueList>>>;
+        object<TValue>(values: List<TValue>): _Chain<TValue | undefined, Dictionary<TValue | undefined>>;
+        object(): _Chain<PairValue<T>, Dictionary<PairValue<T>>>;
 
         /**
         * Wrapped type `any[]`.

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -2262,12 +2262,12 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     extractChainTypes(_.chain(tupleList).object()); // $ExpectType ChainType<Dictionary<number>, number>
 
     // nested lists
-    _.object(level2UnionList); // $ExpectType Dictionary<any>
-    _(level2UnionList).object(); // $ExpectType Dictionary<any>
-    extractChainTypes(_.chain(level2UnionList).object()); // $ExpectType ChainType<Dictionary<any>, any>
+    _.object(level2UnionList); // $ExpectType Dictionary<string | number>
+    _(level2UnionList).object(); // $ExpectType Dictionary<string | number>
+    extractChainTypes(_.chain(level2UnionList).object()); // $ExpectType ChainType<Dictionary<string | number>, string | number>
 
     // non-nested lists
-    _.object(stringRecordList); // $ExpectType Dictionary<never>
+    _.object(stringRecordList); // $ExpectError
     _(stringRecordList).object(); // $ExpectType Dictionary<never>
     extractChainTypes(_.chain(stringRecordList).object()); // $ExpectType ChainType<Dictionary<never>, never>
 }

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -2246,9 +2246,9 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
 // object
 {
     // key and value lists
-    _.object(simpleStringList, simpleNumberList); // $ExpectType Dictionary<number>
-    _(simpleStringList).object(simpleNumberList); // $ExpectType Dictionary<number>
-    extractChainTypes(_.chain(simpleStringList).object(simpleNumberList)); // $ExpectType ChainType<Dictionary<number>, number>
+    _.object(simpleStringList, simpleNumberList); // $ExpectType Dictionary<number | undefined>
+    _(simpleStringList).object(simpleNumberList); // $ExpectType Dictionary<number | undefined>
+    extractChainTypes(_.chain(simpleStringList).object(simpleNumberList)); // $ExpectType ChainType<Dictionary<number | undefined>, number | undefined>
 
     // tuple lists
     _.object(tupleList); // $ExpectType Dictionary<number>
@@ -2259,6 +2259,11 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _.object(level2UnionList); // $ExpectType Dictionary<any>
     _(level2UnionList).object(); // $ExpectType Dictionary<any>
     extractChainTypes(_.chain(level2UnionList).object()); // $ExpectType ChainType<Dictionary<any>, any>
+
+    // non-nested lists
+    _.object(stringRecordList); // $ExpectType Dictionary<never>
+    _(stringRecordList).object(); // $ExpectType Dictionary<never>
+    extractChainTypes(_.chain(stringRecordList).object()); // $ExpectType ChainType<Dictionary<never>, never>
 }
 
 // chunk

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -656,6 +656,7 @@ declare const resultUnionStringListMemoIterator: (prev: string | number, value: 
 declare const anyCollectionVoidIterator: (element: any, index: string | number, collection: any) => void;
 
 const simpleNumber = 7;
+declare const simpleNumberList: _.List<number>;
 declare const simpleNumberDictionary: _.Dictionary<number>;
 
 declare const simpleBooleanList: _.List<boolean>;
@@ -670,6 +671,9 @@ declare const stringy: StringRecord | string;
 type Truthies = string | number | boolean | object | Function | StringRecord | (() => void);
 declare const truthyFalsyList: _.List<Truthies | _.AnyFalsy>;
 declare const maybeTruthyFalsyList: _.List<Truthies | _.AnyFalsy> | null | undefined;
+
+declare const level2UnionList: _.List<_.List<string | number>>;
+declare const tupleList: _.List<[string, number]>;
 
 // avoid referencing types under test directly by translating them to other types to avoid needing to make lots of changes if
 // the types under test need to be refactored
@@ -2217,6 +2221,44 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _.unique(stringRecordList, true, stringRecordPropertyPath); // $ExpectType StringRecord[]
     _(stringRecordList).unique(true, stringRecordPropertyPath); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordList).unique(true, stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+}
+
+// zip
+{
+    _.zip(simpleStringList, simpleNumberList, stringRecordList); // $ExpectType any[][]
+    _(simpleStringList).zip(simpleNumberList, stringRecordList); // $ExpectType any[][]
+    extractChainTypes(_.chain(simpleStringList).zip(simpleNumberList, stringRecordList)); // $ExpectType ChainType<any[][], any[]>
+}
+
+// unzip
+{
+    // tuple lists
+    _.unzip(tupleList); // $ExpectType any[][]
+    _(tupleList).unzip(); // $ExpectType any[][]
+    extractChainTypes(_.chain(tupleList).unzip()); // $ExpectType ChainType<any[][], any[]>
+
+    // nested lists
+    _.unzip(level2UnionList); // $ExpectType any[][]
+    _(level2UnionList).unzip(); // $ExpectType any[][]
+    extractChainTypes(_.chain(level2UnionList).unzip()); // $ExpectType ChainType<any[][], any[]>
+}
+
+// object
+{
+    // key and value lists
+    _.object(simpleStringList, simpleNumberList); // $ExpectType Dictionary<number>
+    _(simpleStringList).object(simpleNumberList); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(simpleStringList).object(simpleNumberList)); // $ExpectType ChainType<Dictionary<number>, number>
+
+    // tuple lists
+    _.object(tupleList); // $ExpectType Dictionary<number>
+    _(tupleList).object(); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(tupleList).object()); // $ExpectType ChainType<Dictionary<number>, number>
+
+    // nested lists
+    _.object(level2UnionList); // $ExpectType Dictionary<any>
+    _(level2UnionList).object(); // $ExpectType Dictionary<any>
+    extractChainTypes(_.chain(level2UnionList).object()); // $ExpectType ChainType<Dictionary<any>, any>
 }
 
 // chunk

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -2225,9 +2225,15 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
 
 // zip
 {
+    // multiple arguments
     _.zip(simpleStringList, simpleNumberList, stringRecordList); // $ExpectType any[][]
     _(simpleStringList).zip(simpleNumberList, stringRecordList); // $ExpectType any[][]
     extractChainTypes(_.chain(simpleStringList).zip(simpleNumberList, stringRecordList)); // $ExpectType ChainType<any[][], any[]>
+
+    // single arguments
+    _.zip(simpleStringList); // $ExpectType any[][]
+    _(simpleStringList).zip(); // $ExpectType any[][]
+    extractChainTypes(_.chain(simpleStringList).zip()); // $ExpectType ChainType<any[][], any[]>
 }
 
 // unzip


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://underscorejs.org/
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

This PR continues the planned set that will together add up to #45201 and includes the following changes:

- Adds tests for `zip`, `unzip`, and `object`.
- Removes an overload of `UnderscoreStatic.zip` that doesn't seem like it's correct.
- Updates `unzip` functions to not take more than a single input (either a single parameter or the wrapped value).
- Collapses `object` to a single overload that always results in a `Dictionary` of some sort rather than allowing the caller to specify a more exact result through generics and infers its resulting value type when it can, falling back to `any` when it can't.
- Updates the return type of the `_Chain` functions to use the correct wrapped value type `V` (these are more drastic changes than those that partially fix #36308 though).