### PR TITLE
update(weak-napi): add missing export

### DIFF
--- a/types/weak-napi/index.d.ts
+++ b/types/weak-napi/index.d.ts
@@ -16,6 +16,8 @@ declare class WeakRef<T> {}
 declare function weak<T extends object>(object: T, callback?: () => void): WeakRef<T>;
 
 declare namespace weak {
+    // export alias
+    const create: typeof weak;
     /**
      * Returns the actual reference to the Object that this weak reference was created with. If this is called with a dead reference, undefined is returned.
      * @param ref weak reference object

--- a/types/weak-napi/weak-napi-tests.ts
+++ b/types/weak-napi/weak-napi-tests.ts
@@ -6,6 +6,9 @@ const weakReference = weak(obj, () => {
     // collected
 });
 
+// should also work with create alias
+weak.create(obj, () => {}); // $ExpectType WeakRef<{ a: number; }>
+
 const sameType = weak.get(weakReference);
 
 function foo(a: {a: number}) {}


### PR DESCRIPTION
This should silence DT bot complaining about missing export.
The change adds support for module alias:
- `create`

https://github.com/node-ffi-napi/weak-napi/blob/2c84d89222c0cccf1ebc9d2758c916c2e26ae7ee/lib/weak.js#L24

see: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46575#issuecomment-669410094

Thanks!

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)