### PR TITLE
@types/doubleclick-gpt Add campaignId to SlotRenderEndedEvent

### DIFF
--- a/types/doubleclick-gpt/doubleclick-gpt-tests.ts
+++ b/types/doubleclick-gpt/doubleclick-gpt-tests.ts
@@ -267,6 +267,7 @@ googletag.pubads().addEventListener("slotRenderEnded", (event) => {
     console.log(event.isEmpty);
     console.log(event.lineItemId);
     console.log(event.creativeId);
+    console.log(event.campaignId);
 });
 
 // 2. Slot render ended listener, slot specific logic.

--- a/types/doubleclick-gpt/index.d.ts
+++ b/types/doubleclick-gpt/index.d.ts
@@ -189,6 +189,7 @@ declare namespace googletag {
 
         interface SlotRenderEndedEvent extends Event {
             advertiserId?: number;
+            campaignId?: number;
             creativeId?: number;
             isEmpty: boolean;
             lineItemId?: number;


### PR DESCRIPTION
Add `campaignId` field which was added in 2017.

According to archive.org, `SlotRenderEndedEvent.campaignId` field was added to the [doubleclick-dfp Reference documentation](https://developers.google.com/doubleclick-gpt/reference#googletag.events.slotrenderendedevent) sometime between [2016-12-12](https://web.archive.org/web/20161212154312if_/https://developers.google.com/doubleclick-gpt/reference#googletageventsslotrenderendedevent) and [2018-02-01](https://web.archive.org/web/20180201035518if_/https://developers.google.com/doubleclick-gpt/reference#googletageventsslotrenderendedevent). According to the [doubleclick-gpt version history](https://developers.google.com/doubleclick-gpt/versions), the most likely version that first documented this field is v138, 2017-07-14 “Updated documentation for SlotRenderEndedEvent.” Probably it should have been part of #23938 but it wasn’t noticed at that time.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/doubleclick-gpt/reference#googletag.events.slotrenderendedevent
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
