### PR TITLE
Added definitions for @emartech/cls-adapter

### DIFF
--- a/types/emartech__cls-adapter/emartech__cls-adapter-tests.ts
+++ b/types/emartech__cls-adapter/emartech__cls-adapter-tests.ts
@@ -1,0 +1,21 @@
+import ClsAdapter from '@emartech/cls-adapter';
+
+ClsAdapter.createNamespace();
+
+ClsAdapter.getKoaMiddleware();
+
+ClsAdapter.getExpressMiddleware();
+
+ClsAdapter.setOnContext('key', 'myValue');
+
+ClsAdapter.getRequestId();
+
+ClsAdapter.getContextStorage().requestId;
+
+ClsAdapter.addContextStorageToInput()({key: 'myValue'}).requestId;
+ClsAdapter.addContextStorageToInput()({key: 'myValue'}).key;
+
+ClsAdapter.addRequestIdToInput()({key: 'myValue'}).requestId;
+ClsAdapter.addRequestIdToInput()({key: 'myValue'}).key;
+
+ClsAdapter.destroyNamespace();

--- a/types/emartech__cls-adapter/emartech__cls-adapter-tests.ts
+++ b/types/emartech__cls-adapter/emartech__cls-adapter-tests.ts
@@ -1,4 +1,4 @@
-import ClsAdapter from '@emartech/cls-adapter';
+import ClsAdapter = require('@emartech/cls-adapter');
 
 ClsAdapter.createNamespace();
 

--- a/types/emartech__cls-adapter/emartech__cls-adapter-tests.ts
+++ b/types/emartech__cls-adapter/emartech__cls-adapter-tests.ts
@@ -1,5 +1,10 @@
 import ClsAdapter = require('@emartech/cls-adapter');
 
+interface ContextDef {
+    extraKey: string;
+    boolKey: boolean;
+}
+
 ClsAdapter.createNamespace();
 
 ClsAdapter.getKoaMiddleware();
@@ -10,12 +15,14 @@ ClsAdapter.setOnContext('key', 'myValue');
 
 ClsAdapter.getRequestId();
 
-ClsAdapter.getContextStorage().requestId;
+ClsAdapter.getContextStorage<ContextDef>().requestId;
+ClsAdapter.getContextStorage<ContextDef>().extraKey;
+ClsAdapter.getContextStorage<ContextDef>().boolKey;
 
-ClsAdapter.addContextStorageToInput()({key: 'myValue'}).requestId;
-ClsAdapter.addContextStorageToInput()({key: 'myValue'}).key;
+ClsAdapter.addContextStorageToInput()({ key: 'myValue' }).requestId;
+ClsAdapter.addContextStorageToInput()({ key: 'myValue' }).key;
 
-ClsAdapter.addRequestIdToInput()({key: 'myValue'}).requestId;
-ClsAdapter.addRequestIdToInput()({key: 'myValue'}).key;
+ClsAdapter.addRequestIdToInput()({ key: 'myValue' }).requestId;
+ClsAdapter.addRequestIdToInput()({ key: 'myValue' }).key;
 
 ClsAdapter.destroyNamespace();

