### PR TITLE
kdbxweb: fix wrong type for error code

### DIFF
--- a/types/kdbxweb/index.d.ts
+++ b/types/kdbxweb/index.d.ts
@@ -118,11 +118,13 @@ export class Kdbx {
     static loadXml(data: string, credentials: Credentials): Promise<Kdbx>;
 }
 
+export type KdbxErrorCode = typeof Consts.ErrorCodes[keyof typeof Consts.ErrorCodes];
+
 export class KdbxError {
-    constructor(code: number, message: string);
+    constructor(code: KdbxErrorCode, message: string);
 
     name: "KdbxError";
-    code: number;
+    code: KdbxErrorCode;
     message: string;
 
     // Native method; no parameter or return type inference available
@@ -221,14 +223,14 @@ export const Consts: {
         RecycleBinName: string;
     };
     ErrorCodes: {
-        BadSignature: string;
-        FileCorrupt: string;
-        InvalidArg: string;
-        InvalidKey: string;
-        InvalidVersion: string;
-        MergeError: string;
-        NotImplemented: string;
-        Unsupported: string;
+        NotImplemented: 'NotImplemented';
+        InvalidArg: 'InvalidArg';
+        BadSignature: 'BadSignature';
+        InvalidVersion: 'InvalidVersion';
+        Unsupported: 'Unsupported';
+        FileCorrupt: 'FileCorrupt';
+        InvalidKey: 'InvalidKey';
+        MergeError: 'MergeError';
     };
     Icons: {
         Apple: number;

--- a/types/kdbxweb/kdbxweb-tests.ts
+++ b/types/kdbxweb/kdbxweb-tests.ts
@@ -35,3 +35,6 @@ newDb.cleanup({
 });
 
 newDb.upgrade();
+
+// check error types
+new kdbxweb.KdbxError(kdbxweb.Consts.ErrorCodes.NotImplemented, 'SHA256 not implemented');


### PR DESCRIPTION
Previously `KdbxError.code` was typed as `number`. However, error codes in kbbxweb are [string constants](https://github.com/keeweb/kdbxweb/blob/master/lib/defs/consts.js#L9-L18). This PR updates the typings accordingly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/keeweb/kdbxweb/blob/master/lib/defs/consts.js#L9-L18
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
