### PR TITLE
fix(workbox-webpack-plugin): RuntimeCacheRule interface 

### DIFF
--- a/types/workbox-webpack-plugin/index.d.ts
+++ b/types/workbox-webpack-plugin/index.d.ts
@@ -87,13 +87,13 @@ export interface RuntimeCacheRule {
     /**
      * Cache any same-origin request that matches the pattern.
      */
-    urlPattern?: string | RegExp;
+    urlPattern: string | RegExp;
 
     /**
      * The `handler` values are strings, corresponding to names of the strategies supported by
      * [`workbox.strategies`](https://developers.google.com/web/tools/workbox/reference-docs/latest/workbox.strategies#methods).
      */
-    handler?: CacheStrategy;
+    handler: CacheStrategy;
 
     /**
      * The `options` properties can be used to configure instances of the cache expiration, cacheable response, and broadcast cache update plugins to apply to a given route.

--- a/types/workbox-webpack-plugin/v3/index.d.ts
+++ b/types/workbox-webpack-plugin/v3/index.d.ts
@@ -86,13 +86,13 @@ export interface RuntimeCacheRule {
     /**
      * Cache any same-origin request that matches the pattern.
      */
-    urlPattern?: string | RegExp;
+    urlPattern: string | RegExp;
 
     /**
      * The `handler` values are strings, corresponding to names of the strategies supported by
      * [`workbox.strategies`](https://developers.google.com/web/tools/workbox/reference-docs/latest/workbox.strategies#methods).
      */
-    handler?: CacheStrategy;
+    handler: CacheStrategy;
 
     /**
      * The `options` properties can be used to configure instances of the cache expiration, cacheable response, and broadcast cache update plugins to apply to a given route.


### PR DESCRIPTION
The property urlPattern and handler is required. So fix
