### PR TITLE
Added support for https in stoppable type def

### DIFF
--- a/types/stoppable/index.d.ts
+++ b/types/stoppable/index.d.ts
@@ -7,14 +7,13 @@
 
 /// <reference types="node" />
 import * as https from 'https';
-import * as http from 'http';
 
 declare namespace stoppable {
-  interface StoppableServer extends https.Server, http.Server {
+  interface StoppableServer extends https.Server {
     stop(callback?: (e: Error, gracefully: boolean) => void): void;
   }
 }
 
-declare function stoppable(server: any, grace?: number): stoppable.StoppableServer;
+declare function stoppable(server: https.Server, grace?: number): stoppable.StoppableServer;
 
 export = stoppable;

--- a/types/stoppable/index.d.ts
+++ b/types/stoppable/index.d.ts
@@ -2,10 +2,11 @@
 // Project: https://github.com/hunterloftis/stoppable
 // Definitions by: Eric Byers <https://github.com/EricByers>
 //                 John Plusjé <https://github.com/jplusje>
+//                 Tobias Andersen <https://github.com/ZaradarDFDS>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
-import { Server } from 'http';
+import { Server } from 'https';
 
 declare namespace stoppable {
   interface StoppableServer extends Server {

--- a/types/stoppable/index.d.ts
+++ b/types/stoppable/index.d.ts
@@ -6,14 +6,15 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
-import { Server } from 'https';
+import * as https from 'https';
+import * as http from 'http';
 
 declare namespace stoppable {
-  interface StoppableServer extends Server {
+  interface StoppableServer extends https.Server, http.Server {
     stop(callback?: (e: Error, gracefully: boolean) => void): void;
   }
 }
 
-declare function stoppable(server: Server, grace?: number): stoppable.StoppableServer;
+declare function stoppable(server: any, grace?: number): stoppable.StoppableServer;
 
 export = stoppable;

--- a/types/stoppable/stoppable-tests.ts
+++ b/types/stoppable/stoppable-tests.ts
@@ -1,12 +1,12 @@
-import * as http from 'http';
+import * as https from 'https';
 import stoppable = require('stoppable');
 
-const server: stoppable.StoppableServer = stoppable(http.createServer());
+const server: stoppable.StoppableServer = stoppable(https.createServer());
 server.stop();
 
-const server2: stoppable.StoppableServer = stoppable(http.createServer(), 10000);
+const server2: stoppable.StoppableServer = stoppable(https.createServer(), 10000);
 server2.stop();
 
-const server3: stoppable.StoppableServer = stoppable(http.createServer());
+const server3: stoppable.StoppableServer = stoppable(https.createServer());
 server.stop((err, gracefully) => {});
 server.close();

--- a/types/stoppable/stoppable-tests.ts
+++ b/types/stoppable/stoppable-tests.ts
@@ -1,12 +1,23 @@
+import * as http from 'http';
 import * as https from 'https';
 import stoppable = require('stoppable');
 
-const server: stoppable.StoppableServer = stoppable(https.createServer());
+const httpsServer: stoppable.StoppableServer = stoppable(https.createServer());
+httpsServer.stop();
+
+const httpsServer2: stoppable.StoppableServer = stoppable(https.createServer(), 10000);
+httpsServer2.stop();
+
+const httpsServer3: stoppable.StoppableServer = stoppable(https.createServer());
+httpsServer.stop((err, gracefully) => {});
+httpsServer.close();
+
+const server: stoppable.StoppableServer = stoppable(http.createServer() as https.Server);
 server.stop();
 
-const server2: stoppable.StoppableServer = stoppable(https.createServer(), 10000);
+const server2: stoppable.StoppableServer = stoppable(http.createServer() as https.Server, 10000);
 server2.stop();
 
-const server3: stoppable.StoppableServer = stoppable(https.createServer());
+const server3: stoppable.StoppableServer = stoppable(http.createServer() as https.Server);
 server.stop((err, gracefully) => {});
 server.close();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hunterloftis/stoppable#usage
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
