### PR TITLE
fix(es‑abstract): Correct `PromiseResolve` type definition

### DIFF
--- a/types/es-abstract/2018/PromiseResolve.d.ts
+++ b/types/es-abstract/2018/PromiseResolve.d.ts
@@ -4,9 +4,9 @@ type PromiseConstructorLikeReturnType<C extends PromiseConstructorLike, T> = C e
     ? R
     : PromiseLike<T>;
 
-declare function PromiseResolve<T>(C: PromiseConstructor, x: T): Promise<T>;
+declare function PromiseResolve<T>(C: PromiseConstructor, x: T | PromiseLike<T>): Promise<T>;
 declare function PromiseResolve<C extends PromiseConstructorLike, T>(
     C: C,
-    x: T,
+    x: T | PromiseLike<T>,
 ): PromiseConstructorLikeReturnType<C, T>;
 export = PromiseResolve;

--- a/types/es-abstract/test/es2018.test.ts
+++ b/types/es-abstract/test/es2018.test.ts
@@ -8,6 +8,11 @@ interface FakePromise<T> extends PromiseLike<T> {
     doStuff(): void;
 }
 
+function testGeneric<T, TReturn>({ done, value }: IteratorResult<T | PromiseLike<T>, TReturn | PromiseLike<TReturn>>) {
+    // $ExpectType Promise<T | TReturn>
+    ES2018.PromiseResolve(Promise, value);
+}
+
 // $ExpectType FakePromise<unknown>
 ES2018.PromiseResolve(FakePromise, any);
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/microsoft/TypeScript/blob/8f04f91ef55cd7e75acc8167abe2dcc429729af8/lib/lib.es2015.promise.d.ts#L141>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
