### PR TITLE
Types for meteor/dburles:collection-helpers [meteor-dburles-collection-helpers]

### DIFF
--- a/types/meteor-dburles-collection-helpers/collectionHelpers.d.ts
+++ b/types/meteor-dburles-collection-helpers/collectionHelpers.d.ts
@@ -45,7 +45,7 @@ declare module 'meteor/dburles:collection-helpers' {
      * Just the non-method/Helper properties of the type, with the methods and Helpers made optional.
      * No need to declare a Collection<Data<T>>; all Collection methods already accept a Data<T>.
      */
-    export type Data<T> = DataBrand<NonData<T>> & NonHelpersOf<NonData<T>> & Partial<HelpersOf<NonData<T>>>;
+    export type Data<T> = DataBrand<T> & NonHelpersOf<T> & Partial<HelpersOf<T>>;
     /**
      * The version of a type that comes out of the collection (with helpers attached).
      */

--- a/types/meteor-dburles-collection-helpers/collectionHelpers.d.ts
+++ b/types/meteor-dburles-collection-helpers/collectionHelpers.d.ts
@@ -1,0 +1,53 @@
+// tslint:disable-next-line no-single-declare-module
+declare module 'meteor/dburles:collection-helpers' {
+    export {};
+    type PropertyNamesMatching<T, TPred> = {
+        [K in keyof T]: T[K] extends TPred ? K : never;
+    }[keyof T];
+    type PropertyNamesNotMatching<T, TPred> = {
+        [K in keyof T]: T[K] extends TPred ? never : K;
+    }[keyof T];
+
+    type NonHelpers<T> = { [K in keyof T]: T[K] & ConflictsWithHelper<T[K]> }[keyof T];
+
+    type HelpersOf<T> = Pick<T, PropertyNamesMatching<Required<T>, Func> | PropertyNamesNotMatching<T, NonHelpers<T>>>;
+    type NonHelpersOf<T> = Pick<
+        T,
+        PropertyNamesNotMatching<Required<T>, Func> & PropertyNamesMatching<T, NonHelpers<T>>
+    >;
+
+    type Func = (...args: any[]) => any;
+
+    type SetThisArg<TThis, T> = {
+        [K in keyof T]: T[K] extends (...args: infer TArgs) => infer TRet
+            ? (this: TThis, ...args: TArgs) => TRet
+            : T[K];
+    };
+
+    interface HelperBrand {
+        _meteor_dburles_collection_helpers_isHelper: true;
+    }
+    type ConflictsWithHelper<T> = T & { _meteor_dburles_collection_helpers_isHelper?: false };
+    interface DataBrand<T> {
+        _meteor_dburles_collection_helpers_isData?: [true, T];
+    }
+    export type NonData<T> = T extends DataBrand<infer U> ? U : T;
+    /**
+     * Use to declare a non-function helper - it'll be optional when inserting values but required when adding helpers
+     */
+    export type Helper<T> = T | (T & HelperBrand);
+    /**
+     * All methods and Helper<T>s declared on the type, made non-optional.
+     * This is what's required when defining helpers for a collection.
+     */
+    export type Helpers<T> = SetThisArg<Full<T>, Required<HelpersOf<NonData<T>>>>;
+    /**
+     * Just the non-method/Helper properties of the type, with the methods and Helpers made optional.
+     * No need to declare a Collection<Data<T>>; "new Collection<T>" already returns one.
+     */
+    export type Data<T> = DataBrand<NonData<T>> & NonHelpersOf<NonData<T>> & Partial<HelpersOf<NonData<T>>>;
+    /**
+     * The version of a type that comes out of the collection (with helpers attached).
+     */
+    export type Full<T> = NonData<T> & Required<HelpersOf<NonData<T>>>;
+}

--- a/types/meteor-dburles-collection-helpers/collectionHelpers.d.ts
+++ b/types/meteor-dburles-collection-helpers/collectionHelpers.d.ts
@@ -8,48 +8,191 @@ declare module 'meteor/dburles:collection-helpers' {
         [K in keyof T]: T[K] extends TPred ? never : K;
     }[keyof T];
 
-    // "T extends T ? ... : never" looks tautological, but actually serves to distribute over union types
-    // https://github.com/microsoft/TypeScript/issues/28791#issuecomment-443520161
-    type NonHelpers<T> = T extends T ? { [K in keyof T]: T[K] & ConflictsWithHelper<T[K]> }[keyof T] : never;
-
-    type HelpersOf<T> = T extends T ? Pick<T, PropertyNamesMatching<Required<T>, Func> | PropertyNamesNotMatching<T, NonHelpers<T>>> : never;
-    type NonHelpersOf<T> = T extends T ? Pick<
-        T,
-        PropertyNamesNotMatching<Required<T>, Func> & PropertyNamesMatching<T, NonHelpers<T>>
-    > : never;
-
-    type Func = (...args: any[]) => any;
-
-    type SetThisArg<TThis, T> = T extends T ? {
-        [K in keyof T]: T[K] extends (...args: infer TArgs) => infer TRet
-            ? (this: TThis, ...args: TArgs) => TRet
-            : T[K];
-    } : never;
-
-    interface HelperBrand {
-        _meteor_dburles_collection_helpers_isHelper: true;
-    }
-    type ConflictsWithHelper<T> = T & { _meteor_dburles_collection_helpers_isHelper?: false };
-    interface DataBrand<T> {
-        _meteor_dburles_collection_helpers_isData?: [true, T];
-    }
-    export type NonData<T> = T extends DataBrand<infer U> ? U : T;
     /**
      * Use to declare a non-function helper - it'll be optional when inserting values but required when adding helpers
+     * Tip: Use OptionalHelper<T> to declare a helper you might or might not provide - it won't be required
+     * when providing helpers, and won't be guaranteed on Full<T>
      */
-    export type Helper<T> = T | (T & HelperBrand);
+    // "T extends T ? ... : never" looks tautological, but actually serves to distribute over union types
+    // https://github.com/microsoft/TypeScript/issues/28791#issuecomment-443520161
+    export type Helper<T> = T extends T
+        ? T extends FlavorUnsupportedTypes
+            ? T | HelperBrand
+            : T & HelperFlavor
+        : never;
+
+    // where possible, helpers are tagged as (T & HelperFlavor)
+    // this is a technique called "flavoring" - (T & HelperFlavor) is assignable both to and from T for most T,
+    // but the presence of the flavor can be checked since (T & HelperFlavor) is also assignable to HelperFlavor
+    // (note that HelperFlavor is a "weak type" - since all its properties are optional, you might think anything
+    // would be assignable to it, but Typescript prohibits assigning any type that doesn't share at least one
+    // property with it)
+    // weirdly, ({} & HelperFlavor) still accepts {}!
+    interface HelperFlavor {
+        _meteor_dburles_collection_helpers_isHelper?: Flavor;
+    }
+    // for types where (T & HelperFlavor) === never, (T | HelperBrand) is used instead,
+    // and the HelperBrand is stripped off in HelpersOf
+    // this is less preferable, because it means:
+    // - on a value of the original interface type TInterface, Helper<null> and Helper<T | null> properties will
+    //   not be assignable to null or to (T | null) respectively
+    // - Helpers<Helpers<T>> !== Helpers<T> when T has Helper<null> or Helper<T | null> properties
+    // however, this appears to be a limitation of Typescript (with strict null checks on, null and undefined
+    // simply *can't* extend anything besides themselves (and void in undefined's case), so there's no way to
+    // flavor them)
+    interface HelperBrand {
+        _meteor_dburles_collection_helpers_isBrandUnsupportedHelper: Brand;
+    }
+    // types where HelperBrand will be used instead of HelperFlavor
+    type FlavorUnsupportedTypes = null | undefined;
+
     /**
      * All methods and Helper<T>s declared on the type, made non-optional.
      * This is what's required when defining helpers for a collection.
      */
-    export type Helpers<T> = SetThisArg<Full<T>, T extends T ? Required<HelpersOf<NonData<T>>> : never>;
+    export type Helpers<T> = FlavorAsHelpers<
+        T,
+        // methods will only ever get called on a Full<T> (unless you directly declare a Helpers<T>, but *why*)
+        ThisType<Full<T>> & (T extends T ? HelpersOf<NonHelpers<NonData<T>>> : never)
+    >;
+
+    // used to flavor Helpers<T> so we can get back to the original T if needed
+    // not to be confused with HelperFlavor
+    interface HelpersFlavor<T> {
+        _meteor_dburles_collection_helpers_isHelpersOf?: [Flavor, T];
+    }
+    // apply HelpersFlavor, but only if the resulting type wouldn't be never or weak
+    type FlavorAsHelpers<TOriginal, TToFlavor> = [TToFlavor] extends [TToFlavor & HelpersFlavor<TOriginal>]
+        ? TToFlavor & HelpersFlavor<TOriginal>
+        : TToFlavor;
+    /**
+     * NonHelpers<Helpers<T>> === T
+     */
+    export type NonHelpers<T> = T extends HelpersFlavor<infer U> ? U : T;
+
+    // To get all the helper properties, we union the list of function properties and the list of Helper<T> properties.
+    // Make anything not marked optional required, and anything marked optional optional.
+    type HelpersOf<T> = T extends T
+        ? RemoveHelperBrands<
+              Required<
+                  Pick<
+                      T,
+                      Exclude<
+                          PropertyNamesMatching<Required<T>, Func> | HelperNames<Required<T>>,
+                          OptionalHelperNames<Required<T>>
+                      >
+                  >
+              > &
+                  Partial<Pick<T, OptionalHelperNames<Required<T>>>>
+          >
+        : never;
+
+    type Func = (...args: any[]) => any;
+
+    // The names of all properties of T with either a HelperBrand or a HelperFlavor (whether required or optional)
+    type HelperNames<T> = T extends T
+        ? {
+              [K in keyof T]: Exclude<T[K], undefined> extends infer NoUndefined
+                  ? [HelperBrand] extends [NoUndefined]
+                      ? K
+                      : [HelperBrand | OptionalHelperBrand] extends [NoUndefined]
+                      ? K
+                      : [Required<NoUndefined>] extends [Required<HelperFlavor>]
+                      ? K
+                      : [Required<NoUndefined>] extends [Required<HelperFlavor & OptionalHelperFlavor>]
+                      ? K
+                      : never
+                  : never;
+          }[keyof T]
+        : never;
+
+    // We also want to strip brands from the flavor-unsupported types - since the brands are no longer needed to
+    // tell us which types are helpers, *
+    type RemoveHelperBrands<T> = {
+        [K in keyof T]: Exclude<RemoveHelperFlavorForVoid<T[K]>, HelperBrand | OptionalHelperBrand>;
+    };
+
+    // void is a bit of a weird case; unlike the others, it doesn't explicitly become never when flavored,
+    // and (void & HelperFlavor) *is* assignable to void, but only other expressions of type (void & HelperFlavor)
+    // are assignable to it
+    // however, this is just enough to let us support it with a bit of special-casing - convert it back to normal
+    // void when stripping helper brands, and Helpers<TInterface>.helperVoidProperty can be assigned undefined!
+    // This is one way to make a helper with an optional value that can be read off a raw TInterface (although
+    // Helper<T | false> would work almost as well).
+    // tslint:disable-next-line void-return
+    type RemoveHelperFlavorForVoid<T> = T extends void & HelperFlavor ? void : T;
+
+    // however, we can do better
+    /**
+     * Use this to indicate a helper which can be omitted when providing helpers.
+     * Just marking the property as optional won't make it optional when providing helpers, as that's overloaded
+     * as meaning "an instance of this interface can be created from an object literal without providing its
+     * helpers". If you actually want a helper that's only sometimes there, use this.
+     */
+    export type OptionalHelper<T> = T extends T
+        ? T extends FlavorUnsupportedTypes
+            ? T | HelperBrand | OptionalHelperBrand | undefined
+            : (T & HelperFlavor & OptionalHelperFlavor) | undefined
+        : never;
+    interface OptionalHelperFlavor {
+        _meteor_dburles_collection_helpers_isOptionalHelper?: Flavor;
+    }
+    interface OptionalHelperBrand {
+        _meteor_dburles_collection_helpers_isBrandUnsupportedOptionalHelper?: Brand;
+    }
+    type OptionalHelperNames<T> = T extends T
+        ? {
+              [K in keyof T]: Exclude<T[K], undefined> extends infer NoUndefined
+                  ? [HelperBrand | OptionalHelperBrand] extends [NoUndefined]
+                      ? K
+                      : [Required<NoUndefined>] extends [Required<HelperFlavor & OptionalHelperFlavor>]
+                      ? K
+                      : never
+                  : never;
+          }[keyof T]
+        : never;
+
+    interface DataFlavor<T> {
+        _meteor_dburles_collection_helpers_isData?: [Flavor, T];
+    }
     /**
      * Just the non-method/Helper properties of the type, with the methods and Helpers made optional.
      * No need to declare a Collection<Data<T>>; all Collection methods already accept a Data<T>.
      */
-    export type Data<T> = DataBrand<T> & NonHelpersOf<T> & (T extends T ? Partial<HelpersOf<T>> : never);
+    export type Data<T> = DataFlavor<T> & NonHelpersOf<T> & (T extends T ? Partial<HelpersOf<T>> : never);
+    /**
+     * NonData<Data<T>> === T
+     */
+    export type NonData<T> = T extends DataFlavor<infer U> ? U : T;
+
+    // All the members of T that aren't helpers
+    type NonHelpersOf<T> = T extends T
+        ? Pick<
+              T,
+              Exclude<
+                  PropertyNamesNotMatching<Required<T>, Func>,
+                  HelperNames<Required<T>> | OptionalHelperNames<Required<T>>
+              >
+          >
+        : never;
+
     /**
      * The version of a type that comes out of the collection (with helpers attached).
      */
-    export type Full<T> = NonData<T> & (T extends T ? Required<HelpersOf<NonData<T>>> : never);
+    export type Full<T> = NonData<NonHelpers<T>> & (T extends T ? HelpersOf<NonData<NonHelpers<T>>> : never);
+
+    type Brand = "_meteor_dburles_collection_helpers_brand";
+    type Flavor = "_meteor_dburles_collection_helpers_flavor";
+
+    /**
+     * Collection.helpers<AllowPartial>() allows declaring only some of a collection's helpers,
+     * rather than enforcing that they be declared all at once.
+     * Only use this if you know what you're doing - it's assumed that all of a collection's helpers
+     * will be provided before any items are retrieved from it.
+     */
+    export type AllowPartial = "_meteor_dburles_collection_helpers_allowPartial";
+    /**
+     * Some subset of a collection's helpers - only used by Collection.helpers<allowPartial>()
+     */
+    export type PartialHelpers<T> = ThisType<NonData<NonHelpers<T>>> & Partial<Helpers<T>>;
 }

