### PR TITLE
Add types for node-red-node-test-helper

### DIFF
--- a/types/node-red-node-test-helper/index.d.ts
+++ b/types/node-red-node-test-helper/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/node-red/node-red-node-test-helper#readme
 // Definitions by: Alex Kaul <https://github.com/alexk111>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.1
 
 import { EventEmitter } from 'events';
 import { Node, NodeDef, NodeInitializer, NodeCredentials } from 'node-red';

--- a/types/node-red-node-test-helper/index.d.ts
+++ b/types/node-red-node-test-helper/index.d.ts
@@ -1,0 +1,136 @@
+// Type definitions for node-red-node-test-helper 0.2
+// Project: https://github.com/node-red/node-red-node-test-helper#readme
+// Definitions by: Alex Kaul <https://github.com/alexk111>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { EventEmitter } from 'events';
+import { Node, NodeDef, NodeInitializer, NodeCredentials } from 'node-red';
+import { LocalSettings } from '@node-red/runtime';
+import { SinonSpy } from 'sinon';
+import * as supertest from 'supertest';
+
+declare class NodeTestHelper extends EventEmitter {
+    init(nodeRedRuntime: string, userSettings?: LocalSettings): void;
+
+    /**
+     * Loads a flow then starts the flow.
+     * @param testNode Initializer function of a node to be tested. This node will be
+     * registered, and can be used in testFlows.
+     * @param testFlows Flow data to test a node. If you want to use flow data exported
+     * from Node-RED editor, export the flow to the clipboard and paste the content into
+     * your test scripts.
+     * @param testCredentials Optional node credentials.
+     * @param cb Function to call back when testFlows has been started.
+     */
+    load(
+        testNode: nodeRedNodeTestHelper.TestNodeInitializer,
+        testFlows: nodeRedNodeTestHelper.TestFlows,
+        testCredentials?: nodeRedNodeTestHelper.TestCredentials<{}>,
+        cb?: () => void,
+    ): Promise<void>;
+
+    /**
+     * Returns promise to stop all flows, clean up test runtime.
+     */
+    unload(): Promise<void>;
+
+    /**
+     * Returns a node instance by id in the testFlow. Any node that is defined in testFlows
+     * can be retrieved, including any helper node added to the flow.
+     * @param id Node id
+     */
+    getNode(id: string): Node;
+
+    /**
+     * Stop all flows.
+     */
+    clearFlows(): Promise<void>;
+
+    /**
+     * Create http (supertest) request to the editor/admin url.
+     * @example
+     * ```
+     * helper.request().post('/inject/invalid').expect(404).end(done);
+     * ```
+     */
+    request(): supertest.SuperTest<supertest.Test>;
+
+    /**
+     * Merges any userSettings with the defaults returned by `RED.settings`. Each
+     * invocation of this method will overwrite the previous userSettings to prevent
+     * unexpected problems in your tests.
+     *
+     * This will enable you to replicate your production environment within your tests,
+     * for example where you're using the `functionGlobalContext` to enable extra node
+     * modules within your functions.
+     * @example
+     * ```
+     * // functions can now access os via global.get('os')
+     * helper.settings({ functionGlobalContext: { os:require('os') } });
+     *
+     * // reset back to defaults
+     * helper.settings({ });
+     * ```
+     * @param userSettings - an object containing the runtime settings
+     * @returns custom userSettings merged with default RED.settings
+     */
+    settings(userSettings: Partial<LocalSettings>): LocalSettings;
+
+    /**
+     * Starts a Node-RED server for testing nodes that depend on http or web sockets endpoints
+     * like the debug node. To start a Node-RED server before all test cases:
+     * ```
+     * before((done) => {
+     *     helper.startServer(done);
+     * });
+     * ```
+     * @param done callback
+     */
+    startServer(done?: () => void): void;
+
+    /**
+     * Stop server. Generally called after unload() complete. For example, to unload a flow then
+     * stop a server after each test:
+     * ```
+     * afterEach((done) => {
+     *     helper.unload().then(() => {
+     *         helper.stopServer(done);
+     *     });
+     * });
+     * ```
+     * @param done callback
+     */
+    stopServer(done?: () => void): void;
+
+    /**
+     * Return the URL of the helper server including the ephemeral port used when starting the server.
+     */
+    url(): string;
+
+    /**
+     * Return a spy on the logs to look for events from the node under test. For example:
+     * ```
+     * const logEvents = helper.log().args.filter((evt) => {
+     *     return evt[0].type === "batch";
+     * });
+     * ```
+     */
+    log(): SinonSpy;
+}
+
+declare const nodeRedNodeTestHelper: NodeTestHelper & {
+    NodeTestHelper: typeof NodeTestHelper;
+};
+
+declare namespace nodeRedNodeTestHelper {
+    type TestNodeInitializer = NodeInitializer | NodeInitializer[];
+    type TestFlowsItem<TNodeDef extends NodeDef = NodeDef> = Partial<TNodeDef> & {
+        id: string;
+        type: string;
+        wires?: string[][];
+    };
+    type TestFlows = TestFlowsItem[];
+    type TestCredentials<TCred> = NodeCredentials<TCred>;
+}
+
+export = nodeRedNodeTestHelper;

--- a/types/node-red-node-test-helper/node-red-node-test-helper-tests.ts
+++ b/types/node-red-node-test-helper/node-red-node-test-helper-tests.ts
@@ -1,0 +1,45 @@
+import { NodeInitializer, NodeDef } from 'node-red';
+import * as helper from 'node-red-node-test-helper';
+
+const anotherHelper = new helper.NodeTestHelper();
+
+function helperTests(testHelper: typeof anotherHelper) {
+    testHelper.startServer(() => {});
+    testHelper.stopServer(() => {});
+
+    interface SomeNodeDef extends NodeDef {
+        key: string;
+    }
+
+    type FlowsItem = helper.TestFlowsItem<SomeNodeDef>;
+
+    function withFlowsItem(item: FlowsItem) {
+        // $ExpectType string
+        item.id;
+        // $ExpectType string
+        item.type;
+        // $ExpectType string | undefined
+        item.key;
+        // $ExpectError
+        item.invalidKey;
+    }
+
+    type Flows = FlowsItem[];
+    const flows: Flows = [{ id: 'n1', type: 'some-node', name: 'some-node' }];
+
+    function withNodeInitializer(nodeInitializer: NodeInitializer) {
+        // $ExpectType Promise<void>
+        testHelper.load(nodeInitializer, flows, () => {});
+    }
+    // $ExpectType Promise<void>
+    testHelper.unload();
+
+    // $ExpectType Node<{}>
+    const n = testHelper.getNode('some-node');
+
+    // $ExpectType Promise<void>
+    testHelper.clearFlows();
+}
+
+helperTests(helper);
+helperTests(anotherHelper);

--- a/types/node-red-node-test-helper/tsconfig.json
+++ b/types/node-red-node-test-helper/tsconfig.json
@@ -1,0 +1,43 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@node-red/editor-api": [
+                "node-red__editor-api"
+            ],
+            "@node-red/editor-client": [
+                "node-red__editor-client"
+            ],
+            "@node-red/registry": [
+                "node-red__registry"
+            ],
+            "@node-red/runtime": [
+                "node-red__runtime"
+            ],
+            "@node-red/util": [
+                "node-red__util"
+            ],
+            "@sinonjs/fake-timers": [
+                "sinonjs__fake-timers"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "node-red-node-test-helper-tests.ts"
+    ]
+}

--- a/types/node-red-node-test-helper/tslint.json
+++ b/types/node-red-node-test-helper/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
