### PR TITLE
[react-native-video-player] added optional android expansion file props to source

### DIFF
--- a/types/react-native-video-player/index.d.ts
+++ b/types/react-native-video-player/index.d.ts
@@ -9,7 +9,7 @@ import { VideoProperties } from 'react-native-video';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 
 export interface VideoPlayerProps {
-    video?: { uri?: string } | number;
+    video?: { uri?: string, mainVer?: number, patchVer?: number } | number;
     thumbnail?: ImageSourcePropType;
     endThumbnail?: ImageSourcePropType;
     videoWidth?: number;


### PR DESCRIPTION
react-native-video-player uses react-native-video to render, which [supports optional properties](https://github.com/react-native-community/react-native-video#android-expansion-file-usage>) to load a video from an Android expansion file. 