### PR TITLE
Update kap-plugin for conf 7

### DIFF
--- a/types/kap-plugin/index.d.ts
+++ b/types/kap-plugin/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/wulkano/kap/blob/master/docs/plugins.md
 // Definitions by: Connor Peet <https://github.com/connor4312>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.2
+// Minimum TypeScript Version: 3.8
 
 import * as got from 'got';
 import * as ElectronStore from 'electron-store';

--- a/types/kap-plugin/kap-plugin-tests.ts
+++ b/types/kap-plugin/kap-plugin-tests.ts
@@ -20,12 +20,11 @@ const service: KapShareService<Config> = {
         greeting: { type: 'string', default: true },
     },
     action: async context => {
-        // $ExpectType string
+        // $ExpectType string | undefined
         const name = context.config.get('name');
 
         context.config.get('accessToken');
 
-        // $ExpectError
         context.config.get('unknown');
 
         await context.request(`https://example.com/greet/${name}`);

--- a/types/kap-plugin/tsconfig.json
+++ b/types/kap-plugin/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": [
             "es6"
         ],
+        "target": "es2015",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,


### PR DESCRIPTION
1. conf 7 uses #private, which requires Typescript 3.8 and target: "es2015" or higher.
2. conf 7's get returns `string | undefined`, not `string`, which is stricter.
3. conf 7's get accepts any `string`, not just the declared property names, which is less strict.