### PR TITLE
[react-autosuggest] Add ref to InputProps

### DIFF
--- a/types/react-autosuggest/index.d.ts
+++ b/types/react-autosuggest/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-autosuggest 10.0.2
+// Type definitions for react-autosuggest 10.0
 // Project: http://react-autosuggest.js.org/, https://github.com/moroshko/react-autosuggest
 // Definitions by: Nicolas Schmitt <https://github.com/nicolas-schmitt>
 //                 Philip Ottesen <https://github.com/pjo256>

--- a/types/react-autosuggest/index.d.ts
+++ b/types/react-autosuggest/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-autosuggest 9.3
+// Type definitions for react-autosuggest 10.0.2
 // Project: http://react-autosuggest.js.org/, https://github.com/moroshko/react-autosuggest
 // Definitions by: Nicolas Schmitt <https://github.com/nicolas-schmitt>
 //                 Philip Ottesen <https://github.com/pjo256>

--- a/types/react-autosuggest/index.d.ts
+++ b/types/react-autosuggest/index.d.ts
@@ -68,6 +68,7 @@ declare namespace Autosuggest {
         onChange(event: React.FormEvent<any>, params: ChangeEvent): void;
         onBlur?(event: React.FocusEvent<any>, params?: BlurEvent<TSuggestion>): void;
         value: string;
+        ref?: React.Ref<HTMLInputElement>;
     }
 
     interface SuggestionSelectedEventData<TSuggestion> {

--- a/types/react-autosuggest/react-autosuggest-tests.tsx
+++ b/types/react-autosuggest/react-autosuggest-tests.tsx
@@ -68,6 +68,7 @@ export class ReactAutosuggestBasicTest extends React.Component<any, any> {
         suggestions: this.getSuggestions('')
     };
     // endregion region Rendering methods
+    inputRef = React.createRef<HTMLInputElement>();
     render(): JSX.Element {
         const {value, suggestions} = this.state;
 
@@ -77,8 +78,6 @@ export class ReactAutosuggestBasicTest extends React.Component<any, any> {
             suggestionFocused: 'active',
             sectionTitle: { color: 'blue' }
         };
-
-        inputRef = React.createRef<HTMLInputElement>();
 
         return <Autosuggest
             suggestions={suggestions}
@@ -94,7 +93,7 @@ export class ReactAutosuggestBasicTest extends React.Component<any, any> {
                 value,
                 onChange: (e, changeEvent) => this.onChange(e, changeEvent),
                 onBlur: (e) => { console.log(e.relatedTarget); },
-                ref: inputRef
+                ref: this.inputRef
             }}
             theme={theme}/>;
     }

--- a/types/react-autosuggest/react-autosuggest-tests.tsx
+++ b/types/react-autosuggest/react-autosuggest-tests.tsx
@@ -78,6 +78,8 @@ export class ReactAutosuggestBasicTest extends React.Component<any, any> {
             sectionTitle: { color: 'blue' }
         };
 
+        inputRef = React.createRef<HTMLInputElement>();
+
         return <Autosuggest
             suggestions={suggestions}
             onSuggestionsFetchRequested={this
@@ -91,7 +93,8 @@ export class ReactAutosuggestBasicTest extends React.Component<any, any> {
                 placeholder: `Type 'c'`,
                 value,
                 onChange: (e, changeEvent) => this.onChange(e, changeEvent),
-                onBlur: (e) => { console.log(e.relatedTarget); }
+                onBlur: (e) => { console.log(e.relatedTarget); },
+                ref: inputRef
             }}
             theme={theme}/>;
     }


### PR DESCRIPTION
**If changing an existing definition:**
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
[Compare 10.0.0 with 10.0.1](https://github.com/moroshko/react-autosuggest/compare/v10.0.0...v10.0.1#diff-783fc77db90054c5525b2b73b5ceebc0R38
)
[Comment in issue #629](https://github.com/moroshko/react-autosuggest/issues/629#issuecomment-619412793)
