### PR TITLE
feat(react): Add unstable_useOpaqueIdentifier

### DIFF
--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -164,6 +164,9 @@ declare module '.' {
      */
     export function unstable_useTransition(config?: SuspenseConfig | null): [TransitionStartFunction, boolean];
 
+    /**
+     * @private
+     */
     const opaqueIdentifierBranding: unique symbol;
     /**
      * WARNING: Don't use this as a `string`.

--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -163,4 +163,23 @@ declare module '.' {
      * @see https://reactjs.org/docs/concurrent-mode-reference.html#usetransition
      */
     export function unstable_useTransition(config?: SuspenseConfig | null): [TransitionStartFunction, boolean];
+
+    const opaqueIdentifierBranding: unique symbol;
+    /**
+     * WARNING: Don't use this as a `string`.
+     *
+     * This is an opaque type that is not supposed to type-check structurally.
+     * It is only valid if returned from React methods and passed to React e.g. `<button aria-labelledby={opaqueIdentifier} />`
+     */
+    // We can't create a type that would be rejected for string concatenation or `.toString()` calls.
+    // So in order to not have to add `string | OpaqueIdentifier` to every react-dom host prop we intersect it with `string`.
+    type OpaqueIdentifier = string & {
+        readonly [opaqueIdentifierBranding]: unknown;
+        // While this would cause `const stringified: string = opaqueIdentifier.toString()` to not type-check it also adds completions while typing.
+        // It would also still allow string concatenation.
+        // Unsure which is better. Not type-checking or not suggesting.
+        // toString(): void;
+    };
+
+    export function unstable_useOpaqueIdentifier(): OpaqueIdentifier;
 }

--- a/types/react/test/experimental.tsx
+++ b/types/react/test/experimental.tsx
@@ -45,3 +45,14 @@ function useExperimentalHooks() {
         return '';
     }
 }
+
+
+function Dialog() {
+    const nameId = React.unstable_useOpaqueIdentifier();
+
+    return (
+        <div role="dialog" aria-labelledby={nameId}>
+            <h2 id={nameId}></h2>
+        </div>
+    );
+}

--- a/types/react/test/experimental.tsx
+++ b/types/react/test/experimental.tsx
@@ -5,7 +5,11 @@ import React = require('react');
 function useExperimentalHooks() {
     const [toggle, setToggle] = React.useState(false);
 
-    const [startTransition, done] = React.unstable_useTransition({ busyMinDurationMs: 100, busyDelayMs: 200, timeoutMs: 300 });
+    const [startTransition, done] = React.unstable_useTransition({
+        busyMinDurationMs: 100,
+        busyDelayMs: 200,
+        timeoutMs: 300,
+    });
     // $ExpectType boolean
     done;
 
@@ -46,7 +50,6 @@ function useExperimentalHooks() {
     }
 }
 
-
 function Dialog() {
     const nameId = React.unstable_useOpaqueIdentifier();
 
@@ -55,4 +58,14 @@ function Dialog() {
             <h2 id={nameId}></h2>
         </div>
     );
+}
+
+function InvalidOpaqueIdentifierUsage() {
+    const id = React.unstable_useOpaqueIdentifier();
+    // undesired, would warn in React should not type-check
+    const stringified1: string = id.toString();
+    // undesired, would warn in React should not type-check
+    const stringified2: string = id + '';
+
+    return null;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  
  - PR that introduced the version: https://github.com/facebook/react/pull/17322
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- ~[ ]~ If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

