### PR TITLE
[@types/underscore] Collection and Array Tests - SortBy, IndexBy, CountBy, and Invoke

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -493,26 +493,18 @@ declare module _ {
         ): TypeOfCollection<V> | number;
 
         /**
-        * Returns a sorted copy of list, ranked in ascending order by the results of running each value
-        * through iterator. Iterator may also be the string name of the property to sort by (eg. length).
-        * @param list Sorts this list.
-        * @param iterator Sort iterator for each element within `list`.
-        * @param context `this` object in `iterator`, optional.
-        * @return A sorted copy of `list`.
-        **/
-        sortBy<T, TSort>(
-            list: _.List<T>,
-            iterator?: _.ListIterator<T, TSort>,
-            context?: any): T[];
-
-        /**
-        * @see _.sortBy
-        * @param iterator Sort iterator for each element within `list`.
-        **/
-        sortBy<T>(
-            list: _.List<T>,
-            iterator: string,
-            context?: any): T[];
+         * Returns a (stably) sorted copy of `collection`, ranked in ascending
+         * order by the results of running each value through `iteratee`.
+         * @param collection The collection to sort.
+         * @param iteratee An iteratee that provides the value to sort by for
+         * each item in `collection`.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns A sorted copy of `collection`.
+         **/
+        sortBy<V extends Collection<any>>(
+            collection: V,
+            iteratee?: Iteratee<V, any>,
+            context?: any): TypeOfCollection<V>[];
 
         /**
          * Splits a collection into sets, grouped by the result of running each value through iteratee.
@@ -528,45 +520,40 @@ declare module _ {
         ): Dictionary<TypeOfCollection<V>[]>;
 
         /**
-        * Given a `list`, and an `iterator` function that returns a key for each element in the list (or a property name),
-        * returns an object with an index of each item.  Just like _.groupBy, but for when you know your keys are unique.
-        **/
-        indexBy<T>(
-            list: _.List<T>,
-            iterator: _.ListIterator<T, any>,
-            context?: any): _.Dictionary<T>;
+         * Given a `collection` and an `iteratee` function that returns a key
+         * for each element in `collection`, returns an object that acts as an
+         * index of each item.  Just like `groupBy`, but for when you know your
+         * keys are unique.
+         * @param collection The collection to index.
+         * @param iteratee An iteratee that provides the value to index by for
+         * each item in `collection`.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns A dictionary where each item in `collection` is assigned to
+         * the property designated by `iteratee`.
+         **/
+        indexBy<V extends Collection<any>>(
+            collection: V,
+            iteratee?: Iteratee<V, any>,
+            context?: any): Dictionary<TypeOfCollection<V>>;
 
         /**
-        * @see _.indexBy
-        * @param iterator Property on each object to index them by.
-        **/
-        indexBy<T>(
-            list: _.List<T>,
-            iterator: string,
-            context?: any): _.Dictionary<T>;
-
-        /**
-        * Sorts a list into groups and returns a count for the number of objects in each group. Similar
-        * to groupBy, but instead of returning a list of values, returns a count for the number of values
-        * in that group.
-        * @param list Group elements in this list and then count the number of elements in each group.
-        * @param iterator Group iterator for each element within `list`, return the key to group the element by.
-        * @param context `this` object in `iterator`, optional.
-        * @return An object with the group names as properties where each property contains the number of elements in that group.
-        **/
-        countBy<T>(
-            list: _.List<T>,
-            iterator?: _.ListIterator<T, any>,
-            context?: any): _.Dictionary<number>;
-
-        /**
-        * @see _.countBy
-        * @param iterator Function name
-        **/
-        countBy<T>(
-            list: _.List<T>,
-            iterator: string,
-            context?: any): _.Dictionary<number>;
+         * Sorts a `collection` into groups and returns a count for the number
+         * of objects in each group. Similar to `groupBy`, but instead of
+         * returning a list of values, returns a count for the number of values
+         * in that group.
+         * @param collection The collection to count.
+         * @param iteratee An iteratee that provides the value to count by for
+         * each item in `collection`.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns A dictionary with the group names provided by `iteratee` as
+         * properties where each property contains the count of the grouped
+         * elements from `collection`.
+         **/
+        countBy<V extends Collection<any>>(
+            collection: V,
+            iteratee?: Iteratee<V, any>,
+            context?: any
+        ): Dictionary<number>;
 
         /**
          * Returns a shuffled copy of the collection, using a version of the Fisher-Yates shuffle.
@@ -4189,16 +4176,15 @@ declare module _ {
         min(iteratee?: Iteratee<V, any>, context?: any): T | number;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.sortBy
-        **/
-        sortBy(iterator?: _.ListIterator<T, any>, context?: any): T[];
-
-        /**
-        * Wrapped type `any[]`.
-        * @see _.sortBy
-        **/
-        sortBy(iterator: string, context?: any): T[];
+         * Returns a (stably) sorted copy of the wrapped collection, ranked in
+         * ascending order by the results of running each value through
+         * `iteratee`.
+         * @param iteratee An iteratee that provides the value to sort by for
+         * each item in the wrapped collection.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns A sorted copy of the wrapped collection.
+         **/
+        sortBy(iteratee?: Iteratee<V, any>, context?: any): T[];
 
         /**
          * Splits a collection into sets, grouped by the result of running each value through iteratee.
@@ -4209,28 +4195,33 @@ declare module _ {
         groupBy(iteratee: Iteratee<V, any>, context?: any): Dictionary<T[]>;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.indexBy
-        **/
-        indexBy(iterator: _.ListIterator<T, any>, context?: any): _.Dictionary<T>;
+         * Given the warpped collection and an `iteratee` function that returns
+         * a key for each element in `collection`, returns an object that acts
+         * as an index of each item.  Just like `groupBy`, but for when you
+         * know your keys are unique.
+         * @param collection The collection to index.
+         * @param iteratee An iteratee that provides the value to index by for
+         * each item in the wrapped collection.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns A dictionary where each item in the wrapped collection is
+         * assigned to the property designated by `iteratee`.
+         **/
+        indexBy(iteratee?: Iteratee<V, any>, context?: any): Dictionary<T>;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.indexBy
-        **/
-        indexBy(iterator: string, context?: any): _.Dictionary<T>;
-
-        /**
-        * Wrapped type `any[]`.
-        * @see _.countBy
-        **/
-        countBy(iterator?: _.ListIterator<T, any>, context?: any): _.Dictionary<number>;
-
-        /**
-        * Wrapped type `any[]`.
-        * @see _.countBy
-        **/
-        countBy(iterator: string, context?: any): _.Dictionary<number>;
+         * Sorts the wrapped collection into groups and returns a count for the
+         * number of objects in each group. Similar to `groupBy`, but instead
+         * of returning a list of values, returns a count for the number of
+         * values in that group.
+         * @param collection The collection to count.
+         * @param iteratee An iteratee that provides the value to count by for
+         * each item in the wrapped collection.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns A dictionary with the group names provided by `iteratee` as
+         * properties where each property contains the count of the grouped
+         * elements from the wrapped collection.
+         **/
+        countBy(iteratee?: Iteratee<V, any>, context?: any): Dictionary<number>;
 
         /**
          * Returns a shuffled copy of the wrapped collection, using a version of the Fisher-Yates shuffle.
@@ -5200,16 +5191,16 @@ declare module _ {
         min(iteratee?: _ChainIteratee<V, any, T>, context?: any): _ChainSingle<T | number>;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.sortBy
-        **/
-        sortBy(iterator?: _.ListIterator<T, any>, context?: any): _Chain<T, T[]>;
-
-        /**
-        * Wrapped type `any[]`.
-        * @see _.sortBy
-        **/
-        sortBy(iterator: string, context?: any): _Chain<T, T[]>;
+         * Returns a (stably) sorted copy of the wrapped collection, ranked in
+         * ascending order by the results of running each value through
+         * `iteratee`.
+         * @param iteratee An iteratee that provides the value to sort by for
+         * each item in the wrapped collection.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns A chain wrapper around a sorted copy of the wrapped
+         * collection.
+         **/
+        sortBy(iteratee?: _ChainIteratee<V, any, T>, context?: any): _Chain<T, T[]>;
 
         /**
          * Splits a collection into sets, grouped by the result of running each value through iteratee.
@@ -5221,28 +5212,34 @@ declare module _ {
         groupBy(iterator: _ChainIteratee<V, any, T>, context?: any): _Chain<T[], Dictionary<T[]>>;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.indexBy
-        **/
-        indexBy(iterator: _.ListIterator<T, any>, context?: any): _Chain<T>;
+         * Given the warpped collection and an `iteratee` function that returns
+         * a key for each element in `collection`, returns an object that acts
+         * as an index of each item.  Just like `groupBy`, but for when you
+         * know your keys are unique.
+         * @param collection The collection to index.
+         * @param iteratee An iteratee that provides the value to index by for
+         * each item in the wrapped collection.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns A chain wrapper around a dictionary where each item in the
+         * wrapped collection is assigned to the property designated by
+         * `iteratee`.
+         **/
+        indexBy(iteratee?: _ChainIteratee<V, any, T>, context?: any): _Chain<T, Dictionary<T>>;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.indexBy
-        **/
-        indexBy(iterator: string, context?: any): _Chain<T>;
-
-        /**
-        * Wrapped type `any[]`.
-        * @see _.countBy
-        **/
-        countBy(iterator?: _.ListIterator<T, any>, context?: any): _Chain<T>;
-
-        /**
-        * Wrapped type `any[]`.
-        * @see _.countBy
-        **/
-        countBy(iterator: string, context?: any): _Chain<T>;
+         * Sorts the wrapped collection into groups and returns a count for the
+         * number of objects in each group. Similar to `groupBy`, but instead
+         * of returning a list of values, returns a count for the number of
+         * values in that group.
+         * @param collection The collection to count.
+         * @param iteratee An iteratee that provides the value to count by for
+         * each item in the wrapped collection.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns A chain wrapper around a dictionary with the group names
+         * provided by `iteratee` as properties where each property contains
+         * the count of the grouped elements from the wrapped collection.
+         **/
+        countBy(iterator?: _ChainIteratee<V, any, T>, context?: any): _Chain<number, Dictionary<number>>;
 
         /**
          * Returns a shuffled copy of the wrapped collection, using a version of the Fisher-Yates shuffle.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -525,7 +525,7 @@ declare module _ {
          **/
         groupBy<V extends Collection<any>>(
             collection: V,
-            iteratee?: Iteratee<V, any>,
+            iteratee?: Iteratee<V, EnumerableKey>,
             context?: any
         ): Dictionary<TypeOfCollection<V>[]>;
 
