### PR TITLE
[Bluebird] support then -> static .all -> then

### DIFF
--- a/types/bluebird/bluebird-tests.ts
+++ b/types/bluebird/bluebird-tests.ts
@@ -1,10 +1,11 @@
 // Tests by: Bart van der Schoor <https://github.com/Bartvds>
+// Minimum TypeScript Version: 4.0
 
 // Note: replicate changes to all overloads in both definition and test file
 // Note: keep both static and instance members inline (so similar)
 
 // Note: try to maintain the ordering and separators, and keep to the pattern
-// Minimum TypeScript Version: 4.0
+
 
 import * as Bluebird from "bluebird";
 

--- a/types/bluebird/bluebird-tests.ts
+++ b/types/bluebird/bluebird-tests.ts
@@ -244,6 +244,14 @@ barProm = barProm.then((value: Bar) => {
     return Bluebird.resolve(bar);
 });
 
+Bluebird.resolve()
+    .then(() => ["" as string, Bluebird.resolve(0 as number)])
+    .all()
+    .then(([x1, x2]) => {
+        const y1: string = x1;
+        const y2: number = x2;
+    });
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 // $ExpectType Bluebird<void | Foo>

--- a/types/bluebird/bluebird-tests.ts
+++ b/types/bluebird/bluebird-tests.ts
@@ -244,6 +244,7 @@ barProm = barProm.then((value: Bar) => {
     return Bluebird.resolve(bar);
 });
 
+// Minimum TypeScript Version: 4.0
 Bluebird.resolve()
     .then(() => ["", Bluebird.resolve(0)])
     .all()

--- a/types/bluebird/bluebird-tests.ts
+++ b/types/bluebird/bluebird-tests.ts
@@ -4,6 +4,7 @@
 // Note: keep both static and instance members inline (so similar)
 
 // Note: try to maintain the ordering and separators, and keep to the pattern
+// Minimum TypeScript Version: 4.0
 
 import * as Bluebird from "bluebird";
 
@@ -244,7 +245,6 @@ barProm = barProm.then((value: Bar) => {
     return Bluebird.resolve(bar);
 });
 
-// Minimum TypeScript Version: 4.0
 Bluebird.resolve()
     .then(() => ["", Bluebird.resolve(0)])
     .all()

--- a/types/bluebird/bluebird-tests.ts
+++ b/types/bluebird/bluebird-tests.ts
@@ -245,7 +245,7 @@ barProm = barProm.then((value: Bar) => {
 });
 
 Bluebird.resolve()
