### PR TITLE
update(express-fileupload): document defaults for options

### DIFF
--- a/types/express-fileupload/express-fileupload-tests.ts
+++ b/types/express-fileupload/express-fileupload-tests.ts
@@ -32,6 +32,8 @@ const uploadHandler: RequestHandler = (req: Request, res: Response, next: NextFu
 };
 
 app.post('/upload', uploadHandler);
+app.use(fileUpload());
+app.use(fileUpload({}));
 app.use(fileUpload({ debug: true }));
 app.use(fileUpload({ safeFileNames: /\\/g }));
 app.use(fileUpload({ safeFileNames: true }));
@@ -40,6 +42,22 @@ app.use(fileUpload({ safeFileNames: true, preserveExtension: 2 }));
 app.use(fileUpload({ abortOnLimit: true }));
 app.use(fileUpload({ responseOnLimit: 'Size Limit reached' }));
 app.use(fileUpload({ limitHandler: true }));
+app.use(
+    fileUpload({
+        abortOnLimit: false,
+        createParentPath: false,
+        debug: false,
+        limitHandler: false,
+        parseNested: false,
+        preserveExtension: false,
+        responseOnLimit: 'proper messsage',
+        safeFileNames: false,
+        tempFileDir: '/temp',
+        uploadTimeout: 30 * 1_000,
+        uriDecodeFileNames: false,
+        useTempFiles: false,
+    }),
+);
 app.use(
     fileUpload({
         limitHandler: (req, res, next) => {
@@ -54,4 +72,4 @@ app.use(
 );
 app.use(fileUpload({ useTempFiles: true, tempFileDir: 'temp2/' }));
 app.use(fileUpload({ limitHandler: true }));
-app.use(fileUpload({ uploadTimeout: 6000 }));
+app.use(fileUpload({ uploadTimeout: 6_000 }));

--- a/types/express-fileupload/index.d.ts
+++ b/types/express-fileupload/index.d.ts
@@ -49,7 +49,10 @@ declare namespace fileUpload {
      * @see {@link https://github.com/richardgirges/express-fileupload#available-options}
      */
     interface Options {
-        /** Automatically creates the directory path specified in `.mv(filePathName)` */
+        /**
+         * Automatically creates the directory path specified in `.mv(filePathName)`
+         * @default false
+         */
         createParentPath?: boolean;
         /**
          * Applies uri decoding to file names if set true.
@@ -61,12 +64,15 @@ declare namespace fileUpload {
          * You can use custom regex to determine what to strip.
          * If set to true, non-alphanumeric characters except dashes and underscores will be stripped.
          * This option is off by default.
+         * @default false
          */
         safeFileNames?: boolean | RegExp;
         /**
          * Preserves filename extension when using safeFileNames option.
          * If set to `true`, will default to an extension length of 3.
-         * If set to `Number`, this will be the max allowable extension length. If an extension is smaller than the extension length, it remains untouched. If the extension is longer, it is shifted.
+         * If set to `Number`, this will be the max allowable extension length.
+         * If an extension is smaller than the extension length, it remains untouched. If the extension is longer, it is shifted.
+         * @default false
          */
         preserveExtension?: boolean | number;
         /**
@@ -77,16 +83,19 @@ declare namespace fileUpload {
         abortOnLimit?: boolean;
         /**
          * Response which will be send to client if file size limit exceeded when `abortOnLimit` set to `true`.
+         * @default 'File size limit has been reached'
          */
         responseOnLimit?: string;
         /**
          * User defined limit handler which will be invoked if the file is bigger than configured limits.
+         * @default false
          */
         limitHandler?: boolean | express.RequestHandler;
         /**
          * By default this module uploads files into RAM.
          * Setting this option to True turns on using temporary files instead of utilising RAM. This avoids memory overflow issues when uploading large files
          * or in case of uploading lots of files at same time.
+         * @default false
          */
         useTempFiles?: boolean;
         /**
@@ -94,6 +103,7 @@ declare namespace fileUpload {
          * Used along with the `useTempFiles` option.
          * By default this module uses 'tmp' folder in the current working directory.
          * You can use trailing slash, but it is not necessary.
+         * @default '/tmp'
          */
         tempFileDir?: string;
         /**
@@ -102,6 +112,7 @@ declare namespace fileUpload {
          *
          * When this option is enabled they are parsed in order to be nested like this:
          * `{'name': 'John', 'hobbies': ['Cinema', 'Bike']}`
+         * @default false
          */
         parseNested?: boolean;
         /**


### PR DESCRIPTION
The options support multiple types, so that's important to provide a
hint which type (and what value) is used by default.

Relevant documentation:
https://github.com/richardgirges/express-fileupload#available-options

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)