### PR TITLE
spotify-api: Fixed playlist-object-simplified not having a description

### DIFF
--- a/types/spotify-api/index.d.ts
+++ b/types/spotify-api/index.d.ts
@@ -985,6 +985,10 @@ declare namespace SpotifyApi {
          */
         collaborative: boolean;
         /**
+         * The playlist description. Only returned for modified, verified playlists, otherwise null.
+         */
+        description: string | null;
+        /**
          * The [Spotify ID](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids) for the playlist.
          */
         id: string;
@@ -1023,10 +1027,6 @@ declare namespace SpotifyApi {
      * [](https://developer.spotify.com/web-api/object-model/#playlist-object-full)
      */
     interface PlaylistObjectFull extends PlaylistBaseObject {
-        /**
-         * The playlist description. Only returned for modified, verified playlists, otherwise null.
-         */
-        description: string | null;
         /**
          * Information about the followers of the playlist.
          */

--- a/types/spotify-api/spotify-api-tests.ts
+++ b/types/spotify-api/spotify-api-tests.ts
@@ -3379,6 +3379,7 @@ const featuredPlaylists : SpotifyApi.ListOfFeaturedPlaylistsResponse = {
     "href" : "https://api.spotify.com/v1/browse/featured-playlists?country=SE&timestamp=2015-12-25T15:10:15&offset=0&limit=2",
     "items" : [ {
       "collaborative" : false,
+      "description": "",
       "external_urls" : {
         "spotify" : "http://open.spotify.com/user/spotify/playlist/16BpjqQV1Ey0HeDueNDSYz"
       },
@@ -3409,6 +3410,7 @@ const featuredPlaylists : SpotifyApi.ListOfFeaturedPlaylistsResponse = {
       "uri" : "spotify:user:spotify:playlist:16BpjqQV1Ey0HeDueNDSYz"
     }, {
       "collaborative" : false,
+      "description": "",
       "external_urls" : {
         "spotify" : "http://open.spotify.com/user/spotify/playlist/7nUikuZL4MgIXS43cMpQZE"
       },
@@ -4072,6 +4074,7 @@ const categoryPlaylists : SpotifyApi.CategoryPlaylistsReponse = {
     "href" : "https://api.spotify.com/v1/browse/categories/party/playlists?country=BR&offset=0&limit=2",
     "items" : [ {
       "collaborative" : false,
+      "description": "",
       "external_urls" : {
         "spotify" : "http://open.spotify.com/user/spotifybrazilian/playlist/6U9RHRz1G477YpMNeLy9uI"
       },
@@ -4102,6 +4105,7 @@ const categoryPlaylists : SpotifyApi.CategoryPlaylistsReponse = {
       "uri" : "spotify:user:spotifybrazilian:playlist:6U9RHRz1G477YpMNeLy9uI"
     }, {
       "collaborative" : false,
+      "description": "",
       "external_urls" : {
         "spotify" : "http://open.spotify.com/user/spotifybrazilian/playlist/4k7EZPI3uKMz4aRRrLVfen"
       },
@@ -6885,6 +6889,7 @@ const searchPlaylists : SpotifyApi.PlaylistSearchResponse = {
     "href" : "https://api.spotify.com/v1/search?query=Summer&offset=20&limit=2&type=playlist",
     "items" : [ {
       "collaborative" : false,
+      "description": "",
       "external_urls" : {
         "spotify" : "http://open.spotify.com/user/twistoffame/playlist/4atqr0nDMUxQFLd09yhk9w"
       },
@@ -6923,6 +6928,7 @@ const searchPlaylists : SpotifyApi.PlaylistSearchResponse = {
       "uri" : "spotify:user:twistoffame:playlist:4atqr0nDMUxQFLd09yhk9w"
     }, {
       "collaborative" : false,
+      "description": "",
       "external_urls" : {
         "spotify" : "http://open.spotify.com/user/1174077483/playlist/3fAKyVYIkAiinuipRUGJHj"
       },
@@ -7664,6 +7670,7 @@ const usersPlaylists : SpotifyApi.ListOfUsersPlaylistsResponse = {
   "href" : "https://api.spotify.com/v1/users/wizzler/playlists?offset=0&limit=2",
   "items" : [ {
     "collaborative" : false,
+    "description": "",
     "external_urls" : {
       "spotify" : "http://open.spotify.com/user/wizzler/playlist/6yRf9SJ1YiAhNAu7UCwgXQ"
     },
@@ -7694,6 +7701,7 @@ const usersPlaylists : SpotifyApi.ListOfUsersPlaylistsResponse = {
     "uri" : "spotify:user:wizzler:playlist:6yRf9SJ1YiAhNAu7UCwgXQ"
   }, {
     "collaborative" : false,
+    "description": "",
     "external_urls" : {
       "spotify" : "http://open.spotify.com/user/wizzler/playlist/3FJd21jWvCjGCLx7eKrext"
     },
@@ -7743,6 +7751,7 @@ const currentUsersPlaylists : SpotifyApi.ListOfUsersPlaylistsResponse = {
   "href" : "https://api.spotify.com/v1/users/wizzler/playlists?offset=0&limit=2",
   "items" : [ {
     "collaborative" : false,
+    "description": "",
     "external_urls" : {
       "spotify" : "http://open.spotify.com/user/wizzler/playlist/6yRf9SJ1YiAhNAu7UCwgXQ"
     },
@@ -7773,6 +7782,7 @@ const currentUsersPlaylists : SpotifyApi.ListOfUsersPlaylistsResponse = {
     "uri" : "spotify:user:wizzler:playlist:6yRf9SJ1YiAhNAu7UCwgXQ"
   }, {
     "collaborative" : false,
+    "description": "",
     "external_urls" : {
       "spotify" : "http://open.spotify.com/user/wizzler/playlist/3FJd21jWvCjGCLx7eKrext"
     },


### PR DESCRIPTION
Both the playlist-object-full and playlist-object-simplified have the description field [in the spotify api](https://developer.spotify.com/documentation/web-api/reference/object-model/#playlist-object-simplified), with the same comment.
Moving the field from PlaylistObjectFull to PlaylistBaseObject is a fairly logical fix.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.spotify.com/documentation/web-api/reference/object-model/#playlist-object-simplified
