### PR TITLE
[@types/react-jsonschema-form] Fix incorrect typings for getWidget and hasWidget function parameters

### DIFF
--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -310,13 +310,13 @@ declare module 'react-jsonschema-form/lib/utils' {
 
     export function getWidget(
         schema: JSONSchema6,
-        widget: Widget,
+        widget: Widget | string,
         registeredWidgets?: { [name: string]: Widget },
-    ): Widget | Error;
+    ): Widget;
 
     export function hasWidget(
         schema: JSONSchema6,
-        widget: Widget,
+        widget: Widget | string,
         registeredWidgets?: { [name: string]: Widget },
     ): boolean;
 

--- a/types/react-jsonschema-form/react-jsonschema-form-tests.tsx
+++ b/types/react-jsonschema-form/react-jsonschema-form-tests.tsx
@@ -21,6 +21,8 @@ import {
     isFixedItems,
     stubExistingAdditionalProperties,
     retrieveSchema,
+    hasWidget,
+    getWidget,
 } from 'react-jsonschema-form/lib/utils';
 import validateFormData from 'react-jsonschema-form/lib/validate';
 
@@ -272,7 +274,27 @@ const TestForm = (props: React.ComponentProps<'form'>) => <form {...props} />;
 export const customTagNameUsingComponent = (schema: JSONSchema6) => {
     return <Form schema={schema} tagName={TestForm} />;
 };
-  
+
+export const hasWidgetDefaultExample = (schema: JSONSchema6) => {
+    return hasWidget(schema, BooleanCustomWidget);
+};
+
+export const hasWidgetStringExample = (schema: JSONSchema6) => {
+    return hasWidget(schema, 'select');
+};
+
+export const getWidgetDefaultExample = (schema: JSONSchema6) => {
+    return getWidget(schema, BooleanCustomWidget);
+};
+
+export const getWidgetRegisteredWidgetsExample = (schema: JSONSchema6) => {
+    return getWidget(schema, 'checkbox', { checkbox: BooleanCustomWidget });
+};
+
+export const getWidgetStringExample = (schema: JSONSchema6) => {
+    return getWidget(schema, 'select');
+};
+
 const idSchema: IdSchema<{ test: {} }> = {
     $id: 'test',
     test: {


### PR DESCRIPTION
Please fill in this template.

**Package: @types/react-jsonschema-form**

[getWidget function](https://github.com/rjsf-team/react-jsonschema-form/blob/1.x/src/utils.js#L91-L129)
[Where it shows that the widget parameter can be a string](https://github.com/rjsf-team/react-jsonschema-form/blob/1.x/src/utils.js#L110)
[hasWidget function](https://github.com/rjsf-team/react-jsonschema-form/blob/1.x/src/utils.js#L131-L145) just uses the `getWidget` function, so the widget parameter is the same

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
