### PR TITLE
[yup]: add support for string.uuid

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -129,6 +129,7 @@ export interface StringSchema<T extends string | null | undefined = string | und
     ): StringSchema<T>;
     email(message?: StringLocale['email']): StringSchema<T>;
     url(message?: StringLocale['url']): StringSchema<T>;
+    uuid(message?: StringLocale['uuid']): StringSchema<T>;
     ensure(): StringSchema<T>;
     trim(message?: StringLocale['trim']): StringSchema<T>;
     lowercase(message?: StringLocale['lowercase']): StringSchema<T>;
@@ -588,6 +589,7 @@ export interface StringLocale {
     matches?: TestOptionsMessage<{ regex: RegExp }>;
     email?: TestOptionsMessage<{ regex: RegExp }>;
     url?: TestOptionsMessage<{ regex: RegExp }>;
+    uuid?: TestOptionsMessage<{ regex: RegExp }>;
     trim?: TestOptionsMessage;
     lowercase?: TestOptionsMessage;
     uppercase?: TestOptionsMessage;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -354,6 +354,9 @@ function strSchemaTests(strSchema: yup.StringSchema) {
     strSchema.url('bad url');
     strSchema.url(() => 'bad url');
     strSchema.url(({ regex }) => `Does not match ${regex}`);
+    strSchema.uuid();
+    strSchema.uuid('invalid uuid');
+    strSchema.uuid(() => 'invalid uuid');
     strSchema.ensure();
     strSchema.trim();
     strSchema.trim('trimmed');
@@ -631,6 +634,7 @@ const exhaustiveLocalObjectconst: LocaleObject = {
         matches: '${path} must match the following: "${regex}"',
         email: '${path} must be a valid email',
         url: '${path} must be a valid URL',
+        uuid: '${path} must be a valid UUID',
         trim: '${path} must be a trimmed string',
         lowercase: '${path} must be a lowercase string',
         uppercase: '${path} must be a upper case string',


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquense/yup/commit/8f2bd2b1c33615e7e68b90796d0bf6619fc7c51c
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.