### PR TITLE
[phoenix] Update typings for v1.5

### DIFF
--- a/types/phoenix/index.d.ts
+++ b/types/phoenix/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for phoenix 1.4
+// Type definitions for phoenix 1.5
 // Project: https://github.com/phoenixframework/phoenix
 // Definitions by: Mirosław Ciastek <https://github.com/mciastek>
 //                 John Goff <https://github.com/John-Goff>
@@ -51,7 +51,10 @@ export interface SocketConnectOption {
   logger: (kind: string, message: string, data: any) => void;
   reconnectAfterMs: (tries: number) => number;
   rejoinAfterMs: (tries: number) => number;
+  vsn: string;
 }
+
+export type MessageRef = string;
 
 export class Socket {
   constructor(endPoint: string, opts?: Partial<SocketConnectOption>);
@@ -71,12 +74,13 @@ export class Socket {
   log(kind: string, message: string, data: any): void;
   hasLogger(): boolean;
 
-  onOpen(callback: (cb: any) => void): void;
-  onClose(callback: (cb: any) => void): void;
-  onError(callback: (cb: any) => void): void;
-  onMessage(callback: (cb: any) => void): void;
+  onOpen(callback: (cb: any) => void): MessageRef;
+  onClose(callback: (cb: any) => void): MessageRef;
+  onError(callback: (cb: any) => void): MessageRef;
+  onMessage(callback: (cb: any) => void): MessageRef;
 
-  makeRef(): string;
+  makeRef(): MessageRef;
+  off(refs: MessageRef[]): void;
 }
 
 export class LongPoll {
@@ -177,4 +181,11 @@ export type PresenceOnLeaveCallback = (
 
 export interface PresenceOpts {
   events?: { state: string; diff: string };
+}
+
+export class Timer {
+  constructor(callback: () => void,  timerCalc: (tries: number) => number)
+
+  reset(): void;
+  scheduleTimeout(): void;
 }

--- a/types/phoenix/index.d.ts
+++ b/types/phoenix/index.d.ts
@@ -7,185 +7,169 @@
 // TypeScript Version: 2.4
 
 export class Push {
-  constructor(
-    channel: Channel,
-    event: string,
-    payload: object,
-    timeout: number,
-  );
+    constructor(channel: Channel, event: string, payload: object, timeout: number);
 
-  send(): void;
-  resend(timeout: number): void;
+    send(): void;
+    resend(timeout: number): void;
 
-  receive(status: string, callback: (response?: any) => any): this;
+    receive(status: string, callback: (response?: any) => any): this;
 }
 
 export class Channel {
-  constructor(topic: string, params?: object | (() => object), socket?: Socket);
+    constructor(topic: string, params?: object | (() => object), socket?: Socket);
 
-  join(timeout?: number): Push;
-  leave(timeout?: number): Push;
+    join(timeout?: number): Push;
+    leave(timeout?: number): Push;
 
-  onClose(callback: (payload: any, ref: any, joinRef: any) => void): void;
-  onError(callback: (reason?: any) => void): void;
-  onMessage(event: string, payload: any, ref: any): any;
+    onClose(callback: (payload: any, ref: any, joinRef: any) => void): void;
+    onError(callback: (reason?: any) => void): void;
+    onMessage(event: string, payload: any, ref: any): any;
 
-  on(event: string, callback: (response?: any) => void): number;
-  off(event: string, ref?: number): void;
+    on(event: string, callback: (response?: any) => void): number;
+    off(event: string, ref?: number): void;
 
-  push(event: string, payload: object, timeout?: number): Push;
+    push(event: string, payload: object, timeout?: number): Push;
 }
 
 export type BinaryType = 'arraybuffer' | 'blob';
 export type ConnectionState = 'connecting' | 'open' | 'closing' | 'closed';
 
 export interface SocketConnectOption {
-  binaryType: BinaryType;
-  params: object | (() => object);
-  transport: string;
-  timeout: number;
-  heartbeatIntervalMs: number;
-  longpollerTimeout: number;
-  encode: (payload: object, callback: (encoded: any) => void) => void;
-  decode: (payload: string, callback: (decoded: any) => void) => void;
-  logger: (kind: string, message: string, data: any) => void;
-  reconnectAfterMs: (tries: number) => number;
-  rejoinAfterMs: (tries: number) => number;
-  vsn: string;
+    binaryType: BinaryType;
+    params: object | (() => object);
+    transport: string;
+    timeout: number;
+    heartbeatIntervalMs: number;
+    longpollerTimeout: number;
+    encode: (payload: object, callback: (encoded: any) => void) => void;
+    decode: (payload: string, callback: (decoded: any) => void) => void;
+    logger: (kind: string, message: string, data: any) => void;
+    reconnectAfterMs: (tries: number) => number;
+    rejoinAfterMs: (tries: number) => number;
+    vsn: string;
 }
 
 export type MessageRef = string;
 
 export class Socket {
-  constructor(endPoint: string, opts?: Partial<SocketConnectOption>);
+    constructor(endPoint: string, opts?: Partial<SocketConnectOption>);
 
-  protocol(): string;
-  endPointURL(): string;
+    protocol(): string;
+    endPointURL(): string;
 
-  connect(params?: any): void;
-  disconnect(callback?: () => void, code?: number, reason?: string): void;
-  connectionState(): ConnectionState;
-  isConnected(): boolean;
+    connect(params?: any): void;
+    disconnect(callback?: () => void, code?: number, reason?: string): void;
+    connectionState(): ConnectionState;
+    isConnected(): boolean;
 
-  remove(channel: Channel): void;
-  channel(topic: string, chanParams?: object): Channel;
-  push(data: object): void;
+    remove(channel: Channel): void;
+    channel(topic: string, chanParams?: object): Channel;
+    push(data: object): void;
 
-  log(kind: string, message: string, data: any): void;
-  hasLogger(): boolean;
+    log(kind: string, message: string, data: any): void;
+    hasLogger(): boolean;
 
-  onOpen(callback: (cb: any) => void): MessageRef;
-  onClose(callback: (cb: any) => void): MessageRef;
-  onError(callback: (cb: any) => void): MessageRef;
-  onMessage(callback: (cb: any) => void): MessageRef;
+    onOpen(callback: (cb: any) => void): MessageRef;
+    onClose(callback: (cb: any) => void): MessageRef;
+    onError(callback: (cb: any) => void): MessageRef;
+    onMessage(callback: (cb: any) => void): MessageRef;
 
-  makeRef(): MessageRef;
-  off(refs: MessageRef[]): void;
+    makeRef(): MessageRef;
+    off(refs: MessageRef[]): void;
 }
 
 export class LongPoll {
-  constructor(endPoint: string);
+    constructor(endPoint: string);
 
-  normalizeEndpoint(endPoint: string): string;
-  endpointURL(): string;
+    normalizeEndpoint(endPoint: string): string;
+    endpointURL(): string;
 
-  closeAndRetry(): void;
-  ontimeout(): void;
+    closeAndRetry(): void;
+    ontimeout(): void;
 
-  poll(): void;
+    poll(): void;
 
-  send(body: any): void;
-  close(code?: any, reason?: any): void;
+    send(body: any): void;
+    close(code?: any, reason?: any): void;
 }
 
 // tslint:disable:no-unnecessary-class
 export class Ajax {
-  static states: {[state: string]: number};
+    static states: { [state: string]: number };
 
-  static request(
-    method: string,
-    endPoint: string,
-    accept: string,
-    body: any,
-    timeout?: number,
-    ontimeout?: any,
-    callback?: (response?: any) => void
-  ): void;
+    static request(
+        method: string,
+        endPoint: string,
+        accept: string,
+        body: any,
+        timeout?: number,
+        ontimeout?: any,
+        callback?: (response?: any) => void,
+    ): void;
 
-  static xdomainRequest(
-    req: any,
-    method: string,
-    endPoint: string,
-    body: any,
-    timeout?: number,
-    ontimeout?: any,
-    callback?: (response?: any) => void
-  ): void;
+    static xdomainRequest(
+        req: any,
+        method: string,
+        endPoint: string,
+        body: any,
+        timeout?: number,
+        ontimeout?: any,
+        callback?: (response?: any) => void,
+    ): void;
 
-  static xhrRequest(
-    req: any,
-    method: string,
-    endPoint: string,
-    accept: string,
-    body: any,
-    timeout?: number,
-    ontimeout?: any,
-    callback?: (response?: any) => void
-  ): void;
+    static xhrRequest(
+        req: any,
+        method: string,
+        endPoint: string,
+        accept: string,
+        body: any,
+        timeout?: number,
+        ontimeout?: any,
+        callback?: (response?: any) => void,
+    ): void;
 
-  static parseJSON(resp: string): JSON;
-  static serialize(obj: any, parentKey: string): string;
-  static appendParams(url: string, params: any): string;
+    static parseJSON(resp: string): JSON;
+    static serialize(obj: any, parentKey: string): string;
+    static appendParams(url: string, params: any): string;
 }
 
 export class Presence {
-  constructor(channel: Channel, opts?: PresenceOpts);
+    constructor(channel: Channel, opts?: PresenceOpts);
 
-  onJoin(callback: PresenceOnJoinCallback): void;
-  onLeave(callback: PresenceOnLeaveCallback): void;
-  onSync(callback: () => void): void;
-  list<T = any>(chooser?: (key: string, presence: any) => T): T[];
-  inPendingSyncState(): boolean;
+    onJoin(callback: PresenceOnJoinCallback): void;
+    onLeave(callback: PresenceOnLeaveCallback): void;
+    onSync(callback: () => void): void;
+    list<T = any>(chooser?: (key: string, presence: any) => T): T[];
+    inPendingSyncState(): boolean;
 
-  static syncState(
-    currentState: object,
-    newState: object,
-    onJoin?: PresenceOnJoinCallback,
-    onLeave?: PresenceOnLeaveCallback
-  ): any;
+    static syncState(
+        currentState: object,
+        newState: object,
+        onJoin?: PresenceOnJoinCallback,
+        onLeave?: PresenceOnLeaveCallback,
+    ): any;
 
-  static syncDiff(
-    currentState: object,
-    diff: {joins: object; leaves: object},
-    onJoin?: PresenceOnJoinCallback,
-    onLeave?: PresenceOnLeaveCallback
-  ): any;
+    static syncDiff(
+        currentState: object,
+        diff: { joins: object; leaves: object },
+        onJoin?: PresenceOnJoinCallback,
+        onLeave?: PresenceOnLeaveCallback,
+    ): any;
 
-  static list<T = any>(
-    presences: object,
-    chooser?: (key: string, presence: any) => T,
-  ): T[];
+    static list<T = any>(presences: object, chooser?: (key: string, presence: any) => T): T[];
 }
 
-export type PresenceOnJoinCallback = (
-  key?: string,
-  currentPresence?: any,
-  newPresence?: any
-) => void;
+export type PresenceOnJoinCallback = (key?: string, currentPresence?: any, newPresence?: any) => void;
 
-export type PresenceOnLeaveCallback = (
-  key?: string,
-  currentPresence?: any,
-  newPresence?: any
-) => void;
+export type PresenceOnLeaveCallback = (key?: string, currentPresence?: any, newPresence?: any) => void;
 
 export interface PresenceOpts {
-  events?: { state: string; diff: string };
+    events?: { state: string; diff: string };
 }
 
 export class Timer {
-  constructor(callback: () => void,  timerCalc: (tries: number) => number)
+    constructor(callback: () => void, timerCalc: (tries: number) => number);
 
-  reset(): void;
-  scheduleTimeout(): void;
+    reset(): void;
+    scheduleTimeout(): void;
 }

--- a/types/phoenix/index.d.ts
+++ b/types/phoenix/index.d.ts
@@ -7,156 +7,156 @@
 // TypeScript Version: 2.4
 
 export class Push {
-    constructor(channel: Channel, event: string, payload: object, timeout: number);
+  constructor(channel: Channel, event: string, payload: object, timeout: number);
 
-    send(): void;
-    resend(timeout: number): void;
+  send(): void;
+  resend(timeout: number): void;
 
-    receive(status: string, callback: (response?: any) => any): this;
+  receive(status: string, callback: (response?: any) => any): this;
 }
 
 export class Channel {
-    constructor(topic: string, params?: object | (() => object), socket?: Socket);
+  constructor(topic: string, params?: object | (() => object), socket?: Socket);
 
-    join(timeout?: number): Push;
-    leave(timeout?: number): Push;
+  join(timeout?: number): Push;
+  leave(timeout?: number): Push;
 
-    onClose(callback: (payload: any, ref: any, joinRef: any) => void): void;
-    onError(callback: (reason?: any) => void): void;
-    onMessage(event: string, payload: any, ref: any): any;
+  onClose(callback: (payload: any, ref: any, joinRef: any) => void): void;
+  onError(callback: (reason?: any) => void): void;
+  onMessage(event: string, payload: any, ref: any): any;
 
-    on(event: string, callback: (response?: any) => void): number;
-    off(event: string, ref?: number): void;
+  on(event: string, callback: (response?: any) => void): number;
+  off(event: string, ref?: number): void;
 
-    push(event: string, payload: object, timeout?: number): Push;
+  push(event: string, payload: object, timeout?: number): Push;
 }
 
 export type BinaryType = 'arraybuffer' | 'blob';
 export type ConnectionState = 'connecting' | 'open' | 'closing' | 'closed';
 
 export interface SocketConnectOption {
-    binaryType: BinaryType;
-    params: object | (() => object);
-    transport: string;
-    timeout: number;
-    heartbeatIntervalMs: number;
-    longpollerTimeout: number;
-    encode: (payload: object, callback: (encoded: any) => void) => void;
-    decode: (payload: string, callback: (decoded: any) => void) => void;
-    logger: (kind: string, message: string, data: any) => void;
-    reconnectAfterMs: (tries: number) => number;
-    rejoinAfterMs: (tries: number) => number;
-    vsn: string;
+  binaryType: BinaryType;
+  params: object | (() => object);
+  transport: string;
+  timeout: number;
+  heartbeatIntervalMs: number;
+  longpollerTimeout: number;
+  encode: (payload: object, callback: (encoded: any) => void) => void;
+  decode: (payload: string, callback: (decoded: any) => void) => void;
+  logger: (kind: string, message: string, data: any) => void;
+  reconnectAfterMs: (tries: number) => number;
+  rejoinAfterMs: (tries: number) => number;
+  vsn: string;
 }
 
 export type MessageRef = string;
 
 export class Socket {
-    constructor(endPoint: string, opts?: Partial<SocketConnectOption>);
+  constructor(endPoint: string, opts?: Partial<SocketConnectOption>);
 
-    protocol(): string;
-    endPointURL(): string;
+  protocol(): string;
+  endPointURL(): string;
 
-    connect(params?: any): void;
-    disconnect(callback?: () => void, code?: number, reason?: string): void;
-    connectionState(): ConnectionState;
-    isConnected(): boolean;
+  connect(params?: any): void;
+  disconnect(callback?: () => void, code?: number, reason?: string): void;
+  connectionState(): ConnectionState;
+  isConnected(): boolean;
 
-    remove(channel: Channel): void;
-    channel(topic: string, chanParams?: object): Channel;
-    push(data: object): void;
+  remove(channel: Channel): void;
+  channel(topic: string, chanParams?: object): Channel;
+  push(data: object): void;
 
-    log(kind: string, message: string, data: any): void;
-    hasLogger(): boolean;
+  log(kind: string, message: string, data: any): void;
+  hasLogger(): boolean;
 
-    onOpen(callback: (cb: any) => void): MessageRef;
-    onClose(callback: (cb: any) => void): MessageRef;
-    onError(callback: (cb: any) => void): MessageRef;
-    onMessage(callback: (cb: any) => void): MessageRef;
+  onOpen(callback: (cb: any) => void): MessageRef;
+  onClose(callback: (cb: any) => void): MessageRef;
+  onError(callback: (cb: any) => void): MessageRef;
+  onMessage(callback: (cb: any) => void): MessageRef;
 
-    makeRef(): MessageRef;
-    off(refs: MessageRef[]): void;
+  makeRef(): MessageRef;
+  off(refs: MessageRef[]): void;
 }
 
 export class LongPoll {
-    constructor(endPoint: string);
+  constructor(endPoint: string);
 
-    normalizeEndpoint(endPoint: string): string;
-    endpointURL(): string;
+  normalizeEndpoint(endPoint: string): string;
+  endpointURL(): string;
 
-    closeAndRetry(): void;
-    ontimeout(): void;
+  closeAndRetry(): void;
+  ontimeout(): void;
 
-    poll(): void;
+  poll(): void;
 
-    send(body: any): void;
-    close(code?: any, reason?: any): void;
+  send(body: any): void;
+  close(code?: any, reason?: any): void;
 }
 
 // tslint:disable:no-unnecessary-class
 export class Ajax {
-    static states: { [state: string]: number };
+  static states: { [state: string]: number };
 
-    static request(
-        method: string,
-        endPoint: string,
-        accept: string,
-        body: any,
-        timeout?: number,
-        ontimeout?: any,
-        callback?: (response?: any) => void,
-    ): void;
+  static request(
+    method: string,
+    endPoint: string,
+    accept: string,
+    body: any,
+    timeout?: number,
+    ontimeout?: any,
+    callback?: (response?: any) => void,
+  ): void;
 
-    static xdomainRequest(
-        req: any,
-        method: string,
-        endPoint: string,
-        body: any,
-        timeout?: number,
-        ontimeout?: any,
-        callback?: (response?: any) => void,
-    ): void;
+  static xdomainRequest(
+    req: any,
+    method: string,
+    endPoint: string,
+    body: any,
+    timeout?: number,
+    ontimeout?: any,
+    callback?: (response?: any) => void,
+  ): void;
 
-    static xhrRequest(
-        req: any,
-        method: string,
-        endPoint: string,
-        accept: string,
-        body: any,
-        timeout?: number,
-        ontimeout?: any,
-        callback?: (response?: any) => void,
-    ): void;
+  static xhrRequest(
+    req: any,
+    method: string,
+    endPoint: string,
+    accept: string,
+    body: any,
+    timeout?: number,
+    ontimeout?: any,
+    callback?: (response?: any) => void,
+  ): void;
 
-    static parseJSON(resp: string): JSON;
-    static serialize(obj: any, parentKey: string): string;
-    static appendParams(url: string, params: any): string;
+  static parseJSON(resp: string): JSON;
+  static serialize(obj: any, parentKey: string): string;
+  static appendParams(url: string, params: any): string;
 }
 
 export class Presence {
-    constructor(channel: Channel, opts?: PresenceOpts);
+  constructor(channel: Channel, opts?: PresenceOpts);
 
-    onJoin(callback: PresenceOnJoinCallback): void;
-    onLeave(callback: PresenceOnLeaveCallback): void;
-    onSync(callback: () => void): void;
-    list<T = any>(chooser?: (key: string, presence: any) => T): T[];
-    inPendingSyncState(): boolean;
+  onJoin(callback: PresenceOnJoinCallback): void;
+  onLeave(callback: PresenceOnLeaveCallback): void;
+  onSync(callback: () => void): void;
+  list<T = any>(chooser?: (key: string, presence: any) => T): T[];
+  inPendingSyncState(): boolean;
 
-    static syncState(
-        currentState: object,
-        newState: object,
-        onJoin?: PresenceOnJoinCallback,
-        onLeave?: PresenceOnLeaveCallback,
-    ): any;
+  static syncState(
+    currentState: object,
+    newState: object,
+    onJoin?: PresenceOnJoinCallback,
+    onLeave?: PresenceOnLeaveCallback,
+  ): any;
 
-    static syncDiff(
-        currentState: object,
-        diff: { joins: object; leaves: object },
-        onJoin?: PresenceOnJoinCallback,
-        onLeave?: PresenceOnLeaveCallback,
-    ): any;
+  static syncDiff(
+    currentState: object,
+    diff: { joins: object; leaves: object },
+    onJoin?: PresenceOnJoinCallback,
+    onLeave?: PresenceOnLeaveCallback,
+  ): any;
 
-    static list<T = any>(presences: object, chooser?: (key: string, presence: any) => T): T[];
+  static list<T = any>(presences: object, chooser?: (key: string, presence: any) => T): T[];
 }
 
 export type PresenceOnJoinCallback = (key?: string, currentPresence?: any, newPresence?: any) => void;
@@ -164,12 +164,12 @@ export type PresenceOnJoinCallback = (key?: string, currentPresence?: any, newPr
 export type PresenceOnLeaveCallback = (key?: string, currentPresence?: any, newPresence?: any) => void;
 
 export interface PresenceOpts {
-    events?: { state: string; diff: string };
+  events?: { state: string; diff: string };
 }
 
 export class Timer {
-    constructor(callback: () => void, timerCalc: (tries: number) => number);
+  constructor(callback: () => void, timerCalc: (tries: number) => number);
 
-    reset(): void;
-    scheduleTimeout(): void;
+  reset(): void;
+  scheduleTimeout(): void;
 }

--- a/types/phoenix/phoenix-tests.ts
+++ b/types/phoenix/phoenix-tests.ts
@@ -8,6 +8,13 @@ function test_socket() {
       rejoinAfterMs: tries => 1000,
   });
   socket.connect();
+
+  const openRef = socket.onOpen(() => {console.log('Socket opened')});
+  const closeRef = socket.onClose(() => {console.log('Socket closed')});
+  const errorRef = socket.onError(() => {console.log('Error on socket')});
+  const messageRef = socket.onMessage(() => {console.log('Message on socket')});
+
+  socket.off([openRef, closeRef, errorRef, messageRef]);
 }
 
 function test_channel() {

--- a/types/phoenix/phoenix-tests.ts
+++ b/types/phoenix/phoenix-tests.ts
@@ -1,97 +1,97 @@
 import { Socket, Channel, Presence, Timer } from 'phoenix';
 
 function test_socket() {
-    const socket = new Socket('/ws', {
-        binaryType: 'arraybuffer',
-        params: { userToken: '123' },
-        reconnectAfterMs: tries => 1000,
-        rejoinAfterMs: tries => 1000,
-        vsn: '2.0.0',
-    });
-    socket.connect();
+  const socket = new Socket('/ws', {
+    binaryType: 'arraybuffer',
+    params: { userToken: '123' },
+    reconnectAfterMs: tries => 1000,
+    rejoinAfterMs: tries => 1000,
+    vsn: '2.0.0',
+  });
+  socket.connect();
 
-    const openRef = socket.onOpen(() => {
-        console.log('Socket opened');
-    });
-    const closeRef = socket.onClose(() => {
-        console.log('Socket closed');
-    });
-    const errorRef = socket.onError(() => {
-        console.log('Error on socket');
-    });
-    const messageRef = socket.onMessage(() => {
-        console.log('Message on socket');
-    });
+  const openRef = socket.onOpen(() => {
+    console.log('Socket opened');
+  });
+  const closeRef = socket.onClose(() => {
+    console.log('Socket closed');
+  });
+  const errorRef = socket.onError(() => {
+    console.log('Error on socket');
+  });
+  const messageRef = socket.onMessage(() => {
+    console.log('Message on socket');
+  });
 
-    socket.off([openRef, closeRef, errorRef, messageRef]);
+  socket.off([openRef, closeRef, errorRef, messageRef]);
 }
 
 function test_channel() {
-    const socket = new Socket('/ws', { params: { userToken: '123' } });
-    socket.connect();
+  const socket = new Socket('/ws', { params: { userToken: '123' } });
+  socket.connect();
 
-    const channel = socket.channel('room:123', { token: '123' });
+  const channel = socket.channel('room:123', { token: '123' });
 
-    channel.on('new_msg', msg => console.log('Got message', msg));
+  channel.on('new_msg', msg => console.log('Got message', msg));
 
-    channel
-        .push('new_msg', { body: 'some value' }, 10000)
-        .receive('ok', msg => console.log('created message', msg))
-        .receive('error', reasons => console.log('create failed', reasons))
-        .receive('timeout', () => console.log('Networking issue...'));
+  channel
+    .push('new_msg', { body: 'some value' }, 10000)
+    .receive('ok', msg => console.log('created message', msg))
+    .receive('error', reasons => console.log('create failed', reasons))
+    .receive('timeout', () => console.log('Networking issue...'));
 
-    channel
-        .join()
-        .receive('ok', ({ messages }) => console.log('catching up', messages))
-        .receive('error', ({ reason }) => console.log('failed join', reason))
-        .receive('timeout', () => console.log('Networking issue. Still waiting...'));
+  channel
+    .join()
+    .receive('ok', ({ messages }) => console.log('catching up', messages))
+    .receive('error', ({ reason }) => console.log('failed join', reason))
+    .receive('timeout', () => console.log('Networking issue. Still waiting...'));
 }
 
 function test_hooks() {
-    const socket = new Socket('/ws', { params: { userToken: '123' } });
-    socket.connect();
+  const socket = new Socket('/ws', { params: { userToken: '123' } });
+  socket.connect();
 
-    socket.onError(() => console.log('there was an error with the connection!'));
-    socket.onClose(() => console.log('the connection dropped'));
+  socket.onError(() => console.log('there was an error with the connection!'));
+  socket.onClose(() => console.log('the connection dropped'));
 
-    const channel = socket.channel('room:123', { token: '123' });
+  const channel = socket.channel('room:123', { token: '123' });
 
-    channel.onError(() => console.log('there was an error!'));
-    channel.onClose(() => console.log('the channel has gone away gracefully'));
+  channel.onError(() => console.log('there was an error!'));
+  channel.onClose(() => console.log('the channel has gone away gracefully'));
 }
 
 function test_presence() {
-    const socket = new Socket('/ws', { params: { userToken: '123' } });
+  const socket = new Socket('/ws', { params: { userToken: '123' } });
 
-    const channel = socket.channel('room:123', { token: '123' });
-    const presence = new Presence(channel);
+  const channel = socket.channel('room:123', { token: '123' });
+  const presence = new Presence(channel);
 
-    let presenceState = {};
+  let presenceState = {};
 
-    const logState = (state: object) => {
-        Presence.list(state, (id: string) => id).forEach(console.log);
-    };
+  const logState = (state: object) => {
+    Presence.list(state, (id: string) => id).forEach(console.log);
+  };
 
-    channel.on('presence_state', state => {
-        presenceState = Presence.syncState(presenceState, state);
-        logState(presenceState);
-    });
+  channel.on('presence_state', state => {
+    presenceState = Presence.syncState(presenceState, state);
+    logState(presenceState);
+  });
 
-    channel.on('presence_diff', diff => {
-        presenceState = Presence.syncState(presenceState, diff);
-        logState(presenceState);
-    });
+  channel.on('presence_diff', diff => {
+    presenceState = Presence.syncState(presenceState, diff);
+    logState(presenceState);
+  });
 
-    socket.connect();
+  socket.connect();
 
-    channel.join();
+  channel.join();
 }
 
 function test_timer() {
-    const reconnectTimer = new Timer(
-        () => console.log('connect'),
-        tries => [1000, 5000, 10000][tries - 1] || 10000,
-    );
-    reconnectTimer.scheduleTimeout(); // fires after 5000
-    reconnectTimer.reset();
+  const reconnectTimer = new Timer(
+    () => console.log('connect'),
+    tries => [1000, 5000, 10000][tries - 1] || 10000,
+  );
+  reconnectTimer.scheduleTimeout(); // fires after 5000
+  reconnectTimer.reset();
 }

--- a/types/phoenix/phoenix-tests.ts
+++ b/types/phoenix/phoenix-tests.ts
@@ -1,77 +1,87 @@
 import { Socket, Channel, Presence } from 'phoenix';
 
 function test_socket() {
-  const socket = new Socket('/ws', {
-      binaryType: 'arraybuffer',
-      params: { userToken: '123' },
-      reconnectAfterMs: tries => 1000,
-      rejoinAfterMs: tries => 1000,
-  });
-  socket.connect();
+    const socket = new Socket('/ws', {
+        binaryType: 'arraybuffer',
+        params: { userToken: '123' },
+        reconnectAfterMs: tries => 1000,
+        rejoinAfterMs: tries => 1000,
+    });
+    socket.connect();
 
-  const openRef = socket.onOpen(() => {console.log('Socket opened')});
-  const closeRef = socket.onClose(() => {console.log('Socket closed')});
-  const errorRef = socket.onError(() => {console.log('Error on socket')});
-  const messageRef = socket.onMessage(() => {console.log('Message on socket')});
+    const openRef = socket.onOpen(() => {
+        console.log('Socket opened');
+    });
+    const closeRef = socket.onClose(() => {
+        console.log('Socket closed');
+    });
+    const errorRef = socket.onError(() => {
+        console.log('Error on socket');
+    });
+    const messageRef = socket.onMessage(() => {
+        console.log('Message on socket');
+    });
 
-  socket.off([openRef, closeRef, errorRef, messageRef]);
+    socket.off([openRef, closeRef, errorRef, messageRef]);
 }
 
 function test_channel() {
-  const socket = new Socket('/ws', {params: {userToken: '123'}});
-  socket.connect();
+    const socket = new Socket('/ws', { params: { userToken: '123' } });
+    socket.connect();
 
-  const channel = socket.channel('room:123', {token: '123'});
+    const channel = socket.channel('room:123', { token: '123' });
 
-  channel.on('new_msg', msg => console.log('Got message', msg));
+    channel.on('new_msg', msg => console.log('Got message', msg));
 
-  channel.push('new_msg', {body: 'some value'}, 10000)
-   .receive('ok', (msg) => console.log('created message', msg))
-   .receive('error', (reasons) => console.log('create failed', reasons))
-   .receive('timeout', () => console.log('Networking issue...'));
+    channel
+        .push('new_msg', { body: 'some value' }, 10000)
+        .receive('ok', msg => console.log('created message', msg))
+        .receive('error', reasons => console.log('create failed', reasons))
+        .receive('timeout', () => console.log('Networking issue...'));
 
-  channel.join()
-    .receive('ok', ({messages}) => console.log('catching up', messages))
-    .receive('error', ({reason}) => console.log('failed join', reason))
-    .receive('timeout', () => console.log('Networking issue. Still waiting...'));
+    channel
+        .join()
+        .receive('ok', ({ messages }) => console.log('catching up', messages))
+        .receive('error', ({ reason }) => console.log('failed join', reason))
+        .receive('timeout', () => console.log('Networking issue. Still waiting...'));
 }
 
 function test_hooks() {
-  const socket = new Socket('/ws', {params: {userToken: '123'}});
-  socket.connect();
+    const socket = new Socket('/ws', { params: { userToken: '123' } });
+    socket.connect();
 
-  socket.onError(() => console.log('there was an error with the connection!'));
-  socket.onClose(() => console.log('the connection dropped'));
+    socket.onError(() => console.log('there was an error with the connection!'));
+    socket.onClose(() => console.log('the connection dropped'));
 
-  const channel = socket.channel('room:123', {token: '123'});
+    const channel = socket.channel('room:123', { token: '123' });
 
-  channel.onError(() => console.log('there was an error!'));
-  channel.onClose(() => console.log('the channel has gone away gracefully'));
+    channel.onError(() => console.log('there was an error!'));
+    channel.onClose(() => console.log('the channel has gone away gracefully'));
 }
 
 function test_presence() {
-  const socket = new Socket('/ws', {params: {userToken: '123'}});
+    const socket = new Socket('/ws', { params: { userToken: '123' } });
 
-  const channel = socket.channel('room:123', {token: '123'});
-  const presence = new Presence(channel);
+    const channel = socket.channel('room:123', { token: '123' });
+    const presence = new Presence(channel);
 
-  let presenceState = {};
+    let presenceState = {};
 
-  const logState = (state: object) => {
-    Presence.list(state, (id: string) => id).forEach(console.log);
-  };
+    const logState = (state: object) => {
+        Presence.list(state, (id: string) => id).forEach(console.log);
+    };
 
-  channel.on('presence_state', (state) => {
-    presenceState = Presence.syncState(presenceState, state);
-    logState(presenceState);
-  });
+    channel.on('presence_state', state => {
+        presenceState = Presence.syncState(presenceState, state);
+        logState(presenceState);
+    });
 
-  channel.on('presence_diff', (diff) => {
-    presenceState = Presence.syncState(presenceState, diff);
-    logState(presenceState);
-  });
+    channel.on('presence_diff', diff => {
+        presenceState = Presence.syncState(presenceState, diff);
+        logState(presenceState);
+    });
 
-  socket.connect();
+    socket.connect();
 
-  channel.join();
+    channel.join();
 }

--- a/types/phoenix/phoenix-tests.ts
+++ b/types/phoenix/phoenix-tests.ts
@@ -6,6 +6,7 @@ function test_socket() {
         params: { userToken: '123' },
         reconnectAfterMs: tries => 1000,
         rejoinAfterMs: tries => 1000,
+        vsn: '2.0.0'
     });
     socket.connect();
 

--- a/types/phoenix/phoenix-tests.ts
+++ b/types/phoenix/phoenix-tests.ts
@@ -1,4 +1,4 @@
-import { Socket, Channel, Presence } from 'phoenix';
+import { Socket, Channel, Presence, Timer } from 'phoenix';
 
 function test_socket() {
     const socket = new Socket('/ws', {
@@ -6,7 +6,7 @@ function test_socket() {
         params: { userToken: '123' },
         reconnectAfterMs: tries => 1000,
         rejoinAfterMs: tries => 1000,
-        vsn: '2.0.0'
+        vsn: '2.0.0',
     });
     socket.connect();
 
@@ -85,4 +85,13 @@ function test_presence() {
     socket.connect();
 
     channel.join();
+}
+
+function test_timer() {
+    const reconnectTimer = new Timer(
+        () => console.log('connect'),
+        tries => [1000, 5000, 10000][tries - 1] || 10000,
+    );
+    reconnectTimer.scheduleTimeout(); // fires after 5000
+    reconnectTimer.reset();
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

## Motivation

- There was some API changes on the [version 1.5](https://diff.intrinsic.com/phoenix/1.4.0/1.5.4) of phoenix package.
- The `Timer` class was missing from the typings.

## Changes

- Include new `vsn` option to Socket constructor. https://github.com/phoenixframework/phoenix/pull/3533
- Include new typing for `Socket.off` method. https://github.com/phoenixframework/phoenix/pull/3553 https://github.com/thiamsantos/phoenix/commit/5c98c571da8adcb5ec8a5b126e1da6cb1892ac24
- Update typings for `onOpen`, `onClose`, `onError`, `onMessage` method of Socket.
- Add missing [`Timer` class](https://hexdocs.pm/phoenix/js/#timer).

