### PR TITLE
[@types/mongodb] allow MongoDB 4.2 update with aggregations

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1426,6 +1426,25 @@ export type UpdateQuery<TSchema> = {
     $bit?: {
         [key: string]: { [key in 'and' | 'or' | 'xor']?: number };
     };
+} | Array<UpdateAggregation<TSchema>>;
+
+/** https://docs.mongodb.com/v4.2/release-notes/4.2/#update-enhancements */
+export type UpdateAggregation<TSchema> = {
+    /** Can be any valid expression */
+    $replaceWith: object
+} | {
+    $replaceRoot: {
+        /** Can be any valid expression */
+        newRoot: object
+    }
+} | {
+    $unset: keyof TSchema | string | Array<keyof TSchema | string>
+} | {
+    $project: SchemaMember<TSchema, number | boolean | any>
+} | {
+    $set: SchemaMember<TSchema, any>
+} | {
+    $addFields: SchemaMember<TSchema, any>
 };
 
 /** https://docs.mongodb.com/manual/reference/operator/query/type/#available-types */

--- a/types/mongodb/test/collection/updateX.ts
+++ b/types/mongodb/test/collection/updateX.ts
@@ -138,10 +138,8 @@ async function run() {
             }
         }
     });
-    buildUpdateQuery({
-        // $ExpectError
-        $addToSet: { subInterfaceArray: { field1: 123 } }
-    });
+    // $ExpectError
+    buildUpdateQuery({ $addToSet: { subInterfaceArray: { field1: 123 } } });
 
     buildUpdateQuery({ $pop: { fruitTags: 1 } });
     buildUpdateQuery({ $pop: { fruitTags: -1 } });
@@ -193,12 +191,17 @@ async function run() {
             }
         }
     });
-    buildUpdateQuery({
-        // $ExpectError
-        $push: { subInterfaceArray: { field1: 123 } }
-    });
+    // $ExpectError
+    buildUpdateQuery({ $push: { subInterfaceArray: { field1: 123 } } });
     // buildUpdateQuery({ $push: { 'dot.notation': 1 } });
     // buildUpdateQuery({ $push: { 'subInterfaceArray.$[]': { $in: ['a'] } } });
+
+    buildUpdateQuery([
+        { $set: { dateField: "$$NOW", subInterfaceArray: ["$subInterfaceField"] } },
+        { $unset: ["maybeFruitTags", "optionalNumberField"] }
+    ]);
+    // $ExpectError
+    buildUpdateQuery([ { $otherOp: { stringField: 'value' } } ]);
 
     collectionTType.updateOne({ stringField: 'bla' }, justASample);
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://docs.mongodb.com/v4.2/release-notes/4.2/#update-enhancements>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
