### PR TITLE
react-native-calendars: Add missing enableSwipeMonths prop

### DIFF
--- a/types/react-native-calendars/index.d.ts
+++ b/types/react-native-calendars/index.d.ts
@@ -311,7 +311,15 @@ export interface CalendarBaseProps {
     webAriaLevel?: number;
 }
 
-export class Calendar extends React.Component<CalendarMarkingProps & CalendarBaseProps> { }
+export type CalendarProps = CalendarMarkingProps &
+    CalendarBaseProps & {
+        /**
+         * Enable the option to swipe between months. Default = false
+         */
+        enableSwipeMonths?: boolean;
+    };
+
+export class Calendar extends React.Component<CalendarProps> {}
 
 export interface CalendarListBaseProps extends CalendarBaseProps {
     /**

--- a/types/react-native-calendars/react-native-calendars-tests.tsx
+++ b/types/react-native-calendars/react-native-calendars-tests.tsx
@@ -9,6 +9,8 @@ declare const Arrow: React.SFC<unknown>;
 <Calendar
     // Initially visible month. Default = Date()
     current={'2012-03-01'}
+    // Enable the option to swipe between months. Default = false
+    enableSwipeMonths={true}
     // Minimum date that can be selected, dates before minDate will be grayed out. Default = undefined
     minDate={'2012-05-10'}
     // Maximum date that can be selected, dates after maxDate will be grayed out. Default = undefined


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
 - https://github.com/wix/react-native-calendars/search?q=enableSwipeMonths&unscoped_q=enableSwipeMonths
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

A little more explanation for the changes:

- We cannot simply use `CalendarBaseProps` for `CalendarListBaseProps ` directly anymore because `enableSwipeMonths` is not compatible with `CalendarList`. Therefore I opted to pick the properties we actually want, rather than trying to exclude only the one we don't - it's a bit safer this way for future versions. Happy to reimplement this if other's disagree though 😄 