### PR TITLE
Updated `Entry` in webpack to include new keyed version

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -174,8 +174,8 @@ declare namespace webpack {
             | string[]
             | {
                   import: string | string[];
-                  dependOn: string | string[];
-                  filename: string;
+                  dependOn?: string | string[];
+                  filename?: string;
               };
     }
 

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -29,17 +29,17 @@
 
 import { Hash as CryptoHash } from 'crypto';
 import {
-  Tapable,
-  HookMap,
-  SyncBailHook,
-  SyncHook,
-  SyncLoopHook,
-  SyncWaterfallHook,
-  AsyncParallelBailHook,
-  AsyncParallelHook,
-  AsyncSeriesBailHook,
-  AsyncSeriesHook,
-  AsyncSeriesWaterfallHook,
+    Tapable,
+    HookMap,
+    SyncBailHook,
+    SyncHook,
+    SyncLoopHook,
+    SyncWaterfallHook,
+    AsyncParallelBailHook,
+    AsyncParallelHook,
+    AsyncSeriesBailHook,
+    AsyncSeriesHook,
+    AsyncSeriesWaterfallHook,
 } from 'tapable';
 import * as UglifyJS from 'uglify-js';
 import * as anymatch from 'anymatch';
@@ -49,18 +49,14 @@ import { ConcatSource } from 'webpack-sources';
 export = webpack;
 
 declare function webpack(
-    options:
-        | webpack.Configuration
-        | webpack.ConfigurationFactory,
+    options: webpack.Configuration | webpack.ConfigurationFactory,
     handler: webpack.Compiler.Handler,
 ): webpack.Compiler.Watching | webpack.Compiler;
 declare function webpack(options?: webpack.Configuration): webpack.Compiler;
 
 declare function webpack(
-    options:
-        | webpack.Configuration[]
-        | webpack.MultiConfigurationFactory,
-    handler: webpack.MultiCompiler.Handler
+    options: webpack.Configuration[] | webpack.MultiConfigurationFactory,
+    handler: webpack.MultiCompiler.Handler,
 ): webpack.MultiWatching | webpack.MultiCompiler;
 declare function webpack(options: webpack.Configuration[]): webpack.MultiCompiler;
 
