### PR TITLE
[@types/cbor] Add ArrayBufferView as alternative type, for browsers

### DIFF
--- a/types/cbor/index.d.ts
+++ b/types/cbor/index.d.ts
@@ -25,16 +25,16 @@ export class Decoder extends stream.Transform {
     constructor(options?: DecoderOptions);
 
     static nullcheck(val: any): any;
-    static decodeFirstSync(input: string | Buffer, options?: DecodeOptions | string): any;
-    static decodeAllSync(input: string | Buffer, options?: DecodeOptions | string): any[];
+    static decodeFirstSync(input: string | Buffer | ArrayBufferView, options?: DecodeOptions | string): any;
+    static decodeAllSync(input: string | Buffer | ArrayBufferView, options?: DecodeOptions | string): any[];
 
-    static decodeFirst(input: string | Buffer, cb: decodeCallback): void;
-    static decodeFirst(input: string | Buffer, options: DecodeOptions | string, cb: decodeCallback): void;
-    static decodeFirst(input: string | Buffer, options?: DecodeOptions | string): Promise<any>;
+    static decodeFirst(input: string | Buffer | ArrayBufferView, cb: decodeCallback): void;
+    static decodeFirst(input: string | Buffer | ArrayBufferView, options: DecodeOptions | string, cb: decodeCallback): void;
+    static decodeFirst(input: string | Buffer | ArrayBufferView, options?: DecodeOptions | string): Promise<any>;
 
-    static decodeAll(input: string | Buffer, cb: decodeAllCallback): void;
-    static decodeAll(input: string | Buffer, options: DecodeOptions | string, cb: decodeAllCallback): void;
-    static decodeAll(input: string | Buffer, options?: DecodeOptions | string): Promise<any>;
+    static decodeAll(input: string | Buffer | ArrayBufferView, cb: decodeAllCallback): void;
+    static decodeAll(input: string | Buffer | ArrayBufferView, options: DecodeOptions | string, cb: decodeAllCallback): void;
+    static decodeAll(input: string | Buffer | ArrayBufferView, options?: DecodeOptions | string): Promise<any>;
 }
 
 export interface EncoderOptions extends stream.TransformOptions {
@@ -55,10 +55,10 @@ export class Encoder extends stream.Transform {
     pushAny(input: any): boolean;
     removeLoopDetectors(obj: any): boolean;
 
-    static encode(...objs: any[]): Buffer;
-    static encodeCanonical(...objs: any[]): Buffer;
-    static encodeOne(obj: any, options?: EncoderOptions): Buffer;
-    static encodeAsync(obj: any, options?: EncoderOptions): Promise<Buffer>;
+    static encode(...objs: any[]): Buffer | ArrayBufferView;
+    static encodeCanonical(...objs: any[]): Buffer | ArrayBufferView;
+    static encodeOne(obj: any, options?: EncoderOptions): Buffer | ArrayBufferView;
+    static encodeAsync(obj: any, options?: EncoderOptions): Promise<Buffer | ArrayBufferView>;
 }
 
 export class Simple {
@@ -89,9 +89,9 @@ type commentCallback = (error?: Error, commented?: string) => void;
 export class Commented extends stream.Transform {
     constructor(options?: CommentedOptions);
 
-    static comment(input: string | Buffer, cb: commentCallback): void;
-    static comment(input: string | Buffer, options: CommentOptions | string, cb: commentCallback): void;
-    static comment(input: string | Buffer, options?: CommentOptions | string): Promise<string>;
+    static comment(input: string | Buffer | ArrayBufferView, cb: commentCallback): void;
+    static comment(input: string | Buffer | ArrayBufferView, options: CommentOptions | string, cb: commentCallback): void;
+    static comment(input: string | Buffer | ArrayBufferView, options?: CommentOptions | string): Promise<string>;
 }
 
 declare class CborMap extends Map {
@@ -119,8 +119,8 @@ type diagnoseCallback = (error?: Error, str?: string) => void;
 export class Diagnose extends stream.Transform {
     constructor(options?: DiagnoseOptions);
 
-    static diagnose(input: string | Buffer, encoding?: string): Promise<string>;
-    static diagnose(input: string | Buffer, cb: diagnoseCallback): void;
+    static diagnose(input: string | Buffer | ArrayBufferView, encoding?: string): Promise<string>;
+    static diagnose(input: string | Buffer | ArrayBufferView, cb: diagnoseCallback): void;
 }
 
 export const decode: typeof Decoder.decodeFirstSync;


### PR DESCRIPTION
I'm not sure whether this is the proper way to do this given that the current types are correct, just not for browser usage. Also, I am aware of the suggestions regarding missing properties produced by the test. I intend to resolve that in a separate PR as that is a separate matter, but if it is preferable I can push those changes here instead. 

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.) — Not sure how I'd do this given that this is a browser-only change and I presume the tests run in Node
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: I couldn't find any docs mentioning this, but here's an issue: https://github.com/hildjj/node-cbor/issues/92 and here's a commit: https://github.com/hildjj/node-cbor/commit/b513130f9e1a2ed35f85e01d71fba79c7ef82deb
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing) — Not sure how I'd do this given that this is a browser-only change
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
