### PR TITLE
[@types/chromecast-caf-receiver] Add media command functions to chromecast-caf-receiver

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -941,7 +941,7 @@ export class PlayerManager {
      * Combinations are described as summations; for example, Pause+Seek+StreamVolume+Mute == 15.
      */
     setSupportedMediaCommands(supportedMediaCommands: number, broadcastStatus?: boolean): void;
-    
+
     /**
      * Remove commands from receiver supported media commands.
      * @param supportedMediaCommands A bitmask of media commands supported by the application.
@@ -960,7 +960,7 @@ export class PlayerManager {
      * Gets the current receiver supported media commands.
      * Should only be called after calling receiver start, otherwise it returns 0.
      * This reflects the current media status. E.g. during ads playback, SEEK might not be supported.
-     * 
+     *
      * @returns A bitmask of media commands supported by the application.
      */
     getCurrentSupportedMediaCommands(): number;
@@ -969,7 +969,7 @@ export class PlayerManager {
      * Gets receiver supported media commands. Should only be called after calling receiver start, otherwise it returns 0.
      * This is the static supported media commands set by receiver application.
      * It won't be updated based on current media status.
-     * 
+     *
      * @returns A bitmask of media commands supported by the application.
      */
     getSupportedMediaCommands(): number;

--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -941,6 +941,38 @@ export class PlayerManager {
      * Combinations are described as summations; for example, Pause+Seek+StreamVolume+Mute == 15.
      */
     setSupportedMediaCommands(supportedMediaCommands: number, broadcastStatus?: boolean): void;
+    
+    /**
+     * Remove commands from receiver supported media commands.
+     * @param supportedMediaCommands A bitmask of media commands supported by the application.
+     * @param broadcastStatus Whether the senders should be notified about the change (if not provided, the senders will be notified).
+     */
+    removeSupportedMediaCommands(supportedMediaCommands: number, broadcastStatus?: boolean): void;
+
+    /**
+     * Add commands to receiver supported media commands.
+     * @param supportedMediaCommands A bitmask of media commands supported by the application.
+     * @param broadcastStatus Whether the senders should be notified about the change (if not provided, the senders will be notified).
+     */
+    addSupportedMediaCommands(supportedMediaCommands: number, broadcastStatus?: boolean): void;
+
+    /**
+     * Gets the current receiver supported media commands.
+     * Should only be called after calling receiver start, otherwise it returns 0.
+     * This reflects the current media status. E.g. during ads playback, SEEK might not be supported.
+     * 
+     * @returns A bitmask of media commands supported by the application.
+     */
+    getCurrentSupportedMediaCommands(): number;
+
+    /**
+     * Gets receiver supported media commands. Should only be called after calling receiver start, otherwise it returns 0.
+     * This is the static supported media commands set by receiver application.
+     * It won't be updated based on current media status.
+     * 
+     * @returns A bitmask of media commands supported by the application.
+     */
+    getSupportedMediaCommands(): number;
 
     /**
      * Stops currently playing media.


### PR DESCRIPTION
Add missing media command functions to `cast.framework.d.ts`

Add function [removeSupportedMediaCommands](https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.PlayerManager#removeSupportedMediaCommands)
Add function [addSupportedMediaCommands](https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.PlayerManager#addSupportedMediaCommands)
Add function [getSupportedMediaCommands](https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.PlayerManager#getSupportedMediaCommands)
Add function [getCurrentSupportedMediaCommands](https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.PlayerManager#getCurrentSupportedMediaCommands)

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
