### PR TITLE
[@types/update-notifier] Use Boxen's options type directly

### DIFF
--- a/types/update-notifier/index.d.ts
+++ b/types/update-notifier/index.d.ts
@@ -6,6 +6,7 @@
 //                 Michael Grinich <https://github.com/grinich>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.2
 
 import boxen = require('boxen');
 import ConfigStore = require('configstore');

--- a/types/update-notifier/index.d.ts
+++ b/types/update-notifier/index.d.ts
@@ -7,6 +7,7 @@
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+import boxen = require('boxen');
 import ConfigStore = require('configstore');
 
 export = UpdateNotifier;
@@ -45,14 +46,6 @@ declare namespace UpdateNotifier {
         shouldNotifyInNpmScript?: boolean;
     }
 
-    interface BoxenOptions {
-        padding?: number;
-        margin?: number;
-        align?: string;
-        borderColor?: string;
-        borderStyle?: string;
-    }
-
     interface NotifyOptions {
         /** Message that will be shown when an update is available */
         message?: string;
@@ -61,7 +54,8 @@ declare namespace UpdateNotifier {
         /** Include the -g argument in the default message's npm i recommendation */
         isGlobal?: boolean;
         /** Options object that will be passed to `boxen` */
-        boxenOptions?: BoxenOptions;
+        /** See https://github.com/sindresorhus/boxen/blob/master/index.d.ts */
+        boxenOptions?: boxen.Options;
     }
 
     interface Package {

--- a/types/update-notifier/index.d.ts
+++ b/types/update-notifier/index.d.ts
@@ -53,8 +53,10 @@ declare namespace UpdateNotifier {
         defer?: boolean;
         /** Include the -g argument in the default message's npm i recommendation */
         isGlobal?: boolean;
-        /** Options object that will be passed to `boxen` */
-        /** See https://github.com/sindresorhus/boxen/blob/master/index.d.ts */
+        /**
+         * Options object that will be passed to `boxen`
+         * See https://github.com/sindresorhus/boxen/blob/master/index.d.ts
+         */
         boxenOptions?: boxen.Options;
     }
 

--- a/types/update-notifier/package.json
+++ b/types/update-notifier/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "boxen": "^4.2.0"
+    }
+}

--- a/types/update-notifier/tsconfig.json
+++ b/types/update-notifier/tsconfig.json
@@ -3,7 +3,8 @@
         "module": "commonjs",
         "lib": [
             "es6",
-            "dom"
+            "dom",
+            "esnext"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/update-notifier/update-notifier-tests.ts
+++ b/types/update-notifier/update-notifier-tests.ts
@@ -26,7 +26,11 @@ if (notifier.update) {
         isGlobal: true,
         boxenOptions: {
             padding: 1,
-            margin: 1,
+            margin: {
+                top: 1,
+                bottom: 1,
+                left: 2,
+            },
             align: 'center',
             borderColor: 'yellow',
             borderStyle: 'round',

--- a/types/update-notifier/update-notifier-tests.ts
+++ b/types/update-notifier/update-notifier-tests.ts
@@ -1,5 +1,6 @@
 /// <reference types="node" />
 
+import boxen = require('boxen');
 import UpdateNotifier = require('update-notifier');
 
 let notifier = UpdateNotifier();
@@ -30,10 +31,11 @@ if (notifier.update) {
                 top: 1,
                 bottom: 1,
                 left: 2,
+                right: 2,
             },
             align: 'center',
             borderColor: 'yellow',
-            borderStyle: 'round',
+            borderStyle: boxen.BorderStyle.Round,
         },
     });
 }


### PR DESCRIPTION
This adds support for, for example: `margin: { top: 0, left: 3, bottom: 1 },`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
  - ⚠️ `yarn tsc types/update-notifier/index.d.ts` was successful after I added `@types/configstore` to `package.json` locally.

~~⚠️ Halp, how can I add `boxen` as a dependency somewhere? There is no `package.json` so I'm not sure how to compile/test. Thanks! 🙏~~  Done!

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/sindresorhus/boxen/blob/master/index.d.ts>
- If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
