### PR TITLE
fix: update apollo-upload-client to v14

### DIFF
--- a/types/apollo-upload-client/index.d.ts
+++ b/types/apollo-upload-client/index.d.ts
@@ -1,11 +1,10 @@
-// Type definitions for apollo-upload-client 8.1
+// Type definitions for apollo-upload-client 14.0
 // Project: https://github.com/jaydenseric/apollo-upload-client#readme
 // Definitions by: Edward Sammut Alessi <https://github.com/Slessi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
-import { ApolloLink } from "apollo-link";
-import { HttpOptions } from "apollo-link-http-common";
+import { ApolloLink, HttpOptions } from "@apollo/client";
 
 export { ReactNativeFile } from "extract-files";
 

--- a/types/apollo-upload-client/package.json
+++ b/types/apollo-upload-client/package.json
@@ -1,8 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "apollo-link": "^1.2.12",
-        "apollo-link-http-common": "^0.2.4",
+        "@apollo/client": "^3.0.0",
         "graphql": "^14.5.3"
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jaydenseric/apollo-upload-client/pull/175
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed