### PR TITLE
update(express-status-monitor): `heap` option missing

### DIFF
--- a/types/express-status-monitor/express-status-monitor-tests.ts
+++ b/types/express-status-monitor/express-status-monitor-tests.ts
@@ -15,6 +15,7 @@ app.use(
             cpu: true,
             mem: false,
             load: true,
+            heap: true,
         },
         ignoreStartsWith: '/admin',
         healthChecks: [],

--- a/types/express-status-monitor/index.d.ts
+++ b/types/express-status-monitor/index.d.ts
@@ -20,6 +20,8 @@ declare namespace e {
             cpu?: boolean;
             mem?: boolean;
             load?: boolean;
+            /** @default true */
+            heap?: boolean;
             responseTime?: boolean;
             rps?: boolean;
             statusCodes?: boolean;


### PR DESCRIPTION
This adds missing configuration option:
https://github.com/RafalWilinski/express-status-monitor/commit/cd0108968c9afd6e521c690abeddf0d59e0036c5
https://github.com/RafalWilinski/express-status-monitor#options

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)