### PR TITLE
[base16] Add default export and clean up types

### DIFF
--- a/types/base16/base16-tests.ts
+++ b/types/base16/base16-tests.ts
@@ -1,25 +1,25 @@
 import * as base16 from 'base16';
 
-const colorScheme: base16.Base16Theme = base16.solarized;
+const base16Theme: base16.Base16Theme = base16.solarized;
 
-const scheme: string = colorScheme.scheme;
-const author: string = colorScheme.author;
-const base00: string = colorScheme.base00;
-const base01: string = colorScheme.base01;
-const base02: string = colorScheme.base02;
-const base03: string = colorScheme.base03;
-const base04: string = colorScheme.base04;
-const base05: string = colorScheme.base05;
-const base06: string = colorScheme.base06;
-const base07: string = colorScheme.base07;
-const base08: string = colorScheme.base08;
-const base09: string = colorScheme.base09;
-const base0A: string = colorScheme.base0A;
-const base0B: string = colorScheme.base0B;
-const base0C: string = colorScheme.base0C;
-const base0D: string = colorScheme.base0D;
-const base0E: string = colorScheme.base0E;
-const base0F: string = colorScheme.base0F;
+const scheme: string = base16Theme.scheme;
+const author: string = base16Theme.author;
+const base00: string = base16Theme.base00;
+const base01: string = base16Theme.base01;
+const base02: string = base16Theme.base02;
+const base03: string = base16Theme.base03;
+const base04: string = base16Theme.base04;
+const base05: string = base16Theme.base05;
+const base06: string = base16Theme.base06;
+const base07: string = base16Theme.base07;
+const base08: string = base16Theme.base08;
+const base09: string = base16Theme.base09;
+const base0A: string = base16Theme.base0A;
+const base0B: string = base16Theme.base0B;
+const base0C: string = base16Theme.base0C;
+const base0D: string = base16Theme.base0D;
+const base0E: string = base16Theme.base0E;
+const base0F: string = base16Theme.base0F;
 
-const defaultColorScheme = base16.default;
-const defaultSchemeAuthor = defaultColorScheme.author;
+const defaultBase16Theme = base16.default;
+const defaultSchemeAuthor = defaultBase16Theme.author;

--- a/types/base16/base16-tests.ts
+++ b/types/base16/base16-tests.ts
@@ -1,25 +1,25 @@
 import * as base16 from 'base16';
 
-const colorScheme: base16.Base16Theme = base16.solarized
+const colorScheme: base16.Base16Theme = base16.solarized;
 
-const scheme: string = colorScheme.scheme
-const author: string = colorScheme.author
-const base00: string = colorScheme.base00
-const base01: string = colorScheme.base01
-const base02: string = colorScheme.base02
-const base03: string = colorScheme.base03
-const base04: string = colorScheme.base04
-const base05: string = colorScheme.base05
-const base06: string = colorScheme.base06
-const base07: string = colorScheme.base07
-const base08: string = colorScheme.base08
-const base09: string = colorScheme.base09
-const base0A: string = colorScheme.base0A
-const base0B: string = colorScheme.base0B
-const base0C: string = colorScheme.base0C
-const base0D: string = colorScheme.base0D
-const base0E: string = colorScheme.base0E
-const base0F: string = colorScheme.base0F
+const scheme: string = colorScheme.scheme;
+const author: string = colorScheme.author;
+const base00: string = colorScheme.base00;
+const base01: string = colorScheme.base01;
+const base02: string = colorScheme.base02;
+const base03: string = colorScheme.base03;
+const base04: string = colorScheme.base04;
+const base05: string = colorScheme.base05;
+const base06: string = colorScheme.base06;
+const base07: string = colorScheme.base07;
+const base08: string = colorScheme.base08;
+const base09: string = colorScheme.base09;
+const base0A: string = colorScheme.base0A;
+const base0B: string = colorScheme.base0B;
+const base0C: string = colorScheme.base0C;
+const base0D: string = colorScheme.base0D;
+const base0E: string = colorScheme.base0E;
+const base0F: string = colorScheme.base0F;
 
 const defaultColorScheme = base16.default;
 const defaultSchemeAuthor = defaultColorScheme.author;

--- a/types/base16/base16-tests.ts
+++ b/types/base16/base16-tests.ts
@@ -1,6 +1,6 @@
 import * as base16 from 'base16';
 
-const colorScheme: base16.ColorScheme = base16.solarized
+const colorScheme: base16.Base16Theme = base16.solarized
 
 const scheme: string = colorScheme.scheme
 const author: string = colorScheme.author
@@ -20,3 +20,6 @@ const base0C: string = colorScheme.base0C
 const base0D: string = colorScheme.base0D
 const base0E: string = colorScheme.base0E
 const base0F: string = colorScheme.base0F
+
+const defaultColorScheme = base16.default;
+const defaultSchemeAuthor = defaultColorScheme.author;

--- a/types/base16/index.d.ts
+++ b/types/base16/index.d.ts
@@ -56,6 +56,7 @@ export const harmonic: Base16Theme;
 export const hopscotch: Base16Theme;
 export const isotope: Base16Theme;
 export const marrakesh: Base16Theme;
+export const mocha: Base16Theme;
 export const monokai: Base16Theme;
 export const ocean: Base16Theme;
 export const paraiso: Base16Theme;

--- a/types/base16/index.d.ts
+++ b/types/base16/index.d.ts
@@ -1,13 +1,14 @@
 // Type definitions for base16-js 1.0.0
 // Project: https://github.com/gaearon/base16-js
 // Definitions by: Alec Hill <https://github.com/alechill>
