### PR TITLE
fix: Fixing incorrect passport AuthenticateOptions

### DIFF
--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -54,7 +54,7 @@ declare namespace passport {
         successMessage?: boolean | string;
         successRedirect?: string;
         successReturnToOrRedirect?: string;
-        state?: string;
+        customState?: string;
         pauseStream?: boolean;
         userProperty?: string;
         passReqToCallback?: boolean;


### PR DESCRIPTION
In the AuthenticateOptions interface, `state: string` should be `customState: string`. I have verified that passing state does nothing, while passing customState ensures `req.body.state` is the value passed.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Passport's code indicates that neither `state` or `customState` are options. It looks like the `customState` option comes from the strategy being used, in my case Azure AD.
https://github.com/jaredhanson/passport/blob/master/lib/middleware/authenticate.js
https://github.com/AzureAD/passport-azure-ad/blob/5724e684ee7b72f94fee59cdbe035f6424f4a3d0/README.md#413-options-available-for-passportauthenticate
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
