### PR TITLE
[tingle.js]: setContent() accepts Node

### DIFF
--- a/types/tingle.js/index.d.ts
+++ b/types/tingle.js/index.d.ts
@@ -17,7 +17,7 @@ export interface Options {
 }
 export class modal {
     constructor(options?: Options);
-    setContent(content: string | Element): void;
+    setContent(content: string | Node): void;
     getContent(): HTMLDivElement;
     destroy(): void;
     open(): void;

--- a/types/tingle.js/tingle.js-tests.ts
+++ b/types/tingle.js/tingle.js-tests.ts
@@ -6,6 +6,10 @@ instance.checkOverflow();
 instance.close();
 instance.close();
 
+instance.setContent("string content");
+instance.setContent(new Node());
+instance.setContent(new DocumentFragment());
+
 instance = new modal({
     onOpen() {
         this.checkOverflow();


### PR DESCRIPTION
`modal.setContent(content)` internally calls `appendChild(content)` if `content` is not a string. Thus, it can accept any object that is a `Node`, including `DocumentFragment` objects. Therefore, the parameter type can be widened from `string | Element` to `string | Node`. Since the parameter type has been widened, any code that calls `setContent()` should be unaffected.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/robinparisi/tingle/blob/928dea3626ef3c3664df8daee0d7ad328bbed56d/src/tingle.js#L177>
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
