### PR TITLE
update(swagger-ui-dist): update module detail and minor version bump

### DIFF
--- a/types/swagger-ui-dist/absolute-path.d.ts
+++ b/types/swagger-ui-dist/absolute-path.d.ts
@@ -1,0 +1,8 @@
+/*
+ * getAbsoluteFSPath
+ * @return When run in NodeJS env, returns the absolute path to the current directory
+ *                  When run outside of NodeJS, will return an error message
+ */
+declare function getAbsoluteFSPath(): string;
+
+export = getAbsoluteFSPath;

--- a/types/swagger-ui-dist/index.d.ts
+++ b/types/swagger-ui-dist/index.d.ts
@@ -1,26 +1,28 @@
-// Type definitions for swagger-ui-dist 3.x
+// Type definitions for swagger-ui-dist 3.30
 // Project: https://github.com/swagger-api/swagger-ui#readme
 // Definitions by: Haowen <https://github.com/haowen737>
 //                 Bryce <https://github.com/brycematheson1234>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+import implementation = require('./absolute-path');
 
-export {};
 export as namespace SwaggerUIDist;
 
 /**
  * get an absolute path to swagger ui for static file serving
  */
-export function getAbsoluteFSPath(): string;
-export function absolutePath(): string;
+export const getAbsoluteFSPath: typeof implementation;
+export const absolutePath: typeof implementation;
+export const SwaggerUIStandalonePreset: any;
+export const SwaggerUIBundle: SwaggerUIBundle;
 
 export interface Url {
-  url: string;
-  name: string;
+    url: string;
+    name: string;
 }
 
 export interface Spec {
-  [k: string]: any;
+    [k: string]: any;
 }
 
 export interface SwaggerConfigs {
@@ -97,35 +99,31 @@ export interface SwaggerConfigs {
      *  Function to intercept remote definition, "Try it out", and OAuth 2.0 requests.
      *  Accepts one argument requestInterceptor(request) and must return the modified request, or a Promise that resolves to the modified request.
      */
-    requestInterceptor?: ((request: SwaggerRequest) => SwaggerRequest);
+    requestInterceptor?: (request: SwaggerRequest) => SwaggerRequest;
 
     /**
      *  Function to intercept remote definition, "Try it out", and OAuth 2.0 responses.
      *  Accepts one argument responseInterceptor(response) and must return the modified response, or a Promise that resolves to the modified response.
      */
-    responseInterceptor?: ((response: SwaggerResponse) => SwaggerResponse);
+    responseInterceptor?: (response: SwaggerResponse) => SwaggerResponse;
 
     [k: string]: any;
 }
 
 export interface SwaggerUIBundle {
-  (a?: SwaggerConfigs): any;
+    (a?: SwaggerConfigs): any;
 
-  [k: string]: any;
+    [k: string]: any;
 
-  getConfigs(): SwaggerConfigs;
+    getConfigs(): SwaggerConfigs;
 }
 
-export const SwaggerUIBundle: SwaggerUIBundle;
-
 export interface SwaggerRequest {
-  url: string;
-  credentials: string;
-  [k: string]: any;
+    url: string;
+    credentials: string;
+    [k: string]: any;
 }
 
 export interface SwaggerResponse {
-  [k: string]: any;
+    [k: string]: any;
 }
-
-export const SwaggerUIStandalonePreset: any;

--- a/types/swagger-ui-dist/swagger-ui-dist-tests.ts
+++ b/types/swagger-ui-dist/swagger-ui-dist-tests.ts
@@ -1,6 +1,25 @@
-import * as SwaggerUIDist from "swagger-ui-dist";
+import SwaggerUIDist = require('swagger-ui-dist');
+import express = require('express');
+import { getAbsoluteFSPath, absolutePath as absolutePathAlias, SwaggerUIBundle } from 'swagger-ui-dist';
+import absolutePath = require('swagger-ui-dist/absolute-path');
 
 SwaggerUIDist.getAbsoluteFSPath(); // $ExpectType string
 SwaggerUIDist.absolutePath(); // $ExpectType string
-
+getAbsoluteFSPath(); // $ExpectType string
+absolutePathAlias(); // $ExpectType string
+absolutePath(); // $ExpectType string
 SwaggerUIDist.SwaggerUIBundle();
+SwaggerUIDist.SwaggerUIBundle.getConfigs();
+
+// api tests
+
+const app = express();
+app.use(express.static(absolutePath()));
+app.listen(3000);
+
+const ui = SwaggerUIBundle({
+    url: 'https://petstore.swagger.io/v2/swagger.json',
+    dom_id: '#swagger-ui',
+    presets: [SwaggerUIBundle.presets.apis, SwaggerUIBundle.SwaggerUIStandalonePreset],
+    layout: 'StandaloneLayout',
+});


### PR DESCRIPTION
This commit tries to correct the module definition to match actual shape
of the module:
- direct access to exported absolute path function
- namespace based access from main module
- minor version bump (3.30)
- maintainer added
- minor cleanup

This change should be backward compatible with pre-existing client code.

https://github.com/swagger-api/swagger-ui/blob/master/swagger-ui-dist-package/absolute-path.js
https://github.com/swagger-api/swagger-ui/blob/master/swagger-ui-dist-package/index.js
https://www.npmjs.com/package/swagger-ui-dist

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)