### PR TITLE
Update domutils and htmlparser2 to be pinned to domhandler@2.x

### DIFF
--- a/types/domutils/package.json
+++ b/types/domutils/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+      "domhandler": "^2.4.0"
+  }
+}

--- a/types/htmlparser2/package.json
+++ b/types/htmlparser2/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+      "domhandler": "^2.4.0"
+  }
+}


### PR DESCRIPTION
domhandler@3.x starts to includes [its own type declarations](https://github.com/fb55/domhandler/blob/v3.0.0/src/index.ts). Unfortunately, those type declarations are incompatible with @types/domutils and @types/htmlparser2.

In particular `DomElement` is not defined `domhandler@3.x`'s types. [Here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/domutils/index.d.ts#L6) and [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/htmlparser2/index.d.ts#L17) `domhandler@3.x`'s types could be referenced instead of `@types/domhandler`.

This PR makes it so we are pinned to the right major version of domhandler compatible with the type definitions here.

* * *

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: not changing any types
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing): n/a
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.