### PR TITLE
[@types/mongodb] Support readonly arrays in schemas

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -46,7 +46,7 @@ import { checkServerIdentity } from 'tls';
 // We can use TypeScript Omit once minimum required TypeScript Version is above 3.5
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
-type FlattenIfArray<T> = T extends Array<infer R> ? R : T;
+type FlattenIfArray<T> = T extends ReadonlyArray<infer R> ? R : T;
 
 export function connect(uri: string, options?: MongoClientOptions): Promise<MongoClient>;
 export function connect(uri: string, callback: MongoCallback<MongoClient>): void;
@@ -1338,7 +1338,7 @@ export type OnlyFieldsOfType<TSchema, FieldType = any, AssignableType = FieldTyp
 
 export type MatchKeysAndValues<TSchema> = ReadonlyPartial<TSchema> & DotAndArrayNotation<any>;
 
-type Unpacked<Type> = Type extends Array<infer Element> ? Element : Type;
+type Unpacked<Type> = Type extends ReadonlyArray<infer Element> ? Element : Type;
 
 type UpdateOptionalId<T> = T extends { _id?: any } ? OptionalId<T> : T;
 
@@ -1356,30 +1356,30 @@ export type ArrayOperator<Type> = {
 };
 
 export type SetFields<TSchema> = ({
-    readonly [key in KeysOfAType<TSchema, any[] | undefined>]?: UpdateOptionalId<Unpacked<TSchema[key]>> | AddToSetOperators<Array<UpdateOptionalId<Unpacked<TSchema[key]>>>>;
+    readonly [key in KeysOfAType<TSchema, ReadonlyArray<any> | undefined>]?: UpdateOptionalId<Unpacked<TSchema[key]>> | AddToSetOperators<Array<UpdateOptionalId<Unpacked<TSchema[key]>>>>;
 } &
-    NotAcceptedFields<TSchema, any[] | undefined>) & {
+    NotAcceptedFields<TSchema, ReadonlyArray<any> | undefined>) & {
     readonly [key: string]: AddToSetOperators<any> | any;
 };
 
 export type PushOperator<TSchema> = ({
-    readonly [key in KeysOfAType<TSchema, any[]>]?: UpdateOptionalId<Unpacked<TSchema[key]>> | ArrayOperator<Array<UpdateOptionalId<Unpacked<TSchema[key]>>>>;
+    readonly [key in KeysOfAType<TSchema, ReadonlyArray<any>>]?: UpdateOptionalId<Unpacked<TSchema[key]>> | ArrayOperator<Array<UpdateOptionalId<Unpacked<TSchema[key]>>>>;
 } &
-    NotAcceptedFields<TSchema, any[]>) & {
+    NotAcceptedFields<TSchema, ReadonlyArray<any>>) & {
     readonly [key: string]: ArrayOperator<any> | any;
 };
 
 export type PullOperator<TSchema> = ({
-    readonly [key in KeysOfAType<TSchema, any[]>]?: Partial<Unpacked<TSchema[key]>> | ObjectQuerySelector<Unpacked<TSchema[key]>>;
+    readonly [key in KeysOfAType<TSchema, ReadonlyArray<any>>]?: Partial<Unpacked<TSchema[key]>> | ObjectQuerySelector<Unpacked<TSchema[key]>>;
 } &
-    NotAcceptedFields<TSchema, any[]>) & {
+    NotAcceptedFields<TSchema, ReadonlyArray<any>>) & {
     readonly [key: string]: QuerySelector<any> | any;
 };
 
 export type PullAllOperator<TSchema> = ({
-    readonly [key in KeysOfAType<TSchema, any[]>]?: TSchema[key];
+    readonly [key in KeysOfAType<TSchema, ReadonlyArray<any>>]?: TSchema[key];
 } &
-    NotAcceptedFields<TSchema, any[]>) & {
+    NotAcceptedFields<TSchema, ReadonlyArray<any>>) & {
     readonly [key: string]: any[];
 };
 
