### PR TITLE
update(terser-webpack-plugin): v4 update

### DIFF
--- a/types/terser-webpack-plugin/index.d.ts
+++ b/types/terser-webpack-plugin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for terser-webpack-plugin 3.0
+// Type definitions for terser-webpack-plugin 4.0
 // Project: https://github.com/webpack-contrib/terser-webpack-plugin
 // Definitions by: Daniel Schopf <https://github.com/Danscho>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
@@ -107,13 +107,6 @@ declare namespace TerserPlugin {
          * @default true
          */
         extractComments?: boolean | string | RegExp | ExtractCommentFn | ExtractCommentOptions;
-
-        /**
-         * Allow to filter terser warnings.
-         * ⚠️ The source argument will contain undefined if you don't use source maps.
-         * @default () => true
-         */
-        warningsFilter?: (warning: string, file: string, source?: string) => boolean | null | undefined;
     }
 }
 

--- a/types/terser-webpack-plugin/terser-webpack-plugin-tests.ts
+++ b/types/terser-webpack-plugin/terser-webpack-plugin-tests.ts
@@ -112,24 +112,6 @@ const _ = webpack({
                     banner: false,
                 },
             }),
-            // warningsFilter
-            new TerserPlugin({
-                warningsFilter: (warning, file, source) => {
-                    if (/Dropping unreachable code/i.test(warning)) {
-                        return true;
-                    }
-
-                    if (/file\.js/i.test(file)) {
-                        return true;
-                    }
-
-                    if (/source\.js/i.test(source!)) {
-                        return true;
-                    }
-
-                    return false;
-                },
-            }),
             // varia
             new TerserPlugin({
                 terserOptions: {


### PR DESCRIPTION
This updates definition file to match v4.
Version 4 is breaking and it removes one configuration option:
- `warningsFilter` removed, no replacement
- version bump

https://github.com/webpack-contrib/terser-webpack-plugin/compare/v3.1.0...v4.0.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.