### PR TITLE
[material-ui] fix: makeSelectable omit inner component's onChange property

### DIFF
--- a/types/material-ui-datatables/index.d.ts
+++ b/types/material-ui-datatables/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/hyojin/material-ui-datatables#readme
 // Definitions by: Ravi L. <https://github.com/coding2012>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// Minimum TypeScript Version: 3.5
 
 import * as React from 'react';
 

--- a/types/material-ui-pagination/index.d.ts
+++ b/types/material-ui-pagination/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/lo-tp/material-ui-pagination
 // Definitions by: m0a <https://m0a.github.io>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// Minimum TypeScript Version: 3.5
 import * as React from 'react';
 export interface PaginationProps {
     total: number;

--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -14,7 +14,7 @@
 //                 Sam Walsh <https://github.com/samwalshnz>
 //                 Tim de Koning <https://github.com/reggino>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// Minimum TypeScript Version: 3.5
 
 /// <reference types="react" />
 /// <reference types="react-addons-linked-state-mixin" />
@@ -1192,7 +1192,7 @@ declare namespace __MaterialUI {
         }
 
         // union types for higher order components in TypeScript 1.8: https://github.com/Microsoft/TypeScript/issues/4362
-        export function makeSelectable<P extends {}>(component: React.ComponentClass<P>): React.ComponentClass<P & SelectableProps>;
+        export function makeSelectable<P extends {}>(component: React.ComponentClass<P>): React.ComponentClass<Omit<P, 'onChange'> & SelectableProps>;
     }
 
     namespace Menus {

--- a/types/material-ui/material-ui-tests.tsx
+++ b/types/material-ui/material-ui-tests.tsx
@@ -4227,7 +4227,7 @@ function wrapState(ComposedComponent: ComponentClass<__MaterialUI.List.Selectabl
   };
 }
 
-const SelectableList = wrapState(makeSelectable<{}>(List));
+const SelectableList = wrapState(makeSelectable(List));
 
 const ListExampleSelectable = () => (
   <Paper>
@@ -4262,6 +4262,12 @@ const ListExampleSelectable = () => (
       />
     </SelectableList>
   </Paper>
+);
+
+const DirectSelectableList = makeSelectable(List);
+
+const DirectSelectableListExample = () => (
+    <DirectSelectableList onChange={(e, v) => console.log(v)} />
 );
 
 // "http://www.material-ui.com/#/components/menu"

--- a/types/react-material-ui-form-validator/index.d.ts
+++ b/types/react-material-ui-form-validator/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Frank Brullo <https://github.com/FrankBrullo>
 //                 J.R <https://github.com/jrguenin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 3.5
 
 import * as React from 'react';
 import { SelectFieldProps, TextFieldProps } from 'material-ui';


### PR DESCRIPTION
This does update the minimum TypeScript version from 2.8 to 3.5 for the use of `Omit<,>`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
