### PR TITLE
fix(mongodb): support Decimal128 type for Update

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -38,7 +38,7 @@
 /// <reference types="node" />
 /// <reference lib="esnext.asynciterable" />
 
-import { Binary, ObjectId, Timestamp } from 'bson';
+import { Binary, Decimal128, ObjectId, Timestamp } from 'bson';
 import { EventEmitter } from 'events';
 import { Readable, Writable } from 'stream';
 import { checkServerIdentity } from 'tls';
@@ -1387,10 +1387,10 @@ export type PullAllOperator<TSchema> = ({
 export type UpdateQuery<TSchema> = {
     /** https://docs.mongodb.com/manual/reference/operator/update-field/ */
     $currentDate?: OnlyFieldsOfType<TSchema, Date, true | { $type: 'date' | 'timestamp' }>;
-    $inc?: OnlyFieldsOfType<TSchema, number | undefined>;
+    $inc?: OnlyFieldsOfType<TSchema, number | Decimal128 | undefined>;
     $min?: MatchKeysAndValues<TSchema>;
     $max?: MatchKeysAndValues<TSchema>;
-    $mul?: OnlyFieldsOfType<TSchema, number | undefined>;
+    $mul?: OnlyFieldsOfType<TSchema, number | Decimal128 | undefined>;
     $rename?: { [key: string]: string };
     $set?: MatchKeysAndValues<TSchema>;
     $setOnInsert?: MatchKeysAndValues<TSchema>;

--- a/types/mongodb/test/collection/updateX.ts
+++ b/types/mongodb/test/collection/updateX.ts
@@ -1,4 +1,4 @@
-import { connect, ObjectId, UpdateQuery } from 'mongodb';
+import { connect, Decimal128, ObjectId, UpdateQuery } from 'mongodb';
 import { connectionString } from '../index';
 
 // collection.updateX tests
@@ -18,6 +18,7 @@ async function run() {
     interface TestModel {
         stringField: string;
         numberField: number;
+        decimal128Field: Decimal128;
         optionalNumberField?: number;
         dateField: Date;
         otherDateField: Date;
@@ -46,6 +47,7 @@ async function run() {
     // buildUpdateQuery({ $currentDate: { stringField: true } }); // stringField is not a date Field
 
     buildUpdateQuery({ $inc: { numberField: 1 } });
+    buildUpdateQuery({ $inc: { decimal128Field: Decimal128.fromString('1.23') } });
     buildUpdateQuery({ $inc: { optionalNumberField: 1 } });
     buildUpdateQuery({ $inc: { 'dot.notation': 2 } });
     buildUpdateQuery({ $inc: { 'subInterfaceArray.$': -10 } });
@@ -53,6 +55,7 @@ async function run() {
     buildUpdateQuery({ $inc: { 'subInterfaceArray.$[]': 1000.2 } });
 
     buildUpdateQuery({ $min: { numberField: 1 } });
+    buildUpdateQuery({ $min: { decimal128Field: Decimal128.fromString('1.23') } });
     buildUpdateQuery({ $min: { stringField: 'a' } });
     buildUpdateQuery({ $min: { 'dot.notation': 2 } });
     buildUpdateQuery({ $min: { 'subInterfaceArray.$': 'string' } });
@@ -62,6 +65,7 @@ async function run() {
     // buildUpdateQuery({ $min: { numberField: 'a' } }); // Matches the type of the keys
 
     buildUpdateQuery({ $max: { numberField: 1 } });
+    buildUpdateQuery({ $max: { decimal128Field: Decimal128.fromString('1.23') } });
     buildUpdateQuery({ $max: { stringField: 'a' } });
     buildUpdateQuery({ $max: { 'dot.notation': 2 } });
     buildUpdateQuery({ $max: { 'subInterfaceArray.$': -10 } });
@@ -71,6 +75,7 @@ async function run() {
     // buildUpdateQuery({ $min: { numberField: 'a' } }); // Matches the type of the keys
 
     buildUpdateQuery({ $mul: { numberField: 1 } });
+    buildUpdateQuery({ $mul: { decimal128Field: Decimal128.fromString('1.23') } });
     buildUpdateQuery({ $mul: { optionalNumberField: 1 } });
     buildUpdateQuery({ $mul: { 'dot.notation': 2 } });
     buildUpdateQuery({ $mul: { 'subInterfaceArray.$': -10 } });
@@ -78,6 +83,7 @@ async function run() {
     buildUpdateQuery({ $mul: { 'subInterfaceArray.$[]': 1000.2 } });
 
     buildUpdateQuery({ $set: { numberField: 1 } });
+    buildUpdateQuery({ $set: { decimal128Field: Decimal128.fromString('1.23') } });
     buildUpdateQuery({ $set: { stringField: 'a' } });
     // $ExpectError
     buildUpdateQuery({ $set: { stringField: 123 } });
@@ -87,6 +93,7 @@ async function run() {
     buildUpdateQuery({ $set: { 'subInterfaceArray.$[]': 1000.2 } });
 
     buildUpdateQuery({ $setOnInsert: { numberField: 1 } });
+    buildUpdateQuery({ $setOnInsert: { decimal128Field: Decimal128.fromString('1.23') } });
     buildUpdateQuery({ $setOnInsert: { stringField: 'a' } });
     // $ExpectError
     buildUpdateQuery({ $setOnInsert: { stringField: 123 } });
@@ -96,6 +103,7 @@ async function run() {
     buildUpdateQuery({ $setOnInsert: { 'subInterfaceArray.$[]': 1000.2 } });
 
     buildUpdateQuery({ $unset: { numberField: '' } });
+    buildUpdateQuery({ $unset: { decimal128Field: '' } });
     buildUpdateQuery({ $unset: { dateField: '' } });
     buildUpdateQuery({ $unset: { 'dot.notation': '' } });
     buildUpdateQuery({ $unset: { 'subInterfaceArray.$': '' } });
@@ -103,6 +111,7 @@ async function run() {
     buildUpdateQuery({ $unset: { 'subInterfaceArray.$[]': '' } });
 
     buildUpdateQuery({ $unset: { numberField: 1 } });
+    buildUpdateQuery({ $unset: { decimal128Field: 1 } });
     buildUpdateQuery({ $unset: { dateField: 1 } });
     buildUpdateQuery({ $unset: { 'dot.notation': 1 } });
     buildUpdateQuery({ $unset: { 'subInterfaceArray.$': 1 } });


### PR DESCRIPTION
Both `$inc` and `$mul` support an amount that could be `Decimal128`
type.
More information can be found on:
https://docs.mongodb.com/manual/reference/operator/update/inc/
https://docs.mongodb.com/manual/reference/operator/update/mul/

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (urls posted above - and part of the commit message).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
