### PR TITLE
[@testing-library/react-hooks] Correct WatchOptions based on documentation

### DIFF
--- a/types/testing-library__react-hooks/index.d.ts
+++ b/types/testing-library__react-hooks/index.d.ts
@@ -1,11 +1,11 @@
 // Type definitions for @testing-library/react-hooks 3.3
 // Project: https://github.com/testing-library/react-hooks-testing-library
 // Definitions by: Michael Peyper <https://github.com/mpeyper>
-//                 Sarah Dayan <https://github.com/sarahdayan>
+//                Sarah Dayan <https://github.com/sarahdayan>
+//                SeoYeon Lee <https://github.com/iamssen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
-import { ComponentType } from 'react';
 export { act } from 'react-test-renderer';
 
 export interface RenderHookOptions<P> {
@@ -19,15 +19,21 @@ export interface HookResult<R> {
 }
 
 export interface WaitOptions {
+    interval?: number;
     timeout?: number;
     suppressErrors?: boolean;
 }
 
 export interface RenderHookResult<P, R> {
     readonly result: HookResult<R>;
-    readonly waitForNextUpdate: (options?: WaitOptions) => Promise<void>;
+    readonly waitForNextUpdate: (options?: Pick<WaitOptions, 'timeout'>) => Promise<void>;
     readonly waitForValueToChange: (selector: () => any, options?: WaitOptions) => Promise<void>;
-    readonly wait: (callback: () => boolean | void, options?: WaitOptions) => Promise<void>;
+    /** @deprecated use waitFor instead */
+    readonly wait: (
+        callback: () => boolean | void,
+        options?: Pick<WaitOptions, 'timeout' | 'suppressErrors'>,
+    ) => Promise<void>;
+    readonly waitFor: (callback: () => boolean | void, options?: WaitOptions) => Promise<void>;
     readonly unmount: () => boolean;
     readonly rerender: (newProps?: P) => void;
 }

--- a/types/testing-library__react-hooks/index.d.ts
+++ b/types/testing-library__react-hooks/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @testing-library/react-hooks 3.3
+// Type definitions for @testing-library/react-hooks 3.4
 // Project: https://github.com/testing-library/react-hooks-testing-library
 // Definitions by: Michael Peyper <https://github.com/mpeyper>
 //                Sarah Dayan <https://github.com/sarahdayan>

--- a/types/testing-library__react-hooks/testing-library__react-hooks-tests.tsx
+++ b/types/testing-library__react-hooks/testing-library__react-hooks-tests.tsx
@@ -1,5 +1,5 @@
+import { act, cleanup, renderHook } from '@testing-library/react-hooks';
 import * as React from 'react';
-import { renderHook, act, cleanup } from '@testing-library/react-hooks';
 
 const { useState, createContext, useContext } = React;
 
@@ -114,4 +114,26 @@ function checkTypesWithPromiseResult() {
 
 function checkTypesForCleanup() {
     cleanup(); // $ExpectType Promise<void>
+}
+
+async function checkWatchOptions() {
+    // arrange
+    const { wait, waitFor, waitForNextUpdate, waitForValueToChange } = renderHook(() => {});
+
+    // assert : check types
+    // https://github.com/testing-library/react-hooks-testing-library/blob/master/docs/api-reference.md#wait
+    await wait(() => {});
+    await wait(() => {}, { timeout: 10000, suppressErrors: true });
+
+    // https://github.com/testing-library/react-hooks-testing-library/blob/master/docs/api-reference.md#waitfor
+    await waitFor(() => {});
+    await waitFor(() => {}, { interval: 1000, timeout: 10000, suppressErrors: true });
+
+    // https://github.com/testing-library/react-hooks-testing-library/blob/master/docs/api-reference.md#waitfornextupdate
+    await waitForNextUpdate();
+    await waitForNextUpdate({ timeout: 10000 });
+
+    // https://github.com/testing-library/react-hooks-testing-library/blob/master/docs/api-reference.md#waitforvaluetochange
+    await waitForValueToChange(() => null);
+    await waitForValueToChange(() => null, { interval: 1000, timeout: 10000, suppressErrors: true });
 }


### PR DESCRIPTION
<https://github.com/testing-library/react-hooks-testing-library/blob/master/docs/api-reference.md#async-utilities>

# Changes

1. Added `waitFor()`
2. Made `wait()` to `@deprecate`
3. Correct `WatchOptions` based on documentation


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/testing-library/react-hooks-testing-library/blob/master/docs/api-reference.md#async-utilities>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
