### PR TITLE
update(terser-webpack-plugin): update to v4.1

### DIFF
--- a/types/terser-webpack-plugin/index.d.ts
+++ b/types/terser-webpack-plugin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for terser-webpack-plugin 4.0
+// Type definitions for terser-webpack-plugin 4.1
 // Project: https://github.com/webpack-contrib/terser-webpack-plugin
 // Definitions by: Daniel Schopf <https://github.com/Danscho>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
@@ -13,10 +13,8 @@ import { MinifyOptions } from 'terser';
  */
 declare namespace TerserPlugin {
     interface MinifyResult {
-        error: any;
         map: any;
         code: any;
-        warnings: any;
         extractedComments: any;
     }
 

--- a/types/terser-webpack-plugin/terser-webpack-plugin-tests.ts
+++ b/types/terser-webpack-plugin/terser-webpack-plugin-tests.ts
@@ -50,10 +50,8 @@ const _ = webpack({
                 minify: (file, sourceMap) => {
                     const results: TerserPlugin.MinifyResult = {
                         code: '',
-                        error: '',
                         extractedComments: [''],
                         map: '',
-                        warnings: [''],
                     };
                     return results;
                 },
@@ -129,6 +127,22 @@ const _ = webpack({
                 },
                 extractComments: false,
             }),
+            new TerserPlugin({
+                terserOptions: {
+                  ecma: undefined,
+                  parse: {},
+                  compress: {},
+                  mangle: true, // Note `mangle.properties` is `false` by default.
+                  module: false,
+                  output: undefined,
+                  toplevel: false,
+                  nameCache: undefined,
+                  ie8: false,
+                  keep_classnames: undefined,
+                  keep_fnames: false,
+                  safari10: false,
+                },
+              }),
         ],
     },
 });


### PR DESCRIPTION
- limit types of props returned with result, this is actually 4.0
public API change:
https://github.com/webpack-contrib/terser-webpack-plugin/compare/v4.0.0...v4.1.0

- tests updated
- minor version bump

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)