### PR TITLE
Allow ember__runloop's next to be called without arguments

### DIFF
--- a/types/ember__runloop/ember__runloop-tests.ts
+++ b/types/ember__runloop/ember__runloop-tests.ts
@@ -170,6 +170,10 @@ function testNext() {
         // code to be executed in the next run loop,
         // which will be scheduled after the current one
     });
+    run.next(() => {
+        // code to be executed in the next run loop,
+        // which will be scheduled after the current one
+    });
 }
 
 function testOnce() {

--- a/types/ember__runloop/index.d.ts
+++ b/types/ember__runloop/index.d.ts
@@ -163,6 +163,11 @@ export interface RunNamespace {
       method: RunMethod<Target>,
       ...args: any[]
   ): EmberRunTimer;
+  next(
+    method: () => void,
+    ...args: any[]
+  ): EmberRunTimer;
+
   /**
    * Cancels a scheduled item. Must be a value returned by `run.later()`,
    * `run.once()`, `run.scheduleOnce()`, `run.next()`, `run.debounce()`, or


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes.

The method is document here: https://api.emberjs.com/ember/3.20/functions/@ember%2Frunloop/next. However, due to what appears to be a bug in the documentation generator, target is not marked as optional. However, if you view the source you can clearly see it marked as such: https://github.com/emberjs/ember.js/blob/v3.20.2/packages/%40ember/runloop/index.js#L537. For further verification, we can look at the underlying backburner code to see that target is also optional there: https://github.com/BackburnerJS/backburner.js/blob/master/lib/index.ts#L429.