### PR TITLE
[@types/lodash] Update typings of predictors in lang

### DIFF
--- a/types/lodash/common/lang.d.ts
+++ b/types/lodash/common/lang.d.ts
@@ -1447,7 +1447,7 @@ declare module "../index" {
          * _.isSymbol('abc');
          * // => false
          */
-        isSymbol(value: any): boolean;
+        isSymbol(value: any): value is symbol;
     }
 
     interface LoDashImplicitWrapper<TValue> {

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -2058,7 +2058,7 @@ declare namespace _ {
     type LodashIsSafeInteger = (value: any) => boolean;
     type LodashIsSet = (value: any) => value is Set<any>;
     type LodashIsString = (value: any) => value is string;
-    type LodashIsSymbol = (value: any) => boolean;
+    type LodashIsSymbol = (value: any) => value is symbol;
     type LodashIsTypedArray = (value: any) => boolean;
     type LodashIsUndefined = (value: any) => value is undefined;
     type LodashIsWeakMap = (value: any) => value is WeakMap<object, any>;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -4449,6 +4449,12 @@ fp.now(); // $ExpectType number
     _(42).isSymbol(); // $ExpectType boolean
     _.chain([]).isSymbol(); // $ExpectType LoDashExplicitWrapper<boolean>
     fp.isSymbol(anything); // $ExpectType boolean
+    if (fp.isSymbol(anything)) {
+        anything; // $ExpectType symbol
+    }
+    if (_.isSymbol(anything)) {
+        anything; // $ExpectType symbol
+    }
 }
 
 // _.isTypedArray

--- a/types/lodash/ts3.1/common/lang.d.ts
+++ b/types/lodash/ts3.1/common/lang.d.ts
@@ -1250,7 +1250,7 @@ declare module "../index" {
          * _.isSymbol('abc');
          * // => false
          */
-        isSymbol(value: any): boolean;
+        isSymbol(value: any): value is symbol;
     }
     interface LoDashImplicitWrapper<TValue> {
         /**

--- a/types/lodash/ts3.1/fp.d.ts
+++ b/types/lodash/ts3.1/fp.d.ts
@@ -1999,7 +1999,7 @@ declare namespace _ {
     type LodashIsSafeInteger = (value: any) => boolean;
     type LodashIsSet = (value: any) => value is Set<any>;
     type LodashIsString = (value: any) => value is string;
-    type LodashIsSymbol = (value: any) => boolean;
+    type LodashIsSymbol = (value: any) => value is symbol;
     type LodashIsTypedArray = (value: any) => boolean;
     type LodashIsUndefined = (value: any) => value is undefined;
     type LodashIsWeakMap = (value: any) => value is WeakMap<object, any>;

--- a/types/lodash/ts3.1/lodash-tests.ts
+++ b/types/lodash/ts3.1/lodash-tests.ts
@@ -4462,6 +4462,12 @@ fp.now(); // $ExpectType number
     _(42).isSymbol(); // $ExpectType boolean
     _.chain([]).isSymbol(); // $ExpectType PrimitiveChain<boolean>
     fp.isSymbol(anything); // $ExpectType boolean
+    if (fp.isSymbol(anything)) {
+        anything; // $ExpectType symbol
+    }
+    if (_.isSymbol(anything)) {
+        anything; // $ExpectType symbol
+    }
 }
 
 // _.isTypedArray


### PR DESCRIPTION
Replace return type of below methods with is operator
- isSymbol
---
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
---
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [isSymbol](https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12157)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
