### PR TITLE
[@types/jsforce] Adding replayId and changing createdDate and type to…

### DIFF
--- a/types/jsforce/jsforce-tests.ts
+++ b/types/jsforce/jsforce-tests.ts
@@ -716,7 +716,8 @@ batch.on("response", (rets: sf.BatchResultInfo[]) => {
 
 salesforceConnection.streaming.topic("InvoiceStatementUpdates").subscribe((message) => {
     console.log('Event Type : ' + message.event.type);
-    console.log('Event Created : ' + message.event.createdDate);
+    console.log('Replay Id : ' + message.event.replayId);
+    console.log('Object Id : ' + message.sobject.Id);
     console.log('Object Id : ' + message.sobject.Id);
 });
 const exitCallback = () => process.exit(1);

--- a/types/jsforce/streaming.d.ts
+++ b/types/jsforce/streaming.d.ts
@@ -7,10 +7,11 @@ import { Topic } from './topic';
 
 export interface StreamingMessage {
     event: {
-        type: object
-        createdDate: any;
+        type: string;
+        createdDate: string;
+        replayId?: number;
     };
-    sobject: Record
+    sobject: Record;
 }
 
 export class Streaming extends EventEmitter {
@@ -20,12 +21,12 @@ export class Streaming extends EventEmitter {
     subscribe(name: string, listener: StreamingMessage): any; // Faye Subscription
     topic(name: string): Topic;
     unsubscribe(name: string, listener: StreamingMessage): Streaming;
-    createClient(extensions?: Array<any>): any // Faye Client
+    createClient(extensions?: Array<any>): any; // Faye Client
 }
 
 export namespace StreamingExtension {
     export class Replay {
-        constructor(channel: string, replayId: number)
+        constructor(channel: string, replayId: number);
     }
     export class AuthFailure {
         constructor(failureCallback: () => any);


### PR DESCRIPTION
… string on StreamingMesssage interface

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Docs link here](https://developer.salesforce.com/docs/atlas.en-us.api_streaming.meta/api_streaming/pushtopic_queries.htm) Also, see screenshot below from debugger.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)


![Screen Shot 2020-08-04 at 1 22 52 PM](https://user-images.githubusercontent.com/1296154/89330853-7499f600-d656-11ea-9026-908ed8bbc710.png)

The types for `createdDate` and `type` are both string. These are just json events sent from the faye client which doesn't do any conversion to Date or anything o
