### PR TITLE
Fixed rollup-plugin-postcss function types

### DIFF
--- a/types/rollup-plugin-postcss/index.d.ts
+++ b/types/rollup-plugin-postcss/index.d.ts
@@ -13,7 +13,7 @@ export interface PostCssPluginOptions {
     plugins?: any[];
     inject?: boolean | {
         insertAt?: 'top' | string;
-    };
+    } | ((cssVariableName: string, fileId: string) => string);
     extract?: boolean | string;
     modules?: boolean | unknown;
     autoModules?: boolean;
@@ -26,10 +26,10 @@ export interface PostCssPluginOptions {
     };
     name?: any[] | any[][];
     loaders?: any[];
-    namedExports?(...args: any[]): void | boolean;
-    parser?(...args: any[]): void | string;
-    syntax?(...args: any[]): void | string;
-    stringifier?(...args: any[]): void | string;
+    namedExports?: ((name: string) => string) | boolean;
+    parser?: ((...args: any[]) => void) | string;
+    syntax?: ((...args: any[]) => void) | string;
+    stringifier?: ((...args: any[]) => void) | string;
     onImport?: (id: any) => void;
 }
 


### PR DESCRIPTION
The typing as is is pretty broken. `parser?(...args: any[]): void | string` means “a method that returns undefined or a string” while the docs say “a function OR a string”.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/egoist/rollup-plugin-postcss#options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.