### PR TITLE
Expected type in react-native Animated tests should include null

### DIFF
--- a/types/react-native/test/animated.tsx
+++ b/types/react-native/test/animated.tsx
@@ -27,7 +27,7 @@ type X = React.PropsWithoutRef<React.ComponentProps<typeof ForwardComp>>;
 
 type Props = React.ComponentPropsWithRef<typeof Animated.Text>;
 const AnimatedWrapperComponent: React.FunctionComponent<Props> = ({
-                                                                      key, // $ExpectType string | number | undefined
+                                                                      key, // $ExpectType string | number | null | undefined
                                                                       ...props
 }) => <Animated.Text {...props} />
 


### PR DESCRIPTION
I'm not sure how this passed CI tests. Perhaps dependencies changed?
