### PR TITLE
[@types/mmmagic] fix detection callback result type for MAGIC_CONTINUE

### DIFF
--- a/types/mmmagic/index.d.ts
+++ b/types/mmmagic/index.d.ts
@@ -10,10 +10,7 @@
  * Result is a string, except when MAGIC_CONTINUE is set,
  * then it is an array of string
  */
-type DetectionCallback =
-    ((err: Error, result: string) => void) |
-    ((err: Error, result: string[]) => void) |
-    ((err: Error, result: string | string[]) => void)
+type DetectionCallback = ((err: Error, result: string | string[]) => void)
 
 export type bitmask = number;
 export declare class Magic {

--- a/types/mmmagic/index.d.ts
+++ b/types/mmmagic/index.d.ts
@@ -5,13 +5,22 @@
 
 /// <reference types="node" />
 
+/**
+ * callback for detect() and detectFile()
+ * Result is a string, except when MAGIC_CONTINUE is set,
+ * then it is an array of string
+ */
+type DetectionCallback =
+    ((err: Error, result: string) => void) |
+    ((err: Error, result: string[]) => void) |
+    ((err: Error, result: string | string[]) => void)
 
 export type bitmask = number;
 export declare class Magic {
     constructor(magicPath?: string, mask?: bitmask);
     constructor(mask?: bitmask);
-    detectFile(path: string, callback: (err: Error, result: string) => void): void;
-    detect(data: Buffer, callback: (err: Error, result: string) => void): void;
+    detectFile(path: string, callback: DetectionCallback): void;
+    detect(data: Buffer, callback: DetectionCallback): void;
 }
 export declare var MAGIC_NONE: bitmask; // no flags set
 export declare var MAGIC_DEBUG: bitmask; // turn on debugging

--- a/types/mmmagic/mmmagic-tests.ts
+++ b/types/mmmagic/mmmagic-tests.ts
@@ -5,16 +5,18 @@ import Magic = require("mmmagic");
 var magic: Magic.Magic;
 
 magic = new Magic.Magic();
-magic.detectFile('node_modules/mmmagic/build/Release/magic.node', function(err: Error, result: string) {
+magic.detectFile('node_modules/mmmagic/build/Release/magic.node', function(err: Error, result: string | string[]) {
     if (err) throw err;
+    if (typeof result !== 'string') throw new Error('expected a string');
     console.log(result);
     // output on Windows with 32-bit node:
 });
 
 // get mime type for a file
 magic = new Magic.Magic(Magic.MAGIC_MIME_TYPE);
-magic.detectFile('node_modules/mmmagic/build/Release/magic.node', function(err: Error, result: string) {
+magic.detectFile('node_modules/mmmagic/build/Release/magic.node', function(err: Error, result) {
     if (err) throw err;
+    if (typeof result !== 'string') throw new Error('expected a string');
     console.log(result);
 });
 
@@ -22,15 +24,16 @@ magic.detectFile('node_modules/mmmagic/build/Release/magic.node', function(err: 
 magic = new Magic.Magic();
 var buf = new Buffer('import Options\nfrom os import unlink, symlink');
 
-magic.detect(buf, function(err: Error, result: string) {
+magic.detect(buf, function(err: Error, result: string | string[]) {
     if (err) throw err;
+    if (typeof result !== 'string') throw new Error('expected a string');
     console.log(result);
     // output: Python script, ASCII text executable
 });
 
 // get all mime type canidates
 const magics = new Magic.Magic(Magic.MAGIC_MIME_TYPE | Magic.MAGIC_CONTINUE);
-magic.detectFile('node_modules/mmmagic/build/Release/magic.node', function(err: Error, result: string[]) {
+magic.detectFile('node_modules/mmmagic/build/Release/magic.node', function(err, result) {
     if (err) throw err;
     if (!Array.isArray(result)) throw new Error('expected an array')
     console.log(result);

--- a/types/mmmagic/mmmagic-tests.ts
+++ b/types/mmmagic/mmmagic-tests.ts
@@ -27,3 +27,16 @@ magic.detect(buf, function(err: Error, result: string) {
     console.log(result);
     // output: Python script, ASCII text executable
 });
+
+// get all mime type canidates
+const magics = new Magic.Magic(Magic.MAGIC_MIME_TYPE | Magic.MAGIC_CONTINUE);
+magic.detectFile('node_modules/mmmagic/build/Release/magic.node', function(err: Error, result: string[]) {
+    if (err) throw err;
+    if (!Array.isArray(result)) throw new Error('expected an array')
+    console.log(result);
+});
+magic.detect(buf, function(err: Error, result: string | string[]) {
+    if (err) throw err;
+    if (!Array.isArray(result)) throw new Error('expected an array')
+    console.log(result);
+})


### PR DESCRIPTION
As from the [documentation](https://www.npmjs.com/package/mmmagic) and comments included in the changed source:

    MAGIC_CONTINUE - Return all matches (returned as an array of strings)

So callbacks to `detect` and `detectFile` should have its result argument be a `string` or `string[]` - although the documentation of these functions fails to mention this fact. I added tests for the `MAGIC_CONTINUE` case (which would previously either fail to compile with `string[]` or compile with `string` but pass a `string[]` at runtime).