### PR TITLE
react-image-gallery: Update 'disableArrowKeys' to 'disableKeyDown'

### DIFF
--- a/types/react-image-gallery/index.d.ts
+++ b/types/react-image-gallery/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-image-gallery 1.08
+// Type definitions for react-image-gallery 1.0
 // Project: https://github.com/xiaolin/react-image-gallery
 // Definitions by: Adam Webb <https://github.com/adamwpc>
 //                 William Tio <https://github.com/WToa>

--- a/types/react-image-gallery/index.d.ts
+++ b/types/react-image-gallery/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-image-gallery 0.9
+// Type definitions for react-image-gallery 1.08
 // Project: https://github.com/xiaolin/react-image-gallery
 // Definitions by: Adam Webb <https://github.com/adamwpc>
 //                 William Tio <https://github.com/WToa>
@@ -49,7 +49,7 @@ export interface ReactImageGalleryProps {
     showPlayButton?: boolean;
     showFullscreenButton?: boolean;
     disableThumbnailScroll?: boolean;
-    disableArrowKeys?: boolean;
+    disableKeyDown?: boolean;
     disableSwipe?: boolean;
     useBrowserFullscreen?: boolean;
     preventDefaultTouchmoveEvent?: boolean;

--- a/types/react-image-gallery/react-image-gallery-tests.tsx
+++ b/types/react-image-gallery/react-image-gallery-tests.tsx
@@ -38,7 +38,8 @@ class ImageGallery extends React.Component {
             items: [galleryItem],
             autoPlay: false,
             showFullscreenButton: false,
-            renderThumbInner: this.renderThumbInner
+            renderThumbInner: this.renderThumbInner,
+            disableKeyDown: false
         };
 
         return <ReactImageGallery ref={(r) => this.gallery = r} {...props} />;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/xiaolin/react-image-gallery> ctrl+f for 'disableKeyDown' - 'disableArrowKeys' no longer exists
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
