### PR TITLE
fix(set-link): currect augmentation

### DIFF
--- a/types/set-link/index.d.ts
+++ b/types/set-link/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import { RequestHandler } from "express";
+import { RequestHandler, Response } from "express";
 
 declare module 'express-serve-static-core' {
     interface Response {
@@ -12,6 +12,6 @@ declare module 'express-serve-static-core' {
     }
 }
 
-declare const middleware: RequestHandler;
+declare const middleware: RequestHandler & { attach(res: Response): void };
 
 export = middleware;

--- a/types/set-link/index.d.ts
+++ b/types/set-link/index.d.ts
@@ -6,7 +6,7 @@
 
 import { RequestHandler } from "express";
 
-declare module 'express' {
+declare module 'express-serve-static-core' {
     interface Response {
         setLink(link: string, rel: string): void;
     }

--- a/types/set-link/set-link-tests.ts
+++ b/types/set-link/set-link-tests.ts
@@ -6,5 +6,6 @@ const app = express();
 app.use(setLink);
 
 function handler(req: express.Request, res: express.Response) {
+    setLink.attach(res);
     res.setLink('http://example.com/', 'self');
 }


### PR DESCRIPTION
I think this is the right way to augment express?

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://stackoverflow.com/a/55718334/1103498>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

