### PR TITLE
[@types/simpl-schema] Allow passing SimpleSchemaDefinition to extend method

### DIFF
--- a/types/simpl-schema/index.d.ts
+++ b/types/simpl-schema/index.d.ts
@@ -141,7 +141,7 @@ interface SimpleSchemaStatic {
   objectKeys(keyPrefix: any): any[];
   validate(obj: any, options?: ValidationOption): void;
   validator(options?: ValidationOption): (obj: any) => boolean;
-  extend(otherSchema: SimpleSchemaStatic): SimpleSchemaStatic;
+  extend(otherSchema: SimpleSchemaStatic | SimpleSchemaDefinition): SimpleSchemaStatic;
   extendOptions(options: string[]): void;
   RegEx: {
       Email: RegExp;

--- a/types/simpl-schema/simpl-schema-tests.ts
+++ b/types/simpl-schema/simpl-schema-tests.ts
@@ -84,4 +84,7 @@ new SimpleSchema({
     subSchema: StringSchemaWithOptions
 });
 
+SimpleSchema.extend(schema);
+SimpleSchema.extend(StringSchema);
+
 SimpleSchema.extendOptions(['autoform']);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The official readme (https://github.com/aldeed/simpl-schema#extending-schemas) shows that it's possible to pass simple object when extending a schema.
