### PR TITLE
fix: name should be optional in `insert` and `replace` methods in `ReplaceSource`

### DIFF
--- a/types/webpack-sources/index.d.ts
+++ b/types/webpack-sources/index.d.ts
@@ -178,11 +178,11 @@ export class ReplaceSource extends Source implements SourceAndMapMixin {
     /**
      * Replaces chars from start (0-indexed, inclusive) to end (0-indexed, inclusive) with replacement.
      */
-    replace(start: number, end: number, newValue: string, name: string): void;
+    replace(start: number, end: number, newValue: string, name?: string): void;
     /**
      * Inserts the insertion before char pos (0-indexed).
      */
-    insert(pos: number, newValue: string, name: string): void;
+    insert(pos: number, newValue: string, name?: string): void;
     /**
      * Get decorated Source.
      */

--- a/types/webpack-sources/webpack-sources-tests.ts
+++ b/types/webpack-sources/webpack-sources-tests.ts
@@ -69,8 +69,10 @@ const tests = (source: Source, options: MapOptions, hash: Hash, sourceMap: RawSo
     rawSource.updateHash(hash); // $ExpectType void
 
     const replaceSource = new ReplaceSource(rawSource, 'replaceSource');
+    replaceSource.replace(0, 0, 'newValue');
+    replaceSource.insert(0, 'newValue');
     replaceSource.replace(0, 0, 'newValue', 'name');
-    replaceSource.insert(0, 'newValue', 'insert');
+    replaceSource.insert(0, 'newValue', 'name');
     replaceSource.source(); // $ExpectType string
     replaceSource.original(); // $ExpectType Source
     replaceSource.node(options); // $ExpectType SourceNode


### PR DESCRIPTION


https://github.com/webpack/webpack-sources/blob/29ca74603f6332dd25337d1d9f2a41fc58cd8f14/test/ReplaceSource.js#L31-L34

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/webpack/webpack-sources/blob/29ca74603f6332dd25337d1d9f2a41fc58cd8f14/test/ReplaceSource.js#L31-L34
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
