### PR TITLE
feature(parse): make `Schema` generic

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -987,7 +987,7 @@ namespace Parse {
          * @param targetClass  Name of the target Pointer Class
          * @return Returns the schema, so you can chain this call.
          */
-        addRelation(name: string, targetClass: string): this;
+        addRelation(name: string, targetClass: string, options?: Schema.FieldOptions<Relation>): this;
 
         addString(name: string, options?: Schema.FieldOptions<string>): this;
 

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -486,12 +486,12 @@ namespace Parse {
         fetchAllIfNeeded<T extends Object>(list: T[], options?: Object.FetchAllOptions): Promise<T[]>;
         fetchAllIfNeededWithInclude<T extends Object>(
             list: T[],
-            keys: string | Array<string | string[]>,
+            keys: keyof T['attributes'] | Array<keyof T['attributes']>,
             options?: RequestOptions
         ): Promise<T[]>;
         fetchAllWithInclude<T extends Object>(
             list: T[],
-            keys: string | Array<string | string[]>,
+            keys: keyof T['attributes'] | Array<keyof T['attributes']>,
             options?: RequestOptions,
         ): Promise<T[]>;
         fromJSON<T extends Object>(json: any, override?: boolean): T;

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -1168,6 +1168,18 @@ function testObject() {
 
         // $ExpectError
         objTyped.fetchWithInclude([[[ 'example' ]]]);
+
+        // $ExpectType Promise<Object<{ example: string; }>[]>
+        Parse.Object.fetchAllIfNeededWithInclude([objTyped], 'example');
+
+        // $ExpectError
+        Parse.Object.fetchAllIfNeededWithInclude([objTyped], 'notAnAttribute');
+
+        // $ExpectType Promise<Object<{ example: string; }>[]>
+        Parse.Object.fetchAllWithInclude([objTyped], 'example');
+
+        // $ExpectError
+        Parse.Object.fetchAllWithInclude([objTyped], 'notAnAttribute');
     }
 
     function testGet(objUntyped: Parse.Object, objTyped: Parse.Object<{ example: number }>) {

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -931,6 +931,59 @@ async function test_schema(
     schema.purge().then(results => {});
     schema.save().then(results => {});
     schema.update().then(results => {});
+
+    function testGenericType() {
+        interface iTestAttributes {
+            arrField: any[];
+            boolField: boolean;
+            stringField: string;
+            numField: number;
+            dateField: Date;
+            fileField: Parse.File;
+            geoPointField: Parse.GeoPoint;
+            polygonField: Parse.Polygon;
+            objectField: object;
+            relationField: Parse.Relation;
+            pointerField: Parse.Pointer | Parse.Object;
+        }
+        class TestObject extends Parse.Object<iTestAttributes> { }
+
+        const schema = new Parse.Schema<TestObject>('TestObject');
+        schema.addArray('arrField');
+        schema.addBoolean('boolField');
+        schema.addDate('dateField');
+        schema.addFile('fileField');
+        schema.addGeoPoint('geoPointField');
+        schema.addNumber('numField');
+        schema.addObject('objectField');
+        schema.addPointer('pointerField', 'FooClass');
+        schema.addPolygon('polygonField');
+        schema.addRelation('relationField', 'FooClass');
+        schema.addString('stringField');
+
+        // $ExpectError
+        schema.addArray('wrong');
+        // $ExpectError
+        schema.addBoolean('wrong');
+        // $ExpectError
+        schema.addDate('wrong');
+        // $ExpectError
+        schema.addFile('wrong');
+        // $ExpectError
+        schema.addGeoPoint('wrong');
+        // $ExpectError
+        schema.addNumber('wrong');
+        // $ExpectError
+        schema.addObject('wrong');
+        // $ExpectError
+        schema.addPointer('wrong', 'FooClass');
+        // $ExpectError
+        schema.addPolygon('wrong');
+        // $ExpectError
+        schema.addRelation('wrong', 'FooClass');
+        // $ExpectError
+        schema.addString('wrong');
+    }
 }
 
 function testObject() {

--- a/types/parse/ts3.7/index.d.ts
+++ b/types/parse/ts3.7/index.d.ts
@@ -458,12 +458,12 @@ namespace Parse {
         fetchAllIfNeeded<T extends Object>(list: T[], options?: Object.FetchAllOptions): Promise<T[]>;
         fetchAllIfNeededWithInclude<T extends Object>(
             list: T[],
-            keys: string | Array<string | string[]>,
+            keys: keyof T['attributes'] | Array<keyof T['attributes']>,
             options?: RequestOptions
         ): Promise<T[]>;
         fetchAllWithInclude<T extends Object>(
             list: T[],
-            keys: string | Array<string | string[]>,
+            keys: keyof T['attributes'] | Array<keyof T['attributes']>,
             options?: RequestOptions,
         ): Promise<T[]>;
         fromJSON<T extends Object>(json: any, override?: boolean): T;

--- a/types/parse/ts3.7/index.d.ts
+++ b/types/parse/ts3.7/index.d.ts
@@ -909,7 +909,7 @@ namespace Parse {
      * schema.save();
      * ```
      */
-    class Schema {
+    class Schema<T extends Object = any> {
         constructor(className: string);
 
         /**
@@ -920,12 +920,12 @@ namespace Parse {
          */
         static all(): Promise<Schema[]>;
 
-        addArray(name: string, options?: Schema.FieldOptions<any[]>): this;
-        addBoolean(name: string, options?: Schema.FieldOptions<boolean>): this;
-        addDate(name: string, options?: Schema.FieldOptions<Date>): this;
+        addArray(key: Schema.AttrType<T, any[]>, options?: Schema.FieldOptions<any[]>): this;
+        addBoolean(key: Schema.AttrType<T, boolean>, options?: Schema.FieldOptions<boolean>): this;
+        addDate(key: Schema.AttrType<T, Date>, options?: Schema.FieldOptions<Date>): this;
         addField<T extends Schema.TYPE = any>(name: string, type?: T, options?: Schema.FieldOptions): this;
-        addFile(name: string, options?: Schema.FieldOptions<File>): this;
-        addGeoPoint(name: string, options?: Schema.FieldOptions<GeoPoint>): this;
+        addFile(key: Schema.AttrType<T, File>, options?: Schema.FieldOptions<File>): this;
+        addGeoPoint(key: Schema.AttrType<T, GeoPoint>, options?: Schema.FieldOptions<GeoPoint>): this;
 
         /**
          * Adding an Index to Create / Update a Schema
@@ -939,8 +939,9 @@ namespace Parse {
          */
         addIndex(name: string, index: Schema.Index): this;
 
-        addNumber(name: string, options?: Schema.FieldOptions<number>): this;
-        addObject(name: string, options?: Schema.FieldOptions<object>): this;
+        addNumber(key: Schema.AttrType<T, number>, options?: Schema.FieldOptions<number>): this;
+
+        addObject(key: Schema.AttrType<T, object>, options?: Schema.FieldOptions<object>): this;
 
         /**
          * Adding Pointer Field
@@ -948,9 +949,9 @@ namespace Parse {
          * @param targetClass  Name of the target Pointer Class
          * @return Returns the schema, so you can chain this call.
          */
-        addPointer(name: string, targetClass: string, options?: Schema.FieldOptions<Pointer>): this;
+        addPointer(key: Schema.AttrType<T, Object | Pointer>, targetClass: string, options?: Schema.FieldOptions<Pointer>): this;
 
-        addPolygon(name: string, options?: Schema.FieldOptions<Polygon>): this;
+        addPolygon(key: Schema.AttrType<T, Polygon>, options?: Schema.FieldOptions<Polygon>): this;
 
         /**
          * Adding Relation Field
@@ -958,9 +959,9 @@ namespace Parse {
          * @param targetClass  Name of the target Pointer Class
          * @return Returns the schema, so you can chain this call.
          */
-        addRelation(name: string, targetClass: string): this;
+        addRelation(key: Schema.AttrType<T, Relation>, targetClass: string, options?: Schema.FieldOptions<Relation>): this;
 
-        addString(name: string, options?: Schema.FieldOptions<string>): this;
+        addString(key: Schema.AttrType<T, string>, options?: Schema.FieldOptions<string>): this;
 
         /**
          * Removing a Schema from Parse Can only be used on Schema without objects
@@ -989,7 +990,7 @@ namespace Parse {
         get(): Promise<Schema>;
 
         /**
-         * Removes all objects from a Schema (class) in Parse. EXERCISE CAUTION, running this will delete all objects for this schema and cannot be reversed
+         * Removes all objects from a Schema (class) in  EXERCISE CAUTION, running this will delete all objects for this schema and cannot be reversed
          */
         // TODO Fix Promise<any>
         purge(): Promise<any>;
@@ -1000,6 +1001,12 @@ namespace Parse {
         save(): Promise<Schema>;
 
         /**
+         * Sets Class Level Permissions when creating / updating a Schema.
+         * EXERCISE CAUTION, running this may override CLP for this schema and cannot be reversed
+         */
+        setCLP(clp: Schema.CLP): this;
+
+        /**
          * Update a Schema on Parse
          */
         update(): Promise<Schema>;
@@ -1007,15 +1014,46 @@ namespace Parse {
 
     namespace Schema {
         type TYPE = 'String' | 'Number' | 'Boolean' | 'Date' | 'File' | 'GeoPoint' | 'Polygon' | 'Array' | 'Object' | 'Pointer' | 'Relation';
+        type FieldType = string | number | boolean | Date | File | GeoPoint | Polygon | any[] | object | Pointer | Relation;
+        type AttrType<T extends Object, V> = Extract<{ [K in keyof T['attributes']]: T['attributes'][K] extends V ? K : never }[keyof T['attributes']], string>;
 
         interface FieldOptions
-            <T extends string | number | boolean | Date | File | GeoPoint | Polygon | any[] | object | Pointer | Relation = any> {
+            <T extends FieldType = any> {
             required?: boolean;
             defaultValue?: T;
         }
 
         interface Index {
             [fieldName: string]: TYPE;
+        }
+
+        /**
+         * The id of a `_User` object or a role name prefixed by `'role:'`.
+         * @example
+         *  '*': false, // public
+         *  requiresAuthentication: false,
+         * 'role:Admin': true,
+         *  'idOfASpecificUser': true
+         */
+        interface CLPField {
+            '*'?: boolean;
+            requiresAuthentication?: boolean;
+            /** `role:Admin` */
+            [userIdOrRoleName: string]: boolean | undefined;
+        }
+
+        interface CLP {
+            find?: CLPField;
+            get?: CLPField;
+            count?: CLPField;
+            create?: CLPField;
+            update?: CLPField;
+            delete?: CLPField;
+            addField?: CLPField;
+            /** Array of fields that point to a `_User` object's ID or a `Role` object's name */
+            readUserFields?: string[];
+            /** Array of fields that point to a `_User` object's ID or a `Role` object's name */
+            writeUserFields?: string[];
         }
     }
 

--- a/types/parse/ts3.7/parse-tests.ts
+++ b/types/parse/ts3.7/parse-tests.ts
@@ -831,19 +831,18 @@ async function test_cancel_query() {
     query.cancel();
 }
 
-type FieldType = string | number | boolean | Date | Parse.File | Parse.GeoPoint | any[] | object | Parse.Pointer | Parse.Polygon | Parse.Relation;
 async function test_schema(
-    anyField: FieldType,
-    notString: Exclude<FieldType, string>,
-    notNumber: Exclude<FieldType, number>,
-    notboolean: Exclude<FieldType, boolean>,
-    notDate: Exclude<FieldType, Date>,
-    notFile: Exclude<FieldType, Parse.File>,
-    notGeopoint: Exclude<FieldType, Parse.GeoPoint[]>,
-    notArray: Exclude<FieldType, any[]>,
-    notObject: Exclude<FieldType, object>,
-    notPointer: Exclude<FieldType, Parse.Pointer>,
-    notPolygon: Exclude<FieldType, Parse.Polygon>
+    anyField: Parse.Schema.FieldType,
+    notString: Exclude<Parse.Schema.FieldType, string>,
+    notNumber: Exclude<Parse.Schema.FieldType, number>,
+    notboolean: Exclude<Parse.Schema.FieldType, boolean>,
+    notDate: Exclude<Parse.Schema.FieldType, Date>,
+    notFile: Exclude<Parse.Schema.FieldType, Parse.File>,
+    notGeopoint: Exclude<Parse.Schema.FieldType, Parse.GeoPoint[]>,
+    notArray: Exclude<Parse.Schema.FieldType, any[]>,
+    notObject: Exclude<Parse.Schema.FieldType, object>,
+    notPointer: Exclude<Parse.Schema.FieldType, Parse.Pointer>,
+    notPolygon: Exclude<Parse.Schema.FieldType, Parse.Polygon>
 ) {
     Parse.Schema.all();
 
@@ -927,11 +926,64 @@ async function test_schema(
 
     schema.deleteField('defaultFieldString');
     schema.deleteIndex('testIndex');
-    schema.delete().then(results => {});
-    schema.get().then(results => {});
-    schema.purge().then(results => {});
-    schema.save().then(results => {});
-    schema.update().then(results => {});
+    schema.delete().then(results => { });
+    schema.get().then(results => { });
+    schema.purge().then(results => { });
+    schema.save().then(results => { });
+    schema.update().then(results => { });
+
+    function testGenericType() {
+        interface iTestAttributes {
+            arrField: any[];
+            boolField: boolean;
+            stringField: string;
+            numField: number;
+            dateField: Date;
+            fileField: Parse.File;
+            geoPointField: Parse.GeoPoint;
+            polygonField: Parse.Polygon;
+            objectField: object;
+            relationField: Parse.Relation;
+            pointerField: Parse.Pointer | Parse.Object;
+        }
+        class TestObject extends Parse.Object<iTestAttributes> { }
+
+        const schema = new Parse.Schema<TestObject>('TestObject');
+        schema.addArray('arrField');
+        schema.addBoolean('boolField');
+        schema.addDate('dateField');
+        schema.addFile('fileField');
+        schema.addGeoPoint('geoPointField');
+        schema.addNumber('numField');
+        schema.addObject('objectField');
+        schema.addPointer('pointerField', 'FooClass');
+        schema.addPolygon('polygonField');
+        schema.addRelation('relationField', 'FooClass');
+        schema.addString('stringField');
+
+        // $ExpectError
+        schema.addArray('wrong');
+        // $ExpectError
+        schema.addBoolean('wrong');
+        // $ExpectError
+        schema.addDate('wrong');
+        // $ExpectError
+        schema.addFile('wrong');
+        // $ExpectError
+        schema.addGeoPoint('wrong');
+        // $ExpectError
+        schema.addNumber('wrong');
+        // $ExpectError
+        schema.addObject('wrong');
+        // $ExpectError
+        schema.addPointer('wrong', 'FooClass');
+        // $ExpectError
+        schema.addPolygon('wrong');
+        // $ExpectError
+        schema.addRelation('wrong', 'FooClass');
+        // $ExpectError
+        schema.addString('wrong');
+    }
 }
 
 function testObject() {

--- a/types/parse/ts3.7/parse-tests.ts
+++ b/types/parse/ts3.7/parse-tests.ts
@@ -1168,6 +1168,18 @@ function testObject() {
 
         // $ExpectError
         objTyped.fetchWithInclude([[[ 'example' ]]]);
+
+        // $ExpectType Promise<Object<{ example: string; }>[]>
+        Parse.Object.fetchAllIfNeededWithInclude([objTyped], 'example');
+
+        // $ExpectError
+        Parse.Object.fetchAllIfNeededWithInclude([objTyped], 'notAnAttribute');
+
+        // $ExpectType Promise<Object<{ example: string; }>[]>
+        Parse.Object.fetchAllWithInclude([objTyped], 'example');
+
+        // $ExpectError
+        Parse.Object.fetchAllWithInclude([objTyped], 'notAnAttribute');
     }
 
     function testGet(objUntyped: Parse.Object, objTyped: Parse.Object<{ example: number }>) {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/parse-community/Parse-SDK-JS/blob/master/src/ParseSchema.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
