### PR TITLE
@types/podcast - Allow passing a duration in string format

### DIFF
--- a/types/podcast/index.d.ts
+++ b/types/podcast/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for podcast 1.1
+// Type definitions for podcast 1.3
 // Project: https://github.com/maxnowack/node-podcast
 // Definitions by: Niklas Mollenhauer <https://github.com/nikeee>
 //                 Malo Bourgon <https://github.com/malob>

--- a/types/podcast/index.d.ts
+++ b/types/podcast/index.d.ts
@@ -71,7 +71,7 @@ declare namespace Podcast {
         itunesExplicit?: boolean;
         itunesSubtitle?: string;
         itunesSummary?: string;
-        itunesDuration?: number;
+        itunesDuration?: number | string;
         itunesImage?: string;
         itunesSeason?: number;
         itunesEpisode?: number;

--- a/types/podcast/podcast-tests.ts
+++ b/types/podcast/podcast-tests.ts
@@ -55,8 +55,12 @@ const feedItem: Podcast.Item = {
     itunesEpisodeType: 'bonus',
 };
 
+// Test with duration formatted as string
+const feedItem2: Podcast.Item = { ...feedItem, itunesDuration: '01:30:58' };
+
 const feed1 = new Podcast(feedOptions);
 feed1.addItem(feedItem);
+feed1.addItem(feedItem2);
 const feed1Xml = feed1.buildXml();
 
 const feed2 = new Podcast(feedOptions, [feedItem]);


### PR DESCRIPTION
See related discussion: https://github.com/maxnowack/node-podcast/pull/39#issuecomment-669125856

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/maxnowack/node-podcast/pull/39#issuecomment-669125856
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
