### PR TITLE
google-apps-script: Fix changeType in onChange

### DIFF
--- a/types/google-apps-script/google-apps-script-events.d.ts
+++ b/types/google-apps-script/google-apps-script-events.d.ts
@@ -41,7 +41,16 @@ declare namespace GoogleAppsScript {
       source: Spreadsheet.Spreadsheet;
     }
 
-    enum SheetsOnChangeChangeType { EDIT, INSERT_ROW, INSERT_COLUMN, REMOVE_ROW, REMOVE_COLUMN, INSERT_GRID, REMOVE_GRID, FORMAT, OTHER }
+    type SheetsOnChangeChangeType =
+      | 'EDIT'
+      | 'INSERT_ROW'
+      | 'INSERT_COLUMN'
+      | 'REMOVE_ROW'
+      | 'REMOVE_COLUMN'
+      | 'INSERT_GRID'
+      | 'REMOVE_GRID'
+      | 'FORMAT'
+      | 'OTHER';
     interface SheetsOnChange extends AppsScriptEvent {
       changeType: SheetsOnChangeChangeType;
     }

--- a/types/google-apps-script/google-apps-script-tests.ts
+++ b/types/google-apps-script/google-apps-script-tests.ts
@@ -164,3 +164,9 @@ const createFolderAndGetDescription = () => {
   // Get description. Expect 'DESC'.
   Logger.log(folder.getDescription().toUpperCase());
 };
+
+function onChange(e: GoogleAppsScript.Events.SheetsOnChange) {
+  if (e.changeType === 'FORMAT') {
+    console.log('Formatting change detected');
+  }
+}

--- a/types/google-apps-script/google-apps-script.spreadsheet.d.ts
+++ b/types/google-apps-script/google-apps-script.spreadsheet.d.ts
@@ -1317,6 +1317,10 @@ declare namespace GoogleAppsScript {
      *     }
      */
     enum ProtectionType { RANGE, SHEET }
+
+    type FontLine = "none" | "underline" | "line-through";
+    type FontStyle = "normal" | "italic";
+    type FontWeight = "normal" | "bold";
     /**
      * Access and modify spreadsheet ranges. A range can be a single cell in a sheet or a group of
      * adjacent cells in a sheet.
@@ -1381,14 +1385,14 @@ declare namespace GoogleAppsScript {
       getFontColors(): string[][];
       getFontFamilies(): string[][];
       getFontFamily(): string;
-      getFontLine(): string;
-      getFontLines(): string[][];
+      getFontLine(): FontLine;
+      getFontLines(): FontLine[][];
       getFontSize(): Integer;
       getFontSizes(): Integer[][];
-      getFontStyle(): string;
-      getFontStyles(): string[][];
-      getFontWeight(): string;
-      getFontWeights(): string[][];
+      getFontStyle(): FontStyle;
+      getFontStyles(): FontStyle[][];
+      getFontWeight(): FontWeight;
+      getFontWeights(): FontWeight[][];
       getFormula(): string;
       getFormulaR1C1(): string | null;
       getFormulas(): string[][];
@@ -1461,14 +1465,14 @@ declare namespace GoogleAppsScript {
       setFontColors(colors: any[][]): Range;
       setFontFamilies(fontFamilies: (string | null)[][]): Range;
       setFontFamily(fontFamily: string | null): Range;
-      setFontLine(fontLine: "underline" | "line-through" | "none" | null): Range;
-      setFontLines(fontLines: ("underline" | "line-through" | "none" | null)[][]): Range;
+      setFontLine(fontLine: FontLine | null): Range;
+      setFontLines(fontLines: (FontLine | null)[][]): Range;
       setFontSize(size: Integer): Range;
       setFontSizes(sizes: Integer[][]): Range;
-      setFontStyle(fontStyle: "italic" | "normal" | null): Range;
-      setFontStyles(fontStyles: ("italic" | "normal" | null)[][]): Range;
-      setFontWeight(fontWeight: "bold" | "normal" | null): Range;
-      setFontWeights(fontWeights: ("bold" | "normal" | null)[][]): Range;
+      setFontStyle(fontStyle: FontStyle | null): Range;
+      setFontStyles(fontStyles: (FontStyle | null)[][]): Range;
+      setFontWeight(fontWeight: FontWeight | null): Range;
+      setFontWeights(fontWeights: (FontWeight | null)[][]): Range;
       setFormula(formula: string): Range;
       setFormulaR1C1(formula: string): Range;
       setFormulas(formulas: string[][]): Range;
@@ -1532,10 +1536,10 @@ declare namespace GoogleAppsScript {
       setBorder(top: boolean | null, left: boolean | null, bottom: boolean | null, right: boolean | null, vertical: boolean | null, horizontal: boolean | null, color: string | null, style: BorderStyle | null): RangeList;
       setFontColor(color: string | null): RangeList;
       setFontFamily(fontFamily: string | null): RangeList;
-      setFontLine(fontLine: "underline" | "line-through" | "none" | null): RangeList;
+      setFontLine(fontLine: FontLine | null): RangeList;
       setFontSize(size: Integer): RangeList;
-      setFontStyle(fontStyle: "italic" | "normal" | null): RangeList;
-      setFontWeight(fontWeight: "bold" | "normal" | null): RangeList;
+      setFontStyle(fontStyle: FontStyle | null): RangeList;
+      setFontWeight(fontWeight: FontWeight | null): RangeList;
       setFormula(formula: string): RangeList;
       setFormulaR1C1(formula: string): RangeList;
       setHorizontalAlignment(alignment: "left" | "center" | "normal" | null): RangeList;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/apps-script/guides/triggers/events#change
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

I've run the following in a real script:

```ts
function onChange({ changeType }) {
  console.log(changeType); // Prints "FORMAT"
  console.log(typeof changeType); // Prints "string"
}
```

And it appears that `SheetsOnChangeChangeType` is a string enum, not a numeric one. Typed as a union for simplicity.

Piggybacked `FontLine`, `FontStyle`, `FontWeight` improvements in since this PR is taking a while.