### PR TITLE
fix(googlemaps): store type for inference

### DIFF
--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -42,7 +42,7 @@ let mapOptions: google.maps.MapOptions = {
 };
 
 /***** Create map *****/
-let map: google.maps.Map = new google.maps.Map(document.createElement('div'), mapOptions);
+let map: google.maps.Map = new google.maps.Map(document.createElement('div'), mapOptions); // $ExpectType Map<HTMLDivElement>
 
 /***** Fitting map to bounds *****/
 map.fitBounds(

--- a/types/googlemaps/reference/map.d.ts
+++ b/types/googlemaps/reference/map.d.ts
@@ -135,6 +135,12 @@ declare namespace google.maps {
     /** @see {@link https://developers.google.com/maps/documentation/javascript/reference/map#Map Maps JavaScript API} */
     class Map<E extends Element = Element> extends MVCObject {
         /**
+         * Store generic type to allow inference.
+         * @see {@link https://github.com/Microsoft/TypeScript/wiki/FAQ#why-doesnt-type-inference-work-on-this-interface-interface-foot--}
+         */
+        private mapDiv: E;
+
+        /**
          * Creates a new map inside of the given HTML container, which is typically a DIV element.
          * @see {@link https://developers.google.com/maps/documentation/javascript/reference/map#Map.constructor Maps JavaScript API}
          */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Inference was not actually working for the generic Map<Element>.  See https://github.com/Microsoft/TypeScript/wiki/FAQ#why-doesnt-type-inference-work-on-this-interface-interface-foot-- for more information on the issue.