### PR TITLE
[@types/yup] fix InferType working with nested optional properties 

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -639,7 +639,9 @@ type KeyOfUndefined<T> = {
 type PreserveNull<T> = T extends null ? null : never;
 type PreserveUndefined<T> = T extends undefined ? undefined : never;
 type PreserveOptionals<T> = PreserveNull<T> | PreserveUndefined<T>;
-type Id<T> = { [K in keyof T]: T[K] };
+type Id<T> = {
+    [K in keyof T]: T[K] extends object ? InnerInferType<T[K]> : T[K];
+};
 type RequiredProps<T> = Pick<T, Exclude<keyof T, KeyOfUndefined<T>>>;
 type NotRequiredProps<T> = Partial<Pick<T, KeyOfUndefined<T>>>;
 type InnerInferType<T> =

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -798,7 +798,15 @@ const personSchema = yup.object({
     // handle nested optional property
     address: yup.object({
         line1: yup.string().required(),
-        line2: yup.string().optional()
+        line2: yup.string().optional(),
+        area: yup.object({
+            country: yup.string().required(),
+            region: yup.string().optional()
+        }).required(),
+    }).required(),
+    addressBook: yup.object({
+        phoneNumbers: yup.array(yup.string()).defined(),
+        lastUpdated: yup.date().optional()
     }).required(),
     email: yup
         .string()
@@ -856,7 +864,11 @@ const minimalPerson: Person = {
     canBeNull: null,
     mustBeAString: '',
     address: {
-        line1: '123 Fake Street'
+        line1: '123 Fake Street',
+        area: { country: 'Australia' }
+    },
+    addressBook: {
+        phoneNumbers: ['123-456-789']
     }
 };
 
@@ -871,7 +883,11 @@ const person: Person = {
     children: null,
     address: {
         line1: 'Unit 1',
-        line2: '456 Fake Street'
+        line2: '456 Fake Street',
+        area: { country: 'America', region: 'WA' }
+    },
+    addressBook: {
+        phoneNumbers: []
     }
 };
 
@@ -886,6 +902,12 @@ person.friends = new Set(["Amy", "Beth"]);
 
 // $ExpectError
 person.address = {};
+// $ExpectError
+person.address = { area: {}, line1: '' };
+// $ExpectError
+person.addressBook = {};
+// $ExpectError
+person.addressBook = { phoneNumbers: null };
 // $ExpectError
 person.gender = 1;
 // $ExpectError

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -795,6 +795,11 @@ enum Gender {
 const personSchema = yup.object({
     firstName: yup.string().defined(), // $ExpectType StringSchema<string>
     gender: yup.mixed<Gender>().defined().oneOf([Gender.Male, Gender.Female]),
+    // handle nested optional property
+    address: yup.object({
+        line1: yup.string().required(),
+        line2: yup.string().optional()
+    }).required(),
     email: yup
         .string()
         .nullable()
@@ -850,6 +855,9 @@ const minimalPerson: Person = {
     gender: Gender.Female,
     canBeNull: null,
     mustBeAString: '',
+    address: {
+        line1: '123 Fake Street'
+    }
 };
 
 const person: Person = {
@@ -861,6 +869,10 @@ const person: Person = {
     isAlive: null,
     mustBeAString: '',
     children: null,
+    address: {
+        line1: 'Unit 1',
+        line2: '456 Fake Street'
+    }
 };
 
 person.email = 'some@email.com';
@@ -872,6 +884,8 @@ person.children = ['1', '2', '3'];
 person.children = undefined;
 person.friends = new Set(["Amy", "Beth"]);
 
+// $ExpectError
+person.address = {};
 // $ExpectError
 person.gender = 1;
 // $ExpectError


### PR DESCRIPTION
fixes #45100

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/45100
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.