### PR TITLE
Updates to reflect correct usage of interface-datastore, datastore-core, and datastore-level

### DIFF
--- a/types/datastore-core/index.d.ts
+++ b/types/datastore-core/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 
-import { Adapter, Key } from 'interface-datastore';
+import { Adapter, Key, Options } from 'interface-datastore';
 
 /**
  * Transform function object to converting back-and-forth between key spaces.
@@ -67,30 +67,32 @@ export namespace shard {
  * the way keys look to the user, for example namespacing
  * keys, reversing them, etc.
  */
-export interface KeytransformDatastore<Value = Buffer> extends Adapter<Value> {
+export class KeytransformDatastore<Value = Buffer> extends Adapter<Value> {
+    constructor(child: Adapter<Value>, transform: Transform);
     child: Adapter<Value>;
     transform: Transform;
+    open(): Promise<void>;
+    close(): Promise<void>;
+    put(key: Key, val: Value, options?: Options): Promise<void>;
+    get(key: Key, options?: Options): Promise<Value>;
+    has(key: Key): Promise<boolean>;
+    delete(key: Key, options?: Options): Promise<void>;
 }
-
-export interface KeytransformDatastoreConstructor {
-    new <Value = Buffer>(child: Adapter<Value>, transform: Transform): KeytransformDatastore<Value>;
-}
-
-export const KeytransformDatastore: KeytransformDatastoreConstructor;
 
 /**
  * A datastore that can combine multiple stores inside various
  * key prefixs.
  */
-export interface MountDatastore extends Adapter<any> {
+export class MountDatastore<Value = Buffer> extends Adapter<Value> {
+    constructor(mounts: Array<Mount<Value>>);
     mounts: Array<Mount<any>>;
+    open(): Promise<void>;
+    close(): Promise<void>;
+    put(key: Key, val: Value, options?: Options): Promise<void>;
+    get(key: Key, options?: Options): Promise<Value>;
+    has(key: Key): Promise<boolean>;
+    delete(key: Key, options?: Options): Promise<void>;
 }
-
-export interface MountDatastoreConstructor {
-    new (mounts: Array<Mount<any>>): MountDatastore;
-}
-
-export const MountDatastore: MountDatastoreConstructor;
 
 /**
  * Wraps a given datastore into a keytransform which
@@ -101,15 +103,10 @@ export const MountDatastore: MountDatastoreConstructor;
  * `/hello/world`.
  *
  */
-export interface NamespaceDatastore<Value = Buffer> extends KeytransformDatastore<Value> {
+export class NamespaceDatastore<Value = Buffer> extends KeytransformDatastore<Value> {
+    constructor(child: Adapter<Value>, prefix: Key);
     prefix: Key;
 }
-
-export interface NamespaceDatastoreConstructor {
-    new (child: Adapter<any>, prefix: Key): NamespaceDatastore;
-}
-
-export const NamespaceDatastore: NamespaceDatastoreConstructor;
 
 /**
  * A datastore that can combine multiple stores. Puts and deletes
@@ -118,15 +115,16 @@ export const NamespaceDatastore: NamespaceDatastoreConstructor;
  * last one first.
  *
  */
-export interface TieredDatastore extends Adapter<any> {
-    stores: Array<Adapter<any>>;
+export class TieredDatastore<Value = Buffer> extends Adapter<Value> {
+    constructor(stores: Array<Adapter<Value>>);
+    stores: Array<Adapter<Value>>;
+    open(): Promise<void>;
+    close(): Promise<void>;
+    put(key: Key, val: Value, options?: Options): Promise<void>;
+    get(key: Key, options?: Options): Promise<Value>;
+    has(key: Key): Promise<boolean>;
+    delete(key: Key, options?: Options): Promise<void>;
 }
-
-export interface TieredDatastoreConstructor {
-    new (stores: Array<Adapter<any>>): TieredDatastore;
-}
-
-export const TieredDatastore: TieredDatastoreConstructor;
 
 /**
  * Backend independent abstraction of go-ds-flatfs.
@@ -134,16 +132,17 @@ export const TieredDatastore: TieredDatastoreConstructor;
  * Wraps another datastore such that all values are stored
  * sharded according to the given sharding function.
  */
-export interface ShardingDatastore<Value = Buffer> extends Adapter<Value> {
+export class ShardingDatastore<Value = Buffer> extends Adapter<Value> {
+    constructor(stores: Array<Adapter<Value>>);
     child: KeytransformDatastore<Value>;
     shard: shard.Shard;
+    open(): Promise<void>;
+    close(): Promise<void>;
+    put(key: Key, val: Value, options?: Options): Promise<void>;
+    get(key: Key, options?: Options): Promise<Value>;
+    has(key: Key): Promise<boolean>;
+    delete(key: Key, options?: Options): Promise<void>;
+    static createOrOpen<Value = Buffer>(store: Adapter<Value>, shard: shard.Shard): Promise<ShardingDatastore<Value>>;
+    static open<Value = Buffer>(store: Adapter<Value>): Promise<ShardingDatastore<Value>>;
+    static create<Value = Buffer>(store: Adapter<Value>, shard: shard.Shard): Promise<ShardingDatastore<Value>>;
 }
-
-export interface ShardingDatastoreConstructor {
-    new <Value = Buffer>(stores: Array<Adapter<Value>>): ShardingDatastore<Value>;
-    createOrOpen<Value = Buffer>(store: Adapter<Value>, shard: shard.Shard): Promise<ShardingDatastore<Value>>;
-    open<Value = Buffer>(store: Adapter<Value>): Promise<ShardingDatastore<Value>>;
-    create<Value = Buffer>(store: Adapter<Value>, shard: shard.Shard): Promise<ShardingDatastore<Value>>;
-}
-
-export const ShardingDatastore: ShardingDatastoreConstructor;

--- a/types/datastore-level/index.d.ts
+++ b/types/datastore-level/index.d.ts
@@ -6,7 +6,7 @@
 // TypeScript Version: 3.6
 
 import { LevelUp } from 'levelup';
-import { Batch, Adapter } from 'interface-datastore';
+import { Batch, Adapter, Key } from 'interface-datastore';
 import { AbstractLevelDOWN, AbstractIterator, AbstractBatch } from 'abstract-leveldown';
 
 interface LevelDatastoreBatch<Value = Buffer> extends Batch<Value> {
@@ -19,6 +19,12 @@ interface LevelDatastoreBatch<Value = Buffer> extends Batch<Value> {
 interface LevelDatastore<Value = Buffer> extends Adapter<Value> {
     db: LevelUp<AbstractLevelDOWN<string, Value>, AbstractIterator<string, Value>>;
     batch(): LevelDatastoreBatch<Value>;
+    open(): Promise<void>;
+    close(): Promise<void>;
+    put(key: Key, val: Value): Promise<void>;
+    get(key: Key): Promise<Value>;
+    has(key: Key): Promise<boolean>;
+    delete(key: Key): Promise<void>;
 }
 
 interface LevelDatastoreOptions {

--- a/types/interface-datastore/index.d.ts
+++ b/types/interface-datastore/index.d.ts
@@ -102,13 +102,6 @@ export abstract class Adapter<Value = Buffer> {
      */
     batch(): Batch<Value>;
     /**
-     * Yield all datastore values
-     *
-     * @param q
-     * @param options
-     */
-    abstract _all(q?: Query<Value>, options?: Options): AsyncIterable<Pair<Value>>;
-    /**
      * Query the store.
      *
      * @param q


### PR DESCRIPTION
This is a single commit that was left off of the previous update. A result of some local git mangling, it would be great to sneak this update in ASAP: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46387. My apologies for the initial oversight!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ipfs/js-datastore-core/releases/tag/v1.1.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
