### PR TITLE
[react] mark KeyboardEvent keyCode and charCode as deprecated

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1200,6 +1200,7 @@ declare namespace React {
 
     interface KeyboardEvent<T = Element> extends SyntheticEvent<T, NativeKeyboardEvent> {
         altKey: boolean;
+        /** @deprecated */
         charCode: number;
         ctrlKey: boolean;
         /**
@@ -1210,6 +1211,7 @@ declare namespace React {
          * See the [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#named-key-attribute-values). for possible values
          */
         key: string;
+        /** @deprecated */
         keyCode: number;
         locale: string;
         location: number;


### PR DESCRIPTION
Following up from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45267...

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/microsoft/TypeScript/blob/2ebdf9fdce23184416e30bb6140a9ece6d81052d/lib/lib.dom.d.ts#L9646
  - https://github.com/microsoft/TypeScript/blob/2ebdf9fdce23184416e30bb6140a9ece6d81052d/lib/lib.dom.d.ts#L9652
  - https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
  - https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/charCode
