### PR TITLE
xml2json: `alternateTextNode` accepts strings too

### DIFF
--- a/types/xml2json/index.d.ts
+++ b/types/xml2json/index.d.ts
@@ -77,5 +77,5 @@ export interface JsonOptions {
      * Changes the default textNode property from $t to _t when option is set to true.
      * Alternatively a string can be specified which will override $t to what ever the string is.
      */
-    alternateTextNode?: boolean;
+    alternateTextNode?: boolean | string;
 }

--- a/types/xml2json/xml2json-tests.ts
+++ b/types/xml2json/xml2json-tests.ts
@@ -1,6 +1,6 @@
 import * as parser from 'xml2json';
 
-let xml = "<foo attr=\"value\">bar</foo>";
+let xml = '<foo attr="value">bar</foo>';
 
 // xml to json
 const jsonString: string = parser.toJson(xml);
@@ -15,10 +15,14 @@ const jsonObject: {} = parser.toJson(xml, {
     coerce: false,
     sanitize: true,
     trim: true,
-    arrayNotation: false
+    arrayNotation: false,
 });
 
 // json to xml with XmlOptions
 xml = parser.toXml(jsonObject, {
-    sanitize: true
+    sanitize: true,
 });
+
+// Test `alternateTextNode`.
+parser.toJson(xml, { alternateTextNode: true });
+parser.toJson(xml, { alternateTextNode: 'value' });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/buglabs/node-xml2json
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

