### PR TITLE
[yup] Exclude null and undefined from the schema returned by "ensure" on string schemas

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -129,7 +129,7 @@ export interface StringSchema<T extends string | null | undefined = string | und
     ): StringSchema<T>;
     email(message?: StringLocale['email']): StringSchema<T>;
     url(message?: StringLocale['url']): StringSchema<T>;
-    ensure(): StringSchema<T>;
+    ensure(): StringSchema<Exclude<T, undefined | null>>;
     trim(message?: StringLocale['trim']): StringSchema<T>;
     lowercase(message?: StringLocale['lowercase']): StringSchema<T>;
     uppercase(message?: StringLocale['uppercase']): StringSchema<T>;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -370,6 +370,7 @@ function strSchemaTests(strSchema: yup.StringSchema) {
 const strSchema = yup.string(); // $ExpectType StringSchema<string | undefined>
 strSchema.oneOf(["hello", "world"] as const); // $ExpectType StringSchema<"hello" | "world" | undefined>
 strSchema.required().oneOf(["hello", "world"] as const); // $ExpectType StringSchema<"hello" | "world">
+strSchema.ensure(); // $ExpectType StringSchema<string>
 strSchemaTests(strSchema);
 
 // $ExpectError


### PR DESCRIPTION
The documentation for [`string.ensure()`](https://github.com/jquense/yup#stringensure-schema) states that `undefined` and `null` values will be transformed into an empty string, which I believe means that the `null` and `undefined` types should be excluded from the `StringSchema`'s inner type. 

The current `ensure` declaration just returns a `StringSchema` with the same type as the schema `ensure` was called on.

```typescript
import * as Yup from 'yup';

const schema1 = Yup.string().ensure(); 
// expected: Yup.StringSchema<string>
// actual: Yup.StringSchema<string | undefined>
```

Checklist:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquense/yup#stringensure-schema
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
