### PR TITLE
[@types/shopify-buy] Add language to the Config interface

### DIFF
--- a/types/shopify-buy/index.d.ts
+++ b/types/shopify-buy/index.d.ts
@@ -33,6 +33,7 @@ declare namespace ShopifyBuy {
     export interface Config {
         domain: string;
         storefrontAccessToken: string;
+        language?: string;
     }
 
     export interface ProductResource {


### PR DESCRIPTION
If the Shopify store supports multiple languages, the Storefront API can return translated resource types and fields.

```ts
// Initializing a client to return translated content
const clientWithTranslatedContent = Client.buildClient({
  domain: 'your-shop-name.myshopify.com',
  storefrontAccessToken: 'your-storefront-access-token',
  language: 'ja-JP'
});
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Shopify/js-buy-sdk#initializing-the-client
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
N/A as the change require adding locales to the existing shopfront.