@@ -1398,7 +1398,7 @@ export type UpdateQuery<TSchema> = {
 
     /** https://docs.mongodb.com/manual/reference/operator/update-array/ */
     $addToSet?: SetFields<TSchema>;
-    $pop?: OnlyFieldsOfType<TSchema, any[], 1 | -1>;
+    $pop?: OnlyFieldsOfType<TSchema, ReadonlyArray<any>, 1 | -1>;
     $pull?: PullOperator<TSchema>;
     $push?: PushOperator<TSchema>;
     $pullAll?: PullAllOperator<TSchema>;
@@ -1456,7 +1456,7 @@ type BitwiseQuery =
 // array types can be searched using their element type
 type RegExpForString<T> = T extends string ? (RegExp | T): T;
 type MongoAltQuery<T> =
-    T extends Array<infer U> ? (T | RegExpForString<U>):
+    T extends ReadonlyArray<infer U> ? (T | RegExpForString<U>):
     RegExpForString<T>;
 
 /** https://docs.mongodb.com/manual/reference/operator/query/#query-selectors */
@@ -1494,9 +1494,9 @@ export type QuerySelector<T> = {
     $maxDistance?: number;
     // Array
     // TODO: define better types for $all and $elemMatch
-    $all?: T extends Array<infer U> ? any[] : never;
-    $elemMatch?: T extends Array<infer U> ? object : never;
-    $size?: T extends Array<infer U> ? number : never;
+    $all?: T extends ReadonlyArray<infer U> ? any[] : never;
+    $elemMatch?: T extends ReadonlyArray<infer U> ? object : never;
+    $size?: T extends ReadonlyArray<infer U> ? number : never;
     // Bitwise
     $bitsAllClear?: BitwiseQuery;
     $bitsAllSet?: BitwiseQuery;

--- a/types/mongodb/test/collection/bulkWrite.ts
+++ b/types/mongodb/test/collection/bulkWrite.ts
@@ -22,6 +22,7 @@ async function run() {
         dateField: Date;
         fruitTags: string[];
         maybeFruitTags?: FruitTypes[];
+        readonlyFruitTags: ReadonlyArray<string>;
         subInterfaceField: SubTestSchema;
         subInterfaceArray: SubTestSchema[];
     }
@@ -33,6 +34,7 @@ async function run() {
         numberField: 123,
         dateField: new Date(),
         fruitTags: ['apple'],
+        readonlyFruitTags: ['pear'],
         subInterfaceField: {
             field1: 'foo',
             field2: 'bar'

--- a/types/mongodb/test/collection/distinct.ts
+++ b/types/mongodb/test/collection/distinct.ts
@@ -7,6 +7,7 @@ async function run() {
     foo: number;
     nested: { num: number; };
     array: string[];
+    readonlyArray: ReadonlyArray<string>;
     test: string;
   }
 
@@ -40,4 +41,8 @@ async function run() {
   collection.distinct('array'); // $ExpectType Promise<string[]>
   collection.distinct('array', { foo: 1 }); // $ExpectType Promise<string[]>
   collection.distinct('array', { foo: 1 }, { maxTimeMS: 400 }); // $ExpectType Promise<string[]>
+
+  collection.distinct('readonlyArray'); // $ExpectType Promise<string[]>
+  collection.distinct('readonlyArray', { foo: 1 }); // $ExpectType Promise<string[]>
+  collection.distinct('readonlyArray', { foo: 1 }, { maxTimeMS: 400 }); // $ExpectType Promise<string[]>
 }

--- a/types/mongodb/test/collection/filterQuery.ts
+++ b/types/mongodb/test/collection/filterQuery.ts
@@ -28,7 +28,7 @@ async function run() {
     createdAt: Date;       // date field
     schools: string[];     // array of string
     scores: number[];      // array of number
-    friends?: UserModel[]; // array of objects
+    friends?: ReadonlyArray<UserModel>; // readonly array of objects
   }
 
   const sampleUser: UserModel = {

--- a/types/mongodb/test/collection/findX.ts
+++ b/types/mongodb/test/collection/findX.ts
@@ -17,10 +17,12 @@ async function run() {
     stringField: string;
     numberField?: number;
     fruitTags: string[];
+    readonlyFruitTags: ReadonlyArray<string>;
   }
   const collectionT = db.collection<TestModel>('testCollection');
   collectionT.find({
     $and: [{ numberField: { $gt: 0 } }, { numberField: { $lt: 100 } }],
+    readonlyFruitTags: {$all: ['apple', 'pear']}
   });
   const res: Cursor<TestModel> = collectionT.find({});
 

--- a/types/mongodb/test/collection/updateX.ts
+++ b/types/mongodb/test/collection/updateX.ts
@@ -23,6 +23,7 @@ async function run() {
         otherDateField: Date;
         oneMoreDateField: Date;
         fruitTags: string[];
+        readonlyFruitTags: ReadonlyArray<string>;
         maybeFruitTags?: FruitTypes[];
         subInterfaceField: SubTestModel;
         subInterfaceArray: SubTestModel[];
@@ -115,6 +116,8 @@ async function run() {
     // $ExpectError
     buildUpdateQuery({ $addToSet: { fruitTags: 123 } });
     buildUpdateQuery({ $addToSet: { fruitTags: { $each: ['stringField'] } } });
+    buildUpdateQuery({$addToSet: {readonlyFruitTags: 'apple'}});
+    buildUpdateQuery({$addToSet: {readonlyFruitTags: { $each: ['apple'] }}});
     buildUpdateQuery({ $addToSet: { maybeFruitTags: 'apple' } });
     buildUpdateQuery({ $addToSet: { 'dot.notation': 'stringField' } });
     buildUpdateQuery({ $addToSet: { 'dot.notation': { $each: ['stringfield'] } } });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/A (only affects being able to use array filter queries with schemas such as `{a: readonly string[]}`)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.