### PR TITLE
Adding type definitions for query-string-params.

### DIFF
--- a/types/query-string-params/index.d.ts
+++ b/types/query-string-params/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for query-string-params 1.7
+// Project: https://github.com/bansalrachita/query-string-params#readme
+// Definitions by: Rachita <https://github.com/bansalrachita>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Transforms complex object in a URL search string.
+ * For e.g. {orgType: ["a", "b", "c"], orgId: ["x ", "y"]} -> "orgType=a,b,c&orgId=x,y"
+ */
+export function propertyToUrl(obj: SearchParamOptions): string;
+
+/**
+ * Transforms a URL search string to an object.
+ * For e.g. "?foo=xyz&bar=abc" -> {{foo: [xyz]}, {bar: [abc]}}
+ */
+export function urlToProperty(url: string): SearchParamOptions;
+
+/**
+ * Transforms a URL search string to an object.
+ * For e.g. "?foo=xyz&bar=abc" -> [{foo: [xyz]}, {bar: [abc]}]
+ */
+export function urlToList(url: string): SearchParamOptions[];
+
+/**
+ * Search params options.
+ * Can be in the form of key value pair where
+ * the key is a string and value is an array of strings.
+ */
+export interface SearchParamOptions {
+    [name: string]: string[];
+}

--- a/types/query-string-params/query-string-params-tests.ts
+++ b/types/query-string-params/query-string-params-tests.ts
@@ -1,0 +1,9 @@
+import { urlToProperty, urlToList, propertyToUrl } from 'query-string-params';
+
+urlToProperty(''); // $ExpectType SearchParamOptions
+urlToList(''); // $ExpectType SearchParamOptions[]
+propertyToUrl({}); // $ExpectType string
+
+urlToProperty('foo=x,y&bar=z'); // $ExpectType SearchParamOptions
+urlToList('foo=x,y&bar=z'); // $ExpectType SearchParamOptions[]
+propertyToUrl({ foo: ['a', 'b'], bar: ['c'] }); // $ExpectType string

--- a/types/query-string-params/tsconfig.json
+++ b/types/query-string-params/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "query-string-params-tests.ts"
+    ],
+    "baseUrl": "types"
+}

--- a/types/query-string-params/tslint.json
+++ b/types/query-string-params/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