-    .then(() => ["" as string, Bluebird.resolve(0 as number)])
+    .then(() => ["", Bluebird.resolve(0)])
     .all()
     .then(([x1, x2]) => {
         const y1: string = x1;

--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/petkaantonov/bluebird
 // Definitions by: Leonard Hecker <https://github.com/lhecker>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.2
+// TypeScript Version: 4.0
 
 /*!
  * The code following this comment originates from:
@@ -72,6 +72,7 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
    *
    * Alias `.caught();` for compatibility with earlier ECMAScript version.
    */
+  catch<T extends unknown[]>(onReject?: (error: any) => [...T] | undefined | null): Bluebird<[...T] | R>;
   catch<U = R>(onReject: ((error: any) => Resolvable<U>) | undefined | null): Bluebird<U | R>;
 
   /**
@@ -678,6 +679,7 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
   /**
    * Create a promise that is resolved with the given `value`. If `value` is a thenable or promise, the returned promise will assume its state.
    */
+  static resolve<T extends unknown[]>(value: Bluebird<[...T]>): Bluebird<[...T]>;
   static resolve(): Bluebird<void>;
   static resolve<R>(value: Resolvable<R>): Bluebird<R>;
 

--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -58,12 +58,8 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
    * The new promise will be rejected or resolved depending on the passed `fulfilledHandler`, `rejectedHandler` and the state of this promise.
    */
   // Based on PromiseLike.then, but returns a Bluebird instance.
-  then<T1, T2, T3, T4, T5>(onFulfill?: (value: R) => [T1, T2, T3, T4, T5], onReject?: (error: any) => [T1, T2, T3, T4, T5]): Bluebird<[T1, T2, T3, T4, T5]>;
-  then<T1, T2, T3, T4>(onFulfill?: (value: R) => [T1, T2, T3, T4], onReject?: (error: any) => [T1, T2, T3, T4]): Bluebird<[T1, T2, T3, T4]>;
-  then<T1, T2, T3>(onFulfill?: (value: R) => [T1, T2, T3], onReject?: (error: any) => [T1, T2, T3]): Bluebird<[T1, T2, T3]>;
-  then<T1, T2>(onFulfill?: (value: R) => [T1, T2], onReject?: (error: any) => [T1, T2]): Bluebird<[T1, T2]>;
-  then<T1>(onFulfill?: (value: R) => [T1], onReject?: (error: any) => [T1]): Bluebird<[T1]>;
-  then<T1>(onFulfill?: (value: R) => Resolvable<T1>, onReject?: (error: any) => Resolvable<T1>): Bluebird<T1>;
+  then<T extends any[]>(onFulfill?: (value: R) => Resolvable<[...T]>, onReject?: (error: any) => Resolvable<[...T]>): Bluebird<[...T]>;
+  then<T>(onFulfill?: (value: R) => Resolvable<T>, onReject?: (error: any) => Resolvable<T>): Bluebird<T>;
   then<TResult1 = R, TResult2 = never>(
       onfulfilled?: ((value: R) => Resolvable<TResult1>) | null,
       onrejected?: ((reason: any) => Resolvable<TResult2>) | null
@@ -571,11 +567,8 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
   /**
    * Same as calling `Promise.all(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
    */
-  all<T1, T2, T3, T4, T5>(this: Bluebird<[Resolvable<T1>, Resolvable<T2>, Resolvable<T3>, Resolvable<T4>, Resolvable<T5>]>): Bluebird<[T1, T2, T3, T4, T5]>;
-  all<T1, T2, T3, T4>(this: Bluebird<[Resolvable<T1>, Resolvable<T2>, Resolvable<T3>, Resolvable<T4>]>): Bluebird<[T1, T2, T3, T4]>;
-  all<T1, T2, T3>(this: Bluebird<[Resolvable<T1>, Resolvable<T2>, Resolvable<T3>]>): Bluebird<[T1, T2, T3]>;
-  all<T1, T2>(this: Bluebird<[Resolvable<T1>, Resolvable<T2>]>): Bluebird<[T1, T2]>;
-  all<T1>(this: Bluebird<[Resolvable<T1>]>): Bluebird<[T1]>;
+
+  all<T extends unknown[]>(this: Bluebird<[...T]>): Bluebird<{ [P in keyof T]: T[P] extends Resolvable<infer U> ? U : T[P] }>;
   all<R>(this: Bluebird<Iterable<Resolvable<R>>>): Bluebird<R[]>;
 
   /**

--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -58,7 +58,12 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
    * The new promise will be rejected or resolved depending on the passed `fulfilledHandler`, `rejectedHandler` and the state of this promise.
    */
   // Based on PromiseLike.then, but returns a Bluebird instance.
-  then<U>(onFulfill?: (value: R) => Resolvable<U>, onReject?: (error: any) => Resolvable<U>): Bluebird<U>; // For simpler signature help.
+  then<T1, T2, T3, T4, T5>(onFulfill?: (value: R) => [T1, T2, T3, T4, T5], onReject?: (error: any) => [T1, T2, T3, T4, T5]): Bluebird<[T1, T2, T3, T4, T5]>;
+  then<T1, T2, T3, T4>(onFulfill?: (value: R) => [T1, T2, T3, T4], onReject?: (error: any) => [T1, T2, T3, T4]): Bluebird<[T1, T2, T3, T4]>;
+  then<T1, T2, T3>(onFulfill?: (value: R) => [T1, T2, T3], onReject?: (error: any) => [T1, T2, T3]): Bluebird<[T1, T2, T3]>;
+  then<T1, T2>(onFulfill?: (value: R) => [T1, T2], onReject?: (error: any) => [T1, T2]): Bluebird<[T1, T2]>;
+  then<T1>(onFulfill?: (value: R) => [T1], onReject?: (error: any) => [T1]): Bluebird<[T1]>;
+  then<T1>(onFulfill?: (value: R) => Resolvable<T1>, onReject?: (error: any) => Resolvable<T1>): Bluebird<T1>;
   then<TResult1 = R, TResult2 = never>(
       onfulfilled?: ((value: R) => Resolvable<TResult1>) | null,
       onrejected?: ((reason: any) => Resolvable<TResult2>) | null


### PR DESCRIPTION
e.g. `Promise.resolve([x1, x2]).all().then([x1, x2])`
