### PR TITLE
Update redux-form to expose ReduxFormContext, bump to 8.3

### DIFF
--- a/types/redux-form/index.d.ts
+++ b/types/redux-form/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for redux-form 8.2
+// Type definitions for redux-form 8.3
 // Project: https://github.com/erikras/redux-form, https://redux-form.com
 // Definitions by: Daniel Lytkin <https://github.com/aikoven>
 //                 Karol Janyst <https://github.com/LKay>

--- a/types/redux-form/lib/reduxForm.d.ts
+++ b/types/redux-form/lib/reduxForm.d.ts
@@ -1,4 +1,5 @@
 import {
+    Context,
     Component,
     ComponentType,
     SyntheticEvent
@@ -134,7 +135,7 @@ export interface ConfigProps<FormData = {}, P = {}, ErrorType = string> {
     warn?(values: FormData, props: DecoratedFormProps<FormData, P, ErrorType>): FormWarnings<FormData>;
 }
 
-export interface ReduxFormContext {
+export interface FormContext {
     form: string;
     getFormState: GetFormState;
     asyncValidate: {
@@ -157,8 +158,10 @@ export interface ReduxFormContext {
 }
 
 export interface WrappedReduxFormContext {
-    _reduxForm: ReduxFormContext;
+    _reduxForm: FormContext;
 }
+
+export declare const ReduxFormContext: Context<FormContext>;
 
 export interface FormInstance<FormData, P> extends Component<P> {
     dirty: boolean;

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -26,6 +26,7 @@ import {
     SubmissionError,
     FieldArrayFieldsProps,
     DecoratedFormProps,
+    ReduxFormContext
 } from 'redux-form';
 
 import {
@@ -486,5 +487,17 @@ class TestFormComponent2 extends React.Component<TestFormComponentProps & Inject
 
         handleSubmit((values) => ({ foo: ['string'], _error: [] }));
         return null;
+    }
+}
+
+// Test ReduxFormContext
+// See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46798
+class TestReduxFormContext extends React.Component {
+    render() {
+        return (
+            <ReduxFormContext.Consumer>
+                {values => <div>{values.form}</div>}
+            </ReduxFormContext.Consumer>
+        );
     }
 }


### PR DESCRIPTION
Only new feature in 8.3 is exposing `ReduxFormContext`:
https://github.com/redux-form/redux-form/releases/tag/v8.3.0

Reused existing type and exposed as a `React.Context`.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/redux-form/redux-form/releases/tag/v8.3.0>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
