### PR TITLE
update(follow-redirects): update module definition

### DIFF
--- a/types/follow-redirects/OTHER_FILES.txt
+++ b/types/follow-redirects/OTHER_FILES.txt
@@ -1,2 +1,0 @@
-http.d.ts
-https.d.ts

--- a/types/follow-redirects/follow-redirects-tests.ts
+++ b/types/follow-redirects/follow-redirects-tests.ts
@@ -1,39 +1,67 @@
-import { http, https } from 'follow-redirects';
+import followRedirects = require('follow-redirects');
+import { http, https, wrap } from 'follow-redirects';
+import url = require('url');
+import browserHttp = require('follow-redirects/http');
+import browserHttps = require('follow-redirects/https');
 
-http.request({
-    host: 'localhost',
-    path: '/a/b',
-    port: 8000,
-    maxRedirects: 12,
-    beforeRedirect: (options, { headers }) => {
-        headers; // $ExpectType IncomingHttpHeaders
-        options.followRedirects = false;
+followRedirects.maxRedirects = 10;
+followRedirects.maxBodyLength = 20 * 1024 * 1024;
+
+const wrappedProtocols = wrap({
+    http: require('http'),
+    https: require('https'),
+});
+wrappedProtocols.maxBodyLength = 20;
+wrappedProtocols.maxBodyLength = 20 * 1024 * 1024;
+
+const options = url.parse('http://bit.ly/900913');
+options.maxRedirects = 10;
+options.beforeRedirect = options => {
+    if (options.hostname === 'example.com') {
+        options.auth = 'user:password';
+    }
+};
+
+http.request(options);
+http.request(
+    {
+        host: 'localhost',
+        path: '/a/b',
+        port: 8000,
+        maxRedirects: 12,
+        beforeRedirect: (options, { headers }) => {
+            headers; // $ExpectType IncomingHttpHeaders
+            options.followRedirects = false;
+        },
     },
-}, (response) => {
-    console.log(response.responseUrl, response.redirects);
-    response.on('data', (chunk) => {
-        console.log(chunk);
-    });
-}).on('error', (err) => {
+    response => {
+        console.log(response.responseUrl, response.redirects);
+        response.on('data', chunk => {
+            console.log(chunk);
+        });
+    },
+).on('error', err => {
     console.error(err);
 });
 
 const request = http.request({});
 request.end();
 
-http.get('http://bit.ly/900913', (response) => {
-    response.on('data', (chunk) => {
+http.get('http://bit.ly/900913', response => {
+    response.on('data', chunk => {
         console.log(chunk);
     });
-}).on('error', (err) => {
+}).on('error', err => {
     console.error(err);
 });
 
-https.get('http://bit.ly/900913', (response) => {
-    console.log(response.responseUrl, response.redirects);
-    response.on('data', (chunk) => {
-        console.log(chunk);
+https
+    .get('http://bit.ly/900913', response => {
+        console.log(response.responseUrl, response.redirects);
+        response.on('data', chunk => {
+            console.log(chunk);
+        });
+    })
+    .on('error', (err: Error) => {
+        console.error(err);
     });
-}).on('error', (err: Error) => {
-    console.error(err);
-});

--- a/types/follow-redirects/index.d.ts
+++ b/types/follow-redirects/index.d.ts
@@ -4,127 +4,116 @@
 //                 Claas Ahlrichs <https://github.com/claasahl>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference types="node" />
 
-import * as coreHttp from 'http';
-import * as coreHttps from 'https';
-import { Writable } from 'stream';
+import coreHttp = require('http');
+import coreHttps = require('https');
+import { Agent, IncomingHttpHeaders, RequestOptions } from 'http';
 
-export interface WrappableRequest {
-    getHeader?(...args: any[]): any;
-    setHeader(...args: any[]): any;
-    removeHeader(...args: any[]): any;
+/**
+ * Drop-in replacement for Node's http and https modules that automatically follows redirects.
+ */
 
-    abort?(...args: any[]): any;
-    flushHeaders?(...args: any[]): any;
-    setNoDelay?(...args: any[]): any;
-    setSocketKeepAlive?(...args: any[]): any;
-    setTimeout?(...args: any[]): any;
-}
-export interface WrappableResponse {
-    statusCode?: number;
-    headers: {
-        location?: string
-    };
-    destroy(): any;
+export as namespace followRedirects;
+
+declare module 'http' {
+    // tslint:disable-next-line no-empty-interface
+    interface RequestOptions extends RedirectOptions {}
+
+    interface IncomingMessage {
+        responseUrl?: string;
+        redirects: Redirect[];
+    }
 }
 
-export interface Scheme<Options, Request extends WrappableRequest, Response> {
-    request(options: Options, callback?: (res: Response) => any): Request;
+declare module 'url' {
+    // tslint:disable-next-line no-empty-interface
+    interface UrlWithStringQuery extends RedirectOptions {}
 }
 
-export interface RedirectableRequest<Request extends WrappableRequest, Response> extends Writable {
-    setHeader: Request['setHeader'];
-    removeHeader: Request['removeHeader'];
-    abort: Request['abort'];
-    flushHeaders: Request['flushHeaders'];
-    getHeader: Request['getHeader'];
-    setNoDelay: Request['setNoDelay'];
-    setSocketKeepAlive: Request['setSocketKeepAlive'];
-    setTimeout: Request['setTimeout'];
-
-    addListener(event: string, listener: (...args: any[]) => void): this;
-    addListener(event: "response", listener: (response: Response) => void): this;
-    addListener(event: "error", listener: (err: Error) => void): this;
-
-    emit(event: string | symbol, ...args: any[]): boolean;
-    emit(event: "response", response: Response): boolean;
-    emit(event: "error", err: Error): boolean;
-
-    on(event: string, listener: (...args: any[]) => void): this;
-    on(event: "response", listener: (response: Response) => void): this;
-    on(event: "error", listener: (err: Error) => void): this;
-
-    once(event: string, listener: (...args: any[]) => void): this;
-    once(event: "response", listener: (response: Response) => void): this;
-    once(event: "error", listener: (err: Error) => void): this;
-
-    prependListener(event: string, listener: (...args: any[]) => void): this;
-    prependListener(event: "response", listener: (response: Response) => void): this;
-    prependListener(event: "error", listener: (err: Error) => void): this;
-
-    prependOnceListener(event: string, listener: (...args: any[]) => void): this;
-    prependOnceListener(event: "response", listener: (response: Response) => void): this;
-    prependOnceListener(event: "error", listener: (err: Error) => void): this;
-}
-
-export interface RedirectScheme<Options, Request extends WrappableRequest, Response> {
-    request(
-        options: string | Options & FollowOptions<Options>,
-        callback?: (res: Response & FollowResponse) => void
-    ): RedirectableRequest<Request, Response>;
-    get(
-        options: string | Options & FollowOptions<Options>,
-        callback?: (res: Response & FollowResponse) => void
-    ): RedirectableRequest<Request, Response>;
-}
-
-export type Override<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
-export interface FollowOptions<Options> {
+interface RedirectOptions {
+    /**
+     * whether redirects should be followed
+     * @default true
+     */
     followRedirects?: boolean;
+    /**
+     * sets the maximum number of allowed redirects;
+     * if exceeded, an error will be emitted.
+     * @default 21
+     */
     maxRedirects?: number;
+    /**
+     * sets the maximum size of the request body; if exceeded, an error will be emitted.
+     * @default 10 * 1024 * 1024
+     */
     maxBodyLength?: number;
-    beforeRedirect?: (options: Options & FollowOptions<Options>, responseDetails: ResponseDetails) => void;
-    agents?: {
-        http?: coreHttp.Agent;
-        https?: coreHttps.Agent;
-    };
+    /**
+     * Optionally change the request options on redirects, or abort the request by throwing an error.
+     */
+    beforeRedirect?: BeforeRedirect;
+    /**
+     * sets the agent option per protocol, since HTTP and HTTPS use different agents.
+     * Example value: `{ http: new http.Agent(), https: new https.Agent() }`
+     */
+    agents?: Agents;
+    /**
+     * whether to store the redirected response details into the redirects array on the response object.
+     * @default false
+     */
     trackRedirects?: boolean;
 }
 
-export interface FollowResponse {
-    responseUrl: string;
-    redirects: Redirect[];
+interface BeforeRedirect {
+    /**
+     * Use this function to adjust the options upon redirecting,
+     * or to cancel the request by throwing an error
+     */
+    (options: RequestOptions, responseDetails: ResponseDetails): void;
 }
 
-export interface Redirect {
+interface Agents {
+    http?: Agent;
+    https?: Agent;
+}
+
+interface Redirect {
     url: string;
-    headers: coreHttp.IncomingHttpHeaders;
+    headers: IncomingHttpHeaders;
     statusCode: number;
 }
 
-export interface  ResponseDetails {
+interface ResponseDetails {
     headers: coreHttp.IncomingHttpHeaders;
 }
 
-export const http: Override<typeof coreHttp, RedirectScheme<
-    coreHttp.RequestOptions,
-    coreHttp.ClientRequest,
-    coreHttp.IncomingMessage
->>;
-export const https: Override<typeof coreHttps, RedirectScheme<
-    coreHttps.RequestOptions,
-    coreHttp.ClientRequest,
-    coreHttp.IncomingMessage
->>;
+interface Protocols {
+    http: typeof coreHttp;
+    https: typeof coreHttps;
+}
 
-export type WrappedScheme<T extends Scheme<any, any, any>> = Override<T, RedirectScheme<
-    T extends Scheme<infer Options, any, any> ? Options : never,
-    T extends Scheme<any, infer Request, any> ? Request : never,
-    T extends Scheme<any, any, infer Response> ? Response : never
->>;
+/**
+ * Drop-in replacement for Node's http and https modules that automatically follows redirects.
+ */
+interface FollowRedirects {
+    wrap(protocols: Protocols): FollowRedirects;
+    /**
+     * sets the maximum number of allowed redirects; if exceeded, an error will be emitted.
+     * @default 10 * 1024 * 1024
+     */
+    maxBodyLength: number;
 
-export function wrap<T extends {[key: string]: Scheme<any, any, any>}>(protocols: T): {
-    [K in keyof T]: WrappedScheme<T[K]>
-};
+    /**
+     * sets the maximum number of allowed redirects; if exceeded, an error will be emitted.
+     * @default 21
+     */
+    maxRedirects: number;
+
+    http: typeof coreHttp;
+
+    https: typeof coreHttps;
+}
+
+declare const followRedirects: FollowRedirects;
+
+export = followRedirects;


### PR DESCRIPTION
This commit updates details of module implementation, trying to simplify details,
switching to classic module augmentation for NodeJS native modules and to
interface based exports for module itself.

Augmentation:
- `RequestOptions` and `IncomingMessage` from `http`, to augment features
added by `follow-redirects` on the http protocol
- `UrlWithStringQuery` from 'url`, to augment options for requests.

The remaning features are exported as part of the module declaration.

As the pros here, the exported definition allows now overriding global
configuration and pre-request configuration in backward compatible fashion.

- minor version bump
- minor cleanup in header and source code

https://github.com/follow-redirects/follow-redirects#follow-redirects

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.