### PR TITLE
update(postman-collection): collection `Cookie` updates

### DIFF
--- a/types/postman-collection/index.d.ts
+++ b/types/postman-collection/index.d.ts
@@ -242,11 +242,20 @@ export class Cookie extends PropertyBase<CookieDefinition> implements Exclude<Co
 
   valueOf(): string;
 
+  /** Check whether an object is an instance of PostmanCookie. */
   static isCookie(obj: any): boolean;
-
+  /** Unparses a single Cookie. */
+  static unparseSingle(cookie: CookieDefinition): string;
+  /** Stringifies an Array or {@link PropertyList} of Cookies into a single string. */
+  static unparse(cookies: CookieDefinition[]): string;
+  /**
+   * Converts the Cookie to a single Set-Cookie header string.
+   */
+  static stringify(cookie: CookieDefinition): string;
+  /** Cookie header parser */
   static parse(str: string): CookieDefinition;
-
-  static splitParam(param: string): { key: string; value: string | boolean };
+  /** Splits a Cookie parameter into a key and a value */
+  private static splitParam(param: string): { key: string; value: string | boolean };
 }
 
 export class CookieList extends PropertyList<Cookie> {

--- a/types/postman-collection/postman-collection-tests.ts
+++ b/types/postman-collection/postman-collection-tests.ts
@@ -212,9 +212,9 @@ cookie.update(cookieDef); // $ExpectType void
 cookie.valueOf(); // $ExpectType string
 
 pmCollection.Cookie.isCookie({}); // $ExpectType boolean
-pmCollection.Cookie.parse('string'); // $ExpectType CookieDefinition
-pmCollection.Cookie.splitParam('string'); // $ExpectType { key: string; value: string | boolean; }
-
+const parsed = pmCollection.Cookie.parse('string'); // $ExpectType CookieDefinition
+const unparsed = pmCollection.Cookie.unparseSingle(parsed); // $ExpectType string
+pmCollection.Cookie.stringify(parsed); // $ExpectType string
 // CookieList Tests
 
 const cookieList = new pmCollection.CookieList(null, [cookie]);


### PR DESCRIPTION
- update class methods and add missing one:
- `unparseSingle`, `unparse`,  `stringify`
- mark `splitParam` to hide it from users. It's used only within its own
  class (and with tests). It seems not intented to be used outside of
  package seeing this `@private` tag.

  https://github.com/postmanlabs/postman-collection/blob/develop/lib/collection/cookie.js

  Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)