### PR TITLE
[json-stream-stringify] Expose stack property

### DIFF
--- a/types/json-stream-stringify/index.d.ts
+++ b/types/json-stream-stringify/index.d.ts
@@ -9,4 +9,5 @@ import { Readable } from "stream";
 export default class JsonStreamStringify extends Readable {
     constructor(value: any, replacer?: ((key: any, value: any) => any) | any[], spaces?: string | number, cycle?: boolean);
     path(): [string, number];
+    stack: string[];
 }

--- a/types/json-stream-stringify/json-stream-stringify-tests.ts
+++ b/types/json-stream-stringify/json-stream-stringify-tests.ts
@@ -162,4 +162,5 @@ jsonStream = new JsonStreamStringify({}, undefined, undefined, true);
     const a = { foo: 'bar' };
     const arr = [a, a];
     jsonStream = new JsonStreamStringify(arr);
+    jsonStream.stack.join('');
 }


### PR DESCRIPTION
This property exists in the main documentation for how to surface errors
during the stringification.

Source: https://github.com/Faleij/json-stream-stringify/blob/ea93309addc1bad9d6179cdce0f09f42db2c82e8/README.md#L114

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

