### PR TITLE
[react-select] Add GroupedOptionsType as a valid type for defaultOptions

### DIFF
--- a/types/react-select/src/Async.d.ts
+++ b/types/react-select/src/Async.d.ts
@@ -2,13 +2,13 @@ import * as React from 'react';
 import Select, { Props as SelectProps } from './Select';
 import { handleInputChange } from './utils';
 import manageState from './stateManager';
-import { OptionsType, InputActionMeta, OptionTypeBase } from './types';
+import { GroupedOptionsType, OptionsType, InputActionMeta, OptionTypeBase } from './types';
 
 export interface AsyncProps<OptionType extends OptionTypeBase> {
   /* The default set of options to show before the user starts searching. When
      set to `true`, the results for loadOptions('') will be autoloaded.
      Default: false. */
-  defaultOptions?: OptionsType<OptionType> | boolean;
+  defaultOptions?: GroupedOptionsType<OptionType> | OptionsType<OptionType> | boolean;
   /* Function that returns a promise, which is the set of options to be used
      once the promise resolves. */
   loadOptions: (inputValue: string, callback: ((options: OptionsType<OptionType>) => void)) => Promise<any> | void;


### PR DESCRIPTION
defaultOptions, when not a boolean, substitutes in for the options prop when there is no input. The types for defaultOptions and options should be at parity such that grouped options are supported.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/Async.js#L180
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)