### PR TITLE
new package: validate-npm-package-name

### DIFF
--- a/types/validate-npm-package-license/index.d.ts
+++ b/types/validate-npm-package-license/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for validate-npm-package-license 3.0
+// Project: https://github.com/npm/validate-npm-package-license
+// Definitions by: Gabriel Fournier <https://github.com/carboneater>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace validateLicense {
+    interface Result {
+        inFile?: string;
+        spdx?: true;
+        unlicensed?: true;
+        validForOldPackages: boolean;
+        validForNewPackages: boolean;
+        warnings?: string[];
+    }
+}
+
+declare function validateLicense(license: string): validateLicense.Result;
+
+export = validateLicense;

--- a/types/validate-npm-package-license/index.d.ts
+++ b/types/validate-npm-package-license/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for validate-npm-package-license 3.0
-// Project: https://github.com/npm/validate-npm-package-license
+// Project: https://github.com/kemitchell/validate-npm-package-license.js#readme
 // Definitions by: Gabriel Fournier <https://github.com/carboneater>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/validate-npm-package-license/tsconfig.json
+++ b/types/validate-npm-package-license/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "validate-npm-package-license-tests.ts"
+    ]
+}

--- a/types/validate-npm-package-license/tslint.json
+++ b/types/validate-npm-package-license/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/validate-npm-package-license/validate-npm-package-license-tests.ts
+++ b/types/validate-npm-package-license/validate-npm-package-license-tests.ts
@@ -1,0 +1,9 @@
+import validateLicense = require('validate-npm-package-license');
+
+validateLicense('MIT'); // $ExpectType Result
+validateLicense('BSD-2-Clause'); // $ExpectType Result
+validateLicense('Apache-2.0'); // $ExpectType Result
+validateLicense('ISC'); // $ExpectType Result
+validateLicense('UNLICENSED'); // $ExpectType Result
+validateLicense('(GPL-3.0-only OR BSD-2-Clause)'); // $ExpectType Result
+validateLicense('LicenseRef-Made-Up'); // $ExpectType Result


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
