### PR TITLE
[@types/branch-sdk] Update incorrect function name: getBrowserFingerprint

### DIFF
--- a/types/branch-sdk/branch-sdk-tests.ts
+++ b/types/branch-sdk/branch-sdk-tests.ts
@@ -82,7 +82,7 @@ BranchSDK.setBranchViewData(_custom_data_deep_link_data); // $ExpectType void
 BranchSDK.closeJourney(); // $ExpectType void
 BranchSDK.closeJourney(_noop_callback_without_data); // $ExpectType void
 
-BranchSDK.getBrowserFingerprint(_noop_callback_with_data); // $ExpectType void
+BranchSDK.getBrowserFingerprintId(_noop_callback_with_data); // $ExpectType void
 
 BranchSDK.track('test-event'); // $ExpectType void
 BranchSDK.track('test-event', { foo: 'bar' }); // $ExpectType void

--- a/types/branch-sdk/index.d.ts
+++ b/types/branch-sdk/index.d.ts
@@ -472,7 +472,7 @@ export function logout(callback?: (err: BranchError) => void): void;
  *
  * @param callback callback to read a user's browser-fingerprint-id
  */
-export function getBrowserFingerprint(
+export function getBrowserFingerprintId(
     callback: (err: BranchError, browser_fingerprint: FingerprintResponse) => void,
 ): void;
 


### PR DESCRIPTION
The method name doesn't match. The git history of the sdk seems to indicate that it was always named like this, and hasn't been changed.

This warning is output by `npm test` in master:
> :"The declaration doesn't match the JavaScript module 'branch-sdk'. Reason:\nThe JavaScript module exports a property named 'getBrowserFingerprintId', which is missing from the declaration module."}

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
-- SDK source: https://github.com/BranchMetrics/web-branch-deep-linking-attribution/blob/426790c32cdd0e86cdae30d29387080d568b73cd/src/6_branch.js#L853
-- SDK Documentation: https://help.branch.io/developers-hub/docs/web-full-reference#section-get-browser-fingerprint-id-callback
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.