### PR TITLE
[polygon-lookup] Add types for polygon-lookup

### DIFF
--- a/types/polygon-lookup/index.d.ts
+++ b/types/polygon-lookup/index.d.ts
@@ -1,0 +1,50 @@
+// Type definitions for polygon-lookup 2.6
+// Project: https://github.com/pelias/polygon-lookup
+// Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { FeatureCollection, Polygon } from 'geojson';
+import RBush from 'rbush';
+
+declare namespace PolygonLookup {
+    interface BBox {
+        maxX: number;
+        maxY: number;
+        minX: number;
+        minY: number;
+    }
+}
+
+declare class PolygonLookup {
+    constructor(featureCollection?: FeatureCollection);
+
+    /** A spatial index for `this.polygons`. */
+    rtree: RBush<PolygonLookup.BBox[]>;
+    polygons: FeatureCollection;
+
+    /**
+     * Find polygon(s) that a point intersects. Execute a bounding-box search to
+     * narrow down the candidate polygons to a small subset, and then perform
+     * additional point-in-polygon intersections to resolve any ambiguities.
+     *
+     * @param x The x-coordinate of the point.
+     * @param y The y-coordinate of the point.
+     * @param limit Number of results to return (`-1` to return all the results).
+     * @return  If one or more bounding box intersections are
+     * found and limit is `undefined`, return the first polygon that intersects
+     * (`x`, `y`); otherwise, `undefined`. If a limit is passed in, return
+     * intersecting polygons as a GeoJSON `FeatureCollection`.
+     */
+    search(x: number, y: number): Polygon | undefined;
+    search(x: number, y: number, limit: number): FeatureCollection | undefined;
+
+    /**
+     * Build a spatial index for a set of polygons, and store both the polygons and
+     * the index in this `PolygonLookup`.
+     *
+     * @param collection A GeoJSON-formatted `FeatureCollection`.
+     */
+    loadFeatureCollection(collection: FeatureCollection): void;
+}
+
+export = PolygonLookup;

--- a/types/polygon-lookup/polygon-lookup-tests.ts
+++ b/types/polygon-lookup/polygon-lookup-tests.ts
@@ -1,0 +1,27 @@
+import PolygonLookup = require('polygon-lookup');
+import { FeatureCollection } from 'geojson';
+
+const featureCollection: FeatureCollection = {
+    type: 'FeatureCollection',
+    features: [
+        {
+            type: 'Feature',
+            properties: { id: 'bar' },
+            geometry: {
+                type: 'Polygon',
+                coordinates: [
+                    [
+                        [0, 1],
+                        [2, 1],
+                        [3, 4],
+                        [1, 5],
+                    ],
+                ],
+            },
+        },
+    ],
+};
+
+const lookup = new PolygonLookup(featureCollection);
+lookup.search(1, 2);
+lookup.search(1, 2, 1);

--- a/types/polygon-lookup/tsconfig.json
+++ b/types/polygon-lookup/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "polygon-lookup-tests.ts"
+    ]
+}

--- a/types/polygon-lookup/tslint.json
+++ b/types/polygon-lookup/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.