### PR TITLE
Define cloudfront headers closer to an object in aws-lambda

### DIFF
--- a/types/aws-lambda/common/cloudfront.d.ts
+++ b/types/aws-lambda/common/cloudfront.d.ts
@@ -9,7 +9,7 @@ export interface CloudFrontHeaders {
     [name: string]: Array<{
         key?: string;
         value: string;
-    }>;
+    }> | undefined;
 }
 
 export type CloudFrontOrigin =


### PR DESCRIPTION
## Change
When getting the headers of a lambda@edge request it is possible for some headers to just not exist in that object, but with the current definitions it is assumed that it's impossible for a header not to be defined, this PR brings the type closer to the definition of an object by simply adding undefined as a possible value, thus acknowledging the possibility of a missing header.

## Problems
This change could be backwards incompatible, but if someone isn't testing whether a header exists in their cloudfront headers then their code is probably broken already.

## Boilerplate
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I don't think that the following items are relevant for this PR (maybe testing? I'm not sure how to test for this)

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>> -> Not relevant
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. -> No substantial changes
