### PR TITLE
[reactstrap]: Add missing Alert props

### DIFF
--- a/types/reactstrap/lib/Alert.d.ts
+++ b/types/reactstrap/lib/Alert.d.ts
@@ -5,10 +5,14 @@ import { FadeProps } from './Fade';
 export interface UncontrolledAlertProps extends React.HTMLAttributes<HTMLElement> {
     [key: string]: any;
     className?: string;
+    closeClassName?: string;
+    closeAriaLabel?: string;
     cssModule?: CSSModule;
     color?: string;
+    fade?: boolean;
     tag?: string | React.ReactType;
     transition?: FadeProps;
+    innerRef?: React.Ref<HTMLElement>;
 }
 export interface AlertProps extends UncontrolledAlertProps {
     isOpen?: boolean;

--- a/types/reactstrap/reactstrap-tests.tsx
+++ b/types/reactstrap/reactstrap-tests.tsx
@@ -94,7 +94,13 @@ import {
 const Examplea = (props: any) => {
   return (
     <div>
-      <Alert color="success">
+      <Alert
+        color="success"
+        closeClassName="close"
+        closeAriaLabel="close"
+        fade={false}
+        innerRef={React.createRef()}
+      >
         <strong>Well done!</strong> You successfully read this important alert message.
       </Alert>
       <Alert color="info">


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/reactstrap/reactstrap/blob/aa63f997e0b75a9b420945d0c5a9a78984da1e48/src/Alert.js#L7-L24
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Not all of the props are in the documentation, so I linked to the code instead.