### PR TITLE
update(browser-resolve): missing options and v2 bump

### DIFF
--- a/types/browser-resolve/browser-resolve-tests.ts
+++ b/types/browser-resolve/browser-resolve-tests.ts
@@ -1,5 +1,7 @@
 import resolve = require('browser-resolve');
 
+const fixturesDir = __dirname + '/fixtures/node_modules';
+
 const basic_test_async = (callback: (err?: Error | null, resolved?: string) => void) => {
     // $ExpectType void
     resolve('typescript', (error, resolved) => {
@@ -22,6 +24,7 @@ resolve(
         modules: {
             fs: './fs-shim.js',
         },
+        paths: [fixturesDir],
     },
     (error, resolved) => {
         if (error) {
@@ -39,8 +42,16 @@ resolve.sync('typescript', {
 
 resolve.sync('@scope/my-module', {
     browser: 'module',
-    packageFilter: pkg => {
+    packageFilter: (pkg: any) => {
         pkg.module = pkg.module || pkg.browser;
+        return pkg;
+    },
+});
+resolve.sync('@scope/my-module', {
+    browser: 'module',
+    packageFilter: (pkg: any, pkgdir: string) => {
+        pkg.module = pkg.module || pkg.browser;
+        console.log(`pkgdir: ${pkgdir}`);
         return pkg;
     },
 });

--- a/types/browser-resolve/index.d.ts
+++ b/types/browser-resolve/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for browser-resolve 1.11
+// Type definitions for browser-resolve 2.0
 // Project: https://github.com/defunctzombie/node-browser-resolve
 // Definitions by: Mario Nebl <https://github.com/marionebl>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
@@ -26,6 +26,10 @@ declare function resolve(id: string, opts: resolve.AsyncOpts, cb: resolve.Callba
 declare namespace resolve {
     interface Opts {
         /**
+         * directory to begin resolving from
+         */
+        basedir?: string;
+        /**
          * the 'browser' property to use from package.json
          * @default 'browser'
          */
@@ -38,7 +42,15 @@ declare namespace resolve {
          * modules object with id to path mappings to consult before doing manual resolution
          * (use to provide core modules)
          */
-        modules?: any;
+        modules?: { [id: string]: string };
+        /**
+         * transform the parsed package.json contents before looking at the main field
+         */
+        packageFilter?: (info: any, pkgdir: string) => any;
+        /**
+         * require.paths array to use if nothing is found on the normal node_modules recursive walk
+         */
+        paths?: string[];
     }
 
     type AsyncOpts = resv.AsyncOpts & Opts;


### PR DESCRIPTION
The `browser-resolve` is now at v2, mith non-api changes, but let us
use the v2 release to add missing options and refine details:
- `baseDir`
- `paths`
- `modules` type as hash map
- `packageFilter` second parameter (barely used, but it's here)
- version bump

https://github.com/browserify/browser-resolve/releases/tag/v2.0.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)