### PR TITLE
Fix types for CSS modules

### DIFF
--- a/types/css-modules/css-modules-tests.ts
+++ b/types/css-modules/css-modules-tests.ts
@@ -1,21 +1,25 @@
-import styles from './main.sass';
-import * as classNames from 'classnames';
+import * as css from './styles.css';
+import * as less from './styles.less';
+import * as sass from './styles.sass';
+import * as scss from './styles.scss';
+import * as styl from './styles.styl';
 
-class App {
-    private readonly theme: string;
-    constructor(theme: string) {
-        this.theme = theme;
-    }
+css; // $ExpectType CSSModule
 
-    render() {
-        // as a style tag (using webpack's css-loader)
-        const tpl = `<div style="${styles.toString()}"></div>`;
-        // or as scoped unique classes, also latest typescript versions allow prop access using dot like styles.darkUI instead of styles['darkUI']
-        return `
-            <div class="${classNames((this.theme === 'dark') ?
-                styles.darkUI :
-                styles.lightUI.toString())}">
-            </div>
-        `;
-    }
-}
+css.customCssClassName; // $ExpectType string
+
+less; // $ExpectType CSSModule
+
+less.customLessClassName; // $ExpectType string
+
+sass; // $ExpectType CSSModule
+
+sass.customSassClassName; // $ExpectType string
+
+scss; // $ExpectType CSSModule
+
+scss.customScssClassName; // $ExpectType string
+
+styl; // $ExpectType CSSModule
+
+styl.customStylClassName; // $ExpectType string

--- a/types/css-modules/index.d.ts
+++ b/types/css-modules/index.d.ts
@@ -1,38 +1,61 @@
 // Type definitions for css-modules 1.0
 // Project: https://github.com/css-modules/css-modules
 // Definitions by: NeekSandhu <https://github.com/NeekSandhu>
+//                 Remco Haszing <https://github.com/remcohaszing>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-interface Stringifyable {
+interface CSSModule {
     /**
-     * Stringifies the imported stylesheet for use with inline style tags
-     */
-    toString(): string;
-}
-interface SelectorNode {
-    /**
-     * Returns the specific selector from imported stylesheet as string
+     * Returns the specific selector from imported stylesheet as string.
      */
     [key: string]: string;
 }
 
 declare module '*.css' {
-    const styles: SelectorNode & Stringifyable;
-    export default styles;
+    /**
+     * A CSS module.
+     */
+    const styles: CSSModule;
+    export = styles;
 }
 
 declare module '*.scss' {
-    const styles: SelectorNode & Stringifyable;
-    export default styles;
+    /**
+     * An SCSS based CSS module.
+     *
+     * https://sass-lang.com
+     */
+    const styles: CSSModule;
+    export = styles;
 }
 
 declare module '*.sass' {
-    const styles: SelectorNode & Stringifyable;
-    export default styles;
+    /**
+     * A Sass based CSS module.
+     *
+     * https://sass-lang.com
+     */
+    const styles: CSSModule;
+    export = styles;
 }
 
 declare module '*.less' {
-    const styles: SelectorNode & Stringifyable;
-    export default styles;
+    /**
+     * A Less based CSS module.
+     *
+     * http://lesscss.org
+     */
+    const styles: CSSModule;
+    export = styles;
+}
+
+declare module '*.styl' {
+    /**
+     * A Stylus based CSS module.
+     *
+     * https://stylus-lang.com
+     */
+    const styles: CSSModule;
+    export = styles;
 }


### PR DESCRIPTION
CSS modules are exported using `module.exports`, not as default export.

The `toString()` method has been removed, because it exists on objects by default.

`SelectorNode` has been renamed to `CSSModule`, because this is more in line with the CSS modules documentation.

Support has been added for `.styl` files.

TSDoc has been added for each module type.

The tests have been adjusted to test every module type. Also the tests are now more to the point on a technical level
instead of representing example usage.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.