### PR TITLE
Backbone fixes

### DIFF
--- a/types/backbone.paginator/backbone.paginator-tests.ts
+++ b/types/backbone.paginator/backbone.paginator-tests.ts
@@ -11,7 +11,7 @@ var makeFetchOptions = <TCol extends Backbone.PageableCollection<TestModel>>() =
     beforeSend: (jqxhr: JQueryXHR) => {},
     success: (model: TestModel, response: any, options: any) => {},
     error:   (collection: TCol, jqxhr: JQueryXHR, options: any) => {},
-    parse: '',
+    parse: false,
   };
 };
 

--- a/types/backbone/backbone-tests.ts
+++ b/types/backbone/backbone-tests.ts
@@ -245,6 +245,8 @@ class ArbitraryCollection extends Backbone.Collection { }
 function test_collection() {
 
     var books = new Books();
+    books.set([{title: "Title 0", author: "Johan" }]);
+    books.reset();
 
     var book1: Book = new Book({ title: "Title 1", author: "Mike" });
     books.add(book1);
@@ -401,6 +403,12 @@ namespace v1Changes {
         function test_url() {
             Employee.prototype.url = () => '/employees';
             EmployeeCollection.prototype.url = () => '/employees';
+        }
+
+        function test_model_create_with_collection() {
+            var collection = new Books();
+            var employee = new Book({}, {collection, parse: true})
+            employee.collection
         }
 
         function test_parse() {

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -214,6 +214,10 @@ declare namespace Backbone {
         sync(...arg: any[]): JQueryXHR;
     }
 
+    /**
+     * E - Extensions to the model constructor options. You can accept additional constructor options
+     * by listing them in the E parameter.
+     */
     class Model<T = any, S = Backbone.ModelSetOptions, E = {}> extends ModelBase implements Events {
 
         /**

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -26,10 +26,12 @@ declare namespace Backbone {
         sort?: boolean;
     }
 
-    interface CollectionSetOptions extends Silenceable {
+    interface CollectionSetOptions extends Parseable, Silenceable {
         add?: boolean;
         remove?: boolean;
         merge?: boolean;
+        at?: number;
+        sort?: boolean;
     }
 
     interface HistoryOptions extends Silenceable {
@@ -59,15 +61,23 @@ declare namespace Backbone {
     }
 
     interface Parseable {
-        parse?: any;
+        parse?: boolean;
     }
 
     interface PersistenceOptions {
         url?: string;
         data?: any;
         beforeSend?: (jqxhr: JQueryXHR) => void;
+        timeout?: number;
+        // TODO: copy all parameters from JQueryAjaxSettings except success/error callbacks?
         success?: (modelOrCollection?: any, response?: any, options?: any) => void;
         error?: (modelOrCollection?: any, jqxhr?: JQueryXHR, options?: any) => void;
+        emulateJSON?: boolean;
+        emulateHTTP?: boolean;
+    }
+
+    interface ModelConstructorOptions<TModel extends Model = Model> extends ModelSetOptions, Parseable {
+        collection?: Backbone.Collection<TModel>;
     }
 
     interface ModelSetOptions extends Silenceable, Validable {
@@ -212,7 +222,7 @@ declare namespace Backbone {
         changed: any[];
         cidPrefix: string;
         cid: string;
-        collection: Collection<any>;
+        collection: Collection<this>;
 
         private _changing: boolean;
         private _previousAttributes : any;
@@ -243,10 +253,10 @@ declare namespace Backbone {
          * any instantiation logic is run for the Model.
          * @see https://backbonejs.org/#Model-preinitialize
          */
-        preinitialize(attributes?: T, options?: any): void;
+        preinitialize(attributes?: T, options?: ModelConstructorOptions<this>): void;
 
-        constructor(attributes?: T, options?: any);
-        initialize(attributes?: T, options?: any): void;
+        constructor(attributes?: T, options?: ModelConstructorOptions);
+        initialize(attributes?: T, options?: ModelConstructorOptions<this>): void;
 
         fetch(options?: ModelFetchOptions): JQueryXHR;
 
@@ -287,7 +297,7 @@ declare namespace Backbone {
         isNew(): boolean;
         isValid(options?:any): boolean;
         previous(attribute: string): any;
-        previousAttributes(): any[];
+        previousAttributes(): any;
         save(attributes?: any, options?: ModelSaveOptions): any;
         unset(attribute: string, options?: Silenceable): Model;
         validate(attributes: any, options?: any): any;
@@ -355,7 +365,7 @@ declare namespace Backbone {
         pop(options?: Silenceable): TModel;
         remove(model: {}|TModel, options?: Silenceable): TModel;
         remove(models: ({}|TModel)[], options?: Silenceable): TModel[];
-        reset(models?: TModel[], options?: Silenceable): TModel[];
+        reset(models?: ({}|TModel)[], options?: Silenceable): TModel[];
 
         /**
          *
@@ -368,7 +378,7 @@ declare namespace Backbone {
          * @param models
          * @param options
          */
-        set(models?: TModel[], options?: CollectionSetOptions): TModel[];
+        set(models?: ({}|TModel)[], options?: CollectionSetOptions): TModel[];
         shift(options?: Silenceable): TModel;
         sort(options?: Silenceable): Collection<TModel>;
         unshift(model: TModel, options?: AddOptions): TModel;

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -8,6 +8,7 @@
 //                 Julian Gonggrijp <https://github.com/jgonggrijp>
 //                 Kyle Scully <https://github.com/zieka>
 //                 Robert Kesterson <https://github.com/rkesters>
+//                 Bulat Khasanov <https://github.com/khasanovbi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -79,6 +80,8 @@ declare namespace Backbone {
     interface ModelConstructorOptions<TModel extends Model = Model> extends ModelSetOptions, Parseable {
         collection?: Backbone.Collection<TModel>;
     }
+
+    type CombinedModelConstructorOptions<E, M extends Model<any, any, E> = Model> = ModelConstructorOptions<M> & E;
 
     interface ModelSetOptions extends Silenceable, Validable {
     }
@@ -211,7 +214,7 @@ declare namespace Backbone {
         sync(...arg: any[]): JQueryXHR;
     }
 
-    class Model<T = any, S = Backbone.ModelSetOptions> extends ModelBase implements Events {
+    class Model<T = any, S = Backbone.ModelSetOptions, E = {}> extends ModelBase implements Events {
 
         /**
         * Do not use, prefer TypeScript's extend functionality.
@@ -253,10 +256,10 @@ declare namespace Backbone {
          * any instantiation logic is run for the Model.
          * @see https://backbonejs.org/#Model-preinitialize
          */
-        preinitialize(attributes?: T, options?: ModelConstructorOptions<this>): void;
+        preinitialize(attributes?: T, options?: CombinedModelConstructorOptions<E, this>): void;
 
-        constructor(attributes?: T, options?: ModelConstructorOptions);
-        initialize(attributes?: T, options?: ModelConstructorOptions<this>): void;
+        constructor(attributes?: T, options?: CombinedModelConstructorOptions<E>);
+        initialize(attributes?: T, options?: CombinedModelConstructorOptions<E, this>): void;
 
         fetch(options?: ModelFetchOptions): JQueryXHR;
 


### PR DESCRIPTION
- Allow to pass bare object to set/reset methods
- Extend collection set options
- Use strict parse boolean instead of any in Parseable
- Add timeout, emulateJSON, emulateHTTP to PersistenceOptions
- Add ModelConstructorOptions
- Fix previousAttributes type

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/jashkenas/backbone/blob/master/backbone.js>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
