### PR TITLE
[@types/react-native-canvas] Fix Canvas#toDataURL type definition.

### DIFF
--- a/types/react-native-canvas/index.d.ts
+++ b/types/react-native-canvas/index.d.ts
@@ -131,7 +131,7 @@ export interface CanvasRenderingContext2D {
 export default class Canvas extends React.Component<CanvasProps> {
     width: number;
     height: number;
-    toDataURL: () => string;
+    toDataURL: () => Promise<string>;
     getContext: (context: string) => CanvasRenderingContext2D;
 }
 

--- a/types/react-native-canvas/react-native-canvas-tests.tsx
+++ b/types/react-native-canvas/react-native-canvas-tests.tsx
@@ -130,6 +130,20 @@ class CanvasTest extends React.Component {
         });
     }
 
+    handleToDataURL(canvas: Canvas) {
+        canvas.width = 100;
+        canvas.height = 100;
+
+        const context = canvas.getContext('2d');
+
+        context.fillStyle = 'purple';
+        context.fillRect(0, 0, 100, 100);
+
+        canvas.toDataURL().then((dataURL: string) => {
+            void dataURL;
+        });
+    }
+
     render() {
         return (
             <View>
@@ -155,6 +169,9 @@ class CanvasTest extends React.Component {
                     </Example>
                     <Example sample={require('./images/embed-html.png')}>
                         <Canvas ref={this.handleEmbedHTML} />
+                    </Example>
+                    <Example sample={require('./images/to-data-url.png')}>
+                        <Canvas ref={this.handleToDataURL} />
                     </Example>
                 </ScrollView>
             </View>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/iddan/react-native-canvas#canvastodataurl
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
