### PR TITLE
fix(multer): export Multer class contract for consumption

### DIFF
--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -7,9 +7,8 @@
 //                 HyunSeob Lee <https://github.com/hyunseob>
 //                 Pierre Tchuente <https://github.com/PierreTchuente>
 //                 Oliver Emery <https://github.com/thrymgjol>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
-
 import { Request, RequestHandler } from 'express';
 import { Readable } from 'stream';
 
@@ -62,57 +61,6 @@ declare global {
     }
 }
 
-declare class Multer {
-    /**
-     * Returns middleware that processes a single file associated with the
-     * given form field.
-     *
-     * The `Request` object will be populated with a `file` object containing
-     * information about the processed file.
-     *
-     * @param fieldName Name of the multipart form field to process.
-     */
-    single(fieldName: string): RequestHandler;
-    /**
-     * Returns middleware that processes multiple files sharing the same field
-     * name.
-     *
-     * The `Request` object will be populated with a `files` array containing
-     * an information object for each processed file.
-     *
-     * @param fieldName Shared name of the multipart form fields to process.
-     * @param maxCount Optional. Maximum number of files to process. (default: Infinity)
-     * @throws `MulterError('LIMIT_UNEXPECTED_FILE')` if more than `maxCount` files are associated with `fieldName`
-     */
-    array(fieldName: string, maxCount?: number): RequestHandler;
-    /**
-     * Returns middleware that processes multiple files associated with the
-     * given form fields.
-     *
-     * The `Request` object will be populated with a `files` object which
-     * maps each field name to an array of the associated file information
-     * objects.
-     *
-     * @param fields Array of `Field` objects describing multipart form fields to process.
-     * @throws `MulterError('LIMIT_UNEXPECTED_FILE')` if more than `maxCount` files are associated with `fieldName` for any field.
-     */
-    fields(fields: ReadonlyArray<multer.Field>): RequestHandler;
-    /**
-     * Returns middleware that processes all files contained in the multipart
-     * request.
-     *
-     * The `Request` object will be populated with a `files` array containing
-     * an information object for each processed file.
-     */
-    any(): RequestHandler;
-    /**
-     * Returns middleware that accepts only non-file multipart form fields.
-     *
-     * @throws `MulterError('LIMIT_UNEXPECTED_FILE')` if any file is encountered.
-     */
-    none(): RequestHandler;
-}
-
  /**
   * Returns a Multer instance that provides several methods for generating
   * middleware that process files uploaded in `multipart/form-data` format.
@@ -127,9 +75,63 @@ declare class Multer {
   * populated with an entry mapping the field name to its string value, or array
   * of string values if multiple fields share the same name.
   */
-declare function multer(options?: multer.Options): Multer;
+declare function multer(options?: multer.Options): multer.Multer;
 
 declare namespace multer {
+    /**
+     * @see {@link https://github.com/expressjs/multer#api}
+     */
+    interface Multer {
+        /**
+         * Returns middleware that processes a single file associated with the
+         * given form field.
+         *
+         * The `Request` object will be populated with a `file` object containing
+         * information about the processed file.
+         *
+         * @param fieldName Name of the multipart form field to process.
+         */
+        single(fieldName: string): RequestHandler;
+        /**
+         * Returns middleware that processes multiple files sharing the same field
+         * name.
+         *
+         * The `Request` object will be populated with a `files` array containing
+         * an information object for each processed file.
+         *
+         * @param fieldName Shared name of the multipart form fields to process.
+         * @param maxCount Optional. Maximum number of files to process. (default: Infinity)
+         * @throws `MulterError('LIMIT_UNEXPECTED_FILE')` if more than `maxCount` files are associated with `fieldName`
+         */
+        array(fieldName: string, maxCount?: number): RequestHandler;
+        /**
+         * Returns middleware that processes multiple files associated with the
+         * given form fields.
+         *
+         * The `Request` object will be populated with a `files` object which
+         * maps each field name to an array of the associated file information
+         * objects.
+         *
+         * @param fields Array of `Field` objects describing multipart form fields to process.
+         * @throws `MulterError('LIMIT_UNEXPECTED_FILE')` if more than `maxCount` files are associated with `fieldName` for any field.
+         */
+        fields(fields: ReadonlyArray<Field>): RequestHandler;
+        /**
+         * Returns middleware that processes all files contained in the multipart
+         * request.
+         *
+         * The `Request` object will be populated with a `files` array containing
+         * an information object for each processed file.
+         */
+        any(): RequestHandler;
+        /**
+         * Returns middleware that accepts only non-file multipart form fields.
+         *
+         * @throws `MulterError('LIMIT_UNEXPECTED_FILE')` if any file is encountered.
+         */
+        none(): RequestHandler;
+    }
+
     /**
      * Returns a `StorageEngine` implementation configured to store files on
      * the local file system.
@@ -140,6 +142,7 @@ declare namespace multer {
      * character filenames.
      */
     function diskStorage(options: DiskStorageOptions): StorageEngine;
+
     /**
      * Returns a `StorageEngine` implementation configured to store files in
      * memory as `Buffer` objects.

--- a/types/multer/multer-tests.ts
+++ b/types/multer/multer-tests.ts
@@ -1,5 +1,7 @@
 import express = require('express');
 import multer = require('multer');
+import { Multer } from 'multer';
+import assert = require('assert');
 
 const upload = multer({
     dest: 'uploads/',
@@ -9,6 +11,9 @@ const upload = multer({
         cb(new Error(`I don't have a clue!`));
     },
 });
+
+upload; // $ExpectType Multer
+assert.strictEqual(upload.constructor.name, 'Multer');
 
 const app = express();
 
@@ -37,7 +42,7 @@ const diskStorage = multer.diskStorage({
     }
 });
 
-const diskUpload = multer({ storage: diskStorage });
+const diskUpload: Multer = multer({ storage: diskStorage });
 
 const memoryStorage = multer.memoryStorage();
-const memoryUpload = multer({ storage: memoryStorage });
+const memoryUpload: Multer = multer({ storage: memoryStorage });


### PR DESCRIPTION
This tries to fix issue with non-exported interface of the multer class
to the creation code itself, which prevents from using instance methods
in proper way.
See #41970 for discussion of the problem.

/cc @restjohn

Thanks!

Fixes #41970

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)