--- a/types/meteor-dburles-collection-helpers/collectionHelpers.d.ts
+++ b/types/meteor-dburles-collection-helpers/collectionHelpers.d.ts
@@ -43,7 +43,7 @@ declare module 'meteor/dburles:collection-helpers' {
     export type Helpers<T> = SetThisArg<Full<T>, Required<HelpersOf<NonData<T>>>>;
     /**
      * Just the non-method/Helper properties of the type, with the methods and Helpers made optional.
-     * No need to declare a Collection<Data<T>>; "new Collection<T>" already returns one.
+     * No need to declare a Collection<Data<T>>; all Collection methods already accept a Data<T>.
      */
     export type Data<T> = DataBrand<NonData<T>> & NonHelpersOf<NonData<T>> & Partial<HelpersOf<NonData<T>>>;
     /**

--- a/types/meteor-dburles-collection-helpers/index.d.ts
+++ b/types/meteor-dburles-collection-helpers/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for non-npm package Atmosphere package dburles:collection-helpers 1.1
+// Project: https://github.com/dburles/meteor-collection-helpers
+// Definitions by: Artemis Kearney <https://github.com/artemiswkearney>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.7
+
+/// <reference path="./mongo.d.ts" />
+/// <reference path="./collectionHelpers.d.ts" />

--- a/types/meteor-dburles-collection-helpers/meteor-dburles-collection-helpers-tests.ts
+++ b/types/meteor-dburles-collection-helpers/meteor-dburles-collection-helpers-tests.ts
@@ -167,3 +167,20 @@ recursiveHelpers.helpers({
 const roh1 = recursiveOptionalHelpers.insert({ value: 3 });
 // $ExpectType number
 recursiveHelpers.findOne(rh1)!.factorial(4);
+
+// regression test:
+// { ...OptionalId<Data<T>>, _id: T['id'] } should be assignable to Data<T>
+// (tested here with upsert)
+
+interface MandatoryId {
+    _id: string;
+    value: number;
+}
+const mandatoryIds = new Mongo.Collection<MandatoryId>('mandatoryIds');
+mandatoryIds.helpers({});
+const withoutId: Mongo.OptionalId<MandatoryId> = {
+    value: 3
+};
+
+// $ExpectType number | undefined
+mandatoryIds.upsert("new ID", { ...withoutId, _id: "new ID" }).numberAffected;

--- a/types/meteor-dburles-collection-helpers/meteor-dburles-collection-helpers-tests.ts
+++ b/types/meteor-dburles-collection-helpers/meteor-dburles-collection-helpers-tests.ts
@@ -22,6 +22,9 @@ interface Book {
 const Books = new Mongo.Collection<Book>('books');
 const Authors = new Mongo.Collection<Author>('authors');
 
+// $ExpectType Collection<Book>
+Books;
+
 // when inserting items, only data properties are required
 const author1 = Authors.insert({
     firstName: 'Charles',

--- a/types/meteor-dburles-collection-helpers/meteor-dburles-collection-helpers-tests.ts
+++ b/types/meteor-dburles-collection-helpers/meteor-dburles-collection-helpers-tests.ts
@@ -1,0 +1,166 @@
+import { Mongo } from 'meteor/mongo';
+import { Helper, Data, Full } from 'meteor/dburles:collection-helpers';
+
+interface Author {
+    _id?: string;
+    firstName: string;
+    lastName: string;
+    // function properties are automatically detected as helpers; no need to specify
+    fullName: () => string;
+    books: () => Mongo.Cursor<Book>;
+}
+
+interface Book {
+    _id?: string;
+    authorId: string;
+    name: string;
+    author: () => Author | undefined;
+    // use Helper<T> to declare non-function helpers
+    foo: Helper<string>;
+}
+
+const Books = new Mongo.Collection<Book>('books');
+const Authors = new Mongo.Collection<Author>('authors');
+
+// when inserting items, only data properties are required
+const author1 = Authors.insert({
+    firstName: 'Charles',
+    lastName: 'Darwin',
+});
+
+const author2 = Authors.insert({
+    firstName: 'Carl',
+    lastName: 'Sagan',
+});
+
+const book1 = Books.insert({
+    authorId: author1,
+    name: 'On the Origin of Species',
+});
+
+const book2 = Books.insert({
+    authorId: author2,
+    name: 'Contact',
+});
+
+// when providing helpers, no data properties but all helpers are required
+// all helpers must be provided at once; this is the only way to typecheck that none are forgotten
+// $ExpectType void
+Books.helpers({
+    author() {
+        return Authors.findOne(this.authorId);
+    },
+    foo: 'bar',
+});
+// $ExpectError
+Books.helpers({
+    author() {
+        return Authors.findOne(this.authorId);
+    },
+});
+
+Authors.helpers({
+    fullName() {
+        return `${this.firstName} ${this.lastName}`;
+    },
+    books() {
+        return Books.find({ authorId: this._id });
+    },
+});
+
+const book = Books.findOne(book1)!;
+const author: Author | undefined = book.author();
+
+// can modify resulting Book and update Books with it, even though it has helpers attached
+book.name = 'Renamed Book';
+// $ExpectType number
+Books.update(book._id!, book);
+
+// with mandatory helpers, new objects can be declared directly as Data<T>
+const bookData: Data<Book> = {
+    authorId: 'Author',
+    name: 'Name',
+};
+
+// this interface has its helpers declared as optional; this makes instantiating the interface easier,
+// but means you need to specify Full<T> to say an object has had its helpers attached
+interface OptionalHelpers {
+    _id: string;
+    value: number;
+    increment?: () => void;
+    zero?: Helper<number>;
+}
+
+const optionalHelpers = new Mongo.Collection<OptionalHelpers>('optionalHelpers');
+// optional helpers still have to be provided when calling helpers
+// $ExpectError
+optionalHelpers.helpers({});
+// $ExpectError
+optionalHelpers.helpers({
+    increment() {
+        this.value++;
+    },
+});
+// $ExpectType void
+optionalHelpers.helpers({
+    increment() {
+        this.value++;
+    },
+    zero: 0,
+});
+
+const optionalHelper1 = optionalHelpers.insert({ value: 2 });
+// Helpers are still guaranteed on the results of findOne, even though helpers were declared optional
+// $ExpectType void
+optionalHelpers.findOne(optionalHelper1)!.increment();
+// same goes for find
+// $ExpectType void
+optionalHelpers.find(optionalHelper1).fetch()[0].increment();
+
+const foundOptionalHelpers1: OptionalHelpers = optionalHelpers.findOne(optionalHelper1)!;
+// however, variables of the interface type will be missing their helpers unless declared as Full<T>
+// $ExpectError
+foundOptionalHelpers1.increment();
+
+// you can do this, but it's kinda ugly imo
+const foundOptionalHelpers1Full: Full<OptionalHelpers> = optionalHelpers.findOne(optionalHelper1)!;
+// $ExpectType void
+foundOptionalHelpers1Full.increment();
+
+// helpers can call themselves recursively
+interface RecursiveHelpers {
+    _id: string;
+    value: number;
+    factorial: (arg: number) => number;
+}
+
+const recursiveHelpers = new Mongo.Collection<RecursiveHelpers>('recursiveHelpers');
+recursiveHelpers.helpers({
+    factorial(x) {
+        if (x <= 1) return 1;
+        return this.factorial(x - 1);
+    },
+});
+
+const rh1 = recursiveHelpers.insert({ value: 3 });
+// $ExpectType number
+recursiveHelpers.findOne(rh1)!.factorial(4);
+
+// even when optional!
+interface RecursiveOptionalHelpers {
+    _id: string;
+    value: number;
+    factorial?: (arg: number) => number;
+}
+
+const recursiveOptionalHelpers = new Mongo.Collection<RecursiveHelpers>('recursiveHelpers');
+recursiveHelpers.helpers({
+    factorial(x) {
+        if (x <= 1) return 1;
+        return this.factorial(x - 1);
+    },
+});
+
+const roh1 = recursiveOptionalHelpers.insert({ value: 3 });
+// $ExpectType number
+recursiveHelpers.findOne(rh1)!.factorial(4);

--- a/types/meteor-dburles-collection-helpers/mongo.d.ts
+++ b/types/meteor-dburles-collection-helpers/mongo.d.ts
@@ -64,13 +64,13 @@ declare module 'meteor/mongo' {
                 multi?: boolean;
                 upsert?: boolean;
                 arrayFilters?: Array<{ [identifier: string]: any }>;
-				// ditto
-				// tslint:disable-next-line ban-types
+                                // ditto
+                                // tslint:disable-next-line ban-types
             }, callback?: Function): number;
             upsert(selector: Selector<T> | ObjectID | string, modifier: Modifier<Data<T>>, options?: {
                 multi?: boolean;
-				// ditto
-				// tslint:disable-next-line ban-types
+                                // ditto
+                                // tslint:disable-next-line ban-types
             }, callback?: Function): {
                 numberAffected?: number; insertedId?: string;
             };

--- a/types/meteor-dburles-collection-helpers/mongo.d.ts
+++ b/types/meteor-dburles-collection-helpers/mongo.d.ts
@@ -1,17 +1,18 @@
-import { Helpers, Full, Data } from 'meteor/dburles:collection-helpers';
+import { Helpers, Full, Data, AllowPartial, PartialHelpers } from 'meteor/dburles:collection-helpers';
 import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
-// tslint:disable-next-line no-single-declare-module
 
 // Cursor<T> and Collection<T> are pulled from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/meteor/mongo.d.ts
 // and should be kept in sync with any changes to it
 // only modified properties are included
 
+// tslint:disable-next-line no-single-declare-module
 declare module 'meteor/mongo' {
     namespace Mongo {
         interface Collection<T> {
             /**
              * Provide the definitions here for the methods and Helper<T>s you declared on your item interface.
+             * Use helpers<AllowPartial> if you want to provide the helpers across multiple calls.
              * Tip: If you make those properties non-optional, they still won't be required when inserting items,
              * but you'll know that any object of your interface type has them.
              * Alternatively, if they're marked optional on your interface, they'll still be guaranteed on any
@@ -21,7 +22,10 @@ declare module 'meteor/mongo' {
              * If you plan to mostly pass around items that came out of a collection, make them required and use Data<T>
              * when creating new items.
              */
-            helpers(helpers: Helpers<T>): void;
+            helpers<allowPartial extends (false | AllowPartial) = false>(
+                // tslint:disable-next-line no-unnecessary-generics
+                helpers: (allowPartial extends AllowPartial ? PartialHelpers<T> : Helpers<T>)
+            ): void;
 
             // modifications:
             // - replaced T with Full<T> & T everywhere Collection._transform is applied
@@ -60,19 +64,30 @@ declare module 'meteor/mongo' {
             // ditto
             // tslint:disable-next-line ban-types
             insert(doc: OptionalId<Data<T>>, callback?: Function): string;
-            update(selector: Selector<T> | ObjectID | string, modifier: Modifier<Data<T>>, options?: {
-                multi?: boolean;
-                upsert?: boolean;
-                arrayFilters?: Array<{ [identifier: string]: any }>;
-                                // ditto
-                                // tslint:disable-next-line ban-types
-            }, callback?: Function): number;
-            upsert(selector: Selector<T> | ObjectID | string, modifier: Modifier<Data<T>>, options?: {
-                multi?: boolean;
-                                // ditto
-                                // tslint:disable-next-line ban-types
-            }, callback?: Function): {
-                numberAffected?: number; insertedId?: string;
+            update(
+                selector: Selector<T> | ObjectID | string,
+                modifier: Modifier<Data<T>>,
+                options?: {
+                    multi?: boolean;
+                    upsert?: boolean;
+                    arrayFilters?: Array<{ [identifier: string]: any }>;
+                },
+                // ditto
+                // tslint:disable-next-line ban-types
+                callback?: Function,
+            ): number;
+            upsert(
+                selector: Selector<T> | ObjectID | string,
+                modifier: Modifier<Data<T>>,
+                options?: {
+                    multi?: boolean;
+                },
+                // ditto
+                // tslint:disable-next-line ban-types
+                callback?: Function,
+            ): {
+                numberAffected?: number;
+                insertedId?: string;
             };
         }
 

--- a/types/meteor-dburles-collection-helpers/mongo.d.ts
+++ b/types/meteor-dburles-collection-helpers/mongo.d.ts
@@ -1,0 +1,72 @@
+import { Helpers, Full, Data } from 'meteor/dburles:collection-helpers';
+import { Mongo } from 'meteor/mongo';
+// tslint:disable-next-line no-single-declare-module
+
+// CollectionStatic, Collection.find, and Collection.findOne are pulled from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/meteor/mongo.d.ts
+// and should be kept in sync with any changes to it
+
+declare module 'meteor/mongo' {
+    namespace Mongo {
+        // tslint:disable-next-line no-var-keyword
+        var Collection: CollectionStatic;
+        interface CollectionStatic {
+            // modifications: return type Collection<T> -> Collection<Data<T>>
+            new <T>(
+                name: string | null,
+                options?: {
+                    // using Object because @types/meteor still uses it here
+                    // tslint:disable-next-line ban-types
+                    connection?: Object | null;
+                    idGeneration?: string;
+                    // ditto for Function
+                    // tslint:disable-next-line ban-types
+                    transform?: Function | null;
+                },
+            // this is a collection type
+            // tslint:disable-next-line no-unnecessary-generics
+            ): Collection<Data<T>>;
+        }
+        interface Collection<T> {
+            /**
+             * Provide the definitions here for the methods and Helper<T>s you declared on your item interface.
+             * Tip: If you make those properties non-optional, they still won't be required when inserting items,
+             * but you'll know that any object of your interface type has them.
+             * Alternatively, if they're marked optional on your interface, they'll still be guaranteed on any
+             * object you get out of the collection.
+             * If you plan to pass around and create a lot of items pre-insertion, make them optional and use Full<T>
+             * for ones with helpers attached.
+             * If you plan to mostly pass around items that came out of a collection, make them required and use Data<T>
+             * when creating new items.
+             */
+            helpers(helpers: Helpers<T>): void;
+
+            // modifications: replaced T in return type with Full<T>
+
+            find(
+                selector?: Selector<T> | ObjectID | string,
+                options?: {
+                    sort?: SortSpecifier;
+                    skip?: number;
+                    limit?: number;
+                    fields?: FieldSpecifier;
+                    reactive?: boolean;
+                    // ditto
+                    // tslint:disable-next-line ban-types
+                    transform?: Function | null;
+                },
+            ): Cursor<Full<T>>;
+            findOne(
+                selector?: Selector<T> | ObjectID | string,
+                options?: {
+                    sort?: SortSpecifier;
+                    skip?: number;
+                    fields?: FieldSpecifier;
+                    reactive?: boolean;
+                    // ditto
+                    // tslint:disable-next-line ban-types
+                    transform?: Function | null;
+                },
+            ): Full<T> | undefined;
+        }
+    }
+}

--- a/types/meteor-dburles-collection-helpers/mongo.d.ts
+++ b/types/meteor-dburles-collection-helpers/mongo.d.ts
@@ -60,6 +60,20 @@ declare module 'meteor/mongo' {
             // ditto
             // tslint:disable-next-line ban-types
             insert(doc: OptionalId<Data<T>>, callback?: Function): string;
+            update(selector: Selector<T> | ObjectID | string, modifier: Modifier<Data<T>>, options?: {
+                multi?: boolean;
+                upsert?: boolean;
+                arrayFilters?: Array<{ [identifier: string]: any }>;
+				// ditto
+				// tslint:disable-next-line ban-types
+            }, callback?: Function): number;
+            upsert(selector: Selector<T> | ObjectID | string, modifier: Modifier<Data<T>>, options?: {
+                multi?: boolean;
+				// ditto
+				// tslint:disable-next-line ban-types
+            }, callback?: Function): {
+                numberAffected?: number; insertedId?: string;
+            };
         }
 
         // modifications: replaced T with Full<T> & T everywhere Collection._transform is applied

--- a/types/meteor-dburles-collection-helpers/tsconfig.json
+++ b/types/meteor-dburles-collection-helpers/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "meteor-dburles-collection-helpers-tests.ts"
+    ]
+}

--- a/types/meteor-dburles-collection-helpers/tslint.json
+++ b/types/meteor-dburles-collection-helpers/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.