### PR TITLE
fix(node): restore `process` & `console` globals

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -36,6 +36,9 @@ interface NodeRequire extends NodeJS.Require {}
 interface RequireResolve extends NodeJS.RequireResolve {}
 interface NodeModule extends NodeJS.Module {}
 
+declare var process: NodeJS.Process;
+declare var console: Console;
+
 declare var __filename: string;
 declare var __dirname: string;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [WEB-46630](https://youtrack.jetbrains.com/issue/WEB-46630), [github comment](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45846#issuecomment-663917850).
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

-------

This reverts the removing of the `console` & `process` globals from `globals.d.ts` in #45846 & #45849, as doing so causes problems with WebStorm (reported as [WEB-46630](https://youtrack.jetbrains.com/issue/WEB-46630)) relating to its ability to determine type information for features such as automatic importing & inline parameter hints for methods.

While I suspect this is a bug in WebStorm, it's very disruptive and the release cycles for WebStorm are a *lot* less frequent than ours, so given that having these two globals doesn't seem to cause trouble elsewhere I think it's worth keeping them until the WebStorm team have had a chance to access and ship any changes they need to make to the IDE :)