### PR TITLE
Added types for node-canvas-with-twemoji

### DIFF
--- a/types/node-canvas-with-twemoji/index.d.ts
+++ b/types/node-canvas-with-twemoji/index.d.ts
@@ -1,0 +1,6 @@
+// Type definitions for node-canvas-with-twemoji 0.1
+// Project: https://github.com/cagpie/node-canvas-with-twemoj
+// Definitions by: Abh80 <https://github.com/abh80/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function fillTextWithTwemoji(context:object,text:string,x:number,y:number): void;

--- a/types/node-canvas-with-twemoji/node-canvas-with-twemoji-test.ts
+++ b/types/node-canvas-with-twemoji/node-canvas-with-twemoji-test.ts
@@ -1,0 +1,8 @@
+import {fillTextWithTwemoji} from 'node-canvas-with-twemoji'
+import {createCanvas} from 'canvas'
+const canvas = createCanvas(200,200)
+const ctx = canvas.getContext('2d')
+async function GenerateCanvas(){
+    await fillTextWithTwemoji(ctx,'This is a test',20,20)
+}
+GenerateCanvas()

--- a/types/node-canvas-with-twemoji/tsconfig.json
+++ b/types/node-canvas-with-twemoji/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "node-canvas-with-twemoji-test.ts"
+    ]
+}

--- a/types/node-canvas-with-twemoji/tslint.json
+++ b/types/node-canvas-with-twemoji/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Added Types for [node-canvas-with-twemoji](https://github.com/cagpie/node-canvas-with-twemoji)
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

