### PR TITLE
Fix ember data's adapterError type in types/ember-data/index.d.ts

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -254,7 +254,9 @@ export namespace DS {
      * subclasses are used to indicate specific error states. The following
      * subclasses are provided:
      */
-    class AdapterError extends Ember.Object {}
+    class AdapterError extends Ember.Object {
+        constructor(errors: any[], message?: 'string')
+    }
     /**
      * A `DS.InvalidError` is used by an adapter to signal the external API
      * was unable to process a request because the content was not
@@ -264,9 +266,7 @@ export namespace DS {
      * transition to the `invalid` state and the errors will be set to the
      * `errors` property on the record.
      */
-    class InvalidError extends AdapterError {
-        constructor(errors: any[]);
-    }
+    class InvalidError extends AdapterError {}
     /**
      * A `DS.TimeoutError` is used by an adapter to signal that a request
      * to the external API has timed out. I.e. no response was received from

--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -254,9 +254,7 @@ export namespace DS {
      * subclasses are used to indicate specific error states. The following
      * subclasses are provided:
      */
-    class AdapterError extends Ember.Object {
-        constructor(errors: any[], message?: 'string')
-    }
+    class AdapterError extends Ember.Object {}
     /**
      * A `DS.InvalidError` is used by an adapter to signal the external API
      * was unable to process a request because the content was not
@@ -266,27 +264,35 @@ export namespace DS {
      * transition to the `invalid` state and the errors will be set to the
      * `errors` property on the record.
      */
-    class InvalidError extends AdapterError {}
+    class InvalidError extends AdapterError {
+        constructor(errors: any[], message?: string)
+    }
     /**
      * A `DS.TimeoutError` is used by an adapter to signal that a request
      * to the external API has timed out. I.e. no response was received from
      * the external API within an allowed time period.
      */
-    class TimeoutError extends AdapterError {}
+    class TimeoutError extends AdapterError {
+        constructor(errors: any[], message?: string)
+    }
     /**
      * A `DS.AbortError` is used by an adapter to signal that a request to
      * the external API was aborted. For example, this can occur if the user
      * navigates away from the current page after a request to the external API
      * has been initiated but before a response has been received.
      */
-    class AbortError extends AdapterError {}
+    class AbortError extends AdapterError {
+        constructor(errors: any[], message?: string)
+    }
     /**
      * A `DS.UnauthorizedError` equates to a HTTP `401 Unauthorized` response
      * status. It is used by an adapter to signal that a request to the external
      * API was rejected because authorization is required and has failed or has not
      * yet been provided.
      */
-    class UnauthorizedError extends AdapterError {}
+    class UnauthorizedError extends AdapterError {
+        constructor(errors: any[], message?: string)
+    }
     /**
      * A `DS.ForbiddenError` equates to a HTTP `403 Forbidden` response status.
      * It is used by an adapter to signal that a request to the external API was
@@ -294,13 +300,17 @@ export namespace DS {
      * provided and is valid, then the authenticated user does not have the
      * necessary permissions for the request.
      */
-    class ForbiddenError extends AdapterError {}
+    class ForbiddenError extends AdapterError {
+        constructor(errors: any[], message?: string)
+    }
     /**
      * A `DS.NotFoundError` equates to a HTTP `404 Not Found` response status.
      * It is used by an adapter to signal that a request to the external API
      * was rejected because the resource could not be found on the API.
      */
-    class NotFoundError extends AdapterError {}
+    class NotFoundError extends AdapterError {
+        constructor(errors: any[], message?: string)
+    }
     /**
      * A `DS.ConflictError` equates to a HTTP `409 Conflict` response status.
      * It is used by an adapter to indicate that the request could not be processed
@@ -308,13 +318,17 @@ export namespace DS {
      * creating a record with a client generated id but that id is already known
      * to the external API.
      */
-    class ConflictError extends AdapterError {}
+    class ConflictError extends AdapterError {
+        constructor(errors: any[], message?: string)
+    }
     /**
      * A `DS.ServerError` equates to a HTTP `500 Internal Server Error` response
      * status. It is used by the adapter to indicate that a request has failed
      * because of an error in the external API.
      */
-    class ServerError extends AdapterError {}
+    class ServerError extends AdapterError {
+        constructor(errors: any[], message?: string)
+    }
     /**
      * Holds validation errors for a given record, organized by attribute names.
      */

--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -254,7 +254,9 @@ export namespace DS {
      * subclasses are used to indicate specific error states. The following
      * subclasses are provided:
      */
-    class AdapterError extends Ember.Object {}
+    class AdapterError extends Ember.Object {
+        constructor(errors: any[], message?: string)
+    }
     /**
      * A `DS.InvalidError` is used by an adapter to signal the external API
      * was unable to process a request because the content was not
@@ -264,35 +266,27 @@ export namespace DS {
      * transition to the `invalid` state and the errors will be set to the
      * `errors` property on the record.
      */
-    class InvalidError extends AdapterError {
-        constructor(errors: any[], message?: string)
-    }
+    class InvalidError extends AdapterError {}
     /**
      * A `DS.TimeoutError` is used by an adapter to signal that a request
      * to the external API has timed out. I.e. no response was received from
      * the external API within an allowed time period.
      */
-    class TimeoutError extends AdapterError {
-        constructor(errors: any[], message?: string)
-    }
+    class TimeoutError extends AdapterError {}
     /**
      * A `DS.AbortError` is used by an adapter to signal that a request to
      * the external API was aborted. For example, this can occur if the user
      * navigates away from the current page after a request to the external API
      * has been initiated but before a response has been received.
      */
-    class AbortError extends AdapterError {
-        constructor(errors: any[], message?: string)
-    }
+    class AbortError extends AdapterError {}
     /**
      * A `DS.UnauthorizedError` equates to a HTTP `401 Unauthorized` response
      * status. It is used by an adapter to signal that a request to the external
      * API was rejected because authorization is required and has failed or has not
      * yet been provided.
      */
-    class UnauthorizedError extends AdapterError {
-        constructor(errors: any[], message?: string)
-    }
+    class UnauthorizedError extends AdapterError {}
     /**
      * A `DS.ForbiddenError` equates to a HTTP `403 Forbidden` response status.
      * It is used by an adapter to signal that a request to the external API was
@@ -300,17 +294,13 @@ export namespace DS {
      * provided and is valid, then the authenticated user does not have the
      * necessary permissions for the request.
      */
-    class ForbiddenError extends AdapterError {
-        constructor(errors: any[], message?: string)
-    }
+    class ForbiddenError extends AdapterError {}
     /**
      * A `DS.NotFoundError` equates to a HTTP `404 Not Found` response status.
      * It is used by an adapter to signal that a request to the external API
      * was rejected because the resource could not be found on the API.
      */
-    class NotFoundError extends AdapterError {
-        constructor(errors: any[], message?: string)
-    }
+    class NotFoundError extends AdapterError {}
     /**
      * A `DS.ConflictError` equates to a HTTP `409 Conflict` response status.
      * It is used by an adapter to indicate that the request could not be processed
@@ -318,17 +308,13 @@ export namespace DS {
      * creating a record with a client generated id but that id is already known
      * to the external API.
      */
-    class ConflictError extends AdapterError {
-        constructor(errors: any[], message?: string)
-    }
+    class ConflictError extends AdapterError {}
     /**
      * A `DS.ServerError` equates to a HTTP `500 Internal Server Error` response
      * status. It is used by the adapter to indicate that a request has failed
      * because of an error in the external API.
      */
-    class ServerError extends AdapterError {
-        constructor(errors: any[], message?: string)
-    }
+    class ServerError extends AdapterError {}
     /**
      * Holds validation errors for a given record, organized by attribute names.
      */


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.) 
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emberjs/data/blob/v3.20.0/packages/adapter/addon/error.js#L74
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The ember-data adapter error type does not seem to match what the ember data code is actually doing. See here for actual code: https://github.com/emberjs/data/blob/v3.20.0/packages/adapter/addon/error.js#L74.  

The current type gives a ts error when passing in a second argument. For example, when doing the below: 
` throw new NotFoundError([], 'error message i'm providing')`

the error: `Expected 0-1 arguments, but got 2.`

I have tried changing the type to fix the above but have encountered test fails which I'm not totally sure how to fix.  Would someone be able to have a look 👀 Thanks!