@@ -543,7 +543,7 @@ declare module _ {
          **/
         indexBy<V extends Collection<any>>(
             collection: V,
-            iteratee?: Iteratee<V, any>,
+            iteratee?: Iteratee<V, EnumerableKey>,
             context?: any): Dictionary<TypeOfCollection<V>>;
 
         /**
@@ -561,7 +561,7 @@ declare module _ {
          **/
         countBy<V extends Collection<any>>(
             collection: V,
-            iteratee?: Iteratee<V, any>,
+            iteratee?: Iteratee<V, EnumerableKey>,
             context?: any
         ): Dictionary<number>;
 
@@ -4213,7 +4213,7 @@ declare module _ {
          * properties where each property contains the grouped elements from
          * the wrapped collection.
          **/
-        groupBy(iteratee?: Iteratee<V, any>, context?: any): Dictionary<T[]>;
+        groupBy(iteratee?: Iteratee<V, EnumerableKey>, context?: any): Dictionary<T[]>;
 
         /**
          * Given the warpped collection and an `iteratee` function that returns
@@ -4227,7 +4227,7 @@ declare module _ {
          * @returns A dictionary where each item in the wrapped collection is
          * assigned to the property designated by `iteratee`.
          **/
-        indexBy(iteratee?: Iteratee<V, any>, context?: any): Dictionary<T>;
+        indexBy(iteratee?: Iteratee<V, EnumerableKey>, context?: any): Dictionary<T>;
 
         /**
          * Sorts the wrapped collection into groups and returns a count for the
@@ -4242,7 +4242,7 @@ declare module _ {
          * properties where each property contains the count of the grouped
          * elements from the wrapped collection.
          **/
-        countBy(iteratee?: Iteratee<V, any>, context?: any): Dictionary<number>;
+        countBy(iteratee?: Iteratee<V, EnumerableKey>, context?: any): Dictionary<number>;
 
         /**
          * Returns a shuffled copy of the wrapped collection, using a version of the Fisher-Yates shuffle.
@@ -5240,7 +5240,7 @@ declare module _ {
          * provided by `iteratee` as properties where each property contains
          * the grouped elements from the wrapped collection.
          **/
-        groupBy(iteratee?: _ChainIteratee<V, any, T>, context?: any): _Chain<T[], Dictionary<T[]>>;
+        groupBy(iteratee?: _ChainIteratee<V, EnumerableKey, T>, context?: any): _Chain<T[], Dictionary<T[]>>;
 
         /**
          * Given the warpped collection and an `iteratee` function that returns
@@ -5255,7 +5255,7 @@ declare module _ {
          * wrapped collection is assigned to the property designated by
          * `iteratee`.
          **/
-        indexBy(iteratee?: _ChainIteratee<V, any, T>, context?: any): _Chain<T, Dictionary<T>>;
+        indexBy(iteratee?: _ChainIteratee<V, EnumerableKey, T>, context?: any): _Chain<T, Dictionary<T>>;
 
         /**
          * Sorts the wrapped collection into groups and returns a count for the
@@ -5270,7 +5270,7 @@ declare module _ {
          * provided by `iteratee` as properties where each property contains
          * the count of the grouped elements from the wrapped collection.
          **/
-        countBy(iterator?: _ChainIteratee<V, any, T>, context?: any): _Chain<number, Dictionary<number>>;
+        countBy(iterator?: _ChainIteratee<V, EnumerableKey, T>, context?: any): _Chain<number, Dictionary<number>>;
 
         /**
          * Returns a shuffled copy of the wrapped collection, using a version of the Fisher-Yates shuffle.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -507,15 +507,19 @@ declare module _ {
             context?: any): TypeOfCollection<V>[];
 
         /**
-         * Splits a collection into sets, grouped by the result of running each value through iteratee.
+         * Splits a `collection` into sets that are grouped by the result of
+         * running each value through `iteratee`.
          * @param collection The collection to group.
-         * @param iteratee An iteratee that provides the value to group by for each item in the collection.
+         * @param iteratee An iteratee that provides the value to group by for
+         * each item in `collection`.
          * @param context `this` object in `iteratee`, optional.
-         * @returns A dictionary with the group names as properties where each property contains the grouped elements from the collection.
+         * @returns A dictionary with the group names provided by `iteratee` as
+         * properties where each property contains the grouped elements from
+         * `collection`.
          **/
         groupBy<V extends Collection<any>>(
             collection: V,
-            iteratee: Iteratee<V, any>,
+            iteratee?: Iteratee<V, any>,
             context?: any
         ): Dictionary<TypeOfCollection<V>[]>;
 
@@ -4187,12 +4191,17 @@ declare module _ {
         sortBy(iteratee?: Iteratee<V, any>, context?: any): T[];
 
         /**
-         * Splits a collection into sets, grouped by the result of running each value through iteratee.
-         * @param iteratee An iteratee that provides the value to group by for each item in the collection.
+         * Splits the warpped collection into sets that are grouped by the
+         * result of running each value through `iteratee`.
+         * @param collection The collection to group.
+         * @param iteratee An iteratee that provides the value to group by for
+         * each item in the wrapped collection.
          * @param context `this` object in `iteratee`, optional.
-         * @returns A dictionary with the group names as properties where each property contains the grouped elements from the collection.
+         * @returns A dictionary with the group names provided by `iteratee` as
+         * properties where each property contains the grouped elements from
+         * the wrapped collection.
          **/
-        groupBy(iteratee: Iteratee<V, any>, context?: any): Dictionary<T[]>;
+        groupBy(iteratee?: Iteratee<V, any>, context?: any): Dictionary<T[]>;
 
         /**
          * Given the warpped collection and an `iteratee` function that returns
@@ -5203,13 +5212,17 @@ declare module _ {
         sortBy(iteratee?: _ChainIteratee<V, any, T>, context?: any): _Chain<T, T[]>;
 
         /**
-         * Splits a collection into sets, grouped by the result of running each value through iteratee.
-         * @param iteratee An iteratee that provides the value to group by for each item in the collection.
+         * Splits the warpped collection into sets that are grouped by the
+         * result of running each value through `iteratee`.
+         * @param collection The collection to group.
+         * @param iteratee An iteratee that provides the value to group by for
+         * each item in the wrapped collection.
          * @param context `this` object in `iteratee`, optional.
-         * @returns A dictionary with the group names as properties where each property contains the grouped elements from the collection
-         * in a chain wrapper.
+         * @returns A chain wrapper around a dictionary with the group names
+         * provided by `iteratee` as properties where each property contains
+         * the grouped elements from the wrapped collection.
          **/
-        groupBy(iterator: _ChainIteratee<V, any, T>, context?: any): _Chain<T[], Dictionary<T[]>>;
+        groupBy(iteratee?: _ChainIteratee<V, any, T>, context?: any): _Chain<T[], Dictionary<T[]>>;
 
         /**
          * Given the warpped collection and an `iteratee` function that returns

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -431,16 +431,22 @@ declare module _ {
         includes: UnderscoreStatic['contains'];
 
         /**
-        * Calls the method named by methodName on each value in the list. Any extra arguments passed to
-        * invoke will be forwarded on to the method invocation.
-        * @param list The element's in this list will each have the method `methodName` invoked.
-        * @param methodName The method's name to call on each element within `list`.
-        * @param arguments Additional arguments to pass to the method `methodName`.
-        **/
-        invoke<T extends {}>(
-            list: _.List<T>,
+         * Calls the method named by `methodName` on each value in
+         * `collection`. Any extra arguments passed to invoke will be forwarded
+         * on to the method invocation.
+         * @param collection The collection of elements to invoke `methodName`
+         * on.
+         * @param methodName The name of the method to call on each element in
+         * `collection`.
+         * @param args Additional arguments to pass to method `methodName`.
+         * @returns An array containing the result of the method call for each
+         * item in `collection`.
+         **/
+        invoke(
+            list: Collection<any>,
             methodName: string,
-            ...args: any[]): any;
+            ...args: any[]
+        ): any[];
 
         /**
          * A convenient version of what is perhaps the most common use-case for map: extracting a list of
@@ -4134,10 +4140,16 @@ declare module _ {
         includes: Underscore<T, V>['contains'];
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.invoke
-        **/
-        invoke(methodName: string, ...args: any[]): any;
+         * Calls the method named by `methodName` on each value in the wrapped
+         * collection. Any extra arguments passed to invoke will be forwarded
+         * on to the method invocation.
+         * @param methodName The name of the method to call on each element in
+         * the wrapped collection.
+         * @param args Additional arguments to pass to method `methodName`.
+         * @returns An array containing the result of the method call for each
+         * item in the wrapped collection.
+         **/
+        invoke(methodName: string, ...args: any[]): any[];
 
         /**
          * A convenient version of what is perhaps the most common use-case for map: extracting a list of
@@ -5152,10 +5164,16 @@ declare module _ {
         includes: _Chain<T, V>['contains'];
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.invoke
-        **/
-        invoke(methodName: string, ...args: any[]): _Chain<T>;
+         * Calls the method named by `methodName` on each value in the wrapped
+         * collection. Any extra arguments passed to invoke will be forwarded
+         * on to the method invocation.
+         * @param methodName The name of the method to call on each element in
+         * the wrapped collection.
+         * @param args Additional arguments to pass to method `methodName`.
+         * @returns A chain wrapper around an array containing the result of
+         * the method call for each item in the wrapped collection.
+         **/
+        invoke(methodName: string, ...args: any[]): _Chain<any, any[]>;
 
         /**
          * A convenient version of what is perhaps the most common use-case for map: extracting a list of

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1939,6 +1939,16 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _(stringRecordDictionary).groupBy(stringRecordDictionaryValueIterator, context); // $ExpectType Dictionary<StringRecord[]>
     _.chain(stringRecordDictionary).groupBy(stringRecordDictionaryValueIterator, context); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
 
+    // partial object iteratee - lists
+    _.groupBy(stringRecordList, partialStringRecord); // $ExpectType Dictionary<StringRecord[]>
+    _(stringRecordList).groupBy(partialStringRecord); // $ExpectType Dictionary<StringRecord[]>
+    _.chain(stringRecordList).groupBy(partialStringRecord); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
+
+    // partial object iteratee - dictionaries
+    _.groupBy(stringRecordDictionary, partialStringRecord); // $ExpectType Dictionary<StringRecord[]>
+    _(stringRecordDictionary).groupBy(partialStringRecord); // $ExpectType Dictionary<StringRecord[]>
+    _.chain(stringRecordDictionary).groupBy(partialStringRecord); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
+
     // property name iteratee - lists
     _.groupBy(stringRecordList, stringRecordProperty); // $ExpectType Dictionary<StringRecord[]>
     _(stringRecordList).groupBy(stringRecordProperty); // $ExpectType Dictionary<StringRecord[]>
@@ -1958,6 +1968,16 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _.groupBy(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord[]>
     _(stringRecordDictionary).groupBy(stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord[]>
     _.chain(stringRecordDictionary).groupBy(stringRecordPropertyPath); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
+
+    // identity iteratee - lists
+    _.groupBy(stringRecordList); // $ExpectType Dictionary<StringRecord[]>
+    _(stringRecordList).groupBy(); // $ExpectType Dictionary<StringRecord[]>
+    _.chain(stringRecordList).groupBy(); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
+
+    // identity iteratee - dictionaries
+    _.groupBy(stringRecordDictionary); // $ExpectType Dictionary<StringRecord[]>
+    _(stringRecordDictionary).groupBy(); // $ExpectType Dictionary<StringRecord[]>
+    _.chain(stringRecordDictionary).groupBy(); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
 }
 
 // indexBy

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1874,6 +1874,59 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     extractChainTypes(_.chain(numberDictionary).min()); // $ExpectType ChainType<number, never>
 }
 
+// sortBy
+{
+    // function iterator - lists
+    _.sortBy(stringRecordList, stringRecordListValueIterator); // $ExpectType StringRecord[]
+    _(stringRecordList).sortBy(stringRecordListValueIterator, context); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).sortBy(stringRecordListValueIterator)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // function iterator - dictionaries
+    _.sortBy(stringRecordDictionary, stringRecordDictionaryValueIterator, context); // $ExpectType StringRecord[]
+    _(stringRecordDictionary).sortBy(stringRecordDictionaryValueIterator); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordDictionary).sortBy(stringRecordDictionaryValueIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // partial object iterator - lists
+    _.sortBy(stringRecordList, partialStringRecord); // $ExpectType StringRecord[]
+    _(stringRecordList).sortBy(partialStringRecord); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).sortBy(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // partial object iterator - dictionaries
+    _.sortBy(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecord[]
+    _(stringRecordDictionary).sortBy(partialStringRecord); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordDictionary).sortBy(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // property name iterator - lists
+    _.sortBy(stringRecordList, stringRecordProperty); // $ExpectType StringRecord[]
+    _(stringRecordList).sortBy(stringRecordProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).sortBy(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // property name iterator - dictionaries
+    _.sortBy(stringRecordDictionary, stringRecordProperty); // $ExpectType StringRecord[]
+    _(stringRecordDictionary).sortBy(stringRecordProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordDictionary).sortBy(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // property path iterator - lists
+    _.sortBy(stringRecordList, stringRecordPropertyPath); // $ExpectType StringRecord[]
+    _(stringRecordList).sortBy(stringRecordPropertyPath); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).sortBy(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // property path iterator - dictionaries
+    _.sortBy(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType StringRecord[]
+    _(stringRecordDictionary).sortBy(stringRecordPropertyPath); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordDictionary).sortBy(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // identity iterator - lists
+    _.sortBy(stringRecordList); // $ExpectType StringRecord[]
+    _(stringRecordList).sortBy(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordList).sortBy()); // $ExpectType ChainType<StringRecord[], StringRecord>
+
+    // identity iterator - dictionaries
+    _.sortBy(stringRecordDictionary); // $ExpectType StringRecord[]
+    _(stringRecordDictionary).sortBy(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(stringRecordDictionary).sortBy()); // $ExpectType ChainType<StringRecord[], StringRecord>
+}
+
 // groupBy
 {
     // function iteratee - lists
@@ -1905,6 +1958,112 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _.groupBy(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord[]>
     _(stringRecordDictionary).groupBy(stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord[]>
     _.chain(stringRecordDictionary).groupBy(stringRecordPropertyPath); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
+}
+
+// indexBy
+{
+    // function iterator - lists
+    _.indexBy(stringRecordList, stringRecordListValueIterator); // $ExpectType Dictionary<StringRecord>
+    _(stringRecordList).indexBy(stringRecordListValueIterator, context); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(stringRecordList).indexBy(stringRecordListValueIterator)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+
+    // function iterator - dictionaries
+    _.indexBy(stringRecordDictionary, stringRecordDictionaryValueIterator, context); // $ExpectType Dictionary<StringRecord>
+    _(stringRecordDictionary).indexBy(stringRecordDictionaryValueIterator); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(stringRecordDictionary).indexBy(stringRecordDictionaryValueIterator, context)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+
+    // partial object iterator - lists
+    _.indexBy(stringRecordList, partialStringRecord); // $ExpectType Dictionary<StringRecord>
+    _(stringRecordList).indexBy(partialStringRecord); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(stringRecordList).indexBy(partialStringRecord)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+
+    // partial object iterator - dictionaries
+    _.indexBy(stringRecordDictionary, partialStringRecord); // $ExpectType Dictionary<StringRecord>
+    _(stringRecordDictionary).indexBy(partialStringRecord); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(stringRecordDictionary).indexBy(partialStringRecord)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+
+    // property name iterator - lists
+    _.indexBy(stringRecordList, stringRecordProperty); // $ExpectType Dictionary<StringRecord>
+    _(stringRecordList).indexBy(stringRecordProperty); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(stringRecordList).indexBy(stringRecordProperty)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+
+    // property name iterator - dictionaries
+    _.indexBy(stringRecordDictionary, stringRecordProperty); // $ExpectType Dictionary<StringRecord>
+    _(stringRecordDictionary).indexBy(stringRecordProperty); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(stringRecordDictionary).indexBy(stringRecordProperty)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+
+    // property path iterator - lists
+    _.indexBy(stringRecordList, stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord>
+    _(stringRecordList).indexBy(stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(stringRecordList).indexBy(stringRecordPropertyPath)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+
+    // property path iterator - dictionaries
+    _.indexBy(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord>
+    _(stringRecordDictionary).indexBy(stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(stringRecordDictionary).indexBy(stringRecordPropertyPath)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+
+    // identity iterator - lists
+    _.indexBy(stringRecordList); // $ExpectType Dictionary<StringRecord>
+    _(stringRecordList).indexBy(); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(stringRecordList).indexBy()); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+
+    // identity iterator - dictionaries
+    _.indexBy(stringRecordDictionary); // $ExpectType Dictionary<StringRecord>
+    _(stringRecordDictionary).indexBy(); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(stringRecordDictionary).indexBy()); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+}
+
+// countBy
+{
+    // function iterator - lists
+    _.countBy(stringRecordList, stringRecordListValueIterator); // $ExpectType Dictionary<number>
+    _(stringRecordList).countBy(stringRecordListValueIterator, context); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(stringRecordList).countBy(stringRecordListValueIterator)); // $ExpectType ChainType<Dictionary<number>, number>
+
+    // function iterator - dictionaries
+    _.countBy(stringRecordDictionary, stringRecordDictionaryValueIterator, context); // $ExpectType Dictionary<number>
+    _(stringRecordDictionary).countBy(stringRecordDictionaryValueIterator); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(stringRecordDictionary).countBy(stringRecordDictionaryValueIterator, context)); // $ExpectType ChainType<Dictionary<number>, number>
+
+    // partial object iterator - lists
+    _.countBy(stringRecordList, partialStringRecord); // $ExpectType Dictionary<number>
+    _(stringRecordList).countBy(partialStringRecord); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(stringRecordList).countBy(partialStringRecord)); // $ExpectType ChainType<Dictionary<number>, number>
+
+    // partial object iterator - dictionaries
+    _.countBy(stringRecordDictionary, partialStringRecord); // $ExpectType Dictionary<number>
+    _(stringRecordDictionary).countBy(partialStringRecord); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(stringRecordDictionary).countBy(partialStringRecord)); // $ExpectType ChainType<Dictionary<number>, number>
+
+    // property name iterator - lists
+    _.countBy(stringRecordList, stringRecordProperty); // $ExpectType Dictionary<number>
+    _(stringRecordList).countBy(stringRecordProperty); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(stringRecordList).countBy(stringRecordProperty)); // $ExpectType ChainType<Dictionary<number>, number>
+
+    // property name iterator - dictionaries
+    _.countBy(stringRecordDictionary, stringRecordProperty); // $ExpectType Dictionary<number>
+    _(stringRecordDictionary).countBy(stringRecordProperty); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(stringRecordDictionary).countBy(stringRecordProperty)); // $ExpectType ChainType<Dictionary<number>, number>
+
+    // property path iterator - lists
+    _.countBy(stringRecordList, stringRecordPropertyPath); // $ExpectType Dictionary<number>
+    _(stringRecordList).countBy(stringRecordPropertyPath); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(stringRecordList).countBy(stringRecordPropertyPath)); // $ExpectType ChainType<Dictionary<number>, number>
+
+    // property path iterator - dictionaries
+    _.countBy(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType Dictionary<number>
+    _(stringRecordDictionary).countBy(stringRecordPropertyPath); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(stringRecordDictionary).countBy(stringRecordPropertyPath)); // $ExpectType ChainType<Dictionary<number>, number>
+
+    // identity iterator - lists
+    _.countBy(stringRecordList); // $ExpectType Dictionary<number>
+    _(stringRecordList).countBy(); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(stringRecordList).countBy()); // $ExpectType ChainType<Dictionary<number>, number>
+
+    // identity iterator - dictionaries
+    _.countBy(stringRecordDictionary); // $ExpectType Dictionary<number>
+    _(stringRecordDictionary).countBy(); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(stringRecordDictionary).countBy()); // $ExpectType ChainType<Dictionary<number>, number>
 }
 
 // shuffle

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -654,6 +654,20 @@ declare const numberRecordDictionaryValueIterator: (element: NumberRecord, key: 
 const numberList: _.List<number> = { 0: 0, 1: 1, length: 2 };
 const numberDictionary: _.Dictionary<number> = { a: 0, b: 1 };
 
+interface NoParameterFunctionRecord {
+    a: () => number;
+}
+
+declare const noParameterFunctionRecordList: _.List<NoParameterFunctionRecord>;
+declare const noParameterFunctionRecordDictionary: _.Dictionary<NoParameterFunctionRecord>;
+
+interface TwoParameterFunctionRecord {
+    a: (arg0: number, arg1: string) => void;
+}
+
+declare const twoParameterFunctionRecordList: _.List<TwoParameterFunctionRecord>;
+declare const twoParameterFunctionRecordDictionary: _.Dictionary<TwoParameterFunctionRecord>;
+
 const simpleString = 'abc';
 
 const simpleStringArray: string[] = ['a', 'c'];
@@ -1755,6 +1769,19 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _.includes(stringRecordList, stringRecordList[0], simpleNumber); // $ExpectType boolean
     _(stringRecordList).includes(stringRecordList[0], simpleNumber); // $ExpectType boolean
     extractChainTypes(_.chain(stringRecordList).includes(stringRecordList[0], simpleNumber)); // $ExpectType ChainType<boolean, never>
+}
+
+// invoke
+{
+    // function without parameters
+    _.invoke(noParameterFunctionRecordList, stringRecordProperty); // $ExpectType any[]
+    _(noParameterFunctionRecordList).invoke(stringRecordProperty); // $ExpectType any[]
+    extractChainTypes(_.chain(noParameterFunctionRecordList).invoke(stringRecordProperty)); // $ExpectType ChainType<any[], any>
+
+    // function with parameters
+    _.invoke(twoParameterFunctionRecordDictionary, stringRecordProperty, simpleNumber, simpleString); // $ExpectType any[]
+    _(twoParameterFunctionRecordDictionary).invoke(stringRecordProperty, simpleNumber, simpleString); // $ExpectType any[]
+    extractChainTypes(_.chain(twoParameterFunctionRecordDictionary).invoke(stringRecordProperty, simpleNumber, simpleString)); // $ExpectType ChainType<any[], any>
 }
 
 // pluck

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1778,7 +1778,7 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
 
 // max
 {
-    // function iterator - lists
+    // function iteratee - lists
     _.max(numberRecordList, numberRecordListValueIterator); // $ExpectType number | NumberRecord
     _.max(numberRecordList, numberRecordListValueIterator, context); // $ExpectType number | NumberRecord
     _(numberRecordList).max(numberRecordListValueIterator); // $ExpectType number | NumberRecord
@@ -1786,7 +1786,7 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     extractChainTypes(_.chain(numberRecordList).max(numberRecordListValueIterator)); // $ExpectType ChainType<number | NumberRecord, never>
     extractChainTypes(_.chain(numberRecordList).max(numberRecordListValueIterator, context)); // $ExpectType ChainType<number | NumberRecord, never>
 
-    // function iterator - dictionaries
+    // function iteratee - dictionaries
     _.max(numberRecordDictionary, numberRecordDictionaryValueIterator); // $ExpectType number | NumberRecord
     _.max(numberRecordDictionary, numberRecordDictionaryValueIterator, context); // $ExpectType number | NumberRecord
     _(numberRecordDictionary).max(numberRecordDictionaryValueIterator); // $ExpectType number | NumberRecord
@@ -1794,32 +1794,32 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     extractChainTypes(_.chain(numberRecordDictionary).max(numberRecordDictionaryValueIterator)); // $ExpectType ChainType<number | NumberRecord, never>
     extractChainTypes(_.chain(numberRecordDictionary).max(numberRecordDictionaryValueIterator, context)); // $ExpectType ChainType<number | NumberRecord, never>
 
-    // property name iterator - lists
+    // property name iteratee - lists
     _.max(numberRecordList, stringRecordProperty); // $ExpectType number | NumberRecord
     _(numberRecordList).max(stringRecordProperty); // $ExpectType number | NumberRecord
     extractChainTypes(_.chain(numberRecordList).max(stringRecordProperty)); // $ExpectType ChainType<number | NumberRecord, never>
 
-    // property name iterator - dictionaries
+    // property name iteratee - dictionaries
     _.max(numberRecordDictionary, stringRecordProperty); // $ExpectType number | NumberRecord
     _(numberRecordDictionary).max(stringRecordProperty); // $ExpectType number | NumberRecord
     extractChainTypes(_.chain(numberRecordDictionary).max(stringRecordProperty)); // $ExpectType ChainType<number | NumberRecord, never>
 
-    // property path iterator - lists
+    // property path iteratee - lists
     _.max(numberRecordList, stringRecordPropertyPath); // $ExpectType number | NumberRecord
     _(numberRecordList).max(stringRecordPropertyPath); // $ExpectType number | NumberRecord
     extractChainTypes(_.chain(numberRecordList).max(stringRecordPropertyPath)); // $ExpectType ChainType<number | NumberRecord, never>
 
-    // property path iterator - dictionaries
+    // property path iteratee - dictionaries
     _.max(numberRecordDictionary, stringRecordPropertyPath); // $ExpectType number | NumberRecord
     _(numberRecordDictionary).max(stringRecordPropertyPath); // $ExpectType number | NumberRecord
     extractChainTypes(_.chain(numberRecordDictionary).max(stringRecordPropertyPath)); // $ExpectType ChainType<number | NumberRecord, never>
 
-    // identity iterator - lists
+    // identity iteratee - lists
     _.max(numberList); // $ExpectType number
     _(numberList).max(); // $ExpectType number
     extractChainTypes(_.chain(numberList).max()); // $ExpectType ChainType<number, never>
 
-    // identity iterator - dictionaries
+    // identity iteratee - dictionaries
     _.max(numberDictionary); // $ExpectType number
     _(numberDictionary).max(); // $ExpectType number
     extractChainTypes(_.chain(numberDictionary).max()); // $ExpectType ChainType<number, never>
@@ -1827,7 +1827,7 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
 
 // min
 {
-    // function iterator - lists
+    // function iteratee - lists
     _.min(numberRecordList, numberRecordListValueIterator); // $ExpectType number | NumberRecord
     _.min(numberRecordList, numberRecordListValueIterator, context); // $ExpectType number | NumberRecord
     _(numberRecordList).min(numberRecordListValueIterator); // $ExpectType number | NumberRecord
@@ -1835,7 +1835,7 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     extractChainTypes(_.chain(numberRecordList).min(numberRecordListValueIterator)); // $ExpectType ChainType<number | NumberRecord, never>
     extractChainTypes(_.chain(numberRecordList).min(numberRecordListValueIterator, context)); // $ExpectType ChainType<number | NumberRecord, never>
 
-    // function iterator - dictionaries
+    // function iteratee - dictionaries
     _.min(numberRecordDictionary, numberRecordDictionaryValueIterator); // $ExpectType number | NumberRecord
     _.min(numberRecordDictionary, numberRecordDictionaryValueIterator, context); // $ExpectType number | NumberRecord
     _(numberRecordDictionary).min(numberRecordDictionaryValueIterator); // $ExpectType number | NumberRecord
@@ -1843,32 +1843,32 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     extractChainTypes(_.chain(numberRecordDictionary).min(numberRecordDictionaryValueIterator)); // $ExpectType ChainType<number | NumberRecord, never>
     extractChainTypes(_.chain(numberRecordDictionary).min(numberRecordDictionaryValueIterator, context)); // $ExpectType ChainType<number | NumberRecord, never>
 
-    // property name iterator - lists
+    // property name iteratee - lists
     _.min(numberRecordList, stringRecordProperty); // $ExpectType number | NumberRecord
     _(numberRecordList).min(stringRecordProperty); // $ExpectType number | NumberRecord
     extractChainTypes(_.chain(numberRecordList).min(stringRecordProperty)); // $ExpectType ChainType<number | NumberRecord, never>
 
-    // property name iterator - dictionaries
+    // property name iteratee - dictionaries
     _.min(numberRecordDictionary, stringRecordProperty); // $ExpectType number | NumberRecord
     _(numberRecordDictionary).min(stringRecordProperty); // $ExpectType number | NumberRecord
     extractChainTypes(_.chain(numberRecordDictionary).min(stringRecordProperty)); // $ExpectType ChainType<number | NumberRecord, never>
 
-    // property path iterator - lists
+    // property path iteratee - lists
     _.min(numberRecordList, stringRecordPropertyPath); // $ExpectType number | NumberRecord
     _(numberRecordList).min(stringRecordPropertyPath); // $ExpectType number | NumberRecord
     extractChainTypes(_.chain(numberRecordList).min(stringRecordPropertyPath)); // $ExpectType ChainType<number | NumberRecord, never>
 
-    // property path iterator - dictionaries
+    // property path iteratee - dictionaries
     _.min(numberRecordDictionary, stringRecordPropertyPath); // $ExpectType number | NumberRecord
     _(numberRecordDictionary).min(stringRecordPropertyPath); // $ExpectType number | NumberRecord
     extractChainTypes(_.chain(numberRecordDictionary).min(stringRecordPropertyPath)); // $ExpectType ChainType<number | NumberRecord, never>
 
-    // identity iterator - lists
+    // identity iteratee - lists
     _.min(numberList); // $ExpectType number
     _(numberList).min(); // $ExpectType number
     extractChainTypes(_.chain(numberList).min()); // $ExpectType ChainType<number, never>
 
-    // identity iterator - dictionaries
+    // identity iteratee - dictionaries
     _.min(numberDictionary); // $ExpectType number
     _(numberDictionary).min(); // $ExpectType number
     extractChainTypes(_.chain(numberDictionary).min()); // $ExpectType ChainType<number, never>
@@ -1876,52 +1876,52 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
 
 // sortBy
 {
-    // function iterator - lists
+    // function iteratee - lists
     _.sortBy(stringRecordList, stringRecordListValueIterator); // $ExpectType StringRecord[]
     _(stringRecordList).sortBy(stringRecordListValueIterator, context); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordList).sortBy(stringRecordListValueIterator)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
-    // function iterator - dictionaries
+    // function iteratee - dictionaries
     _.sortBy(stringRecordDictionary, stringRecordDictionaryValueIterator, context); // $ExpectType StringRecord[]
     _(stringRecordDictionary).sortBy(stringRecordDictionaryValueIterator); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordDictionary).sortBy(stringRecordDictionaryValueIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
-    // partial object iterator - lists
+    // partial object iteratee - lists
     _.sortBy(stringRecordList, partialStringRecord); // $ExpectType StringRecord[]
     _(stringRecordList).sortBy(partialStringRecord); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordList).sortBy(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
-    // partial object iterator - dictionaries
+    // partial object iteratee - dictionaries
     _.sortBy(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecord[]
     _(stringRecordDictionary).sortBy(partialStringRecord); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordDictionary).sortBy(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
-    // property name iterator - lists
+    // property name iteratee - lists
     _.sortBy(stringRecordList, stringRecordProperty); // $ExpectType StringRecord[]
     _(stringRecordList).sortBy(stringRecordProperty); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordList).sortBy(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
-    // property name iterator - dictionaries
+    // property name iteratee - dictionaries
     _.sortBy(stringRecordDictionary, stringRecordProperty); // $ExpectType StringRecord[]
     _(stringRecordDictionary).sortBy(stringRecordProperty); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordDictionary).sortBy(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
-    // property path iterator - lists
+    // property path iteratee - lists
     _.sortBy(stringRecordList, stringRecordPropertyPath); // $ExpectType StringRecord[]
     _(stringRecordList).sortBy(stringRecordPropertyPath); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordList).sortBy(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
-    // property path iterator - dictionaries
+    // property path iteratee - dictionaries
     _.sortBy(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType StringRecord[]
     _(stringRecordDictionary).sortBy(stringRecordPropertyPath); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordDictionary).sortBy(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
-    // identity iterator - lists
+    // identity iteratee - lists
     _.sortBy(stringRecordList); // $ExpectType StringRecord[]
     _(stringRecordList).sortBy(); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordList).sortBy()); // $ExpectType ChainType<StringRecord[], StringRecord>
 
-    // identity iterator - dictionaries
+    // identity iteratee - dictionaries
     _.sortBy(stringRecordDictionary); // $ExpectType StringRecord[]
     _(stringRecordDictionary).sortBy(); // $ExpectType StringRecord[]
     extractChainTypes(_.chain(stringRecordDictionary).sortBy()); // $ExpectType ChainType<StringRecord[], StringRecord>
@@ -1962,52 +1962,52 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
 
 // indexBy
 {
-    // function iterator - lists
+    // function iteratee - lists
     _.indexBy(stringRecordList, stringRecordListValueIterator); // $ExpectType Dictionary<StringRecord>
     _(stringRecordList).indexBy(stringRecordListValueIterator, context); // $ExpectType Dictionary<StringRecord>
     extractChainTypes(_.chain(stringRecordList).indexBy(stringRecordListValueIterator)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
-    // function iterator - dictionaries
+    // function iteratee - dictionaries
     _.indexBy(stringRecordDictionary, stringRecordDictionaryValueIterator, context); // $ExpectType Dictionary<StringRecord>
     _(stringRecordDictionary).indexBy(stringRecordDictionaryValueIterator); // $ExpectType Dictionary<StringRecord>
     extractChainTypes(_.chain(stringRecordDictionary).indexBy(stringRecordDictionaryValueIterator, context)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
-    // partial object iterator - lists
+    // partial object iteratee - lists
     _.indexBy(stringRecordList, partialStringRecord); // $ExpectType Dictionary<StringRecord>
     _(stringRecordList).indexBy(partialStringRecord); // $ExpectType Dictionary<StringRecord>
     extractChainTypes(_.chain(stringRecordList).indexBy(partialStringRecord)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
-    // partial object iterator - dictionaries
+    // partial object iteratee - dictionaries
     _.indexBy(stringRecordDictionary, partialStringRecord); // $ExpectType Dictionary<StringRecord>
     _(stringRecordDictionary).indexBy(partialStringRecord); // $ExpectType Dictionary<StringRecord>
     extractChainTypes(_.chain(stringRecordDictionary).indexBy(partialStringRecord)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
-    // property name iterator - lists
+    // property name iteratee - lists
     _.indexBy(stringRecordList, stringRecordProperty); // $ExpectType Dictionary<StringRecord>
     _(stringRecordList).indexBy(stringRecordProperty); // $ExpectType Dictionary<StringRecord>
     extractChainTypes(_.chain(stringRecordList).indexBy(stringRecordProperty)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
-    // property name iterator - dictionaries
+    // property name iteratee - dictionaries
     _.indexBy(stringRecordDictionary, stringRecordProperty); // $ExpectType Dictionary<StringRecord>
     _(stringRecordDictionary).indexBy(stringRecordProperty); // $ExpectType Dictionary<StringRecord>
     extractChainTypes(_.chain(stringRecordDictionary).indexBy(stringRecordProperty)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
-    // property path iterator - lists
+    // property path iteratee - lists
     _.indexBy(stringRecordList, stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord>
     _(stringRecordList).indexBy(stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord>
     extractChainTypes(_.chain(stringRecordList).indexBy(stringRecordPropertyPath)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
-    // property path iterator - dictionaries
+    // property path iteratee - dictionaries
     _.indexBy(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord>
     _(stringRecordDictionary).indexBy(stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord>
     extractChainTypes(_.chain(stringRecordDictionary).indexBy(stringRecordPropertyPath)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
-    // identity iterator - lists
+    // identity iteratee - lists
     _.indexBy(stringRecordList); // $ExpectType Dictionary<StringRecord>
     _(stringRecordList).indexBy(); // $ExpectType Dictionary<StringRecord>
     extractChainTypes(_.chain(stringRecordList).indexBy()); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
-    // identity iterator - dictionaries
+    // identity iteratee - dictionaries
     _.indexBy(stringRecordDictionary); // $ExpectType Dictionary<StringRecord>
     _(stringRecordDictionary).indexBy(); // $ExpectType Dictionary<StringRecord>
     extractChainTypes(_.chain(stringRecordDictionary).indexBy()); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
@@ -2015,52 +2015,52 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
 
 // countBy
 {
-    // function iterator - lists
+    // function iteratee - lists
     _.countBy(stringRecordList, stringRecordListValueIterator); // $ExpectType Dictionary<number>
     _(stringRecordList).countBy(stringRecordListValueIterator, context); // $ExpectType Dictionary<number>
     extractChainTypes(_.chain(stringRecordList).countBy(stringRecordListValueIterator)); // $ExpectType ChainType<Dictionary<number>, number>
 
-    // function iterator - dictionaries
+    // function iteratee - dictionaries
     _.countBy(stringRecordDictionary, stringRecordDictionaryValueIterator, context); // $ExpectType Dictionary<number>
     _(stringRecordDictionary).countBy(stringRecordDictionaryValueIterator); // $ExpectType Dictionary<number>
     extractChainTypes(_.chain(stringRecordDictionary).countBy(stringRecordDictionaryValueIterator, context)); // $ExpectType ChainType<Dictionary<number>, number>
 
-    // partial object iterator - lists
+    // partial object iteratee - lists
     _.countBy(stringRecordList, partialStringRecord); // $ExpectType Dictionary<number>
     _(stringRecordList).countBy(partialStringRecord); // $ExpectType Dictionary<number>
     extractChainTypes(_.chain(stringRecordList).countBy(partialStringRecord)); // $ExpectType ChainType<Dictionary<number>, number>
 
-    // partial object iterator - dictionaries
+    // partial object iteratee - dictionaries
     _.countBy(stringRecordDictionary, partialStringRecord); // $ExpectType Dictionary<number>
     _(stringRecordDictionary).countBy(partialStringRecord); // $ExpectType Dictionary<number>
     extractChainTypes(_.chain(stringRecordDictionary).countBy(partialStringRecord)); // $ExpectType ChainType<Dictionary<number>, number>
 
-    // property name iterator - lists
+    // property name iteratee - lists
     _.countBy(stringRecordList, stringRecordProperty); // $ExpectType Dictionary<number>
     _(stringRecordList).countBy(stringRecordProperty); // $ExpectType Dictionary<number>
     extractChainTypes(_.chain(stringRecordList).countBy(stringRecordProperty)); // $ExpectType ChainType<Dictionary<number>, number>
 
-    // property name iterator - dictionaries
+    // property name iteratee - dictionaries
     _.countBy(stringRecordDictionary, stringRecordProperty); // $ExpectType Dictionary<number>
     _(stringRecordDictionary).countBy(stringRecordProperty); // $ExpectType Dictionary<number>
     extractChainTypes(_.chain(stringRecordDictionary).countBy(stringRecordProperty)); // $ExpectType ChainType<Dictionary<number>, number>
 
-    // property path iterator - lists
+    // property path iteratee - lists
     _.countBy(stringRecordList, stringRecordPropertyPath); // $ExpectType Dictionary<number>
     _(stringRecordList).countBy(stringRecordPropertyPath); // $ExpectType Dictionary<number>
     extractChainTypes(_.chain(stringRecordList).countBy(stringRecordPropertyPath)); // $ExpectType ChainType<Dictionary<number>, number>
 
-    // property path iterator - dictionaries
+    // property path iteratee - dictionaries
     _.countBy(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType Dictionary<number>
     _(stringRecordDictionary).countBy(stringRecordPropertyPath); // $ExpectType Dictionary<number>
     extractChainTypes(_.chain(stringRecordDictionary).countBy(stringRecordPropertyPath)); // $ExpectType ChainType<Dictionary<number>, number>
 
-    // identity iterator - lists
+    // identity iteratee - lists
     _.countBy(stringRecordList); // $ExpectType Dictionary<number>
     _(stringRecordList).countBy(); // $ExpectType Dictionary<number>
     extractChainTypes(_.chain(stringRecordList).countBy()); // $ExpectType ChainType<Dictionary<number>, number>
 
-    // identity iterator - dictionaries
+    // identity iteratee - dictionaries
     _.countBy(stringRecordDictionary); // $ExpectType Dictionary<number>
     _(stringRecordDictionary).countBy(); // $ExpectType Dictionary<number>
     extractChainTypes(_.chain(stringRecordDictionary).countBy()); // $ExpectType ChainType<Dictionary<number>, number>


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://underscorejs.org/
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

This PR continues the planned set that will together add up to #45201 and includes the following changes:

- Adds tests for `sortBy`, `indexBy`, `countBy`, and `invoke`.
- Updates `sortBy`, `indexBy`, `countBy`, and `invoke` to use `Collection` and `Iteratee` to partially fix #20623.
- Updates `invoke` return types from `any` and `T` to `any[]`.
- Updates the return type of `_Chain.sortBy`, `_Chain.indexBy`, `_Chain.countBy`, and `_Chain.invoke` to use the correct wrapped value type `V` to partially fix #36308.
- Updates the collection type result for `_Chain.countBy` to be `number` instead of `T`.
- Updates overloads of `groupBy` to be more consistent with these overloads by making tweaks to summary comments, making `iteratee` optional, and adding tests for all `iteratee` types.
- Updates test group comments for `max` and `min` to say "iteratee" instead of "iterator" because I messed that up in my last PR.

This is the last PR in the Collections family.