### PR TITLE
update(postman-collection): remove private api

### DIFF
--- a/types/postman-collection/index.d.ts
+++ b/types/postman-collection/index.d.ts
@@ -254,8 +254,6 @@ export class Cookie extends PropertyBase<CookieDefinition> implements Exclude<Co
   static stringify(cookie: CookieDefinition): string;
   /** Cookie header parser */
   static parse(str: string): CookieDefinition;
-  /** Splits a Cookie parameter into a key and a value */
-  private static splitParam(param: string): { key: string; value: string | boolean };
 }
 
 export class CookieList extends PropertyList<Cookie> {

--- a/types/postman-collection/postman-collection-tests.ts
+++ b/types/postman-collection/postman-collection-tests.ts
@@ -195,7 +195,7 @@ cookieDef.extensions; // $ExpectType { key: string; value: string; }[] | undefin
 
 let cookie = new pmCollection.Cookie();
 cookie = new pmCollection.Cookie(cookieDef);
-
+cookie.name; // $ExpectType string | undefined
 cookie.domain; // $ExpectType string
 cookie.expires; // $ExpectType Date
 cookie.extensions; // $ExpectType { key: string; value: string; }[] | undefined
@@ -206,11 +206,8 @@ cookie.path; // $ExpectType string
 cookie.secure; // $ExpectType boolean | undefined
 cookie.session; // $ExpectType boolean | undefined
 cookie.value; // $ExpectType string | undefined
-
 cookie.update(cookieDef); // $ExpectType void
-
 cookie.valueOf(); // $ExpectType string
-
 pmCollection.Cookie.isCookie({}); // $ExpectType boolean
 const parsed = pmCollection.Cookie.parse('string'); // $ExpectType CookieDefinition
 const unparsed = pmCollection.Cookie.unparseSingle(parsed); // $ExpectType string


### PR DESCRIPTION
As discussed here:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46361#discussion_r460709330
this removes private api (not expected to be used when consuming
package)

Minor test change to speedup DT bot.

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)