### PR TITLE
React-Phone-Number-Input: Fixing the countrySelectProps to be an object instead of a number

### DIFF
--- a/types/react-phone-number-input/index.d.ts
+++ b/types/react-phone-number-input/index.d.ts
@@ -117,7 +117,7 @@ export interface PhoneInputProps extends Omit<React.InputHTMLAttributes<string>,
      * Country <select/> component props. Along with the usual DOM properties such as aria-label
      * and tabIndex, some custom properties are supported, such as arrowComponent and unicodeFlags.
      */
-    countrySelectProps?: number;
+    countrySelectProps?: object;
     /**
      * A two-letter country code for formatting `value`
      * when a user inputs a national phone number (example: `(213) 373-4253`).

--- a/types/react-phone-number-input/react-phone-number-input-tests.tsx
+++ b/types/react-phone-number-input/react-phone-number-input-tests.tsx
@@ -17,6 +17,7 @@ const test1 = (
         placeholder="Place holder"
         international={true}
         country={'US'}
+        countrySelectProps={{ tabIndex: '-1' }}
     >
         <div>panel 1</div>
         <div>panel 2</div>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://catamphetamine.github.io/react-phone-number-input/docs/styleguide/index.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
