### PR TITLE
[react-native] type LayoutChangeEvent as NativeSyntheticEvent

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -847,11 +847,7 @@ export interface LayoutRectangle {
 }
 
 // @see TextProps.onLayout
-export interface LayoutChangeEvent {
-    nativeEvent: {
-        layout: LayoutRectangle;
-    };
-}
+export type LayoutChangeEvent = NativeSyntheticEvent<{ layout: LayoutRectangle }>;
 
 interface TextLayoutLine {
     ascender: number;
@@ -2924,7 +2920,7 @@ export interface ActivityIndicatorIOSProps extends ViewProps {
     /**
      * Invoked on mount and layout changes with
      */
-    onLayout?: (event: { nativeEvent: { layout: { x: number; y: number; width: number; height: number } } }) => void;
+    onLayout?: (event: LayoutChangeEvent) => void;
 
     /**
      * Size of the indicator.

--- a/types/react-native/test/animated.tsx
+++ b/types/react-native/test/animated.tsx
@@ -167,13 +167,15 @@ function TestAnimatedAPI() {
             <ForwardComp ref={ForwardCompRef} width={1} />
             <AnimatedForwardComp ref={AnimatedForwardCompRef} width={10} />
             <Animated.Image style={position.getTranslateTransform()} source={{ uri: 'https://picsum.photos/200' }} />
-
             <Animated.View
-              testID='expect-type-animated-view'
-              style={{opacity: v1}}
-              onLayout={event => {
-                event; // $ExpectType LayoutChangeEvent
-              }}
+                testID="expect-type-animated-view"
+                style={{ opacity: v1 }}
+                onLayout={event => {
+                    const x = event.nativeEvent.layout.x; // $ExpectType number
+                    const y = event.nativeEvent.layout.y; // $ExpectType number
+                    const width = event.nativeEvent.layout.width; // $ExpectType number
+                    const height = event.nativeEvent.layout.height; // $ExpectType number
+                }}
             />;
 
             <Animated.FlatList

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -105,6 +105,7 @@ import {
     LogBox,
     ColorValue,
     TextLayoutEventData,
+    LayoutChangeEvent,
 } from 'react-native';
 
 declare module 'react-native' {
@@ -865,6 +866,15 @@ class TextInputTest extends React.Component<{}, { username: string }> {
 }
 
 class TextTest extends React.Component {
+    handleOnLayout = (e: LayoutChangeEvent) => {
+        testNativeSyntheticEvent(e);
+
+        const x = e.nativeEvent.layout.x; // $ExpectType number
+        const y = e.nativeEvent.layout.y; // $ExpectType number
+        const width = e.nativeEvent.layout.width; // $ExpectType number
+        const height = e.nativeEvent.layout.height; // $ExpectType number
+    };
+
     handleOnTextLayout = (e: NativeSyntheticEvent<TextLayoutEventData>) => {
         testNativeSyntheticEvent(e);
 
@@ -888,6 +898,7 @@ class TextTest extends React.Component {
                 ellipsizeMode="head"
                 lineBreakMode="clip"
                 numberOfLines={2}
+                onLayout={this.handleOnLayout}
                 onTextLayout={this.handleOnTextLayout}
             >
                 Test text


### PR DESCRIPTION
Hi !
I just updated the LayoutChangeEvent and typed it as a NativeSyntheticEvent, because it is typed that way in react-native repository: https://github.com/facebook/react-native/blob/master/Libraries/Types/CoreEventTypes.js#L76



Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/blob/master/Libraries/Types/CoreEventTypes.js#L76
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