@@ -70,7 +66,7 @@ declare namespace webpack {
 
     interface Configuration {
         /** Enable production optimizations or development hints. */
-        mode?: "development" | "production" | "none";
+        mode?: 'development' | 'production' | 'none';
         /** Name of the configuration. Used when loading multiple configurations. */
         name?: string;
         /**
@@ -109,7 +105,18 @@ declare namespace webpack {
          * - "atom" Alias for electron-main.
          * - "electron" Alias for electron-main.
          */
-        target?: 'web' | 'webworker' | 'node' | 'async-node' | 'node-webkit' | 'atom' | 'electron' | 'electron-renderer' | 'electron-preload' | 'electron-main' | ((compiler?: any) => void);
+        target?:
+            | 'web'
+            | 'webworker'
+            | 'node'
+            | 'async-node'
+            | 'node-webkit'
+            | 'atom'
+            | 'electron'
+            | 'electron-renderer'
+            | 'electron-preload'
+            | 'electron-main'
+            | ((compiler?: any) => void);
         /** Report the first error as a hard error instead of tolerating it. */
         bail?: boolean;
         /** Capture timing information for each module. */
@@ -143,7 +150,7 @@ declare namespace webpack {
 
     interface CliConfigOptions {
         config?: string;
-        mode?: Configuration["mode"];
+        mode?: Configuration['mode'];
         env?: string;
         'config-register'?: string;
         configRegister?: string;
@@ -151,21 +158,28 @@ declare namespace webpack {
         configName?: string;
     }
 
-    type ConfigurationFactory = ((
+    type ConfigurationFactory = (
         env: string | Record<string, boolean | number | string> | undefined,
         args: CliConfigOptions,
-    ) => Configuration | Promise<Configuration>);
+    ) => Configuration | Promise<Configuration>;
 
-    type MultiConfigurationFactory = ((
+    type MultiConfigurationFactory = (
         env: string | Record<string, boolean | number | string> | undefined,
         args: CliConfigOptions,
-    ) => Configuration[] | Promise<Configuration[]>);
+    ) => Configuration[] | Promise<Configuration[]>;
 
     interface Entry {
-        [name: string]: string | string[];
+        [name: string]:
+            | string
+            | string[]
+            | {
+                  import: string | string[];
+                  dependOn: string | string[];
+                  filename: string;
+              };
     }
 
-    type EntryFunc = () => (string | string[] | Entry | Promise<string | string[] | Entry>);
+    type EntryFunc = () => string | string[] | Entry | Promise<string | string[] | Entry>;
 
     interface DevtoolModuleFilenameTemplateInfo {
         identifier: string;
@@ -214,7 +228,7 @@ declare namespace webpack {
         /** The filename of the Hot Update Main File. It is inside the output.path directory. */
         hotUpdateMainFilename?: string;
         /** If set, export the bundle as library. output.library is the name. */
-        library?: string | string[] | {[key: string]: string};
+        library?: string | string[] | { [key: string]: string };
         /**
          * Which format to export the library:
          * - "var" - Export by setting a variable: var Library = xxx (default)
@@ -261,7 +275,18 @@ declare namespace webpack {
         futureEmitAssets?: boolean;
     }
 
-    type LibraryTarget = 'var' | 'assign' | 'this' | 'window' | 'global' | 'commonjs' | 'commonjs2' | 'amd' | 'umd' | 'jsonp' | 'system';
+    type LibraryTarget =
+        | 'var'
+        | 'assign'
+        | 'this'
+        | 'window'
+        | 'global'
+        | 'commonjs'
+        | 'commonjs2'
+        | 'amd'
+        | 'umd'
+        | 'jsonp'
+        | 'system';
 
     type AuxiliaryCommentObject = { [P in LibraryTarget]: string };
 
@@ -354,7 +379,7 @@ declare namespace webpack {
          *
          * @see aliasFields
          */
-        alias?: { [key: string]: string; };
+        alias?: { [key: string]: string };
 
         /**
          * Whether to use a cache for resolving, or the specific object
@@ -370,7 +395,7 @@ declare namespace webpack {
          *
          * Defaults to `() => true`.
          */
-        cachePredicate?(data: { path: string, request: string }): boolean;
+        cachePredicate?(data: { path: string; request: string }): boolean;
 
         /**
          * A list of additional resolve plugins which should be applied.
@@ -416,7 +441,7 @@ declare namespace webpack {
         /**
          * Callback with an Error
          */
-        (error: {}): void; /* tslint:disable-line */
+        (error: {}): void /* tslint:disable-line */;
         /**
          * Externalize the dependency
          */
@@ -452,31 +477,31 @@ declare namespace webpack {
         | ((path: string) => boolean)
         | RuleSetConditions
         | {
-            /**
-             * Logical AND
-             */
-            and?: RuleSetCondition[];
-            /**
-             * Exclude all modules matching any of these conditions
-             */
-            exclude?: RuleSetCondition;
-            /**
-             * Exclude all modules matching not any of these conditions
-             */
-            include?: RuleSetCondition;
-            /**
-             * Logical NOT
-             */
-            not?: RuleSetCondition[];
-            /**
-             * Logical OR
-             */
-            or?: RuleSetCondition[];
-            /**
-             * Exclude all modules matching any of these conditions
-             */
-            test?: RuleSetCondition;
-        };
+              /**
+               * Logical AND
+               */
+              and?: RuleSetCondition[];
+              /**
+               * Exclude all modules matching any of these conditions
+               */
+              exclude?: RuleSetCondition;
+              /**
+               * Exclude all modules matching not any of these conditions
+               */
+              include?: RuleSetCondition;
+              /**
+               * Logical NOT
+               */
+              not?: RuleSetCondition[];
+              /**
+               * Logical OR
+               */
+              or?: RuleSetCondition[];
+              /**
+               * Exclude all modules matching any of these conditions
+               */
+              test?: RuleSetCondition;
+          };
 
     // A hack around circular type referencing
     interface RuleSetConditions extends Array<RuleSetCondition> {}
@@ -485,7 +510,7 @@ declare namespace webpack {
         /**
          * Enforce this rule as pre or post step
          */
-        enforce?: "pre" | "post";
+        enforce?: 'pre' | 'post';
         /**
          * Shortcut for resource.exclude
          */
@@ -533,7 +558,7 @@ declare namespace webpack {
         /**
          * Module type to use for the module
          */
-        type?: "javascript/auto" | "javascript/dynamic" | "javascript/esm" | "json" | "webassembly/experimental";
+        type?: 'javascript/auto' | 'javascript/dynamic' | 'javascript/esm' | 'json' | 'webassembly/experimental';
         /**
          * Match the resource path of the module
          */
@@ -560,10 +585,7 @@ declare namespace webpack {
         use?: RuleSetUse;
     }
 
-    type RuleSetUse =
-        | RuleSetUseItem
-        | RuleSetUseItem[]
-        | ((data: any) => RuleSetUseItem | RuleSetUseItem[]);
+    type RuleSetUse = RuleSetUseItem | RuleSetUseItem[] | ((data: any) => RuleSetUseItem | RuleSetUseItem[]);
 
     interface RuleSetLoader {
         /**
@@ -584,14 +606,9 @@ declare namespace webpack {
         query?: RuleSetQuery;
     }
 
-    type RuleSetUseItem =
-        | string
-        | RuleSetLoader
-        | ((data: any) => string | RuleSetLoader);
+    type RuleSetUseItem = string | RuleSetLoader | ((data: any) => string | RuleSetLoader);
 
-    type RuleSetQuery =
-        | string
-        | { [k: string]: any };
+    type RuleSetQuery = string | { [k: string]: any };
 
     /**
      * @deprecated Use RuleSetCondition instead
@@ -605,13 +622,54 @@ declare namespace webpack {
 
     namespace Options {
         // tslint:disable-next-line:max-line-length
-        type Devtool = 'eval' | 'inline-source-map' | 'cheap-eval-source-map' | 'cheap-source-map' | 'cheap-module-eval-source-map' | 'cheap-module-source-map' | 'eval-source-map'
-            | 'source-map' | 'nosources-source-map' | 'hidden-source-map' | 'nosources-source-map' | 'inline-cheap-source-map' | 'inline-cheap-module-source-map' | '@eval'
-            | '@inline-source-map' | '@cheap-eval-source-map' | '@cheap-source-map' | '@cheap-module-eval-source-map' | '@cheap-module-source-map' | '@eval-source-map'
-            | '@source-map' | '@nosources-source-map' | '@hidden-source-map' | '@nosources-source-map' | '#eval' | '#inline-source-map' | '#cheap-eval-source-map'
-            | '#cheap-source-map' | '#cheap-module-eval-source-map' | '#cheap-module-source-map' | '#eval-source-map' | '#source-map' | '#nosources-source-map'
-            | '#hidden-source-map' | '#nosources-source-map' | '#@eval' | '#@inline-source-map' | '#@cheap-eval-source-map' | '#@cheap-source-map' | '#@cheap-module-eval-source-map'
-            | '#@cheap-module-source-map' | '#@eval-source-map' | '#@source-map' | '#@nosources-source-map' | '#@hidden-source-map' | '#@nosources-source-map' | boolean;
+        type Devtool =
+            | 'eval'
+            | 'inline-source-map'
+            | 'cheap-eval-source-map'
+            | 'cheap-source-map'
+            | 'cheap-module-eval-source-map'
+            | 'cheap-module-source-map'
+            | 'eval-source-map'
+            | 'source-map'
+            | 'nosources-source-map'
+            | 'hidden-source-map'
+            | 'nosources-source-map'
+            | 'inline-cheap-source-map'
+            | 'inline-cheap-module-source-map'
+            | '@eval'
+            | '@inline-source-map'
+            | '@cheap-eval-source-map'
+            | '@cheap-source-map'
+            | '@cheap-module-eval-source-map'
+            | '@cheap-module-source-map'
+            | '@eval-source-map'
+            | '@source-map'
+            | '@nosources-source-map'
+            | '@hidden-source-map'
+            | '@nosources-source-map'
+            | '#eval'
+            | '#inline-source-map'
+            | '#cheap-eval-source-map'
+            | '#cheap-source-map'
+            | '#cheap-module-eval-source-map'
+            | '#cheap-module-source-map'
+            | '#eval-source-map'
+            | '#source-map'
+            | '#nosources-source-map'
+            | '#hidden-source-map'
+            | '#nosources-source-map'
+            | '#@eval'
+            | '#@inline-source-map'
+            | '#@cheap-eval-source-map'
+            | '#@cheap-source-map'
+            | '#@cheap-module-eval-source-map'
+            | '#@cheap-module-source-map'
+            | '#@eval-source-map'
+            | '#@source-map'
+            | '#@nosources-source-map'
+            | '#@hidden-source-map'
+            | '#@nosources-source-map'
+            | boolean;
 
         interface Performance {
             /** This property allows webpack to control what files are used to calculate performance hints. */
@@ -639,7 +697,7 @@ declare namespace webpack {
             /** Assign modules to a cache group */
             test?: ((...args: any[]) => boolean) | string | RegExp;
             /** Select chunks for determining cache group content (defaults to \"initial\", \"initial\" and \"all\" requires adding these chunks to the HTML) */
-            chunks?: "initial" | "async" | "all" | ((chunk: compilation.Chunk) => boolean);
+            chunks?: 'initial' | 'async' | 'all' | ((chunk: compilation.Chunk) => boolean);
             /** Ignore minimum size, minimum chunks and maximum requests and always create chunks for this cache group */
             enforce?: boolean;
             /** Priority of this cache group */
@@ -661,7 +719,7 @@ declare namespace webpack {
         }
         interface SplitChunksOptions {
             /** Select chunks for determining shared modules (defaults to \"async\", \"initial\" and \"all\" requires adding these chunks to the HTML) */
-            chunks?: "initial" | "async" | "all" | ((chunk: compilation.Chunk) => boolean);
+            chunks?: 'initial' | 'async' | 'all' | ((chunk: compilation.Chunk) => boolean);
             /** Minimal size for the created chunk */
             minSize?: number;
             /** Maximum size for the created chunk */
@@ -675,7 +733,12 @@ declare namespace webpack {
             /** Give chunks created a name (chunks with equal name are merged) */
             name?: boolean | string | ((...args: any[]) => any);
             /** Assign modules to a cache group (modules from different cache groups are tried to keep in separate chunks) */
-            cacheGroups?: false | string | ((...args: any[]) => any) | RegExp | { [key: string]: CacheGroupsOptions | false };
+            cacheGroups?:
+                | false
+                | string
+                | ((...args: any[]) => any)
+                | RegExp
+                | { [key: string]: CacheGroupsOptions | false };
             /** Override the default name separator (~) when generating names automatically (name: true)  */
             automaticNameDelimiter?: string;
         }
@@ -716,7 +779,7 @@ declare namespace webpack {
             /** Finds modules which are shared between chunk and splits them into separate chunks to reduce duplication or separate vendor modules from application modules. */
             splitChunks?: SplitChunksOptions | false;
             /** Create a separate chunk for the webpack runtime code and chunk hash maps. This chunk should be inlined into the HTML */
-            runtimeChunk?: boolean | "single" | "multiple" | RuntimeChunkOptions;
+            runtimeChunk?: boolean | 'single' | 'multiple' | RuntimeChunkOptions;
             /** Avoid emitting assets when errors occur. */
             noEmitOnErrors?: boolean;
             /** Instead of numeric ids, give modules readable names for better debugging. */
@@ -724,9 +787,9 @@ declare namespace webpack {
             /** Instead of numeric ids, give chunks readable names for better debugging. */
             namedChunks?: boolean;
             /** Tells webpack which algorithm to use when choosing module ids. Default false. */
-            moduleIds?: boolean | "natural" | "named" | "hashed" | "size" | "total-size";
+            moduleIds?: boolean | 'natural' | 'named' | 'hashed' | 'size' | 'total-size';
             /** Tells webpack which algorithm to use when choosing chunk ids. Default false. */
-            chunkIds?: boolean | "natural" | "named" | "size" | "total-size";
+            chunkIds?: boolean | 'natural' | 'named' | 'size' | 'total-size';
             /** Defines the process.env.NODE_ENV constant to a compile-time-constant value. This allows to remove development only code from code. */
             nodeEnv?: string | false;
             /** Use the minimizer (optimization.minimizer, by default uglify-js) to minimize output assets. */
@@ -780,11 +843,9 @@ declare namespace webpack {
     }
 
     namespace compilation {
-        class Asset {
-        }
+        class Asset {}
 
-        class DependenciesBlock {
-        }
+        class DependenciesBlock {}
 
         class Module extends DependenciesBlock {
             constructor(type: string, context?: string);
@@ -813,9 +874,12 @@ declare namespace webpack {
             used: null | boolean;
             usedExports: false | true | string[] | null;
             optimizationBailout: string | any[];
-            _rewriteChunkInReasons: {
-                oldChunk: Chunk, newChunks: Chunk[]
-            } | undefined;
+            _rewriteChunkInReasons:
+                | {
+                      oldChunk: Chunk;
+                      newChunks: Chunk[];
+                  }
+                | undefined;
             useSourceMap: boolean;
             _source: any;
 
@@ -849,8 +913,7 @@ declare namespace webpack {
             unbuild(): void;
         }
 
-        class Record {
-        }
+        class Record {}
 
         class Chunk {
             constructor(name?: string);
@@ -908,21 +971,18 @@ declare namespace webpack {
                 size: number,
                 options: {
                     chunkOverhead?: number;
-                    entryChunkMultiplicator?: number
+                    entryChunkMultiplicator?: number;
                 },
             ): number;
             modulesSize(): number;
-            size(options?: {
-                chunkOverhead?: number;
-                entryChunkMultiplicator?: number
-            }): number;
+            size(options?: { chunkOverhead?: number; entryChunkMultiplicator?: number }): number;
             integratedSize(otherChunk: Chunk, options: any): number | false;
-            sortModules(
-                sortByFn: (module1: Module, module2: Module) => -1 | 0 | 1
-            ): void;
+            sortModules(sortByFn: (module1: Module, module2: Module) => -1 | 0 | 1): void;
             sortItems(): void;
             getAllAsyncChunks(): Set<Chunk>;
-            getChunkMaps(realHash: boolean): {
+            getChunkMaps(
+                realHash: boolean,
+            ): {
                 hash: any;
                 contentHash: any;
                 name: any;
@@ -931,14 +991,11 @@ declare namespace webpack {
             getChildIdsByOrdersMap(includeDirectChildren?: boolean): any;
             // tslint:disable-next-line:ban-types
             getChunkModuleMaps(filterFn: Function): { id: any; hash: any };
-            hasModuleInGraph(
-                filterFn: (module: Module) => boolean,
-                filterChunkFn: (chunk: Chunk) => boolean
-            ): boolean;
+            hasModuleInGraph(filterFn: (module: Module) => boolean, filterChunkFn: (chunk: Chunk) => boolean): boolean;
             toString(): string;
         }
 
-        type GroupOptions = string | { name?: string; };
+        type GroupOptions = string | { name?: string };
 
         class ChunkGroup {
             chunks: Chunk[];
@@ -955,8 +1012,7 @@ declare namespace webpack {
             setParents(newParents: Iterable<ChunkGroup>): void;
         }
 
-        class ChunkHash {
-        }
+        class ChunkHash {}
 
         interface SourcePosition {
             line: number;
@@ -1165,20 +1221,25 @@ declare namespace webpack {
         }
 
         class MainTemplate extends Tapable {
-          hooks: {
-            jsonpScript?: SyncWaterfallHook<string, Chunk, string>;
-            require: SyncWaterfallHook<string, Chunk, string>;
-            requireExtensions: SyncWaterfallHook<string, Chunk, string>;
-            requireEnsure: SyncWaterfallHook<string, Chunk, string>;
-            localVars: SyncWaterfallHook<string, Chunk, string>;
-            afterStartup: SyncWaterfallHook<string, Chunk, string>;
-            hash: SyncHook<CryptoHash>;
-            hashForChunk: SyncHook<CryptoHash, Chunk>;
-          };
-          outputOptions: Output;
-          requireFn: string;
-          renderRequireFunctionForModule(hash: string, chunk: Chunk, varModuleId?: number | string): string;
-          renderAddModule(hash: string, chunk: Chunk, varModuleId: number | string | undefined, varModule: string): string;
+            hooks: {
+                jsonpScript?: SyncWaterfallHook<string, Chunk, string>;
+                require: SyncWaterfallHook<string, Chunk, string>;
+                requireExtensions: SyncWaterfallHook<string, Chunk, string>;
+                requireEnsure: SyncWaterfallHook<string, Chunk, string>;
+                localVars: SyncWaterfallHook<string, Chunk, string>;
+                afterStartup: SyncWaterfallHook<string, Chunk, string>;
+                hash: SyncHook<CryptoHash>;
+                hashForChunk: SyncHook<CryptoHash, Chunk>;
+            };
+            outputOptions: Output;
+            requireFn: string;
+            renderRequireFunctionForModule(hash: string, chunk: Chunk, varModuleId?: number | string): string;
+            renderAddModule(
+                hash: string,
+                chunk: Chunk,
+                varModuleId: number | string | undefined,
+                varModule: string,
+            ): string;
         }
         class ChunkTemplate extends Tapable {}
         class HotUpdateChunkTemplate extends Tapable {}
@@ -1253,20 +1314,28 @@ declare namespace webpack {
             hash?: string;
             getStats(): Stats;
             addChunkInGroup(groupOptions: GroupOptions): ChunkGroup;
-            addChunkInGroup(groupOptions: GroupOptions, module: Module, loc: DependencyLocation, request: string): ChunkGroup;
+            addChunkInGroup(
+                groupOptions: GroupOptions,
+                module: Module,
+                loc: DependencyLocation,
+                request: string,
+            ): ChunkGroup;
             addModule(module: CompilationModule, cacheGroup: any): any;
             // tslint:disable-next-line:ban-types
             addEntry(context: any, entry: any, name: any, callback: Function): void;
 
-            getPath(filename: string, data: {
-                hash?: any,
-                chunk?: any,
-                filename?: string,
-                basename?: string,
-                query?: any,
-                contentHashType?: string,
-                contentHash?: string,
-            }): string;
+            getPath(
+                filename: string,
+                data: {
+                    hash?: any;
+                    chunk?: any;
+                    filename?: string;
+                    basename?: string;
+                    query?: any;
+                    contentHashType?: string;
+                    contentHash?: string;
+                },
+            ): string;
 
             /**
              * @deprecated Compilation.applyPlugins is deprecated. Use new API on `.hooks` instead
@@ -1379,7 +1448,7 @@ declare namespace webpack {
         sortWith(sortFn: (a: T, b: T) => number): void;
         sort(): void;
         getFromCache(fn: (set: SortableSet<T>) => T[]): T[];
-        getFromUnorderedCache(fn: (set: SortableSet<T>) => string|number|T[]): any;
+        getFromUnorderedCache(fn: (set: SortableSet<T>) => string | number | T[]): any;
     }
 
     class Compiler extends Tapable implements ICompiler {
@@ -1451,8 +1520,8 @@ declare namespace webpack {
         endTime?: number;
 
         static filterWarnings(
-          warnings: string[],
-          warningsFilter?: Array<string | RegExp | ((warning: string) => boolean)>
+            warnings: string[],
+            warningsFilter?: Array<string | RegExp | ((warning: string) => boolean)>,
         ): string[];
         /**
          * Returns the default json options from the stats preset.
@@ -1478,14 +1547,7 @@ declare namespace webpack {
     }
 
     namespace Stats {
-        type Preset
-            = boolean
-            | 'errors-only'
-            | 'errors-warnings'
-            | 'minimal'
-            | 'none'
-            | 'normal'
-            | 'verbose';
+        type Preset = boolean | 'errors-only' | 'errors-warnings' | 'minimal' | 'none' | 'normal' | 'verbose';
 
         interface ToJsonOptionsObject {
             /** fallback value for stats options when an option is not defined (has precedence over local webpack defaults) */
@@ -1567,17 +1629,20 @@ declare namespace webpack {
         interface ChunkGroup {
             assets: string[];
             chunks: Array<number | string>;
-            children: Record<string, {
-                assets: string[];
-                chunks: Array<number | string>;
-                name: string;
-            }>;
+            children: Record<
+                string,
+                {
+                    assets: string[];
+                    chunks: Array<number | string>;
+                    name: string;
+                }
+            >;
             childAssets: Record<string, string[]>;
             isOverSizeLimit?: boolean;
         }
 
-        type ReasonType
-            = 'amd define'
+        type ReasonType =
+            | 'amd define'
             | 'amd require array'
             | 'amd require context'
             | 'amd require'
@@ -1721,7 +1786,13 @@ declare namespace webpack {
             warnings: string[];
         }
 
-        type StatsExcludeFilter = string | string[] | RegExp | RegExp[] | ((assetName: string) => boolean) | Array<(assetName: string) => boolean>;
+        type StatsExcludeFilter =
+            | string
+            | string[]
+            | RegExp
+            | RegExp[]
+            | ((assetName: string) => boolean)
+            | Array<(assetName: string) => boolean>;
 
         interface ToStringOptionsObject extends ToJsonOptionsObject {
             /** `webpack --colors` equivalent */
@@ -1757,10 +1828,10 @@ declare namespace webpack {
     }
 
     class DefinePlugin extends Plugin {
-        constructor(definitions: {[key: string]: DefinePlugin.CodeValueObject});
+        constructor(definitions: { [key: string]: DefinePlugin.CodeValueObject });
         static runtimeValue(
             fn: ({ module }: { module: compilation.Module }) => DefinePlugin.CodeValuePrimitive,
-            fileDependencies?: true | string[]
+            fileDependencies?: true | string[],
         ): DefinePlugin.RuntimeValue;
     }
 
@@ -1768,12 +1839,12 @@ declare namespace webpack {
         class RuntimeValue {
             constructor(
                 fn: ({ module }: { module: compilation.Module }) => CodeValuePrimitive,
-                fileDependencies?: string[]
+                fileDependencies?: string[],
             );
             exec(parser: compilation.normalModuleFactory.Parser): CodeValuePrimitive;
         }
         type CodeValuePrimitive = string | number | boolean | RegExp | RuntimeValue | null | undefined;
-        type CodeValueObject = CodeValuePrimitive | {[key: string]: CodeValueObject};
+        type CodeValueObject = CodeValuePrimitive | { [key: string]: CodeValueObject };
     }
 
     class DllPlugin extends Plugin {
@@ -1824,7 +1895,7 @@ declare namespace webpack {
             /**
              * An object containing `content` and `name`.
              */
-            manifest: { content: string, name: string } | string;
+            manifest: { content: string; name: string } | string;
 
             /**
              * The name where the DLL is exposed.
@@ -1859,11 +1930,13 @@ declare namespace webpack {
         interface Options {
             append?: false | string;
             columns?: boolean;
-            lineToLine?: boolean | {
-                exclude?: Condition | Condition[];
-                include?: Condition | Condition[];
-                test?: Condition | Condition[];
-            };
+            lineToLine?:
+                | boolean
+                | {
+                      exclude?: Condition | Condition[];
+                      include?: Condition | Condition[];
+                      test?: Condition | Condition[];
+                  };
             module?: boolean;
             moduleFilenameTemplate?: string;
             sourceRoot?: string;
@@ -1879,11 +1952,7 @@ declare namespace webpack {
     }
 
     class HashedModuleIdsPlugin extends Plugin {
-        constructor(options?: {
-            hashFunction?: string,
-            hashDigest?: string,
-            hashDigestLength?: number
-        });
+        constructor(options?: { hashFunction?: string; hashDigest?: string; hashDigestLength?: number });
     }
 
     class HotModuleReplacementPlugin extends Plugin {
@@ -1989,11 +2058,13 @@ declare namespace webpack {
             fallbackModuleFilenameTemplate?: string;
             filename?: null | false | string;
             include?: Condition | Condition[];
-            lineToLine?: boolean | {
-                exclude?: Condition | Condition[];
-                include?: Condition | Condition[];
-                test?: Condition | Condition[];
-            };
+            lineToLine?:
+                | boolean
+                | {
+                      exclude?: Condition | Condition[];
+                      include?: Condition | Condition[];
+                      test?: Condition | Condition[];
+                  };
             module?: boolean;
             moduleFilenameTemplate?: string;
             noSources?: boolean;
@@ -2013,7 +2084,7 @@ declare namespace webpack {
 
     namespace optimize {
         /** @deprecated use config.optimization.concatenateModules */
-        class ModuleConcatenationPlugin extends Plugin { }
+        class ModuleConcatenationPlugin extends Plugin {}
         class AggressiveMergingPlugin extends Plugin {
             constructor(options?: AggressiveMergingPlugin.Options);
         }
@@ -2096,19 +2167,22 @@ declare namespace webpack {
                 exclude?: Condition | Condition[];
                 include?: Condition | Condition[];
                 /** Parallelization can speedup your build significantly and is therefore highly recommended. */
-                parallel?: boolean | { cache: boolean, workers: boolean | number };
+                parallel?: boolean | { cache: boolean; workers: boolean | number };
                 sourceMap?: boolean;
                 test?: Condition | Condition[];
             }
         }
     }
 
-    namespace dependencies {
-    }
+    namespace dependencies {}
 
     namespace loader {
         interface Loader extends Function {
-            (this: LoaderContext, source: string | Buffer, sourceMap?: RawSourceMap): string | Buffer | void | undefined;
+            (this: LoaderContext, source: string | Buffer, sourceMap?: RawSourceMap):
+                | string
+                | Buffer
+                | void
+                | undefined;
 
             /**
              * The order of chained loaders are always called from right to left.
@@ -2128,7 +2202,11 @@ declare namespace webpack {
             raw?: boolean;
         }
 
-        type loaderCallback = (err: Error | undefined | null, content?: string | Buffer, sourceMap?: RawSourceMap) => void;
+        type loaderCallback = (
+            err: Error | undefined | null,
+            content?: string | Buffer,
+            sourceMap?: RawSourceMap,
+        ) => void;
 
         interface LoaderContext {
             /**
@@ -2248,7 +2326,10 @@ declare namespace webpack {
              * instance of NormalModule). Use this function if you need to know the source code
              * of another module to generate the result.
              */
-            loadModule(request: string, callback: (err: Error | null, source: string, sourceMap: RawSourceMap, module: Module) => void): any;
+            loadModule(
+                request: string,
+                callback: (err: Error | null, source: string, sourceMap: RawSourceMap, module: Module) => void,
+            ): any;
 
             /**
              * Resolve a request like a require expression.
@@ -2315,7 +2396,15 @@ declare namespace webpack {
              * Target of compilation. Passed from configuration options.
              * Example values: "web", "node"
              */
-            target: 'web' | 'webworker' | 'async-node' | 'node' | 'electron-main' | 'electron-renderer' | 'node-webkit' | string;
+            target:
+                | 'web'
+                | 'webworker'
+                | 'async-node'
+                | 'node'
+                | 'electron-main'
+                | 'electron-renderer'
+                | 'node-webkit'
+                | string;
 
             /**
              * This boolean is set to true when this is compiled by webpack.
@@ -2380,9 +2469,11 @@ declare namespace webpack {
 
         function asString(str: string | string[]): string;
 
-        function getModulesArrayBounds(modules: ReadonlyArray<{
-            id: string | number;
-        }>): [number, number] | false;
+        function getModulesArrayBounds(
+            modules: ReadonlyArray<{
+                id: string | number;
+            }>,
+        ): [number, number] | false;
 
         function renderChunkModules(
             chunk: compilation.Chunk,

--- a/types/webpack/test/index.ts
+++ b/types/webpack/test/index.ts
@@ -2,9 +2,7 @@ import webpack = require('webpack');
 import { Tapable } from 'tapable';
 import { RawSourceMap } from 'source-map';
 
-const {
-    optimize,
-} = webpack;
+const { optimize } = webpack;
 
 let plugins: webpack.Plugin[];
 
@@ -16,9 +14,7 @@ let plugins: webpack.Plugin[];
  * optimize
  */
 
-const {
-    AggressiveMergingPlugin,
-} = optimize;
+const { AggressiveMergingPlugin } = optimize;
 
 plugins = [
     new AggressiveMergingPlugin(),
@@ -35,12 +31,12 @@ let rule: webpack.Rule;
 let plugin: webpack.Plugin;
 declare const __dirname: string;
 
-rule = { test: /\.png$/, loader: "url-loader?mimetype=image/png" };
+rule = { test: /\.png$/, loader: 'url-loader?mimetype=image/png' };
 
 rule = {
     test: /\.png$/,
-    loader: "url-loader",
-    query: { mimetype: "image/png" }
+    loader: 'url-loader',
+    query: { mimetype: 'image/png' },
 };
 
 //
@@ -48,69 +44,72 @@ rule = {
 //
 
 configuration = {
-    entry: () => './demo'
+    entry: () => './demo',
 };
 
 configuration = {
-    entry: () => ['./demo', './demo2']
+    entry: () => ['./demo', './demo2'],
 };
 
 configuration = {
     entry: () => ({
-        p1: "./page1",
-        p2: "./page2",
-        p3: "./page3"
-    })
+        p1: './page1',
+        p2: './page2',
+        p3: './page3',
+    }),
 };
 
 configuration = {
-    entry: () => new Promise((resolve) => resolve('./demo'))
+    entry: () => new Promise(resolve => resolve('./demo')),
 };
 
 configuration = {
-    entry: () => new Promise((resolve) => resolve(['./demo', './demo2']))
+    entry: () => new Promise(resolve => resolve(['./demo', './demo2'])),
 };
 
 configuration = {
-    entry: () => new Promise((resolve) => resolve({
-        p1: "./page1",
-        p2: "./page2",
-        p3: "./page3"
-    }))
+    entry: () =>
+        new Promise(resolve =>
+            resolve({
+                p1: './page1',
+                p2: './page2',
+                p3: './page3',
+            }),
+        ),
 };
 
 //
 // https://webpack.js.org/configuration/externals/
 //
 configuration = {
-    externals : {
-        react: 'react'
+    externals: {
+        react: 'react',
     },
 };
 
 configuration = {
-    externals : {
-        lodash : {
+    externals: {
+        lodash: {
             commonjs: 'lodash',
             amd: 'lodash',
-            root: '_' // indicates global variable
-        }
-      },
+            root: '_', // indicates global variable
+        },
+    },
 };
 
 configuration = {
-    externals : {
-        subtract : {
-            root: ['math', 'subtract']
-        }
-    }
+    externals: {
+        subtract: {
+            root: ['math', 'subtract'],
+        },
+    },
 };
 
 configuration = {
     externals: [
         // Disable TSLint for allowing non-arrow functions
         /* tslint:disable-next-line */
-        function(context, request, callback) {
+        function (context, request, callback) {
             /* tslint:disable-next-line */
             if (/^yourregex$/.test(request)) {
                 // Disable TSLint for allowing non-arrow functions
@@ -159,41 +158,41 @@ configuration = {
             // String
             react: 'react',
             // Object
-            lodash : {
+            lodash: {
                 commonjs: 'lodash',
                 amd: 'lodash',
-                root: '_' // indicates global variable
+                root: '_', // indicates global variable
             },
             // Array
-            subtract: ['./math', 'subtract']
-            },
-            // Disable TSLint for allowing non-arrow functions
-            /* tslint:disable-next-line */
-            function(context, request, callback) {
-              if (/^yourregex$/.test(request)) {
+            subtract: ['./math', 'subtract'],
+        },
+        // Disable TSLint for allowing non-arrow functions
+        /* tslint:disable-next-line */
+        function (context, request, callback) {
+            if (/^yourregex$/.test(request)) {
                 // Disable TSLint for bypassing 'no-void-expression' to align with Webpack documentation
                 /* tslint:disable-next-line */
                 return callback(null, 'commonjs ' + request);
-              }
-              callback(null, {});
-            },
-            // Regex
-            /^(jquery|\$)$/i
-    ]
+            }
+            callback(null, {});
+        },
+        // Regex
+        /^(jquery|\$)$/i,
+    ],
 };
 
 configuration = {
     externals: [
-        "add",
+        'add',
         {
             subtract: {
-                root: "subtract",
-                commonjs2: "./subtract",
-                commonjs: ["./math", "subtract"],
-                amd: "subtract"
-            }
-        }
-    ]
+                root: 'subtract',
+                commonjs2: './subtract',
+                commonjs: ['./math', 'subtract'],
+                amd: 'subtract',
+            },
+        },
+    ],
 };
 
 //
@@ -202,25 +201,45 @@ configuration = {
 
 configuration = {
     entry: {
-        p1: "./page1",
-        p2: "./page2",
-        p3: "./page3"
+        p1: './page1',
+        p2: './page2',
+        p3: './page3',
     },
     output: {
-        filename: "[name].entry.chunk.js"
-    }
+        filename: '[name].entry.chunk.js',
+    },
 };
 
 configuration = {
     entry: {
-        p1: "./page1",
-        p2: "./page2",
-        p3: "./page3",
-        ap1: "./admin/page1",
-        ap2: "./admin/page2"
+        p1: './page1',
+        p2: './page2',
+        p3: './page3',
+        ap1: './admin/page1',
+        ap2: './admin/page2',
     },
     output: {
-        filename: "[name].js"
+        filename: '[name].js',
+    },
+};
+
+//
+// https://webpack.js.org/configuration/entry-context/#entry
+//
+
+configuration = {
+    entry: {
+        p1: {
+            import: './page1',
+            dependOn: 'p2',
+        },
+        p2: {
+            import: './page2',
+            filename: 'pages/page2.js',
+        },
+        p3: {
+            import: './page3',
+        },
     },
 };
 
@@ -230,52 +249,44 @@ configuration = {
 
 configuration = {
     output: {
-        path: path.join(__dirname, "assets", "[hash]"),
-        publicPath: "assets/[hash]/",
-        filename: "output.[hash].bundle.js",
-        chunkFilename: "[id].[hash].bundle.js",
+        path: path.join(__dirname, 'assets', '[hash]'),
+        publicPath: 'assets/[hash]/',
+        filename: 'output.[hash].bundle.js',
+        chunkFilename: '[id].[hash].bundle.js',
         hashFunction: 'sha256',
         hashDigestLength: 64,
-    }
+    },
 };
 
-configuration = { output: { chunkFilename: "[chunkhash].bundle.js" } };
+configuration = { output: { chunkFilename: '[chunkhash].bundle.js' } };
 
 //
 // https://webpack.github.io/docs/configuration.html
 //
 
 configuration = {
-    entry: [
-        "./entry1",
-        "./entry2"
-    ]
+    entry: ['./entry1', './entry2'],
 };
 
 configuration = {
-    devtool: "inline-source-map"
+    devtool: 'inline-source-map',
 };
 
 configuration = {
-    devtool: false
+    devtool: false,
 };
 
 configuration = {
     resolve: {
-        modules: [__dirname]
-    }
+        modules: [__dirname],
+    },
 };
 
 rule = {
     test: /\.jsx$/,
-    include: [
-        path.resolve(__dirname, "app/src"),
-        path.resolve(__dirname, "app/test")
-    ],
-    exclude: [
-        path.resolve(__dirname, "node_modules")
-    ],
-    loader: "babel-loader"
+    include: [path.resolve(__dirname, 'app/src'), path.resolve(__dirname, 'app/test')],
+    exclude: [path.resolve(__dirname, 'node_modules')],
+    loader: 'babel-loader',
 };
 
 rule = {
@@ -283,103 +294,91 @@ rule = {
     resourceQuery: /module/,
     loader: 'css-loader',
     options: {
-        modules: true
-    }
+        modules: true,
+    },
 };
 
 declare const require: any;
 declare const path: any;
 configuration = {
-  plugins: [
-    function apply(this: webpack.Compiler, compiler: webpack.Compiler) {
-      const prevTimestamps = new Map<string, number>();
-      const startTime = Date.now();
+    plugins: [
+        function apply(this: webpack.Compiler, compiler: webpack.Compiler) {
+            const prevTimestamps = new Map<string, number>();
+            const startTime = Date.now();
 
-      this.hooks.emit.tap(
-        'SomePlugin',
-        (compilation: webpack.compilation.Compilation) => {
-          for (const filepath in compilation.fileTimestamps.keys()) {
-            const prevTimestamp = prevTimestamps.get(filepath) || startTime;
-            const newTimestamp =
-              compilation.fileTimestamps.get(filepath) || Infinity;
-            if (prevTimestamp < newTimestamp) {
-              this.inputFileSystem.readFileSync(filepath).toString('utf-8');
-            }
-          }
+            this.hooks.emit.tap('SomePlugin', (compilation: webpack.compilation.Compilation) => {
+                for (const filepath in compilation.fileTimestamps.keys()) {
+                    const prevTimestamp = prevTimestamps.get(filepath) || startTime;
+                    const newTimestamp = compilation.fileTimestamps.get(filepath) || Infinity;
+                    if (prevTimestamp < newTimestamp) {
+                        this.inputFileSystem.readFileSync(filepath).toString('utf-8');
+                    }
+                }
+            });
+
+            compiler.hooks.afterCompile.tap('SomePlugin', (compilation: webpack.compilation.Compilation) => {
+                ['path/to/extra/dep', 'another/extra/dep'].forEach(path => compilation.fileDependencies.add(path));
+            });
+
+            this.hooks.afterEmit.tapAsync('afterEmit', (stats, callback) => {
+                this.outputFileSystem.writeFile(
+                    path.join(__dirname, '...', 'stats.json'),
+                    JSON.stringify(stats.getStats().toJson()),
+                    callback,
+                );
+            });
+
+            this.hooks.beforeRun.tap('SomePlugin', (compiler: webpack.Compiler) => {});
+            this.hooks.run.tap('SomePlugin', (compiler: webpack.Compiler) => {});
+
+            compiler.hooks.compilation.tap('SomePlugin', compilation => {
+                const { mainTemplate } = compilation;
+                mainTemplate.requireFn.trimLeft();
+                mainTemplate.outputOptions.crossOriginLoading;
+                mainTemplate.hooks.require.tap('SomePlugin', resource => {
+                    return `console.log('A module is required'); ${resource}`;
+                });
+                mainTemplate.hooks.requireExtensions.tap('SomePlugin', resource => {
+                    return resource.trimLeft();
+                });
+                mainTemplate.hooks.requireEnsure.tap(
+                    'SomePlugin',
+                    (resource, chunk, hash, chunkIdExpression: string) => {
+                        mainTemplate.renderRequireFunctionForModule(hash, chunk, 'moduleId');
+                        mainTemplate.renderAddModule(hash, chunk, 'moduleId', JSON.stringify({ ok: true }));
+                        return `${resource};/* additional requests for ${chunkIdExpression} */`;
+                    },
+                );
+                mainTemplate.hooks.localVars.tap('SomePlugin', resource => {
+                    return resource.trimLeft();
+                });
+                mainTemplate.hooks.afterStartup.tap('SomePlugin', (resource, chunk) => {
+                    if (chunk.name) {
+                        return `/* In named chunk: ${chunk.name} */ ${resource};`;
+                    } else {
+                        return resource;
+                    }
+                });
+                mainTemplate.hooks.hash.tap('SomePlugin', hash => {
+                    hash.update('SomePlugin');
+                    hash.update('1');
+                });
+                mainTemplate.hooks.hashForChunk.tap('SomePlugin', (hash, chunk) => {
+                    if (chunk.name) {
+                        hash.update(chunk.name);
+                    }
+                });
+                if (mainTemplate.hooks.jsonpScript == null) {
+                    return;
+                }
+                mainTemplate.hooks.jsonpScript.tap('SomePlugin', (source, chunk, hash) => {
+                    source.trimLeft();
+                    hash.trimLeft();
+                    return chunk.name;
+                });
+            });
         },
-      );
-
-      compiler.hooks.afterCompile.tap(
-        'SomePlugin',
-        (compilation: webpack.compilation.Compilation) => {
-          ['path/to/extra/dep', 'another/extra/dep'].forEach(path =>
-            compilation.fileDependencies.add(path),
-          );
-        },
-      );
-
-      this.hooks.afterEmit.tapAsync('afterEmit', (stats, callback) => {
-        this.outputFileSystem.writeFile(
-          path.join(__dirname, '...', 'stats.json'),
-          JSON.stringify(stats.getStats().toJson()),
-          callback,
-        );
-      });
-
-      this.hooks.beforeRun.tap(
-        'SomePlugin',
-        (compiler: webpack.Compiler) => {},
-      );
-      this.hooks.run.tap('SomePlugin', (compiler: webpack.Compiler) => {});
-
-      compiler.hooks.compilation.tap('SomePlugin', compilation => {
-        const { mainTemplate } = compilation;
-        mainTemplate.requireFn.trimLeft();
-        mainTemplate.outputOptions.crossOriginLoading;
-        mainTemplate.hooks.require.tap('SomePlugin', resource => {
-            return `console.log('A module is required'); ${resource}`;
-        });
-        mainTemplate.hooks.requireExtensions.tap('SomePlugin', resource => {
-          return resource.trimLeft();
-        });
-        mainTemplate.hooks.requireEnsure.tap('SomePlugin', (resource, chunk, hash, chunkIdExpression: string) => {
-          mainTemplate.renderRequireFunctionForModule(hash, chunk, 'moduleId');
-          mainTemplate.renderAddModule(hash, chunk, 'moduleId', JSON.stringify({ ok: true }));
-          return `${resource};/* additional requests for ${chunkIdExpression} */`;
-        });
-        mainTemplate.hooks.localVars.tap('SomePlugin', resource => {
-          return resource.trimLeft();
-        });
-        mainTemplate.hooks.afterStartup.tap('SomePlugin', (resource, chunk) => {
-            if (chunk.name) {
-                return `/* In named chunk: ${chunk.name} */ ${resource};`;
-            } else {
-                return resource;
-            }
-        });
-        mainTemplate.hooks.hash.tap('SomePlugin', hash => {
-            hash.update('SomePlugin');
-            hash.update('1');
-        });
-        mainTemplate.hooks.hashForChunk.tap('SomePlugin', (hash, chunk) => {
-            if (chunk.name) {
-                hash.update(chunk.name);
-            }
-        });
-        if (mainTemplate.hooks.jsonpScript == null) {
-          return;
-        }
-        mainTemplate.hooks.jsonpScript.tap(
-          'SomePlugin',
-          (source, chunk, hash) => {
-            source.trimLeft();
-            hash.trimLeft();
-            return chunk.name;
-          },
-        );
-      });
-    },
-  ],
+    ],
 };
 
 //
@@ -407,38 +406,36 @@ plugin = new webpack.ContextReplacementPlugin(
     resourceRegExp,
     newContentResource,
     newContentRecursive,
-    newContentRegExp);
-plugin = new webpack.ContextReplacementPlugin(
-    resourceRegExp,
-    newContentResource,
-    newContentRecursive);
-plugin = new webpack.ContextReplacementPlugin(
-    resourceRegExp,
-    newContentResource);
+    newContentRegExp,
+);
+plugin = new webpack.ContextReplacementPlugin(resourceRegExp, newContentResource, newContentRecursive);
+plugin = new webpack.ContextReplacementPlugin(resourceRegExp, newContentResource);
 plugin = new webpack.ContextReplacementPlugin(resourceRegExp);
 plugin = new webpack.DllPlugin({
     context: 'dir-context',
     name: 'dll-name',
-    path: 'manifest-path'
+    path: 'manifest-path',
 });
-plugin = new webpack.DllPlugin([{
-    context: 'dir-context',
-    name: 'dll-name',
-    path: 'manifest-path'
-}]);
+plugin = new webpack.DllPlugin([
+    {
+        context: 'dir-context',
+        name: 'dll-name',
+        path: 'manifest-path',
+    },
+]);
 plugin = new webpack.DllReferencePlugin({
     content: 'dll content',
     context: 'dir-context',
     manifest: {
         content: 'dll content',
-        name: 'dll name'
+        name: 'dll name',
     },
     name: 'dll name',
     scope: 'dll prefix',
-    sourceType: 'var'
+    sourceType: 'var',
 });
 plugin = new webpack.ExternalsPlugin('this', 'react');
-plugin = new webpack.ExternalsPlugin('this', {jquery: 'jQuery'});
+plugin = new webpack.ExternalsPlugin('this', { jquery: 'jQuery' });
 plugin = new webpack.ExternalsPlugin('this', (context, request, callback) => {
     if (request === 'jquery') {
         callback(null, 'jQuery');
@@ -452,7 +449,7 @@ plugin = new webpack.PrefetchPlugin(context, request);
 plugin = new webpack.PrefetchPlugin(request);
 plugin = new webpack.BannerPlugin('banner');
 plugin = new webpack.BannerPlugin({
-    banner: 'banner'
+    banner: 'banner',
 });
 plugin = new webpack.BannerPlugin({
     banner: 'banner',
@@ -460,7 +457,7 @@ plugin = new webpack.BannerPlugin({
     exclude: /index/,
     include: 'test',
     raw: false,
-    test: ['test', /index/]
+    test: ['test', /index/],
 });
 plugin = new webpack.optimize.DedupePlugin();
 plugin = new webpack.optimize.LimitChunkCountPlugin(options);
@@ -470,13 +467,13 @@ plugin = new webpack.optimize.OccurrenceOrderPlugin(preferEntry);
 plugin = new webpack.optimize.UglifyJsPlugin(options);
 plugin = new webpack.optimize.UglifyJsPlugin();
 plugin = new webpack.optimize.UglifyJsPlugin({
-    parallel: true
+    parallel: true,
 });
 plugin = new webpack.optimize.UglifyJsPlugin({
     parallel: {
         cache: true,
-        workers: 2
-    }
+        workers: 2,
+    },
 });
 plugin = new webpack.optimize.UglifyJsPlugin({
     compress: {
@@ -492,65 +489,51 @@ plugin = new webpack.optimize.UglifyJsPlugin({
     beautify: true,
     test: 'foo',
     exclude: /node_modules/,
-    include: 'test'
+    include: 'test',
 });
 plugin = new webpack.optimize.UglifyJsPlugin({
     mangle: {
-        reserved: ['$super', '$', 'exports', 'require']
-    }
+        reserved: ['$super', '$', 'exports', 'require'],
+    },
 });
 plugin = new webpack.optimize.UglifyJsPlugin({
-    comments: (astNode: any, comment: any) => false
+    comments: (astNode: any, comment: any) => false,
 });
 plugin = new webpack.DefinePlugin(definitions);
 plugin = new webpack.DefinePlugin({
-    VERSION: JSON.stringify("5fa3b9"),
+    VERSION: JSON.stringify('5fa3b9'),
     BROWSER_SUPPORTS_HTML5: true,
-    TWO: "1+1",
-    "typeof window": JSON.stringify("object"),
+    TWO: '1+1',
+    'typeof window': JSON.stringify('object'),
     OBJECT: {
-        foo: "bar",
+        foo: 'bar',
         bar: {
-            DEEP_RUNTIME: webpack.DefinePlugin.runtimeValue(
-                () => JSON.stringify("DEEP_RUUNTIME")
-            ),
+            DEEP_RUNTIME: webpack.DefinePlugin.runtimeValue(() => JSON.stringify('DEEP_RUUNTIME')),
             foofoo: {
-                barbar: false
-            }
-        }
+                barbar: false,
+            },
+        },
     },
-    RUNTIME: webpack.DefinePlugin.runtimeValue(
-        () => JSON.stringify("TEST_VALUE")
-    )
+    RUNTIME: webpack.DefinePlugin.runtimeValue(() => JSON.stringify('TEST_VALUE')),
 });
 plugin = new webpack.DefinePlugin({
-    TEST_RUNTIME: webpack.DefinePlugin.runtimeValue(
-        ({ module }) => JSON.stringify(module.context)
-    )
+    TEST_RUNTIME: webpack.DefinePlugin.runtimeValue(({ module }) => JSON.stringify(module.context)),
 });
 plugin = new webpack.DefinePlugin({
-    TEST_RUNTIME: webpack.DefinePlugin.runtimeValue(
-        () => JSON.stringify("TEST_VALUE"),
-        ["value.txt"]
-    )
+    TEST_RUNTIME: webpack.DefinePlugin.runtimeValue(() => JSON.stringify('TEST_VALUE'), ['value.txt']),
 });
 plugin = new webpack.DefinePlugin({
-    TEST_RUNTIME: webpack.DefinePlugin.runtimeValue(
-        () => JSON.stringify("TEST_VALUE"),
-        true
-    )
+    TEST_RUNTIME: webpack.DefinePlugin.runtimeValue(() => JSON.stringify('TEST_VALUE'), true),
 });
 plugin = new webpack.ProvidePlugin(definitions);
 plugin = new webpack.ProvidePlugin({
-    $: "jquery"
+    $: 'jquery',
 });
 plugin = new webpack.SourceMapDevToolPlugin({
     //// asset matching
     test: /\.js$/,
     // include: Condition | Condition[],
-    exclude: [
-        /node_modules/
-    ],
+    exclude: [/node_modules/],
     //
     //// file and reference
     filename: null, // | string
@@ -562,7 +545,7 @@ plugin = new webpack.SourceMapDevToolPlugin({
     //// quality/performance
     module: true,
     columns: true,
-    lineToLine: false // | { test?: Condition | Condition[], ... }
+    lineToLine: false, // | { test?: Condition | Condition[], ... }
 });
 plugin = new webpack.EvalSourceMapDevToolPlugin(false);
 plugin = new webpack.HotModuleReplacementPlugin();
@@ -570,36 +553,37 @@ plugin = new webpack.ExtendedAPIPlugin();
 plugin = new webpack.NoEmitOnErrorsPlugin();
 plugin = new webpack.WatchIgnorePlugin(paths);
 plugin = new webpack.LoaderOptionsPlugin({
-    debug: true
+    debug: true,
 });
 plugin = new webpack.EnvironmentPlugin(['a', 'b']);
 plugin = new webpack.EnvironmentPlugin({ a: true, b: 'c' });
-plugin = new webpack.ProgressPlugin((percent: number, message: string) => { });
-plugin = new webpack.ProgressPlugin((percent: number, message: string, moduleProgress?: string, activeModules?: string, moduleName?: string) => { });
+plugin = new webpack.ProgressPlugin((percent: number, message: string) => {});
+plugin = new webpack.ProgressPlugin(
+    (percent: number, message: string, moduleProgress?: string, activeModules?: string, moduleName?: string) => {},
+);
 plugin = new webpack.ProgressPlugin({ profile: true });
 plugin = new webpack.ProgressPlugin({ activeModules: true, entries: false });
 plugin = new webpack.HashedModuleIdsPlugin();
 plugin = new webpack.HashedModuleIdsPlugin({
     hashFunction: 'sha256',
     hashDigest: 'hex',
-    hashDigestLength: 20
+    hashDigestLength: 20,
 });
-plugin = new webpack.SingleEntryPlugin(
-    '/home',
-    './main.js',
-    'main'
-);
+plugin = new webpack.SingleEntryPlugin('/home', './main.js', 'main');
 
 //
 // http://webpack.github.io/docs/node.js-api.html
 //
 
 // returns a Compiler instance
-webpack({
-    // configuration
-}, (err, stats) => {
-    // ...
-});
+webpack(
+    {
+        // configuration
+    },
+    (err, stats) => {
+        // ...
+    },
+);
 
 // returns a Compiler instance
 let compiler = webpack({
@@ -610,75 +594,90 @@ compiler.run((err, stats) => {
     // ...
 });
 // or
-compiler.watch({ // watch options:
-    aggregateTimeout: 300, // wait so long for more changes
-    poll: true // use polling instead of native watchers
-    // pass a number to set the polling interval
-}, (err, stats) => {
-    // ...
-});
+compiler.watch(
+    {
+        // watch options:
+        aggregateTimeout: 300, // wait so long for more changes
+        poll: true, // use polling instead of native watchers
+        // pass a number to set the polling interval
+    },
+    (err, stats) => {
+        // ...
+    },
+);
 // or
-compiler.watch({ // watch options:
-    ignored: 'foo/**/*'
-}, (err, stats) => {
-    // ...
-});
+compiler.watch(
+    {
+        // watch options:
+        ignored: 'foo/**/*',
+    },
+    (err, stats) => {
+        // ...
+    },
+);
 // or
-compiler.watch({ // watch options:
-    ignored: /node_modules/
-}, (err, stats) => {
-    // ...
-});
+compiler.watch(
+    {
+        // watch options:
+        ignored: /node_modules/,
+    },
+    (err, stats) => {
+        // ...
+    },
+);
 
 declare function handleFatalError(err: Error): void;
 declare function handleSoftErrors(errs: string[]): void;
 declare function handleWarnings(errs: string[]): void;
 declare function successfullyCompiled(): void;
 
-webpack({
-    // configuration
-}, (err, stats) => {
-    if (err) {
-        handleFatalError(err);
-        return;
-    }
-    const jsonStats = stats.toJson();
-    const jsonStatsWithAllOptions = stats.toJson({
-        assets: true,
-        assetsSort: "field",
-        builtAt: true,
-        cached: true,
-        children: true,
-        chunks: true,
-        chunkGroups: true,
-        chunkModules: true,
-        chunkOrigins: true,
-        chunksSort: "field",
-        context: "../src/",
-        errors: true,
-        errorDetails: true,
-        hash: true,
-        modules: true,
-        modulesSort: "field",
-        publicPath: true,
-        reasons: true,
-        source: true,
-        timings: true,
-        version: true,
-        warnings: true,
-        warningsFilter: ["filter", /filter/],
-        excludeAssets: ["filter", "excluded"]
-    });
+webpack(
+    {
+        // configuration
+    },
+    (err, stats) => {
+        if (err) {
+            handleFatalError(err);
+            return;
+        }
+        const jsonStats = stats.toJson();
+        const jsonStatsWithAllOptions = stats.toJson({
+            assets: true,
+            assetsSort: 'field',
+            builtAt: true,
+            cached: true,
+            children: true,
+            chunks: true,
+            chunkGroups: true,
+            chunkModules: true,
+            chunkOrigins: true,
+            chunksSort: 'field',
+            context: '../src/',
+            errors: true,
+            errorDetails: true,
+            hash: true,
+            modules: true,
+            modulesSort: 'field',
+            publicPath: true,
+            reasons: true,
+            source: true,
+            timings: true,
+            version: true,
+            warnings: true,
+            warningsFilter: ['filter', /filter/],
+            excludeAssets: ['filter', 'excluded'],
+        });
 
-    if (jsonStats.errors.length > 0) {
-        handleSoftErrors(jsonStats.errors);
-        return;
-    }
-    if (jsonStats.warnings.length > 0) {
-        handleWarnings(jsonStats.warnings);
-    }
-    successfullyCompiled();
-});
+        if (jsonStats.errors.length > 0) {
+            handleSoftErrors(jsonStats.errors);
+            return;
+        }
+        if (jsonStats.warnings.length > 0) {
+            handleWarnings(jsonStats.warnings);
+        }
+        successfullyCompiled();
+    },
+);
 
 declare const fs: any;
 
@@ -686,7 +685,7 @@ compiler = webpack({});
 compiler.outputFileSystem = fs;
 compiler.run((err, stats) => {
     // ...
-    const fileContent = fs.readFileSync("...");
+    const fileContent = fs.readFileSync('...');
 });
 
 //
@@ -695,13 +694,10 @@ compiler.run((err, stats) => {
 
 rule = {
     test: {
-        or: [
-            require.resolve("./a"),
-            require.resolve("./c"),
-        ]
+        or: [require.resolve('./a'), require.resolve('./c')],
     },
-    loader: "./loader",
-    options: "third"
+    loader: './loader',
+    options: 'third',
 };
 
 configuration = {
@@ -711,47 +707,38 @@ configuration = {
                 oneOf: [
                     {
                         test: {
-                            and: [
-                                /a.\.js$/,
-                                /b\.js$/
-                            ]
+                            and: [/a.\.js$/, /b\.js$/],
                         },
-                        loader: "./loader?first"
+                        loader: './loader?first',
                     },
                     {
-                        test: [
-                            require.resolve("./a"),
-                            require.resolve("./c"),
-                        ],
-                        issuer: require.resolve("./b"),
+                        test: [require.resolve('./a'), require.resolve('./c')],
+                        issuer: require.resolve('./b'),
                         use: [
-                            "./loader?second-1",
+                            './loader?second-1',
                             {
-                                loader: "./loader",
-                                options: "second-2"
+                                loader: './loader',
+                                options: 'second-2',
                             },
                             {
-                                loader: "./loader",
+                                loader: './loader',
                                 options: {
-                                    get: () => "second-3"
-                                }
-                            }
-                        ]
+                                    get: () => 'second-3',
+                                },
+                            },
+                        ],
                     },
                     {
                         test: {
-                            or: [
-                                require.resolve("./a"),
-                                require.resolve("./c"),
-                            ]
+                            or: [require.resolve('./a'), require.resolve('./c')],
                         },
-                        loader: "./loader",
-                        options: "third"
-                    }
-                ]
-            }
-        ]
-    }
+                        loader: './loader',
+                        options: 'third',
+                    },
+                ],
+            },
+        ],
+    },
 };
 
 class TestResolvePlugin implements webpack.ResolvePlugin {
@@ -780,8 +767,8 @@ function loader(this: webpack.loader.LoaderContext, source: string | Buffer, sou
 
     this.addDependency('');
 
-    this.loadModule('path', (err: Error | null, result: string, sourceMap: RawSourceMap, module: webpack.Module) => { });
-    this.resolve('context', 'request', (err: Error, result: string) => { });
+    this.loadModule('path', (err: Error | null, result: string, sourceMap: RawSourceMap, module: webpack.Module) => {});
+    this.resolve('context', 'request', (err: Error, result: string) => {});
 
     this.emitWarning('warning message');
     this.emitWarning(new Error('warning message'));
@@ -793,26 +780,25 @@ function loader(this: webpack.loader.LoaderContext, source: string | Buffer, sou
 }
 
 (loader as webpack.loader.Loader).raw = true;
-(loader as webpack.loader.Loader).pitch = (remainingRequest: string, precedingRequest: string, data: any) => { };
+(loader as webpack.loader.Loader).pitch = (remainingRequest: string, precedingRequest: string, data: any) => {};
 const loaderRef: webpack.loader.Loader = loader;
 console.log(loaderRef.raw === true);
 
 /**
  * New v4 tests
  */
+configuration = {};
+
 configuration = {
+    mode: 'development',
 };
 
 configuration = {
-    mode: "development"
+    mode: 'production',
 };
 
 configuration = {
-    mode: "production"
-};
-
-configuration = {
-    mode: "development",
+    mode: 'development',
     optimization: {
         removeAvailableModules: true,
         removeEmptyChunks: true,
@@ -828,14 +814,14 @@ configuration = {
         noEmitOnErrors: false,
         namedModules: true,
         namedChunks: true,
-        nodeEnv: "development",
+        nodeEnv: 'development',
         minimize: false,
-        portableRecords: false
-    }
+        portableRecords: false,
+    },
 };
 
 configuration = {
-    mode: "production",
+    mode: 'production',
     optimization: {
         removeAvailableModules: true,
         removeEmptyChunks: true,
@@ -846,19 +832,19 @@ configuration = {
         usedExports: true,
         sideEffects: true,
         concatenateModules: true,
-        splitChunks: { chunks: "async", minChunks: 2 },
+        splitChunks: { chunks: 'async', minChunks: 2 },
         runtimeChunk: true,
         noEmitOnErrors: true,
         namedModules: false,
         namedChunks: false,
-        nodeEnv: "production",
+        nodeEnv: 'production',
         minimize: true,
-        portableRecords: true
-    }
+        portableRecords: true,
+    },
 };
 
 configuration = {
-    mode: "production",
+    mode: 'production',
     optimization: {
         splitChunks: {
             minSize: 30000,
@@ -866,72 +852,62 @@ configuration = {
             cacheGroups: {
                 default: false,
                 vendor: {
-                    chunks: "initial",
-                    test: "node_modules",
-                    name: "vendor",
+                    chunks: 'initial',
+                    test: 'node_modules',
+                    name: 'vendor',
                     minSize: 30000,
                     maxSize: 50000,
-                    enforce: true
-                }
-            }
-        }
+                    enforce: true,
+                },
+            },
+        },
     },
 };
 
 configuration = {
-    mode: "production",
+    mode: 'production',
     optimization: {
         splitChunks: {
             cacheGroups: {
                 common: {
                     name: 'common',
                     chunks(chunk: webpack.compilation.Chunk) {
-                        const allowedChunks = [
-                            'renderer',
-                            'component-window',
-                        ];
+                        const allowedChunks = ['renderer', 'component-window'];
                         return allowedChunks.indexOf(chunk.name) >= 0;
                     },
-                    minChunks: 2
-                }
-            }
-        }
+                    minChunks: 2,
+                },
+            },
+        },
     },
 };
 
-plugin = new webpack.SplitChunksPlugin({ chunks: "async", minChunks: 2 });
+plugin = new webpack.SplitChunksPlugin({ chunks: 'async', minChunks: 2 });
 
 class SingleEntryDependency extends webpack.compilation.Dependency {}
 class MultiEntryDependency extends webpack.compilation.Dependency {}
 class MultiModuleFactory extends Tapable {}
 class MultiEntryPlugin extends webpack.Plugin {
     apply(compiler: webpack.Compiler) {
-        compiler.hooks.compilation.tap(
-            "MultiEntryPlugin",
-            (compilation, { normalModuleFactory }) => {
-                compilation.dependencyFactories.set(MultiEntryDependency, new MultiModuleFactory());
-            }
-        );
-        compiler.hooks.make.tapAsync(
-            "MultiEntryPlugin",
-            (compilation, callback) => {
-                const dep = new MultiEntryPlugin();
-                compilation.addEntry("", {}, "", () => {});
-            }
-        );
+        compiler.hooks.compilation.tap('MultiEntryPlugin', (compilation, { normalModuleFactory }) => {
+            compilation.dependencyFactories.set(MultiEntryDependency, new MultiModuleFactory());
+        });
+        compiler.hooks.make.tapAsync('MultiEntryPlugin', (compilation, callback) => {
+            const dep = new MultiEntryPlugin();
+            compilation.addEntry('', {}, '', () => {});
+        });
     }
 }
 
 class IgnorePlugin extends webpack.Plugin {
-    checkIgnore(result: any) {
-    }
+    checkIgnore(result: any) {}
 
     apply(compiler: webpack.Compiler) {
-        compiler.hooks.normalModuleFactory.tap("IgnorePlugin", nmf => {
-            nmf.hooks.beforeResolve.tap("IgnorePlugin", this.checkIgnore);
+        compiler.hooks.normalModuleFactory.tap('IgnorePlugin', nmf => {
+            nmf.hooks.beforeResolve.tap('IgnorePlugin', this.checkIgnore);
         });
-        compiler.hooks.contextModuleFactory.tap("IgnorePlugin", cmf => {
-            cmf.hooks.beforeResolve.tap("IgnorePlugin", this.checkIgnore);
+        compiler.hooks.contextModuleFactory.tap('IgnorePlugin', cmf => {
+            cmf.hooks.beforeResolve.tap('IgnorePlugin', this.checkIgnore);
         });
     }
 }
@@ -940,39 +916,30 @@ class DllEntryDependency extends webpack.compilation.Dependency {}
 class DllModuleFactory extends Tapable {}
 class DllEntryPlugin extends webpack.Plugin {
     apply(compiler: webpack.Compiler) {
-        compiler.hooks.compilation.tap(
-            "DllEntryPlugin",
-            (compilation, { normalModuleFactory }) => {
-                const dllModuleFactory = new DllModuleFactory();
-                compilation.dependencyFactories.set(
-                    DllEntryDependency,
-                    dllModuleFactory
-                );
-                compilation.dependencyFactories.set(
-                    SingleEntryDependency,
-                    normalModuleFactory
-                );
-            }
-        );
-        compiler.hooks.make.tapAsync("DllEntryPlugin", (compilation, callback) => {
-            compilation.addEntry("", new DllEntryDependency(), "", callback);
+        compiler.hooks.compilation.tap('DllEntryPlugin', (compilation, { normalModuleFactory }) => {
+            const dllModuleFactory = new DllModuleFactory();
+            compilation.dependencyFactories.set(DllEntryDependency, dllModuleFactory);
+            compilation.dependencyFactories.set(SingleEntryDependency, normalModuleFactory);
+        });
+        compiler.hooks.make.tapAsync('DllEntryPlugin', (compilation, callback) => {
+            compilation.addEntry('', new DllEntryDependency(), '', callback);
         });
     }
 }
 
 class BannerPlugin extends webpack.Plugin {
     apply(compiler: webpack.Compiler) {
-        compiler.hooks.compilation.tap("BannerPlugin", compilation  => {
-            compilation.hooks.optimizeChunkAssets.tap("BannerPlugin", chunks => {
+        compiler.hooks.compilation.tap('BannerPlugin', compilation => {
+            compilation.hooks.optimizeChunkAssets.tap('BannerPlugin', chunks => {
                 for (const chunk of chunks) {
                     if (!chunk.canBeInitial()) {
                         continue;
                     }
                     for (const file of chunk.files) {
-                        const pathA = compilation.getPath("", {});
-                        const pathB = compilation.getPath("", {
-                            contentHash: "abc",
-                            contentHashType: "javascript",
+                        const pathA = compilation.getPath('', {});
+                        const pathB = compilation.getPath('', {
+                            contentHash: 'abc',
+                            contentHashType: 'javascript',
                         });
                     }
                 }
@@ -983,29 +950,23 @@ class BannerPlugin extends webpack.Plugin {
 
 class DefinePlugin extends webpack.Plugin {
     apply(compiler: webpack.Compiler) {
-        compiler.hooks.compilation.tap(
-            "DefinePlugin",
-            (compilation, { normalModuleFactory }) => {
-                normalModuleFactory.hooks.parser
-                    .for("javascript/auto")
-                    .tap("DefinePlugin", (parser) => {
-                        parser.hooks.evaluateIdentifier
-                            .for("TEST")
-                            .tap("DefinePlugin", () => {});
-                    });
-            }
-        );
+        compiler.hooks.compilation.tap('DefinePlugin', (compilation, { normalModuleFactory }) => {
+            normalModuleFactory.hooks.parser.for('javascript/auto').tap('DefinePlugin', parser => {
+                parser.hooks.evaluateIdentifier.for('TEST').tap('DefinePlugin', () => {});
+            });
+        });
     }
 }
 
 class ChunkGroupTestPlugin extends webpack.Plugin {
     apply(compiler: webpack.Compiler) {
-        compiler.hooks.compilation.tap("ChunkGroupTestPlugin", compilation  => {
+        compiler.hooks.compilation.tap('ChunkGroupTestPlugin', compilation => {
             const namedChunkGroupA = compilation.addChunkInGroup('vendors-a');
             const namedChunkGroupB = compilation.addChunkInGroup({ name: 'vendors-b' });
             const unnamedChunkGroup = compilation.addChunkInGroup({});
             if (namedChunkGroupA.getNumberOfChildren() > 0) {
-                for (const chunk of namedChunkGroupA.chunks) {}
+                for (const chunk of namedChunkGroupA.chunks) {
+                }
             }
             Array.from(namedChunkGroupA.childrenIterable).forEach(childGroup => {
                 namedChunkGroupA.removeChild(childGroup);
@@ -1014,7 +975,7 @@ class ChunkGroupTestPlugin extends webpack.Plugin {
             Array.from(namedChunkGroupA.parentsIterable).forEach(parentGroup => {});
             namedChunkGroupA.setParents([namedChunkGroupB]);
             namedChunkGroupA.setParents(new Set([unnamedChunkGroup]));
-            compilation.hooks.optimizeModules.tap("ChunkGroupTestPlugin", modules => {
+            compilation.hooks.optimizeModules.tap('ChunkGroupTestPlugin', modules => {
                 for (const module of modules) {
                     const group = compilation.addChunkInGroup('module', module, { start: { line: 0 } }, 'module.js');
                     if (module.index) {
@@ -1027,7 +988,7 @@ class ChunkGroupTestPlugin extends webpack.Plugin {
                     break;
                 }
             });
-            compilation.hooks.optimizeChunks.tap("ChunkGroupTestPlugin", chunks => {
+            compilation.hooks.optimizeChunks.tap('ChunkGroupTestPlugin', chunks => {
                 const firstChunk = chunks[0];
                 for (const groupChunk of namedChunkGroupA.chunks) {
                     namedChunkGroupA.insertChunk(firstChunk, groupChunk);
@@ -1043,12 +1004,12 @@ configuration = {
             {
                 test: /\.css$/,
                 oneOf: [
-                    { resourceQuery: /global/, use: ["style-loader", "css-loader"] },
-                    { use: ["to-string-loader", "css-loader"] }
-                ]
-            }
-        ]
-    }
+                    { resourceQuery: /global/, use: ['style-loader', 'css-loader'] },
+                    { use: ['to-string-loader', 'css-loader'] },
+                ],
+            },
+        ],
+    },
 };
 
 configuration = {
@@ -1068,41 +1029,41 @@ configuration = {
                     'foo-loader',
                     {
                         loader: 'bar-loader',
-                        query: 'baz'
-                    }
+                        query: 'baz',
+                    },
                 ],
-                use: () => ([
+                use: () => [
                     'foo-loader',
                     {
                         loader: 'bar-loader',
                         query: {
-                            baz: 'qux'
-                        }
+                            baz: 'qux',
+                        },
                     },
-                ])
-            }
-        ]
-    }
+                ],
+            },
+        ],
+    },
 };
 
 let profiling = new webpack.debug.ProfilingPlugin();
 profiling = new webpack.debug.ProfilingPlugin({ outputPath: './path.json' });
 
 configuration = {
-    plugins: [profiling]
+    plugins: [profiling],
 };
 
 compiler.hooks.done.tap('foo', stats => {
-  if (stats.startTime === undefined || stats.endTime === undefined) {
-    throw new Error('Well, this is odd');
-  }
+    if (stats.startTime === undefined || stats.endTime === undefined) {
+        throw new Error('Well, this is odd');
+    }
 
-  console.log(`Compiled in ${stats.endTime - stats.startTime}ms`);
+    console.log(`Compiled in ${stats.endTime - stats.startTime}ms`);
 });
 
 const multiCompiler = webpack([{}, {}]);
 
-multiCompiler.hooks.done.tap('foo', (multiStats) => {
+multiCompiler.hooks.done.tap('foo', multiStats => {
     const [firstStat] = multiStats.stats;
 
     if (multiStats.hasWarnings() || multiStats.hasErrors()) {
@@ -1132,56 +1093,48 @@ webpack.Template.asString(['a']).trimLeft();
 webpack.Template.getModulesArrayBounds([{ id: 'a' }]);
 
 function testTemplateFn() {
-  const result = webpack.Template.getModulesArrayBounds([{ id: 1 }]);
-  if (result === false) {
-    return;
-  }
-  Math.max(...result);
+    const result = webpack.Template.getModulesArrayBounds([{ id: 1 }]);
+    if (result === false) {
+        return;
+    }
+    Math.max(...result);
 }
 
 const chunk = new webpack.compilation.Chunk('name');
 
 chunk.sortModules((module1, module2) => {
-  if (module1)
-      return 1;
-  else if (module2)
-      return -1;
-  return 0;
+    if (module1) return 1;
+    else if (module2) return -1;
+    return 0;
 });
 chunk.addMultiplierAndOverhead(12, {});
 chunk.addMultiplierAndOverhead(12, {
-  chunkOverhead: 1,
-  entryChunkMultiplicator: 2
+    chunkOverhead: 1,
+    entryChunkMultiplicator: 2,
 });
 chunk.size();
 chunk.size({});
 chunk.size({
-  chunkOverhead: 1,
-  entryChunkMultiplicator: 2
+    chunkOverhead: 1,
+    entryChunkMultiplicator: 2,
 });
 chunk.hasModuleInGraph(
-  m => m.type === "webassembly/async",
-  chunk => chunk.name === "vendor"
+    m => m.type === 'webassembly/async',
+    chunk => chunk.name === 'vendor',
 );
 
 const moduleTemplate = ({} as any) as webpack.compilation.ModuleTemplate;
 webpack.Template.renderChunkModules(
-  chunk,
-  (_, num) => {
-    Math.max(num, 2);
-    return true;
-  },
-  moduleTemplate,
-  [],
+    chunk,
+    (_, num) => {
+        Math.max(num, 2);
+        return true;
+    },
+    moduleTemplate,
+    [],
 );
 
-webpack.Template.renderChunkModules(
-  chunk,
-  () => false,
-  moduleTemplate,
-  [],
-  'a',
-);
+webpack.Template.renderChunkModules(chunk, () => false, moduleTemplate, [], 'a');
 
 // https://webpack.js.org/configuration/output/#outputfilename
 configuration = {
@@ -1196,34 +1149,34 @@ configuration = {
 class LoggingPlugin extends webpack.Plugin {
     apply(compiler: webpack.Compiler): void {
         const infrastructureLogger: webpack.Logger = compiler.getInfrastructureLogger('LoggingPlugin');
-        infrastructureLogger.error("File not found");
-        infrastructureLogger.warn("Ignoring unknown configuration option");
-        infrastructureLogger.info("Maintaining flux");
-        infrastructureLogger.debug("Dynamic reloads are inside the frobnitz");
-        infrastructureLogger.trace("Something might have gone wrong here");
-        infrastructureLogger.group("Start of messages");
+        infrastructureLogger.error('File not found');
+        infrastructureLogger.warn('Ignoring unknown configuration option');
+        infrastructureLogger.info('Maintaining flux');
+        infrastructureLogger.debug('Dynamic reloads are inside the frobnitz');
+        infrastructureLogger.trace('Something might have gone wrong here');
+        infrastructureLogger.group('Start of messages');
         infrastructureLogger.groupEnd();
-        infrastructureLogger.groupCollapsed("Start of collapsed messages");
+        infrastructureLogger.groupCollapsed('Start of collapsed messages');
         infrastructureLogger.groupEnd();
-        infrastructureLogger.status("50% complete");
+        infrastructureLogger.status('50% complete');
         infrastructureLogger.clear();
-        infrastructureLogger.profile("How long does this take");
+        infrastructureLogger.profile('How long does this take');
         infrastructureLogger.profileEnd();
 
         compiler.hooks.emit.tap('LoggingPlugin', compilation => {
             const logger = compilation.getLogger('LoggingPlugin');
-            logger.error("File not found");
-            logger.warn("Ignoring unknown configuration option");
-            logger.info("Maintaining flux");
-            logger.debug("Dynamic reloads are inside the frobnitz");
-            logger.trace("Something might have gone wrong here");
-            logger.group("Start of messages");
+            logger.error('File not found');
+            logger.warn('Ignoring unknown configuration option');
+            logger.info('Maintaining flux');
+            logger.debug('Dynamic reloads are inside the frobnitz');
+            logger.trace('Something might have gone wrong here');
+            logger.group('Start of messages');
             logger.groupEnd();
-            logger.groupCollapsed("Start of collapsed messages");
+            logger.groupCollapsed('Start of collapsed messages');
             logger.groupEnd();
-            logger.status("50% complete");
+            logger.status('50% complete');
             logger.clear();
-            logger.profile("How long does this take");
+            logger.profile('How long does this take');
             logger.profileEnd();
         });
     }
@@ -1240,12 +1193,12 @@ compiler.hooks.compilation.tap('SomePlugin', compilation => {
     stats.sortOrderRegular('!field'); // $ExpectType boolean
 });
 
-const config1: webpack.ConfigurationFactory = (env) => {
+const config1: webpack.ConfigurationFactory = env => {
     env; // $ExpectType string | Record<string, string | number | boolean> | undefined
     return {};
 };
 
-const config2: webpack.MultiConfigurationFactory = (env) => {
+const config2: webpack.MultiConfigurationFactory = env => {
     env; // $ExpectType string | Record<string, string | number | boolean> | undefined
     return [];
 };


### PR DESCRIPTION
webpack's `entry` items support an object version that includes the `import`, `dependOn`, and `filename` keys

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/configuration/entry-context/#entry
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.