### PR TITLE
[redux-state-sync] correct type for BroadcastChannelOptions

### DIFF
--- a/types/redux-state-sync/index.d.ts
+++ b/types/redux-state-sync/index.d.ts
@@ -6,7 +6,7 @@
 // TypeScript Version: 2.4
 
 import { Store, Reducer, Middleware, AnyAction } from "redux";
-import BroadcastChannel from "broadcast-channel";
+import BroadcastChannel, { BroadcastChannelOptions } from "broadcast-channel";
 
 export interface Stamp {
     $uuid: string;
@@ -20,7 +20,7 @@ export interface Config {
     predicate?: (action: AnyAction) => boolean | null;
     blacklist?: string[];
     whitelist?: string[];
-    broadcastChannelOption?: object | null;
+    broadcastChannelOption?: BroadcastChannelOptions;
     prepareState?: (state: any) => any;
 }
 

--- a/types/redux-state-sync/redux-state-sync-tests.ts
+++ b/types/redux-state-sync/redux-state-sync-tests.ts
@@ -16,9 +16,7 @@ const middleware = createStateSyncMiddleware({
 });
 
 // $ExpectError
-const middleware = createStateSyncMiddleware({
-    broadcastChannelOption: null,
-});
+const middlewareError = createStateSyncMiddleware({ broadcastChannelOption: null });
 
 function rootReducer(state: TestState, action: Action): TestState {
     return state;

--- a/types/redux-state-sync/redux-state-sync-tests.ts
+++ b/types/redux-state-sync/redux-state-sync-tests.ts
@@ -15,6 +15,11 @@ const middleware = createStateSyncMiddleware({
     prepareState: (state) => state,
 });
 
+// $ExpectError
+const middleware = createStateSyncMiddleware({
+    broadcastChannelOption: null,
+});
+
 function rootReducer(state: TestState, action: Action): TestState {
     return state;
 }


### PR DESCRIPTION
`BroadcastChannelOptions` is more specific than `object`, and also `null` is incorrect - it is only allowed to be `undefined` in `broadcast-channel`, which is covered by the `?` already:

https://github.com/pubkey/broadcast-channel/blob/8d2ee79aad2780e9df3ab4e1386548a9a323f8bb/dist/lib/options.js#L9
https://github.com/pubkey/broadcast-channel/blob/8d2ee79aad2780e9df3ab4e1386548a9a323f8bb/types/broadcast-channel.d.ts#L45-L46

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
well actually I can't run the linter nor the tests locally, they all produce errors unrelated to this project for me
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
this also errors out with errors from other projects

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see above
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
