### PR TITLE
[react-dates] fixed inaccurate renderCalendarDay props

### DIFF
--- a/types/react-dates/index.d.ts
+++ b/types/react-dates/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/airbnb/react-dates
 // Definitions by: Artur Ampilogov <https://github.com/ArturAmpilogov>
 //                 Nathan Holland <https://github.com/NathanNZ>
+//                 Chris Griebel <https://github.com/cgriebel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 // Required fields are made according to 'minimum REQUIRED setup' in https://github.com/airbnb/react-dates/blob/master/README.md
@@ -113,7 +114,7 @@ declare namespace ReactDates {
         onNextMonthClick?: (newCurrentMonth: momentPropTypes.momentObj) => void;
 
         // day presentation and interaction related props
-        renderCalendarDay?: (day: momentPropTypes.momentObj) => string | JSX.Element;
+        renderCalendarDay?: (props: CalendarDayShape) => JSX.Element;
         renderDayContents?: (day: momentPropTypes.momentObj) => string | JSX.Element;
         minimumNights?: number;
         minDate?: momentPropTypes.momentObj;
@@ -143,10 +144,13 @@ declare namespace ReactDates {
     // shape/IconPositionShape.js
     type IconPositionShape = 'before' | 'after';
 
-    // type/OpenDirectionShape.js
+    // shape/ModifiersShape.js
+    type ModifiersShape = Set<string>;
+
+    // shape/OpenDirectionShape.js
     type OpenDirectionShape = 'down' | 'up';
 
-    // shpae/OrientationShape.js
+    // shape/OrientationShape.js
     type OrientationShape = 'horizontal' | 'vertical';
 
     // shape/ScrollableOrientationShape.js
@@ -227,7 +231,7 @@ declare namespace ReactDates {
         ) => void;
 
         // day presentation and interaction related props
-        renderCalendarDay?: (day: momentPropTypes.momentObj) => string | JSX.Element;
+        renderCalendarDay?: (props: CalendarDayShape) => JSX.Element;
         renderDayContents?: (day: momentPropTypes.momentObj) => string | JSX.Element;
         enableOutsideDays?: boolean;
         isDayBlocked?: (day: any) => boolean;
@@ -391,8 +395,29 @@ declare namespace ReactDates {
 
     // COMPONENTS
     //
-    // components/DateRangePicker.js
 
+    // components/CalendarDay.jsx
+    type DayMouseEventHandler = (day: momentPropTypes.momentObj | null, event: React.MouseEvent) => void;
+
+    interface CalendarDayShape {
+        day?: momentPropTypes.momentObj | null;
+        daySize?: number;
+        isOutsideDay?: boolean;
+        modifiers?: ModifiersShape;
+        isFocused?: boolean;
+        tabIndex?: 0 | -1;
+        onDayClick?: DayMouseEventHandler;
+        onDayMouseEnter?: DayMouseEventHandler;
+        onDayMouseLeave?: DayMouseEventHandler;
+        renderDayContents?: (day: momentPropTypes.momentObj) => string | JSX.Element;
+        ariaLabelFormat?: string;
+        phrases?: CalendarDayPhrases;
+    }
+
+    type CalendarDay = React.ClassicComponentClass<CalendarDayShape>;
+    var CalendarDay: React.ClassicComponentClass<CalendarDayShape>;
+
+    // components/DateRangePicker.js
     type DateRangePicker = React.ClassicComponentClass<DateRangePickerShape>;
     var DateRangePicker: React.ClassicComponentClass<DateRangePickerShape>;
 
@@ -461,7 +486,7 @@ declare namespace ReactDates {
         onPrevMonthClick?: (newCurrentMonth: momentPropTypes.momentObj) => void;
         onNextMonthClick?: (newCurrentMonth: momentPropTypes.momentObj) => void;
         onOutsideClick?: (e: any) => void;
-        renderCalendarDay?: (day: momentPropTypes.momentObj) => string | JSX.Element;
+        renderCalendarDay?: (props: CalendarDayShape) => JSX.Element;
         renderDayContents?: (day: momentPropTypes.momentObj) => string | JSX.Element;
         renderCalendarInfo?: () => string | JSX.Element;
         calendarInfoPosition?: CalendarInfoPositionShape;

--- a/types/react-dates/react-dates-tests.tsx
+++ b/types/react-dates/react-dates-tests.tsx
@@ -12,7 +12,33 @@ import {
         isSameDay,
         toISODateString,
         toLocalizedDateString,
-        toMomentObject } from "react-dates";
+        toMomentObject,
+        CalendarDay} from "react-dates";
+
+class CalendarDayFullTest extends React.Component {
+    render() {
+        return <CalendarDay
+            day={null}
+            daySize={39}
+            isOutsideDay={false}
+            modifiers={new Set<string>()}
+            isFocused={false}
+            tabIndex={-1}
+            onDayClick={() => {}}
+            onDayMouseEnter={() => {}}
+            onDayMouseLeave={() => {}}
+            renderDayContents={(day: moment.Moment) => ""}
+            ariaLabelFormat={"dddd, LL"}
+            phrases={{
+                chooseAvailableDate: ({ date }) => date,
+                dateIsUnavailable: ({ date }) => `Not available. ${date}`,
+                dateIsSelected: ({ date }) => `Selected. ${date}`,
+                dateIsSelectedAsStartDate: ({ date }) => `Selected as start date. ${date}`,
+                dateIsSelectedAsEndDate: ({ date }) => `Selected as end date. ${date}`,
+              }}
+          />
+    }
+}
 
 class SingleDatePickerMinimumTest extends React.Component {
     render() {
@@ -69,6 +95,7 @@ class SingleDatePickerFullTest extends React.Component {
                     small={true}
                     navPosition="navPositionTop"
                     dayPickerNavigationInlineStyles={{width: '10'}}
+                    renderCalendarDay={(props) => <CalendarDay {...props} />}
                     />
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [CalendarDay.jsx](https://github.com/airbnb/react-dates/blob/v17.1.0/src/components/CalendarDay.jsx)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

 fixes #36501.