### PR TITLE
[@types/react] useCallback: Do not sets callbacks args to any

### DIFF
--- a/types/react-router/test/RouterContext.tsx
+++ b/types/react-router/test/RouterContext.tsx
@@ -51,7 +51,7 @@ const MultiStepSignup: React.FC = () => {
     }, [location.pathname]);
 
     const handleNextStep = React.useCallback(
-        event => {
+        (event: React.FormEvent<HTMLFormElement>) => {
             event.preventDefault();
 
             if (isLastStep) {

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1090,8 +1090,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#usecallback
      */
-    // TODO (TypeScript 3.0): <T extends (...args: never[]) => unknown>
-    function useCallback<T extends (...args: any[]) => any>(callback: T, deps: DependencyList): T;
+    function useCallback<T extends Function>(callback: T, deps: DependencyList): T;
     /**
      * `useMemo` will only recompute the memoized value when one of the `deps` has changed.
      *

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1090,6 +1090,10 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#usecallback
      */
+    // Using `Function` because we do not want to type args as `...any[]`,
+    // as this would permit ommitting types of the args in the callback.
+    // see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/46309
+    // tslint:disable-next-line: ban-types
     function useCallback<T extends Function>(callback: T, deps: DependencyList): T;
     /**
      * `useMemo` will only recompute the memoized value when one of the `deps` has changed.


### PR DESCRIPTION
The current definition explicetely sets the callbacks args to any.
This allow user to omit types when they use `useCallback`.

Changing to the less preferred `Function` fixes it.
We do not need the args in the defintion, we only want to ensure the
return function has the same type as the provided callback.

https://github.com/DefinitelyTyped/DefinitelyTyped/issues/46309


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>


