### PR TITLE
Revert #46290 "[luxon] Changed typings for some datetime and duration …"

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -271,25 +271,25 @@ export class DateTime {
     toBSON(): Date;
     toFormat(format: string, options?: DateTimeFormatOptions): string;
     toHTTP(): string;
-    toISO(options?: ToISOTimeOptions): string | null;
+    toISO(options?: ToISOTimeOptions): string;
     /** Returns an ISO 8601-compliant string representation of this DateTime's date component */
-    toISODate(options?: ToISODateOptions): string | null;
-    toISOTime(options?: ToISOTimeOptions): string | null;
-    toISOWeekDate(): string | null;
+    toISODate(options?: ToISODateOptions): string;
+    toISOTime(options?: ToISOTimeOptions): string;
+    toISOWeekDate(): string;
     toJSDate(): Date;
-    toJSON(): string | null;
+    toJSON(): string;
     toLocal(): DateTime;
     toLocaleParts(options?: LocaleOptions & DateTimeFormatOptions): any[];
-    toLocaleString(options?: LocaleOptions & DateTimeFormatOptions): string | null;
+    toLocaleString(options?: LocaleOptions & DateTimeFormatOptions): string;
     toMillis(): number;
     toObject(options?: { includeConfig?: boolean }): DateObject;
     toRelative(options?: ToRelativeOptions): string | null;
     toRelativeCalendar(options?: ToRelativeCalendarOptions): string | null;
-    toRFC2822(): string | null;
+    toRFC2822(): string;
     toSeconds(): number;
-    toSQL(options?: ToSQLOptions): string | null;
-    toSQLDate(): string | null;
-    toSQLTime(options?: ToSQLOptions): string | null;
+    toSQL(options?: ToSQLOptions): string;
+    toSQLDate(): string;
+    toSQLTime(options?: ToSQLOptions): string;
     toString(): string;
     toUTC(offset?: number, options?: ZoneOptions): DateTime;
     until(other: DateTime): Interval;
@@ -364,10 +364,10 @@ export class Duration {
     shiftTo(...units: DurationUnit[]): Duration;
     mapUnits(fn: (x: number, u: DurationUnit) => number): Duration;
     toFormat(format: string, options?: DurationToFormatOptions): string;
-    toISO(): string | null;
-    toJSON(): string | null;
+    toISO(): string;
+    toJSON(): string;
     toObject(options?: { includeConfig?: boolean }): DurationObject;
-    toString(): string | null;
+    toString(): string;
     valueOf(): number;
 }
 

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -68,29 +68,29 @@ getters.isInLeapYear;
 
 dt.toBSON(); // $ExpectType Date
 dt.toHTTP(); // $ExpectType string
-dt.toISO(); // $ExpectType string | null
-dt.toISO({ includeOffset: true, format: 'extended' }); // $ExpectType string | null
-dt.toISODate(); // $ExpectType string | null
-dt.toISODate({ format: 'basic'}); // $ExpectType string | null
-dt.toISOTime(); // $ExpectType string | null
-dt.toISOTime({ format: 'basic' }); // $ExpectType string | null
-dt.toISOWeekDate(); // $ExpectType string | null
+dt.toISO(); // $ExpectType string
+dt.toISO({ includeOffset: true, format: 'extended' }); // $ExpectType string
+dt.toISODate(); // $ExpectType string
+dt.toISODate({ format: 'basic'}); // $ExpectType string
+dt.toISOTime(); // $ExpectType string
+dt.toISOTime({ format: 'basic' }); // $ExpectType string
+dt.toISOWeekDate(); // $ExpectType string
 dt.toJSDate(); // $ExpectType Date
-dt.toJSON(); // $ExpectType string | null
-dt.toLocaleString(); // $ExpectType string | null
-dt.toLocaleString({ month: 'long', day: 'numeric' }); // $ExpectType string | null
-dt.toLocaleString(DateTime.DATE_MED); // $ExpectType string | null
+dt.toJSON(); // $ExpectType string
+dt.toLocaleString(); // $ExpectType string
+dt.toLocaleString({ month: 'long', day: 'numeric' }); // $ExpectType string
+dt.toLocaleString(DateTime.DATE_MED); // $ExpectType string
 dt.toMillis(); // $ExpectType number
 dt.toMillis(); // $ExpectType number
 dt.toRelative(); // $ExpectType string | null
 dt.toRelativeCalendar(); // $ExpectType string | null
-dt.toRFC2822(); // $ExpectType string | null
+dt.toRFC2822(); // $ExpectType string
 dt.toSeconds(); // $ExpectType number
-dt.toSQL(); // $ExpectType string | null
-dt.toSQL({ includeOffset: false, includeZone: true }); // $ExpectType string | null
-dt.toSQLDate(); // $ExpectType string | null
-dt.toSQLTime(); // $ExpectType string | null
-dt.toSQLTime({ includeOffset: false, includeZone: true }); // $ExpectType string | null
+dt.toSQL(); // $ExpectType string
+dt.toSQL({ includeOffset: false, includeZone: true }); // $ExpectType string
+dt.toSQLDate(); // $ExpectType string
+dt.toSQLTime(); // $ExpectType string
+dt.toSQLTime({ includeOffset: false, includeZone: true }); // $ExpectType string
 dt.valueOf(); // $ExpectType number
 
 // $ExpectType string | null
@@ -158,7 +158,7 @@ dur.seconds; // $ExpectType number
 
 dur.as('seconds'); // $ExpectType number
 dur.toObject();
-dur.toISO(); // $ExpectType string | null
+dur.toISO(); // $ExpectType string
 dur.normalize(); // $ExpectType Duration
 dur.mapUnits((x, u) => u === 'hours' ? x * 2 : x); // $ExpectType Duration
 
@@ -216,7 +216,7 @@ Settings.defaultZone = Settings.defaultZone;
 
 /* Intl */
 // prettier-ignore
-DateTime.local().setLocale('el').toLocaleString(DateTime.DATE_FULL); // $ExpectType string | null
+DateTime.local().setLocale('el').toLocaleString(DateTime.DATE_FULL); // $ExpectType string
 dt.locale; // $ExpectType string
 DateTime.local().setLocale('fr').locale; // $ExpectType string
 DateTime.local().reconfigure({ locale: 'fr' }).locale; // $ExpectType string
@@ -226,8 +226,8 @@ DateTime.local().locale; // $ExpectType string
 
 Settings.defaultLocale = DateTime.local().resolvedLocaleOpts().locale;
 
-dt.setLocale('fr').toLocaleString(DateTime.DATE_FULL); // $ExpectType string | null
-dt.toLocaleString({ locale: 'es', ...DateTime.DATE_FULL }); // $ExpectType string | null
+dt.setLocale('fr').toLocaleString(DateTime.DATE_FULL); // $ExpectType string
+dt.toLocaleString({ locale: 'es', ...DateTime.DATE_FULL }); // $ExpectType string
 dt.setLocale('fr').toFormat('MMMM dd, yyyy GG'); // $ExpectType string
 
 DateTime.fromFormat('septembre 25, 2017 après Jésus-Christ', 'MMMM dd, yyyy GG', { locale: 'fr' });
@@ -264,11 +264,11 @@ Settings.defaultZoneName = 'Asia/Tokyo';
 
 /* Calendars */
 // prettier-ignore
-DateTime.fromISO('2017-W23-3').plus({ weeks: 1, days: 2 }).toISOWeekDate(); // $ExpectType string | null
+DateTime.fromISO('2017-W23-3').plus({ weeks: 1, days: 2 }).toISOWeekDate(); // $ExpectType string
 
 const dtHebrew = DateTime.local().reconfigure({ outputCalendar: 'hebrew' });
 dtHebrew.outputCalendar; // $ExpectType string
-dtHebrew.toLocaleString(); // $ExpectType string | null
+dtHebrew.toLocaleString(); // $ExpectType string
 
 DateTime.fromObject({ outputCalendar: 'buddhist' }).toLocaleString(DateTime.DATE_FULL);
 Settings.defaultOutputCalendar = 'persian';
@@ -310,7 +310,7 @@ dur.toObject().days; // $ExpectType number | undefined
 dur.as('minutes'); // $ExpectType number
 dur.shiftTo('minutes').toObject().minutes; // $ExpectType number | undefined
 // prettier-ignore
-DateTime.fromISO('2017-05-15').plus(dur).toISO(); // $ExpectType string | null
+DateTime.fromISO('2017-05-15').plus(dur).toISO(); // $ExpectType string
 
 const end = DateTime.fromISO('2017-03-13');
 const start = DateTime.fromISO('2017-02-13');


### PR DESCRIPTION
This reverts commit 1702c0248dfc7c33b8b1a7f3539a11d943784856.
Please see discussion here:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46290

The reason behind this revert is somehow decreased devx for users of
the DT package itself - even if the change was legit and in-line with the
original source code. 

The problematic part is Luxon public API docs, I would say, do not properly describe the possible
outcomes of changed API methods and it seems for a time being, we should stick to
the public API.

Example:
https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html#instance-method-toISO
This makes all implementation to expect 'string', while the underlying code states it can be 'string | null'.
This is OK for JS, but somehow more challenging for TS:
https://moment.github.io/luxon/docs/file/src/datetime.js.html#lineNumber1520

Thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).