### PR TITLE
@types/async-redis: Exported types from index

### DIFF
--- a/types/async-redis/index.d.ts
+++ b/types/async-redis/index.d.ts
@@ -29,4 +29,4 @@ export interface AsyncRedisConstructor {
 }
 
 declare const AsyncRedis: AsyncRedisConstructor;
-export = AsyncRedis;
+export default AsyncRedis;

--- a/types/async-redis/index.d.ts
+++ b/types/async-redis/index.d.ts
@@ -6,15 +6,15 @@
 
 import { Commands, RedisClient, ClientOpts } from 'redis';
 
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
-type Omitted = Omit<RedisClient, keyof Commands<boolean>>;
+export type Omitted = Omit<RedisClient, keyof Commands<boolean>>;
 
-interface Promisified<T = RedisClient>
+export interface Promisified<T = RedisClient>
     extends Omitted,
         Commands<Promise<boolean>> {}
 
-interface AsyncRedisConstructor {
+export interface AsyncRedisConstructor {
   new (port: number, host?: string, options?: ClientOpts): Promisified;
   new (unix_socket: string, options?: ClientOpts): Promisified;
   new (redis_url: string, options?: ClientOpts): Promisified;


### PR DESCRIPTION
Export async-redis types, allowing consuming applications to reference them.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I have not changed or removed anything, just exporting types/interfaces that are already present.
