### PR TITLE
[react-vis] Update Highlight components props to optional to match documentation

### DIFF
--- a/types/react-vis/index.d.ts
+++ b/types/react-vis/index.d.ts
@@ -429,10 +429,10 @@ export class LineMarkSeriesCanvas extends AbstractSeries<LineMarkSeriesCanvasPro
 export interface HighlightProps extends AbstractSeriesProps<LineMarkSeriesPoint> {
     enableX?: boolean;
     enableY?: boolean;
-    highlightHeight: number;
-    highlightWidth: number;
-    highlightX: string | number;
-    highlightY: string | number;
+    highlightHeight?: number;
+    highlightWidth?: number;
+    highlightX?: string | number;
+    highlightY?: string | number;
     onBrushStart: (row: any) => any;
     onDragStart: (row: any) => any;
     onBrush: (row: any) => any;


### PR DESCRIPTION
A few of the props for the Highlight component are marked as always defined when they are actually optional based on the documentation. This PR updates the Highlights prop interface to take `undefined` for these props.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: http://uber.github.io/react-vis/documentation/api-reference/brushing-and-dragging you can see the documentation indicates all of these props (highlightHeight, highlightWidth, highlightX, highlightY) are optional
