### PR TITLE
Updates types on react-native-calendars

### DIFF
--- a/types/react-native-calendars/index.d.ts
+++ b/types/react-native-calendars/index.d.ts
@@ -62,6 +62,7 @@ export interface CalendarTheme {
     "stylesheet.day.single"?: CalendarThemeIdStyle;
     "stylesheet.day.multiDot"?: CalendarThemeIdStyle;
     "stylesheet.day.period"?: CalendarThemeIdStyle;
+    "stylesheet.dot"?: CalendarThemeIdStyle;
 }
 
 export type DateCallbackHandler = (date: DateObject) => void;


### PR DESCRIPTION
"stylesheet.dot" can be reached when defining the theme of the calendar but eslint views it as an error so it should probably be included in the types.
