### PR TITLE
[@types/chart.js] add missing label options to ChartData and CommonAxes

### DIFF
--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -269,6 +269,8 @@ declare namespace Chart {
 
     interface ChartData {
         labels?: Array<string | string[] | number | number[] | Date | Date[] | Moment | Moment[]>;
+        xLabels?: Array<string | string[] | number | number[] | Date | Date[] | Moment | Moment[]>;
+        yLabels?: Array<string | string[] | number | number[] | Date | Date[] | Moment | Moment[]>;
         datasets?: ChartDataSets[];
     }
 

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -737,6 +737,7 @@ declare namespace Chart {
         scaleLabel?: ScaleTitleOptions;
         time?: TimeScale;
         offset?: boolean;
+        labels?: Array<string | string[] | number | number[] | Date | Date[] | Moment | Moment[]>;
         beforeUpdate?(scale?: any): void;
         beforeSetDimension?(scale?: any): void;
         beforeDataLimits?(scale?: any): void;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

I just leave this here for reference. I currently don't have the time to do an in-depth check of chart.js to see if there is other stuff missing or incorrect.
I just used these settings lately and was surprised when tsc told me those fields do not exist.
The version of this package somehow seems to be in the future. The latest release I could find was 2.9.3 (the types are: 2.9.23)
Links with documentation for the missing options is in the commits.