### PR TITLE
[@types/underscore] Collection and Array Tests - IndexOf, LastIndexOf, FindIndex, and FindLastIndex

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -820,7 +820,7 @@ declare module _ {
          * @param list A list of [key, value] pairs or a list of keys.
          * @param values If `list` is a list of keys, a list of values
          * corresponding to those keys.
-         * @retursn An object comprised of the provided keys and values.
+         * @returns An object comprised of the provided keys and values.
          **/
         object<TList extends List<EnumerableKey>, TValue>(
             list: TList,
@@ -831,64 +831,72 @@ declare module _ {
         ): Dictionary<PairValue<TypeOfList<TList>>>;
 
         /**
-        * Returns the index at which value can be found in the array, or -1 if value is not present in the array.
-        * Uses the native indexOf function unless it's missing. If you're working with a large array, and you know
-        * that the array is already sorted, pass true for isSorted to use a faster binary search ... or, pass a number
-        * as the third argument in order to look for the first matching value in the array after the given index.
-        * @param array The array to search for the index of `value`.
-        * @param value The value to search for within `array`.
-        * @param isSorted True if the array is already sorted, optional, default = false.
-        * @return The index of `value` within `array`.
-        **/
-        indexOf<T>(
-            array: _.List<T>,
-            value: T,
-            isSorted?: boolean): number;
+         * Returns the index at which `value` can be found in `list`, or -1 if
+         * `value` is not present. If you're working with a large list and you
+         * know that the list is already sorted, pass true for
+         * `isSortedOrFromIndex` to use a faster binary search...or, pass a
+         * number in order to look for the first matching value in the list
+         * after the given index.
+         * @param list The list to search for the index of `value`.
+         * @param value The value to search for within `list`.
+         * @param isSortedOrFromIndex True if `list` is already sorted OR the
+         * starting index for the search, optional.
+         * @returns The index of the first occurrence of `value` within `list`
+         * or -1 if `value` is not found.
+         **/
+        indexOf<V extends List<any>>(
+            list: V,
+            value: TypeOfList<V>,
+            isSortedOrFromIndex?: boolean | number
+        ): number;
 
         /**
-        * @see _indexof
-        **/
-        indexOf<T>(
-            array: _.List<T>,
-            value: T,
-            startFrom: number): number;
+         * Returns the index of the last occurrence of `value` in `list`, or -1
+         * if `value` is not present. Pass `fromIndex` to start your search at
+         * a given index.
+         * @param list The list to search for the last occurrence of `value`.
+         * @param value The value to search for within `list`.
+         * @param fromIndex The starting index for the search, optional.
+         * @returns The index of the last occurrence of `value` within `list`
+         * or -1 if `value` is not found.
+         **/
+        lastIndexOf<V extends List<any>>(
+            list: V,
+            value: TypeOfList<V>,
+            fromIndex?: number
+        ): number;
 
         /**
-        * Returns the index of the last occurrence of value in the array, or -1 if value is not present. Uses the
-        * native lastIndexOf function if possible. Pass fromIndex to start your search at a given index.
-        * @param array The array to search for the last index of `value`.
-        * @param value The value to search for within `array`.
-        * @param from The starting index for the search, optional.
-        * @return The index of the last occurrence of `value` within `array`.
-        **/
-        lastIndexOf<T>(
-            array: _.List<T>,
-            value: T,
-            from?: number): number;
+         * Returns the first index of an element in `list` where the `iteratee`
+         * truth test passes, otherwise returns -1.
+         * @param list The list to search for the index of the first element
+         * that passes the truth test.
+         * @param iteratee The truth test to apply.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns The index of the first element in `list` where the
+         * truth test passes or -1 if no elements pass.
+         **/
+        findIndex<V extends List<any>>(
+            list: V,
+            iteratee?: Iteratee<V, boolean>,
+            context?: any
+        ): number;
 
         /**
-        * Returns the first index of an element in `array` where the predicate truth test passes
-        * @param array The array to search for the index of the first element where the predicate truth test passes.
-        * @param predicate Predicate function.
-        * @param context `this` object in `predicate`, optional.
-        * @return Returns the index of an element in `array` where the predicate truth test passes or -1.`
-        **/
-        findIndex<T>(
-            array: _.List<T>,
-            predicate: _.ListIterator<T, boolean> | {},
-            context?: any): number;
-
-        /**
-        * Returns the last index of an element in `array` where the predicate truth test passes
-        * @param array The array to search for the index of the last element where the predicate truth test passes.
-        * @param predicate Predicate function.
-        * @param context `this` object in `predicate`, optional.
-        * @return Returns the index of an element in `array` where the predicate truth test passes or -1.`
-        **/
-        findLastIndex<T>(
-            array: _.List<T>,
-            predicate: _.ListIterator<T, boolean> | {},
-            context?: any): number;
+         * Returns the last index of an element in `list` where the `iteratee`
+         * truth test passes, otherwise returns -1.
+         * @param list The list to search for the index of the last element
+         * that passes the truth test.
+         * @param iteratee The truth test to apply.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns The index of the last element in `list` where the
+         * truth test passes or -1 if no elements pass.
+         **/
+        findLastIndex<V extends List<any>>(
+            list: V,
+            iteratee?: Iteratee<V, boolean>,
+            context?: any
+        ): number;
 
         /**
          * Uses a binary search to determine the lowest index at which the
@@ -4457,31 +4465,62 @@ declare module _ {
         object(): Dictionary<PairValue<T>>;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.indexOf
-        **/
-        indexOf(value: T, isSorted?: boolean): number;
+         * Returns the index at which `value` can be found in the wrapped list,
+         * or -1 if `value` is not present. If you're working with a large list
+         * and you know that the list is already sorted, pass true for
+         * `isSortedOrFromIndex` to use a faster binary search...or, pass a
+         * number in order to look for the first matching value in the list
+         * after the given index.
+         * @param value The value to search for within the wrapped list.
+         * @param isSortedOrFromIndex True if the wrapped list is already
+         * sorted OR the starting index for the search, optional.
+         * @returns The index of the first occurrence of `value` within the
+         * wrapped list or -1 if `value` is not found.
+         **/
+        indexOf(
+            value: T,
+            isSortedOrFromIndex?: boolean | number
+        ): number;
 
         /**
-        * @see _.indexOf
-        **/
-        indexOf(value: T, startFrom: number): number;
+         * Returns the index of the last occurrence of `value` in the wrapped
+         * list, or -1 if `value` is not present. Pass `fromIndex` to start
+         * your search at a given index.
+         * @param value The value to search for within the wrapped list.
+         * @param fromIndex The starting index for the search, optional.
+         * @returns The index of the last occurrence of `value` within the
+         * wrapped list or -1 if `value` is not found.
+         **/
+        lastIndexOf(
+            value: T,
+            fromIndex?: number
+        ): number;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.lastIndexOf
-        **/
-        lastIndexOf(value: T, from?: number): number;
+         * Returns the first index of an element in the wrapped list where the
+         * `iteratee` truth test passes, otherwise returns -1.
+         * @param iteratee The truth test to apply.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns The index of the first element in the wrapped list where
+         * the truth test passes or -1 if no elements pass.
+         **/
+        findIndex(
+            iteratee?: Iteratee<V, boolean>,
+            context?: any
+        ): number;
 
         /**
-        * @see _.findIndex
-        **/
-        findIndex(predicate: _.ListIterator<T, boolean> | {}, context?: any): number;
-
-        /**
-        * @see _.findLastIndex
-        **/
-        findLastIndex(predicate: _.ListIterator<T, boolean> | {}, context?: any): number;
+         * Returns the last index of an element in the wrapped list where the
+         * `iteratee` truth test passes, otherwise returns -1.
+         * @param iteratee The truth test to apply.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns The index of the last element in the wrapped list where the
+         * truth test passes or -1 if no elements pass.
+         **/
+        findLastIndex(
+            iteratee?: Iteratee<V, boolean>,
+            context?: any
+        ): number;
 
         /**
          * Uses a binary search to determine the lowest index at which the
@@ -5535,31 +5574,63 @@ declare module _ {
         object(): _Chain<PairValue<T>, Dictionary<PairValue<T>>>;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.indexOf
-        **/
-        indexOf(value: T, isSorted?: boolean): _ChainSingle<number>;
+         * Returns the index at which `value` can be found in the wrapped list,
+         * or -1 if `value` is not present. If you're working with a large list
+         * and you know that the list is already sorted, pass true for
+         * `isSortedOrFromIndex` to use a faster binary search...or, pass a
+         * number in order to look for the first matching value in the list
+         * after the given index.
+         * @param value The value to search for within the wrapped list.
+         * @param isSortedOrFromIndex True if the wrapped list is already
+         * sorted OR the starting index for the search, optional.
+         * @returns A chain wrapper around the index of the first occurrence of
+         * `value` within the wrapped list or -1 if `value` is not found.
+         **/
+        indexOf(
+            value: T,
+            isSortedOrFromIndex?: boolean | number
+        ): _ChainSingle<number>;
 
         /**
-        * @see _.indexOf
-        **/
-        indexOf(value: T, startFrom: number): _ChainSingle<number>;
+         * Returns the index of the last occurrence of `value` in the wrapped
+         * list, or -1 if `value` is not present. Pass `fromIndex` to start
+         * your search at a given index.
+         * @param value The value to search for within the wrapped list.
+         * @param fromIndex The starting index for the search, optional.
+         * @returns A chain wrapper around the index of the last occurrence of
+         * `value` within the wrapped list or -1 if `value` is not found.
+         **/
+        lastIndexOf(
+            value: T,
+            fromIndex?: number
+        ): _ChainSingle<number>;
 
         /**
-        * Wrapped type `any[]`.
-        * @see _.lastIndexOf
-        **/
-        lastIndexOf(value: T, from?: number): _ChainSingle<number>;
+         * Returns the first index of an element in the wrapped list where the
+         * `iteratee` truth test passes, otherwise returns -1.
+         * @param iteratee The truth test to apply.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns A chain wrapper around the index of the first element in
+         * the wrapped list where the truth test passes or -1 if no elements
+         * pass.
+         **/
+        findIndex(
+            iteratee?: Iteratee<V, boolean>,
+            context?: any
+        ): _ChainSingle<number>;
 
         /**
-        * @see _.findIndex
-        **/
-        findIndex(predicate: _.ListIterator<T, boolean> | {}, context?: any): _ChainSingle<number>;
-
-        /**
-        * @see _.findLastIndex
-        **/
-        findLastIndex(predicate: _.ListIterator<T, boolean> | {}, context?: any): _ChainSingle<number>;
+         * Returns the last index of an element in the wrapped list where the
+         * `iteratee` truth test passes, otherwise returns -1.
+         * @param iteratee The truth test to apply.
+         * @param context `this` object in `iteratee`, optional.
+         * @returns A chain wrapper around the index of the last element in the
+         * wrapped list where the truth test passes or -1 if no elements pass.
+         **/
+        findLastIndex(
+            iteratee?: Iteratee<V, boolean>,
+            context?: any
+        ): _ChainSingle<number>;
 
         /**
          * Uses a binary search to determine the lowest index at which the

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -2723,6 +2723,99 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     extractChainTypes(_.chain(simpleString).chunk(length)); // $ExpectType ChainType<string[][], string[]>
 }
 
+// indexOf
+{
+    // not sorted, from zero
+    _.indexOf(stringRecordList, stringRecordList[0]); // $ExpectType number
+    _(stringRecordList).indexOf(stringRecordList[0]); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).indexOf(stringRecordList[0])); // $ExpectType ChainType<number, never>
+
+    // sorted
+    _.indexOf(stringRecordList, stringRecordList[0], true); // $ExpectType number
+    _(stringRecordList).indexOf(stringRecordList[0], true); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).indexOf(stringRecordList[0], true)); // $ExpectType ChainType<number, never>
+
+    // from index
+    _.indexOf(stringRecordList, stringRecordList[0], simpleNumber); // $ExpectType number
+    _(stringRecordList).indexOf(stringRecordList[0], simpleNumber); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).indexOf(stringRecordList[0], simpleNumber)); // $ExpectType ChainType<number, never>
+}
+
+// lastIndexOf
+{
+    // from zero
+    _.lastIndexOf(stringRecordList, stringRecordList[0]); // $ExpectType number
+    _(stringRecordList).lastIndexOf(stringRecordList[0]); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).lastIndexOf(stringRecordList[0])); // $ExpectType ChainType<number, never>
+
+    // from index
+    _.lastIndexOf(stringRecordList, stringRecordList[0], simpleNumber); // $ExpectType number
+    _(stringRecordList).lastIndexOf(stringRecordList[0], simpleNumber); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).lastIndexOf(stringRecordList[0], simpleNumber)); // $ExpectType ChainType<number, never>
+}
+
+// findIndex
+{
+    // function iteratee
+    _.findIndex(stringRecordList, stringRecordListBooleanIterator); // $ExpectType number
+    _.findIndex(stringRecordList, stringRecordListBooleanIterator, context); // $ExpectType number
+    _(stringRecordList).findIndex(stringRecordListBooleanIterator); // $ExpectType number
+    _(stringRecordList).findIndex(stringRecordListBooleanIterator, context); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).findIndex(stringRecordListBooleanIterator)); // $ExpectType ChainType<number, never>
+    extractChainTypes(_.chain(stringRecordList).findIndex(stringRecordListBooleanIterator, context)); // $ExpectType ChainType<number, never>
+
+    // partial object iteratee
+    _.findIndex(stringRecordList, partialStringRecord); // $ExpectType number
+    _(stringRecordList).findIndex(partialStringRecord); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).findIndex(partialStringRecord)); // $ExpectType ChainType<number, never>
+
+    // property name iteratee
+    _.findIndex(stringRecordList, stringRecordProperty); // $ExpectType number
+    _(stringRecordList).findIndex(stringRecordProperty); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).findIndex(stringRecordProperty)); // $ExpectType ChainType<number, never>
+
+    // property path iteratee
+    _.findIndex(stringRecordList, stringRecordPropertyPath); // $ExpectType number
+    _(stringRecordList).findIndex(stringRecordPropertyPath); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).findIndex(stringRecordPropertyPath)); // $ExpectType ChainType<number, never>
+
+    // identity iteratee
+    _.findIndex(stringRecordList); // $ExpectType number
+    _(stringRecordList).findIndex(); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).findIndex()); // $ExpectType ChainType<number, never>
+}
+
+// findLastIndex
+{
+    // function iteratee
+    _.findLastIndex(stringRecordList, stringRecordListBooleanIterator); // $ExpectType number
+    _.findLastIndex(stringRecordList, stringRecordListBooleanIterator, context); // $ExpectType number
+    _(stringRecordList).findLastIndex(stringRecordListBooleanIterator); // $ExpectType number
+    _(stringRecordList).findLastIndex(stringRecordListBooleanIterator, context); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).findLastIndex(stringRecordListBooleanIterator)); // $ExpectType ChainType<number, never>
+    extractChainTypes(_.chain(stringRecordList).findLastIndex(stringRecordListBooleanIterator, context)); // $ExpectType ChainType<number, never>
+
+    // partial object iteratee
+    _.findLastIndex(stringRecordList, partialStringRecord); // $ExpectType number
+    _(stringRecordList).findLastIndex(partialStringRecord); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).findLastIndex(partialStringRecord)); // $ExpectType ChainType<number, never>
+
+    // property name iteratee
+    _.findLastIndex(stringRecordList, stringRecordProperty); // $ExpectType number
+    _(stringRecordList).findLastIndex(stringRecordProperty); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).findLastIndex(stringRecordProperty)); // $ExpectType ChainType<number, never>
+
+    // property path iteratee
+    _.findLastIndex(stringRecordList, stringRecordPropertyPath); // $ExpectType number
+    _(stringRecordList).findLastIndex(stringRecordPropertyPath); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).findLastIndex(stringRecordPropertyPath)); // $ExpectType ChainType<number, never>
+
+    // identity iteratee
+    _.findLastIndex(stringRecordList); // $ExpectType number
+    _(stringRecordList).findLastIndex(); // $ExpectType number
+    extractChainTypes(_.chain(stringRecordList).findLastIndex()); // $ExpectType ChainType<number, never>
+}
+
 // sortedIndex
 {
     // identity iteratee
@@ -2752,19 +2845,6 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _.sortedIndex(stringRecordList, stringRecordList[0], stringRecordPropertyPath); // $ExpectType number
     _(stringRecordList).sortedIndex(stringRecordList[0], stringRecordPropertyPath); // $ExpectType number
     extractChainTypes(_.chain(stringRecordList).sortedIndex(stringRecordList[0], stringRecordPropertyPath)); // $ExpectType ChainType<number, never>
-}
-
-// findIndex and findLastIndex
-{
-    _([1, 2, 3, 1, 2, 3]).findIndex(num => num % 2 === 0); // $ExpectType number
-    _([{a: 'a'}, {a: 'b'}]).findIndex({a: 'b'}); // $ExpectType number
-    _.chain([1, 2, 3, 1, 2, 3]).findIndex(num => num % 2 === 0).value(); // $ExpectType number
-    _.chain([{a: 'a'}, {a: 'b'}]).findIndex({a: 'b'}).value(); // $ExpectType number
-
-    _([1, 2, 3, 1, 2, 3]).findLastIndex(num => num % 2 === 0); // $ExpectType number
-    _([{a: 'a'}, {a: 'b'}]).findLastIndex({ a: 'b' }); // $ExpectType number
-    _.chain([1, 2, 3, 1, 2, 3]).findLastIndex(num => num % 2 === 0).value(); // $ExpectType number
-    _.chain([{a: 'a'}, {a: 'b'}]).findLastIndex({ a: 'b' }).value(); // $ExpectType number
 }
 
 // range


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://underscorejs.org/
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

This PR continues the planned set that will together add up to #45201 and includes the following changes:

- Adds tests for `indexOf`, `lastIndexOf`, `findIndex`, and `findLastIndex`.
- Combines overloads of `indexOf` into a single overload.
- Updates `findIndex` and `findLastIndex` to use `Iteratee`.
- Fixes `retursn` in summary comments for `UnderscoreStatic.object` from a previous PR in the set.

This is the last PR in the Arrays family and the last PR in the set aside from cleanup.