### PR TITLE
fix(@testing-library/jest-dom): amend JSDoc detail

### DIFF
--- a/types/testing-library__jest-dom/index.d.ts
+++ b/types/testing-library__jest-dom/index.d.ts
@@ -210,12 +210,9 @@ declare namespace jest {
          * @description
          * Assert whether a string representing a HTML element is contained in another element.
          * @example
-         * <span data-testid="parent">
-         *   <span data-testid="child"></span>
-         * </span>
+         * <span data-testid="parent"><span data-testid="child"></span></span>
          *
-         * const parent = getByTestId('parent')
-         * expect(parent).toContainerHTML(<span data-testid="child"></span>)
+         * expect(getByTestId('parent')).toContainHTML('<span data-testid="child"></span>')
          * @see
          * [testing-library/jest-dom#tocontainhtml](https:github.com/testing-library/jest-dom#tocontainhtml)
          */


### PR DESCRIPTION
This updates the JSDoc comment for `toContainHTML` method to be aligned
with current upstream source:

https://github.com/testing-library/jest-dom/blob/51ed5bfddd18c89ece27b659b792f86dc74c43ee/README.md#tocontainhtml

/cc @mario-orlicky

Thanks!

Fixes #46319

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes