### PR TITLE
[ramda] Add missing definition for xor(a, b)

### DIFF
--- a/types/ramda/OTHER_FILES.txt
+++ b/types/ramda/OTHER_FILES.txt
@@ -245,6 +245,7 @@ es/when.d.ts
 es/where.d.ts
 es/whereEq.d.ts
 es/without.d.ts
+es/xor.d.ts
 es/xprod.d.ts
 es/zip.d.ts
 es/zipObj.d.ts
@@ -498,6 +499,7 @@ src/when.d.ts
 src/where.d.ts
 src/whereEq.d.ts
 src/without.d.ts
+src/xor.d.ts
 src/xprod.d.ts
 src/zip.d.ts
 src/zipObj.d.ts

--- a/types/ramda/es/xor.d.ts
+++ b/types/ramda/es/xor.d.ts
@@ -1,0 +1,2 @@
+import { xor } from '../index';
+export default xor;

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -28,6 +28,7 @@
 //                 Philippe Mills <https://github.com/Philippe-mills>
 //                 Saul Mirone <https://github.com/Saul-Mirone>
 //                 Nicholai Nissen <https://github.com/Nicholaiii>
+//                 Mike Deverell <https://github.com/devrelm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.7
 
@@ -2111,6 +2112,14 @@ export function whereEq<T>(spec: T): <U>(obj: U) => boolean;
  */
 export function without<T>(list1: readonly T[], list2: readonly T[]): T[];
 export function without<T>(list1: readonly T[]): (list2: readonly T[]) => T[];
+
+/**
+ * Exclusive disjunction logical operation.
+ * Returns `true` if one of the arguments is truthy and the other is falsy.
+ * Otherwise, it returns `false`.
+ */
+export function xor(a: any, b: any): boolean;
+export function xor(a: any): (b: any) => boolean;
 
 /**
  * Creates a new list out of the two supplied by creating each possible pair from the lists.

--- a/types/ramda/src/xor.d.ts
+++ b/types/ramda/src/xor.d.ts
@@ -1,0 +1,2 @@
+import { xor } from '../index';
+export default xor ;

--- a/types/ramda/test/xor-tests.ts
+++ b/types/ramda/test/xor-tests.ts
@@ -1,0 +1,97 @@
+import * as R from 'ramda';
+
+() => {
+  // $ExpectType boolean
+  R.xor(true, true);
+
+  // $ExpectType boolean
+  R.xor(true, false);
+
+  // $ExpectType boolean
+  R.xor(false, true);
+
+  // $ExpectType boolean
+  R.xor(false, false);
+
+  // $ExpectType boolean
+  R.xor(0, false);
+
+  // $ExpectType boolean
+  R.xor(false, 0);
+
+  // $ExpectType boolean
+  R.xor(0, 0);
+
+  // $ExpectType boolean
+  R.xor('foo', 0);
+
+  // $ExpectType boolean
+  R.xor({}, 0);
+
+  // $ExpectType boolean
+  R.xor([], 0);
+
+  // $ExpectType boolean
+  R.xor('', 0);
+
+  // $ExpectType boolean
+  R.xor(NaN, 0);
+
+  // $ExpectType boolean
+  R.xor(null, 0);
+
+  // $ExpectType boolean
+  R.xor(undefined, 0);
+};
+
+() => {
+  // $ExpectType (b: any) => boolean
+  R.xor(true);
+
+  // $ExpectType (b: any) => boolean
+  R.xor('foo');
+};
+
+() => {
+  // $ExpectType boolean
+  R.xor(true)(true);
+
+  // $ExpectType boolean
+  R.xor(true)(false);
+
+  // $ExpectType boolean
+  R.xor(false)(true);
+
+  // $ExpectType boolean
+  R.xor(false)(false);
+
+  // $ExpectType boolean
+  R.xor(0)(false);
+
+  // $ExpectType boolean
+  R.xor(false)(0);
+
+  // $ExpectType boolean
+  R.xor(0)(0);
+
+  // $ExpectType boolean
+  R.xor('foo')(0);
+
+  // $ExpectType boolean
+  R.xor({})(0);
+
+  // $ExpectType boolean
+  R.xor([])(0);
+
+  // $ExpectType boolean
+  R.xor('')(0);
+
+  // $ExpectType boolean
+  R.xor(NaN)(0);
+
+  // $ExpectType boolean
+  R.xor(null)(0);
+
+  // $ExpectType boolean
+  R.xor(undefined)(0);
+};

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -242,6 +242,7 @@
         "test/where-tests.ts",
         "test/whereEq-tests.ts",
         "test/without-tests.ts",
+        "test/xor-tests.ts",
         "test/xprod-tests.ts",
         "test/zip-tests.ts",
         "test/zipObj-tests.ts",


### PR DESCRIPTION
Adds one of two missing properties mentioned in Danger comments in prior PRs, like the one here:  https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46441#issuecomment-666027533.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   https://ramdajs.com/docs/#xor
   https://github.com/ramda/ramda/blob/v0.27.0/source/xor.js
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~