### PR TITLE
[@types/yup] fix InferType working with nested optional properties within arrays

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -640,12 +640,12 @@ type PreserveNull<T> = T extends null ? null : never;
 type PreserveUndefined<T> = T extends undefined ? undefined : never;
 type PreserveOptionals<T> = PreserveNull<T> | PreserveUndefined<T>;
 type Id<T> = {
-    [K in keyof T]: T[K] extends object ? InnerInferType<T[K]> : T[K];
+    [K in keyof T]: InnerInferType<T[K]>
 };
 type RequiredProps<T> = Pick<T, Exclude<keyof T, KeyOfUndefined<T>>>;
 type NotRequiredProps<T> = Partial<Pick<T, KeyOfUndefined<T>>>;
 type InnerInferType<T> =
-    | (T extends Array<infer T> ? InnerInferTypeArray<T> : Id<NotRequiredProps<T> & RequiredProps<T>>)
+    | (T extends Array<infer T> ? InnerInferTypeArray<T> : T extends Date ? T : T extends object ? Id<NotRequiredProps<T> & RequiredProps<T>> : T)
     | PreserveOptionals<T>;
 interface InnerInferTypeArray<T> extends Array<InnerInferType<T>> {}
 type InferredArrayType<T> = T extends Array<infer U> ? U : T;

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -645,7 +645,7 @@ type Id<T> = {
 type RequiredProps<T> = Pick<T, Exclude<keyof T, KeyOfUndefined<T>>>;
 type NotRequiredProps<T> = Partial<Pick<T, KeyOfUndefined<T>>>;
 type InnerInferType<T> =
-    | (T extends Array<infer T> ? InnerInferTypeArray<T> : T extends Date ? T : T extends object ? Id<NotRequiredProps<T> & RequiredProps<T>> : T)
+    | (T extends Array<infer T> ? InnerInferTypeArray<T> : T extends Date | Set<infer P> | Map<infer K, infer V> ? T : T extends object ? Id<NotRequiredProps<T> & RequiredProps<T>> : T)
     | PreserveOptionals<T>;
 interface InnerInferTypeArray<T> extends Array<InnerInferType<T>> {}
 type InferredArrayType<T> = T extends Array<infer U> ? U : T;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -808,6 +808,22 @@ const personSchema = yup.object({
         phoneNumbers: yup.array(yup.string()).defined(),
         lastUpdated: yup.date().optional()
     }).required(),
+    nestedArrays: yup.object({
+        requiredStrings: yup.array(yup.string().required()).defined(),
+        requiredObjects: yup.array(
+            yup.object({
+                required: yup.string().required(),
+                optional: yup.string().optional()
+            })
+        ).defined()
+    }),
+    requiredObjectsArray: yup.array(
+        yup.object({
+            required: yup.string().required(),
+            optional: yup.string().optional()
+        })
+    ),
+    nullableDate: yup.date().nullable().optional(),
     email: yup
         .string()
         .nullable()
@@ -888,8 +904,20 @@ const person: Person = {
     },
     addressBook: {
         phoneNumbers: []
-    }
+    },
+    nestedArrays: {
+        requiredStrings: ['123', '456', '789'],
+        requiredObjects: [{ required: '' }]
+    },
+    requiredObjectsArray: [{ required: '' }],
+    nullableDate: new Date()
 };
+
+function readPhoneNumbers(arg: string[]) {}
+readPhoneNumbers(person.nestedArrays!.requiredStrings);
+
+function readDate(arg?: Date | null) {}
+readDate(person.nullableDate);
 
 person.email = 'some@email.com';
 person.email = undefined;
@@ -908,6 +936,12 @@ person.address = { area: {}, line1: '' };
 person.addressBook = {};
 // $ExpectError
 person.addressBook = { phoneNumbers: null };
+// $ExpectError
+person.requiredObjectsArray = [{ optional: '' }];
+// $ExpectError
+person.nestedArrays = { requiredObjects: [{ optional: '' }], requiredStrings: [] };
+// $ExpectError
+person.nestedArrays = { requiredObjects: [], requiredStrings: [undefined] };
 // $ExpectError
 person.gender = 1;
 // $ExpectError

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -857,7 +857,16 @@ const personSchema = yup.object({
             // tslint:disable-next-line:no-invalid-template-strings
             "${path} must be a Set of strings",
             (value): value is undefined | null | Set<string> =>
-                value === null || value === undefined || (value instanceof Set && Array.from(value.values()).every(el => typeof el === "string")))
+                value === null || value === undefined || (value instanceof Set && Array.from(value.values()).every(el => typeof el === "string"))),
+    mapObject: yup
+        .mixed()
+        .test(
+            'is-Map',
+            // tslint:disable-next-line:no-invalid-template-strings
+            "${path} must be a Map of string:string",
+            (value): value is undefined | null | Map<string, string> => value === null || value === undefined ||
+                (value instanceof Map && Array.from(value.entries()).every(([key, val]) => typeof key === 'string' && typeof val === 'string'))
+        )
 }).defined();
 
 type Person = yup.InferType<typeof personSchema>;
@@ -910,7 +919,8 @@ const person: Person = {
         requiredObjects: [{ required: '' }]
     },
     requiredObjectsArray: [{ required: '' }],
-    nullableDate: new Date()
+    nullableDate: new Date(),
+    mapObject: new Map()
 };
 
 function readPhoneNumbers(arg: string[]) {}
@@ -954,6 +964,8 @@ person.mustBeAString = null;
 person.mustBeAString = undefined;
 // $ExpectError
 person.friends = new Set([1, 2, 3]);
+// $ExpectError
+person.mapObject = new Map([ ['number', 3] ]);
 // $ExpectError
 person.friends = ["Amy", "Beth"];
 


### PR DESCRIPTION
This is a companion PR for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46518

Similar to the bug resolved in that PR, this PR will resolve optional properties within an array, when that array is nested.

I will push my test scenarios first, to show that they currently fail, and then push a fix afterwards.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46518
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.