### PR TITLE
Added closeToTime to typings

### DIFF
--- a/types/chai-datetime/chai-datetime-tests.ts
+++ b/types/chai-datetime/chai-datetime-tests.ts
@@ -27,6 +27,14 @@ function test_afterTime(){
     assert.afterTime(date, date);
 }
 
+function test_closeToTime(){
+    const date: Date = new Date(2014, 1, 1, 6, 0);
+    const closeDate: Date = new Date(2014, 1, 1, 6, 1);
+    expect(date).to.be.closeToTime(closeDate, 120);
+    date.should.be.closeToTime(closeDate, 120);
+    assert.closeToTime(date, closeDate, 120);
+}
+
 function test_withinTime(){
     const date: Date = new Date(2014, 7, 1);
     const fromDate: Date = new Date(2014, 1, 1);

--- a/types/chai-datetime/index.d.ts
+++ b/types/chai-datetime/index.d.ts
@@ -15,6 +15,7 @@ declare global {
         interface Assertion {
             afterDate(date: Date): Assertion;
             beforeDate(date: Date): Assertion;
+            closeToTime(date: Date, deltaInSeconds: number): Assertion;
             equalDate(date: Date): Assertion;
             withinDate(dateFrom: Date, dateTo: Date): Assertion;
             afterTime(date: Date): Assertion;
@@ -27,6 +28,7 @@ declare global {
             equalTime(val: Date, exp: Date, msg?: string): void;
             notEqualTime(val: Date, exp: Date, msg?: string): void;
             beforeTime(val: Date, exp: Date, msg?: string): void;
+            closeToTime(val: Date, exp: Date, deltaInSeconds: number, msg?: string): void;
             notBeforeTime(val: Date, exp: Date, msg?: string): void;
             afterTime(val: Date, exp: Date, msg?: string): void;
             notAfterTime(val: Date, exp: Date, msg?: string): void;


### PR DESCRIPTION
Please fill in this template.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [ x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.chaijs.com/plugins/chai-datetime/ -> closeToTime()
- [N/A ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [N/A ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


