### PR TITLE
[@types/json-schema-faker] Change jsf.generate Return Type to any

### DIFF
--- a/types/json-schema-faker/index.d.ts
+++ b/types/json-schema-faker/index.d.ts
@@ -13,7 +13,7 @@ declare namespace jsf {
     function define(name: string, cb: () => void): any;
     function reset(name: string): any;
     function locate(name: string): any;
-    function generate(schema: Schema, refs?: string | Schema[]): any[];
+    function generate(schema: Schema, refs?: string | Schema[]): any;
     function resolve(schema: Schema, refs?: string | Schema[], cwd?: string): Promise<any[]>;
     function option(option: string | OptionInputObject, value?: any): any;
 

--- a/types/json-schema-faker/json-schema-faker-tests.ts
+++ b/types/json-schema-faker/json-schema-faker-tests.ts
@@ -97,6 +97,13 @@ const testSchema: Schema = {
     },
 };
 
+const testListSchema: Schema = {
+    type: 'array',
+    minItems: 5,
+    maxItems: 5,
+    items: testSchema,
+};
+
 const testRef: jsf.Schema[] = [
     {
         id: 'otherSchema',
@@ -106,7 +113,10 @@ const testRef: jsf.Schema[] = [
 
 // generate
 const generated = jsf.generate(testSchema);
-generated.forEach(testItem);
+testItem(generated);
+
+const generatedList = jsf.generate(testListSchema);
+generatedList.forEach(testItem);
 
 // resolve
 jsf.resolve(testSchema, testRef).then(res => {


### PR DESCRIPTION
## Reasoning
The `jsf.generate` return type should be able to handle regular objects (`type: "object"`) in addition to arrays (`type: "array"`). Right now, trying to cast a single generated object to any given interface results in an error since TypeScript is being told only to expect an array.

cc: @baremaximum  @peterblazejewicz 

## Checklist
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/json-schema-faker/json-schema-faker/tree/master/docs>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
