### PR TITLE
[@types/ember__test-helpers] Fix incorrect module name for setup-oneror

### DIFF
--- a/types/ember__test-helpers/index.d.ts
+++ b/types/ember__test-helpers/index.d.ts
@@ -60,7 +60,7 @@ declare module '@ember/test-helpers' {
     export { default as setupApplicationContext } from '@ember/test-helpers/setup-application-context';
     export { default as teardownApplicationContext } from '@ember/test-helpers/teardown-application-context';
     export { default as validateErrorHandler } from '@ember/test-helpers/validate-error-handler';
-    export { setupOnerror, resetOnerror } from '@ember/test-helpers/onerror';
+    export { default as setupOnerror, resetOnerror } from '@ember/test-helpers/setup-onerror';
 }
 
 declare module '@ember/test-helpers/dom/click' {
@@ -224,8 +224,8 @@ declare module '@ember/test-helpers/validate-error-handler' {
     export default function(callback?: (error: Error) => void): { isValid: boolean, message: string };
 }
 
-declare module '@ember/test-helpers/onerror' {
-    export function setupOnerror(handler: (error: unknown) => void): void;
+declare module '@ember/test-helpers/setup-onerror' {
+    export default function setupOnerror(handler: (error: unknown) => void): void;
     export function resetOnerror(): void;
 }
 


### PR DESCRIPTION
It looks like I’ve submitted incorrect module structure in my previous PR :-(
It doesn’t matter if you import these helpers from main module like:
`import { setupOnerror, resetOnerror } from '@ember/test-helpers';`
but if for some reason you’d want to import them directly it won’t work.
This PR allows you to also import like this:
`import setupOnerror, { resetOnerror } from '@ember/test-helpers/setup-onerror';`

See: https://github.com/emberjs/ember-test-helpers/blob/master/addon-test-support/%40ember/test-helpers/setup-onerror.ts

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/emberjs/ember-test-helpers/blob/master/addon-test-support/%40ember/test-helpers/setup-onerror.ts>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
