### PR TITLE
mpv-script: Fix return type of mp.get_osd_size()

### DIFF
--- a/types/mpv-script/index.d.ts
+++ b/types/mpv-script/index.d.ts
@@ -25,6 +25,12 @@ declare namespace mp {
         remove(): void;
     }
 
+    interface OSDSize {
+        width?: number;
+        height?: number;
+        aspect?: number;
+    }
+
     interface FileInfo {
         mode: number;
         size: number;
@@ -115,7 +121,7 @@ declare namespace mp {
 
     function create_osd_overlay(format: 'ass-events'): OSDOverlay;
 
-    function get_osd_size(): [number, number, number];
+    function get_osd_size(): OSDSize | undefined;
 
     function add_hook(name: string, priority: number, fn: () => void): void;
 

--- a/types/mpv-script/mpv-script-tests.ts
+++ b/types/mpv-script/mpv-script-tests.ts
@@ -53,3 +53,14 @@ mp.observe_property('test', 'none', name => {});
 mp.observe_property('test', 'none', (name, value) => {});
 // $ExpectError
 mp.observe_property('test', undefined, (name, value) => {});
+
+// $ExpectType OSDSize | undefined
+const osd_size = mp.get_osd_size();
+if (osd_size) {
+    // $ExpectType number | undefined
+    osd_size.width;
+    // $ExpectType number | undefined
+    osd_size.height;
+    // $ExpectType number | undefined
+    osd_size.aspect;
+}


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [api doc](https://mpv.io/manual/stable/#scripting-apis-identical-to-lua)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The mentioned function was listed under "identical to lua" (the javascript api is based on the lua api). But on closer inspection it isn't actually identical.  