### PR TITLE
[trusted-types] Fix issue with types that could not be named

### DIFF
--- a/types/trusted-types/trusted-types-tests.ts
+++ b/types/trusted-types/trusted-types-tests.ts
@@ -15,7 +15,8 @@ const rules = {
     createScriptURL: (s: string) => s,
 };
 
-const policy = TT.createPolicy('test', rules);
+const createPolicy = TT.createPolicy;
+const policy = createPolicy('test', rules);
 
 // $ExpectType string
 policy.name;
@@ -82,6 +83,19 @@ genericPolicy2.createHTML('', true, {});
 genericPolicy2.createScript('', true, {});
 // $ExpectType TrustedScriptURL
 genericPolicy2.createScriptURL('', true, {});
+
+const castedAsGenericPolicy: TrustedTypePolicy = TT.createPolicy('castedAsGeneric', {
+    createHTML: (val: string, option1: number, option2: boolean) => val,
+    createScriptURL: (val: string) => val,
+    createScript: (val: string) => val,
+});
+
+// $ExpectType TrustedHTML
+castedAsGenericPolicy.createHTML('', true, {});
+// $ExpectType TrustedScript
+castedAsGenericPolicy.createScript('', true, {});
+// $ExpectType TrustedScriptURL
+castedAsGenericPolicy.createScriptURL('', true, {});
 
 // Ensure the types are globally available
 let trustedHTML: TrustedHTML = null as any;


### PR DESCRIPTION
The new Trusted Types definitions introduced by #46321 contained an
unexported interface, which caused type checking errors when
trustedTypes.createPolicy was referenced, but not called. This fixes
that by removing the interface, and instead adding a type parameter to
the public TrustedTypePolicy interface.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
https://w3c.github.io/webappsec-trusted-types/dist/spec/