### PR TITLE
cloudmersive-virus-api-client: fix arg type for scanWebsite

### DIFF
--- a/types/cloudmersive-virus-api-client/cloudmersive-virus-api-client-tests.ts
+++ b/types/cloudmersive-virus-api-client/cloudmersive-virus-api-client-tests.ts
@@ -42,4 +42,4 @@ apinstance.scanFileAdvanced(
     (error: any, data: CloudmersiveVirusApiClient.VirusScanAdvancedResult, response: any) => {},
 );
 // $ExpectType any
-apinstance.scanWebsite('', (error: any, data: CloudmersiveVirusApiClient.WebsiteScanResult, response: any) => {});
+apinstance.scanWebsite({ Url: '' }, (error: any, data: CloudmersiveVirusApiClient.WebsiteScanResult, response: any) => {});

--- a/types/cloudmersive-virus-api-client/index.d.ts
+++ b/types/cloudmersive-virus-api-client/index.d.ts
@@ -164,7 +164,7 @@ export interface ScanFileAdvanced {
 }
 
 export interface ScanWebsite {
-    (input: string, callback: (error: any, data: WebsiteScanResult, response: any) => any): any;
+    (input: WebsiteScanRequest, callback: (error: any, data: WebsiteScanResult, response: any) => any): any;
 }
 
 export interface VirusFound {


### PR DESCRIPTION
`scanWebsite()` takes a WebsiteScanRequest as its first argument, not
a string. Adjust definition and test to reflect this.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.cloudmersive.com/virus-api
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
