### PR TITLE
feat(node): EventEmitter.errorMonitor v12 backport

### DIFF
--- a/types/node/v12/events.d.ts
+++ b/types/node/v12/events.d.ts
@@ -12,7 +12,19 @@ declare module "events" {
     namespace internal {
         function once(emitter: NodeEventTarget, event: string | symbol): Promise<any[]>;
         function once(emitter: DOMEventTarget, event: string): Promise<any[]>;
-         class EventEmitter extends internal {
+
+        /**
+         * This symbol shall be used to install a listener for only monitoring `'error'`
+         * events. Listeners installed using this symbol are called before the regular
+         * `'error'` listeners are called.
+         *
+         * Installing a listener using this symbol does not change the behavior once an
+         * `'error'` event is emitted, therefore the process will still crash if no
+         * regular `'error'` listener is installed.
+         */
+        const errorMonitor: unique symbol;
+
+        class EventEmitter extends internal {
             /** @deprecated since v4.0.0 */
             static listenerCount(emitter: EventEmitter, event: string | symbol): number;
             static defaultMaxListeners: number;

--- a/types/node/v12/test/events.ts
+++ b/types/node/v12/test/events.ts
@@ -82,3 +82,8 @@ const any: any = 1;
         }
     }, 'name');
 }
+
+{
+    emitter.on(events.errorMonitor, listener);
+    emitter.on(events.EventEmitter.errorMonitor, listener);
+}


### PR DESCRIPTION
see: #45469 some symbols are not ported to v12
https://nodejs.org/docs/latest-v12.x/api/events.html#events_eventemitter_errormonitor

/cc @orgads

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)