### PR TITLE
Added types for rgb2hex

### DIFF
--- a/types/rgb2hex/index.d.ts
+++ b/types/rgb2hex/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: abh80 <https://github.com/abh80>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 declare function hex2rgb(rgb: string): {
-	hex: string;
-	alpha: number;
+    hex: string;
+    alpha: number;
 };
 export = hex2rgb;

--- a/types/rgb2hex/index.d.ts
+++ b/types/rgb2hex/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for rgb2hex 0.2
+// Project: https://github.com/christian-bromann/rgb2hex
+// Definitions by: abh80 <https://github.com/abh80>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+declare function hex2rgb(rgb: string): {
+	hex: string;
+	alpha: number;
+};
+export = hex2rgb;

--- a/types/rgb2hex/rgb2hex-tests.ts
+++ b/types/rgb2hex/rgb2hex-tests.ts
@@ -1,0 +1,3 @@
+import rgb2hex = require('rgb2hex');
+rgb2hex('rgb(210,43,2525)');
+rgb2hex('rgba(12,173,22,.67)');

--- a/types/rgb2hex/tsconfig.json
+++ b/types/rgb2hex/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "rgb2hex-tests.ts"
+    ]
+}

--- a/types/rgb2hex/tslint.json
+++ b/types/rgb2hex/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Added types for [rgb2hex](https://github.com/christian-bromann/rgb2hex)
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

