### PR TITLE
[@types/underscore] Object Tests - Pick and Omit

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -169,8 +169,7 @@ declare module _ {
     type PickSelector<V> = (keyof V)[] | string[] | ObjectIterator<TypeOfDictionary<V, any>, boolean, V>;
 
     type _Pick<V, I> =
-        V extends never ? any
-        : Extract<I, keyof V> extends never ? Partial<V>
+        Extract<I, keyof V> extends never ? Partial<V>
         : Pick<V, Extract<I, keyof V>>;
 
     // switch to Omit when the minimum TS version moves past 3.5

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -166,12 +166,12 @@ declare module _ {
 
     type Truthy<T> = Exclude<T, AnyFalsy>;
 
-    type _Pick<V, K> =
+    type _Pick<V, K extends string> =
         Extract<K, keyof V> extends never ? Partial<V>
         : Pick<V, Extract<K, keyof V>>;
 
     // switch to Omit when the minimum TS version moves past 3.5
-    type _Omit<V, K> =
+    type _Omit<V, K extends string> =
         V extends never ? any
         : Extract<K, keyof V> extends never ? Partial<V>
         : Pick<V, Exclude<keyof V, K>>;

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -3544,7 +3544,7 @@ declare module _ {
 
         /**
          * Return a copy of `object` that is filtered to only have values for
-         * the whitelisted keys (or array of keys).
+         * the allowed keys (or array of keys).
          * @param object The object to pick specific keys in.
          * @param keys The keys to keep on `object`.
          * @returns A copy of `object` with only the `keys` properties.
@@ -3563,7 +3563,7 @@ declare module _ {
         pick<V>(object: V, iterator: ObjectIterator<TypeOfDictionary<V, any>, boolean, V>): Partial<V>;
 
         /**
-         * Return a copy of `object` that is filtered to omit the blacklisted
+         * Return a copy of `object` that is filtered to omit the disallowed
          * keys (or array of keys).
          * @param object The object to omit specific keys from.
          * @param keys The keys to omit from `object`.
@@ -4757,7 +4757,7 @@ declare module _ {
 
         /**
          * Return a copy of the wrapped object that is filtered to only have
-         * values for the whitelisted keys (or array of keys).
+         * values for the allowed keys (or array of keys).
          * @param keys The keys to keep on the wrapped object.
          * @returns A copy of the wrapped object with only the `keys`
          * properties.
@@ -4776,7 +4776,7 @@ declare module _ {
 
         /**
          * Return a copy of the wrapped object that is filtered to omit the
-         * blacklisted keys (or array of keys).
+         * disallowed keys (or array of keys).
          * @param keys The keys to omit from the wrapped object.
          * @returns A copy of the wrapped object without the `keys` properties.
          **/
@@ -5889,7 +5889,7 @@ declare module _ {
 
         /**
          * Return a copy of the wrapped object that is filtered to only have
-         * values for the whitelisted keys (or array of keys).
+         * values for the allowed keys (or array of keys).
          * @param keys The keys to keep on the wrapped object.
          * @returns A chain wrapper around a copy of the wrapped object with
          * only the `keys` properties.
@@ -5908,7 +5908,7 @@ declare module _ {
 
         /**
          * Return a copy of the wrapped object that is filtered to omit the
-         * blacklisted keys (or array of keys).
+         * disallowed keys (or array of keys).
          * @param keys The keys to omit from the wrapped object.
          * @returns A chain wrapper around a copy of the wrapped object without
          * the `keys` properties.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -3552,7 +3552,7 @@ declare module _ {
          * @param keys The keys to keep on `object`.
          * @returns A copy of `object` with only the `keys` properties.
          **/
-        pick<V extends object, K extends string>(obj: V, ...keys: K[]): _Pick<V, K>;
+        pick<V extends object, K extends string>(object: V, ...keys: K[]): _Pick<V, K>;
 
         /**
          * Return a copy of `object` that is filtered to only have values for
@@ -3563,7 +3563,7 @@ declare module _ {
          * @returns A copy of `object` with only the keys selected by
          * `keysOrIterator`.
          **/
-        pick<V extends object, I extends PickSelector<V>>(obj: V, keysOrIterator: I): _Pick<V, ListItemOrSelf<I>>;
+        pick<V extends object, I extends PickSelector<V>>(object: V, keysOrIterator: I): _Pick<V, ListItemOrSelf<I>>;
 
         /**
          * Return a copy of `object` that is filtered to omit the blacklisted
@@ -3572,7 +3572,7 @@ declare module _ {
          * @param keys The keys to omit from `object`.
          * @returns A copy of `object` without the `keys` properties.
          **/
-        omit<V extends object, K extends string>(obj: V, ...keys: K[]): _Omit<V, K>;
+        omit<V extends object, K extends string>(object: V, ...keys: K[]): _Omit<V, K>;
 
         /**
          * Return a copy of `object` that is filtered to not have values for
@@ -3583,7 +3583,7 @@ declare module _ {
          * @returns A copy of `object` without the keys selected by
          * `keysOrIterator`.
          **/
-        omit<V extends object, I extends PickSelector<V>>(obj: V, keysOrIterator: I): _Omit<V, ListItemOrSelf<I>>;
+        omit<V extends object, I extends PickSelector<V>>(object: V, keysOrIterator: I): _Omit<V, ListItemOrSelf<I>>;
 
         /**
         * Fill in null and undefined properties in object with values from the defaults objects,
@@ -4788,7 +4788,6 @@ declare module _ {
         /**
          * Return a copy of the wrapped object that is filtered to not have
          * values for the keys selected by a truth test.
-         * @param object The object to omit specific keys from.
          * @param keysOrIterator A set of keys or a truth test that selects the
          * keys to omit from the wrapped object.
          * @returns A copy of the wrapped object without the keys selected by
@@ -5922,7 +5921,6 @@ declare module _ {
         /**
          * Return a copy of the wrapped object that is filtered to not have
          * values for the keys selected by a truth test.
-         * @param object The object to omit specific keys from.
          * @param keysOrIterator A set of keys or a truth test that selects the
          * keys to omit from the wrapped object.
          * @returns A chain wrapper around a copy of the wrapped object without

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -166,17 +166,15 @@ declare module _ {
 
     type Truthy<T> = Exclude<T, AnyFalsy>;
 
-    type PickSelector<V> = (keyof V)[] | string[] | ObjectIterator<TypeOfDictionary<V, any>, boolean, V>;
-
-    type _Pick<V, I> =
-        Extract<I, keyof V> extends never ? Partial<V>
-        : Pick<V, Extract<I, keyof V>>;
+    type _Pick<V, K> =
+        Extract<K, keyof V> extends never ? Partial<V>
+        : Pick<V, Extract<K, keyof V>>;
 
     // switch to Omit when the minimum TS version moves past 3.5
-    type _Omit<V, I> =
+    type _Omit<V, K> =
         V extends never ? any
-        : Extract<I, keyof V> extends never ? Partial<V>
-        : Pick<V, Exclude<keyof V, I>>;
+        : Extract<K, keyof V> extends never ? Partial<V>
+        : Pick<V, Exclude<keyof V, K>>;
 
     type _ChainSingle<V> = _Chain<TypeOfCollection<V>, V>;
 
@@ -3551,18 +3549,18 @@ declare module _ {
          * @param keys The keys to keep on `object`.
          * @returns A copy of `object` with only the `keys` properties.
          **/
-        pick<V, K extends string>(object: V, ...keys: K[]): _Pick<V, K>;
+        pick<V, K extends string>(object: V, ...keys: (K | K[])[]): _Pick<V, K>;
 
         /**
          * Return a copy of `object` that is filtered to only have values for
          * the keys selected by a truth test.
          * @param object The object to pick specific keys in.
-         * @param keysOrIterator A set of keys or a truth test that selects the
-         * keys to keep on `object`.
+         * @param iterator A truth test that selects the keys to keep on
+         * `object`.
          * @returns A copy of `object` with only the keys selected by
-         * `keysOrIterator`.
+         * `iterator`.
          **/
-        pick<V, I extends PickSelector<V>>(object: V, keysOrIterator: I): _Pick<V, ListItemOrSelf<I>>;
+        pick<V>(object: V, iterator: ObjectIterator<TypeOfDictionary<V, any>, boolean, V>): Partial<V>;
 
         /**
          * Return a copy of `object` that is filtered to omit the blacklisted
@@ -3571,18 +3569,18 @@ declare module _ {
          * @param keys The keys to omit from `object`.
          * @returns A copy of `object` without the `keys` properties.
          **/
-        omit<V, K extends string>(object: V, ...keys: K[]): _Omit<V, K>;
+        omit<V, K extends string>(object: V, ...keys: (K | K[])[]): _Omit<V, K>;
 
         /**
          * Return a copy of `object` that is filtered to not have values for
          * the keys selected by a truth test.
          * @param object The object to omit specific keys from.
-         * @param keysOrIterator A set of keys or a truth test that selects the
-         * keys to omit from `object`.
+         * @param iterator A truth test that selects the keys to omit from
+         * `object`.
          * @returns A copy of `object` without the keys selected by
-         * `keysOrIterator`.
+         * `iterator`.
          **/
-        omit<V, I extends PickSelector<V>>(object: V, keysOrIterator: I): _Omit<V, ListItemOrSelf<I>>;
+        omit<V>(object: V, iterator: ObjectIterator<TypeOfDictionary<V, any>, boolean, V>): Partial<V>;
 
         /**
         * Fill in null and undefined properties in object with values from the defaults objects,
@@ -4764,17 +4762,17 @@ declare module _ {
          * @returns A copy of the wrapped object with only the `keys`
          * properties.
          **/
-        pick<K extends string>(...keys: K[]): _Pick<V, K>;
+        pick<K extends string>(...keys: (K | K[])[]): _Pick<V, K>;
 
         /**
          * Return a copy of the wrapped object that is filtered to only have
          * values for the keys selected by a truth test.
-         * @param keysOrIterator A set of keys or a truth test that selects the
-         * keys to keep on the wrapped object.
+         * @param iterator A truth test that selects the keys to keep on the
+         * wrapped object.
          * @returns A copy of the wrapped object with only the keys selected by
-         * `keysOrIterator`.
+         * `iterator`.
          **/
-        pick<I extends PickSelector<V>>(keysOrIterator: I): _Pick<V, ListItemOrSelf<I>>;
+        pick(iterator: ObjectIterator<TypeOfDictionary<V, any>, boolean, V>): Partial<V>;
 
         /**
          * Return a copy of the wrapped object that is filtered to omit the
@@ -4782,17 +4780,17 @@ declare module _ {
          * @param keys The keys to omit from the wrapped object.
          * @returns A copy of the wrapped object without the `keys` properties.
          **/
-        omit<K extends string>(...keys: K[]): _Omit<V, K>;
+        omit<K extends string>(...keys: (K | K[])[]): _Omit<V, K>;
 
         /**
          * Return a copy of the wrapped object that is filtered to not have
          * values for the keys selected by a truth test.
-         * @param keysOrIterator A set of keys or a truth test that selects the
-         * keys to omit from the wrapped object.
+         * @param iterator A truth test that selects the keys to omit from the
+         * wrapped object.
          * @returns A copy of the wrapped object without the keys selected by
-         * `keysOrIterator`.
+         * `iterator`.
          **/
-        omit<I extends PickSelector<V>>(keysOrIterator: I): _Omit<V, ListItemOrSelf<I>>;
+        omit(iterator: ObjectIterator<TypeOfDictionary<V, any>, boolean, V>): Partial<V>;
 
         /**
         * Wrapped type `object`.
@@ -5896,17 +5894,17 @@ declare module _ {
          * @returns A chain wrapper around a copy of the wrapped object with
          * only the `keys` properties.
          **/
-        pick<K extends string>(...keys: K[]): _ChainSingle<_Pick<V, K>>;
+        pick<K extends string>(...keys: (K | K[])[]): _ChainSingle<_Pick<V, K>>;
 
         /**
          * Return a copy of the wrapped object that is filtered to only have
          * values for the keys selected by a truth test.
-         * @param keysOrIterator A set of keys or a truth test that selects the
-         * keys to keep on the wrapped object.
+         * @param iterator A truth test that selects the keys to keep on the
+         * wrapped object.
          * @returns A chain wrapper around a copy of the wrapped object with
-         * only the keys selected by `keysOrIterator`.
+         * only the keys selected by `iterator`.
          **/
-        pick<I extends PickSelector<V>>(keysOrIterator: I): _ChainSingle<_Pick<V, ListItemOrSelf<I>>>;
+        pick(iterator: ObjectIterator<TypeOfDictionary<V, any>, boolean, V>): _ChainSingle<Partial<V>>;
 
         /**
          * Return a copy of the wrapped object that is filtered to omit the
@@ -5915,17 +5913,17 @@ declare module _ {
          * @returns A chain wrapper around a copy of the wrapped object without
          * the `keys` properties.
          **/
-        omit<K extends string>(...keys: K[]): _ChainSingle<_Omit<V, K>>;
+        omit<K extends string>(...keys: (K | K[])[]): _ChainSingle<_Omit<V, K>>;
 
         /**
          * Return a copy of the wrapped object that is filtered to not have
          * values for the keys selected by a truth test.
-         * @param keysOrIterator A set of keys or a truth test that selects the
-         * keys to omit from the wrapped object.
+         * @param iterator A truth test that selects the keys to omit from the
+         * wrapped object.
          * @returns A chain wrapper around a copy of the wrapped object without
-         * the keys selected by `keysOrIterator`.
+         * the keys selected by `iterator`.
          **/
-        omit<I extends PickSelector<V>>(keysOrIterator: I): _ChainSingle<_Omit<V, ListItemOrSelf<I>>>;
+        omit(iterator: ObjectIterator<TypeOfDictionary<V, any>, boolean, V>): _ChainSingle<Partial<V>>;
 
         /**
         * Wrapped type `object`.

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -3551,7 +3551,7 @@ declare module _ {
          * @param keys The keys to keep on `object`.
          * @returns A copy of `object` with only the `keys` properties.
          **/
-        pick<V extends object, K extends string>(object: V, ...keys: K[]): _Pick<V, K>;
+        pick<V, K extends string>(object: V, ...keys: K[]): _Pick<V, K>;
 
         /**
          * Return a copy of `object` that is filtered to only have values for
@@ -3562,7 +3562,7 @@ declare module _ {
          * @returns A copy of `object` with only the keys selected by
          * `keysOrIterator`.
          **/
-        pick<V extends object, I extends PickSelector<V>>(object: V, keysOrIterator: I): _Pick<V, ListItemOrSelf<I>>;
+        pick<V, I extends PickSelector<V>>(object: V, keysOrIterator: I): _Pick<V, ListItemOrSelf<I>>;
 
         /**
          * Return a copy of `object` that is filtered to omit the blacklisted
@@ -3571,7 +3571,7 @@ declare module _ {
          * @param keys The keys to omit from `object`.
          * @returns A copy of `object` without the `keys` properties.
          **/
-        omit<V extends object, K extends string>(object: V, ...keys: K[]): _Omit<V, K>;
+        omit<V, K extends string>(object: V, ...keys: K[]): _Omit<V, K>;
 
         /**
          * Return a copy of `object` that is filtered to not have values for
@@ -3582,7 +3582,7 @@ declare module _ {
          * @returns A copy of `object` without the keys selected by
          * `keysOrIterator`.
          **/
-        omit<V extends object, I extends PickSelector<V>>(object: V, keysOrIterator: I): _Omit<V, ListItemOrSelf<I>>;
+        omit<V, I extends PickSelector<V>>(object: V, keysOrIterator: I): _Omit<V, ListItemOrSelf<I>>;
 
         /**
         * Fill in null and undefined properties in object with values from the defaults objects,

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -2985,9 +2985,9 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     extractChainTypes(_.chain(mixedTypeRecord).pick('a', 'b')); // $ExpectType ChainType<Pick<MixedTypeRecord, "a" | "b">, number | StringRecord>
 
     // individual key parameters - any
-    _.pick(anyValue, 'a', 'b'); // $ExpectType any
-    _(anyValue).pick('a', 'b'); // $ExpectType any
-    extractChainTypes(_.chain(anyValue).pick('a', 'b')); // $ExpectType ChainType<any, any>
+    _.pick(anyValue, 'a', 'b'); // $ExpectType Pick<any, "a" | "b">
+    _(anyValue).pick('a', 'b'); // $ExpectType Pick<any, "a" | "b">
+    extractChainTypes(_.chain(anyValue).pick('a', 'b')); // $ExpectType ChainType<Pick<any, "a" | "b">, any>
 
     // key array - record
     _.pick(mixedTypeRecord, ['a', 'b']); // $ExpectType Pick<MixedTypeRecord, "a" | "b">
@@ -2995,9 +2995,9 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     extractChainTypes(_.chain(mixedTypeRecord).pick(['a', 'b'])); // $ExpectType ChainType<Pick<MixedTypeRecord, "a" | "b">, number | StringRecord>
 
     // key array - any
-    _.pick(anyValue, ['a', 'b']); // $ExpectType any
-    _(anyValue).pick(['a', 'b']); // $ExpectType any
-    extractChainTypes(_.chain(anyValue).pick(['a', 'b'])); // $ExpectType ChainType<any, any>
+    _.pick(anyValue, ['a', 'b']); // $ExpectType Pick<any, "a" | "b">
+    _(anyValue).pick(['a', 'b']); // $ExpectType Pick<any, string>
+    extractChainTypes(_.chain(anyValue).pick(['a', 'b'])); // $ExpectType ChainType<Pick<any, string>, any>
 
     // string list - record
     _.pick(mixedTypeRecord, simpleStringArray); // $ExpectType Partial<MixedTypeRecord>
@@ -3005,9 +3005,9 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     extractChainTypes(_.chain(mixedTypeRecord).pick(simpleStringArray)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingStringRecord | undefined>
 
     // string array - any
-    _.pick(anyValue, simpleStringArray); // $ExpectType any
-    _(anyValue).pick(simpleStringArray); // $ExpectType any
-    extractChainTypes(_.chain(anyValue).pick(simpleStringArray)); // $ExpectType ChainType<any, any>
+    _.pick(anyValue, simpleStringArray); // $ExpectType Pick<any, string>
+    _(anyValue).pick(simpleStringArray); // $ExpectType Pick<any, string>
+    extractChainTypes(_.chain(anyValue).pick(simpleStringArray)); // $ExpectType ChainType<Pick<any, string>, any>
 
     // function iteratee - record
     _.pick(mixedTypeRecord, mixedTypeRecordBooleanIterator); // $ExpectType Partial<MixedTypeRecord>
@@ -3020,9 +3020,9 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     extractChainTypes(_.chain(stringRecordDictionary).pick(stringRecordDictionaryBooleanIterator)); // $ExpectType ChainType<Partial<Dictionary<StringRecord>>, StringRecordOrUndefined>
 
     // function iteratee - any
-    _.pick(anyValue, anyBooleanIterator); // $ExpectType any
-    _(anyValue).pick(anyBooleanIterator); // $ExpectType any
-    extractChainTypes(_.chain(anyValue).pick(anyBooleanIterator)); // $ExpectType ChainType<any, any>
+    _.pick(anyValue, anyBooleanIterator); // $ExpectType Partial<any>
+    _(anyValue).pick(anyBooleanIterator); // $ExpectType Partial<any>
+    extractChainTypes(_.chain(anyValue).pick(anyBooleanIterator)); // $ExpectType ChainType<Partial<any>, any>
 }
 
 // omit

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -743,6 +743,7 @@ declare const stringListMemoIterator: (prev: _.Dictionary<number>, value: string
 declare const resultUnionStringListMemoIterator: (prev: string | number, value: string, index: number, str: string) => string | number;
 
 declare const anyCollectionVoidIterator: (element: any, index: string | number, collection: any) => void;
+declare const anyBooleanIterator: (element: any, key: string | number, obj: any) => boolean;
 
 const simpleNumber = 7;
 declare const simpleNumberList: _.List<number>;
@@ -2974,6 +2975,102 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _.findKey(mixedTypeRecord); // $ExpectType "a" | "b" | "c" | undefined
     _(mixedTypeRecord).findKey(); // $ExpectType "a" | "b" | "c" | undefined
     extractChainTypes(_.chain(mixedTypeRecord).findKey()); // $ExpectType ChainType<"a" | "b" | "c" | undefined, string>
+}
+
+// pick
+{
+    // individual key parameters - record
+    _.pick(mixedTypeRecord, 'a', 'b'); // $ExpectType Pick<MixedTypeRecord, "a" | "b">
+    _(mixedTypeRecord).pick('a', 'b'); // $ExpectType Pick<MixedTypeRecord, "a" | "b">
+    extractChainTypes(_.chain(mixedTypeRecord).pick('a', 'b')); // $ExpectType ChainType<Pick<MixedTypeRecord, "a" | "b">, number | StringRecord>
+
+    // individual key parameters - any
+    _.pick(anyValue, 'a', 'b'); // $ExpectType any
+    _(anyValue).pick('a', 'b'); // $ExpectType any
+    extractChainTypes(_.chain(anyValue).pick('a', 'b')); // $ExpectType ChainType<any, any>
+
+    // key array - record
+    _.pick(mixedTypeRecord, ['a', 'b']); // $ExpectType Pick<MixedTypeRecord, "a" | "b">
+    _(mixedTypeRecord).pick(['a', 'b']); // $ExpectType Pick<MixedTypeRecord, "a" | "b">
+    extractChainTypes(_.chain(mixedTypeRecord).pick(['a', 'b'])); // $ExpectType ChainType<Pick<MixedTypeRecord, "a" | "b">, number | StringRecord>
+
+    // key array - any
+    _.pick(anyValue, ['a', 'b']); // $ExpectType any
+    _(anyValue).pick(['a', 'b']); // $ExpectType any
+    extractChainTypes(_.chain(anyValue).pick(['a', 'b'])); // $ExpectType ChainType<any, any>
+
+    // string list - record
+    _.pick(mixedTypeRecord, simpleStringArray); // $ExpectType Partial<MixedTypeRecord>
+    _(mixedTypeRecord).pick(simpleStringArray); // $ExpectType Partial<MixedTypeRecord>
+    extractChainTypes(_.chain(mixedTypeRecord).pick(simpleStringArray)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingStringRecord | undefined>
+
+    // string array - any
+    _.pick(anyValue, simpleStringArray); // $ExpectType any
+    _(anyValue).pick(simpleStringArray); // $ExpectType any
+    extractChainTypes(_.chain(anyValue).pick(simpleStringArray)); // $ExpectType ChainType<any, any>
+
+    // function iteratee - record
+    _.pick(mixedTypeRecord, mixedTypeRecordBooleanIterator); // $ExpectType Partial<MixedTypeRecord>
+    _(mixedTypeRecord).pick(mixedTypeRecordBooleanIterator); // $ExpectType Partial<MixedTypeRecord>
+    extractChainTypes(_.chain(mixedTypeRecord).pick(mixedTypeRecordBooleanIterator)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingStringRecord | undefined>
+
+    // function iteratee - dictionary
+    _.pick(stringRecordDictionary, stringRecordDictionaryBooleanIterator); // $ExpectType Partial<Dictionary<StringRecord>>
+    _(stringRecordDictionary).pick(stringRecordDictionaryBooleanIterator); // $ExpectType Partial<Dictionary<StringRecord>>
+    extractChainTypes(_.chain(stringRecordDictionary).pick(stringRecordDictionaryBooleanIterator)); // $ExpectType ChainType<Partial<Dictionary<StringRecord>>, StringRecordOrUndefined>
+
+    // function iteratee - any
+    _.pick(anyValue, anyBooleanIterator); // $ExpectType any
+    _(anyValue).pick(anyBooleanIterator); // $ExpectType any
+    extractChainTypes(_.chain(anyValue).pick(anyBooleanIterator)); // $ExpectType ChainType<any, any>
+}
+
+// omit
+{
+    // individual key parameters - record
+    _.omit(mixedTypeRecord, 'a', 'b'); // $ExpectType Pick<MixedTypeRecord, "c">
+    _(mixedTypeRecord).omit('a', 'b'); // $ExpectType Pick<MixedTypeRecord, "c">
+    extractChainTypes(_.chain(mixedTypeRecord).omit('a', 'b')); // $ExpectType ChainType<Pick<MixedTypeRecord, "c">, NonIntersectingProperties>
+
+    // individual key parameters - any
+    _.omit(anyValue, 'a', 'b'); // $ExpectType any
+    _(anyValue).omit('a', 'b'); // $ExpectType any
+    extractChainTypes(_.chain(anyValue).omit('a', 'b')); // $ExpectType ChainType<any, any>
+
+    // key array - record
+    _.omit(mixedTypeRecord, ['a', 'b']); // $ExpectType Pick<MixedTypeRecord, "c">
+    _(mixedTypeRecord).omit(['a', 'b']); // $ExpectType Pick<MixedTypeRecord, "c">
+    extractChainTypes(_.chain(mixedTypeRecord).omit(['a', 'b'])); // $ExpectType ChainType<Pick<MixedTypeRecord, "c">, NonIntersectingProperties>
+
+    // key array - any
+    _.omit(anyValue, ['a', 'b']); // $ExpectType any
+    _(anyValue).omit(['a', 'b']); // $ExpectType any
+    extractChainTypes(_.chain(anyValue).omit(['a', 'b'])); // $ExpectType ChainType<any, any>
+
+    // string list - record
+    _.omit(mixedTypeRecord, simpleStringArray); // $ExpectType Partial<MixedTypeRecord>
+    _(mixedTypeRecord).omit(simpleStringArray); // $ExpectType Partial<MixedTypeRecord>
+    extractChainTypes(_.chain(mixedTypeRecord).omit(simpleStringArray)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingStringRecord | undefined>
+
+    // string array - any
+    _.omit(anyValue, simpleStringArray); // $ExpectType any
+    _(anyValue).omit(simpleStringArray); // $ExpectType any
+    extractChainTypes(_.chain(anyValue).omit(simpleStringArray)); // $ExpectType ChainType<any, any>
+
+    // function iteratee - record
+    _.omit(mixedTypeRecord, mixedTypeRecordBooleanIterator); // $ExpectType Partial<MixedTypeRecord>
+    _(mixedTypeRecord).omit(mixedTypeRecordBooleanIterator); // $ExpectType Partial<MixedTypeRecord>
+    extractChainTypes(_.chain(mixedTypeRecord).omit(mixedTypeRecordBooleanIterator)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingStringRecord | undefined>
+
+    // function iteratee - dictionary
+    _.omit(stringRecordDictionary, stringRecordDictionaryBooleanIterator); // $ExpectType Partial<Dictionary<StringRecord>>
+    _(stringRecordDictionary).omit(stringRecordDictionaryBooleanIterator); // $ExpectType Partial<Dictionary<StringRecord>>
+    extractChainTypes(_.chain(stringRecordDictionary).omit(stringRecordDictionaryBooleanIterator)); // $ExpectType ChainType<Partial<Dictionary<StringRecord>>, StringRecordOrUndefined>
+
+    // function iteratee - any
+    _.omit(anyValue, anyBooleanIterator); // $ExpectType any
+    _(anyValue).omit(anyBooleanIterator); // $ExpectType any
+    extractChainTypes(_.chain(anyValue).omit(anyBooleanIterator)); // $ExpectType ChainType<any, any>
 }
 
 // isEqual

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -2999,7 +2999,7 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _(anyValue).pick(['a'], ['b']); // $ExpectType Pick<any, "a" | "b">
     extractChainTypes(_.chain(anyValue).pick(['a'], ['b'])); // $ExpectType ChainType<Pick<any, "a" | "b">, any>
 
-    // the generics in the below cases are only required in TS versions below 3.6
+    // the explicit generics in the below cases are only required in TS versions below 3.6
     // constant strings and string arrays - record
     _.pick<MixedTypeRecord, 'a' | 'b' | 'notAKey'>(mixedTypeRecord, 'a', ['b'], 'notAKey'); // $ExpectType Pick<MixedTypeRecord, "a" | "b">
     _(mixedTypeRecord).pick<'a' | 'b' | 'notAKey'>('a', ['b'], 'notAKey'); // $ExpectType Pick<MixedTypeRecord, "a" | "b">
@@ -3068,7 +3068,7 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _(anyValue).omit(['a'], ['b']); // $ExpectType any
     extractChainTypes(_.chain(anyValue).omit(['a'], ['b'])); // $ExpectType ChainType<any, any>
 
-    // the generics in the below cases are only required in TS versions below 3.6
+    // the explicit generics in the below cases are only required in TS versions below 3.6
     // constant strings and string arrays - record
     _.omit<MixedTypeRecord, 'a' | 'b' | 'notAKey'>(mixedTypeRecord, 'a', ['b'], 'notAKey'); // $ExpectType Pick<MixedTypeRecord, "c">
     _(mixedTypeRecord).omit<'a' | 'b' | 'notAKey'>('a', ['b'], 'notAKey'); // $ExpectType Pick<MixedTypeRecord, "c">

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -730,7 +730,7 @@ interface TwoParameterFunctionRecord {
 declare const twoParameterFunctionRecordList: _.List<TwoParameterFunctionRecord>;
 declare const twoParameterFunctionRecordDictionary: _.Dictionary<TwoParameterFunctionRecord>;
 
-const simpleString = 'abc';
+declare const simpleString: string;
 
 const simpleStringArray: string[] = ['a', 'c'];
 const simpleStringList: _.List<string> = { 0: 'a', 1: 'c', length: 2 };
@@ -2979,47 +2979,68 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
 
 // pick
 {
-    // individual key parameters - record
-    _.pick(mixedTypeRecord, 'a', 'b'); // $ExpectType Pick<MixedTypeRecord, "a" | "b">
-    _(mixedTypeRecord).pick('a', 'b'); // $ExpectType Pick<MixedTypeRecord, "a" | "b">
-    extractChainTypes(_.chain(mixedTypeRecord).pick('a', 'b')); // $ExpectType ChainType<Pick<MixedTypeRecord, "a" | "b">, number | StringRecord>
+    // constant strings - record
+    _.pick(mixedTypeRecord, 'a', 'b', 'notAKey'); // $ExpectType Pick<MixedTypeRecord, "a" | "b">
+    _(mixedTypeRecord).pick('a', 'b', 'notAKey'); // $ExpectType Pick<MixedTypeRecord, "a" | "b">
+    extractChainTypes(_.chain(mixedTypeRecord).pick('a', 'b', 'notAKey')); // $ExpectType ChainType<Pick<MixedTypeRecord, "a" | "b">, number | StringRecord>
 
-    // individual key parameters - any
+    // constant strings - any
     _.pick(anyValue, 'a', 'b'); // $ExpectType Pick<any, "a" | "b">
     _(anyValue).pick('a', 'b'); // $ExpectType Pick<any, "a" | "b">
     extractChainTypes(_.chain(anyValue).pick('a', 'b')); // $ExpectType ChainType<Pick<any, "a" | "b">, any>
 
-    // key array - record
-    _.pick(mixedTypeRecord, ['a', 'b']); // $ExpectType Pick<MixedTypeRecord, "a" | "b">
-    _(mixedTypeRecord).pick(['a', 'b']); // $ExpectType Pick<MixedTypeRecord, "a" | "b">
-    extractChainTypes(_.chain(mixedTypeRecord).pick(['a', 'b'])); // $ExpectType ChainType<Pick<MixedTypeRecord, "a" | "b">, number | StringRecord>
+    // constant string arrays - record
+    _.pick(mixedTypeRecord, ['a'], ['b', 'notAKey']); // $ExpectType Pick<MixedTypeRecord, "a" | "b">
+    _(mixedTypeRecord).pick(['a'], ['b', 'notAKey']); // $ExpectType Pick<MixedTypeRecord, "a" | "b">
+    extractChainTypes(_.chain(mixedTypeRecord).pick(['a'], ['b', 'notAKey'])); // $ExpectType ChainType<Pick<MixedTypeRecord, "a" | "b">, number | StringRecord>
 
-    // key array - any
-    _.pick(anyValue, ['a', 'b']); // $ExpectType Pick<any, "a" | "b">
-    _(anyValue).pick(['a', 'b']); // $ExpectType Pick<any, string>
-    extractChainTypes(_.chain(anyValue).pick(['a', 'b'])); // $ExpectType ChainType<Pick<any, string>, any>
+    // constant string arrays - any
+    _.pick(anyValue, ['a'], ['b']); // $ExpectType Pick<any, "a" | "b">
+    _(anyValue).pick(['a'], ['b']); // $ExpectType Pick<any, "a" | "b">
+    extractChainTypes(_.chain(anyValue).pick(['a'], ['b'])); // $ExpectType ChainType<Pick<any, "a" | "b">, any>
 
-    // string list - record
+    // the generics in the below cases are only required in TS versions below 3.6
+    // constant strings and string arrays - record
+    _.pick<MixedTypeRecord, 'a' | 'b' | 'notAKey'>(mixedTypeRecord, 'a', ['b'], 'notAKey'); // $ExpectType Pick<MixedTypeRecord, "a" | "b">
+    _(mixedTypeRecord).pick<'a' | 'b' | 'notAKey'>('a', ['b'], 'notAKey'); // $ExpectType Pick<MixedTypeRecord, "a" | "b">
+    extractChainTypes(_.chain(mixedTypeRecord).pick<'a' | 'b' | 'notAKey'>('a', ['b'], 'notAKey')); // $ExpectType ChainType<Pick<MixedTypeRecord, "a" | "b">, number | StringRecord>
+
+    // constant strings and string arrays - any
+    _.pick<any, 'a' | 'b'>(anyValue, 'a', ['b']); // $ExpectType Pick<any, "a" | "b">
+    _(anyValue).pick<'a' | 'b'>('a', ['b']); // $ExpectType Pick<any, "a" | "b">
+    extractChainTypes(_.chain(anyValue).pick<'a' | 'b'>('a', ['b'])); // $ExpectType ChainType<Pick<any, "a" | "b">, any>
+
+    // generic strings - record
+    _.pick(mixedTypeRecord, simpleString); // $ExpectType Partial<MixedTypeRecord>
+    _(mixedTypeRecord).pick(simpleString); // $ExpectType Partial<MixedTypeRecord>
+    extractChainTypes(_.chain(mixedTypeRecord).pick(simpleString)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingStringRecord | undefined>
+
+    // generic strings - any
+    _.pick(anyValue, simpleString); // $ExpectType Pick<any, string>
+    _(anyValue).pick(simpleString); // $ExpectType Pick<any, string>
+    extractChainTypes(_.chain(anyValue).pick(simpleString)); // $ExpectType ChainType<Pick<any, string>, any>
+
+    // generic string arrays - record
     _.pick(mixedTypeRecord, simpleStringArray); // $ExpectType Partial<MixedTypeRecord>
     _(mixedTypeRecord).pick(simpleStringArray); // $ExpectType Partial<MixedTypeRecord>
     extractChainTypes(_.chain(mixedTypeRecord).pick(simpleStringArray)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingStringRecord | undefined>
 
-    // string array - any
+    // generic string arrays - any
     _.pick(anyValue, simpleStringArray); // $ExpectType Pick<any, string>
     _(anyValue).pick(simpleStringArray); // $ExpectType Pick<any, string>
     extractChainTypes(_.chain(anyValue).pick(simpleStringArray)); // $ExpectType ChainType<Pick<any, string>, any>
 
-    // function iteratee - record
+    // function - record
     _.pick(mixedTypeRecord, mixedTypeRecordBooleanIterator); // $ExpectType Partial<MixedTypeRecord>
     _(mixedTypeRecord).pick(mixedTypeRecordBooleanIterator); // $ExpectType Partial<MixedTypeRecord>
     extractChainTypes(_.chain(mixedTypeRecord).pick(mixedTypeRecordBooleanIterator)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingStringRecord | undefined>
 
-    // function iteratee - dictionary
+    // function - dictionary
     _.pick(stringRecordDictionary, stringRecordDictionaryBooleanIterator); // $ExpectType Partial<Dictionary<StringRecord>>
     _(stringRecordDictionary).pick(stringRecordDictionaryBooleanIterator); // $ExpectType Partial<Dictionary<StringRecord>>
     extractChainTypes(_.chain(stringRecordDictionary).pick(stringRecordDictionaryBooleanIterator)); // $ExpectType ChainType<Partial<Dictionary<StringRecord>>, StringRecordOrUndefined>
 
-    // function iteratee - any
+    // function - any
     _.pick(anyValue, anyBooleanIterator); // $ExpectType Partial<any>
     _(anyValue).pick(anyBooleanIterator); // $ExpectType Partial<any>
     extractChainTypes(_.chain(anyValue).pick(anyBooleanIterator)); // $ExpectType ChainType<Partial<any>, any>
@@ -3027,50 +3048,71 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
 
 // omit
 {
-    // individual key parameters - record
-    _.omit(mixedTypeRecord, 'a', 'b'); // $ExpectType Pick<MixedTypeRecord, "c">
-    _(mixedTypeRecord).omit('a', 'b'); // $ExpectType Pick<MixedTypeRecord, "c">
-    extractChainTypes(_.chain(mixedTypeRecord).omit('a', 'b')); // $ExpectType ChainType<Pick<MixedTypeRecord, "c">, NonIntersectingProperties>
+    // constant strings - record
+    _.omit(mixedTypeRecord, 'a', 'b', 'notAKey'); // $ExpectType Pick<MixedTypeRecord, "c">
+    _(mixedTypeRecord).omit('a', 'b', 'notAKey'); // $ExpectType Pick<MixedTypeRecord, "c">
+    extractChainTypes(_.chain(mixedTypeRecord).omit('a', 'b', 'notAKey')); // $ExpectType ChainType<Pick<MixedTypeRecord, "c">, NonIntersectingProperties>
 
-    // individual key parameters - any
+    // constant strings - any
     _.omit(anyValue, 'a', 'b'); // $ExpectType any
     _(anyValue).omit('a', 'b'); // $ExpectType any
     extractChainTypes(_.chain(anyValue).omit('a', 'b')); // $ExpectType ChainType<any, any>
 
-    // key array - record
-    _.omit(mixedTypeRecord, ['a', 'b']); // $ExpectType Pick<MixedTypeRecord, "c">
-    _(mixedTypeRecord).omit(['a', 'b']); // $ExpectType Pick<MixedTypeRecord, "c">
-    extractChainTypes(_.chain(mixedTypeRecord).omit(['a', 'b'])); // $ExpectType ChainType<Pick<MixedTypeRecord, "c">, NonIntersectingProperties>
+    // constant string arrays - record
+    _.omit(mixedTypeRecord, ['a'], ['b', 'notAKey']); // $ExpectType Pick<MixedTypeRecord, "c">
+    _(mixedTypeRecord).omit(['a'], ['b', 'notAKey']); // $ExpectType Pick<MixedTypeRecord, "c">
+    extractChainTypes(_.chain(mixedTypeRecord).omit(['a'], ['b', 'notAKey'])); // $ExpectType ChainType<Pick<MixedTypeRecord, "c">, NonIntersectingProperties>
 
-    // key array - any
-    _.omit(anyValue, ['a', 'b']); // $ExpectType any
-    _(anyValue).omit(['a', 'b']); // $ExpectType any
-    extractChainTypes(_.chain(anyValue).omit(['a', 'b'])); // $ExpectType ChainType<any, any>
+    // constant string arrays - any
+    _.omit(anyValue, ['a'], ['b']); // $ExpectType any
+    _(anyValue).omit(['a'], ['b']); // $ExpectType any
+    extractChainTypes(_.chain(anyValue).omit(['a'], ['b'])); // $ExpectType ChainType<any, any>
 
-    // string list - record
+    // the generics in the below cases are only required in TS versions below 3.6
+    // constant strings and string arrays - record
+    _.omit<MixedTypeRecord, 'a' | 'b' | 'notAKey'>(mixedTypeRecord, 'a', ['b'], 'notAKey'); // $ExpectType Pick<MixedTypeRecord, "c">
+    _(mixedTypeRecord).omit<'a' | 'b' | 'notAKey'>('a', ['b'], 'notAKey'); // $ExpectType Pick<MixedTypeRecord, "c">
+    extractChainTypes(_.chain(mixedTypeRecord).omit<'a' | 'b' | 'notAKey'>('a', ['b'], 'notAKey')); // $ExpectType ChainType<Pick<MixedTypeRecord, "c">, NonIntersectingProperties>
+
+    // constant strings and string arrays - any
+    _.omit<any, 'a' | 'b'>(anyValue, 'a', ['b']); // $ExpectType any
+    _(anyValue).omit<'a' | 'b'>('a', ['b']); // $ExpectType any
+    extractChainTypes(_.chain(anyValue).omit<'a' | 'b'>('a', ['b'])); // $ExpectType ChainType<any, any>
+
+    // generic strings - record
+    _.omit(mixedTypeRecord, simpleString); // $ExpectType Partial<MixedTypeRecord>
+    _(mixedTypeRecord).omit(simpleString); // $ExpectType Partial<MixedTypeRecord>
+    extractChainTypes(_.chain(mixedTypeRecord).omit(simpleString)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingStringRecord | undefined>
+
+    // generic strings - any
+    _.omit(anyValue, simpleString); // $ExpectType any
+    _(anyValue).omit(simpleString); // $ExpectType any
+    extractChainTypes(_.chain(anyValue).omit(simpleString)); // $ExpectType ChainType<any, any>
+
+    // generic string arrays - record
     _.omit(mixedTypeRecord, simpleStringArray); // $ExpectType Partial<MixedTypeRecord>
     _(mixedTypeRecord).omit(simpleStringArray); // $ExpectType Partial<MixedTypeRecord>
     extractChainTypes(_.chain(mixedTypeRecord).omit(simpleStringArray)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingStringRecord | undefined>
 
-    // string array - any
+    // generic string arrays - any
     _.omit(anyValue, simpleStringArray); // $ExpectType any
     _(anyValue).omit(simpleStringArray); // $ExpectType any
     extractChainTypes(_.chain(anyValue).omit(simpleStringArray)); // $ExpectType ChainType<any, any>
 
-    // function iteratee - record
+    // function - record
     _.omit(mixedTypeRecord, mixedTypeRecordBooleanIterator); // $ExpectType Partial<MixedTypeRecord>
     _(mixedTypeRecord).omit(mixedTypeRecordBooleanIterator); // $ExpectType Partial<MixedTypeRecord>
     extractChainTypes(_.chain(mixedTypeRecord).omit(mixedTypeRecordBooleanIterator)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingStringRecord | undefined>
 
-    // function iteratee - dictionary
+    // function - dictionary
     _.omit(stringRecordDictionary, stringRecordDictionaryBooleanIterator); // $ExpectType Partial<Dictionary<StringRecord>>
     _(stringRecordDictionary).omit(stringRecordDictionaryBooleanIterator); // $ExpectType Partial<Dictionary<StringRecord>>
     extractChainTypes(_.chain(stringRecordDictionary).omit(stringRecordDictionaryBooleanIterator)); // $ExpectType ChainType<Partial<Dictionary<StringRecord>>, StringRecordOrUndefined>
 
-    // function iteratee - any
-    _.omit(anyValue, anyBooleanIterator); // $ExpectType any
-    _(anyValue).omit(anyBooleanIterator); // $ExpectType any
-    extractChainTypes(_.chain(anyValue).omit(anyBooleanIterator)); // $ExpectType ChainType<any, any>
+    // function - any
+    _.omit(anyValue, anyBooleanIterator); // $ExpectType Partial<any>
+    _(anyValue).omit(anyBooleanIterator); // $ExpectType Partial<any>
+    extractChainTypes(_.chain(anyValue).omit(anyBooleanIterator)); // $ExpectType ChainType<Partial<any>, any>
 }
 
 // isEqual


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://underscorejs.org/#pick, http://underscorejs.org/#omit
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

This PR makes the following changes:

- Adds tests for `pick` and `omit`.
- Combines `pick` and `omit` array and iterator overloads.
- Updates the behavior of the overload that takes a function iterator to yield a `Partial` instead of its current behavior of picking all properties.
- Allows string arrays with unknown string contents to be specified and to yield a `Partial`.
 - Updates `omit` to have similar behavior to `pick` except that an `any` object input will always yield an `any` object output due to issues with `_Omit<any, string>` (including string constants) resulting in `Pick<any, number | symbol>`.

I put this together because I was running into a few errors around `pick` calls with updated type definitions ~and thought that this would fix them, but as it turns out I didn't look at them closely enough and they're actually just legitimate errors~. Nevertheless, this seemed like a useful bit of work to submit.

UPDATE: There were errors around using non-constant string arrays that this fixed, the way that some others moved around and muddied the count just threw me off here.