### PR TITLE
Upgrade types for express-actuator@1.6.0

### DIFF
--- a/types/express-actuator/express-actuator-tests.ts
+++ b/types/express-actuator/express-actuator-tests.ts
@@ -12,4 +12,12 @@ function actuatorTest() {
     app.use(actuator({ basePath: '/management' }));
     app.use(actuator({ infoGitMode: 'simple' }));
     app.use(actuator({ infoGitMode: 'full' }));
+    app.use(actuator({ infoDateFormat: 'YYYY-DD-MM' }));
+    app.use(actuator({
+      infoBuildOptions: {
+        string: '123',
+        bool: true,
+        number: 1
+      }
+    }));
 }

--- a/types/express-actuator/index.d.ts
+++ b/types/express-actuator/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for express-actuator 1.3
+// Type definitions for express-actuator 1.6
 // Project: https://www.npmjs.org/package/express-actuator
 // Definitions by:  Eduardo Silva <https://github.com/etruta>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -24,6 +24,16 @@ declare namespace actuator {
          * @summary infoGitMode.
          */
         infoGitMode?: InfoGitMode;
+
+        /**
+         * @summary DateFormat for info git.time output.
+         */
+        infoDateFormat?: string;
+
+        /**
+         * @summary Extra Options to pass to info build output.
+         */
+        infoBuildOptions?: Record<string, any>;
     }
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Context: New options were added to express-actuator for 1.6.0. https://github.com/rcruzper/express-actuator/pull/31