### PR TITLE
Update Clownface to v1.0

### DIFF
--- a/types/clownface/clownface-tests.ts
+++ b/types/clownface/clownface-tests.ts
@@ -286,8 +286,19 @@ function testOut() {
     cfTerm = cf.out(cf.node([node, node]));
 
     const singleContext: clownface.Clownface<NamedNode, Dataset> = <any> {};
-    let inContext = cfTerm.out(node);
-    inContext = singleContext;
+    let outContext = cfTerm.out(node);
+    outContext = singleContext;
+}
+
+function testOutWithLanguage() {
+    const cf: clownface.Clownface<undefined, Dataset> = <any> {};
+    let cfTerms: Literal[] = cf.out(undefined, { language: 'en' }).terms;
+    cfTerms = cf.out(node).terms;
+    cfTerms = cf.out([node, node]).terms;
+    cfTerms = cf.out(cf.node([node, node])).terms;
+
+    let outTerms: Literal[] = cf.blankNode().out(node, { language: 'en' }).terms;
+    outTerms = cf.blankNode().out(node, { language: ['en', 'de'] }).terms;
 }
 
 function testToArray() {

--- a/types/clownface/clownface-tests.ts
+++ b/types/clownface/clownface-tests.ts
@@ -13,14 +13,14 @@ const dataset: Dataset = <any> {};
 const graph: NamedNode = <any> {};
 
 function testCasting() {
-    const singleNode: clownface.Clownface<NamedNode> = <any> {};
-    const safeContext: clownface.SafeClownface<NamedNode> = singleNode;
-    let noContext: clownface.Clownface = singleNode;
+    const singleNode: clownface.AnyPointer<NamedNode> = <any> {};
+    const safeContext: clownface.MultiPointer<NamedNode> = singleNode;
+    let noContext: clownface.AnyPointer = singleNode;
     noContext = safeContext;
 }
 
 function withoutContext() {
-    const cf: clownface.Clownface<undefined, Dataset> = <any> {};
+    const cf: clownface.AnyPointer<undefined, Dataset> = <any> {};
     const term: undefined = cf.term;
     const terms: Term[] = cf.terms;
     const value: undefined = cf.value;
@@ -29,7 +29,7 @@ function withoutContext() {
 }
 
 function multiContext() {
-    const cf: clownface.Clownface<Array<NamedNode | BlankNode>, Dataset> = <any> {};
+    const cf: clownface.AnyPointer<Array<NamedNode | BlankNode>, Dataset> = <any> {};
     if (cf.term) {
         const definedTerm: NamedNode | BlankNode = cf.term;
     } else {
@@ -46,14 +46,14 @@ function multiContext() {
 }
 
 function singleContext() {
-    const cf: clownface.Clownface<Literal, Dataset> = <any> {};
+    const cf: clownface.AnyPointer<Literal, Dataset> = <any> {};
     const term: Literal = cf.term;
     const terms: [Literal] = cf.terms;
     const value: string = cf.value;
     const values: [string] = cf.values;
     const _context: Array<Context<DatasetCore, Term>> = cf._context;
 
-    const asMultiContext: clownface.Clownface<Literal[] | Literal, Dataset> = cf;
+    const asMultiContext: clownface.AnyPointer<Literal[] | Literal, Dataset> = cf;
 }
 
 function testConstructor() {
@@ -62,13 +62,13 @@ function testConstructor() {
 
     let contructedWithValueHasTermContext: Clownface<Term, Dataset> = new Clownface({ dataset, value: 'foo' });
     contructedWithValueHasTermContext = new Clownface({ dataset, value: ['foo', 'bar'] });
-    const anyTerms: clownface.SafeClownface = new Clownface({ dataset, term: [term, term], value: ['foo', 'bar'] });
+    const anyTerms: clownface.MultiPointer = new Clownface({ dataset, term: [term, term], value: ['foo', 'bar'] });
 
-    const constructedWithSingleTerm: clownface.SingleContextClownface<NamedNode> = new Clownface({ dataset, term: node });
+    const constructedWithSingleTerm: clownface.GraphPointer<NamedNode> = new Clownface({ dataset, term: node });
 }
 
 function testAddIn() {
-    let cf: clownface.Clownface<BlankNode> = <any> {};
+    let cf: clownface.AnyPointer<BlankNode> = <any> {};
     cf = cf.addIn(node);
     cf = cf.addIn(node);
     cf = cf.addIn([ node, node ], node);
@@ -77,23 +77,23 @@ function testAddIn() {
         const values: Array<NamedNode | BlankNode> = child.terms;
     });
     cf = cf.addIn(node, child => {
-        const childNode: clownface.Clownface<BlankNode> = child;
+        const childNode: clownface.AnyPointer<BlankNode> = child;
     });
     cf = cf.addIn(cf.node(node), cf.node(node));
 
-    const manyPredicates: clownface.Clownface<NamedNode[]> = <any> {};
-    const manyObjects: clownface.Clownface<Literal[]> = <any> {};
+    const manyPredicates: clownface.AnyPointer<NamedNode[]> = <any> {};
+    const manyObjects: clownface.AnyPointer<Literal[]> = <any> {};
     cf = cf.addIn(manyPredicates, manyObjects);
 }
 
 function testAddList() {
-    let cf: clownface.Clownface<NamedNode> = <any> {};
+    let cf: clownface.AnyPointer<NamedNode> = <any> {};
     cf = cf.addList(predicate, [node]);
     cf = cf.addList(predicate, [node, node]);
 }
 
 function testAddOut() {
-    let cf: clownface.Clownface<BlankNode> = <any> {};
+    let cf: clownface.AnyPointer<BlankNode> = <any> {};
     cf = cf.addOut(node);
     cf = cf.addOut(node);
     cf = cf.addOut([ node, node ], node);
@@ -102,94 +102,94 @@ function testAddOut() {
         const values: Array<NamedNode | BlankNode> = child.terms;
     });
     cf = cf.addOut(node, child => {
-        const childNode: clownface.Clownface<BlankNode> = child;
+        const childNode: clownface.AnyPointer<BlankNode> = child;
     });
     cf = cf.addOut(cf.node(node), cf.node(node));
 
-    const manyPredicates: clownface.Clownface<NamedNode[]> = <any> {};
-    const manyObjects: clownface.Clownface<Literal[]> = <any> {};
+    const manyPredicates: clownface.AnyPointer<NamedNode[]> = <any> {};
+    const manyObjects: clownface.AnyPointer<Literal[]> = <any> {};
     cf = cf.addOut(manyPredicates, manyObjects);
 }
 
 function testBlankNode() {
-    const cf: clownface.Clownface<Term[], Dataset> = <any> {};
-    let singleBlank: clownface.Clownface<BlankNode, Dataset> = cf.blankNode();
+    const cf: clownface.AnyPointer<Term[], Dataset> = <any> {};
+    let singleBlank: clownface.AnyPointer<BlankNode, Dataset> = cf.blankNode();
     singleBlank = cf.blankNode('label');
-    const multiBlankContext: clownface.Clownface<BlankNode[], Dataset> = cf.blankNode([ 'b1', 'b2' ]);
+    const multiBlankContext: clownface.AnyPointer<BlankNode[], Dataset> = cf.blankNode([ 'b1', 'b2' ]);
 }
 
 function testDeleteIn() {
-    let cf: clownface.Clownface<NamedNode, Dataset> = <any> {};
+    let cf: clownface.AnyPointer<NamedNode, Dataset> = <any> {};
     cf = cf.deleteIn();
     cf = cf.deleteIn(node);
     cf = cf.deleteIn([node, node]);
 }
 
 function testDeleteList() {
-    let cf: clownface.Clownface<NamedNode, Dataset> = <any> {};
+    let cf: clownface.AnyPointer<NamedNode, Dataset> = <any> {};
     cf = cf.deleteList(predicate);
 }
 
 function testDeleteOut() {
-    let cf: clownface.Clownface<BlankNode, Dataset> = <any> {};
+    let cf: clownface.AnyPointer<BlankNode, Dataset> = <any> {};
     cf = cf.deleteOut();
     cf = cf.deleteOut(node);
     cf = cf.deleteOut([node, node]);
 }
 
 function testFactory() {
-    const defaultContext: clownface.Clownface<Term | Term[] | undefined, Dataset> = clownface({ dataset });
+    const defaultContext: clownface.AnyPointer<Term | Term[] | undefined, Dataset> = clownface({ dataset });
 
-    const namedGraph: clownface.Clownface<NamedNode, Dataset> = clownface({ dataset, graph, term: node });
-    const singleFromValue: clownface.Clownface<Literal, Dataset> = clownface({ dataset, value: 'foo' });
+    const namedGraph: clownface.AnyPointer<NamedNode, Dataset> = clownface({ dataset, graph, term: node });
+    const singleFromValue: clownface.AnyPointer<Literal, Dataset> = clownface({ dataset, value: 'foo' });
 
-    const termContext: clownface.Clownface<Term, Dataset> = clownface({
+    const termContext: clownface.AnyPointer<Term, Dataset> = clownface({
         dataset,
         term
     });
 
-    const namedContext: clownface.Clownface<NamedNode, Dataset> = clownface({
+    const namedContext: clownface.AnyPointer<NamedNode, Dataset> = clownface({
         dataset,
         term: node,
     });
 
-    const namedMutlipleTerms: clownface.Clownface<NamedNode[], Dataset> = clownface({
+    const namedMutlipleTerms: clownface.AnyPointer<NamedNode[], Dataset> = clownface({
         dataset,
         term: [node, node],
     });
 
-    const mutlipleValues: clownface.Clownface<Literal[], Dataset> = clownface({
+    const mutlipleValues: clownface.AnyPointer<Literal[], Dataset> = clownface({
         dataset,
         value: ['foo', 'bar'],
     });
 
     const maybeNamed: BlankNode | NamedNode = <any> {};
-    const altContext: clownface.Clownface<BlankNode | NamedNode, Dataset> = clownface({
+    const altContext: clownface.AnyPointer<BlankNode | NamedNode, Dataset> = clownface({
         dataset,
         term: maybeNamed,
     });
 
-    const literalContext: clownface.Clownface<Literal, Dataset> = <any> {};
-    const deriveContextFromOtherGraph: clownface.Clownface<Literal, Dataset> = clownface(literalContext);
+    const literalContext: clownface.AnyPointer<Literal, Dataset> = <any> {};
+    const deriveContextFromOtherGraph: clownface.AnyPointer<Literal, Dataset> = clownface(literalContext);
 
-    const namedNodeContext: clownface.Clownface<NamedNode, Dataset> = <any> {};
-    const deriveContextFromOtherNamedNodeContext: clownface.Clownface<NamedNode, Dataset> = clownface(namedNodeContext);
+    const namedNodeContext: clownface.AnyPointer<NamedNode, Dataset> = <any> {};
+    const deriveContextFromOtherNamedNodeContext: clownface.AnyPointer<NamedNode, Dataset> = clownface(namedNodeContext);
 }
 
 function testFilter() {
-    let mutliple: clownface.Clownface<NamedNode[], Dataset> = <any> {};
+    let mutliple: clownface.AnyPointer<NamedNode[], Dataset> = <any> {};
     mutliple = mutliple.filter(quad => {
-        const copy: clownface.Clownface<NamedNode, Dataset> = quad;
+        const copy: clownface.AnyPointer<NamedNode, Dataset> = quad;
         return true;
     });
 
-    let single: clownface.Clownface<NamedNode, Dataset> = <any> {};
+    let single: clownface.AnyPointer<NamedNode, Dataset> = <any> {};
     single = single.filter(quad => {
-        const copy: clownface.Clownface<NamedNode, Dataset> = quad;
+        const copy: clownface.AnyPointer<NamedNode, Dataset> = quad;
         return true;
     });
 
-    let noContext: clownface.Clownface<undefined, Dataset> = <any> {};
+    let noContext: clownface.AnyPointer<undefined, Dataset> = <any> {};
     noContext = noContext.filter(quad => {
         const copy: never = quad;
         return true;
@@ -197,19 +197,19 @@ function testFilter() {
 }
 
 function testForEach() {
-    let mutliple: clownface.Clownface<NamedNode[], Dataset> = <any> {};
+    let mutliple: clownface.AnyPointer<NamedNode[], Dataset> = <any> {};
     mutliple = mutliple.forEach(quad => {
-        const copy: clownface.Clownface<NamedNode, Dataset> = quad;
+        const copy: clownface.AnyPointer<NamedNode, Dataset> = quad;
         return true;
     });
 
-    let single: clownface.Clownface<NamedNode, Dataset> = <any> {};
+    let single: clownface.AnyPointer<NamedNode, Dataset> = <any> {};
     single = single.forEach(quad => {
-        const copy: clownface.Clownface<NamedNode, Dataset> = quad;
+        const copy: clownface.AnyPointer<NamedNode, Dataset> = quad;
         return true;
     });
 
-    let noContext: clownface.Clownface<undefined, Dataset> = <any> {};
+    let noContext: clownface.AnyPointer<undefined, Dataset> = <any> {};
     noContext = noContext.forEach(quad => {
         const copy: never = quad;
         return true;
@@ -217,41 +217,41 @@ function testForEach() {
 }
 
 function testHas() {
-    const cf: clownface.Clownface<Term, Dataset> = <any> {};
-    let has: clownface.Clownface<Array<NamedNode | BlankNode>, Dataset> = cf.has(predicate, 'Stuart');
+    const cf: clownface.AnyPointer<Term, Dataset> = <any> {};
+    let has: clownface.AnyPointer<Array<NamedNode | BlankNode>, Dataset> = cf.has(predicate, 'Stuart');
     has = cf.has([predicate, predicate], 'Stuart');
     has = cf.has(predicate, [literal, literal]);
 }
 
 function testIn() {
-    const cf: clownface.Clownface<Literal, Dataset> = <any> {};
-    let cfIn: clownface.SafeClownface<NamedNode | BlankNode, Dataset> = cf.in();
+    const cf: clownface.AnyPointer<Literal, Dataset> = <any> {};
+    let cfIn: clownface.MultiPointer<NamedNode | BlankNode, Dataset> = cf.in();
     cfIn = cf.in(node);
     cfIn = cf.in([node, node]);
     cfIn = cf.in(cf.node(node));
     cfIn = cf.in(cf.node([node, node]));
 
-    const singleContext: clownface.Clownface<NamedNode, Dataset> = <any> {};
+    const singleContext: clownface.AnyPointer<NamedNode, Dataset> = <any> {};
     let inContext = cfIn.out(node);
     inContext = singleContext;
 }
 
 function testList() {
-    const cf: clownface.Clownface<NamedNode, Dataset> = <any> {};
-    const listNodes: Iterable<clownface.Clownface<NamedNode, Dataset>> | null = cf.list();
+    const cf: clownface.AnyPointer<NamedNode, Dataset> = <any> {};
+    const listNodes: Iterable<clownface.AnyPointer<NamedNode, Dataset>> | null = cf.list();
 }
 
 function testLiteral() {
-    const cf: clownface.Clownface<undefined, Dataset> = <any> {};
-    let cfOneLit: clownface.Clownface<Literal, Dataset> = cf.literal('foo');
-    const cfLiterasl: clownface.Clownface<Literal[], Dataset> = cf.literal(['foo', 'bar']);
+    const cf: clownface.AnyPointer<undefined, Dataset> = <any> {};
+    let cfOneLit: clownface.AnyPointer<Literal, Dataset> = cf.literal('foo');
+    const cfLiterasl: clownface.AnyPointer<Literal[], Dataset> = cf.literal(['foo', 'bar']);
     cfOneLit = cf.literal('foo', node);
     cfOneLit = cf.literal('foo', 'en');
 }
 
 function testMap() {
-    const singleContext: clownface.Clownface<BlankNode, Dataset> = <any> {};
-    const multiContext: clownface.Clownface<BlankNode, Dataset> = <any> {};
+    const singleContext: clownface.AnyPointer<BlankNode, Dataset> = <any> {};
+    const multiContext: clownface.AnyPointer<BlankNode, Dataset> = <any> {};
     let terms: BlankNode[] = singleContext.map((item) => item.term);
     terms = multiContext.map((item) => item.term);
 
@@ -260,38 +260,38 @@ function testMap() {
 }
 
 function testNamedNode() {
-    const cf: clownface.Clownface<undefined, Dataset> = <any> {};
-    let cfSingleNamed: clownface.Clownface<NamedNode, Dataset> = cf.namedNode(node);
+    const cf: clownface.AnyPointer<undefined, Dataset> = <any> {};
+    let cfSingleNamed: clownface.AnyPointer<NamedNode, Dataset> = cf.namedNode(node);
     cfSingleNamed = cf.namedNode('http://example.com/');
-    const cfNamedMany: clownface.Clownface<NamedNode[], Dataset> = cf.namedNode(['http://example.com/', 'http://example.org/']);
+    const cfNamedMany: clownface.AnyPointer<NamedNode[], Dataset> = cf.namedNode(['http://example.com/', 'http://example.org/']);
 }
 
 function testNode() {
-    const cf: clownface.Clownface<undefined, Dataset> = <any> {};
-    let singleTerm: clownface.Clownface<Term, Dataset> = cf.node(node);
-    let cfLit: clownface.Clownface<Literal, Dataset> = cf.node('foo');
+    const cf: clownface.AnyPointer<undefined, Dataset> = <any> {};
+    let singleTerm: clownface.AnyPointer<Term, Dataset> = cf.node(node);
+    let cfLit: clownface.AnyPointer<Literal, Dataset> = cf.node('foo');
     cfLit = cf.node(123);
-    const cfLitMany: clownface.Clownface<Literal[], Dataset> = cf.node(['foo', 'bar']);
+    const cfLitMany: clownface.AnyPointer<Literal[], Dataset> = cf.node(['foo', 'bar']);
     singleTerm = cf.node('http://example.org/', { type: 'NamedNode' });
-    const cfBlank: clownface.Clownface<BlankNode, Dataset> = cf.node(null, { type: 'BlankNode' });
+    const cfBlank: clownface.AnyPointer<BlankNode, Dataset> = cf.node(null, { type: 'BlankNode' });
     cfLit = cf.node('example', { datatype: node.value });
     cfLit = cf.node('example', { datatype: node });
 }
 
 function testOut() {
-    const cf: clownface.Clownface<undefined, Dataset> = <any> {};
-    let cfTerm: clownface.Clownface<Term[], Dataset> = cf.out();
+    const cf: clownface.AnyPointer<undefined, Dataset> = <any> {};
+    let cfTerm: clownface.AnyPointer<Term[], Dataset> = cf.out();
     cfTerm = cf.out(node);
     cfTerm = cf.out([node, node]);
     cfTerm = cf.out(cf.node([node, node]));
 
-    const singleContext: clownface.Clownface<NamedNode, Dataset> = <any> {};
+    const singleContext: clownface.AnyPointer<NamedNode, Dataset> = <any> {};
     let outContext = cfTerm.out(node);
     outContext = singleContext;
 }
 
 function testOutWithLanguage() {
-    const cf: clownface.Clownface<undefined, Dataset> = <any> {};
+    const cf: clownface.AnyPointer<undefined, Dataset> = <any> {};
     let cfTerms: Literal[] = cf.out(undefined, { language: 'en' }).terms;
     cfTerms = cf.out(node).terms;
     cfTerms = cf.out([node, node]).terms;
@@ -302,66 +302,66 @@ function testOutWithLanguage() {
 }
 
 function testToArray() {
-    const single: clownface.Clownface<Literal, Dataset> = <any> {};
-    const singleToArray: Array<clownface.Clownface<Literal, Dataset>> = single.toArray();
+    const single: clownface.AnyPointer<Literal, Dataset> = <any> {};
+    const singleToArray: Array<clownface.AnyPointer<Literal, Dataset>> = single.toArray();
 
-    const mutliple: clownface.Clownface<Literal[], Dataset> = <any> {};
-    const mutlipleToArray: Array<clownface.Clownface<Literal, Dataset>> = mutliple.toArray();
+    const mutliple: clownface.AnyPointer<Literal[], Dataset> = <any> {};
+    const mutlipleToArray: Array<clownface.AnyPointer<Literal, Dataset>> = mutliple.toArray();
 }
 
 function testMultipleContext() {
-    const safeCf: clownface.Clownface<Term[], Dataset> = <any> {};
+    const safeCf: clownface.AnyPointer<Term[], Dataset> = <any> {};
 
-    let singleBlank: clownface.Clownface<BlankNode, Dataset> = safeCf.blankNode();
+    let singleBlank: clownface.AnyPointer<BlankNode, Dataset> = safeCf.blankNode();
     singleBlank = clownface({ dataset }).blankNode();
     singleBlank = safeCf.blankNode('blank');
     singleBlank = clownface({ dataset }).node(null);
 
-    let singleNamed: clownface.Clownface<NamedNode, Dataset> = clownface({ dataset }).namedNode('urn:foo:bar');
+    let singleNamed: clownface.AnyPointer<NamedNode, Dataset> = clownface({ dataset }).namedNode('urn:foo:bar');
     singleNamed = safeCf.namedNode('http://example.com/a');
     singleNamed = clownface({ dataset }).node(node);
 
-    let singleLiteral: clownface.Clownface<Literal, Dataset> = clownface({ dataset }).literal('foo');
+    let singleLiteral: clownface.AnyPointer<Literal, Dataset> = clownface({ dataset }).literal('foo');
     singleLiteral = safeCf.literal('a');
     singleLiteral = clownface({ dataset }).node('b');
 
-    const fromSingleArrayBLank: clownface.Clownface<BlankNode, Dataset> = safeCf.blankNode([ 'b1' ]);
-    const fromSingleArrayNamed: clownface.Clownface<NamedNode, Dataset> = safeCf.namedNode([ 'http://example.com/a' ]);
-    const fromSingleArrayLiteral: clownface.Clownface<Literal, Dataset> = safeCf.literal([ 'a' ]);
+    const fromSingleArrayBLank: clownface.AnyPointer<BlankNode, Dataset> = safeCf.blankNode([ 'b1' ]);
+    const fromSingleArrayNamed: clownface.AnyPointer<NamedNode, Dataset> = safeCf.namedNode([ 'http://example.com/a' ]);
+    const fromSingleArrayLiteral: clownface.AnyPointer<Literal, Dataset> = safeCf.literal([ 'a' ]);
 
-    let multipleBlanks: clownface.Clownface<BlankNode[], Dataset> = safeCf.blankNode([ 'b1', 'b2' ]);
+    let multipleBlanks: clownface.AnyPointer<BlankNode[], Dataset> = safeCf.blankNode([ 'b1', 'b2' ]);
     multipleBlanks = clownface({ dataset }).node([ null, null ]);
 
-    let multipleNamed: clownface.Clownface<NamedNode[], Dataset> = safeCf.namedNode([ 'http://example.com/a', 'http://example.com/b' ]);
+    let multipleNamed: clownface.AnyPointer<NamedNode[], Dataset> = safeCf.namedNode([ 'http://example.com/a', 'http://example.com/b' ]);
     multipleNamed = clownface({ dataset }).node([ node, node ]);
 
-    let multipleLiterals: clownface.Clownface<Literal[], Dataset> = safeCf.literal([ 'a', 'b' ]);
+    let multipleLiterals: clownface.AnyPointer<Literal[], Dataset> = safeCf.literal([ 'a', 'b' ]);
     multipleLiterals = clownface({ dataset }).node([ 'a', 10, false ]);
 
-    const multipleMixedTerms: clownface.Clownface<Term[], Dataset> = clownface({ dataset }).node([ 'a', node, null ]);
+    const multipleMixedTerms: clownface.AnyPointer<Term[], Dataset> = clownface({ dataset }).node([ 'a', node, null ]);
 }
 
 function testContext() {
-    const fromSingleArrayLiteral: clownface.Clownface<Literal, Dataset> = <any> {};
+    const fromSingleArrayLiteral: clownface.AnyPointer<Literal, Dataset> = <any> {};
     const ctxTerm: Term = fromSingleArrayLiteral._context[0].term;
     const ctxGraph: Quad_Graph | undefined = fromSingleArrayLiteral._context[0].graph;
     const ctxDataset: Dataset = fromSingleArrayLiteral._context[0].dataset;
 }
 
 function addInAddOutRetainsType() {
-    const singleNamed: clownface.Clownface<NamedNode, Dataset> = <any> {};
+    const singleNamed: clownface.AnyPointer<NamedNode, Dataset> = <any> {};
 
-    const addOutSingle: clownface.Clownface<NamedNode, Dataset> = singleNamed.addOut(predicate, 'foo');
-    const addOutSingleObjectArray: clownface.Clownface<NamedNode, Dataset> = singleNamed.addOut(predicate, ['foo', 'bar']);
-    const addOutSinglePredicateArray: clownface.Clownface<NamedNode, Dataset> = singleNamed.addOut([predicate, predicate]);
-    const addOutSingleNoObject: clownface.Clownface<NamedNode, Dataset> = singleNamed.addOut(predicate);
-    const addOutSingleWithCallback: clownface.Clownface<NamedNode, Dataset> = singleNamed.addOut(predicate, () => {});
-    const addOutSingleWithObjectAndCallback: clownface.Clownface<NamedNode, Dataset> = singleNamed.addOut(predicate, 'foo', () => {});
+    const addOutSingle: clownface.AnyPointer<NamedNode, Dataset> = singleNamed.addOut(predicate, 'foo');
+    const addOutSingleObjectArray: clownface.AnyPointer<NamedNode, Dataset> = singleNamed.addOut(predicate, ['foo', 'bar']);
+    const addOutSinglePredicateArray: clownface.AnyPointer<NamedNode, Dataset> = singleNamed.addOut([predicate, predicate]);
+    const addOutSingleNoObject: clownface.AnyPointer<NamedNode, Dataset> = singleNamed.addOut(predicate);
+    const addOutSingleWithCallback: clownface.AnyPointer<NamedNode, Dataset> = singleNamed.addOut(predicate, () => {});
+    const addOutSingleWithObjectAndCallback: clownface.AnyPointer<NamedNode, Dataset> = singleNamed.addOut(predicate, 'foo', () => {});
 
-    const addInSingle: clownface.Clownface<NamedNode, Dataset> = singleNamed.addIn(predicate, 'foo');
-    const addInSingleObjectArray: clownface.Clownface<NamedNode, Dataset> = singleNamed.addIn(predicate, ['foo', 'bar']);
-    const addInSinglePredicateArray: clownface.Clownface<NamedNode, Dataset> = singleNamed.addIn([predicate, predicate]);
-    const addInSingleNoObject: clownface.Clownface<NamedNode, Dataset> = singleNamed.addIn(predicate);
-    const addInSingleWithCallback: clownface.Clownface<NamedNode, Dataset> = singleNamed.addIn(predicate, () => {});
-    const addInSingleWithObjectAndCallback: clownface.Clownface<NamedNode, Dataset> = singleNamed.addIn(predicate, 'foo', () => {});
+    const addInSingle: clownface.AnyPointer<NamedNode, Dataset> = singleNamed.addIn(predicate, 'foo');
+    const addInSingleObjectArray: clownface.AnyPointer<NamedNode, Dataset> = singleNamed.addIn(predicate, ['foo', 'bar']);
+    const addInSinglePredicateArray: clownface.AnyPointer<NamedNode, Dataset> = singleNamed.addIn([predicate, predicate]);
+    const addInSingleNoObject: clownface.AnyPointer<NamedNode, Dataset> = singleNamed.addIn(predicate);
+    const addInSingleWithCallback: clownface.AnyPointer<NamedNode, Dataset> = singleNamed.addIn(predicate, () => {});
+    const addInSingleWithObjectAndCallback: clownface.AnyPointer<NamedNode, Dataset> = singleNamed.addIn(predicate, 'foo', () => {});
 }

--- a/types/clownface/clownface-tests.ts
+++ b/types/clownface/clownface-tests.ts
@@ -197,20 +197,20 @@ function testFilter() {
 }
 
 function testForEach() {
-    const mutliple: clownface.Clownface<NamedNode[], Dataset> = <any> {};
-    mutliple.forEach(quad => {
+    let mutliple: clownface.Clownface<NamedNode[], Dataset> = <any> {};
+    mutliple = mutliple.forEach(quad => {
         const copy: clownface.Clownface<NamedNode, Dataset> = quad;
         return true;
     });
 
-    const single: clownface.Clownface<NamedNode, Dataset> = <any> {};
-    single.forEach(quad => {
+    let single: clownface.Clownface<NamedNode, Dataset> = <any> {};
+    single = single.forEach(quad => {
         const copy: clownface.Clownface<NamedNode, Dataset> = quad;
         return true;
     });
 
-    const noContext: clownface.Clownface<undefined, Dataset> = <any> {};
-    noContext.forEach(quad => {
+    let noContext: clownface.Clownface<undefined, Dataset> = <any> {};
+    noContext = noContext.forEach(quad => {
         const copy: never = quad;
         return true;
     });

--- a/types/clownface/clownface-tests.ts
+++ b/types/clownface/clownface-tests.ts
@@ -238,7 +238,7 @@ function testIn() {
 
 function testList() {
     const cf: clownface.Clownface<NamedNode, Dataset> = <any> {};
-    const listNodes: Iterable<clownface.Clownface<NamedNode, Dataset>> = cf.list();
+    const listNodes: Iterable<clownface.Clownface<NamedNode, Dataset>> | null = cf.list();
 }
 
 function testLiteral() {

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -51,7 +51,7 @@ declare namespace clownface {
     list(): Iterable<Iteratee<T, D>> | null;
     toArray(): Array<Clownface<T extends undefined ? never : T extends any[] ? T[0] : T, D>>;
     filter(cb: (quad: Iteratee<T, D>) => boolean): Clownface<T, D>;
-    forEach(cb: (quad: Iteratee<T, D>) => void): void;
+    forEach(cb: (quad: Iteratee<T, D>) => void): this;
     map<X>(cb: (quad: Iteratee<T, D>, index: number) => X): X[];
 
     node(value: SingleOrOneElementArray<boolean | string | number>, options?: NodeOptions): Clownface<Literal, D>;

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -36,6 +36,10 @@ declare namespace clownface {
       ? Clownface<T[0], D>
       : Clownface<T, D>;
 
+  interface OutOptions {
+    language?: string | string[]
+  }
+
   interface Clownface<T extends AnyContext = AnyContext, D extends DatasetCore = DatasetCore> {
     readonly term: T extends undefined ? undefined : T extends any[] ? undefined | T[0] : T;
     readonly terms: T extends undefined ? Term[] : T extends any[] ? T : [T];
@@ -72,6 +76,7 @@ declare namespace clownface {
 
     in(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<T extends undefined ? never : NamedNode | BlankNode, D>;
     out(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<T extends undefined ? never : Term, D>;
+    out(predicates?: SingleOrArrayOfTerms<Term>, options?: OutOptions): SafeClownface<T extends undefined ? never : Literal, D>
 
     has(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<Term>): Clownface<Array<NamedNode | BlankNode>, D>;
 

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -61,7 +61,7 @@ declare namespace clownface {
     node<X extends Term[]>(values: X, options?: NodeOptions): AnyPointer<X, D>;
 
     node(value: null, options?: NodeOptions): AnyPointer<BlankNode, D>;
-    node(values: null[], options?: NodeOptions): AnyPointer<BlankNode[], D>;
+    node(values: Array<null>, options?: NodeOptions): AnyPointer<BlankNode[], D>;
 
     node(values: Array<boolean | string | number | Term | null>, options?: NodeOptions): AnyPointer<Term[], D>;
 

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -10,14 +10,14 @@ import { Context } from './lib/Context';
 declare namespace clownface {
   type AnyContext = Term | Term[] | undefined;
 
-  type TermOrClownface<X extends Term = Term> = SafeClownface<X> | X;
+  type TermOrClownface<X extends Term = Term> = MultiPointer<X> | X;
   type TermOrLiteral<X extends Term = Term> = TermOrClownface<X> | string | number | boolean;
 
-  type AddCallback<D extends DatasetCore, X extends Term> = (added: Clownface<X, D>) => void;
+  type AddCallback<D extends DatasetCore, X extends Term> = (added: AnyPointer<X, D>) => void;
   type SingleOrArray<T> = T | readonly T[];
   type SingleOrOneElementArray<T> = T | readonly [T];
 
-  type SingleOrArrayOfTerms<X extends Term> = SingleOrArray<X> | SafeClownface<X>;
+  type SingleOrArrayOfTerms<X extends Term> = SingleOrArray<X> | MultiPointer<X>;
   type SingleOrArrayOfTermsOrLiterals<X extends Term> = SingleOrArray<TermOrLiteral<X>>;
 
   interface NodeOptions {
@@ -27,20 +27,20 @@ declare namespace clownface {
   }
 
   type ClownfaceInit<D extends DatasetCore = DatasetCore>
-    = Partial<Pick<Clownface<AnyContext, D>, 'dataset' | '_context'> & { graph: Quad_Graph }>;
+    = Partial<Pick<AnyPointer<AnyContext, D>, 'dataset' | '_context'> & { graph: Quad_Graph }>;
 
   type Iteratee<T extends AnyContext = undefined, D extends DatasetCore = DatasetCore> =
     T extends undefined
       ? never
       : T extends any[]
-      ? Clownface<T[0], D>
-      : Clownface<T, D>;
+      ? AnyPointer<T[0], D>
+      : AnyPointer<T, D>;
 
   interface OutOptions {
     language?: string | string[]
   }
 
-  interface Clownface<T extends AnyContext = AnyContext, D extends DatasetCore = DatasetCore> {
+  interface AnyPointer<T extends AnyContext = AnyContext, D extends DatasetCore = DatasetCore> {
     readonly term: T extends undefined ? undefined : T extends any[] ? undefined | T[0] : T;
     readonly terms: T extends undefined ? Term[] : T extends any[] ? T : [T];
     readonly value: T extends undefined ? undefined : T extends any[] ? undefined | string[0] : string;
@@ -49,62 +49,62 @@ declare namespace clownface {
     readonly datasets: D[];
     readonly _context: Array<Context<D, Term>>;
     list(): Iterable<Iteratee<T, D>> | null;
-    toArray(): Array<Clownface<T extends undefined ? never : T extends any[] ? T[0] : T, D>>;
-    filter(cb: (quad: Iteratee<T, D>) => boolean): Clownface<T, D>;
+    toArray(): Array<AnyPointer<T extends undefined ? never : T extends any[] ? T[0] : T, D>>;
+    filter(cb: (quad: Iteratee<T, D>) => boolean): AnyPointer<T, D>;
     forEach(cb: (quad: Iteratee<T, D>) => void): this;
     map<X>(cb: (quad: Iteratee<T, D>, index: number) => X): X[];
 
-    node(value: SingleOrOneElementArray<boolean | string | number>, options?: NodeOptions): Clownface<Literal, D>;
-    node(values: Array<boolean | string | number>, options?: NodeOptions): Clownface<Literal[], D>;
+    node(value: SingleOrOneElementArray<boolean | string | number>, options?: NodeOptions): AnyPointer<Literal, D>;
+    node(values: Array<boolean | string | number>, options?: NodeOptions): AnyPointer<Literal[], D>;
 
-    node<X extends Term>(value: SingleOrOneElementArray<X>, options?: NodeOptions): Clownface<X, D>;
-    node<X extends Term[]>(values: X, options?: NodeOptions): Clownface<X, D>;
+    node<X extends Term>(value: SingleOrOneElementArray<X>, options?: NodeOptions): AnyPointer<X, D>;
+    node<X extends Term[]>(values: X, options?: NodeOptions): AnyPointer<X, D>;
 
-    node(value: null, options?: NodeOptions): Clownface<BlankNode, D>;
-    node(values: Array<null>, options?: NodeOptions): Clownface<BlankNode[], D>;
+    node(value: null, options?: NodeOptions): AnyPointer<BlankNode, D>;
+    node(values: Array<null>, options?: NodeOptions): AnyPointer<BlankNode[], D>;
 
-    node(values: Array<boolean | string | number | Term | null>, options?: NodeOptions): Clownface<Term[], D>;
+    node(values: Array<boolean | string | number | Term | null>, options?: NodeOptions): AnyPointer<Term[], D>;
 
-    blankNode(value?: SingleOrOneElementArray<string>): Clownface<BlankNode, D>;
-    blankNode(values: string[]): Clownface<BlankNode[], D>;
+    blankNode(value?: SingleOrOneElementArray<string>): AnyPointer<BlankNode, D>;
+    blankNode(values: string[]): AnyPointer<BlankNode[], D>;
 
-    literal(value: SingleOrOneElementArray<boolean | string | number | Term | null>, languageOrDatatype?: string | NamedNode): Clownface<Literal, D>;
-    literal(values: Array<boolean | string | number | Term | null>, languageOrDatatype?: string | NamedNode): Clownface<Literal[], D>;
+    literal(value: SingleOrOneElementArray<boolean | string | number | Term | null>, languageOrDatatype?: string | NamedNode): AnyPointer<Literal, D>;
+    literal(values: Array<boolean | string | number | Term | null>, languageOrDatatype?: string | NamedNode): AnyPointer<Literal[], D>;
 
-    namedNode(value: SingleOrOneElementArray<string | NamedNode>): Clownface<NamedNode, D>;
-    namedNode(values: Array<string | NamedNode>): Clownface<NamedNode[], D>;
+    namedNode(value: SingleOrOneElementArray<string | NamedNode>): AnyPointer<NamedNode, D>;
+    namedNode(values: Array<string | NamedNode>): AnyPointer<NamedNode[], D>;
 
-    in(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<T extends undefined ? never : NamedNode | BlankNode, D>;
-    out(predicates?: SingleOrArrayOfTerms<Term>): SafeClownface<T extends undefined ? never : Term, D>;
-    out(predicates?: SingleOrArrayOfTerms<Term>, options?: OutOptions): SafeClownface<T extends undefined ? never : Literal, D>
+    in(predicates?: SingleOrArrayOfTerms<Term>): MultiPointer<T extends undefined ? never : NamedNode | BlankNode, D>;
+    out(predicates?: SingleOrArrayOfTerms<Term>): MultiPointer<T extends undefined ? never : Term, D>;
+    out(predicates?: SingleOrArrayOfTerms<Term>, options?: OutOptions): MultiPointer<T extends undefined ? never : Literal, D>
 
-    has(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<Term>): Clownface<Array<NamedNode | BlankNode>, D>;
+    has(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<Term>): AnyPointer<Array<NamedNode | BlankNode>, D>;
 
-    addIn(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): Clownface<T, D>;
-    addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, subjects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): Clownface<T, D>;
+    addIn(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): AnyPointer<T, D>;
+    addIn<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, subjects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): AnyPointer<T, D>;
 
-    addOut(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): Clownface<T, D>;
-    addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): Clownface<T, D>;
+    addOut(predicates: SingleOrArrayOfTerms<Term>, callback?: AddCallback<D, BlankNode>): AnyPointer<T, D>;
+    addOut<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): AnyPointer<T, D>;
 
-    addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): Clownface<T, D>;
+    addList<X extends Term = Term>(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<X>, callback?: AddCallback<D, X>): AnyPointer<T, D>;
 
-    deleteIn(predicates?: SingleOrArrayOfTerms<Term>): Clownface<T, D>;
-    deleteOut(predicates?: SingleOrArrayOfTerms<Term>): Clownface<T, D>;
-    deleteList(predicates: SingleOrArrayOfTerms<Term>): Clownface<T, D>;
+    deleteIn(predicates?: SingleOrArrayOfTerms<Term>): AnyPointer<T, D>;
+    deleteOut(predicates?: SingleOrArrayOfTerms<Term>): AnyPointer<T, D>;
+    deleteList(predicates: SingleOrArrayOfTerms<Term>): AnyPointer<T, D>;
   }
 
-  type SafeClownface<T extends Term = Term, D extends DatasetCore = DatasetCore> = Clownface<T | T[], D>;
-  type SingleContextClownface<T extends Term = Term, D extends DatasetCore = DatasetCore> = Clownface<T, D>;
+  type MultiPointer<T extends Term = Term, D extends DatasetCore = DatasetCore> = AnyPointer<T | T[], D>;
+  type GraphPointer<T extends Term = Term, D extends DatasetCore = DatasetCore> = AnyPointer<T, D>;
 
   type ClownfaceInitWithTerms<T extends Term | Term[], D extends DatasetCore> = ClownfaceInit<D> & { term: T };
   type ClownfaceInitWithValue<D extends DatasetCore> = ClownfaceInit<D> & { value: string };
   type ClownfaceInitWithValues<D extends DatasetCore> = ClownfaceInit<D> & { value: string[] };
 }
 
-declare function clownface<D extends DatasetCore, T extends clownface.AnyContext>(other: clownface.Clownface<T, D>): clownface.Clownface<T, D>;
-declare function clownface<D extends DatasetCore>(options: clownface.ClownfaceInitWithValue<D>): clownface.Clownface<Literal, D>;
-declare function clownface<D extends DatasetCore>(options: clownface.ClownfaceInitWithValues<D>): clownface.Clownface<Literal[], D>;
-declare function clownface<D extends DatasetCore, T extends Term | Term[]>(options: clownface.ClownfaceInitWithTerms<T, D>): clownface.Clownface<T, D>;
-declare function clownface<D extends DatasetCore>(options: clownface.ClownfaceInit<D>): clownface.Clownface<clownface.AnyContext, D>;
+declare function clownface<D extends DatasetCore, T extends clownface.AnyContext>(other: clownface.AnyPointer<T, D>): clownface.AnyPointer<T, D>;
+declare function clownface<D extends DatasetCore>(options: clownface.ClownfaceInitWithValue<D>): clownface.AnyPointer<Literal, D>;
+declare function clownface<D extends DatasetCore>(options: clownface.ClownfaceInitWithValues<D>): clownface.AnyPointer<Literal[], D>;
+declare function clownface<D extends DatasetCore, T extends Term | Term[]>(options: clownface.ClownfaceInitWithTerms<T, D>): clownface.AnyPointer<T, D>;
+declare function clownface<D extends DatasetCore>(options: clownface.ClownfaceInit<D>): clownface.AnyPointer<clownface.AnyContext, D>;
 
 export = clownface;

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for clownface 0.12
+// Type definitions for clownface 1.0
 // Project: https://github.com/rdf-ext/clownface
 // Definitions by: tpluscode <https://github.com/tpluscode>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -44,7 +44,7 @@ declare namespace clownface {
     readonly dataset: D;
     readonly datasets: D[];
     readonly _context: Array<Context<D, Term>>;
-    list(): Iterable<Iteratee<T, D>>;
+    list(): Iterable<Iteratee<T, D>> | null;
     toArray(): Array<Clownface<T extends undefined ? never : T extends any[] ? T[0] : T, D>>;
     filter(cb: (quad: Iteratee<T, D>) => boolean): Clownface<T, D>;
     forEach(cb: (quad: Iteratee<T, D>) => void): void;

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -37,7 +37,7 @@ declare namespace clownface {
       : AnyPointer<T, D>;
 
   interface OutOptions {
-    language?: string | string[]
+    language?: string | string[];
   }
 
   interface AnyPointer<T extends AnyContext = AnyContext, D extends DatasetCore = DatasetCore> {
@@ -61,7 +61,7 @@ declare namespace clownface {
     node<X extends Term[]>(values: X, options?: NodeOptions): AnyPointer<X, D>;
 
     node(value: null, options?: NodeOptions): AnyPointer<BlankNode, D>;
-    node(values: Array<null>, options?: NodeOptions): AnyPointer<BlankNode[], D>;
+    node(values: null[], options?: NodeOptions): AnyPointer<BlankNode[], D>;
 
     node(values: Array<boolean | string | number | Term | null>, options?: NodeOptions): AnyPointer<Term[], D>;
 
@@ -76,7 +76,7 @@ declare namespace clownface {
 
     in(predicates?: SingleOrArrayOfTerms<Term>): MultiPointer<T extends undefined ? never : NamedNode | BlankNode, D>;
     out(predicates?: SingleOrArrayOfTerms<Term>): MultiPointer<T extends undefined ? never : Term, D>;
-    out(predicates?: SingleOrArrayOfTerms<Term>, options?: OutOptions): MultiPointer<T extends undefined ? never : Literal, D>
+    out(predicates?: SingleOrArrayOfTerms<Term>, options?: OutOptions): MultiPointer<T extends undefined ? never : Literal, D>;
 
     has(predicates: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTermsOrLiterals<Term>): AnyPointer<Array<NamedNode | BlankNode>, D>;
 

--- a/types/clownface/lib/Clownface.d.ts
+++ b/types/clownface/lib/Clownface.d.ts
@@ -1,6 +1,6 @@
 import { DatasetCore, Term } from 'rdf-js';
 import {
-    Clownface,
+    AnyPointer,
     ClownfaceInit,
     ClownfaceInitWithTerms,
     ClownfaceInitWithValue,
@@ -8,7 +8,7 @@ import {
     AnyContext,
 } from '..';
 
-interface ClownfaceImpl<T extends AnyContext = AnyContext, D extends DatasetCore = DatasetCore> extends Clownface<T, D> {}
+interface ClownfaceImpl<T extends AnyContext = AnyContext, D extends DatasetCore = DatasetCore> extends AnyPointer<T, D> {}
 
 // tslint:disable-next-line no-unnecessary-class
 declare class ClownfaceImpl<T extends AnyContext = AnyContext, D extends DatasetCore = DatasetCore> {


### PR DESCRIPTION
Introduces latest code changes and also renames the exported interfaces, which I wanted to for some time

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/zazuko/clownface/pull/39
  - https://github.com/zazuko/clownface/pull/41
  - https://github.com/zazuko/clownface/pull/43
  - [diff with previous release](https://github.com/zazuko/clownface/compare/v0.12.3...v1.0.0)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
