### PR TITLE
@types/react-bootstrap-table-next - Update ExpandRowProps interface

### DIFF
--- a/types/react-bootstrap-table-next/index.d.ts
+++ b/types/react-bootstrap-table-next/index.d.ts
@@ -523,13 +523,13 @@ export interface ExpandRowProps<T> {
     renderer: (row: T, rowIndex: number) => JSX.Element;
     expanded?: any[];
     onExpand?: (row: T, isExpand: boolean, rowIndex: number, e: SyntheticEvent) => void;
-    onExpandAll?: (isExpandAll: boolean, results: number[], e: SyntheticEvent) => void;
+    onExpandAll?: (isExpandAll: boolean, results: T[], e: SyntheticEvent) => void;
     nonExpandable?: number[];
     showExpandColumn?: boolean;
     onlyOneExpanding?: boolean;
     expandByColumnOnly?: boolean;
-    expandColumnRenderer?: ReactElement<ExpandColumnRendererProps>;
-    expandHeaderColumnRenderer?: ReactElement<ExpandHeaderColumnRenderer>;
+    expandColumnRenderer?: (props: ExpandColumnRendererProps) => JSX.Element;
+    expandHeaderColumnRenderer?: (renderer: ExpandHeaderColumnRenderer) => JSX.Element;
     expandColumnPosition?: 'left' | 'right';
     className?: string | ((isExpand: boolean, row: T, rowIndex: number) => string);
 }

--- a/types/react-bootstrap-table-next/index.d.ts
+++ b/types/react-bootstrap-table-next/index.d.ts
@@ -529,7 +529,7 @@ export interface ExpandRowProps<T> {
     onlyOneExpanding?: boolean;
     expandByColumnOnly?: boolean;
     expandColumnRenderer?: (props: ExpandColumnRendererProps) => JSX.Element;
-    expandHeaderColumnRenderer?: (renderer: ExpandHeaderColumnRenderer) => JSX.Element;
+    expandHeaderColumnRenderer?: (props: ExpandHeaderColumnRenderer) => JSX.Element;
     expandColumnPosition?: 'left' | 'right';
     className?: string | ((isExpand: boolean, row: T, rowIndex: number) => string);
 }

--- a/types/react-bootstrap-table-next/react-bootstrap-table-next-tests.tsx
+++ b/types/react-bootstrap-table-next/react-bootstrap-table-next-tests.tsx
@@ -7,6 +7,7 @@ import BootstrapTable, {
     ColumnDescription,
     RowSelectionType,
     ROW_SELECT_SINGLE,
+    ExpandRowProps,
 } from 'react-bootstrap-table-next';
 
 interface Product {
@@ -180,3 +181,20 @@ render(
     />,
     document.getElementById('app'),
 );
+
+
+const expandRow: ExpandRowProps<Product> = {
+    renderer: (row: Product) => {
+        return (
+            <div></div>
+        );
+    },
+    expanded: [1, 2],
+    onExpand: (row: Product, isExpand: boolean, rowIndex: number, e: React.SyntheticEvent<Element, Event>) => <div></div>,
+    onExpandAll: (isExpandAll: boolean, results: Product[]) => <div></div>,
+    showExpandColumn: true,
+    expandColumnPosition: 'right',
+    expandByColumnOnly: true,
+    expandHeaderColumnRenderer: ({ isAnyExpands }) => <br />,
+    expandColumnRenderer: ({ expanded }) => <br />,
+};

--- a/types/react-bootstrap-table-next/react-bootstrap-table-next-tests.tsx
+++ b/types/react-bootstrap-table-next/react-bootstrap-table-next-tests.tsx
@@ -182,7 +182,6 @@ render(
     document.getElementById('app'),
 );
 
-
 const expandRow: ExpandRowProps<Product> = {
     renderer: (row: Product) => {
         return (
@@ -190,8 +189,8 @@ const expandRow: ExpandRowProps<Product> = {
         );
     },
     expanded: [1, 2],
-    onExpand: (row: Product, isExpand: boolean, rowIndex: number, e: React.SyntheticEvent<Element, Event>) => <div></div>,
-    onExpandAll: (isExpandAll: boolean, results: Product[]) => <div></div>,
+    onExpand: (row, isExpand, rowIndex, e) => <div></div>,
+    onExpandAll: (isExpandAll, results) => <div></div>,
     showExpandColumn: true,
     expandColumnPosition: 'right',
     expandByColumnOnly: true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react-bootstrap-table.github.io/react-bootstrap-table2/docs/row-expand-props.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
