### PR TITLE
Update to interface-datastore types to 1.0 API

### DIFF
--- a/types/datastore-core/index.d.ts
+++ b/types/datastore-core/index.d.ts
@@ -1,10 +1,10 @@
-// Type definitions for datastore-core 0.7
+// Type definitions for datastore-core 1.1
 // Project: https://github.com/ipfs/js-datastore-core#readme
 // Definitions by: Carson Farmer <https://github.com/carsonfarmer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 
-import { Datastore, Key } from 'interface-datastore';
+import { Adapter, Key } from 'interface-datastore';
 
 /**
  * Transform function object to converting back-and-forth between key spaces.
@@ -35,7 +35,7 @@ export interface Mount<Value = Buffer> {
     /**
      * The child datastore.
      */
-    datastore: Datastore<Value>;
+    datastore: Adapter<Value>;
     /**
      * The mount prefix.
      */
@@ -48,17 +48,17 @@ export namespace shard {
     const PREFIX = '/repo/flatfs/shard/';
     const readme: string;
     class Shard {
-        constructor(length: number)
+        constructor(length: number);
         name: string;
         param: number;
         _padding: string;
         fun(str: string): string;
         toString(): string;
     }
-    class Prefix extends Shard { }
-    class Suffix extends Shard { }
-    class NextToLast extends Shard { }
-    function readShardFun(path: string, store: Datastore): Promise<Shard>;
+    class Prefix extends Shard {}
+    class Suffix extends Shard {}
+    class NextToLast extends Shard {}
+    function readShardFun(path: string, store: Adapter): Promise<Shard>;
     function parseShardFun(str: string): Shard;
 }
 
