### PR TITLE
add typedefs for RecordRTC package

### DIFF
--- a/types/recordrtc/index.d.ts
+++ b/types/recordrtc/index.d.ts
@@ -1,0 +1,181 @@
+// Type definitions for recordrtc 5.6
+// Project: http://RecordRTC.org/
+// Definitions by: Kyle Hensel <https://github.com/k-yle>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export type State = 'inactive' | 'recording' | 'stopped' | 'paused' | 'destroyed';
+
+export interface Disk {
+    audio?: Blob;
+    video?: Blob;
+    gif?: Blob;
+}
+
+export interface Options {
+    type?: 'video' | 'audio' | 'canvas' | 'gif';
+
+    mimeType?:
+        | 'video/webm'
+        | 'audio/webm'
+        | 'video/mp4'
+        | 'video/webm;codecs=vp9'
+        | 'video/webm;codecs=vp8'
+        | 'video/webm;codecs=h264'
+        | 'video/x-matroska;codecs=avc1'
+        | 'video/mpeg'
+        | 'audio/wav'
+        | 'audio/ogg';
+
+    disableLogs?: boolean;
+
+    /** get intervals based blobs value in milliseconds */
+    timeSlice?: number;
+
+    /** requires `timeSlice` to be set */
+    ondataavailable?(cb: (blob: Blob) => void): void;
+
+    /** auto stop recording if camera stops */
+    checkForInactiveTracks?: boolean;
+
+    /** requires timeSlice above */
+    onTimeStamp?(cb: (timestamp: number) => void): void;
+
+    /** both for audio and video tracks */
+    bitsPerSecond?: number;
+
+    /** only for audio track */
+    audioBitsPerSecond?: number;
+
+    /** only for video track */
+    videoBitsPerSecond?: number;
+
+    /** used by CanvasRecorder and WhammyRecorder, it is kind of a "frameRate" */
+    frameInterval?: number;
+
+    /** if you are recording multiple streams into single file, this helps you see what is being recorded */
+    previewStream?(cb: (stream: MediaStream) => void): void;
+
+    /** used by CanvasRecorder and WhammyRecorder */
+    video?: HTMLVideoElement;
+
+    /** used by CanvasRecorder and WhammyRecorder */
+    canvas?: {
+        width: number;
+        height: number;
+    };
+
+    /** used by StereoAudioRecorder, the range is 22050 to 96000 (kHz). */
+    sampleRate?: number;
+
+    /** used by StereoAudioRecorder. the range is 22050 to 96000 (kHz). */
+    desiredSampRate?: number;
+
+    /** used by StereoAudioRecorder */
+    bufferSize?: 256 | 512 | 1024 | 2048 | 4096 | 8192 | 16384;
+
+    /** used by StereoAudioRecorder */
+    numberOfAudioChannels?: 1 | 2;
+
+    /** used by WebAssemblyRecorder */
+    frameRate?: number;
+
+    /** used by WebAssemblyRecorder */
+    bitrate?: number;
+
+    /** used by MultiStreamRecorder - to access HTMLCanvasElement */
+    elementClass?: string;
+}
+
+export default class RecordRTC {
+    constructor(stream: MediaStream | HTMLCanvasElement | HTMLVideoElement | HTMLElement, options?: Options);
+
+    /** start the recording */
+    startRecording(): void;
+
+    /** stop the recording. Call `getBlob` from inside callback function */
+    stopRecording(cb?: () => void): void;
+
+    /** pause the recording */
+    pauseRecording(): void;
+
+    /** resume the recording */
+    resumeRecording(): void;
+
+    /** auto stop recording after specific duration */
+    setRecordingDuration(): void;
+
+    /** reset recorder states and remove the data */
+    reset(): void;
+
+    /** invoke save as dialog */
+    save(fileName: string): void;
+
+    /** returns recorded Blob */
+    getBlob(): Blob;
+
+    /** returns Blob-URL */
+    toURL(): string;
+
+    /** returns Data-URL */
+    getDataURL(): string;
+
+    /** returns internal recorder */
+    getInternalRecorder(): void;
+
+    /** @deprecated initialize the recorder */
+    initRecorder(): void;
+
+    /** fired if recorder's state changes */
+    onStateChanged(cb: (state: State) => void): void;
+
+    /** write recorded blob into indexed-db storage */
+    writeToDisk(options: Disk): void;
+
+    /** get recorded blob from indexded-db storage */
+    getFromDisk(type: 'all' | keyof Disk, cb: (dataURL: string, type: keyof Disk) => void): void;
+
+    /** @deprecated */
+    setAdvertisementArray(webPImages: Array<{ image: string }>): void;
+
+    /** @deprecated clear recorded data */
+    clearRecordedData(): void;
+
+    /** clear memory; clear everything */
+    destroy(): void;
+
+    /** get recorder's state */
+    getState(): void;
+
+    /** recorder's state */
+    readonly state: string;
+
+    /** recorded blob property */
+    readonly blob: Blob;
+
+    /** array buffer; useful only for StereoAudioRecorder */
+    readonly buffer: ArrayBuffer;
+
+    /** RecordRTC version */
+    readonly version: string;
+
+    /** useful only for StereoAudioRecorder */
+    readonly bufferSize: number;
+
+    /** useful only for StereoAudioRecorder */
+    readonly sampleRate: number;
+
+    //
+    // static helpers
+    //
+
+    /** RecordRTC version */
+    static version: string;
+
+    /** Given a number of bytes, this returns a human-readable string, e.g. 1.23 MB */
+    static bytesToSize(size: number): string;
+
+    /** invokes the browser's Save-As dialog */
+    static invokeSaveAsDialog(file: Blob | File, fileName: string): void;
+}
+
+// export as namespace RecordRTC;

