### PR TITLE
[@types/underscore] Support readonly tuples in object calls

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -158,7 +158,7 @@ declare module _ {
     // if T is a list, assume that it contains pairs of some type, so any
     // if T isn't a list, there's no way that it can provide pairs, so never
     type PairValue<T> =
-        T extends [EnumerableKey, infer TValue] ? TValue
+        T extends Readonly<[EnumerableKey, infer TValue]> ? TValue
         : T extends List<infer TValue> ? TValue
         : never;
 

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -622,6 +622,13 @@ _.chain([1, 3, 5])
     .intersection([2, 4, 6, 8], [4, 8])
     .value();
 
+// "as const" isn't supported until TS3.4; the Readonly assertion below mimics its effect
+// $ExpectType Dictionary<number>
+_.chain([{ id: 1, name: 'a' }, { id: 2, name: 'b' }])
+    .map(o => [o.name, o.id] as Readonly<[string, number]>)
+    .object()
+    .value();
+
 // common testing types and objects
 const context = {};
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://underscorejs.org/#object, https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

When installing the 1.10.20 type definitions, I ran across an issue with `object` that I thought it would be nice to fix. By default TS typically infers the type of an array initialization as an array rather than a tuple even if it contains multiple types of objects, but TS3.4 and above supports an `as const` shorthand assertion that will turn any array-initializing declaration into a tuple without needing to manually specify all the types in the tuple (see below). However, the resulting tuple ends up being readonly, and type inference in `PairValue` doesn't currently work with readonly tuples. This fixes that issue while still maintaining support for non-readonly tuples.

```TS
// result is Dictionary<string | number> - the result of map is (string | number)[],
// so type inference can't determine what the value type is definitely going to be
_.chain([{ id: 1, name: 'a' }, { id: 2, name: 'b' }])
    .map(o => [o.name, o.id])
    .object()
    .value();

// result is Dictionary<number> - this works but it's annoying to need to specify
// the types in the tuple
_.chain([{ id: 1, name: 'a' }, { id: 2, name: 'b' }])
    .map(o => [o.name, o.id] as [string, number])
    .object()
    .value();

// result is Dictionary<string | number> - this should work but the result of map is
// `readonly [string, number]`, which does not extend `[string, number]`
_.chain([{ id: 1, name: 'a' }, { id: 2, name: 'b' }])
    .map(o => [o.name, o.id] as const)
    .object()
    .value();
```