### PR TITLE
[chroma-js] Allow null / undefined values in scale function

### DIFF
--- a/types/chroma-js/chroma-js-tests.ts
+++ b/types/chroma-js/chroma-js-tests.ts
@@ -131,6 +131,8 @@ function test_scale() {
     f(0.25);
     f(0.5);
     f(0.75);
+    f(null);
+    f(undefined);
     chroma.scale(['yellow', '008ae5']);
     chroma.scale(['yellow', 'red', 'black']);
     // default domain is [0,1]

--- a/types/chroma-js/index.d.ts
+++ b/types/chroma-js/index.d.ts
@@ -412,7 +412,7 @@ declare namespace chroma {
     interface Scale<OutType = Color> {
         (c: string[]): Scale;
 
-        (value: number): OutType;
+        (value: number | null | undefined): OutType;
 
         domain(d?: number[], n?: number, mode?: string): this;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  documentation explaining what happens when null or undefined is used in the function:
  https://gka.github.io/chroma.js/#scale-nodata
  source code showing valid path for null or undefined (isNaN) values:
  https://github.com/gka/chroma.js/blob/v2.0.0/src/generator/scale.js#L85

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
