### PR TITLE
[@types/mongodb] Redefine OptionalId to make it accept generic types

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1004,13 +1004,7 @@ type ExtractIdType<TSchema> =
     unknown extends U ? ObjectId : U
      : ObjectId; // user has not defined _id on schema
 
-// this makes _id optional
-export type OptionalId<TSchema extends { _id?: any }> =
-    ObjectId extends TSchema['_id']
-        // a Schema with ObjectId _id type or "any" or "indexed type" provided
-        ? EnhancedOmit<TSchema, '_id'> & { _id?: ExtractIdType<TSchema> }
-        // a Schema provided but _id type is not ObjectId
-        : WithId<TSchema>;
+export type OptionalId<TSchema extends { _id?: any }> = Omit<TSchema, '_id'> & { _id?: TSchema['_id'] };
 
 // this adds _id as a required property
 export type WithId<TSchema> = EnhancedOmit<TSchema, '_id'> & { _id: ExtractIdType<TSchema> };


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the readme.
- [x] Avoid common mistakes.
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

https://github.com/DefinitelyTyped/DefinitelyTyped/issues/46375

This PR fixes the `insert{,One,Many}` methods for generic `TSchema` types, with the drawback of breaking type checking on the `_id` property in the `OptionalId` type.

- Before this PR, `OptionalId` was defined with a conditional type that could never resolve when given a generic, because both branches of the conditional used the `ExtractIdType<TSchema>`, to which no generic `TSchema` type could be assigned. This is due to the fact that Typescript does not resolve the constaints of the type variables in conditional types (better explained in https://github.com/microsoft/TypeScript/issues/29225).
```ts
  async function withConstrainedGeneric<T extends { _id: ObjectId }>(param: T) {
    const constrainedGenericCollection = db.collection<T>('testCollection');
    // TS2345: Argument of type 'T' is not assignable to parameter of type 'OptionalId<T>'.
    // Type '{ _id: ObjectId; }' is not assignable to type 'OptionalId<T>'.
    await constrainedGenericCollection.insertOne(param);
  }

  // Due to ExtractIdType not working with any generic
  function withConstrainedGeneric<T extends { _id: number }>(param: T) {
    // Type '0' is not assignable to type 'ExtractIdType '.
    const extracted: ExtractIdType<T> = 0;
  }
```

- We lose the type-safety on the `_id` property in `Collection.insert{,One,Many}` methods with these changes
```ts
  type NumberId = { _id: number, stringField: string }
  const numberIdCollection = db.collection<NumberId>('testCollection');
  await numberIdCollection.insertOne({ stringField: '' }); // Should be an error: non-ObjectId _id must be defined
  await numberIdCollection.insertOne({ _id: '', stringField: '' }); // Should be an error: bad _id type
```

- We also lose the type-safety on "any"-indexed types
```ts
  interface AnyIndexedType {
    stringField: string;
    [key: string]: any;
  }
  const indexTypeCollection1 = db.collection<AnyIndexedType>('testCollection');
  
  await indexTypeCollection1.insert({ stringField: 3 }); // Should be an error
  await indexTypeCollection1.insertOne({}); // Should be an error, stringField is required
```

- The test-cases validating the `_id` property in `insert{,One,Many}` methods have been removed.
- Added test-cases with a generic `TSchema` type.