--- a/types/recordrtc/index.d.ts
+++ b/types/recordrtc/index.d.ts
@@ -3,15 +3,15 @@
 // Definitions by: Kyle Hensel <https://github.com/k-yle>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export type State = 'inactive' | 'recording' | 'stopped' | 'paused' | 'destroyed';
+type State = 'inactive' | 'recording' | 'stopped' | 'paused' | 'destroyed';
 
-export interface Disk {
+interface Disk {
     audio?: Blob;
     video?: Blob;
     gif?: Blob;
 }
 
-export interface Options {
+interface Options {
     type?: 'video' | 'audio' | 'canvas' | 'gif';
 
     mimeType?:
@@ -86,7 +86,7 @@ export interface Options {
     elementClass?: string;
 }
 
-export default class RecordRTC {
+declare class RecordRTC {
     constructor(stream: MediaStream | HTMLCanvasElement | HTMLVideoElement | HTMLElement, options?: Options);
 
     /** start the recording */
@@ -178,4 +178,4 @@ export default class RecordRTC {
     static invokeSaveAsDialog(file: Blob | File, fileName: string): void;
 }
 
-// export as namespace RecordRTC;
+export = RecordRTC;

--- a/types/recordrtc/index.d.ts
+++ b/types/recordrtc/index.d.ts
@@ -3,91 +3,93 @@
 // Definitions by: Kyle Hensel <https://github.com/k-yle>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-type State = 'inactive' | 'recording' | 'stopped' | 'paused' | 'destroyed';
+declare namespace RecordRTC {
+    type State = 'inactive' | 'recording' | 'stopped' | 'paused' | 'destroyed';
 
-interface Disk {
-    audio?: Blob;
-    video?: Blob;
-    gif?: Blob;
-}
+    interface Disk {
+        audio?: Blob;
+        video?: Blob;
+        gif?: Blob;
+    }
 
-interface Options {
-    type?: 'video' | 'audio' | 'canvas' | 'gif';
+    interface Options {
+        type?: 'video' | 'audio' | 'canvas' | 'gif';
 
-    mimeType?:
-        | 'video/webm'
-        | 'audio/webm'
-        | 'video/mp4'
-        | 'video/webm;codecs=vp9'
-        | 'video/webm;codecs=vp8'
-        | 'video/webm;codecs=h264'
-        | 'video/x-matroska;codecs=avc1'
-        | 'video/mpeg'
-        | 'audio/wav'
-        | 'audio/ogg';
+        mimeType?:
+            | 'video/webm'
+            | 'audio/webm'
+            | 'video/mp4'
+            | 'video/webm;codecs=vp9'
+            | 'video/webm;codecs=vp8'
+            | 'video/webm;codecs=h264'
+            | 'video/x-matroska;codecs=avc1'
+            | 'video/mpeg'
+            | 'audio/wav'
+            | 'audio/ogg';
 
-    disableLogs?: boolean;
+        disableLogs?: boolean;
 
-    /** get intervals based blobs value in milliseconds */
-    timeSlice?: number;
+        /** get intervals based blobs value in milliseconds */
+        timeSlice?: number;
 
-    /** requires `timeSlice` to be set */
-    ondataavailable?(cb: (blob: Blob) => void): void;
+        /** requires `timeSlice` to be set */
+        ondataavailable?(cb: (blob: Blob) => void): void;
 
-    /** auto stop recording if camera stops */
-    checkForInactiveTracks?: boolean;
+        /** auto stop recording if camera stops */
+        checkForInactiveTracks?: boolean;
 
-    /** requires timeSlice above */
-    onTimeStamp?(cb: (timestamp: number) => void): void;
+        /** requires timeSlice above */
+        onTimeStamp?(cb: (timestamp: number) => void): void;
 
-    /** both for audio and video tracks */
-    bitsPerSecond?: number;
+        /** both for audio and video tracks */
+        bitsPerSecond?: number;
 
-    /** only for audio track */
-    audioBitsPerSecond?: number;
+        /** only for audio track */
+        audioBitsPerSecond?: number;
 
-    /** only for video track */
-    videoBitsPerSecond?: number;
+        /** only for video track */
+        videoBitsPerSecond?: number;
 
-    /** used by CanvasRecorder and WhammyRecorder, it is kind of a "frameRate" */
-    frameInterval?: number;
+        /** used by CanvasRecorder and WhammyRecorder, it is kind of a "frameRate" */
+        frameInterval?: number;
 
-    /** if you are recording multiple streams into single file, this helps you see what is being recorded */
-    previewStream?(cb: (stream: MediaStream) => void): void;
+        /** if you are recording multiple streams into single file, this helps you see what is being recorded */
+        previewStream?(cb: (stream: MediaStream) => void): void;
 
-    /** used by CanvasRecorder and WhammyRecorder */
-    video?: HTMLVideoElement;
+        /** used by CanvasRecorder and WhammyRecorder */
+        video?: HTMLVideoElement;
 
-    /** used by CanvasRecorder and WhammyRecorder */
-    canvas?: {
-        width: number;
-        height: number;
-    };
+        /** used by CanvasRecorder and WhammyRecorder */
+        canvas?: {
+            width: number;
+            height: number;
+        };
 
-    /** used by StereoAudioRecorder, the range is 22050 to 96000 (kHz). */
-    sampleRate?: number;
+        /** used by StereoAudioRecorder, the range is 22050 to 96000 (kHz). */
+        sampleRate?: number;
 
-    /** used by StereoAudioRecorder. the range is 22050 to 96000 (kHz). */
-    desiredSampRate?: number;
+        /** used by StereoAudioRecorder. the range is 22050 to 96000 (kHz). */
+        desiredSampRate?: number;
 
-    /** used by StereoAudioRecorder */
-    bufferSize?: 256 | 512 | 1024 | 2048 | 4096 | 8192 | 16384;
+        /** used by StereoAudioRecorder */
+        bufferSize?: 256 | 512 | 1024 | 2048 | 4096 | 8192 | 16384;
 
-    /** used by StereoAudioRecorder */
-    numberOfAudioChannels?: 1 | 2;
+        /** used by StereoAudioRecorder */
+        numberOfAudioChannels?: 1 | 2;
 
-    /** used by WebAssemblyRecorder */
-    frameRate?: number;
+        /** used by WebAssemblyRecorder */
+        frameRate?: number;
 
-    /** used by WebAssemblyRecorder */
-    bitrate?: number;
+        /** used by WebAssemblyRecorder */
+        bitrate?: number;
 
-    /** used by MultiStreamRecorder - to access HTMLCanvasElement */
-    elementClass?: string;
+        /** used by MultiStreamRecorder - to access HTMLCanvasElement */
+        elementClass?: string;
+    }
 }
 
 declare class RecordRTC {
-    constructor(stream: MediaStream | HTMLCanvasElement | HTMLVideoElement | HTMLElement, options?: Options);
+    constructor(stream: MediaStream | HTMLCanvasElement | HTMLVideoElement | HTMLElement, options?: RecordRTC.Options);
 
     /** start the recording */
     startRecording(): void;
@@ -126,13 +128,13 @@ declare class RecordRTC {
     initRecorder(): void;
 
     /** fired if recorder's state changes */
-    onStateChanged(cb: (state: State) => void): void;
+    onStateChanged(cb: (state: RecordRTC.State) => void): void;
 
     /** write recorded blob into indexed-db storage */
-    writeToDisk(options: Disk): void;
+    writeToDisk(options: RecordRTC.Disk): void;
 
     /** get recorded blob from indexded-db storage */
-    getFromDisk(type: 'all' | keyof Disk, cb: (dataURL: string, type: keyof Disk) => void): void;
+    getFromDisk(type: 'all' | keyof RecordRTC.Disk, cb: (dataURL: string, type: keyof RecordRTC.Disk) => void): void;
 
     /** @deprecated */
     setAdvertisementArray(webPImages: Array<{ image: string }>): void;

--- a/types/recordrtc/recordrtc-tests.ts
+++ b/types/recordrtc/recordrtc-tests.ts
@@ -1,4 +1,6 @@
-import RecordRTC from 'recordrtc';
+import RecordRTC, { Options } from 'recordrtc';
+
+const opts: Options = {};
 
 navigator.getUserMedia(
     { audio: true, video: true },

--- a/types/recordrtc/recordrtc-tests.ts
+++ b/types/recordrtc/recordrtc-tests.ts
@@ -1,0 +1,26 @@
+import RecordRTC from 'recordrtc';
+
+navigator.getUserMedia(
+    { audio: true, video: true },
+    stream => {
+        const instance = new RecordRTC(stream, {
+            type: 'video',
+            disableLogs: true,
+            bufferSize: 2048,
+        });
+
+        instance.stopRecording(() => {
+            const blob = instance.getBlob();
+        });
+    },
+    console.error,
+);
+
+const canvas = document.querySelector('canvas')!;
+
+const instance2 = new RecordRTC(canvas, {
+    type: 'canvas',
+});
+instance2.stopRecording();
+
+console.log(RecordRTC.version);

--- a/types/recordrtc/tsconfig.json
+++ b/types/recordrtc/tsconfig.json
@@ -10,6 +10,7 @@
         "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
+        "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": ["index.d.ts", "recordrtc-tests.ts"]

--- a/types/recordrtc/tsconfig.json
+++ b/types/recordrtc/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6", "dom"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "recordrtc-tests.ts"]
+}

--- a/types/recordrtc/tslint.json
+++ b/types/recordrtc/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
