### PR TITLE
mmmagic: Callback result is string[] and not string when MAGIC_CONTINUE is set

### DIFF
--- a/types/mmmagic/index.d.ts
+++ b/types/mmmagic/index.d.ts
@@ -10,8 +10,8 @@ export type bitmask = number;
 export declare class Magic {
     constructor(magicPath?: string, mask?: bitmask);
     constructor(mask?: bitmask);
-    detectFile(path: string, callback: (err: Error, result: string) => void): void;
-    detect(data: Buffer, callback: (err: Error, result: string) => void): void;
+    detectFile(path: string, callback: (err: Error, result: string | string[]) => void): void;
+    detect(data: Buffer, callback: (err: Error, result: string | string[]) => void): void;
 }
 export declare var MAGIC_NONE: bitmask; // no flags set
 export declare var MAGIC_DEBUG: bitmask; // turn on debugging


### PR DESCRIPTION
As from the [documentation](https://www.npmjs.com/package/mmmagic) and comments included in the changed source:

    MAGIC_CONTINUE - Return all matches (returned as an array of strings)

So callbacks to `detect` and `detectFile` should have its first argument (result) as a `string` or `string[]`.

I think this is a rather trivial change and current tests are not affected by this change. But if someone thinks I should add new tests with `MAGIC_CONTINUE` enabled, I can do so.