### PR TITLE
xml2json: replace types of `{}` with `Record<string, unknown>`

### DIFF
--- a/types/xml2json/index.d.ts
+++ b/types/xml2json/index.d.ts
@@ -6,10 +6,10 @@
 
 /// <reference types="node" />
 
-export function toJson(xml: string | Buffer, options?: { object?: false } & JsonOptions): string;
-export function toJson(xml: string | Buffer, options?: { object: true } & JsonOptions): {};
+export function toJson(xml: string, options?: { object?: false } & JsonOptions): string;
+export function toJson(xml: string, options?: { object: true } & JsonOptions): Record<string, unknown>;
 
-export function toXml(json: {} | string | Buffer, options?: XmlOptions): string;
+export function toXml(json: Record<string, unknown> | string, options?: XmlOptions): string;
 
 export interface XmlOptions {
     /**

--- a/types/xml2json/index.d.ts
+++ b/types/xml2json/index.d.ts
@@ -6,10 +6,10 @@
 
 /// <reference types="node" />
 
-export function toJson(xml: string, options?: { object?: false } & JsonOptions): string;
-export function toJson(xml: string, options?: { object: true } & JsonOptions): Record<string, unknown>;
+export function toJson(xml: string | Buffer, options?: { object?: false } & JsonOptions): string;
+export function toJson(xml: string | Buffer, options?: { object: true } & JsonOptions): Record<string, unknown>;
 
-export function toXml(json: Record<string, unknown> | string, options?: XmlOptions): string;
+export function toXml(json: Record<string, unknown> | string | Buffer, options?: XmlOptions): string;
 
 export interface XmlOptions {
     /**

--- a/types/xml2json/index.d.ts
+++ b/types/xml2json/index.d.ts
@@ -7,10 +7,7 @@
 /// <reference types="node" />
 
 export function toJson(xml: string | Buffer, options?: { object?: false } & JsonOptions): string;
-export function toJson<T = { [key: string]: unknown }>(
-    xml: string | Buffer,
-    options?: { object: true } & JsonOptions,
-): T;
+export function toJson(xml: string | Buffer, options?: { object: true } & JsonOptions): { [key: string]: unknown };
 
 export function toXml(json: { [key: string]: unknown } | string | Buffer, options?: XmlOptions): string;
 

--- a/types/xml2json/index.d.ts
+++ b/types/xml2json/index.d.ts
@@ -7,9 +7,12 @@
 /// <reference types="node" />
 
 export function toJson(xml: string | Buffer, options?: { object?: false } & JsonOptions): string;
-export function toJson(xml: string | Buffer, options?: { object: true } & JsonOptions): Record<string, unknown>;
+export function toJson<T = { [key: string]: unknown }>(
+    xml: string | Buffer,
+    options?: { object: true } & JsonOptions,
+): T;
 
-export function toXml(json: Record<string, unknown> | string | Buffer, options?: XmlOptions): string;
+export function toXml(json: { [key: string]: unknown } | string | Buffer, options?: XmlOptions): string;
 
 export interface XmlOptions {
     /**

--- a/types/xml2json/xml2json-tests.ts
+++ b/types/xml2json/xml2json-tests.ts
@@ -9,7 +9,7 @@ const jsonString: string = parser.toJson(xml);
 xml = parser.toXml(jsonString);
 
 // xml to json in object mode and JsonOptions
-const jsonObject: Record<string, unknown> = parser.toJson(xml, {
+const jsonObject: { [key: string]: unknown } = parser.toJson(xml, {
     object: true,
     reversible: false,
     coerce: false,
@@ -17,6 +17,9 @@ const jsonObject: Record<string, unknown> = parser.toJson(xml, {
     trim: true,
     arrayNotation: false,
 });
+
+const a: { [key: string]: string } = parser.toJson(xml, { object: true });
+const b: { [key: string]: number } = parser.toJson<{ [key: string]: number }>(xml, { object: true });
 
 // json to xml with XmlOptions
 xml = parser.toXml(jsonObject, {

--- a/types/xml2json/xml2json-tests.ts
+++ b/types/xml2json/xml2json-tests.ts
@@ -9,7 +9,7 @@ const jsonString: string = parser.toJson(xml);
 xml = parser.toXml(jsonString);
 
 // xml to json in object mode and JsonOptions
-const jsonObject: {} = parser.toJson(xml, {
+const jsonObject: Record<string, unknown> = parser.toJson(xml, {
     object: true,
     reversible: false,
     coerce: false,

--- a/types/xml2json/xml2json-tests.ts
+++ b/types/xml2json/xml2json-tests.ts
@@ -18,8 +18,8 @@ const jsonObject: { [key: string]: unknown } = parser.toJson(xml, {
     arrayNotation: false,
 });
 
-const a: { [key: string]: string } = parser.toJson(xml, { object: true });
-const b: { [key: string]: number } = parser.toJson<{ [key: string]: number }>(xml, { object: true });
+const a = parser.toJson(xml, { object: true }) as { [key: string]: string };
+const b = parser.toJson(xml, { object: true }) as { [key: string]: number };
 
 // json to xml with XmlOptions
 xml = parser.toXml(jsonObject, {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

