### PR TITLE
Add types for urban-dictionary

### DIFF
--- a/types/urban-dictionary/index.d.ts
+++ b/types/urban-dictionary/index.d.ts
@@ -1,0 +1,45 @@
+// Type definitions for urban-dictionary 2.2
+// Project: https://github.com/NightfallAlicorn/urban-dictionary
+// Definitions by: Nigecat <https://github.com/Nigecat>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface WordDefinition {
+    definition: string;
+    permalink: string;
+    thumbs_up: number;
+    thumbs_down: number;
+    sound_urls: string[];
+    author: string;
+    word: string;
+    defid: number;
+    current_vote: string;
+    written_on: string;
+    example: string;
+}
+
+/**
+ * Asynchronously obtain Urban Dictionary term entry by defid.
+ * @param id Definition entry to retrieve
+ * @param callback Optional callback to return the data with
+ * @return The word definition data, this is also passed to the callback if it is specified.
+ */
+export function defid(id: number, callback?: (error: Error, object: WordDefinition) => any): Promise<WordDefinition>;
+
+/**
+ * Asynchronously obtain a random definition from Urban Dictionary.
+ * @param callback Optional callback to return the data with
+ * @return The word definition data, this is also passed to the callback if it is specified.
+ */
+export function random(callback?: (error: Error, object: WordDefinition) => any): Promise<WordDefinition>;
+
+/**
+ * Asynchronously obtain Urban Dictionary by term.
+ * @param word Definition to search for
+ * @param callback Optional callback to return the data with
+ * @return Returns a promise object containing entries, tags and sounds properties.
+ */
+export function term(word: string, callback?: (error: Error, entries: WordDefinition[], tags: string[], sounds: string[]) => any): Promise<{
+    entries: WordDefinition[];
+    tags: string[];
+    sounds: string[];
+}>;

--- a/types/urban-dictionary/tsconfig.json
+++ b/types/urban-dictionary/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "urban-dictionary-tests.ts"
+    ]
+}

--- a/types/urban-dictionary/tslint.json
+++ b/types/urban-dictionary/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/urban-dictionary/urban-dictionary-tests.ts
+++ b/types/urban-dictionary/urban-dictionary-tests.ts
@@ -1,0 +1,7 @@
+import methods = require("urban-dictionary");
+
+methods.defid(10085618); // $ExpectType Promise<WordDefinition>
+
+methods.random(); // $ExpectType Promise<WordDefinition>
+
+methods.term("nodejs"); // $ExpectType Promise<{ entries: WordDefinition[]; tags: string[]; sounds: string[]; }>

--- a/types/urban-dictionary/urban-dictionary-tests.ts
+++ b/types/urban-dictionary/urban-dictionary-tests.ts
@@ -5,3 +5,7 @@ methods.defid(10085618); // $ExpectType Promise<WordDefinition>
 methods.random(); // $ExpectType Promise<WordDefinition>
 
 methods.term("nodejs"); // $ExpectType Promise<{ entries: WordDefinition[]; tags: string[]; sounds: string[]; }>
+
+methods.random((error, object) => {
+    object; // $ExpectType WordDefinition
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.