### PR TITLE
[trusted-types] Update definitions to match Trusted Types specification

### DIFF
--- a/types/dompurify/index.d.ts
+++ b/types/dompurify/index.d.ts
@@ -6,7 +6,7 @@
 //                 Exigerr <https://github.com/Exigerr>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 3.1
 /// <reference types="trusted-types"/>
 
 export as namespace DOMPurify;

--- a/types/trusted-types/trusted-types-tests.ts
+++ b/types/trusted-types/trusted-types-tests.ts
@@ -9,19 +9,11 @@ trustedTypes;
 // $ExpectType TrustedTypePolicyFactory | undefined
 window.trustedTypes;
 
-// $ExpectType TrustedTypePolicyFactory | undefined
-window.TrustedTypes;
-
 const rules = {
     createHTML: (s: string) => s,
     createScript: (s: string) => s,
     createScriptURL: (s: string) => s,
-    createURL: (s: string) => s,
 };
-
-// $ExpectType string[]
-TT.getPolicyNames();
-TT.createPolicy('default', rules, true);
 
 const policy = TT.createPolicy('test', rules);
 
@@ -33,8 +25,6 @@ policy.createHTML('');
 policy.createScript('');
 // $ExpectType TrustedScriptURL
 policy.createScriptURL('');
-// $ExpectType TrustedURL
-policy.createURL('');
 
 const htmlOnlyPolicy = TT.createPolicy('htmlOnly', {
     createHTML: (html: string) => {
@@ -55,10 +45,45 @@ TT.isHTML(html);
 TT.isScript(html);
 // $ExpectType boolean
 TT.isScriptURL(html);
-// $ExpectType boolean
-TT.isURL(html);
 
-// Ensure the types are globaly available
+const policyWithArgs = TT.createPolicy('withArgs', {
+    createHTML: (val: string, option1: number, option2: boolean) => val,
+    createScriptURL: (val: string) => val,
+});
+
+// $ExpectType TrustedHTML
+policyWithArgs.createHTML('', 1, true);
+// $ExpectType TrustedScriptURL
+policyWithArgs.createScriptURL('');
+// $ExpectError
+policyWithArgs.createHTML('', '', true);
+// $ExpectError
+policyWithArgs.createHTML('');
+// $ExpectError
+policyWithArgs.createScript('');
+// $ExpectError
+policyWithArgs.createScriptURL('', 1, true);
+
+const genericPolicy = TT.defaultPolicy!;
+
+// $ExpectType TrustedHTML
+genericPolicy.createHTML('', true, {});
+// $ExpectType TrustedScript
+genericPolicy.createScript('', true, {});
+// $ExpectType TrustedScriptURL
+genericPolicy.createScriptURL('', true, {});
+
+const genericOptions: TrustedTypePolicyOptions = {};
+const genericPolicy2 = TT.createPolicy('generic', genericOptions);
+
+// $ExpectType TrustedHTML
+genericPolicy2.createHTML('', true, {});
+// $ExpectType TrustedScript
+genericPolicy2.createScript('', true, {});
+// $ExpectType TrustedScriptURL
+genericPolicy2.createScriptURL('', true, {});
+
+// Ensure the types are globally available
 let trustedHTML: TrustedHTML = null as any;
 const trustedScript: TrustedScript = null as any;
 


### PR DESCRIPTION
This addresses divergence in the current type definitions from the
Trusted Types specification. The types were also rearranged to match
spec order to make comparison easier. Tests were also updated
accordingly.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://w3c.github.io/webappsec-trusted-types/dist/spec/
