### PR TITLE
Fix express-serve-static-core dependents

### DIFF
--- a/types/express-flash-2/index.d.ts
+++ b/types/express-flash-2/index.d.ts
@@ -51,7 +51,7 @@ declare global {
             flash(type: string, msg: string | any[]): void;
 
             locals: {
-                flash: Flash
+                flash?: Flash
             };
         }
     }

--- a/types/i18n/index.d.ts
+++ b/types/i18n/index.d.ts
@@ -458,6 +458,6 @@ declare namespace Express {
     }
 
     interface Response extends i18nAPI {
-        locals: i18nAPI;
+        locals: Partial<i18nAPI>;
     }
 }


### PR DESCRIPTION
express-flash-2 and i18n override `Response.locals`, which worked OK before #46230 since `locals: any` in express-serve-static-core. Now, however, it's `Record<string, any>`, which doesn't actually guarantee that all the properties required by express-flash-2/i18n are present. 

To fix this, I made the properties optional. It's possible that the right fix is to revert #46230 -- I'm not sure how common it is for packages to override properties of Response instead of declare new ones. I *think* most packages just declare new properties, but I could be wrong.
