### PR TITLE
[react-mailchimp-subscribe] Split ResponseArgs

### DIFF
--- a/types/react-mailchimp-subscribe/index.d.ts
+++ b/types/react-mailchimp-subscribe/index.d.ts
@@ -1,10 +1,10 @@
-// Type definitions for react-mailchimp-subscribe 2.0
+// Type definitions for react-mailchimp-subscribe 2.1
 // Project: https://revolunet.github.io/react-mailchimp-subscribe/
 // Definitions by: Omar Diab <https://github.com/osdiab>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
-import { Component, ReactNode } from "react";
+import { Component, ReactNode } from 'react';
 
 // A few common set of form fields, based on defaults in Mailchimp's website
 export interface EmailFormFields {
@@ -17,20 +17,27 @@ export interface NameFormFields extends EmailFormFields {
 }
 
 export interface ClassicFormFields extends NameFormFields {
-    "BIRTHDAY[month]": number;
-    "BIRTHDAY[day]": number;
+    'BIRTHDAY[month]': number;
+    'BIRTHDAY[day]': number;
 }
 
 // library default form just sends EMAIL
 export type DefaultFormFields = EmailFormFields;
 
-export interface ResponseArgs {
-    status: "success" | "error";
+export interface ErrorResponseArgs {
+    status: 'error';
+    message: string | Error;
+}
+
+export interface SuccessResponseArgs {
+    status: 'success';
     message: string;
 }
 
+export type ResponseArgs = ErrorResponseArgs | SuccessResponseArgs;
+
 export interface PendingArgs {
-    status: "sending" | null;
+    status: 'sending' | null;
     message: null;
 }
 
@@ -38,14 +45,11 @@ export interface SubscribeArg<FormFields> {
     subscribe: (data: FormFields) => void;
 }
 
-export type FormHooks<FormFields> = SubscribeArg<FormFields> &
-    (ResponseArgs | PendingArgs);
+export type FormHooks<FormFields> = SubscribeArg<FormFields> & (ErrorResponseArgs | SuccessResponseArgs | PendingArgs);
 
 export interface Props<FormFields> {
     render?: (hooks: FormHooks<FormFields>) => ReactNode;
     url: string;
 }
 
-export default class MailchimpSubscribe<FormFields = DefaultFormFields> extends Component<
-    Props<FormFields>
-> {}
+export default class MailchimpSubscribe<FormFields = DefaultFormFields> extends Component<Props<FormFields>> {}


### PR DESCRIPTION
Split into success and error responses. The 'message' of an error response can also be an instance of Error when the jsonp request to MailChimp fails (e.g. due to timeout errors). Also, bump minor version.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/revolunet/react-mailchimp-subscribe/issues/34#issuecomment-669906622
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
