### PR TITLE
[passport-google-oauth20] Extend Strategy constructor overloads

### DIFF
--- a/types/passport-google-oauth20/index.d.ts
+++ b/types/passport-google-oauth20/index.d.ts
@@ -55,11 +55,32 @@ export class Strategy extends oauth2.Strategy {
         ) => void
     );
     constructor(
+        options: StrategyOptions,
+        verify: (
+            accessToken: string,
+            refreshToken: string,
+            params: any,
+            profile: Profile,
+            done: VerifyCallback
+        ) => void
+    );
+    constructor(
         options: StrategyOptionsWithRequest,
         verify: (
             req: express.Request,
             accessToken: string,
             refreshToken: string,
+            profile: Profile,
+            done: VerifyCallback
+        ) => void
+    );
+    constructor(
+        options: StrategyOptionsWithRequest,
+        verify: (
+            req: express.Request,
+            accessToken: string,
+            refreshToken: string,
+            params: any,
             profile: Profile,
             done: VerifyCallback
         ) => void

--- a/types/passport-google-oauth20/index.d.ts
+++ b/types/passport-google-oauth20/index.d.ts
@@ -10,7 +10,6 @@
 import * as passport from "passport";
 import * as express from "express";
 import * as oauth2 from "passport-oauth2";
-import { OutgoingHttpHeaders } from "http";
 
 export type OAuth2StrategyOptionsWithoutRequiredURLs = Pick<
     oauth2._StrategyOptionsBase,

--- a/types/passport-google-oauth20/index.d.ts
+++ b/types/passport-google-oauth20/index.d.ts
@@ -7,9 +7,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as passport from "passport";
-import * as express from "express";
-import * as oauth2 from "passport-oauth2";
+import passport = require("passport");
+import express = require("express");
+import oauth2 = require("passport-oauth2");
 
 export type OAuth2StrategyOptionsWithoutRequiredURLs = Pick<
     oauth2._StrategyOptionsBase,

--- a/types/passport-google-oauth20/index.d.ts
+++ b/types/passport-google-oauth20/index.d.ts
@@ -7,9 +7,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import passport = require("passport");
-import express = require("express");
-import oauth2 = require("passport-oauth2");
+import * as passport from "passport";
+import * as express from "express";
+import * as oauth2 from "passport-oauth2";
 
 export type OAuth2StrategyOptionsWithoutRequiredURLs = Pick<
     oauth2._StrategyOptionsBase,

--- a/types/passport-google-oauth20/passport-google-oauth20-tests.ts
+++ b/types/passport-google-oauth20/passport-google-oauth20-tests.ts
@@ -78,3 +78,55 @@ passport.use(
         }
     )
 );
+
+passport.use(
+    new google.Strategy(
+        {
+            callbackURL,
+            clientID,
+            clientSecret,
+            passReqToCallback: true
+        },
+        (
+            request: express.Request,
+            accessToken: string,
+            refreshToken: string,
+            params: any,
+            profile: google.Profile,
+            done: (error: any, user?: any) => void
+        ) => {
+            User.findOrCreate(profile.id, profile.provider, (err, user) => {
+                if (err) {
+                    done(err);
+                    return;
+                }
+                done(null, user);
+            });
+        }
+    )
+);
+
+passport.use(
+    new google.Strategy(
+        {
+            callbackURL,
+            clientID,
+            clientSecret,
+        },
+        (
+            accessToken: string,
+            refreshToken: string,
+            params: any,
+            profile: google.Profile,
+            done: (error: any, user?: any) => void
+        ) => {
+            User.findOrCreate(profile.id, profile.provider, (err, user) => {
+                if (err) {
+                    done(err);
+                    return;
+                }
+                done(null, user);
+            });
+        }
+    )
+);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [verify with params](https://github.com/jaredhanson/passport-oauth2/blob/master/lib/strategy.js#L193)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

--

This change adds constructor overloads for the cases where the consumer is interested in accessing the params passed back to be verified by the Google OAuth 2.0 strategy. Relevant source code:

```js
if (self._passReqToCallback) {
  var arity = self._verify.length;
  if (arity == 6) {
    self._verify(req, accessToken, refreshToken, params, profile, verified); // THIS
  } else { // arity == 5
    self._verify(req, accessToken, refreshToken, profile, verified);
  }
} else {
  var arity = self._verify.length;
  if (arity == 5) {
    self._verify(accessToken, refreshToken, params, profile, verified); // AND THIS
  } else { // arity == 4
    self._verify(accessToken, refreshToken, profile, verified);
  }
}
```
