### PR TITLE
[yeoman-environment] Fix incorrect `log` method

### DIFF
--- a/types/yeoman-environment/index.d.ts
+++ b/types/yeoman-environment/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for yeoman-environment 2.10
 // Project: https://github.com/yeoman/environment, http://yeoman.io
 // Definitions by: c4605 <https://github.com/bolasblack>
+//                 Manuel Thalmann <https://github.com/manuth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.3
 

--- a/types/yeoman-environment/lib/util/log.d.ts
+++ b/types/yeoman-environment/lib/util/log.d.ts
@@ -66,11 +66,17 @@ declare namespace createLogger {
          *
          * @param format
          * The format of the log-messages.
+         * See <https://github.com/mikeal/logref> for more info.
          *
          * @param params
          * The parameters to replace variables with.
          */
         (format?: string, params?: Record<string, any>): Logger<TCategories>;
+
+        /**
+         * Writes a log-message.
+         */
+        (...args: Parameters<Console["error"]>): Logger<TCategories>;
 
         /**
          * Writes a log-message.

--- a/types/yeoman-environment/lib/util/log.d.ts
+++ b/types/yeoman-environment/lib/util/log.d.ts
@@ -70,7 +70,7 @@ declare namespace createLogger {
          * @param params
          * The parameters to replace variables with.
          */
-        (format: string, params?: Record<string, any>): Logger<TCategories>;
+        (format?: string, params?: Record<string, any>): Logger<TCategories>;
 
         /**
          * Writes a log-message.

--- a/types/yeoman-environment/yeoman-environment-tests.ts
+++ b/types/yeoman-environment/yeoman-environment-tests.ts
@@ -29,6 +29,8 @@ createLogger({
 Env.util.log({});
 
 defaultLogger.skip("");
+defaultLogger();
+defaultLogger("");
 customLogger.help("");
 
 /* Lookup */

--- a/types/yeoman-generator/index.d.ts
+++ b/types/yeoman-generator/index.d.ts
@@ -7,6 +7,7 @@
 //                 Arthur Corenzan <https://github.com/haggen>
 //                 Richard Lea <https://github.com/chigix>
 //                 Devid Farinelli <https://github.com/misterdev>
+//                 Manuel Thalmann <https://github.com/manuth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.3
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/yeoman/environment/blob/master/lib/util/log.js#L78-L81>
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Related to #46349

@RyanCavanaugh I'm very sorry - I managed it to create incorrect (of sorts) type-definitions for the `log`-method (because there was no API docs about this method).

Will `yeoman-generator`, which depends on `yeoman-environment` be updated automatically?