### PR TITLE
[react] Add MutableRefObject as a possible ref property

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -119,7 +119,7 @@ declare namespace React {
         // otherwise it will infer `{}` instead of `never`
         "ref" extends keyof ComponentPropsWithRef<C>
             ? NonNullable<ComponentPropsWithRef<C>["ref"]> extends Ref<
-                infer Instance
+                infer Instance | undefined
             >
                 ? Instance
                 : never
@@ -137,10 +137,10 @@ declare namespace React {
         key?: Key;
     }
     interface RefAttributes<T> extends Attributes {
-        ref?: Ref<T>;
+        ref?: Ref<T> | MutableRefObject<T | undefined>;
     }
     interface ClassAttributes<T> extends Attributes {
-        ref?: LegacyRef<T>;
+        ref?: LegacyRef<T> | MutableRefObject<T | undefined>;
     }
 
     interface ReactElement<P = any, T extends string | JSXElementConstructor<any> = string | JSXElementConstructor<any>> {

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -83,6 +83,23 @@ export function App() {
     </>;
 }
 
+class ClassComponent extends React.Component {
+    render() {
+        return <div />;
+    }
+}
+export function UseRefApp() {
+    const classComponentRef = React.useRef<ClassComponent>(null);
+    const classComponentMutableRef = React.useRef<ClassComponent>();
+
+    return (
+        <>
+            <ClassComponent ref={classComponentRef} />
+            <ClassComponent  ref={classComponentMutableRef} />
+        </>
+    );
+}
+
 interface Context {
     test: true;
 }

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -388,7 +388,7 @@ imgProps.loading = 'nonsense';
 // $ExpectError
 imgProps.decoding = 'nonsense';
 type ImgPropsWithRef = React.ComponentPropsWithRef<'img'>;
-// $ExpectType ((instance: HTMLImageElement | null) => void) | RefObject<HTMLImageElement> | null | undefined
+// $ExpectType ((instance: HTMLImageElement | null) => void) | RefObject<HTMLImageElement> | MutableRefObject<HTMLImageElement | undefined> | null | undefined
 type ImgPropsWithRefRef = ImgPropsWithRef['ref'];
 type ImgPropsWithoutRef = React.ComponentPropsWithoutRef<'img'>;
 // $ExpectType false


### PR DESCRIPTION
Creating a ref with `React.useRef()` without a default initialiser prevents it from being passed as a ref property. This fixes is.
``` tsx
class ClassComponent extends React.Component {
    render() {
        return <div />;
    }
}
export function UseRefApp() {
    const classComponentRef = React.useRef<ClassComponent>(null); // this returns a RefObject<ClassComponent>
    const classComponentMutableRef = React.useRef<ClassComponent>(); // this returns a MutableRefObject<ClassComponent | undefined>

    return (
        <>
            <ClassComponent ref={classComponentRef} />
            // this used to error because ref does not accept MutableRefObject<T | undefined>
            <ClassComponent ref={classComponentMutableRef} />
        </>
    );
}
```

The docs for [useRef](https://reactjs.org/docs/hooks-reference.html#useref) use both `useRef()` and `useRef(null)` and I've seen both usages in the while. So I find it weird that we would prevent the `useRef()` use case form working.


## Template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

