### PR TITLE
[google.visualization] Change google.charts.load for v49 July 2020

### DIFF
--- a/types/google.visualization/google.visualization-tests.ts
+++ b/types/google.visualization/google.visualization-tests.ts
@@ -554,8 +554,10 @@ function test_formatter_PatternFormat() {
     }
 }
 
-function test_drawChart() {
-        // Define the chart to be drawn.
+function test_ChartsLoadWithCallback() {
+    google.charts.load('current', {packages: ['corechart', 'table', 'sankey']});
+
+    function drawChart() {
         var data = new google.visualization.DataTable();
         data.addColumn('string', 'Element');
         data.addColumn('number', 'Percentage');
@@ -573,12 +575,28 @@ function test_drawChart() {
         }
     }
 
-function test_ChartsLoadWithCallback() {
-    google.charts.load('current', {packages: ['corechart', 'table', 'sankey']});
     google.charts.setOnLoadCallback(drawChart);
 }
 
 function test_ChartsLoadWithPromise() {
+    function drawChart() {
+        var data = new google.visualization.DataTable();
+        data.addColumn('string', 'Element');
+        data.addColumn('number', 'Percentage');
+        data.addRows([
+            ['Nitrogen', 0.78],
+            ['Oxygen', 0.21],
+            ['Other', 0.01]
+        ]);
+
+        // Instantiate and draw the chart.
+        var container = document.getElementById('myPieChart');
+        if (container) {
+            var chart = new google.visualization.PieChart(container);
+            chart.draw(data, {});
+        }
+    }
+    
     google.charts.load('current', {packages: ['corechart', 'table', 'sankey']}).then(drawChart);
 }
 

--- a/types/google.visualization/google.visualization-tests.ts
+++ b/types/google.visualization/google.visualization-tests.ts
@@ -554,10 +554,7 @@ function test_formatter_PatternFormat() {
     }
 }
 
-function test_ChartsLoad() {
-    google.charts.load('current', {packages: ['corechart', 'table', 'sankey']});
-
-    function drawChart() {
+function test_drawChart() {
         // Define the chart to be drawn.
         var data = new google.visualization.DataTable();
         data.addColumn('string', 'Element');
@@ -576,9 +573,14 @@ function test_ChartsLoad() {
         }
     }
 
+function test_ChartsLoadWithCallback() {
+    google.charts.load('current', {packages: ['corechart', 'table', 'sankey']});
     google.charts.setOnLoadCallback(drawChart);
 }
 
+function test_ChartsLoadWithPromise() {
+    google.charts.load('current', {packages: ['corechart', 'table', 'sankey']}).then(drawChart);
+}
 
 function test_ChartAnnotations() {
     var annotations:google.visualization.ChartAnnotations = {

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -5,8 +5,7 @@
 
 declare namespace google {
 
-    // https://developers.google.com/chart/interactive/docs/basic_load_libs#load-settings
-    function load(visualization: string, version: string | number, packages: any): Promise<void>;
+    function load(visualization: string, version: string, packages: any): void;
     function setOnLoadCallback(handler: Function): void;
     function setOnLoadCallback(handler: () => void): void;
 

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -12,7 +12,7 @@ declare namespace google {
 
     // https://developers.google.com/chart/interactive/docs/basic_load_libs
     namespace charts {
-        function load(version: string, packages: Object): void;
+        function load(version: string | number, packages: Object): Promise<void>;
         function setOnLoadCallback(handler: Function): void;
     }
 

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -6,7 +6,7 @@
 declare namespace google {
 
     // https://developers.google.com/chart/interactive/docs/basic_load_libs#load-settings
-    function load(visualization: string, version: string, packages: any): Promise<void>;
+    function load(visualization: string, version: string | number, packages: any): Promise<void>;
     function setOnLoadCallback(handler: Function): void;
     function setOnLoadCallback(handler: () => void): void;
 

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -11,7 +11,7 @@ declare namespace google {
 
     // https://developers.google.com/chart/interactive/docs/basic_load_libs
     namespace charts {
-        function load(version: string | number, packages: Object): Promise<void>;
+        function load(version: string | number, packages: Object, mapsApiKey?: string): Promise<void>;
         function setOnLoadCallback(handler: Function): void;
     }
 

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -5,7 +5,8 @@
 
 declare namespace google {
 
-    function load(visualization: string, version: string, packages: any): void;
+    // https://developers.google.com/chart/interactive/docs/basic_load_libs#load-settings
+    function load(visualization: string, version: string, packages: any): Promise<void>;
     function setOnLoadCallback(handler: Function): void;
     function setOnLoadCallback(handler: () => void): void;
 


### PR DESCRIPTION
Changed the google.charts.load return type to a Promise<void> and version param to accept string or number to match changes to v49 July 2020.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/chart/interactive/docs/release_notes#current:-july-2020