### PR TITLE
update(react-helmet): 6.1 ES exports changes

### DIFF
--- a/types/react-helmet/index.d.ts
+++ b/types/react-helmet/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-helmet 6.0
+// Type definitions for react-helmet 6.1
 // Project: https://github.com/nfl/react-helmet
 // Definitions by: Evan Bremer <https://github.com/evanbb>
 //                 Isman Usoh <https://github.com/isman-usoh>
@@ -8,6 +8,7 @@
 //                 Yamagishi Kazutoshi <https://github.com/ykzts>
 //                 Justin Hall <https://github.com/wKovacs64>
 //                 Andriy2 <https://github.com/Andriy2>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -53,12 +54,17 @@ export interface HelmetProps {
     titleTemplate?: string;
 }
 
-export class Helmet extends React.Component<HelmetProps> {
+declare class Helmet extends React.Component<HelmetProps> {
     static peek(): HelmetData;
     static rewind(): HelmetData;
     static renderStatic(): HelmetData;
     static canUseDOM: boolean;
 }
+
+declare const HelmetExport: typeof Helmet;
+
+export { HelmetExport as Helmet };
+export default HelmetExport;
 
 export interface HelmetData {
     base: HelmetDatum;

--- a/types/react-helmet/react-helmet-tests.tsx
+++ b/types/react-helmet/react-helmet-tests.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { Helmet, HelmetData } from "react-helmet";
+import { Helmet as HelmedNamedExport, HelmetData } from "react-helmet";
+import Helmet from 'react-helmet';
 
 const Application = () =>
     <div className="application">


### PR DESCRIPTION
This commit updates definition by:
- adding support for 6.1 change introducing named and default exports
  support (this fixes errorrs like ` JSX element type 'Helmet' does not
  have any construct or call signatures.`
- minor version bump
- maintainer added

https://github.com/nfl/react-helmet/pull/547
https://github.com/nfl/react-helmet/releases/tag/6.1.0

Thanks!

```ts
import Helmet from 'react-helmet';
import { default as Helmet } from 'react-helmet';
import { Helmet  } from 'react-helmet';
````

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)