### PR TITLE
nova-editor: Various fixes after reviewing Emmet plugin

### DIFF
--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.3
 
-/// https://novadocs.panic.com/extensions/
+// https://novadocs.panic.com/extensions/#javascript-runtime
 
 // This runs in an extension of Apple's JavaScriptCore, manually set libs
 

--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -11,8 +11,8 @@
 /// <reference no-default-lib="true"/>
 /// <reference lib="es2015" />
 
-type ReadableStream = unknown;
-type WritableStream = unknown;
+type ReadableStream<T = any> = unknown;
+type WritableStream<T = any> = unknown;
 
 /// https://novadocs.panic.com/api-reference/assistants-registry/
 
@@ -29,7 +29,7 @@ interface ColorAssistant {
 }
 
 interface CompletionAssistant {
-    provideCompletionItems(editor: TextEditor, context: CompletionContext): CompletionItem[];
+    provideCompletionItems(editor: TextEditor, context: CompletionContext): void | CompletionItem[];
 }
 
 interface IssueAssistant {
@@ -268,11 +268,11 @@ interface File {
 }
 
 interface FileBinaryMode extends File {
-    read(size?: string): ArrayBuffer | null;
+    read(size?: number): ArrayBuffer | null;
 }
 
 interface FileTextMode extends File {
-    read(size?: string): string | null;
+    read(size?: number): string | null;
     readline(): string;
     readlines(): string[];
 }
@@ -310,13 +310,15 @@ type Encoding =
 declare class FileSystem {
     private constructor();
 
-    static F_OK: FileSystemBitField;
-    static R_OK: FileSystemBitField;
-    static W_OK: FileSystemBitField;
-    static X_OK: FileSystemBitField;
-    static START: FileSystemBitField;
-    static CURRENT: FileSystemBitField;
-    static END: FileSystemBitField;
+    constants: {
+        F_OK: FileSystemBitField;
+        R_OK: FileSystemBitField;
+        W_OK: FileSystemBitField;
+        X_OK: FileSystemBitField;
+        START: FileSystemBitField;
+        CURRENT: FileSystemBitField;
+        END: FileSystemBitField;
+    }
 
     F_OK: FileSystemBitField;
     R_OK: FileSystemBitField;
@@ -355,6 +357,7 @@ interface FileSystemWatcher extends Disposable {
 declare class Issue {
     constructor();
     code: number | string;
+    message: string;
     severity: IssueSeverity;
     source: string | null;
     textRange?: Range;
@@ -549,7 +552,7 @@ declare class Scanner {
     constructor(string: string);
 
     readonly string: string;
-    readonly location: number;
+    location: number;
     readonly atEnd: boolean;
     skipChars: Charset;
     caseSensitive: boolean;
@@ -623,18 +626,18 @@ declare class TextEditor {
     static isTextEditor(object: any): object is TextEditor;
 
     readonly document: TextDocument;
-    readonly selectedRange: Range;
-    readonly selectedRanges: Range[];
+    selectedRange: Range;
+    selectedRanges: Range[];
     readonly selectedText: string;
-    readonly softTabs: boolean;
-    readonly tabLength: number;
+    softTabs: boolean;
+    tabLength: number;
     readonly tabText: string;
 
     edit(callback: (edit: TextEditorEdit) => void, options?: unknown): Promise<void>;
     insert(string: string): Promise<void>;
     save(): void;
     getTextInRange(range: Range): string;
-    getLineRangeForRange(range: Range): string;
+    getLineRangeForRange(range: Range): Range;
     onDidChange(callback: (textEditor: TextEditor) => void): void;
     onDidStopChanging(callback: (textEditor: TextEditor) => void): void;
     onWillSave(callback: (textEditor: TextEditor) => void): void;

--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.3
 
-// https://novadocs.panic.com/extensions/#javascript-runtime
+/// https://novadocs.panic.com/extensions/#javascript-runtime
 
 // This runs in an extension of Apple's JavaScriptCore, manually set libs
 

--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -9,7 +9,7 @@
 // This runs in an extension of Apple's JavaScriptCore, manually set libs
 
 /// <reference no-default-lib="true"/>
-/// <reference lib="es2015" />
+/// <reference lib="es7" />
 
 type ReadableStream<T = any> = unknown;
 type WritableStream<T = any> = unknown;

--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -693,6 +693,7 @@ declare class TreeItem {
     name: string;
     collapsibleState: TreeItemCollapsibleState;
     command?: unknown; // https://dev.panic.com/panic/nova-issues/-/issues/909
+    color?: Color;
     contextValue?: string;
     descriptiveText?: string;
     identifier?: string;

--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -690,8 +690,8 @@ interface TreeDataProvider<E> {
 declare class TreeItem {
     constructor(name: string, collapsibleState?: TreeItemCollapsibleState);
 
-    readonly name: string;
-    readonly collapsibleState: TreeItemCollapsibleState;
+    name: string;
+    collapsibleState: TreeItemCollapsibleState;
     command?: unknown; // https://dev.panic.com/panic/nova-issues/-/issues/909
     contextValue?: string;
     descriptiveText?: string;

--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -502,9 +502,9 @@ declare class Process {
     readonly stdout?: ReadableStream | WritableStream | null;
     readonly stderr?: ReadableStream | WritableStream | null;
 
-    onStdout(callback: (line: string) => void): void;
-    onStderr(callback: (line: string) => void): void;
-    onDidExit(callback: (status: number) => void): void;
+    onStdout(callback: (line: string) => void): Disposable;
+    onStderr(callback: (line: string) => void): Disposable;
+    onDidExit(callback: (status: number) => void): Disposable;
     start(): void;
     signal(signal: string | number): void;
     kill(): void;
@@ -512,8 +512,8 @@ declare class Process {
     // see no-unnecessary-generics for why these aren't stricter
     notify(methodName: string, params?: any): void;
     request(methodName: string, params?: any): Promise<any>;
-    onNotify(methodName: string, callback: (message: ProcessMessage<any, any, any>) => void): void;
-    onRequest(methodName: string, callback: (message: ProcessMessage<any, any, any>) => any): void;
+    onNotify(methodName: string, callback: (message: ProcessMessage<any, any, any>) => void): Disposable;
+    onRequest(methodName: string, callback: (message: ProcessMessage<any, any, any>) => any): Disposable;
 }
 
 /// https://novadocs.panic.com/api-reference/process-message/
@@ -614,8 +614,8 @@ interface TextDocument {
 
     getTextInRange(range: Range): string;
     getLineRangeForRange(range: Range): Range;
-    onDidChangePath(callback: (document: TextDocument, path: string | null) => void): void;
-    onDidChangeSyntax(callback: (document: TextDocument, syntax: string | null) => void): void;
+    onDidChangePath(callback: (document: TextDocument, path: string | null) => void): Disposable;
+    onDidChangeSyntax(callback: (document: TextDocument, syntax: string | null) => void): Disposable;
 }
 
 /// https://novadocs.panic.com/api-reference/text-editor/
@@ -638,12 +638,12 @@ declare class TextEditor {
     save(): void;
     getTextInRange(range: Range): string;
     getLineRangeForRange(range: Range): Range;
-    onDidChange(callback: (textEditor: TextEditor) => void): void;
-    onDidStopChanging(callback: (textEditor: TextEditor) => void): void;
-    onWillSave(callback: (textEditor: TextEditor) => void): void;
-    onDidSave(callback: (textEditor: TextEditor) => void): void;
-    onDidChangeSelection(callback: (textEditor: TextEditor) => void): void;
-    onDidDestroy(callback: (textEditor: TextEditor) => void): void;
+    onDidChange(callback: (textEditor: TextEditor) => void): Disposable;
+    onDidStopChanging(callback: (textEditor: TextEditor) => void): Disposable;
+    onWillSave(callback: (textEditor: TextEditor) => void): Disposable;
+    onDidSave(callback: (textEditor: TextEditor) => void): Disposable;
+    onDidChangeSelection(callback: (textEditor: TextEditor) => void): Disposable;
+    onDidDestroy(callback: (textEditor: TextEditor) => void): Disposable;
     addSelectionForRange(range: Range): void;
     selectToPosition(position: number): void;
     selectUp(rowCount: number): void;
@@ -728,9 +728,9 @@ interface Workspace {
     readonly textEditors: ReadonlyArray<TextEditor>;
     readonly activeTextEditor: TextEditor;
 
-    onDidAddTextEditor(callback: (editor: TextEditor) => void): void;
-    onDidChangePath(callback: (newPath: TextEditor) => void): void;
-    onDidOpenTextDocument(callback: (textDocument: TextDocument) => void): void;
+    onDidAddTextEditor(callback: (editor: TextEditor) => void): Disposable;
+    onDidChangePath(callback: (newPath: TextEditor) => void): Disposable;
+    onDidOpenTextDocument(callback: (textDocument: TextDocument) => void): Disposable;
     contains(path: string): boolean;
     relativizePath(path: string): string;
     openConfig(identifier?: string): void;

--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -21,7 +21,11 @@ type AssistantsRegistrySelector = string | { syntax: string };
 interface AssistantsRegistry {
     registerColorAssistant(selector: AssistantsRegistrySelector, object: ColorAssistant): Disposable;
     registerCompletionAssistant(selector: AssistantsRegistrySelector, object: CompletionAssistant): Disposable;
-    registerIssueAssistant(selector: AssistantsRegistrySelector, object: IssueAssistant): Disposable;
+    registerIssueAssistant(
+        selector: AssistantsRegistrySelector,
+        object: IssueAssistant,
+        options?: { event: "onChange" | "onSave" }
+    ): Disposable;
 }
 
 interface ColorAssistant {

--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -470,7 +470,7 @@ interface Path {
     splitext(path: string): [string, string];
     expanduser(path: string): string;
     isAbsolute(path: string): boolean;
-    join(path: string, ...paths: string[]): string;
+    join(...paths: string[]): string;
     normalize(path: string): string;
     split(path: string): string[];
 }

--- a/types/nova-editor-node/nova-editor-node-tests.ts
+++ b/types/nova-editor-node/nova-editor-node-tests.ts
@@ -118,6 +118,18 @@ p.onDidExit(code => {
 
 p.start();
 
+/// https://novadocs.panic.com/api-reference/issue/
+
+const issue = new Issue();
+
+issue.message = "Undefined name 'foobar'";
+issue.code = "E12";
+issue.severity = IssueSeverity.Error;
+issue.line = 10;
+issue.column = 12;
+
+(new IssueCollection()).set("fileURI", [issue]);
+
 /// https://novadocs.panic.com/api-reference/notification-request/
 
 const request = new NotificationRequest('foobar-not-found');
@@ -161,9 +173,6 @@ process.request('getNames', { sort: 'alpha' }).then(reply => {
 
 process.onNotify('didConnect', message => {});
 
-type ParamType = string & { __t: 'ParamType' };
-type ReplyType = string & { __t: 'ReplyType' };
-type ErrorType = string & { __t: 'ErrorType' };
 process.onRequest('getCount', request => {
     return new Promise((resolve, reject) => {
         resolve({ count: 10 });
@@ -185,10 +194,16 @@ scanner.scanFloat(); // => null
 
 scanner.atEnd; // => true
 
+scanner.location = 42;
+
 /// https://novadocs.panic.com/api-reference/text-editor/
 
 // $ExpectError
 new TextEditor();
+
+declare const editor: TextEditor;
+
+editor.selectedRange = editor.getLineRangeForRange(new Range(4, 2));
 
 /// https://novadocs.panic.com/api-reference/tree-view/
 


### PR DESCRIPTION
This applies a few fixes to the nova types after integrating with the emmet plugin in https://github.com/emmetio/nova-plugin/pull/13. 

- Remove `readonly` from a bunch of properties. The nova docs now specify whether most properties are readonly or settable, and I'd assumed several were readonly that weren't.
- Return `Disposable` from most event handler creation functions. These aren't consistently documented, but I tested by logging at runtime, e.g.
   <img width="577" alt="Screen Shot 2020-08-12 at 17 13 57" src="https://user-images.githubusercontent.com/329222/90045855-ebc33000-dccf-11ea-834a-ddb065fafc59.png">
- Update `ReadableStream` and `WritableStream` to be generic. This is needed for how the emmet plugin defines fetch. There's a larger discussion to be had about how we define streams and fetch in this package, but I'm not dealing with it here.
   (What I'd really like from TypeScript is the ability to "mix and match" standardized JS api features, so I can build my own libs (e.g. take fetch + streams + ... + JavaScriptCore))
- Add missing `message` property to `Issue`


### Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present)
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://novadocs.panic.com/
- ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~
