### PR TITLE
[meteor-mdg-validated-method] Typings for meteor/mdg:validated-method

### DIFF
--- a/types/meteor-mdg-validated-method/index.d.ts
+++ b/types/meteor-mdg-validated-method/index.d.ts
@@ -47,6 +47,7 @@ declare module 'meteor/mdg:validated-method' {
 
     export interface ValidatedMethodOptionsWithMixins<TName extends string, TRun extends (...args: any[]) => any>
         extends ValidatedMethodOptions<TName, TRun> {
+        // Force TRun to be inferred from run itself rather than from the elements of mixins
         mixins?: TRun extends infer TRunAlias
             ? TRunAlias extends TRun
                 ? ReadonlyArray<Mixin<TName, TRunAlias>>

--- a/types/meteor-mdg-validated-method/index.d.ts
+++ b/types/meteor-mdg-validated-method/index.d.ts
@@ -1,0 +1,84 @@
+// Type definitions for non-npm package Atmosphere package mdg:validated-method 1.2
+// Project: https://github.com/meteor/validated-method
+// Definitions by: Artemis Kearney <https://github.com/artemiswkearney>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.7
+
+// Inspiration taken from https://github.com/nicu-chiciuc/typed-meteor-methods, which is Copyright (c) 2020 Chiciuc Nicușor
+
+/// <reference types="meteor"/>
+
+// tslint:disable-next-line no-single-declare-module
+declare module 'meteor/mdg:validated-method' {
+    export {};
+    export type ValidatedMethodName<T> = T extends ValidatedMethod<infer TName, any> ? TName : never;
+    export type ValidatedMethodArg<T> = T extends ValidatedMethod<string, infer TRun> ? Argument<TRun> : never;
+    export type ValidatedMethodReturn<T> = T extends ValidatedMethod<string, infer TRun> ? Return<TRun> : never;
+
+    /**
+     * When declaring a mixin that adds fields to ValidatedMethodOptions, augment this to add them
+     */
+    // tslint:disable-next-line no-empty-interface
+    export interface ValidatedMethodOptionsMixinFields<TRunArg, TRunReturn> {}
+
+    export type NoArguments = undefined;
+
+    export interface ValidatedMethodOptions<TName extends string, TRun extends (...args: any[]) => any>
+        extends ValidatedMethodOptionsMixinFields<Argument<TRun>, Return<TRun>> {
+        // Force the name to be a string literal
+        name: TName & string;
+        validate: ((arg: Argument<TRun> extends NoArguments ? any : Argument<TRun>) => any) | null;
+        applyOptions?: {
+            noRetry?: boolean;
+            returnStubValue?: boolean;
+            throwStubExceptions?: boolean;
+            onResultReceived?: (result: any) => void;
+            [key: string]: any;
+        };
+        run: TRun;
+    }
+
+    export type Mixin<TName extends string, TRun extends (...args: any[]) => any> = (
+        options: ValidatedMethodOptions<TName, TRun>,
+    ) => ValidatedMethodOptions<TName, TRun>;
+    export type GenericMixin = <TName extends string, TRun extends (...args: any[]) => any>(
+        options: ValidatedMethodOptions<TName, TRun>,
+    ) => ValidatedMethodOptions<TName, TRun>;
+
+    export interface ValidatedMethodOptionsWithMixins<TName extends string, TRun extends (...args: any[]) => any>
+        extends ValidatedMethodOptions<TName, TRun> {
+        mixins?: TRun extends infer TRunAlias
+            ? TRunAlias extends TRun
+                ? ReadonlyArray<Mixin<TName, TRunAlias>>
+                : never
+            : never;
+    }
+
+    type Return<TFunc> = TFunc extends (...args: any[]) => infer TReturn ? TReturn : never;
+    type Argument<TFunc> = TFunc extends (...args: infer TArgs) => any
+        ? TArgs extends [infer TArg]
+            ? TArg
+            : NoArguments
+        : never;
+    export type ValidatedMethodOptionsReturn<
+        TOptions extends ValidatedMethodOptions<any, any>
+    > = TOptions extends ValidatedMethodOptions<any, infer TRun> ? Return<TRun> : never;
+    export type ValidatedMethodOptionsArgument<
+        TOptions extends ValidatedMethodOptions<any, any>
+    > = TOptions extends ValidatedMethodOptions<any, infer TRun> ? Argument<TRun> : never;
+
+    export class ValidatedMethod<TName extends string, TRun extends (...args: any[]) => any> {
+        constructor(options: ValidatedMethodOptionsWithMixins<TName, TRun>);
+        call: Argument<TRun> extends NoArguments
+            ? // methods with no argument can be called with () or just a callback
+              ((unusedArg: any, callback: (error: Meteor.Error, result: Return<TRun>) => void) => void) &
+                  ((callback: (error: Meteor.Error, result: Return<TRun>) => void) => void) &
+                  (() => Return<TRun>)
+            : // methods with arguments require those arguments to be called
+              ((arg: Argument<TRun>, callback: (error: Meteor.Error, result: Return<TRun>) => void) => void) &
+                  ((arg: Argument<TRun>) => Return<TRun>);
+        _execute: Argument<TRun> extends NoArguments // methods with no argument can be called without an argument
+            ? (context: { [key: string]: any }) => Return<TRun>
+            : (context: { [key: string]: any }, args: Argument<TRun>) => Return<TRun>;
+    }
+}

--- a/types/meteor-mdg-validated-method/meteor-mdg-validated-method-tests.ts
+++ b/types/meteor-mdg-validated-method/meteor-mdg-validated-method-tests.ts
@@ -1,5 +1,3 @@
-/// <reference types="meteor"/>
-
 // Tests based on https://github.com/meteor/validated-method/blob/master/validated-method-tests.js
 // Some new tests added
 

--- a/types/meteor-mdg-validated-method/meteor-mdg-validated-method-tests.ts
+++ b/types/meteor-mdg-validated-method/meteor-mdg-validated-method-tests.ts
@@ -1,0 +1,209 @@
+/// <reference types="meteor"/>
+
+// Tests based on https://github.com/meteor/validated-method/blob/master/validated-method-tests.js
+// Some new tests added
+
+import {
+    ValidatedMethod,
+    ValidatedMethodOptions,
+    ValidatedMethodOptionsMixinFields,
+    ValidatedMethodOptionsWithMixins,
+    Mixin,
+    GenericMixin,
+} from 'meteor/mdg:validated-method';
+import { SimpleSchema, SimpleSchemaDefinition } from 'simpl-schema';
+
+const plainMethod = new ValidatedMethod({
+    name: 'plainMethod',
+    validate: new SimpleSchema({}).validator(),
+    run() {
+        return 'result';
+    },
+});
+
+const noArgsMethod = new ValidatedMethod({
+    name: 'noArgsMethod',
+    validate: null,
+    run() {
+        return 'result';
+    },
+});
+
+const methodWithArgs = new ValidatedMethod({
+    name: 'methodWithArgs',
+    validate: new SimpleSchema({
+        int: { type: Number },
+        string: { type: String },
+    }).validator(),
+    run(args: { int: number; string: string }) {
+        return 'result';
+    },
+});
+
+const methodThrowsImmediately = new ValidatedMethod({
+    name: 'methodThrowsImmediately',
+    validate: null,
+    run() {
+        throw new Meteor.Error('error');
+    },
+});
+
+const methodReturnsName = new ValidatedMethod({
+    name: 'methodReturnsName',
+    validate: null,
+    run() {
+        return this.name;
+    },
+});
+
+// mixins can add fields to ValidatedMethodOptions
+declare module 'meteor/mdg:validated-method' {
+    interface ValidatedMethodOptionsMixinFields<TRunArg, TRunReturn> {
+        schema?: SimpleSchema;
+    }
+}
+
+function schemaMixin(methodOptions: ValidatedMethodOptions<any, any>) {
+    methodOptions.validate = methodOptions.schema!.validator();
+    return methodOptions;
+}
+
+const methodWithSchemaMixin = new ValidatedMethod({
+    name: 'methodWithSchemaMixin',
+    mixins: [schemaMixin],
+    // note that "validate: null," had to be added here - schemaMixin populates validate, but leaving off validate will *normally* crash,
+    // and mixins changing the type of ValidatedMethodObjects options is not yet supported
+    validate: null,
+    schema: new SimpleSchema({
+        int: { type: Number },
+        string: { type: String },
+    }),
+    run(args: { int: number; string: string }) {
+        return 'result';
+    },
+});
+
+let resultReceived = false;
+const methodWithApplyOptions = new ValidatedMethod({
+    name: 'methodWithApplyOptions',
+    validate: new SimpleSchema({}).validator(),
+    applyOptions: {
+        onResultReceived() {
+            resultReceived = true;
+        },
+    },
+    run() {
+        return 'result';
+    },
+});
+
+// can call plainMethod with ignored args and with callback
+// $ExpectType void
+plainMethod.call({}, (error, result) => {});
+
+// can call noArgsMethod with just callback
+// $ExpectType void
+noArgsMethod.call((error, result) => {});
+
+// can't call methods that have args without those args
+// $ExpectError
+methodWithArgs.call({}, (error, result) => {});
+
+// can call them with correct args and a callback
+// $ExpectType void
+methodWithArgs.call(
+    {
+        int: 5,
+        string: 'what',
+    },
+    (error, result) => {},
+);
+
+// can call them with correct args and no callback, and get correct return type
+// $ExpectType string
+methodWithArgs.call({
+    int: 5,
+    string: 'what',
+});
+
+// can't call methods that have args without those args
+// $ExpectError
+methodWithSchemaMixin.call({}, (error, result) => {});
+
+// can call them with correct args and a callback
+// $ExpectType void
+methodWithSchemaMixin.call(
+    {
+        int: 5,
+        string: 'what',
+    },
+    (error, result) => {},
+);
+
+// can call them with correct args and no callback, and get correct return type
+// $ExpectType string
+methodWithSchemaMixin.call({
+    int: 5,
+    string: 'what',
+});
+
+// mixin can't return void
+new ValidatedMethod({
+    name: 'methodWithFaultySchemaMixin',
+    // $ExpectError
+    mixins: [function nonReturningFunction() {}],
+    run() {
+        return 'result';
+    },
+});
+
+// mixin can't return void, even with multiple mixins
+new ValidatedMethod({
+    name: 'methodWithFaultySchemaMixin',
+    // $ExpectError
+    mixins: [args => args, () => {}],
+    run() {
+        return 'result';
+    },
+});
+
+// identity function is legal mixin
+new ValidatedMethod({
+    name: 'methodWithIdentityMixin',
+    mixins: [args => args],
+    validate: null,
+    run() {
+        return 'result';
+    },
+});
+
+// mixin for specific type only works on that type
+function numberToStringMixin(options: ValidatedMethodOptions<any, (arg: number) => string>) {
+    return options;
+}
+
+// $ExpectType string
+new ValidatedMethod({
+    name: 'methodWithRightTypedMixin',
+    mixins: [numberToStringMixin],
+    validate: null,
+    run(arg: number) {
+        return 'result';
+    },
+}).call(3);
+
+new ValidatedMethod({
+    name: 'methodWithWrongTypedMixin',
+    // $ExpectError
+    mixins: [numberToStringMixin],
+    validate: null,
+    run(args: { arg: string }) {
+        return 3;
+    },
+});
+
+// method can access its name
+// TODO "slice" call is needed here because this method actually returns `Return<() => TName> & string` and I don't know why
+// (the `& string` was something I added so you can at least use the name in weird situations like this, but I don't get why TName isn't getting resolved there - it's clearly known by now!)
+// $ExpectType string
+methodReturnsName.call().slice();

--- a/types/meteor-mdg-validated-method/tsconfig.json
+++ b/types/meteor-mdg-validated-method/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "meteor-mdg-validated-method-tests.ts"
+    ]
+}

--- a/types/meteor-mdg-validated-method/tslint.json
+++ b/types/meteor-mdg-validated-method/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.