--- a/types/emartech__cls-adapter/index.d.ts
+++ b/types/emartech__cls-adapter/index.d.ts
@@ -33,6 +33,7 @@ declare class ContextFactory {
     /**
      * Returns the all the values set on the storage.
      */
+    // tslint:disable-next-line:no-unnecessary-generics
     static getContextStorage: <T = Record<string, unknown>>() => T & {
         requestId: string;
     };

--- a/types/emartech__cls-adapter/index.d.ts
+++ b/types/emartech__cls-adapter/index.d.ts
@@ -1,0 +1,65 @@
+// Type definitions for @emartech/cls-adapter 1.3
+// Project: https://github.com/emartech/cls-adapter
+// Definitions by: Lex Webb <https://github.com/lexwebb>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+import * as Koa from "koa";
+import * as Express from 'express';
+import * as CLS from "cls-hooked";
+
+declare class ClsAdapter {
+    private _namespace: CLS.Namespace;
+
+    /**
+     * Returns a middleware function compatible with Koa that stores (or generates if missing)
+     * the request identifier from the header (X-Request-Id) and sets it on the storage as request_id.
+     */
+    static getKoaMiddleware: () => Koa.Middleware;
+
+    /**
+     * Returns a middleware function compatible with Express that stores (or generates if missing) the request identifier from the header (X-Request-Id) and sets it on the storage as request_id.
+     */
+    static getExpressMiddleware: () => Express.Handler;
+
+    static run: CLS.Namespace["runAndReturn"];
+
+    /**
+     * Sets a key with a given value on the storage.
+     */
+    static setOnContext: CLS.Namespace["set"];
+
+    /**
+     * Returns the all the values set on the storage.
+     */
+    static getContextStorage: () => Partial<({ requestId: string })>;
+
+    /**
+     * Returns the the request identifier set on the storage. The identifiers key is request_id.
+     */
+    static getRequestId: () => string | undefined;
+
+    /**
+     * Returns a function that extends the given object with the current storage.
+     */
+    static addContextStorageToInput: () => <T extends {}>(input: T) => T & { requestId: string };
+
+    /**
+     * Returns a function that extends the given object with the request identifier set on the current storage.
+     */
+    static addRequestIdToInput: () => <T extends {}>(
+        input: T
+    ) => T & { requestId: string };
+
+    /**
+     * Destroys (if exists) the namespace with the name 'session'
+     */
+    static destroyNamespace: () => void;
+
+    /**
+     * Creates (or returns existing namespace) with the namespace name 'session'
+     */
+    static createNamespace: () => CLS.Namespace;
+}
+
+export = ClsAdapter;

--- a/types/emartech__cls-adapter/index.d.ts
+++ b/types/emartech__cls-adapter/index.d.ts
@@ -8,7 +8,7 @@ import * as Koa from "koa";
 import * as Express from 'express';
 import * as CLS from "cls-hooked";
 
-declare class ClsAdapter {
+declare class ContextFactory {
     private _namespace: CLS.Namespace;
 
     /**
@@ -18,7 +18,8 @@ declare class ClsAdapter {
     static getKoaMiddleware: () => Koa.Middleware;
 
     /**
-     * Returns a middleware function compatible with Express that stores (or generates if missing) the request identifier from the header (X-Request-Id) and sets it on the storage as request_id.
+     * Returns a middleware function compatible with Express that stores (or generates if missing)
+     * the request identifier from the header (X-Request-Id) and sets it on the storage as request_id.
      */
     static getExpressMiddleware: () => Express.Handler;
 
@@ -32,7 +33,9 @@ declare class ClsAdapter {
     /**
      * Returns the all the values set on the storage.
      */
-    static getContextStorage: () => Partial<({ requestId: string })>;
+    static getContextStorage: <T = Record<string, unknown>>() => T & {
+        requestId: string;
+    };
 
     /**
      * Returns the the request identifier set on the storage. The identifiers key is request_id.
@@ -62,4 +65,4 @@ declare class ClsAdapter {
     static createNamespace: () => CLS.Namespace;
 }
 
-export = ClsAdapter;
+export = ContextFactory;

--- a/types/emartech__cls-adapter/tsconfig.json
+++ b/types/emartech__cls-adapter/tsconfig.json
@@ -19,8 +19,7 @@
         },
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "esModuleInterop": true
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/emartech__cls-adapter/tsconfig.json
+++ b/types/emartech__cls-adapter/tsconfig.json
@@ -1,0 +1,29 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@emartech/cls-adapter": [
+                "emartech__cls-adapter"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "emartech__cls-adapter-tests.ts"
+    ]
+}

--- a/types/emartech__cls-adapter/tslint.json
+++ b/types/emartech__cls-adapter/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.