### PR TITLE
ws added EventListenerOptions and removed optional flag on callback

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -56,14 +56,23 @@ declare class WebSocket extends events.EventEmitter {
     terminate(): void;
 
     // HTML5 WebSocket events
-    addEventListener(method: 'message', cb?: (event: { data: any; type: string; target: WebSocket }) => void): void;
-    addEventListener(method: 'close', cb?: (event: {
+    addEventListener(method: 'message', cb: (event: {
+        data: any;
+        type: string;
+        target: WebSocket
+    }, options?: WebSocket.EventListenerOptions) => void): void;
+    addEventListener(method: 'close', cb: (event: {
         wasClean: boolean; code: number;
         reason: string; target: WebSocket
-    }) => void): void;
-    addEventListener(method: 'error', cb?: (event: {error: any, message: any, type: string, target: WebSocket }) => void): void;
-    addEventListener(method: 'open', cb?: (event: { target: WebSocket }) => void): void;
-    addEventListener(method: string, listener?: () => void): void;
+    }, options?: WebSocket.EventListenerOptions) => void): void;
+    addEventListener(method: 'error', cb: (event: {
+        error: any,
+        message: any,
+        type: string,
+        target: WebSocket
+    }, options?: WebSocket.EventListenerOptions) => void): void;
+    addEventListener(method: 'open', cb: (event: { target: WebSocket }) => void, options?: WebSocket.EventListenerOptions): void;
+    addEventListener(method: string, listener: () => void, options?: WebSocket.EventListenerOptions): void;
 
     removeEventListener(method: 'message', cb?: (event: { data: any; type: string; target: WebSocket }) => void): void;
     removeEventListener(method: 'close', cb?: (event: {
@@ -190,6 +199,10 @@ declare namespace WebSocket {
         data: Data;
         type: string;
         target: WebSocket;
+    }
+
+    interface EventListenerOptions {
+        once?: boolean;
     }
 
     interface ServerOptions {

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -158,3 +158,10 @@ import * as url from 'url';
     duplex.pipe(process.stdout);
     process.stdin.pipe(duplex);
 }
+
+{
+    const ws = new WebSocket('ws://www.host.com/path');
+    ws.addEventListener('other', () => {});
+    ws.addEventListener('other', () => {}, { once: true });
+    ws.addEventListener('other', () => {}, { once: true });
+}


### PR DESCRIPTION
Fixing types around addEventListener for the ws package:
- Added options (from merged PR: https://github.com/websockets/ws/pull/1754)
- Made callback/listener non-optional, because it isn't optional From documentation: https://github.com/websockets/ws/blob/da42ea17451f11eed54adb54d3beeedbb1c2aa70/doc/ws.md#websocketaddeventlistenertype-listener-options

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/websockets/ws/blob/da42ea17451f11eed54adb54d3beeedbb1c2aa70/doc/ws.md#websocketaddeventlistenertype-listener-options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.