### PR TITLE
bootstrap-fileinput: Allow Upload URL to be string or function

### DIFF
--- a/types/bootstrap-fileinput/bootstrap-fileinput-tests.ts
+++ b/types/bootstrap-fileinput/bootstrap-fileinput-tests.ts
@@ -4,6 +4,7 @@ $('document').on('ready', () => {
     $('#input-id')
         .fileinput({
             uploadUrl: 'http://localhost/file-upload.php',
+            uploadUrlThumb: 'http://localhost/file-thumb-upload.php',
             uploadExtraData: {
                 uploadToken: 'SOME-TOKEN', // for access control / security
             },
@@ -82,4 +83,12 @@ $('document').on('ready', () => {
     $('#input1').fileinput('getFrames');
     $('#input2').fileinput('getFrames', '.file-preview-initial');
     $('#input3').fileinput('getFrames', ':not(.file-preview-success)');
+    $('#input1').fileinput({
+        uploadUrl: () => {
+            return 'http://localhost/file-upload.php';
+        },
+        uploadUrlThumb: () => {
+            return 'http://localhost/file-thumb-upload.php';
+        },
+    });
 });

--- a/types/bootstrap-fileinput/index.d.ts
+++ b/types/bootstrap-fileinput/index.d.ts
@@ -277,8 +277,10 @@ declare namespace BootstrapFileInput {
          * The ajax delete action will send the following data to server via POST:
          *     key: the key setting as setup in initialPreviewConfig['key']
          *     any other extra data passed as key: value pairs either via initialPreviewConfig['extra'] OR deleteExtraData if former is not set.
+         * You can also set deleteUrl as a function callback which will return a string. In that case, the function will get executed every time at runtime.
+         * This will enable you to set a dynamically changing url based on runtime conditions.
          */
-        deleteUrl?: string;
+        deleteUrl?: string | (() => string);
         /**
          * the initial preview caption text to be displayed.
          * If you do not set a value here and initialPreview is set to true this will default to "{preview-file-count} files selected",
@@ -439,8 +441,19 @@ declare namespace BootstrapFileInput {
          *     This is MANDATORY if you want to use advanced features like drag & drop, append/remove files, selectively upload files via ajax etc.
          *     The plugin automatically send $_FILES data to the server with the input `name` attribute as the key if provided.
          *     If input name is not set, the key defaults to file-data.
+         * You can also set uploadUrl as a function callback which will return a string. In that case, the function will get executed at runtime
+         * just before every ajax call. This will enable you to set a dynamic upload url based on runtime / dynamic conditions.
          */
-        uploadUrl?: string;
+        uploadUrl?: string | (() => string);
+        /**
+         * the URL for the ajax upload processing action applicable when each individual file thumbnail is separately uploaded. Defaults to null.
+         * If this is not set, this will default to the uploadUrl setting. This property is useful for synchronous uploads when uploadAsync is
+         * set to false, and you want to set a different server action for batch upload via uploadUrl, but a different server action for single
+         * file thumbnail upload via uploadUrlThumb.
+         * You can also set uploadThumbUrl as a function callback which will return a string. In that case, the function will get executed at
+         * runtime just before every ajax call. This will enable you to set a dynamic upload thumbnail url based on runtime / dynamic conditions.
+         */
+        uploadUrlThumb?: string | (() => string);
         /**
          * whether the batch upload of multiple files will be asynchronous/in parallel.
          * @default true


### PR DESCRIPTION
Updated `uploadUrl` as well as `deleteUrl` to use `string | (() => string)` since the documentation shows that these can specify a function returning a string, which is evaluated whenever needed. Added a missing option, `uploadUrlThumb`, since I noticed it wasn't there.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    * https://plugins.krajee.com/file-input/plugin-options#uploadUrl
    * https://plugins.krajee.com/file-input/plugin-options#uploadUrlThumb
    * https://plugins.krajee.com/file-input/plugin-options#deleteUrl
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
> We run version `5.0.8` and these changes work with that version, but the latest version is `5.1.3`. Since the changes still work on `5.0.x` versions leaving version at `5.0`.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.