+//                 Nathan Bierema <https://github.com/Methuselah96>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**
  * Type describing a syntax highlighting scheme as a JS object, as used in redux dev tools
  * Based on https://github.com/chriskempson/base16
  */
-export interface ColorScheme {
+export interface Base16Theme {
   scheme: string
   author: string
   base00: string
@@ -29,38 +30,40 @@ export interface ColorScheme {
 }
 
 // predefined schemes...
-export var threezerotwofour: ColorScheme
-export var apathy: ColorScheme
-export var ashes: ColorScheme
-export var atelierDune: ColorScheme
-export var atelierForest: ColorScheme
-export var atelierHeath: ColorScheme
-export var atelierLakeside: ColorScheme
-export var atelierSeaside: ColorScheme
-export var bespin: ColorScheme
-export var brewer: ColorScheme
-export var bright: ColorScheme
-export var chalk: ColorScheme
-export var codeschool: ColorScheme
-export var colors: ColorScheme
-export var eighties: ColorScheme
-export var embers: ColorScheme
-export var flat: ColorScheme
-export var google: ColorScheme
-export var grayscale: ColorScheme
-export var greenscreen: ColorScheme
-export var harmonic: ColorScheme
-export var hopscotch: ColorScheme
-export var isotope: ColorScheme
-export var marrakesh: ColorScheme
-export var monokai: ColorScheme
-export var ocean: ColorScheme
-export var paraiso: ColorScheme
-export var pop: ColorScheme
-export var railscasts: ColorScheme
-export var shapeshifter: ColorScheme
-export var solarized: ColorScheme
-export var summerfruit: ColorScheme
-export var tomorrow: ColorScheme
-export var tube: ColorScheme
-export var twilight: ColorScheme
+export const threezerotwofour: Base16Theme;
+export const apathy: Base16Theme;
+export const ashes: Base16Theme;
+export const atelierDune: Base16Theme;
+export const atelierForest: Base16Theme;
+export const atelierHeath: Base16Theme;
+export const atelierLakeside: Base16Theme;
+export const atelierSeaside: Base16Theme;
+export const bespin: Base16Theme;
+export const brewer: Base16Theme;
+export const bright: Base16Theme;
+export const chalk: Base16Theme;
+export const codeschool: Base16Theme;
+export const colors: Base16Theme;
+declare const _default: Base16Theme;
+export default _default;
+export const eighties: Base16Theme;
+export const embers: Base16Theme;
+export const flat: Base16Theme;
+export const google: Base16Theme;
+export const grayscale: Base16Theme;
+export const greenscreen: Base16Theme;
+export const harmonic: Base16Theme;
+export const hopscotch: Base16Theme;
+export const isotope: Base16Theme;
+export const marrakesh: Base16Theme;
+export const monokai: Base16Theme;
+export const ocean: Base16Theme;
+export const paraiso: Base16Theme;
+export const pop: Base16Theme;
+export const railscasts: Base16Theme;
+export const shapeshifter: Base16Theme;
+export const solarized: Base16Theme;
+export const summerfruit: Base16Theme;
+export const tomorrow: Base16Theme;
+export const tube: Base16Theme;
+export const twilight: Base16Theme;

--- a/types/base16/index.d.ts
+++ b/types/base16/index.d.ts
@@ -9,24 +9,24 @@
  * Based on https://github.com/chriskempson/base16
  */
 export interface Base16Theme {
-  scheme: string
-  author: string
-  base00: string
-  base01: string
-  base02: string
-  base03: string
-  base04: string
-  base05: string
-  base06: string
-  base07: string
-  base08: string
-  base09: string
-  base0A: string
-  base0B: string
-  base0C: string
-  base0D: string
-  base0E: string
-  base0F: string
+  scheme: string;
+  author: string;
+  base00: string;
+  base01: string;
+  base02: string;
+  base03: string;
+  base04: string;
+  base05: string;
+  base06: string;
+  base07: string;
+  base08: string;
+  base09: string;
+  base0A: string;
+  base0B: string;
+  base0C: string;
+  base0D: string;
+  base0E: string;
+  base0F: string;
 }
 
 // predefined schemes...

--- a/types/redux-devtools-log-monitor/index.d.ts
+++ b/types/redux-devtools-log-monitor/index.d.ts
@@ -5,7 +5,7 @@
 // TypeScript Version: 2.8
 
 import * as React from 'react'
-import { ColorScheme } from 'base16'
+import { Base16Theme } from 'base16'
 
 interface ILogMonitorProps {
     /**
@@ -14,7 +14,7 @@ interface ILogMonitorProps {
      *
      * @see https://github.com/gaearon/redux-devtools-themes
      */
-    theme?: string | ColorScheme
+    theme?: string | Base16Theme
 
     /**
      * A function that selects the slice of the state for DevTools to show.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gaearon/base16-js/blob/master/src/index.js#L15
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The reason for changing the interface from `ColorScheme` to `Base16Theme` is that I think it more accurately and specifically describes the interface. There are also other references to this type that refer to it as `Base16Theme` (e.g. [this Flow type](https://github.com/alexkuz/react-base16-styling/blob/master/src/types.js.flow#L287-L306)). I'm working on converting [redux-devtools](https://github.com/reduxjs/redux-devtools) to TypeScript and `Base16Theme` would be a more appropriate name in my opinion.
