### PR TITLE
fix: parentEl option can be of type Element or string

### DIFF
--- a/types/daterangepicker/index.d.ts
+++ b/types/daterangepicker/index.d.ts
@@ -174,7 +174,7 @@ declare namespace daterangepicker {
         /**
          * jQuery selector of the parent element that the date range picker will be added to, if not provided this will be 'body'
          */
-        parentEl?: string;
+        parentEl?: Element | string;
     }
 
     interface Locale {


### PR DESCRIPTION
If changing an existing definition:
- [x] According with usage of jQuery, `parentEl` can be of type `string` or `Element` 
      line 119: https://github.com/dangrossman/daterangepicker/blob/master/daterangepicker.js#L119
        ``` this.parentEl = (options.parentEl && $(options.parentEl).length) ? $(options.parentEl) : $(this.parentEl); ```