### PR TITLE
Properly type Lazy.js Sequence.chunk method

### DIFF
--- a/types/lazy.js/lazy.js-tests.ts
+++ b/types/lazy.js/lazy.js-tests.ts
@@ -20,6 +20,8 @@ var barArr: Bar[];
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 var fooSequence: LazyJS.Sequence<Foo>;
+var fooTupleSequence: LazyJS.Sequence<readonly [Foo, Foo, Foo, Foo, Foo]>;
+var fooArrSequence: LazyJS.Sequence<Foo[]>;
 var barSequence: LazyJS.Sequence<Bar>;
 var fooArraySeq: LazyJS.ArrayLikeSequence<Foo>;
 var barArraySeq: LazyJS.ArrayLikeSequence<Bar>;
@@ -29,11 +31,13 @@ var fooAsyncSeq: LazyJS.AsyncSequence<Foo>;
 
 var strSequence: LazyJS.Sequence<string>;
 var anySequence: LazyJS.Sequence<any>;
+var unknownSequence: LazyJS.Sequence<unknown>;
 var stringSeq: LazyJS.StringLikeSequence;
 
 var obj: Object;
 var bool: boolean;
 var num: number;
+var const5: 5;
 var str: string;
 var x: any = null;
 var arr: any[];
@@ -97,7 +101,9 @@ fooArraySeq = Strict([foo, foo]).pop();
 // Sequence
 
 fooAsyncSeq = fooSequence.async(num);
-fooSequence = fooSequence.chunk(num);
+fooArrSequence = fooSequence.chunk(num);
+fooTupleSequence = fooSequence.chunk(const5);
+unknownSequence = fooSequence.chunk(0);
 fooSequence = fooSequence.compact();
 fooSequence = fooSequence.concat(arr);
 fooSequence = fooSequence.consecutive(num);


### PR DESCRIPTION
Assigns proper type to `Sequence.chunk` and improves `Sequence.flatten` return type

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.