### PR TITLE
Fix incorrect circular inheritance

### DIFF
--- a/types/chrome-apps/index.d.ts
+++ b/types/chrome-apps/index.d.ts
@@ -10365,7 +10365,7 @@ declare namespace chrome {
         }
 
         /** @since Chrome 39. */
-        interface DeviceFilter extends Partial<DeviceFilter> { }
+        interface DeviceFilter extends Partial<DeviceFilterStrict> { }
 
         interface TransferInfo {
             /**


### PR DESCRIPTION
Typescript 4.0 check heritage clauses better than earlier versions, so
it now gives an error on

```ts
interface DeviceFilter extends Partial<DeviceFilter> { }
```

It was supposed to be

```ts
interface DeviceFilter extends Partial<DeviceFilterStrict> { }
```
