### PR TITLE
types for @rdfjs/serializer-ntriples

### DIFF
--- a/types/rdfjs__serializer-ntriples/index.d.ts
+++ b/types/rdfjs__serializer-ntriples/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for @rdfjs/serializer-ntriples 1.0
+// Project: https://github.com/rdfjs-base/serializer-ntriples
+// Definitions by: tpluscode <https://github.com/tpluscode>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { EventEmitter } from 'events';
+import { Sink, Stream, BaseQuad, Quad } from 'rdf-js';
+
+
+declare class Serializer<Q extends BaseQuad = Quad> implements Sink<Stream<Q>, EventEmitter> {
+    import(stream: Stream<Q>): EventEmitter;
+}
+
+export = Serializer;

--- a/types/rdfjs__serializer-ntriples/index.d.ts
+++ b/types/rdfjs__serializer-ntriples/index.d.ts
@@ -6,7 +6,6 @@
 import { EventEmitter } from 'events';
 import { Sink, Stream, BaseQuad, Quad } from 'rdf-js';
 
-
 declare class Serializer<Q extends BaseQuad = Quad> implements Sink<Stream<Q>, EventEmitter> {
     import(stream: Stream<Q>): EventEmitter;
 }

--- a/types/rdfjs__serializer-ntriples/rdfjs__serializer-ntriples-tests.ts
+++ b/types/rdfjs__serializer-ntriples/rdfjs__serializer-ntriples-tests.ts
@@ -1,0 +1,11 @@
+import Serializer = require('@rdfjs/serializer-ntriples');
+import { EventEmitter } from 'events';
+import { Sink, Stream } from 'rdf-js';
+
+const stream: Stream = {} as any;
+
+const serializer1 = new Serializer();
+
+const sink: Sink<Stream, EventEmitter> = serializer1;
+
+const eventEmitter1: EventEmitter = serializer1.import(stream);

--- a/types/rdfjs__serializer-ntriples/tsconfig.json
+++ b/types/rdfjs__serializer-ntriples/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@rdfjs/serializer-ntriples": [
+                "rdfjs__serializer-ntriples"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "rdfjs__serializer-ntriples-tests.ts"
+    ]
+}

--- a/types/rdfjs__serializer-ntriples/tslint.json
+++ b/types/rdfjs__serializer-ntriples/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
