### PR TITLE
Add type definitions for react-speech-recognition

### DIFF
--- a/types/react-speech-recognition/index.d.ts
+++ b/types/react-speech-recognition/index.d.ts
@@ -1,0 +1,45 @@
+// Type definitions for react-speech-recognition 3.1
+// Project: https://github.com/JamesBrill/react-speech-recognition#readme
+// Definitions by: OleksandrYehorov <https://github.com/OleksandrYehorov>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface Command {
+    command: string | RegExp;
+    callback: Function;
+    isFuzzyMatch?: boolean;
+    matchInterim?: boolean;
+    fuzzyMatchingThreshold?: number;
+}
+
+export interface ListeningOptions {
+    continuous?: boolean;
+    language?: string;
+}
+
+interface SpeechRecognition {
+    getRecognition(): SpeechRecognition | null;
+    startListening(options?: ListeningOptions): Promise<void>;
+    stopListening(): void;
+    abortListening(): void;
+    browserSupportsSpeechRecognition(): boolean;
+}
+
+export interface SpeechRecognitionOptions {
+    transcribing?: boolean;
+    clearTranscriptOnListen?: boolean;
+    commands?: ReadonlyArray<Command>;
+}
+
+export function useSpeechRecognition(
+    options?: SpeechRecognitionOptions,
+): {
+    transcript: string;
+    interimTranscript: string;
+    finalTranscript: string;
+    listening: boolean;
+    resetTranscript: () => void;
+};
+
+declare const SpeechRecognition: SpeechRecognition;
+
+export default SpeechRecognition;

--- a/types/react-speech-recognition/index.d.ts
+++ b/types/react-speech-recognition/index.d.ts
@@ -5,7 +5,7 @@
 
 interface Command {
     command: string | RegExp;
-    callback: Function;
+    callback: (...args: any[]) => unknown;
     isFuzzyMatch?: boolean;
     matchInterim?: boolean;
     fuzzyMatchingThreshold?: number;

--- a/types/react-speech-recognition/react-speech-recognition-tests.ts
+++ b/types/react-speech-recognition/react-speech-recognition-tests.ts
@@ -1,0 +1,31 @@
+import SpeechRecognition, { useSpeechRecognition } from 'react-speech-recognition';
+
+const {
+    finalTranscript, // $ExpectType string
+    interimTranscript, // $ExpectType string
+    listening, // $ExpectType boolean
+    resetTranscript, // $ExpectType () => void
+    transcript, // $ExpectType string
+} = useSpeechRecognition();
+
+useSpeechRecognition({
+    clearTranscriptOnListen: true,
+    transcribing: true,
+    commands: [
+        {
+            command: 'Command',
+            callback: (command: string, spokenPhrase: string, similarityRatio: number) => {},
+        },
+        {
+            command: 'Command',
+            callback: (...match: string[]) => {},
+        },
+    ],
+});
+
+SpeechRecognition.getRecognition(); // $ExpectType SpeechRecognition | null
+SpeechRecognition.startListening(); // $ExpectType Promise<void>
+SpeechRecognition.startListening({ continuous: true, language: 'en' }); // $ExpectType Promise<void>
+SpeechRecognition.stopListening(); // $ExpectType void
+SpeechRecognition.abortListening(); // $ExpectType void
+SpeechRecognition.browserSupportsSpeechRecognition(); // $ExpectType boolean

--- a/types/react-speech-recognition/tsconfig.json
+++ b/types/react-speech-recognition/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-speech-recognition-tests.ts"
+    ]
+}

--- a/types/react-speech-recognition/tslint.json
+++ b/types/react-speech-recognition/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.