### PR TITLE
[@types/react-native] #46426 Fix AnimatedProps regression

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8984,15 +8984,15 @@ export namespace Animated {
 
     type NonAnimatedProps = 'key' | 'ref';
 
-    export type AnimatedProps<T> =
-        | {
-              [key in keyof T]: key extends NonAnimatedProps ? T[key] : WithAnimatedValue<T[key]>;
-          }
-        | (T extends {
-              ref?: React.Ref<infer R>;
-          }
-              ? { ref?: React.Ref<LegacyRef<R>> }
-              : {});
+    type TAugmentRef<T> = T extends React.Ref<infer R> ? React.Ref<R | LegacyRef<R>> : never;
+
+    export type AnimatedProps<T> = {
+        [key in keyof T]: key extends NonAnimatedProps
+            ? key extends 'ref'
+                ? TAugmentRef<T[key]>
+                : T[key]
+            : WithAnimatedValue<T[key]>;
+    };
 
     export interface AnimatedComponent<T extends React.ComponentType<any>>
         extends React.FC<AnimatedProps<React.ComponentPropsWithRef<T>>> {}

--- a/types/react-native/test/animated.tsx
+++ b/types/react-native/test/animated.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Animated, View, NativeSyntheticEvent, NativeScrollEvent } from 'react-native';
+import { Animated, View, NativeSyntheticEvent, NativeScrollEvent, StyleProp } from 'react-native';
 
 interface CompProps {
     width: number;
@@ -25,8 +25,11 @@ const ForwardComp = React.forwardRef<View, CompProps>(({ width }, ref) => {
 
 type X = React.PropsWithoutRef<React.ComponentProps<typeof ForwardComp>>;
 
-type Props = React.ComponentPropsWithoutRef<typeof Animated.Text>;
-const AnimatedWrapperComponent: React.FunctionComponent<Props> = (props) => <Animated.Text {...props} />
+type Props = React.ComponentPropsWithRef<typeof Animated.Text>;
+const AnimatedWrapperComponent: React.FunctionComponent<Props> = ({
+                                                                      key, // $ExpectType string | number | undefined
+                                                                      ...props
+}) => <Animated.Text {...props} />
 
 function TestAnimatedAPI() {
     // Value


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

This PR fixes the regression bug introduced in #46426 were `AnimatedProps` `ref` part of a type was changed to be a union type. 