### PR TITLE
Fix heremaps group get bounds

### DIFF
--- a/types/heremaps/heremaps-tests.ts
+++ b/types/heremaps/heremaps-tests.ts
@@ -206,3 +206,7 @@ const engineListener = (e: Event) => {
 };
 engine.addEventListener('tap', engineListener);
 engine.removeEventListener('tap', engineListener);
+
+// Get group bounds
+const group = new H.map.Group();
+const bounds = group.getBoundingBox();

--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -1835,7 +1835,7 @@ declare namespace H {
              * Method returns the bounding rectangle for the group. The rectangle is the smallest rectangle that covers all objects. If group doesn't contains objects method returns null.
              * @returns {H.geo.Rect} - geo ractangle that covers all objects in the group
              */
-            getBounds(): H.geo.Rect;
+            getBoundingBox (): H.geo.Rect;
 
             /**
              * To add an object to this group.

--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -1835,7 +1835,7 @@ declare namespace H {
              * Method returns the bounding rectangle for the group. The rectangle is the smallest rectangle that covers all objects. If group doesn't contains objects method returns null.
              * @returns {H.geo.Rect} - geo ractangle that covers all objects in the group
              */
-            getBoundingBox (): H.geo.Rect;
+            getBoundingBox(): H.geo.Rect;
 
             /**
              * To add an object to this group.


### PR DESCRIPTION
See https://developer.here.com/documentation/maps/3.1.17.0/api_reference/H.map.Group.html#getBoundingBox

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
