### PR TITLE
[xar] Add typings for xar

### DIFF
--- a/types/xar/index.d.ts
+++ b/types/xar/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for xar 1.1
+// Project: https://github.com/finnp/xar
+// Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node"/>
+
+import { Readable as ReadableStream } from 'stream';
+
+export interface TOCHeader {
+    cksumAlg: number;
+    size: number;
+    tocLengthCompressed: number;
+    tocLengthUncompressed: number;
+    version: number;
+}
+
+export type ExtractCallback = (error: Error | null, file: Record<string, any>, content?: string) => void;
+export type GetTOCCallback = (
+    error: Error | null,
+    xmlBuffer: Buffer,
+    json: Record<string, any>,
+    header: TOCHeader,
+) => void;
+
+export function extract(data: Buffer, cb: ExtractCallback): void;
+export const unpack: typeof extract;
+
+export function pack(dir: string): ReadableStream;
+export const create: typeof pack;
+
+export function getToc(data: Buffer, cb: GetTOCCallback): void;

--- a/types/xar/tsconfig.json
+++ b/types/xar/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "xar-tests.ts"
+    ]
+}

--- a/types/xar/tslint.json
+++ b/types/xar/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/xar/xar-tests.ts
+++ b/types/xar/xar-tests.ts
@@ -1,0 +1,16 @@
+import * as xar from 'xar';
+
+const data = Buffer.from([]);
+
+xar.getToc(data, (err, xmlBuffer, json, header) => {
+    err;
+    xmlBuffer;
+    json;
+    header; // $ExpectType TOCHeader
+});
+
+xar.unpack(data, (error, file, content) => {
+    error;
+    file;
+    content;
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
