### PR TITLE
Change the description of chrome.audio api

### DIFF
--- a/types/chrome-apps/index.d.ts
+++ b/types/chrome-apps/index.d.ts
@@ -860,7 +860,7 @@ declare namespace chrome {
      * @description
      * The chrome.audio API is provided to allow users to get information
      * about and control the audio devices attached to the system.
-     * This API is currently only implemented for ChromeOS.
+     * This API is currently only available in kiosk mode for ChromeOS.
      */
     namespace audio {
         type StreamType =


### PR DESCRIPTION
The API is only avaiable in kiosk mode, but the documentation does not specify that.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: crbug.com/1099688
