### PR TITLE
Rewrite (thereby fix) types for express-session (second attempt)

### DIFF
--- a/types/cassandra-store/index.d.ts
+++ b/types/cassandra-store/index.d.ts
@@ -6,7 +6,7 @@
 
 /// <reference types="express" />
 
-import { Store } from 'express-session';
+import { Store, SessionData } from 'express-session';
 import { ClientOptions, Client, EmptyCallback } from 'cassandra-driver';
 
 interface CassandraStoreOptions {
@@ -34,4 +34,13 @@ declare class CassandraStore extends Store {
     get table(): string;
 
     set table(value: string);
+
+    get(sid: string, callback: (err: any, session?: SessionData | null) => void): void;
+    set(sid: string, session: SessionData, callback?: (err?: any) => void): void;
+    destroy(sid: string, callback?: (err?: any) => void): void;
+
+    all(callback: (err: any, obj?: SessionData[] | { [sid: string]: SessionData; } | null) => void): void;
+    length(callback: (err: any, length: number) => void): void;
+    clear(callback?: (err?: any) => void): void;
+    touch(sid: string, session: SessionData, callback?: () => void): void;
 }

--- a/types/connect-azuretables/index.d.ts
+++ b/types/connect-azuretables/index.d.ts
@@ -18,7 +18,7 @@ declare namespace connectAzureTable {
     interface AzureTableStore extends session.Store {
         startBackgroundCleanUp(): void;
         cleanUp(): void;
-        update(method: 'SET' | 'TOUCH', sid: string, session: Express.SessionData, callback?: (err: any) => void): void;
+        update(method: 'SET' | 'TOUCH', sid: string, session: session.SessionData, callback?: (err: any) => void): void;
     }
     interface AzureTableStoreOptions {
         logger?: (message: string) => void;

--- a/types/connect-pg-simple/connect-pg-simple-tests.ts
+++ b/types/connect-pg-simple/connect-pg-simple-tests.ts
@@ -1,12 +1,13 @@
 import connectPgSimple = require("connect-pg-simple");
 import session = require("express-session");
+import { Store } from "express-session";
 import * as pg from "pg";
 import express = require('express');
 
 const pgSession = connectPgSimple(session);
 
 const pgPool = new pg.Pool({});
-const store1: session.Store = new pgSession({
+const store1: Store = new pgSession({
     pool: pgPool,
     tableName: "user_sessions",
     pruneSessionInterval: 300
@@ -18,7 +19,7 @@ app.use(session({
     secret: "foo"
 }));
 
-const store2: session.Store = new pgSession({
+const store2: Store = new pgSession({
     conString: "postgres://postgres@localhost:5432/foo",
     ttl: 3600,
     schemaName: "someschema",

--- a/types/connect-pg-simple/index.d.ts
+++ b/types/connect-pg-simple/index.d.ts
@@ -5,7 +5,7 @@
 // TypeScript Version: 2.4
 
 import { RequestHandler } from "express";
-import { Store, SessionOptions } from "express-session";
+import { Store, SessionData, SessionOptions } from "express-session";
 import { Pool, PoolConfig } from "pg";
 
 declare function connectPgSimple(session: (options?: SessionOptions) => RequestHandler): typeof connectPgSimple.PGStore;
@@ -15,6 +15,12 @@ declare namespace connectPgSimple {
       constructor(options?: PGStoreOptions);
       close(): void;
       pruneSessions(callback?: (err: Error) => void): void;
+
+      get(sid: string, callback: (err: any, session?: SessionData | null) => void): void;
+      set(sid: string, session: SessionData, callback?: (err?: any) => void): void;
+      destroy(sid: string, callback?: (err?: any) => void): void;
+
+      touch(sid: string, session: SessionData, callback?: () => void): void;
   }
   interface PGStoreOptions {
       pool?: Pool;

--- a/types/connect-redis/index.d.ts
+++ b/types/connect-redis/index.d.ts
@@ -29,7 +29,7 @@ declare module 'connect-redis' {
             port?: number;
             socket?: string;
             url?: string;
-            ttl?: number | string | ((store: RedisStore, sess: Express.SessionData, sid: string) => number);
+            ttl?: number | string | ((store: RedisStore, sess: session.SessionData, sid: string) => number);
             disableTTL?: boolean;
             disableTouch?: boolean;
             db?: number;

--- a/types/easy-session/easy-session-tests.ts
+++ b/types/easy-session/easy-session-tests.ts
@@ -1,6 +1,3 @@
-
-/// <reference types="express-session" />
-
 import express = require('express');
 import session = require('express-session');
 import cookieParser = require('cookie-parser');

--- a/types/easy-session/index.d.ts
+++ b/types/easy-session/index.d.ts
@@ -4,18 +4,16 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-/// <reference types="express" />
+import express = require('express');
+import expressSession = require('express-session');
 
-declare namespace Express {
-    interface ErrorCallback {
-        (err?: any): void;
-    }
-    export interface Session {
+declare module 'express-session' {
+    interface Session {
         login(callback: Function): void;
-        login(extend: Object, callback: ErrorCallback): void;
-        login(role: string, callback: ErrorCallback): void;
-        login(role: string, extend: Object, callback: ErrorCallback): void;
-        logout(callback: ErrorCallback): void;
+        login(extend: Object, callback: (err?: any) => void): void;
+        login(role: string, callback: (err?: any) => void): void;
+        login(role: string, extend: Object, callback: (err?: any) => void): void;
+        logout(callback: (err?: any) => void): void;
         isLoggedIn(role?: string): boolean;
         isGuest(): boolean;
         isFresh(): boolean;
@@ -25,18 +23,14 @@ declare namespace Express {
     }
 }
 
-declare module "easy-session" {
-    import express = require('express');
-
-    interface SessionOptions {
-        ipCheck?: boolean;
-        uaCheck?: boolean;
-        freshTimeout?: number;
-        maxFreshTimeout?: number;
-    }
-
-    export function main(session: any, options?: SessionOptions): express.RequestHandler;
-    export function isLoggedIn(errorCallback?: Function): express.RequestHandler;
-    export function isFresh(errorCallback?: Function): express.RequestHandler;
-    export function checkRole(role: string, errorCallback?: Function): express.RequestHandler;
+export interface SessionOptions {
+    ipCheck?: boolean;
+    uaCheck?: boolean;
+    freshTimeout?: number;
+    maxFreshTimeout?: number;
 }
+
+export function main(session: typeof expressSession, options?: SessionOptions): express.RequestHandler;
+export function isLoggedIn(errorCallback?: (err?: any) => void): express.RequestHandler;
+export function isFresh(errorCallback?: (err?: any) => void): express.RequestHandler;
+export function checkRole(role: string, errorCallback?: (err?: any) => void): express.RequestHandler;

--- a/types/express-session/express-session-tests.ts
+++ b/types/express-session/express-session-tests.ts
@@ -1,5 +1,6 @@
 import express = require('express');
 import session = require('express-session');
+import { SessionData, Store, MemoryStore, Session, InitializedSession } from 'express-session';
 
 const app = express();
 
@@ -26,7 +27,7 @@ app.use(session({
 app.use(session({
   secret: 'keyboard cat',
   name: 'connect.sid',
-  store: new session.MemoryStore(),
+  store: new MemoryStore(),
   cookie: { path: '/', httpOnly: true, secure: false, sameSite: true },
   genid: (req: express.Request): string => '',
   rolling: false,
@@ -43,27 +44,35 @@ app.use(session({
     unset: 'keep'
 }));
 
-interface MySession extends Express.Session {
-  views: number;
+// Example of adding additional properties to SessionData using declaration merging
+declare module 'express-session' {
+    interface SessionData {
+        views: number;
+    }
+}
+
+// Example of using a function with a type-assertion return type to differentiate between (un)initialized sessions
+function isSessionInitialized(session: Session | InitializedSession): session is InitializedSession {
+    return (session as InitializedSession).views !== undefined;
 }
 
 app.use((req, res, next) => {
-  const sess = req.session as MySession;
-  if (sess.views) {
+  const sess = req.session;
+  if (isSessionInitialized(sess)) {
     sess.views++;
     res.setHeader('Content-Type', 'text/html');
     res.write(`<p>views: ${sess.views}</p>`);
     res.write(`<p>expires in: ${((sess.cookie.maxAge || 0) / 1000)}s</p>`);
     res.end();
   } else {
-    sess.views = 1;
+    (sess as InitializedSession).views = 1;
     res.end('welcome to the session demo. refresh!');
   }
 });
 
 // Custom Session Store
 
-class MyStore extends session.Store {
+class MyStore extends Store {
   private sessions: { [sid: string]: string | undefined };
 
   constructor() {
@@ -71,13 +80,13 @@ class MyStore extends session.Store {
     this.sessions = {};
   }
 
-  get = (sid: string, callback: (err: any, session?: Express.SessionData | null) => void): void => {
+  get = (sid: string, callback: (err: any, session?: SessionData | null) => void): void => {
     const sessionString: string | undefined = this.sessions[sid];
-    const sessionData: Express.SessionData | null = sessionString ? JSON.parse(sessionString) : null;
+    const sessionData: SessionData | null = sessionString ? JSON.parse(sessionString) : null;
     callback(null, sessionData);
   }
 
-  set = (sid: string, session: Express.SessionData, callback?: (err?: any) => void): void => {
+  set = (sid: string, session: SessionData, callback?: (err?: any) => void): void => {
     this.sessions[sid] = JSON.stringify(session);
     if (callback) callback();
   }

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -6,118 +6,356 @@
 //                 Ryan Cannon <https://github.com/ry7n>
 //                 Tom Spencer <https://github.com/fiznool>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+//                 Ravi van Rooijen <https://github.com/HoldYourWaffle>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-/// <reference types="node" />
-
 import express = require('express');
-import node = require('events');
+import { EventEmitter } from 'events';
 
 declare global {
-  namespace Express {
-    interface Request {
-      session?: Session;
-      sessionID?: string;
-    }
+    namespace Express {
+        // Inject additional properties on express.Request
+        interface Request {
+            /**
+             * This request's `Session` object.
+             * Even though this property isn't marked as optional, it won't exist until you use the `express-session` middleware
+             * [Declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) can be used to add your own properties.
+             *
+             * @see SessionData
+             */
+            session: session.Session | session.InitializedSession;
 
-    interface SessionData {
-      [key: string]: any;
-      cookie: SessionCookieData;
+            /**
+             * This request's session ID.
+             * Even though this property isn't marked as optional, it won't exist until you use the `express-session` middleware
+             */
+            sessionID: string;
+        }
     }
-
-    interface SessionCookieData {
-      originalMaxAge: number;
-      path: string;
-      maxAge: number | null;
-      secure?: boolean;
-      httpOnly: boolean;
-      domain?: string;
-      expires: Date | boolean;
-      sameSite?: boolean | string;
-    }
-
-    interface SessionCookie extends SessionCookieData {
-      serialize(name: string, value: string): string;
-    }
-
-    interface Session extends SessionData {
-      id: string;
-      regenerate(callback: (err: any) => void): void;
-      destroy(callback: (err: any) => void): void;
-      reload(callback: (err: any) => void): void;
-      save(callback: (err: any) => void): void;
-      touch(): void;
-      cookie: SessionCookie;
-    }
-  }
 }
+
+export = session;
 
 declare function session(options?: session.SessionOptions): express.RequestHandler;
 
 declare namespace session {
-  interface SessionOptions {
-    secret: string | string[];
-    name?: string;
-    store?: Store | MemoryStore;
-    cookie?: {
-      maxAge?: number;
-      signed?: boolean;
-      expires?: Date;
-      httpOnly?: boolean;
-      path?: string;
-      domain?: string;
-      secure?: boolean | 'auto';
-      encode?: (val: string) => string;
-      sameSite?: boolean | 'lax' | 'strict' | 'none';
-    };
-    genid?(req: express.Request): string;
-    rolling?: boolean;
-    resave?: boolean;
-    proxy?: boolean;
-    saveUninitialized?: boolean;
+    type InitializedSession = Session & SessionData;
+
+    interface SessionOptions {
+        /**
+         * This is the secret used to sign the session cookie. This can be either a string for a single secret, or an array of multiple secrets.
+         * If an array of secrets is provided, **only the first element will be used to sign** the session ID cookie,
+         *   while **all the elements will be considered when verifying the signature** in requests.
+         * The secret itself should be not easily parsed by a human and would best be a random set of characters
+         *
+         * Best practices may include:
+         * - The use of environment variables to store the secret, ensuring the secret itself does not exist in your repository.
+         * - Periodic updates of the secret, while ensuring the previous secret is in the array.
+         *
+         * Using a secret that cannot be guessed will reduce the ability to hijack a session to only guessing the session ID (as determined by the `genid` option).
+         *
+         * Changing the secret value will invalidate all existing sessions.
+         * In order to rotate the secret without invalidating sessions, provide an array of secrets,
+         *   with the new secret as first element of the array, and including previous secrets as the later elements.
+         */
+        secret: string | string[];
+
+        /**
+         * Function to call to generate a new session ID. Provide a function that returns a string that will be used as a session ID.
+         * The function is given the request as the first argument if you want to use some value attached to it when generating the ID.
+         *
+         * The default value is a function which uses the uid-safe library to generate IDs.
+         * Be careful to generate unique IDs so your sessions do not conflict.
+         */
+        genid?(req: express.Request): string;
+
+        /**
+         * The name of the session ID cookie to set in the response (and read from in the request).
+         * The default value is 'connect.sid'.
+         *
+         * Note if you have multiple apps running on the same hostname (this is just the name, i.e. `localhost` or `127.0.0.1`; different schemes and ports do not name a different hostname),
+         *   then you need to separate the session cookies from each other.
+         * The simplest method is to simply set different names per app.
+         */
+        name?: string;
+
+        /**
+         * The session store instance, defaults to a new `MemoryStore` instance.
+         * @see MemoryStore
+         */
+        store?: Store;
+
+        /**
+         * Settings object for the session ID cookie.
+         * @see CookieOptions
+         */
+        cookie?: CookieOptions;
+
+        /**
+         * Force the session identifier cookie to be set on every response. The expiration is reset to the original `maxAge`, resetting the expiration countdown.
+         * The default value is `false`.
+         *
+         * With this enabled, the session identifier cookie will expire in `maxAge` *since the last response was sent* instead of in `maxAge` *since the session was last modified by the server*.
+         * This is typically used in conjuction with short, non-session-length `maxAge` values to provide a quick timeout of the session data
+         *   with reduced potential of it occurring during on going server interactions.
+         *
+         * Note that when this option is set to `true` but the `saveUninitialized` option is set to `false`, the cookie will not be set on a response with an uninitialized session.
+         * This option only modifies the behavior when an existing session was loaded for the request.
+         *
+         * @see saveUninitialized
+         */
+        rolling?: boolean;
+
+        /**
+         * Forces the session to be saved back to the session store, even if the session was never modified during the request.
+         * Depending on your store this may be necessary, but it can also create race conditions where a client makes two parallel requests to your server
+         *   and changes made to the session in one request may get overwritten when the other request ends, even if it made no changes (this behavior also depends on what store you're using).
+         *
+         * The default value is `true`, but using the default has been deprecated, as the default will change in the future.
+         * Please research into this setting and choose what is appropriate to your use-case. Typically, you'll want `false`.
+         *
+         * How do I know if this is necessary for my store? The best way to know is to check with your store if it implements the `touch` method.
+         * If it does, then you can safely set `resave: false`.
+         * If it does not implement the `touch` method and your store sets an expiration date on stored sessions, then you likely need `resave: true`.
+         */
+        resave?: boolean;
+
+        /**
+         * Trust the reverse proxy when setting secure cookies (via the "X-Forwarded-Proto" header).
+         * The default value is undefined.
+         *
+         * - `true`: The `X-Forwarded-Proto` header will be used.
+         * - `false`: All headers are ignored and the connection is considered secure only if there is a direct TLS/SSL connection.
+         * - `undefined`: Uses the "trust proxy" setting from express
+         */
+        proxy?: boolean;
+
+        /**
+         * Forces a session that is "uninitialized" to be saved to the store. A session is uninitialized when it is new but not modified.
+         * Choosing `false` is useful for implementing login sessions, reducing server storage usage, or complying with laws that require permission before setting a cookie.
+         * Choosing `false` will also help with race conditions where a client makes multiple parallel requests without a session.
+         *
+         * The default value is `true`, but using the default has been deprecated, as the default will change in the future.
+         * Please research into this setting and choose what is appropriate to your use-case.
+         *
+         * **If you are using `express-session` in conjunction with PassportJS:**
+         * Passport will add an empty Passport object to the session for use after a user is authenticated, which will be treated as a modification to the session, causing it to be saved.
+         * This has been fixed in PassportJS 0.3.0.
+         */
+        saveUninitialized?: boolean;
+
+        /**
+         * Control the result of unsetting req.session (through delete, setting to null, etc.).
+         * - `destroy`: The session will be destroyed (deleted) when the response ends.
+         * - `keep`: The session in the store will be kept, but modifications made during the request are ignored and not saved.
+         * @default 'keep'
+         */
+        unset?: 'destroy' | 'keep';
+    }
+
+    class Session {
+        private constructor(request: Express.Request, data: SessionData);
+
+        /**
+         * Each session has a unique ID associated with it.
+         * This property is an alias of `req.sessionID` and cannot be modified.
+         * It has been added to make the session ID accessible from the session object.
+         */
+        id: string;
+
+        /**
+         * Each session has a unique cookie object accompany it.
+         * This allows you to alter the session cookie per visitor.
+         * For example we can set `req.session.cookie.expires` to `false` to enable the cookie to remain for only the duration of the user-agent.
+         */
+        cookie: Cookie;
+
+        /** To regenerate the session simply invoke the method. Once complete, a new SID and `Session` instance will be initialized at `req.session` and the `callback` will be invoked. */
+        regenerate(callback: (err: any) => void): this;
+
+        /** Destroys the session and will unset the `req.session` property. Once complete, the `callback` will be invoked. */
+        destroy(callback: (err: any) => void): this;
+
+        /** Reloads the session data from the store and re-populates the `req.session` object. Once complete, the `callback` will be invoked. */
+        reload(callback: (err: any) => void): this;
+
+        /**
+         * Resets the cookie's `maxAge` to `originalMaxAge`
+         * @see Cookie
+         */
+        resetMaxAge(): this;
+
+        /**
+         * Save the session back to the store, replacing the contents on the store with the contents in memory
+         *   (though a store may do something else - consult the store's documentation for exact behavior).
+         *
+         * This method is automatically called at the end of the HTTP response if the session data has been altered
+         *   (though this behavior can be altered with various options in the middleware constructor).
+         * Because of this, typically this method does not need to be called.
+         * There are some cases where it is useful to call this method, for example: redirects, long-lived requests or in WebSockets.
+         */
+        save(callback?: (err: any) => void): this;
+
+        /** Updates the `maxAge` property. Typically this is not necessary to call, as the session middleware does this for you. */
+        touch(): this;
+    }
+
     /**
-     * Control the result of unsetting req.session (through delete, setting to null, etc.).
-     * - 'destroy' The session will be destroyed (deleted) when the response ends.
-     * - 'keep' The session in the store will be kept, but modifications made during the request are ignored and not saved.
-     * @default 'keep'
+     * This interface allows you to declare additional properties on your session object using [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html).
+     *
+     * @example
+     * declare module 'express-session' {
+     *     interface SessionData {
+     *         views: number;
+     *     }
+     * }
+     *
      */
-    unset?: 'destroy' | 'keep';
-  }
+    // tslint:disable-next-line no-empty-interface
+    interface SessionData {
+    }
 
-  interface BaseMemoryStore {
-    get: (sid: string, callback: (err: any, session?: Express.SessionData | null) => void) => void;
-    set: (sid: string, session: Express.Session, callback?: (err?: any) => void) => void;
-    destroy: (sid: string, callback?: (err?: any) => void) => void;
-    length?: (callback: (err: any, length?: number | null) => void) => void;
-    clear?: (callback?: (err?: any) => void) => void;
-  }
+    interface CookieOptions {
+        /**
+         * Specifies the number (in milliseconds) to use when calculating the `Expires Set-Cookie` attribute.
+         * This is done by taking the current server time and adding `maxAge` milliseconds to the value to calculate an `Expires` datetime. By default, no maximum age is set.
+         *
+         * If both `expires` and `maxAge` are set in the options, then the last one defined in the object is what is used.
+         * `maxAge` should be preferred over `expires`.
+         *
+         * @see expires
+         */
+        maxAge?: number;
 
-  abstract class Store extends node.EventEmitter {
-    constructor(config?: any);
+        signed?: boolean;
 
-    regenerate: (req: express.Request, fn: (err?: any) => any) => void;
-    load: (sid: string, fn: (err: any, session?: Express.SessionData | null) => any) => void;
-    createSession: (req: express.Request, sess: Express.SessionData) => void;
+        /**
+         * Specifies the `Date` object to be the value for the `Expires Set-Cookie` attribute.
+         * By default, no expiration is set, and most clients will consider this a "non-persistent cookie" and will delete it on a condition like exiting a web browser application.
+         *
+         * If both `expires` and `maxAge` are set in the options, then the last one defined in the object is what is used.
+         *
+         * @deprecated The `expires` option should not be set directly; instead only use the `maxAge` option
+         * @see maxAge
+         */
+        expires?: Date;
 
-    get: (sid: string, callback: (err: any, session?: Express.SessionData | null) => void) => void;
-    set: (sid: string, session: Express.SessionData, callback?: (err?: any) => void) => void;
-    destroy: (sid: string, callback?: (err?: any) => void) => void;
-    all: (callback: (err: any, obj?: { [sid: string]: Express.SessionData; } | null) => void) => void;
-    length: (callback: (err: any, length?: number | null) => void) => void;
-    clear: (callback?: (err?: any) => void) => void;
-    touch: (sid: string, session: Express.SessionData, callback?: (err?: any) => void) => void;
-  }
+        /**
+         * Specifies the boolean value for the `HttpOnly Set-Cookie` attribute. When truthy, the `HttpOnly` attribute is set, otherwise it is not.
+         * By default, the `HttpOnly` attribute is set.
+         *
+         * Be careful when setting this to `true`, as compliant clients will not allow client-side JavaScript to see the cookie in `document.cookie`.
+         */
+        httpOnly?: boolean;
 
-  class MemoryStore implements BaseMemoryStore {
-    get: (sid: string, callback: (err: any, session?: Express.SessionData | null) => void) => void;
-    set: (sid: string, session: Express.SessionData, callback?: (err?: any) => void) => void;
-    destroy: (sid: string, callback?: (err?: any) => void) => void;
-    all?: (callback: (err: any, obj?: Express.SessionData[] | { [sid: string]: Express.SessionData; } | null) => void) => void;
-    length?: (callback: (err: any, length?: number | null) => void) => void;
-    clear?: (callback?: (err?: any) => void) => void;
-    touch: (sid: string, session: Express.SessionData, callback?: (err?: any) => void) => void;
-  }
+        /**
+         * Specifies the value for the `Path Set-Cookie` attribute.
+         * By default, this is set to '/', which is the root path of the domain.
+         */
+        path?: string;
+
+        /**
+         * Specifies the value for the `Domain Set-Cookie` attribute.
+         * By default, no domain is set, and most clients will consider the cookie to apply to only the current domain.
+         */
+        domain?: string;
+
+        /**
+         * Specifies the boolean value for the `Secure Set-Cookie` attribute. When truthy, the `Secure` attribute is set, otherwise it is not. By default, the `Secure` attribute is not set.
+         * Be careful when setting this to true, as compliant clients will not send the cookie back to the server in the future if the browser does not have an HTTPS connection.
+         *
+         * Please note that `secure: true` is a **recommended option**.
+         * However, it requires an https-enabled website, i.e., HTTPS is necessary for secure cookies.
+         * If `secure` is set, and you access your site over HTTP, **the cookie will not be set**.
+         *
+         * The cookie.secure option can also be set to the special value `auto` to have this setting automatically match the determined security of the connection.
+         * Be careful when using this setting if the site is available both as HTTP and HTTPS, as once the cookie is set on HTTPS, it will no longer be visible over HTTP.
+         * This is useful when the Express "trust proxy" setting is properly setup to simplify development vs production configuration.
+         *
+         * If you have your node.js behind a proxy and are using `secure: true`, you need to set "trust proxy" in express. Please see the [README](https://github.com/expressjs/session) for details.
+         *
+         * Please see the [README](https://github.com/expressjs/session) for an example of using secure cookies in production, but allowing for testing in development based on NODE_ENV.
+         */
+        secure?: boolean | 'auto';
+
+        encode?: (val: string) => string;
+
+        /**
+         * Specifies the boolean or string to be the value for the `SameSite Set-Cookie` attribute.
+         * - `true` will set the `SameSite` attribute to `Strict` for strict same site enforcement.
+         * - `false` will not set the `SameSite` attribute.
+         * - `lax` will set the `SameSite` attribute to `Lax` for lax same site enforcement.
+         * - `none` will set the `SameSite` attribute to `None` for an explicit cross-site cookie.
+         * - `strict` will set the `SameSite` attribute to `Strict` for strict same site enforcement.
+         *
+         * More information about the different enforcement levels can be found in the specification.
+         *
+         * **Note:** This is an attribute that has not yet been fully standardized, and may change in the future.
+         * This also means many clients may ignore this attribute until they understand it.
+         */
+        sameSite?: boolean | 'lax' | 'strict' | 'none';
+    }
+
+    class Cookie implements CookieOptions {
+        /** Returns the original `maxAge` (time-to-live), in milliseconds, of the session cookie. */
+        originalMaxAge: number;
+
+        maxAge?: number;
+        signed?: boolean;
+        expires?: Date;
+        httpOnly?: boolean;
+        path?: string;
+        domain?: string;
+        secure?: boolean | 'auto';
+        sameSite?: boolean | 'lax' | 'strict' | 'none';
+    }
+
+    abstract class Store extends EventEmitter {
+        regenerate(req: express.Request, callback: (err?: any) => any): void;
+        load(sid: string, callback: (err: any, session?: SessionData) => any): void;
+        createSession(req: express.Request, session: SessionData): void;
+
+        /**
+         * Gets the session from the store given a session ID and passes it to `callback`.
+         *
+         * The `session` argument should be a `Session` object if found, otherwise `null` or `undefined` if the session was not found and there was no error.
+         * A special case is made when `error.code === 'ENOENT'` to act like `callback(null, null)`.
+         */
+        abstract get(sid: string, callback: (err: any, session?: SessionData | null) => void): void;
+
+        /** Upsert a session in the store given a session ID and `SessionData` */
+        abstract set(sid: string, session: SessionData, callback?: (err?: any) => void): void;
+
+        /** Destroys the dession with the given session ID. */
+        abstract destroy(sid: string, callback?: (err?: any) => void): void;
+
+        /** Returns all sessions in the store */
+        // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38783, https://github.com/expressjs/session/pull/700#issuecomment-540855551
+        all?(callback: (err: any, obj?: SessionData[] | { [sid: string]: SessionData; } | null) => void): void;
+
+        /** Returns the amount of sessions in the store. */
+        length?(callback: (err: any, length: number) => void): void;
+
+        /** Delete all sessions from the store. */
+        clear?(callback?: (err?: any) => void): void;
+
+        /** "Touches" a given session, resetting the idle timer. */
+        touch?(sid: string, session: SessionData, callback?: () => void): void;
+    }
+
+    /**
+     * **Warning:** the default server-side session storage, `MemoryStore`, is purposely not designed for a production environment.
+     * It will leak memory under most conditions, does not scale past a single process, and is only meant for debugging and developing.
+     */
+    class MemoryStore extends Store {
+        get(sid: string, callback: (err: any, session?: SessionData | null) => void): void;
+        set(sid: string, session: SessionData, callback?: (err?: any) => void): void;
+        destroy(sid: string, callback?: (err?: any) => void): void;
+
+        all(callback: (err: any, obj?: { [sid: string]: SessionData; } | null) => void): void;
+        length(callback: (err: any, length: number) => void): void;
+        clear(callback?: (err?: any) => void): void;
+        touch(sid: string, session: SessionData, callback?: () => void): void;
+    }
 }
-
-export = session;

--- a/types/express-socket.io-session/express-socket.io-session-tests.ts
+++ b/types/express-socket.io-session/express-socket.io-session-tests.ts
@@ -21,6 +21,14 @@ import socketio = require('socket.io');
 const io = socketio(server);
 
 import sharedsession = require('express-socket.io-session');
+import { InitializedSession } from 'express-session';
+
+declare module 'express-session' {
+    interface SessionData {
+        sessionEntry: any;
+        anotherSessionEntry: any;
+    }
+}
 
 io.use(sharedsession(session));
 io.use(sharedsession(session, { autoSave: true, saveUninitialized: true }));
@@ -33,8 +41,8 @@ io.on('connection', (socket) => {
         socket.handshake.session!.id
     ];
     const sessionData = [
-        socket.handshake.session!['sessionEntry'],
-        socket.handshake.session!.anotherSessionEntry
+        (socket.handshake.session as InitializedSession).sessionEntry,
+        (socket.handshake.session as InitializedSession).anotherSessionEntry
     ];
     socket.handshake.session!.touch();
     socket.handshake.session!.regenerate(() => {});

--- a/types/express-socket.io-session/index.d.ts
+++ b/types/express-socket.io-session/index.d.ts
@@ -6,10 +6,11 @@
 
 import socketio = require('socket.io');
 import express = require('express');
+import session = require('express-session');
 
 declare module "socket.io" {
     interface Handshake {
-        session?: Express.Session;
+        session?: session.Session | session.InitializedSession;
         sessionID?: string;
     }
 }

--- a/types/passport.socketio/package.json
+++ b/types/passport.socketio/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "connect-mongo": "^3.1.1"
-    }
-}

--- a/types/passport.socketio/passport.socketio-tests.ts
+++ b/types/passport.socketio/passport.socketio-tests.ts
@@ -1,18 +1,15 @@
 import socketIO = require('socket.io');
 import cookieParser = require('cookie-parser');
 import expressSession = require('express-session');
-import mongoConnect = require('connect-mongo');
 import passportSocketIo = require('passport.socketio');
 
 // With Socket.io >= 1.0 | From the actual repository => https://github.com/jfromaniello/passport.socketio#readme
-
-const sessionStore = new (mongoConnect(expressSession))({ url: '' });
 
 const middleware = passportSocketIo.authorize({
     cookieParser: cookieParser(),
     key: 'express.sid',
     secret: 'session_secret',
-    store: sessionStore,
+    store: new expressSession.MemoryStore(), // memory store is fine for tests
     success: (data, accept) => accept(),
     fail: (data, message, error: boolean, accept) => {
         if (error) {

--- a/types/passport/passport-tests.ts
+++ b/types/passport/passport-tests.ts
@@ -1,6 +1,21 @@
 import * as passport from 'passport';
 import express = require('express');
-import 'express-session';
+import { InitializedSession } from 'express-session';
+
+declare global {
+    namespace Express {
+        interface User {
+            username: string;
+            id?: string;
+        }
+    }
+}
+
+declare module 'express-session' {
+    interface SessionData {
+        error: any;
+    }
+}
 
 class TestStrategy extends passport.Strategy {
     name = 'test';
@@ -87,7 +102,7 @@ app.post('/login', (req, res, next) => {
         if (err) { return next(err); }
         if (!user) {
             if (req.session) {
-                req.session['error'] = info.message;
+                (req.session as InitializedSession).error = info.message;
             }
             return res.redirect('/login');
         }
@@ -145,15 +160,6 @@ passportInstance.use(new TestStrategy());
 
 const authenticator = new passport.Authenticator();
 authenticator.use(new TestStrategy());
-
-declare global {
-    namespace Express {
-        interface User {
-            username: string;
-            id?: string;
-        }
-    }
-}
 
 app.use((req: express.Request, res: express.Response, next: (err?: any) => void) => {
     if (req.user) {


### PR DESCRIPTION
# This is an updated version of #41809

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: The changes of the first attempt (#41809) have been discussed and reviewed by the package maintainer in https://github.com/expressjs/session/pull/656.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


### This PR is a complete rewrite, because the current definitions are simply wrong
The exact changelog (including some of the reasons why the current definitions are wrong) is listed in https://github.com/expressjs/session/pull/656.
The original package maintainer @dougwilson has already reviewed the first-attempt version of these definitions and confirmed that they were correct. @dougwilson, could you check/confirm if these are still accurate?

Although I haven't thoroughly tested it, I'd be very surprised if this rewrite would not be a breaking change (at least concerning import syntax). However, these fixes are desperately needed because the current definitions are pretty much unusable.
This issue has also been noticed in https://github.com/JLuboff/connect-mssql-v2/issues/10.

Unfortunately this fix will most likely break downstream definitions. I have already [comitted to updating the definitions for `express-mysql-session`](https://github.com/chill117/express-mysql-session/pull/93) because I'm using it myself, but the other session stores will (probably) need to be updated as well. I noticed @JLuboff and @bradtaniguchi were also having troubles with the current definitions, perhaps they can shine some light on how their session store would be affected by this?


### As for the definitions themselves
When I wrote these definitions (more than a year ago now), I had to declare the `SessionData` interface in the global scope to make declaration merging work. This feels wrong though, was this (and is this still) actually required or did I miss something?

In the long run I'd prefer integrating these definitions into `express-session` itself, but as discussed in https://github.com/expressjs/session/pull/656 this'll have to wait until the v2 release.

This PR (temporarily) closes #35194 and almost certainly fixes #18529, #18527 and #16480.