@@ -67,13 +67,13 @@ export namespace shard {
  * the way keys look to the user, for example namespacing
  * keys, reversing them, etc.
  */
-export interface KeytransformDatastore<Value = Buffer> extends Datastore<Value> {
-    child: Datastore<Value>;
+export interface KeytransformDatastore<Value = Buffer> extends Adapter<Value> {
+    child: Adapter<Value>;
     transform: Transform;
 }
 
 export interface KeytransformDatastoreConstructor {
-    new <Value = Buffer>(child: Datastore<Value>, transform: Transform): KeytransformDatastore<Value>;
+    new <Value = Buffer>(child: Adapter<Value>, transform: Transform): KeytransformDatastore<Value>;
 }
 
 export const KeytransformDatastore: KeytransformDatastoreConstructor;
@@ -82,12 +82,12 @@ export const KeytransformDatastore: KeytransformDatastoreConstructor;
  * A datastore that can combine multiple stores inside various
  * key prefixs.
  */
-export interface MountDatastore extends Datastore<any> {
+export interface MountDatastore extends Adapter<any> {
     mounts: Array<Mount<any>>;
 }
 
 export interface MountDatastoreConstructor {
-    new(mounts: Array<Mount<any>>): MountDatastore;
+    new (mounts: Array<Mount<any>>): MountDatastore;
 }
 
 export const MountDatastore: MountDatastoreConstructor;
@@ -106,7 +106,7 @@ export interface NamespaceDatastore<Value = Buffer> extends KeytransformDatastor
 }
 
 export interface NamespaceDatastoreConstructor {
-    new(child: Datastore<any>, prefix: Key): NamespaceDatastore;
+    new (child: Adapter<any>, prefix: Key): NamespaceDatastore;
 }
 
 export const NamespaceDatastore: NamespaceDatastoreConstructor;
@@ -118,12 +118,12 @@ export const NamespaceDatastore: NamespaceDatastoreConstructor;
  * last one first.
  *
  */
-export interface TieredDatastore extends Datastore<any> {
-    stores: Array<Datastore<any>>;
+export interface TieredDatastore extends Adapter<any> {
+    stores: Array<Adapter<any>>;
 }
 
 export interface TieredDatastoreConstructor {
-    new(stores: Array<Datastore<any>>): TieredDatastore;
+    new (stores: Array<Adapter<any>>): TieredDatastore;
 }
 
 export const TieredDatastore: TieredDatastoreConstructor;
@@ -134,16 +134,16 @@ export const TieredDatastore: TieredDatastoreConstructor;
  * Wraps another datastore such that all values are stored
  * sharded according to the given sharding function.
  */
-export interface ShardingDatastore<Value = Buffer> extends Datastore<Value> {
+export interface ShardingDatastore<Value = Buffer> extends Adapter<Value> {
     child: KeytransformDatastore<Value>;
     shard: shard.Shard;
 }
 
 export interface ShardingDatastoreConstructor {
-    new <Value = Buffer>(stores: Array<Datastore<Value>>): ShardingDatastore<Value>;
-    createOrOpen<Value = Buffer>(store: Datastore<Value>, shard: shard.Shard): Promise<ShardingDatastore<Value>>;
-    open<Value = Buffer>(store: Datastore<Value>): Promise<ShardingDatastore<Value>>;
-    create<Value = Buffer>(store: Datastore<Value>, shard: shard.Shard): Promise<ShardingDatastore<Value>>;
+    new <Value = Buffer>(stores: Array<Adapter<Value>>): ShardingDatastore<Value>;
+    createOrOpen<Value = Buffer>(store: Adapter<Value>, shard: shard.Shard): Promise<ShardingDatastore<Value>>;
+    open<Value = Buffer>(store: Adapter<Value>): Promise<ShardingDatastore<Value>>;
+    create<Value = Buffer>(store: Adapter<Value>, shard: shard.Shard): Promise<ShardingDatastore<Value>>;
 }
 
 export const ShardingDatastore: ShardingDatastoreConstructor;

--- a/types/datastore-level/datastore-level-tests.ts
+++ b/types/datastore-level/datastore-level-tests.ts
@@ -1,12 +1,12 @@
 import leveldown from 'leveldown';
 import levelup from 'levelup';
 import { Key, Pair, Query, Batch, Datastore } from 'interface-datastore';
-import LevelDatastore, { LevelDatastore as Interface } from 'datastore-level';
+import * as LevelDatastore from 'datastore-level';
 
 const levelStore: Datastore = new LevelDatastore('init-default');
 levelStore.open();
 
-const store: Interface = new LevelDatastore('path', { db: (path, opts) => levelup(leveldown(path), opts) });
+const store = new LevelDatastore('path', { db: (path, opts) => levelup(leveldown(path), opts) });
 store.open();
 
 const k = new Key('/z/one');

--- a/types/datastore-level/datastore-level-tests.ts
+++ b/types/datastore-level/datastore-level-tests.ts
@@ -1,6 +1,6 @@
 import leveldown from 'leveldown';
 import levelup from 'levelup';
-import { Key, Result, Query, Batch, Datastore } from 'interface-datastore';
+import { Key, Pair, Query, Batch, Datastore } from 'interface-datastore';
 import LevelDatastore, { LevelDatastore as Interface } from 'datastore-level';
 
 const levelStore: Datastore = new LevelDatastore('init-default');
@@ -68,10 +68,10 @@ const hello = { key: new Key('/q/1hello'), value: Buffer.from('1') };
 const world = { key: new Key('/z/2world'), value: Buffer.from('2') };
 const hello2 = { key: new Key('/z/3hello2'), value: Buffer.from('3') };
 
-const filter1: Query.Filter = (entry: Result) => !entry.key.toString().endsWith('hello');
-const filter2 = (entry: Result) => entry.key.toString().endsWith('hello2');
+const filter1: Query.Filter = (entry: Pair) => !entry.key.toString().endsWith('hello');
+const filter2 = (entry: Pair) => entry.key.toString().endsWith('hello2');
 
-const order: Query.Order = (res: Result[]) => {
+const order: Query.Order = (res: Pair[]) => {
     return res.sort((a, b) => {
         if (a.value.toString() < b.value.toString()) {
             return -1;
@@ -96,11 +96,11 @@ const query: Query = {
     filters: [filter1, filter2],
     orders: [order],
     offset: 1,
-    limit: 1
+    limit: 1,
 };
 
 const test = async () => {
-    const res: Result[] = [];
+    const res: Pair[] = [];
     for await (const item of store.query(query)) {
         res.push(item);
         const key = item.key.toString();

--- a/types/datastore-level/index.d.ts
+++ b/types/datastore-level/index.d.ts
@@ -1,12 +1,12 @@
-// Type definitions for datastore-level 0.14
+// Type definitions for datastore-level 1.1
 // Project: https://github.com/ipfs/js-datastore-level#readme
-// Definitions by: Carson Farmer <https://github.com/me>
+// Definitions by: Carson Farmer <https://github.com/carsonfarmer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node" />
 // TypeScript Version: 3.6
 
 import { LevelUp } from 'levelup';
-import { Datastore, Batch } from 'interface-datastore';
+import { Batch, Adapter } from 'interface-datastore';
 import { AbstractLevelDOWN, AbstractIterator, AbstractBatch } from 'abstract-leveldown';
 
 export interface LevelDatastoreBatch<Value = Buffer> extends Batch<Value> {
@@ -16,7 +16,7 @@ export interface LevelDatastoreBatch<Value = Buffer> extends Batch<Value> {
 /**
  * A datastore backed by leveldb.
  */
-export interface LevelDatastore<Value = Buffer> extends Datastore<Value> {
+export interface LevelDatastore<Value = Buffer> extends Adapter<Value> {
     db: LevelUp<AbstractLevelDOWN<string, Value>, AbstractIterator<string, Value>>;
     batch(): LevelDatastoreBatch<Value>;
 }

--- a/types/datastore-level/index.d.ts
+++ b/types/datastore-level/index.d.ts
@@ -9,27 +9,27 @@ import { LevelUp } from 'levelup';
 import { Batch, Adapter } from 'interface-datastore';
 import { AbstractLevelDOWN, AbstractIterator, AbstractBatch } from 'abstract-leveldown';
 
-export interface LevelDatastoreBatch<Value = Buffer> extends Batch<Value> {
+interface LevelDatastoreBatch<Value = Buffer> extends Batch<Value> {
     ops: Array<AbstractBatch<string, Value>>;
 }
 
 /**
  * A datastore backed by leveldb.
  */
-export interface LevelDatastore<Value = Buffer> extends Adapter<Value> {
+interface LevelDatastore<Value = Buffer> extends Adapter<Value> {
     db: LevelUp<AbstractLevelDOWN<string, Value>, AbstractIterator<string, Value>>;
     batch(): LevelDatastoreBatch<Value>;
 }
 
-export interface LevelDatastoreOptions {
+interface LevelDatastoreOptions {
     db?: (location: string, options?: any) => LevelUp;
     [key: string]: any;
 }
 
-export interface LevelDatastoreConstructor {
+interface LevelDatastoreConstructor {
     new (path: string, options?: LevelDatastoreOptions): LevelDatastore;
     (path: string, options?: LevelDatastoreOptions): LevelDatastore;
 }
 
 declare const LevelDatastore: LevelDatastoreConstructor;
-export default LevelDatastore;
+export = LevelDatastore;

--- a/types/interface-datastore/index.d.ts
+++ b/types/interface-datastore/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for interface-datastore 0.8
+// Type definitions for interface-datastore 1.0
 // Project: https://github.com/ipfs/interface-datastore#readme
-// Definitions by: Carson Farmer <https://github.com/me>
+// Definitions by: Carson Farmer <https://github.com/carsonfarmer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node" />
 // TypeScript Version: 3.6
@@ -17,6 +17,103 @@ export namespace Errors {
     function dbDeleteFailedError(error: Error): ErrCode;
     function dbWriteFailedError(error: Error): ErrCode;
     function notFoundError(error: Error): ErrCode;
+    function abortedError(error: Error): ErrCode;
+}
+
+/**
+ * Key/Value pair.
+ */
+export interface Pair<Value = Buffer> {
+    key: Key;
+    value: Value;
+}
+
+/**
+ * Options for async operations.
+ */
+export interface Options {
+    signal: AbortSignal;
+}
+
+/**
+ * Base Interface Datastore Adapter.
+ */
+export abstract class Adapter<Value = Buffer> {
+    abstract open(): Promise<void>;
+    abstract close(): Promise<void>;
+    /**
+     * Store the passed value under the passed key
+     *
+     * @param key
+     * @param val
+     * @param options
+     */
+    abstract put(key: Key, val: Value, options?: Options): Promise<void>;
+    /**
+     * Store the given key/value pairs
+     *
+     * @param source
+     * @param options
+     */
+    putMany(
+        source: AsyncIterable<Pair<Value>> | Iterable<Pair<Value>>,
+        options?: Options,
+    ): AsyncIterableIterator<Pair<Value>>;
+
+    /**
+     * Retrieve the value for the passed key
+     *
+     * @param key
+     * @param options
+     */
+    abstract get(key: Key, options?: Options): Promise<Value>;
+    /**
+     * Retrieve values for the passed keys
+     *
+     * @param source
+     * @param options
+     */
+    getMany(source: AsyncIterable<Key> | Iterable<Key>, options?: Options): AsyncIterableIterator<Value>;
+
+    /**
+     * Check for the existence of a value for the passed key
+     *
+     * @param key
+     */
+    abstract has(key: Key): Promise<boolean>;
+
+    /**
+     * Remove the record for the passed key
+     *
+     * @param key
+     * @param options
+     */
+    abstract delete(key: Key, options?: Options): Promise<void>;
+    /**
+     * Remove values for the passed keys
+     *
+     * @param source
+     * @param options
+     */
+    deleteMany(source: AsyncIterable<Key> | Iterable<Key>, options?: Options): AsyncIterableIterator<Key>;
+    /**
+     * Create a new batch object.
+     */
+    batch(): Batch<Value>;
+    /**
+     * Yield all datastore values
+     *
+     * @param q
+     * @param options
+     */
+    abstract _all(q?: Query<Value>, options?: Options): AsyncIterable<Pair<Value>>;
+    /**
+     * Query the store.
+     *
+     * @param q
+     * @param options
+     */
+    query(q: Query<Value>, options?: Options): AsyncIterable<Pair<Value>>;
 }
 
 export namespace utils {
@@ -28,32 +125,26 @@ export namespace utils {
     function tmpdir(): string;
 }
 
-export class MemoryDatastore<Value = Buffer> implements Datastore<Value> {
+export class MemoryDatastore<Value = Buffer> extends Adapter<Value> {
     constructor();
     open(): Promise<void>;
+    close(): Promise<void>;
     put(key: Key, val: Value): Promise<void>;
     get(key: Key): Promise<Value>;
     has(key: Key): Promise<boolean>;
     delete(key: Key): Promise<void>;
-    batch(): Batch<Value>;
-    query(q: Query<Value>): AsyncIterable<Result<Value>>;
-    close(): Promise<void>;
+    _all(): AsyncIterable<Pair<Value>>;
 }
 
 export interface Batch<Value = Buffer> {
     put(key: Key, value: Value): void;
     delete(key: Key): void;
-    commit(): Promise<void>;
-}
-
-export interface Result<Value = Buffer> {
-    key: Key;
-    value: Value;
+    commit(options?: Options): Promise<void>;
 }
 
 export namespace Query {
-    type Filter<T = Buffer> = (item: Result<T>) => boolean;
-    type Order<T = Buffer> = (items: Array<Result<T>>) => Array<Result<T>>;
+    type Filter<Value = Buffer> = (item: Pair<Value>) => boolean;
+    type Order<Value = Buffer> = (items: Array<Pair<Value>>) => Array<Pair<Value>>;
 }
 
 export interface Query<Value = Buffer> {
@@ -242,13 +333,4 @@ export class Key {
     static isKey(key: any): boolean;
 }
 
-export interface Datastore<Value = Buffer> {
-    open(): Promise<void>;
-    put(key: Key, val: Value): Promise<void>;
-    get(key: Key): Promise<Value>;
-    has(key: Key): Promise<boolean>;
-    delete(key: Key): Promise<void>;
-    batch(): Batch<Value>;
-    query(q: Query<Value>): AsyncIterable<Result<Value>>;
-    close(): Promise<void>;
-}
+export type Datastore<Value = Buffer> = Adapter<Value>;

--- a/types/interface-datastore/index.d.ts
+++ b/types/interface-datastore/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Carson Farmer <https://github.com/carsonfarmer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node" />
+/// <reference lib="dom" />
 // TypeScript Version: 3.6
 
 // From https://github.com/IndigoUnited/js-err-code

--- a/types/interface-datastore/interface-datastore-tests.ts
+++ b/types/interface-datastore/interface-datastore-tests.ts
@@ -1,4 +1,4 @@
-import { Key, MemoryDatastore, Result, Query, Batch, Errors, utils, Datastore } from 'interface-datastore';
+import { Key, MemoryDatastore, Pair, Query, Batch, Errors, utils, Datastore, Adapter } from 'interface-datastore';
 
 const store: Datastore = new MemoryDatastore();
 
@@ -41,6 +41,51 @@ store.put(k, Buffer.from('hello')).then(() => {
     });
 });
 
+const putMany = async () => {
+    const source = [];
+    for (let i = 0; i < 100; i++) {
+        source.push({ key: new Key(`/z/key${i}`), value: Buffer.from(`data${i}`) });
+    }
+    for await (const { key, value } of store.putMany(source)) {
+        console.log(key, value);
+    }
+};
+
+putMany();
+
+const getMany = async () => {
+    const k = new Key('/z/one');
+    await store.put(k, Buffer.from('hello'));
+    const source = [k];
+
+    for await (const value of store.getMany(source)) {
+        console.log(value);
+    }
+};
+
+getMany();
+
+const deleteMany = async () => {
+    const data = [];
+    for (let i = 0; i < 100; i++) {
+        data.push({ key: new Key(`/a/key${i}`), value: Buffer.from(`data${i}`) });
+    }
+
+    // Drain them all
+    for await (const { key, value } of store.putMany(data)) {
+        console.log(key, value);
+    }
+
+    const res0 = await Promise.all(data.map(d => store.has(d.key)));
+    res0.forEach(res => typeof res === 'boolean');
+
+    for await (const key of store.deleteMany(data.map(d => d.key))) {
+        console.log(key.toString());
+    }
+};
+
+deleteMany();
+
 const b: Batch = store.batch();
 
 store.put(new Key('/z/old'), Buffer.from('old')).then(() => {
@@ -61,10 +106,10 @@ const hello = { key: new Key('/q/1hello'), value: Buffer.from('1') };
 const world = { key: new Key('/z/2world'), value: Buffer.from('2') };
 const hello2 = { key: new Key('/z/3hello2'), value: Buffer.from('3') };
 
-const filter1: Query.Filter = (entry: Result) => !entry.key.toString().endsWith('hello');
-const filter2 = (entry: Result) => entry.key.toString().endsWith('hello2');
+const filter1: Query.Filter = (entry: Pair) => !entry.key.toString().endsWith('hello');
+const filter2 = (entry: Pair) => entry.key.toString().endsWith('hello2');
 
-const order: Query.Order = (res: Result[]) => {
+const order: Query.Order = (res: Pair[]) => {
     return res.sort((a, b) => {
         if (a.value.toString() < b.value.toString()) {
             return -1;
@@ -89,11 +134,11 @@ const query: Query = {
     filters: [filter1, filter2],
     orders: [order],
     offset: 1,
-    limit: 1
+    limit: 1,
 };
 
 const test = async () => {
-    const res: Result[] = [];
+    const res: Pair[] = [];
     for await (const item of store.query(query)) {
         res.push(item);
         const key = item.key.toString();

--- a/types/interface-datastore/tsconfig.json
+++ b/types/interface-datastore/tsconfig.json
@@ -1,25 +1,16 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": [
-            "es6",
-            "esnext",
-            "esnext.asynciterable"
-        ],
+        "lib": ["DOM", "ES6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
+        "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-    "files": [
-        "index.d.ts",
-        "interface-datastore-tests.ts"
-    ]
+    "files": ["index.d.ts", "interface-datastore-tests.ts"]
 }

--- a/types/interface-datastore/tsconfig.json
+++ b/types/interface-datastore/tsconfig.json
@@ -4,7 +4,8 @@
         "lib": [
             "es6",
             "esnext",
-            "esnext.asynciterable"
+            "esnext.asynciterable",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/interface-datastore/tsconfig.json
+++ b/types/interface-datastore/tsconfig.json
@@ -1,16 +1,25 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": ["DOM", "ES6"],
+        "lib": [
+            "es6",
+            "esnext",
+            "esnext.asynciterable"
+        ],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",
-        "typeRoots": ["../"],
+        "typeRoots": [
+            "../"
+        ],
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-    "files": ["index.d.ts", "interface-datastore-tests.ts"]
+    "files": [
+        "index.d.ts",
+        "interface-datastore-tests.ts"
+    ]
 }

--- a/types/interface-datastore/tsconfig.json
+++ b/types/interface-datastore/tsconfig.json
@@ -4,8 +4,7 @@
         "lib": [
             "es6",
             "esnext",
-            "esnext.asynciterable",
-            "dom"
+            "esnext.asynciterable"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ipfs/interface-datastore/releases/tag/v1.0.4
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
