### PR TITLE
[@types/underscore] Collection and Array Tests - Shortening Cleanup

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -191,9 +191,9 @@ declare module _ {
          **/
         <V>(value: V): Underscore<TypeOfCollection<V>, V>;
 
-        /* *************
-        * Collections *
-        ************* */
+        /***************
+         * Collections *
+         ***************/
 
         /**
          * Iterates over a collection of elements, yielding each in turn to an
@@ -632,9 +632,9 @@ declare module _ {
             context?: any
         ): [TypeOfCollection<V>[], TypeOfCollection<V>[]];
 
-        /*********
-        * Arrays *
-        **********/
+        /**********
+         * Arrays *
+         **********/
 
         /**
          * Returns the first element of `list`. Passing `n` will return the
@@ -3425,9 +3425,9 @@ declare module _ {
         **/
         compose(...functions: Function[]): Function;
 
-        /**********
-        * Objects *
-        ***********/
+        /***********
+         * Objects *
+         ***********/
 
         /**
         * Retrieve all the names of the object's properties.
@@ -3797,9 +3797,9 @@ declare module _ {
          **/
         isUndefined(object: any): object is undefined;
 
-        /* *********
-        * Utility *
-        ********** */
+        /***********
+         * Utility *
+         ***********/
 
         /**
         * Give control of the "_" variable back to its previous owner.
@@ -3934,9 +3934,9 @@ declare module _ {
         **/
         now(): number;
 
-        /* **********
-        * Chaining *
-        *********** */
+        /************
+         * Chaining *
+         ************/
 
         /**
          * Returns a wrapped object. Calling methods on this object will continue to return wrapped objects
@@ -3954,9 +3954,9 @@ declare module _ {
 
     interface Underscore<T, V = T[]> {
 
-        /* *************
-        * Collections *
-        ************* */
+        /***************
+         * Collections *
+         ***************/
 
         /**
          * Iterates over the wrapped collection of elements, yielding each in
@@ -4305,9 +4305,9 @@ declare module _ {
          **/
         partition(iteratee?: Iteratee<V, boolean>, context?: any): [T[], T[]];
 
-        /*********
-        * Arrays *
-        **********/
+        /**********
+         * Arrays *
+         **********/
 
         /**
          * Returns the first element of the wrapped list. Passing `n` will
@@ -4578,9 +4578,9 @@ declare module _ {
          **/
         chunk(length: number): T[][];
 
-        /* ***********
-        * Functions *
-        ************ */
+        /*************
+         * Functions *
+         *************/
 
         /**
         * Wrapped type `Function`.
@@ -4677,9 +4677,9 @@ declare module _ {
         **/
         compose(...functions: Function[]): Function;
 
-        /********* *
+        /***********
          * Objects *
-        ********** */
+         ***********/
 
         /**
         * Wrapped type `object`.
@@ -4967,9 +4967,9 @@ declare module _ {
          **/
         isUndefined(): boolean;
 
-        /********* *
+        /***********
          * Utility *
-        ********** */
+         ***********/
 
         /**
         * Wrapped type `any`.
@@ -5048,9 +5048,9 @@ declare module _ {
         **/
         template(settings?: _.TemplateSettings): CompiledTemplate;
 
-        /********** *
+        /************
          * Chaining *
-        *********** */
+         ************/
 
         /**
          * Returns a wrapped object. Calling methods on this object will continue to return wrapped objects
@@ -5068,9 +5068,9 @@ declare module _ {
 
     interface _Chain<T, V = T[]> {
 
-        /* *************
-        * Collections *
-        ************* */
+        /***************
+         * Collections *
+         ***************/
 
         /**
          * Iterates over the wrapped collection of elements, yielding each in
@@ -5430,9 +5430,9 @@ declare module _ {
          **/
         partition(iteratee?: Iteratee<V, boolean>, context?: any): _Chain<T[], [T[], T[]]>;
 
-        /*********
-        * Arrays *
-        **********/
+        /**********
+         * Arrays *
+         **********/
 
         /**
          * Returns the first element of the wrapped list. Passing `n` will
@@ -5709,9 +5709,9 @@ declare module _ {
          **/
         chunk(length: number): _Chain<T[]>;
 
-        /* ***********
-        * Functions *
-        ************ */
+        /*************
+         * Functions *
+         *************/
 
         /**
         * Wrapped type `Function`.
@@ -5808,9 +5808,9 @@ declare module _ {
         **/
         compose(...functions: Function[]): _Chain<T>;
 
-        /********* *
+        /***********
          * Objects *
-        ********** */
+         ***********/
 
         /**
         * Wrapped type `object`.
@@ -6119,9 +6119,9 @@ declare module _ {
          **/
         isUndefined(): _ChainSingle<boolean>;
 
-        /********* *
+        /***********
          * Utility *
-        ********** */
+         ***********/
 
         /**
         * Wrapped type `any`.
@@ -6200,9 +6200,9 @@ declare module _ {
         **/
         template(settings?: _.TemplateSettings): _Chain<CompiledTemplate>;
 
-        /************* *
-        * Array proxy *
-        ************** */
+        /***************
+         * Array proxy *
+         ***************/
 
         /**
         * Returns a new array comprised of the array on which it is called
@@ -6281,9 +6281,9 @@ declare module _ {
         **/
         unshift(...items: Array<T>): _Chain<T>;
 
-        /********** *
+        /************
          * Chaining *
-        *********** */
+         ************/
 
         /**
           * Returns a wrapped object. Calling methods on this object will continue to return wrapped objects

--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -196,10 +196,9 @@ declare module _ {
          ***************/
 
         /**
-         * Iterates over a collection of elements, yielding each in turn to an
-         * iteratee. The iteratee is bound to the context object, if one is
-         * passed. Each invocation of `iteratee` is called with three
-         * arguments: (element, key, collection).
+         * Iterates over a `collection` of elements, yielding each in turn to
+         * an `iteratee`. The `iteratee` is bound to the context object, if one
+         * is passed.
          * @param collection The collection of elements to iterate over.
          * @param iteratee The iteratee to call for each element in
          * `collection`.
@@ -218,11 +217,11 @@ declare module _ {
         forEach: UnderscoreStatic['each'];
 
         /**
-         * Produces a new array of values by mapping each value in the collection through a transformation function
-         * (iteratee). For function iteratees, each invocation of iteratee is called with three arguments:
-         * (value, key, collection).
-         * @param collection Maps the elements of this collection.
-         * @param iteratee Map iteratee for each element in the collection.
+         * Produces a new array of values by mapping each value in `collection`
+         * through a transformation `iteratee`.
+         * @param collection The collection to transform.
+         * @param iteratee The iteratee to use to transform each item in
+         * `collection`.
          * @param context `this` object in `iteratee`, optional.
          * @returns The mapped result.
          **/
@@ -238,18 +237,20 @@ declare module _ {
         collect: UnderscoreStatic['map'];
 
         /**
-         * Also known as inject and foldl, reduce boils down a collection of values into a
-         * single value. Memo is the initial state of the reduction, and each successive
-         * step of it should be returned by iteratee. The iteratee is passed four arguments:
-         * the memo, then the value and index (or key) of the iteration, and finally a reference
-         * to the entire collection.
+         * Also known as inject and foldl, reduce boils down a `collection` of
+         * values into a single value. `memo` is the initial state of the
+         * reduction, and each successive step of it should be returned by
+         * `iteratee`.
          *
-         * If no memo is passed to the initial invocation of reduce, the iteratee is not invoked
-         * on the first element of the collection. The first element is instead passed as the memo
-         * in the invocation of the iteratee on the next element in the collection.
-         * @param collection Reduces the elements of this collection.
-         * @param iteratee Reduce iteratee function for each element in `collection`.
-         * @param memo Initial reduce state or undefined to use the first collection item as initial state.
+         * If no memo is passed to the initial invocation of reduce, `iteratee`
+         * is not invoked on the first element of `collection`. The first
+         * element is instead passed as the memo in the invocation of
+         * `iteratee` on the next element in `collection`.
+         * @param collection The collection to reduce.
+         * @param iteratee The function to call on each iteration to reduce the
+         * collection.
+         * @param memo The initial reduce state or undefined to use the first
+         * item in `collection` as initial state.
          * @param context `this` object in `iteratee`, optional.
          * @returns The reduced result.
          **/
@@ -261,7 +262,9 @@ declare module _ {
         ): TResult;
         reduce<V extends Collection<any>, TResult = TypeOfCollection<V>>(
             collection: V,
-            iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult | TypeOfCollection<V>, V>
+            iteratee: MemoCollectionIterator<TypeOfCollection<V>,
+                TResult | TypeOfCollection<V>,
+                V>
         ): TResult | TypeOfCollection<V> | undefined;
 
         /**
@@ -277,10 +280,13 @@ declare module _ {
         /**
          * The right-associative version of reduce.
          *
-         * This is not as useful in JavaScript as it would be in a language with lazy evaluation.
-         * @param collection Reduces the elements of this array.
-         * @param iteratee Reduce iteratee function for each element in `collection`.
-         * @param memo Initial reduce state or undefined to use the first collection item as initial state.
+         * This is not as useful in JavaScript as it would be in a language
+         * with lazy evaluation.
+         * @param collection The collection to reduce.
+         * @param iteratee The function to call on each iteration to reduce the
+         * collection.
+         * @param memo The initial reduce state or undefined to use the first
+         * item in `collection` as the initial state.
          * @param context `this` object in `iteratee`, optional.
          * @returns The reduced result.
          **/
@@ -292,7 +298,9 @@ declare module _ {
         ): TResult;
         reduceRight<V extends Collection<any>, TResult = TypeOfCollection<V>>(
             collection: V,
-            iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult | TypeOfCollection<V>, V>
+            iteratee: MemoCollectionIterator<TypeOfCollection<V>,
+                TResult | TypeOfCollection<V>,
+                V>
         ): TResult | TypeOfCollection<V> | undefined;
 
         /**
@@ -301,15 +309,15 @@ declare module _ {
         foldr: UnderscoreStatic['reduceRight'];
 
         /**
-         * Looks through each value in the collection, returning the first one that passes a
-         * truth test (iteratee), or undefined if no value passes the test. The function
-         * returns as soon as it finds an acceptable element, and doesn't traverse the entire
-         * collection.
-         * @param collection Searches for a value in this collection.
+         * Looks through each value in `collection`, returning the first one
+         * that passes a truth test (`iteratee`), or undefined if no value
+         * passes the test. The function returns as soon as it finds an
+         * acceptable element, and doesn't traverse the entire collection.
+         * @param collection The collection to search.
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
-         * @return The first element in `collection` that passes the truth test or undefined
-         * if no elements pass.
+         * @returns The first element in `collection` that passes the truth
+         * test or undefined if no elements pass.
          **/
         find<V extends Collection<any>>(
             collection: V,
@@ -323,8 +331,8 @@ declare module _ {
         detect: UnderscoreStatic['find'];
 
         /**
-         * Looks through each value in the collection, returning an array of all the values that pass a truth
-         * test (iteratee).
+         * Looks through each value in `collection`, returning an array of
+         * all the values that pass a truth test (`iteratee`).
          * @param collection The collection to filter.
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
@@ -342,11 +350,13 @@ declare module _ {
         select: UnderscoreStatic['filter'];
 
         /**
-         * Looks through each value in the collection, returning an array of all the values that matches the
-         * key-value pairs listed in `properties`.
-         * @param collection The collection in which to find elements that match `properties`.
-         * @param properties The properties to check for on the elements within `collection`.
-         * @return The elements in `collection` that match `properties`.
+         * Looks through each value in `collection`, returning an array of all
+         * the elements that match the key-value pairs listed in `properties`.
+         * @param collection The collection in which to find elements that
+         * match `properties`.
+         * @param properties The properties to check for on the elements within
+         * `collection`.
+         * @returns The elements in `collection` that match `properties`.
          **/
         where<V extends Collection<any>>(
             collection: V,
@@ -354,13 +364,15 @@ declare module _ {
         ): TypeOfCollection<V>[];
 
         /**
-         * Looks through the collection and returns the first value that matches all of the key-value
-         * pairs listed in `properties`.
-         * If no match is found, or if list is empty, undefined will be returned.
-         * @param collection The collection in which to find an element that matches `properties`.
-         * @param properties The properties to check for on the elements within `collection`.
-         * @return The first element in `collection` that matches `properties` or undefined if
-         * no match is found.
+         * Looks through `collection` and returns the first value that matches
+         * all of the key-value pairs listed in `properties`. If no match is
+         * found, or if list is empty, undefined will be returned.
+         * @param collection The collection in which to find an element that
+         * matches `properties`.
+         * @param properties The properties to check for on the elements within
+         * `collection`.
+         * @returns The first element in `collection` that matches `properties`
+         * or undefined if no match is found.
          **/
         findWhere<V extends Collection<any>>(
             collection: V,
@@ -368,12 +380,13 @@ declare module _ {
         ): TypeOfCollection<V> | undefined;
 
         /**
-         * Returns the values in `collection` without the elements that pass a truth test (iteratee).
+         * Returns the values in `collection` without the elements that pass a
+         * truth test (`iteratee`).
          * The opposite of filter.
          * @param collection The collection to filter.
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
-         * @return The set of values that fail the truth test.
+         * @returns The set of values that fail the truth test.
          **/
         reject<V extends Collection<any>>(
             collection: V,
@@ -382,9 +395,9 @@ declare module _ {
         ): TypeOfCollection<V>[];
 
         /**
-         * Returns true if all of the values in `collection` pass the `iteratee`
-         * truth test. Short-circuits and stops traversing `collection` if a false
-         * element is found.
+         * Returns true if all of the values in `collection` pass the
+         * `iteratee` truth test. Short-circuits and stops traversing
+         * `collection` if a false element is found.
          * @param collection The collection to evaluate.
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
@@ -402,9 +415,9 @@ declare module _ {
         all: UnderscoreStatic['every'];
 
         /**
-         * Returns true if any of the values in `collection` pass the `iteratee`
-         * truth test. Short-circuits and stops traversing `collection` if a
-         * true element is found.
+         * Returns true if any of the values in `collection` pass the
+         * `iteratee` truth test. Short-circuits and stops traversing
+         * `collection` if a true element is found.
          * @param collection The collection to evaluate.
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
@@ -467,11 +480,13 @@ declare module _ {
         ): any[];
 
         /**
-         * A convenient version of what is perhaps the most common use-case for map: extracting a list of
-         * property values.
+         * A convenient version of what is perhaps the most common use-case for
+         * map: extracting a list of property values.
          * @param collection The collection of items.
-         * @param propertyName The name of a specific property to retrieve from all items.
-         * @returns The set of values for the specified property for each item in the collection.
+         * @param propertyName The name of a specific property to retrieve from
+         * all items in `collection`.
+         * @returns The set of values for the specified `propertyName` for each
+         * item in `collection`.
          **/
         pluck<V extends Collection<any>, K extends EnumerableKey>(
             collection: V,
@@ -531,7 +546,7 @@ declare module _ {
             context?: any): TypeOfCollection<V>[];
 
         /**
-         * Splits a `collection` into sets that are grouped by the result of
+         * Splits `collection` into sets that are grouped by the result of
          * running each value through `iteratee`.
          * @param collection The collection to group.
          * @param iteratee An iteratee that provides the value to group by for
@@ -565,8 +580,8 @@ declare module _ {
             context?: any): Dictionary<TypeOfCollection<V>>;
 
         /**
-         * Sorts a `collection` into groups and returns a count for the number
-         * of objects in each group. Similar to `groupBy`, but instead of
+         * Sorts `collection` into groups and returns a count for the number of
+         * objects in each group. Similar to `groupBy`, but instead of
          * returning a list of values, returns a count for the number of values
          * in that group.
          * @param collection The collection to count.
@@ -584,33 +599,46 @@ declare module _ {
         ): Dictionary<number>;
 
         /**
-         * Returns a shuffled copy of the collection, using a version of the Fisher-Yates shuffle.
+         * Returns a shuffled copy of `collection`, using a version of the
+         * Fisher-Yates shuffle.
          * @param collection The collection to shuffle.
-         * @return A shuffled copy of `collection`.
+         * @returns A shuffled copy of `collection`.
          **/
-        shuffle<V extends Collection<any>>(collection: V): TypeOfCollection<V>[];
+        shuffle<V extends Collection<any>>(
+            collection: V
+        ): TypeOfCollection<V>[];
 
         /**
-         * Produce a random sample from the collection. Pass a number to return `n` random elements from the collection.
-         * Otherwise a single random item will be returned.
+         * Produce a random sample from `collection`. Pass a number to return
+         * `n` random elements from `collection`. Otherwise a single random
+         * item will be returned.
          * @param collection The collection to sample.
-         * @param n The number of elements to sample from the collection.
-         * @return A random sample of `n` elements from `collection` or a single element if `n` is not specified.
+         * @param n The number of elements to sample from `collection`.
+         * @returns A random sample of `n` elements from `collection` or a
+         * single element if `n` is not specified.
          **/
-        sample<V extends Collection<any>>(collection: V, n: number): TypeOfCollection<V>[];
-        sample<V extends Collection<any>>(collection: V): TypeOfCollection<V> | undefined;
+        sample<V extends Collection<any>>(
+            collection: V,
+            n: number
+        ): TypeOfCollection<V>[];
+        sample<V extends Collection<any>>(
+            collection: V
+        ): TypeOfCollection<V> | undefined;
 
         /**
-         * Creates a real Array from the collection (anything that can be
+         * Creates a real Array from `collection` (anything that can be
          * iterated over). Useful for transmuting the arguments object.
          * @param collection The collection to transform into an array.
          * @returns An array containing the elements of `collection`.
          **/
-        toArray<V extends Collection<any>>(collection: V): TypeOfCollection<V>[];
+        toArray<V extends Collection<any>>(
+            collection: V
+        ): TypeOfCollection<V>[];
 
         /**
          * Determines the number of values in `collection`.
-         * @param collection The collection to determine the number of values for.
+         * @param collection The collection to determine the number of values
+         * for.
          * @returns The number of values in `collection`.
          **/
         size(collection: Collection<any>): number;
@@ -644,7 +672,9 @@ declare module _ {
          * @returns The first `n` elements of `list` or the first element if
          * `n` is omitted.
          **/
-        first<V extends List<any>>(list: V): TypeOfList<V> | undefined;
+        first<V extends List<any>>(
+            list: V
+        ): TypeOfList<V> | undefined;
         first<V extends List<any>>(
             list: V,
             n: number
@@ -682,7 +712,9 @@ declare module _ {
          * @returns The last `n` elements of `list` or the last element if `n`
          * is omitted.
          **/
-        last<V extends List<any>>(list: V): TypeOfList<V> | undefined;
+        last<V extends List<any>>(
+            list: V
+        ): TypeOfList<V> | undefined;
         last<V extends List<any>>(
             list: V,
             n: number
@@ -718,23 +750,32 @@ declare module _ {
          * @returns An array containing the elements of `list` without falsy
          * values.
          **/
-        compact<V extends List<any> | null | undefined>(list: V): Truthy<TypeOfList<V>>[];
+        compact<V extends List<any> | null | undefined>(
+            list: V
+        ): Truthy<TypeOfList<V>>[];
 
         /**
-         * Flattens a nested array (the nesting can be to any depth). If you pass shallow, the array will
-         * only be flattened a single level.
-         * @param list The array to flatten.
-         * @param shallow If true then only flatten one level, optional, default = false.
-         * @returns The flattened list.
+         * Flattens a nested `list` (the nesting can be to any depth). If you
+         * pass shallow, the `list` will only be flattened a single level.
+         * @param list The list to flatten.
+         * @param shallow True to only flatten one level, optional,
+         * default = false.
+         * @returns The flattened `list`.
          **/
-        flatten<V extends List<any>>(list: V, shallow?: false): DeepestListItemOrSelf<TypeOfList<V>>[];
-        flatten<V extends List<any>>(list: V, shallow: true): ListItemOrSelf<TypeOfList<V>>[];
+        flatten<V extends List<any>>(
+            list: V,
+            shallow?: false
+        ): DeepestListItemOrSelf<TypeOfList<V>>[];
+        flatten<V extends List<any>>(
+            list: V,
+            shallow: true
+        ): ListItemOrSelf<TypeOfList<V>>[];
 
         /**
          * Returns a copy of `list` with all instances of `values` removed.
          * @param list The list to exclude `values` from.
          * @param values The values to exclude from `list`.
-         * @return An array that contains all elements of `list` except for
+         * @returns An array that contains all elements of `list` except for
          * `values`.
          **/
         without<V extends List<any>>(
@@ -784,7 +825,7 @@ declare module _ {
          * @param iteratee Transform the elements of `list` before comparisons
          * for uniqueness.
          * @param context 'this' object in `iteratee`, optional.
-         * @return An array containing only the unique elements in `list`.
+         * @returns An array containing only the unique elements in `list`.
          **/
         uniq<V extends List<any>>(
             list: V,
@@ -919,7 +960,7 @@ declare module _ {
          * @param iteratee Iteratee to compute the sort ranking of each
          * element including `value`, optional.
          * @param context `this` object in `iteratee`, optional.
-         * @return The index where `value` should be inserted into `list`.
+         * @returns The index where `value` should be inserted into `list`.
          **/
         sortedIndex<V extends List<any>>(
             list: V,
@@ -954,10 +995,12 @@ declare module _ {
         ): number[];
 
         /**
-         * Chunks a list into multiple arrays, each containing length or fewer items.
-         * @param list The list to split.
-         * @param length The maximum size of the inner arrays.
-         * @returns The chunked list.
+         * Chunks `list` into multiple arrays, each containing `length` or
+         * fewer items.
+         * @param list The list to chunk.
+         * @param length The maximum size of the chunks.
+         * @returns The contents of `list` in chunks no greater than `length`
+         * in size.
          **/
         chunk<V extends List<any>>(list: V, length: number): TypeOfList<V>[][]
 
@@ -3466,7 +3509,8 @@ declare module _ {
          * @returns A new object with all of `object`'s property values
          * transformed through `iteratee`.
          */
-        mapObject<V extends object, I extends Iteratee<V, any, TypeOfCollection<V, any>>>(
+        mapObject<V extends object,
+            I extends Iteratee<V, any, TypeOfCollection<V, any>>>(
             object: V,
             iteratee: I,
             context?: any
@@ -3478,7 +3522,9 @@ declare module _ {
          * @param object The object to convert.
          * @returns The list of [key, value] pairs from `object`.
          **/
-        pairs<V extends object>(object: V): [Extract<keyof V, string>, TypeOfCollection<V, any>][];
+        pairs<V extends object>(
+            object: V
+        ): [Extract<keyof V, string>, TypeOfCollection<V, any>][];
 
         /**
         * Returns a copy of the object where the keys have become the values and the values the keys.
@@ -3549,7 +3595,10 @@ declare module _ {
          * @param keys The keys to keep on `object`.
          * @returns A copy of `object` with only the `keys` properties.
          **/
-        pick<V, K extends string>(object: V, ...keys: (K | K[])[]): _Pick<V, K>;
+        pick<V, K extends string>(
+            object: V,
+            ...keys: (K | K[])[]
+        ): _Pick<V, K>;
 
         /**
          * Return a copy of `object` that is filtered to only have values for
@@ -3560,7 +3609,10 @@ declare module _ {
          * @returns A copy of `object` with only the keys selected by
          * `iterator`.
          **/
-        pick<V>(object: V, iterator: ObjectIterator<TypeOfDictionary<V, any>, boolean, V>): Partial<V>;
+        pick<V>(
+            object: V,
+            iterator: ObjectIterator<TypeOfDictionary<V, any>, boolean, V>
+        ): Partial<V>;
 
         /**
          * Return a copy of `object` that is filtered to omit the disallowed
@@ -3569,7 +3621,10 @@ declare module _ {
          * @param keys The keys to omit from `object`.
          * @returns A copy of `object` without the `keys` properties.
          **/
-        omit<V, K extends string>(object: V, ...keys: (K | K[])[]): _Omit<V, K>;
+        omit<V, K extends string>(
+            object: V,
+            ...keys: (K | K[])[]
+        ): _Omit<V, K>;
 
         /**
          * Return a copy of `object` that is filtered to not have values for
@@ -3580,7 +3635,10 @@ declare module _ {
          * @returns A copy of `object` without the keys selected by
          * `iterator`.
          **/
-        omit<V>(object: V, iterator: ObjectIterator<TypeOfDictionary<V, any>, boolean, V>): Partial<V>;
+        omit<V>(
+            object: V,
+            iterator: ObjectIterator<TypeOfDictionary<V, any>, boolean, V>
+        ): Partial<V>;
 
         /**
         * Fill in null and undefined properties in object with values from the defaults objects,
@@ -3668,17 +3726,20 @@ declare module _ {
 
         /**
          * Returns true if `collection` contains no values.
-         * For strings and array-like objects checks if the length property is 0.
+         * For strings and array-like objects checks if the length property is
+         * 0.
          * @param collection The collection to check.
          * @returns True if `collection` has no elements.
          **/
         isEmpty(collection: any): boolean;
 
         /**
-         * Returns true if the keys and values in `properties` are contained in `object`.
+         * Returns true if the keys and values in `properties` are contained in
+         * `object`.
          * @param object The object to check.
          * @param properties The properties to check for in `object`.
-         * @returns True if all keys and values in `properties` are also in `object`.
+         * @returns True if all keys and values in `properties` are also in
+         * `object`.
          **/
         isMatch(object: any, properties: any): boolean;
 
@@ -3704,7 +3765,8 @@ declare module _ {
         isSymbol(object: any): object is symbol;
 
         /**
-         * Returns true if `object` is an Object. Note that JavaScript arrays and functions are objects,
+         * Returns true if `object` is an Object. Note that JavaScript arrays
+         * and functions are objects,
          * while (normal) strings and numbers are not.
          * @param object The object to check.
          * @returns True if `object` is an Object, otherwise false.
@@ -3939,8 +4001,8 @@ declare module _ {
          ************/
 
         /**
-         * Returns a wrapped object. Calling methods on this object will continue to return wrapped objects
-         * until value() is used.
+         * Returns a wrapped object. Calling methods on this object will
+         * continue to return wrapped objects until value() is used.
          * @param value The object to chain.
          * @returns An underscore chain wrapper around the supplied value.
          **/
@@ -3960,15 +4022,17 @@ declare module _ {
 
         /**
          * Iterates over the wrapped collection of elements, yielding each in
-         * turn to an iteratee. The iteratee is bound to the context object, if
-         * one is passed. Each invocation of `iteratee` is called with three
-         * arguments: (element, key, collection).
+         * turn to an `iteratee`. The `iteratee` is bound to the context object,
+         * if one is passed.
          * @param iteratee The iteratee to call for each element in the wrapped
          * collection.
          * @param context 'this' object in `iteratee`, optional.
          * @returns The originally wrapped collection.
          **/
-        each(iteratee: CollectionIterator<TypeOfCollection<V>, void, V>, context?: any): V;
+        each(
+            iteratee: CollectionIterator<TypeOfCollection<V>, void, V>,
+            context?: any
+        ): V;
 
         /**
          * @see each
@@ -3976,10 +4040,10 @@ declare module _ {
         forEach: Underscore<T, V>['each'];
 
         /**
-         * Produces a new array of values by mapping each value in the wrapped collection through a transformation function
-         * (iteratee). For function iterators, each invocation of iterator is called with three arguments:
-         * (value, key, collection).
-         * @param iteratee Map iteratee for each element in the collection.
+         * Produces a new array of values by mapping each value in the wrapped
+         * collection through a transformation `iteratee`.
+         * @param iteratee The iteratee to use to transform each item in the
+         * wrapped collection.
          * @param context `this` object in `iteratee`, optional.
          * @returns The mapped result.
          **/
@@ -3994,26 +4058,31 @@ declare module _ {
         collect: Underscore<T, V>['map'];
 
         /**
-         * Also known as inject and foldl, reduce boils down a collection of wrapped values into a
-         * single value. Memo is the initial state of the reduction, and each successive
-         * step of it should be returned by iteratee. The iteratee is passed four arguments:
-         * the memo, then the value and index (or key) of the iteration, and finally a reference
-         * to the entire collection.
+         * Also known as inject and foldl, reduce boils down the wrapped
+         * collection of values into a single value. `memo` is the initial
+         * state of the reduction, and each successive step of it should be
+         * returned by `iteratee`.
          *
-         * If no memo is passed to the initial invocation of reduce, the iteratee is not invoked
-         * on the first element of the collection. The first element is instead passed as the memo
-         * in the invocation of the iteratee on the next element in the collection.
-         * @param iteratee Reduce iteratee function for each element in the wrapped collection.
-         * @param memo Initial reduce state or undefined to use the first collection item as initial state.
+         * If no memo is passed to the initial invocation of reduce, `iteratee`
+         * is not invoked on the first element of the wrapped collection. The
+         * first element is instead passed as the memo in the invocation of
+         * `iteratee` on the next element in the wrapped collection.
+         * @param iteratee The function to call on each iteration to reduce the
+         * collection.
+         * @param memo The initial reduce state or undefined to use the first
+         * item in `collection` as initial state.
          * @param context `this` object in `iteratee`, optional.
          * @returns The reduced result.
          **/
-        reduce<TResult>(iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult, V>,
+        reduce<TResult>(
+            iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult, V>,
             memo: TResult,
             context?: any
         ): TResult;
         reduce<TResult = TypeOfCollection<V>>(
-            iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult | TypeOfCollection<V>, V>
+            iteratee: MemoCollectionIterator<TypeOfCollection<V>,
+                TResult | TypeOfCollection<V>,
+                V>
         ): TResult | TypeOfCollection<V> | undefined;
 
         /**
@@ -4029,9 +4098,12 @@ declare module _ {
         /**
          * The right-associative version of reduce.
          *
-         * This is not as useful in JavaScript as it would be in a language with lazy evaluation.
-         * @param iteratee Reduce iteratee function for each element in the wrapped collection.
-         * @param memo Initial reduce state or undefined to use the first collection item as initial state.
+         * This is not as useful in JavaScript as it would be in a language
+         * with lazy evaluation.
+         * @param iteratee The function to call on each iteration to reduce the
+         * collection.
+         * @param memo The initial reduce state or undefined to use the first
+         * item in `collection` as the initial state.
          * @param context `this` object in `iteratee`, optional.
          * @returns The reduced result.
          **/
@@ -4041,7 +4113,9 @@ declare module _ {
             context?: any
         ): TResult;
         reduceRight<TResult = TypeOfCollection<V>>(
-            iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult | TypeOfCollection<V>, V>
+            iteratee: MemoCollectionIterator<TypeOfCollection<V>,
+                TResult | TypeOfCollection<V>,
+                V>
         ): TResult | TypeOfCollection<V> | undefined;
 
         /**
@@ -4050,14 +4124,14 @@ declare module _ {
         foldr: Underscore<T, V>['reduceRight'];
 
         /**
-         * Looks through each value in the wrapped collection, returning the first one that passes a
-         * truth test (iteratee), or undefined if no value passes the test. The function
-         * returns as soon as it finds an acceptable element, and doesn't traverse the entire
-         * collection.
+         * Looks through each value in the wrapped collection, returning the
+         * first one that passes a truth test (`iteratee`), or undefined if no
+         * value passes the test. The function returns as soon as it finds an
+         * acceptable element, and doesn't traverse the entire collection.
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
-         * @return The first element in the wrapped collection that passes the truth test or undefined
-         * if no elements pass.
+         * @returns The first element in the wrapped collection that passes the
+         * truth test or undefined if no elements pass.
          **/
         find(iteratee?: Iteratee<V, boolean>, context?: any): T | undefined;
 
@@ -4067,8 +4141,8 @@ declare module _ {
         detect: Underscore<T, V>['find'];
 
         /**
-         * Looks through each value in the wrapped collection, returning an array of all the values that pass a truth
-         * test (iteratee).
+         * Looks through each value in the wrapped collection, returning an
+         * array of all the values that pass a truth test (`iteratee`).
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
          * @returns The set of values that pass the truth test.
@@ -4081,29 +4155,34 @@ declare module _ {
         select: Underscore<T, V>['filter'];
 
         /**
-         * Looks through each value in the wrapped collection, returning an array of all the values that matches the
-         * key-value pairs listed in `properties`.
-         * @param properties The properties to check for on the elements within the wrapped collection.
-         * @return The elements in the wrapped collection that match `properties`.
+         * Looks through each value in the wrapped collection, returning an
+         * array of all the elements that match the key-value pairs listed in
+         * `properties`.
+         * @param properties The properties to check for on the elements within
+         * the wrapped collection.
+         * @returns The elements in the wrapped collection that match
+         * `properties`.
          **/
         where(properties: Partial<T>): T[];
 
         /**
-         * Looks through the wrapped collection and returns the first value that matches all of the key-value
-         * pairs listed in `properties`.
-         * If no match is found, or if list is empty, undefined will be returned.
-         * @param properties The properties to check for on the elements within the wrapped collection.
-         * @return The first element in the wrapped collection that matches `properties` or undefined if
-         * no match is found.
+         * Looks through the wrapped collection and returns the first value
+         * that matches all of the key-value pairs listed in `properties`. If
+         * no match is found, or if list is empty, undefined will be returned.
+         * @param properties The properties to check for on the elements within
+         * the wrapped collection.
+         * @returns The first element in the wrapped collection that matches
+         * `properties` or undefined if no match is found.
          **/
         findWhere(properties: Partial<T>): T | undefined;
 
         /**
-         * Returns the values in the wrapped collection without the elements that pass a truth test (iteratee).
+         * Returns the values in the wrapped collection without the elements
+         * that pass a truth test (`iteratee`).
          * The opposite of filter.
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
-         * @return The set of values that fail the truth test.
+         * @returns The set of values that fail the truth test.
          **/
         reject(iteratee?: Iteratee<V, boolean>, context?: any): T[];
 
@@ -4172,10 +4251,12 @@ declare module _ {
         invoke(methodName: string, ...args: any[]): any[];
 
         /**
-         * A convenient version of what is perhaps the most common use-case for map: extracting a list of
-         * property values.
-         * @param propertyName The name of a specific property to retrieve from all items.
-         * @returns The set of values for the specified property for each item in the collection.
+         * A convenient version of what is perhaps the most common use-case for
+         * map: extracting a list of property values.
+         * @param propertyName The name of a specific property to retrieve from
+         * all items in the wrapped collection.
+         * @returns The set of values for the specified `propertyName` for each
+         * item in the wrapped collection.
          **/
         pluck<K extends EnumerableKey>(
             propertyName: K
@@ -4225,7 +4306,6 @@ declare module _ {
         /**
          * Splits the warpped collection into sets that are grouped by the
          * result of running each value through `iteratee`.
-         * @param collection The collection to group.
          * @param iteratee An iteratee that provides the value to group by for
          * each item in the wrapped collection.
          * @param context `this` object in `iteratee`, optional.
@@ -4233,14 +4313,16 @@ declare module _ {
          * properties where each property contains the grouped elements from
          * the wrapped collection.
          **/
-        groupBy(iteratee?: Iteratee<V, EnumerableKey>, context?: any): Dictionary<T[]>;
+        groupBy(
+            iteratee?: Iteratee<V, EnumerableKey>,
+            context?: any
+        ): Dictionary<T[]>;
 
         /**
          * Given the warpped collection and an `iteratee` function that returns
-         * a key for each element in `collection`, returns an object that acts
-         * as an index of each item.  Just like `groupBy`, but for when you
+         * a key for each element in the wrapped collection, returns an object
+         * that acts as an index of each item.  Just like `groupBy`, but for when you
          * know your keys are unique.
-         * @param collection The collection to index.
          * @param iteratee An iteratee that provides the value to index by for
          * each item in the wrapped collection.
          * @param context `this` object in `iteratee`, optional.
@@ -4254,7 +4336,6 @@ declare module _ {
          * number of objects in each group. Similar to `groupBy`, but instead
          * of returning a list of values, returns a count for the number of
          * values in that group.
-         * @param collection The collection to count.
          * @param iteratee An iteratee that provides the value to count by for
          * each item in the wrapped collection.
          * @param context `this` object in `iteratee`, optional.
@@ -4262,19 +4343,26 @@ declare module _ {
          * properties where each property contains the count of the grouped
          * elements from the wrapped collection.
          **/
-        countBy(iteratee?: Iteratee<V, EnumerableKey>, context?: any): Dictionary<number>;
+        countBy(
+            iteratee?: Iteratee<V, EnumerableKey>,
+            context?: any
+        ): Dictionary<number>;
 
         /**
-         * Returns a shuffled copy of the wrapped collection, using a version of the Fisher-Yates shuffle.
-         * @return A shuffled copy of the wrapped collection.
+         * Returns a shuffled copy of the wrapped collection, using a version
+         * of the Fisher-Yates shuffle.
+         * @returns A shuffled copy of the wrapped collection.
          **/
         shuffle(): T[];
 
         /**
-         * Produce a random sample from the wrapped collection. Pass a number to return `n` random elements from the
-         * wrapped collection. Otherwise a single random item will be returned.
-         * @param n The number of elements to sample from the wrapped collection.
-         * @return A random sample of `n` elements from the wrapped collection or a single element if `n` is not specified.
+         * Produce a random sample from the wrapped collection. Pass a number
+         * to return `n` random elements from the wrapped collection. Otherwise
+         * a single random item will be returned.
+         * @param n The number of elements to sample from the wrapped
+         * collection.
+         * @returns A random sample of `n` elements from the wrapped collection
+         * or a single element if `n` is not specified.
          **/
         sample(n: number): T[];
         sample(): T | undefined;
@@ -4379,9 +4467,11 @@ declare module _ {
         compact(): Truthy<T>[];
 
         /**
-         * Flattens the wrapped nested list (the nesting can be to any depth). If you pass shallow, the list will
-         * only be flattened a single level.
-         * @param shallow If true then only flatten one level, optional, default = false.
+         * Flattens a nested list (the nesting can be to any depth). If you
+         * pass shallow, the wrapped list will only be flattened a single
+         * level.
+         * @param shallow True to only flatten one level, optional,
+         * default = false.
          * @returns The flattened list.
          **/
         flatten(shallow?: false): DeepestListItemOrSelf<T>[];
@@ -4391,7 +4481,7 @@ declare module _ {
          * Returns a copy of the wrapped list with all instances of `values`
          * removed.
          * @param values The values to exclude from the wrapped list.
-         * @return An array that contains all elements of the wrapped list
+         * @returns An array that contains all elements of the wrapped list
          * except for `values`.
          **/
         without(...values: T[]): T[];
@@ -4438,11 +4528,18 @@ declare module _ {
          * @param iteratee Transform the elements of the wrapped list before
          * comparisons for uniqueness.
          * @param context 'this' object in `iteratee`, optional.
-         * @return An array containing only the unique elements in the wrapped
+         * @returns An array containing only the unique elements in the wrapped
          * list.
          **/
-        uniq(isSorted?: boolean, iteratee?: Iteratee<V, any>, cotext?: any): T[];
-        uniq(iteratee?: Iteratee<V, any>, context?: any): T[];
+        uniq(
+            isSorted?: boolean,
+            iteratee?: Iteratee<V, any>,
+            cotext?: any
+        ): T[];
+        uniq(
+            iteratee?: Iteratee<V, any>,
+            context?: any
+        ): T[];
 
         /**
         * @see uniq
@@ -4476,7 +4573,9 @@ declare module _ {
          * values corresponding to those keys.
          * @returns An object comprised of the provided keys and values.
          **/
-        object<TValue>(values: List<TValue>): Dictionary<TValue | undefined>;
+        object<TValue>(
+            values: List<TValue>
+        ): Dictionary<TValue | undefined>;
         object(): Dictionary<PairValue<T>>;
 
         /**
@@ -4548,10 +4647,14 @@ declare module _ {
          * @param iteratee Iteratee to compute the sort ranking of each
          * element including `value`, optional.
          * @param context `this` object in `iteratee`, optional.
-         * @return The index where `value` should be inserted into the wrapped
+         * @returns The index where `value` should be inserted into the wrapped
          * list.
          **/
-        sortedIndex(value: T, iteratee?: Iteratee<V | undefined, any>, context?: any): number;
+        sortedIndex(
+            value: T,
+            iteratee?: Iteratee<V | undefined, any>,
+            context?: any
+        ): number;
 
         /**
          * A function to create flexibly-numbered lists of integers, handy for
@@ -4572,9 +4675,11 @@ declare module _ {
         range(stop?: number, step?: number): number[];
 
         /**
-         * Chunks a wrapped list into multiple arrays, each containing length or fewer items.
-         * @param length The maximum size of the inner arrays.
-         * @returns The chunked list.
+         * Chunks the wrapped list into multiple arrays, each containing
+         * `length` or fewer items.
+         * @param length The maximum size of the chunks.
+         * @returns The contents of the wrapped list in chunks no greater than
+         * `length` in size.
          **/
         chunk(length: number): T[][];
 
@@ -4772,7 +4877,9 @@ declare module _ {
          * @returns A copy of the wrapped object with only the keys selected by
          * `iterator`.
          **/
-        pick(iterator: ObjectIterator<TypeOfDictionary<V, any>, boolean, V>): Partial<V>;
+        pick(
+            iterator: ObjectIterator<TypeOfDictionary<V, any>, boolean, V>
+        ): Partial<V>;
 
         /**
          * Return a copy of the wrapped object that is filtered to omit the
@@ -4790,7 +4897,9 @@ declare module _ {
          * @returns A copy of the wrapped object without the keys selected by
          * `iterator`.
          **/
-        omit(iterator: ObjectIterator<TypeOfDictionary<V, any>, boolean, V>): Partial<V>;
+        omit(
+            iterator: ObjectIterator<TypeOfDictionary<V, any>, boolean, V>
+        ): Partial<V>;
 
         /**
         * Wrapped type `object`.
@@ -4850,27 +4959,32 @@ declare module _ {
          * Performs an optimized deep comparison between the wrapped object
          * and `other` to determine if they should be considered equal.
          * @param other Compare to the wrapped object.
-         * @returns True if the wrapped object should be considered equal to `other`.
+         * @returns True if the wrapped object should be considered equal to
+         * `other`.
          **/
         isEqual(other: any): boolean;
 
         /**
          * Returns true if the wrapped collection contains no values.
-         * For strings and array-like objects checks if the length property is 0.
+         * For strings and array-like objects checks if the length property is
+         * 0.
          * @returns True if the wrapped collection has no elements.
          **/
         isEmpty(): boolean;
 
         /**
-         * Returns true if the keys and values in `properties` are contained in the wrapped object.
+         * Returns true if the keys and values in `properties` are contained in
+         * the wrapped object.
          * @param properties The properties to check for in the wrapped object.
-         * @returns True if all keys and values in `properties` are also in the wrapped object.
+         * @returns True if all keys and values in `properties` are also in the
+         * wrapped object.
          **/
         isMatch(properties: any): boolean;
 
         /**
          * Returns true if the wrapped object is a DOM element.
-         * @returns True if the wrapped object is a DOM element, otherwise false.
+         * @returns True if the wrapped object is a DOM element, otherwise
+         * false.
          **/
         isElement(): boolean;
 
@@ -4887,15 +5001,17 @@ declare module _ {
         isSymbol(): boolean;
 
         /**
-         * Returns true if the wrapped object is an Object. Note that JavaScript arrays
-         * and functions are objects, while (normal) strings and numbers are not.
+         * Returns true if the wrapped object is an Object. Note that
+         * JavaScript arrays and functions are objects, while (normal) strings
+         * and numbers are not.
          * @returns True if the wrapped object is an Object, otherwise false.
          **/
         isObject(): boolean;
 
         /**
          * Returns true if the wrapped object is an Arguments object.
-         * @returns True if the wrapped object is an Arguments object, otherwise false.
+         * @returns True if the wrapped object is an Arguments object,
+         * otherwise false.
          **/
         isArguments(): boolean;
 
@@ -5053,8 +5169,8 @@ declare module _ {
          ************/
 
         /**
-         * Returns a wrapped object. Calling methods on this object will continue to return wrapped objects
-         * until value() is used.
+         * Returns a wrapped object. Calling methods on this object will
+         * continue to return wrapped objects until value() is used.
          * @returns An underscore chain wrapper around the wrapped value.
          **/
         chain(): _Chain<T, V>;
@@ -5074,15 +5190,17 @@ declare module _ {
 
         /**
          * Iterates over the wrapped collection of elements, yielding each in
-         * turn to an iteratee. The iteratee is bound to the context object, if
-         * one is passed. Each invocation of `iteratee` is called with three
-         * arguments: (element, key, collection).
+         * turn to an `iteratee`. The `iteratee` is bound to the context
+         * object, if one is passed.
          * @param iteratee The iteratee to call for each element in the wrapped
          * collection.
          * @param context 'this' object in `iteratee`, optional.
          * @returns A chain wrapper around the originally wrapped collection.
          **/
-        each(iteratee: CollectionIterator<TypeOfCollection<V>, void, V>, context?: any): _Chain<T, V>;
+        each(
+            iteratee: CollectionIterator<TypeOfCollection<V>, void, V>,
+            context?: any
+        ): _Chain<T, V>;
 
         /**
         * @see each
@@ -5090,17 +5208,17 @@ declare module _ {
         forEach: _Chain<T, V>['each'];
 
         /**
-         * Produces a new array of values by mapping each value in the wrapped collection through a transformation function
-         * (iteratee). For function iteratees, each invocation of iteratee is called with three arguments:
-         * (value, key, collection).
-         * @param iterator Map iteratee for each element in the collection.
+         * Produces a new array of values by mapping each value in the wrapped
+         * collection through a transformation `iteratee`.
+         * @param iteratee The iteratee to use to transform each item in the
+         * wrapped collection.
          * @param context `this` object in `iteratee`, optional.
-         * @returns The mapped result in a chain wrapper.
+         * @returns A chain wrapper around the mapped result.
          **/
         map<I extends Iteratee<V, any>>(
             iteratee: I,
             context?: any
-        ): _Chain<IterateeResult<I, T>, IterateeResult<I, T>[]>;
+        ): _Chain<IterateeResult<I, T>>;
 
         /**
          * @see map
@@ -5108,19 +5226,21 @@ declare module _ {
         collect: _Chain<T, V>['map'];
 
         /**
-         * Also known as inject and foldl, reduce boils down a collection of wrapped values into a
-         * single value. Memo is the initial state of the reduction, and each successive
-         * step of it should be returned by iteratee. The iteratee is passed four arguments:
-         * the memo, then the value and index (or key) of the iteration, and finally a reference
-         * to the entire collection.
+         * Also known as inject and foldl, reduce boils down the wrapped
+         * collection of values into a single value. `memo` is the initial
+         * state of the reduction, and each successive step of it should be
+         * returned by `iteratee`.
          *
-         * If no memo is passed to the initial invocation of reduce, the iteratee is not invoked
-         * on the first element of the collection. The first element is instead passed as the memo
-         * in the invocation of the iteratee on the next element in the collection.
-         * @param iteratee Reduce iteratee function for each element in `list`.
-         * @param memo Initial reduce state or undefined to use the first collection item as initial state.
+         * If no memo is passed to the initial invocation of reduce, `iteratee`
+         * is not invoked on the first element of the wrapped collection. The
+         * first element is instead passed as the memo in the invocation of
+         * `iteratee` on the next element in the wrapped collection.
+         * @param iteratee The function to call on each iteration to reduce the
+         * collection.
+         * @param memo The initial reduce state or undefined to use the first
+         * item in `collection` as initial state.
          * @param context `this` object in `iteratee`, optional.
-         * @returns The reduced result in a chain wraper.
+         * @returns A chain wrapper around the reduced result.
          **/
         reduce<TResult>(
             iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult, V>,
@@ -5128,7 +5248,9 @@ declare module _ {
             context?: any
         ): _ChainSingle<TResult>;
         reduce<TResult = TypeOfCollection<V>>(
-            iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult | TypeOfCollection<V>, V>
+            iteratee: MemoCollectionIterator<TypeOfCollection<V>,
+                TResult | TypeOfCollection<V>,
+                V>
         ): _ChainSingle<TResult | TypeOfCollection<V> | undefined>;
 
         /**
@@ -5144,11 +5266,14 @@ declare module _ {
         /**
          * The right-associative version of reduce.
          *
-         * This is not as useful in JavaScript as it would be in a language with lazy evaluation.
-         * @param iteratee Reduce iteratee function for each element in the wrapped collection.
-         * @param memo Initial reduce state or undefined to use the first collection item as initial state.
+         * This is not as useful in JavaScript as it would be in a language
+         * with lazy evaluation.
+         * @param iteratee The function to call on each iteration to reduce the
+         * collection.
+         * @param memo The initial reduce state or undefined to use the first
+         * item in `collection` as the initial state.
          * @param context `this` object in `iteratee`, optional.
-         * @returns The reduced result in a chain wrapper.
+         * @returns A chain wrapper around the reduced result.
          **/
         reduceRight<TResult>(
             iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult, V>,
@@ -5156,7 +5281,9 @@ declare module _ {
             context?: any
         ): _ChainSingle<TResult>;
         reduceRight<TResult = TypeOfCollection<V>>(
-            iteratee: MemoCollectionIterator<TypeOfCollection<V>, TResult | TypeOfCollection<V>, V>
+            iteratee: MemoCollectionIterator<TypeOfCollection<V>,
+                TResult | TypeOfCollection<V>,
+                V>
         ): _ChainSingle<TResult | TypeOfCollection<V> | undefined>;
 
         /**
@@ -5165,16 +5292,20 @@ declare module _ {
         foldr: _Chain<T, V>['reduceRight'];
 
         /**
-         * Looks through each value in the wrapped collection, returning the first one that passes a
-         * truth test (iteratee), or undefined if no value passes the test. The function
-         * returns as soon as it finds an acceptable element, and doesn't traverse the entire
-         * collection.
+         * Looks through each value in the wrapped collection, returning the
+         * first one that passes a truth test (`iteratee`), or undefined if no
+         * value passes the test. The function returns as soon as it finds an
+         * acceptable element, and doesn't traverse the entire collection.
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
-         * @return A chain wrapper containing the first element in the wrapped collection that passes
-         * the truth test or undefined if no elements pass.
+         * @returns A chain wrapper around the first element in the wrapped
+         * collection that passes the truth test or undefined if no elements
+         * pass.
          **/
-        find(iteratee?: Iteratee<V, boolean>, context?: any): _ChainSingle<T | undefined>;
+        find(
+            iteratee?: Iteratee<V, boolean>,
+            context?: any
+        ): _ChainSingle<T | undefined>;
 
         /**
          * @see find
@@ -5182,11 +5313,12 @@ declare module _ {
         detect: _Chain<T, V>['find'];
 
         /**
-         * Looks through each value in the wrapped collection, returning an array of all the values that pass a truth
-         * test (iteratee).
+         * Looks through each value in the wrapped collection, returning an
+         * array of all the values that pass a truth test (`iteratee`).
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
-         * @returns The set of values that pass a truth test in a chain wrapper.
+         * @returns A chain wrapper around the set of values that pass the
+         * truth test.
          **/
         filter(iteratee?: Iteratee<V, any>, context?: any): _Chain<T>;
 
@@ -5196,29 +5328,36 @@ declare module _ {
         select: _Chain<T, V>['filter'];
 
         /**
-         * Looks through each value in the wrapped collection, returning an array of all the values that matches the
-         * key-value pairs listed in `properties`.
-         * @param properties The properties to check for on the elements within the wrapped collection.
-         * @return The elements in the wrapped collection that match `properties` in a chain wrapper.
+         * Looks through each value in the wrapped collection, returning an
+         * array of all the elements that match the key-value pairs listed in
+         * `properties`.
+         * @param properties The properties to check for on the elements within
+         * the wrapped collection.
+         * @returns A chain wrapper around the elements in the wrapped
+         * collection that match `properties`.
          **/
         where(properties: Partial<T>): _Chain<T>;
 
         /**
-         * Looks through the wrapped collection and returns the first value that matches all of the key-value
-         * pairs listed in `properties`.
-         * If no match is found, or if list is empty, undefined will be returned.
-         * @param properties The properties to check for on the elements within the wrapped collection.
-         * @return The first element in the wrapped collection that matches `properties` or undefined if
-         * no match is found. The result will be wrapped in a chain wrapper.
+         * Looks through the wrapped collection and returns the first value
+         * that matches all of the key-value pairs listed in `properties`. If
+         * no match is found, or if list is empty, undefined will be returned.
+         * @param properties The properties to check for on the elements within
+         * the wrapped collection.
+         * @returns A chain wrapper around the first element in the wrapped
+         * collection that matches `properties` or undefined if no match is
+         * found.
          **/
         findWhere(properties: Partial<T>): _ChainSingle<T | undefined>;
 
         /**
-         * Returns the values in the wrapped collection without the elements that pass a truth test (iteratee).
+         * Returns the values in the wrapped collection without the elements
+         * that pass a truth test (`iteratee`).
          * The opposite of filter.
          * @param iteratee The truth test to apply.
          * @param context `this` object in `iteratee`, optional.
-         * @return The set of values that fail the truth test in a chain wrapper.
+         * @returns A chain wrapper around the set of values that fail the
+         * truth test.
          **/
         reject(iteratee?: Iteratee<V, boolean>, context?: any): _Chain<T>;
 
@@ -5231,7 +5370,10 @@ declare module _ {
          * @returns A chain wrapper around true if all elements pass the truth
          * test, otherwise around false.
          **/
-        every(iterator?: Iteratee<V, boolean>, context?: any): _ChainSingle<boolean>;
+        every(
+            iterator?: Iteratee<V, boolean>,
+            context?: any
+        ): _ChainSingle<boolean>;
 
         /**
          * @see every
@@ -5247,7 +5389,10 @@ declare module _ {
          * @returns A chain wrapper around true if any element passed the truth
          * test, otherwise around false.
          **/
-        some(iterator?: Iteratee<V, boolean>, context?: any): _ChainSingle<boolean>;
+        some(
+            iterator?: Iteratee<V, boolean>,
+            context?: any
+        ): _ChainSingle<boolean>;
 
         /**
          * @see some
@@ -5289,10 +5434,12 @@ declare module _ {
         invoke(methodName: string, ...args: any[]): _Chain<any>;
 
         /**
-         * A convenient version of what is perhaps the most common use-case for map: extracting a list of
-         * property values.
-         * @param propertyName The name of a specific property to retrieve from all items.
-         * @returns The set of values for the specified property for each item in the collection in a chain wrapper.
+         * A convenient version of what is perhaps the most common use-case for
+         * map: extracting a list of property values.
+         * @param propertyName The name of a specific property to retrieve from
+         * all items in the wrapped collection.
+         * @returns A chain wrapper around The set of values for the specified
+         * `propertyName` for each item in the wrapped collection.
          **/
         pluck<K extends EnumerableKey>(
             propertyName: K
@@ -5312,7 +5459,10 @@ declare module _ {
          * wrapped collection or around -Infinity if the wrapped collection is
          * empty.
          **/
-        max(iteratee?: Iteratee<V, any>, context?: any): _ChainSingle<T | number>;
+        max(
+            iteratee?: Iteratee<V, any>,
+            context?: any
+        ): _ChainSingle<T | number>;
 
         /**
          * Returns the minimum value in the wrapped collection. If an
@@ -5328,7 +5478,10 @@ declare module _ {
          * wrapped collection or around Infinity if the wrapped collection is
          * empty.
          **/
-        min(iteratee?: Iteratee<V, any>, context?: any): _ChainSingle<T | number>;
+        min(
+            iteratee?: Iteratee<V, any>,
+            context?: any
+        ): _ChainSingle<T | number>;
 
         /**
          * Returns a (stably) sorted copy of the wrapped collection, ranked in
@@ -5345,7 +5498,6 @@ declare module _ {
         /**
          * Splits the warpped collection into sets that are grouped by the
          * result of running each value through `iteratee`.
-         * @param collection The collection to group.
          * @param iteratee An iteratee that provides the value to group by for
          * each item in the wrapped collection.
          * @param context `this` object in `iteratee`, optional.
@@ -5353,14 +5505,16 @@ declare module _ {
          * provided by `iteratee` as properties where each property contains
          * the grouped elements from the wrapped collection.
          **/
-        groupBy(iteratee?: Iteratee<V, EnumerableKey>, context?: any): _Chain<T[], Dictionary<T[]>>;
+        groupBy(
+            iteratee?: Iteratee<V, EnumerableKey>,
+            context?: any
+        ): _Chain<T[], Dictionary<T[]>>;
 
         /**
          * Given the warpped collection and an `iteratee` function that returns
          * a key for each element in `collection`, returns an object that acts
          * as an index of each item.  Just like `groupBy`, but for when you
          * know your keys are unique.
-         * @param collection The collection to index.
          * @param iteratee An iteratee that provides the value to index by for
          * each item in the wrapped collection.
          * @param context `this` object in `iteratee`, optional.
@@ -5368,14 +5522,16 @@ declare module _ {
          * wrapped collection is assigned to the property designated by
          * `iteratee`.
          **/
-        indexBy(iteratee?: Iteratee<V, EnumerableKey>, context?: any): _Chain<T, Dictionary<T>>;
+        indexBy(
+            iteratee?: Iteratee<V, EnumerableKey>,
+            context?: any
+        ): _Chain<T, Dictionary<T>>;
 
         /**
          * Sorts the wrapped collection into groups and returns a count for the
          * number of objects in each group. Similar to `groupBy`, but instead
          * of returning a list of values, returns a count for the number of
          * values in that group.
-         * @param collection The collection to count.
          * @param iteratee An iteratee that provides the value to count by for
          * each item in the wrapped collection.
          * @param context `this` object in `iteratee`, optional.
@@ -5383,20 +5539,27 @@ declare module _ {
          * provided by `iteratee` as properties where each property contains
          * the count of the grouped elements from the wrapped collection.
          **/
-        countBy(iterator?: Iteratee<V, EnumerableKey>, context?: any): _Chain<number, Dictionary<number>>;
+        countBy(
+            iterator?: Iteratee<V, EnumerableKey>,
+            context?: any
+        ): _Chain<number, Dictionary<number>>;
 
         /**
-         * Returns a shuffled copy of the wrapped collection, using a version of the Fisher-Yates shuffle.
-         * @return A shuffled copy of the wrapped collection in a chain wrapper.
+         * Returns a shuffled copy of the wrapped collection, using a version
+         * of the Fisher-Yates shuffle.
+         * @returns A chain wrapper around a shuffled copy of the wrapped
+         * collection.
          **/
         shuffle(): _Chain<T>;
 
         /**
-         * Produce a random sample from the wrapped collection. Pass a number to return `n` random elements from the
-         * wrapped collection. Otherwise a single random item will be returned.
-         * @param n The number of elements to sample from the wrapped collection.
-         * @return A random sample of `n` elements from the wrapped collection or a single element if `n` is not specified.
-         * The result will be wrapped in a chain wrapper.
+         * Produce a random sample from the wrapped collection. Pass a number
+         * to return `n` random elements from the wrapped collection. Otherwise
+         * a single random item will be returned.
+         * @param n The number of elements to sample from the wrapped
+         * collection.
+         * @returns A chain wrapper around a random sample of `n` elements from
+         * the wrapped collection or a single element if `n` is not specified.
          **/
         sample(n: number): _Chain<T>;
         sample(): _ChainSingle<T | undefined>;
@@ -5428,7 +5591,10 @@ declare module _ {
          * collection that satisfied the predicate and the second element
          * contains the elements that did not.
          **/
-        partition(iteratee?: Iteratee<V, boolean>, context?: any): _Chain<T[], [T[], T[]]>;
+        partition(
+            iteratee?: Iteratee<V, boolean>,
+            context?: any
+        ): _Chain<T[], [T[], T[]]>;
 
         /**********
          * Arrays *
@@ -5504,19 +5670,21 @@ declare module _ {
         compact(): _Chain<Truthy<T>>;
 
         /**
-         * Flattens the wrapped nested list (the nesting can be to any depth). If you pass shallow, the list will
-         * only be flattened a single level.
-         * @param shallow If true then only flatten one level, optional, default = false.
-         * @returns The flattened list in a chain wrapper.
+         * Flattens a nested list (the nesting can be to any depth). If you
+         * pass shallow, the wrapped list will only be flattened a single
+         * level.
+         * @param shallow True to only flatten one level, optional,
+         * default = false.
+         * @returns A chain wrapper around the flattened list.
          **/
-        flatten(shallow?: false): _Chain<DeepestListItemOrSelf<T>, DeepestListItemOrSelf<T>[]>;
-        flatten(shallow: true): _Chain<ListItemOrSelf<T>, ListItemOrSelf<T>[]>;
+        flatten(shallow?: false): _Chain<DeepestListItemOrSelf<T>>;
+        flatten(shallow: true): _Chain<ListItemOrSelf<T>>;
 
         /**
          * Returns a copy of the wrapped list with all instances of `values`
          * removed.
          * @param values The values to exclude from the wrapped list.
-         * @return A chain wrapper around an array that contains all elements
+         * @returns A chain wrapper around an array that contains all elements
          * of the wrapped list except for `values`.
          **/
         without(...values: T[]): _Chain<T>;
@@ -5564,11 +5732,18 @@ declare module _ {
          * @param iteratee Transform the elements of the wrapped list before
          * comparisons for uniqueness.
          * @param context 'this' object in `iteratee`, optional.
-         * @return A chain wrapper around an array containing only the unique
+         * @returns A chain wrapper around an array containing only the unique
          * elements in the wrapped list.
          **/
-        uniq(isSorted?: boolean, iteratee?: Iteratee<V, any>, context?: any): _Chain<T>;
-        uniq(iteratee?: Iteratee<V, any>, context?: any): _Chain<T>;
+        uniq(
+            isSorted?: boolean,
+            iteratee?: Iteratee<V, any>,
+            context?: any
+        ): _Chain<T>;
+        uniq(
+            iteratee?: Iteratee<V, any>,
+            context?: any
+        ): _Chain<T>;
 
         /**
         * Wrapped type List<T>.
@@ -5606,7 +5781,9 @@ declare module _ {
          * @returns A chain wrapper around an object comprised of the provided
          * keys and values.
          **/
-        object<TValue>(values: List<TValue>): _Chain<TValue | undefined, Dictionary<TValue | undefined>>;
+        object<TValue>(
+            values: List<TValue>
+        ): _Chain<TValue | undefined, Dictionary<TValue | undefined>>;
         object(): _Chain<PairValue<T>, Dictionary<PairValue<T>>>;
 
         /**
@@ -5679,10 +5856,14 @@ declare module _ {
          * @param iteratee Iteratee to compute the sort ranking of each element
          * including `value`, optional.
          * @param context `this` object in `iteratee`, optional.
-         * @return A chain wrapper around the index where `value` should be
+         * @returns A chain wrapper around the index where `value` should be
          * inserted into the wrapped list.
          **/
-        sortedIndex(value: T, iteratee?: Iteratee<V | undefined, any>, context?: any): _ChainSingle<number>;
+        sortedIndex(
+            value: T,
+            iteratee?: Iteratee<V | undefined, any>,
+            context?: any
+        ): _ChainSingle<number>;
 
         /**
          * A function to create flexibly-numbered lists of integers, handy for
@@ -5703,9 +5884,11 @@ declare module _ {
         range(stop?: number, step?: number): _Chain<number>;
 
         /**
-         * Chunks a wrapped list into multiple arrays, each containing length or fewer items.
-         * @param length The maximum size of the inner arrays.
-         * @returns The wrapped chunked list.
+         * Chunks the wrapped list into multiple arrays, each containing
+         * `length` or fewer items.
+         * @param length The maximum size of the chunks.
+         * @returns A chain wrapper around the contents of the wrapped list in
+         * chunks no greater than `length` in size.
          **/
         chunk(length: number): _Chain<T[]>;
 
@@ -5841,7 +6024,8 @@ declare module _ {
         mapObject<I extends Iteratee<V, any, TypeOfCollection<V, any>>>(
             iteratee: I,
             context?: any
-        ): _Chain<IterateeResult<I, TypeOfCollection<V, any>>, { [K in keyof V]: IterateeResult<I, V[K]> }>;
+        ): _Chain<IterateeResult<I, TypeOfCollection<V, any>>,
+            { [K in keyof V]: IterateeResult<I, V[K]> }>;
 
         /**
          * Convert the wrapped object into a list of [key, value] pairs. The
@@ -5849,7 +6033,7 @@ declare module _ {
          * @returns A chain wrapper around the list of [key, value] pairs from
          * the wrapped object.
          **/
-        pairs(): _Chain<[Extract<keyof V, string>, TypeOfCollection<V, any>], [Extract<keyof V, string>, TypeOfCollection<V, any>][]>;
+        pairs(): _Chain<[Extract<keyof V, string>, TypeOfCollection<V, any>]>;
 
         /**
         * Wrapped type `object`.
@@ -5904,7 +6088,9 @@ declare module _ {
          * @returns A chain wrapper around a copy of the wrapped object with
          * only the keys selected by `iterator`.
          **/
-        pick(iterator: ObjectIterator<TypeOfDictionary<V, any>, boolean, V>): _ChainSingle<Partial<V>>;
+        pick(
+            iterator: ObjectIterator<TypeOfDictionary<V, any>, boolean, V>
+        ): _ChainSingle<Partial<V>>;
 
         /**
          * Return a copy of the wrapped object that is filtered to omit the
@@ -5923,7 +6109,9 @@ declare module _ {
          * @returns A chain wrapper around a copy of the wrapped object without
          * the keys selected by `iterator`.
          **/
-        omit(iterator: ObjectIterator<TypeOfDictionary<V, any>, boolean, V>): _ChainSingle<Partial<V>>;
+        omit(
+            iterator: ObjectIterator<TypeOfDictionary<V, any>, boolean, V>
+        ): _ChainSingle<Partial<V>>;
 
         /**
         * Wrapped type `object`.
@@ -5983,30 +6171,35 @@ declare module _ {
          * Performs an optimized deep comparison between the wrapped object
          * and `other` to determine if they should be considered equal.
          * @param other Compare to the wrapped object.
-         * @returns True if the wrapped object should be considered equal to `other`.
+         * @returns True if the wrapped object should be considered equal to
+         * `other`.
          * The result will be wrapped in a chain wrapper.
          **/
         isEqual(other: any): _ChainSingle<boolean>;
 
         /**
          * Returns true if the wrapped collection contains no values.
-         * For strings and array-like objects checks if the length property is 0.
+         * For strings and array-like objects checks if the length property is
+         * 0.
          * @returns True if the wrapped collection has no elements.
          * The result will be wrapped in a chain wrapper.
          **/
         isEmpty(): _ChainSingle<boolean>;
 
         /**
-         * Returns true if the keys and values in `properties` are contained in the wrapped object.
+         * Returns true if the keys and values in `properties` are contained in
+         * the wrapped object.
          * @param properties The properties to check for in the wrapped object.
-         * @returns True if all keys and values in `properties` are also in the wrapped object.
+         * @returns True if all keys and values in `properties` are also in the
+         * wrapped object.
          * The result will be wrapped in a chain wrapper.
          **/
         isMatch(properties: any): _ChainSingle<boolean>;
 
         /**
          * Returns true if the wrapped object is a DOM element.
-         * @returns True if the wrapped object is a DOM element, otherwise false.
+         * @returns True if the wrapped object is a DOM element, otherwise
+         * false.
          * The result will be wrapped in a chain wrapper.
          **/
         isElement(): _ChainSingle<boolean>;
@@ -6026,8 +6219,9 @@ declare module _ {
         isSymbol(): _ChainSingle<boolean>;
 
         /**
-         * Returns true if the wrapped object is an Object. Note that JavaScript arrays
-         * and functions are objects, while (normal) strings and numbers are not.
+         * Returns true if the wrapped object is an Object. Note that
+         * JavaScript arrays and functions are objects, while (normal) strings
+         * and numbers are not.
          * @returns True if the wrapped object is an Object, otherwise false.
          * The result will be wrapped in a chain wrapper.
          **/
@@ -6035,7 +6229,8 @@ declare module _ {
 
         /**
          * Returns true if the wrapped object is an Arguments object.
-         * @returns True if the wrapped object is an Arguments object, otherwise false.
+         * @returns True if the wrapped object is an Arguments object,
+         * otherwise false.
          * The result will be wrapped in a chain wrapper.
          **/
         isArguments(): _ChainSingle<boolean>;
@@ -6286,8 +6481,8 @@ declare module _ {
          ************/
 
         /**
-          * Returns a wrapped object. Calling methods on this object will continue to return wrapped objects
-          * until value() is used.
+          * Returns a wrapped object. Calling methods on this object will
+          * continue to return wrapped objects until value() is used.
           * @returns An underscore chain wrapper around the wrapped value.
           **/
         chain(): _Chain<T, V>;

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1,9 +1,157 @@
+/**************************************
+ * Common Testing Types and Variables *
+ **************************************/
 declare const $: any;
 declare const window: any;
 declare const alert: (msg: string) => any;
 declare const console: {log: any};
-declare const anyValue: any;
 
+declare const context: object;
+
+// string record (also used to represent a generic record)
+interface StringRecord {
+    a: string;
+    b: string;
+}
+
+interface AugmentedList extends _.List<StringRecord> {
+    notAListProperty: boolean;
+}
+
+interface ExplicitDictionary extends _.Dictionary<StringRecord> {
+    a: StringRecord;
+    b: StringRecord;
+    c: StringRecord;
+}
+
+declare const shallowProperty: 'a';
+declare const deepProperty: string[];
+declare const matcher: Partial<StringRecord>;
+declare const recordTester: (value: StringRecord) => boolean;
+declare const recordStringReducer: (prev: string, value: StringRecord) => string;
+declare const recordUnionReducer: (prev: string | StringRecord, value: StringRecord) => string | StringRecord;
+
+declare const augmentedList: AugmentedList;
+declare const augmentedListIterator: (value: StringRecord, index: number, list: AugmentedList) => void;
+
+declare const recordList: _.List<StringRecord>;
+declare const recordListSelector: (value: StringRecord, index: number, list: _.List<StringRecord>) => string;
+declare const recordMaybeListSelector: (value: StringRecord, index?: number, list?: _.List<StringRecord>) => string;
+declare const recordListTester: (value: StringRecord, index: number, list: _.List<StringRecord>) => boolean;
+declare const recordListUnionIterator: (element: StringRecord, key: number, list: StringRecord[] | _.List<StringRecord>) => void;
+declare const recordListStringReducer: (prev: string, value: StringRecord, index: number, list: _.List<StringRecord>) => string;
+
+declare const recordListUnion: StringRecord[] | _.List<StringRecord>;
+declare const recordListArray: _.List<StringRecord>[];
+declare const level2RecordList: _.List<_.List<StringRecord>>;
+declare const level3RecordList: _.List<_.List<_.List<StringRecord>>>;
+declare const level4RecordList: _.List<_.List<_.List<_.List<StringRecord>>>>;
+declare const maxLevel2RecordArray: (StringRecord | StringRecord[])[];
+declare const maxLevel3RecordArray: (StringRecord | StringRecord[] | StringRecord[][])[];
+
+declare const explicitDictionary: ExplicitDictionary;
+declare const explicitDictionaryIterator: (element: StringRecord, key: string, dictionary: ExplicitDictionary) => void;
+
+declare const recordDictionary: _.Dictionary<StringRecord>;
+declare const recordDictionarySelector: (element: StringRecord, key: string, dictionary: _.Dictionary<StringRecord>) => string;
+declare const recordDictionaryTester: (element: StringRecord, key: string, list: _.Dictionary<StringRecord>) => boolean;
+declare const recordDictionaryStringReducer: (prev: string, element: StringRecord, key: string, dictionary: _.Dictionary<StringRecord>) => string;
+
+declare const maybeRecordList: _.List<StringRecord | undefined>;
+
+// number record
+interface NumberRecord {
+    a: number;
+}
+
+declare const numberRecordList: _.List<NumberRecord>;
+declare const numberRecordListSelector: (value: NumberRecord, index: number, collection: _.List<NumberRecord>) => number;
+
+declare const numberRecordDictionary: _.Dictionary<NumberRecord>;
+declare const numberRecordDictionarySelector: (element: NumberRecord, key: string, collection: _.Dictionary<NumberRecord>) => number;
+
+// function record
+interface NoParametersRecord {
+    a: () => number;
+}
+
+declare const noParametersRecordList: _.List<NoParametersRecord>;
+declare const noParametersRecordDictionary: _.Dictionary<NoParametersRecord>;
+
+interface TwoParametersRecord {
+    a: (arg0: number, arg1: string) => void;
+}
+
+declare const twoParametersRecordList: _.List<TwoParametersRecord>;
+declare const twoParametersRecordDictionary: _.Dictionary<TwoParametersRecord>;
+
+// string
+declare const stringValue: string;
+declare const stringIterator: (value: string, index: number, str: string) => number;
+declare const stringTester: (value: string, index: number, str: string) => boolean;
+declare const stringStringReducer: (prev: string, value: string, index: number, str: string) => string;
+declare const dictionaryStringReducer: (prev: _.Dictionary<number>, value: string, index: number, str: string) => _.Dictionary<number>;
+declare const unionStringReducer: (prev: string | number, value: string, index: number, str: string) => string | number;
+
+declare const stringArray: string[];
+declare const maybeStringArray: string[] | undefined;
+declare const stringList: _.List<string>;
+declare const level2StringList: _.List<_.List<string>>;
+
+// number
+declare const numberValue: number;
+declare const numberList: _.List<number>;
+declare const numberDictionary: _.Dictionary<number>;
+
+// boolean
+declare const booleanList: _.List<boolean>;
+declare const booleanDictionary: _.Dictionary<boolean>;
+
+// any
+declare const anyValue: any;
+declare const anyCollectionIterator: (element: any, index: string | number, collection: any) => void;
+declare const anyCollectionTester: (element: any, index: string | number, collection: any) => boolean;
+
+// never
+declare const neverValue: never;
+
+// truthiness
+type Truthies = string | number | boolean | object | Function | StringRecord | (() => void);
+declare const truthyFalsyList: _.List<Truthies | _.AnyFalsy>;
+declare const maybeTruthyFalsyList: _.List<Truthies | _.AnyFalsy> | null | undefined;
+
+// mixed types
+interface MixedTypeRecord {
+    a: StringRecord;
+    b: number;
+    c: NonIntersecting;
+}
+
+type Intersecting = StringRecord | MixedTypeRecord;
+
+interface NonIntersectingRecord {
+    onlyNonIntersectingRecord: string;
+}
+
+type NonIntersecting = StringRecord | NonIntersectingRecord;
+
+declare const mixedTypeRecord: MixedTypeRecord;
+declare const mixedTypeSelector: (element: any, key: string, object: MixedTypeRecord) => string;
+declare const mixedTypeTester: (element: any, key: string, object: MixedTypeRecord) => boolean;
+
+declare const intersectingPropertiesList: _.List<Intersecting>;
+declare const nonIntersectingList: _.List<NonIntersecting>;
+declare const level2NonIntersectingList: _.List<_.List<NonIntersecting>>;
+
+declare const mixedIterabilityValue: number | number[];
+declare const stringy: StringRecord | string;
+declare const level2UnionList: _.List<_.List<string | number>>;
+declare const tupleList: _.List<[string, number]>;
+declare const maybeFunction: (() => void) | undefined;
+
+/***************
+ * Usage Tests *
+ ***************/
 _.VERSION; // $ExpectType string
 _.each([1, 2, 3], (num) => alert(num.toString()));
 _.each({ one: 1, two: 2, three: 3 }, (value, key) => alert(value.toString()));
@@ -576,16 +724,16 @@ _.chain([[1, 2, 3], [4, undefined, 5], [undefined, undefined, 6]])
 
 // verify that partial objects can be provided without error to where and findWhere for a union type collection
 // where no types in the union share the same property names
-declare const nonIntersectinglTypeUnion: _.Dictionary<{ one: string; } | { two: number; }>;
+declare const nonIntersectingTypeUnion: _.Dictionary<{ one: string; } | { two: number; }>;
 
 // $ExpectType ({ one: string; } | { two: number; })[]
-_.chain(nonIntersectinglTypeUnion)
+_.chain(nonIntersectingTypeUnion)
     .where({ one: 'one' })
     .sample(5)
     .value();
 
 // $ExpectType { one: string; } | { two: number; } | undefined
-_.chain(nonIntersectinglTypeUnion)
+_.chain(nonIntersectingTypeUnion)
     .sample(5)
     .findWhere({ two: 2 })
     .value();
@@ -629,149 +777,9 @@ _.chain([{ id: 1, name: 'a' }, { id: 2, name: 'b' }])
     .object()
     .value();
 
-// common testing types and objects
-const context = {};
-
-interface StringRecord {
-    a: string;
-    b: string;
-}
-
-const stringRecordProperty = 'a';
-const stringRecordPropertyPath = ['a', 'length'];
-const partialStringRecord: Partial<StringRecord> = { a: 'b' };
-
-interface StringRecordAugmentedList extends _.List<StringRecord> {
-    notAListProperty: boolean;
-}
-
-const stringRecordAugmentedList: StringRecordAugmentedList = { 0: { a: 'a', b: 'c' }, 1: { a: 'b', b: 'b' }, 2: { a: 'c', b: 'a' }, length: 3, notAListProperty: true };
-const stringRecordList: _.List<StringRecord> = stringRecordAugmentedList;
-declare const stringRecordListUnion: StringRecord[] | _.List<StringRecord>;
-declare const level2RecordList: _.List<_.List<StringRecord>>;
-declare const level3RecordList: _.List<_.List<_.List<StringRecord>>>;
-declare const level4RecordList: _.List<_.List<_.List<_.List<StringRecord>>>>;
-declare const maxLevel2RecordArray: (StringRecord | StringRecord[])[];
-declare const maxLevel3RecordArray: (StringRecord | StringRecord[] | StringRecord[][])[];
-declare const recordListArray: _.List<StringRecord>[];
-
-const stringRecordAugmentedListVoidIterator = (value: StringRecord, index: number, list: StringRecordAugmentedList) => { value.a += 'b'; };
-const stringRecordListValueIterator = (value: StringRecord, index: number, list: _.List<StringRecord>) => value.a;
-declare const stringRecordOptionalListValueIterator: (value: StringRecord, index?: number, list?: _.List<StringRecord>) => string;
-const stringRecordListBooleanIterator = (value: StringRecord, index: number, list: _.List<StringRecord>) => value.a === 'b';
-const stringRecordPartialBooleanIterator = (value: StringRecord) => value.a === 'b';
-declare const stringRecordListUnionVoidIterator: (element: StringRecord, key: number, list: StringRecord[] | _.List<StringRecord>) => void;
-declare const stringRecordPartialMemoIterator: (prev: string, value: StringRecord) => string;
-declare const stringRecordListMemoIterator: (prev: string, value: StringRecord, index: number, list: _.List<StringRecord>) => string;
-declare const resultUnionPartialMemoIterator: (prev: string | StringRecord, value: StringRecord) => string | StringRecord;
-
-interface StringRecordExplicitDictionary extends _.Dictionary<StringRecord> {
-    a: StringRecord;
-    b: StringRecord;
-    c: StringRecord;
-}
-
-const stringRecordExplicitDictionary: StringRecordExplicitDictionary = { a: { a: 'a', b: 'c' }, b: { a: 'b', b: 'b' }, c: { a: 'c', b: 'a' } };
-const stringRecordDictionary: _.Dictionary<StringRecord> = stringRecordExplicitDictionary;
-
-const stringRecordExplicitDictionaryVoidIterator = (element: StringRecord, key: string, dictionary: StringRecordExplicitDictionary) => { element.a += 'b'; };
-const stringRecordDictionaryValueIterator = (element: StringRecord, key: string, dictionary: _.Dictionary<StringRecord>) => element.a;
-const stringRecordDictionaryBooleanIterator = (element: StringRecord, key: string, list: _.Dictionary<StringRecord>) => element.a === 'b';
-declare const stringRecordDictionaryMemoIterator: (prev: string, element: StringRecord, key: string, dictionary: _.Dictionary<StringRecord>) => string;
-
-type StringRecordOrUndefined = StringRecord | undefined;
-
-const stringRecordOrUndefinedList: _.List<StringRecordOrUndefined> = { 0: { a: 'a', b: 'c' }, 1: { a: 'b', b: 'b' }, 2: undefined, length: 3 };
-
-interface IntersectingMixedTypeRecord {
-    a: boolean;
-    c: string;
-}
-
-type IntersectingProperties = StringRecord | IntersectingMixedTypeRecord;
-
-const intersectingPropertiesList: _.List<IntersectingProperties> = { 0: { a: 'a', b: 'b' }, 1: { a: true, c: 'c' }, length: 2 };
-
-interface NonIntersectingStringRecord {
-    onlyNonIntersectingStringRecord: string;
-}
-
-type NonIntersectingProperties = StringRecord | NonIntersectingStringRecord;
-
-const nonIntersectingPropertiesList: _.List<NonIntersectingProperties> = { 0: { a: 'a', b: 'c' }, 1: { onlyNonIntersectingStringRecord: 'b' }, length: 2 };
-declare const level2NonIntersectingPropertiesList: _.List<_.List<NonIntersectingProperties>>;
-
-interface MixedTypeRecord {
-    a: StringRecord;
-    b: number;
-    c: NonIntersectingProperties;
-}
-
-declare const mixedTypeRecord: MixedTypeRecord;
-declare const mixedTypeRecordValueIterator: (element: any, key: string, object: MixedTypeRecord) => string;
-declare const mixedTypeRecordBooleanIterator: (element: any, key: string, object: MixedTypeRecord) => boolean;
-
-interface NumberRecord {
-    a: number;
-}
-
-declare const numberRecordList: _.List<NumberRecord>;
-declare const numberRecordListValueIterator: (value: NumberRecord, index: number, collection: _.List<NumberRecord>) => number;
-
-declare const numberRecordDictionary: _.Dictionary<NumberRecord>;
-declare const numberRecordDictionaryValueIterator: (element: NumberRecord, key: string, collection: _.Dictionary<NumberRecord>) => number;
-
-const numberList: _.List<number> = { 0: 0, 1: 1, length: 2 };
-const numberDictionary: _.Dictionary<number> = { a: 0, b: 1 };
-
-interface NoParameterFunctionRecord {
-    a: () => number;
-}
-
-declare const noParameterFunctionRecordList: _.List<NoParameterFunctionRecord>;
-declare const noParameterFunctionRecordDictionary: _.Dictionary<NoParameterFunctionRecord>;
-
-interface TwoParameterFunctionRecord {
-    a: (arg0: number, arg1: string) => void;
-}
-
-declare const twoParameterFunctionRecordList: _.List<TwoParameterFunctionRecord>;
-declare const twoParameterFunctionRecordDictionary: _.Dictionary<TwoParameterFunctionRecord>;
-
-declare const simpleString: string;
-
-const simpleStringArray: string[] = ['a', 'c'];
-const simpleStringList: _.List<string> = { 0: 'a', 1: 'c', length: 2 };
-declare const level2StringList: _.List<_.List<string>>;
-
-const stringListValueIterator = (value: string, index: number, str: string) => value.length;
-const stringListBooleanIterator = (value: string, index: number, str: string) => value === 'b';
-declare const stringListSelfMemoIterator: (prev: string, value: string, index: number, str: string) => string;
-declare const stringListMemoIterator: (prev: _.Dictionary<number>, value: string, index: number, str: string) => _.Dictionary<number>;
-declare const resultUnionStringListMemoIterator: (prev: string | number, value: string, index: number, str: string) => string | number;
-
-declare const anyCollectionVoidIterator: (element: any, index: string | number, collection: any) => void;
-declare const anyBooleanIterator: (element: any, key: string | number, obj: any) => boolean;
-
-const simpleNumber = 7;
-declare const simpleNumberList: _.List<number>;
-declare const simpleNumberDictionary: _.Dictionary<number>;
-
-declare const simpleBooleanList: _.List<boolean>;
-declare const simpleBooleanDictionary: _.Dictionary<boolean>;
-
-declare const mixedIterabilityValue: number | number[];
-declare const neverValue: never;
-declare const maybeFunction: (() => void) | undefined;
-declare const maybeStringArray: string[] | undefined;
-declare const stringy: StringRecord | string;
-
-type Truthies = string | number | boolean | object | Function | StringRecord | (() => void);
-declare const truthyFalsyList: _.List<Truthies | _.AnyFalsy>;
-declare const maybeTruthyFalsyList: _.List<Truthies | _.AnyFalsy> | null | undefined;
-
-declare const level2UnionList: _.List<_.List<string | number>>;
-declare const tupleList: _.List<[string, number]>;
+/*******************************
+ * Combinatorial Tests - Types *
+ *******************************/
 
 // avoid referencing types under test directly by translating them to other types to avoid needing to make lots of changes if
 // the types under test need to be refactored
@@ -802,7 +810,7 @@ declare const extractChainTypes: ChainTypeExtractor;
         collection; // $ExpectType List<StringRecord>
         return element.a;
     };
-    listFunctionIteratee(stringRecordList[0], 0, stringRecordList); // $ExpectType string
+    listFunctionIteratee(recordList[0], 0, recordList); // $ExpectType string
 
     const dictionaryFunctionIteratee: _.Iteratee<_.Dictionary<StringRecord>, string> = (element, key, collection) => {
         element; // $ExpectType StringRecord
@@ -810,23 +818,23 @@ declare const extractChainTypes: ChainTypeExtractor;
         collection; // $ExpectType Dictionary<StringRecord>
         return element.a;
     };
-    dictionaryFunctionIteratee(stringRecordDictionary['a'], 'a', stringRecordDictionary); // $ExpectType string
+    dictionaryFunctionIteratee(recordDictionary['a'], 'a', recordDictionary); // $ExpectType string
 
-    const unionCollectionItemFunctionIteratee: _.Iteratee<_.List<IntersectingProperties>, string | boolean> = (element, key, collection) => {
-        element; // $ExpectType IntersectingProperties
+    const unionFunctionIteratee: _.Iteratee<_.List<Intersecting>, string | StringRecord> = (element, key, collection) => {
+        element; // $ExpectType Intersecting
         key; // $ExpectType number
-        collection; // $ExpectType List<IntersectingProperties>
+        collection; // $ExpectType List<Intersecting>
         return element.a;
     };
-    unionCollectionItemFunctionIteratee(intersectingPropertiesList[0], 0, intersectingPropertiesList); // $ExpectType string | boolean
+    unionFunctionIteratee(intersectingPropertiesList[0], 0, intersectingPropertiesList); // $ExpectType string | StringRecord
 
-    const unionCollectionFunctionIteratee: _.Iteratee<_.Dictionary<StringRecord> | StringRecord[], string> = (element, key, collection) => {
+    const collectionFunctionIteratee: _.Iteratee<_.Dictionary<StringRecord> | StringRecord[], string> = (element, key, collection) => {
         element; // $ExpectType StringRecord
         key; // $ExpectType string | number
         collection; // $ExpectType Dictionary<StringRecord> | StringRecord[]
         return element.a;
     };
-    unionCollectionFunctionIteratee(stringRecordDictionary['a'], 'a', stringRecordDictionary); // $ExpectType string
+    collectionFunctionIteratee(recordDictionary['a'], 'a', recordDictionary); // $ExpectType string
 
     const anyFunctionIteratee: _.Iteratee<any, string> = (element, key, collection) => {
         element; // $ExpectType any
@@ -835,57 +843,57 @@ declare const extractChainTypes: ChainTypeExtractor;
         return element.a;
     };
     if (_.isFunction(anyFunctionIteratee)) {
-        anyFunctionIteratee(stringRecordDictionary['a'], 'a', stringRecordDictionary); // $ExpectType string
+        anyFunctionIteratee(recordDictionary['a'], 'a', recordDictionary); // $ExpectType string
     }
 
-    // partial objects
-    const listPartialObjectIteratee: _.Iteratee<_.List<StringRecord>, string> = partialStringRecord;
-    listPartialObjectIteratee; // $ExpectType Partial<StringRecord>
+    // matchers
+    const listMatcherIteratee: _.Iteratee<_.List<StringRecord>, string> = matcher;
+    listMatcherIteratee; // $ExpectType Partial<StringRecord>
 
-    const dictionaryPartialObjectIteratee: _.Iteratee<_.Dictionary<StringRecord>, string> = partialStringRecord;
-    dictionaryPartialObjectIteratee; // $ExpectType Partial<StringRecord>
+    const dictionaryMatcherIteratee: _.Iteratee<_.Dictionary<StringRecord>, string> = matcher;
+    dictionaryMatcherIteratee; // $ExpectType Partial<StringRecord>
 
-    const unionCollectionItemPartialObjectIteratee: _.Iteratee<_.List<IntersectingProperties>, string | boolean> = partialStringRecord;
-    unionCollectionItemPartialObjectIteratee; // $ExpectType Partial<StringRecord>
+    const unionMatcherIteratee: _.Iteratee<_.List<Intersecting>, string | boolean> = matcher;
+    unionMatcherIteratee; // $ExpectType Partial<StringRecord>
 
-    const unionCollectionPartialObjectIteratee: _.Iteratee<StringRecord[] | _.Dictionary<StringRecord>, string> = partialStringRecord;
-    unionCollectionPartialObjectIteratee; // $ExpectType Partial<StringRecord>
+    const collectionUnionMatcherIteratee: _.Iteratee<StringRecord[] | _.Dictionary<StringRecord>, string> = matcher;
+    collectionUnionMatcherIteratee; // $ExpectType Partial<StringRecord>
 
-    const anyPartialObjectIteratee: _.Iteratee<any, string> = partialStringRecord;
-    anyPartialObjectIteratee; // $ExpectType Partial<any>
+    const anyMatcherIteratee: _.Iteratee<any, string> = matcher;
+    anyMatcherIteratee; // $ExpectType Partial<any>
 
-    // property names
-    const listPropertyNameIteratee: _.Iteratee<_.List<StringRecord>, string> = stringRecordProperty;
-    listPropertyNameIteratee; // $ExpectType string
+    // shallow properties
+    const listShallowPropertyIteratee: _.Iteratee<_.List<StringRecord>, string> = shallowProperty;
+    listShallowPropertyIteratee; // $ExpectType string
 
-    const dictionaryPropertyNameIteratee: _.Iteratee<_.Dictionary<StringRecord>, string> = stringRecordProperty;
-    dictionaryPropertyNameIteratee; // $ExpectType string
+    const dictionaryShallowPropertyIteratee: _.Iteratee<_.Dictionary<StringRecord>, string> = shallowProperty;
+    dictionaryShallowPropertyIteratee; // $ExpectType string
 
-    const unionCollectionItemPropertyNameIteratee: _.Iteratee<_.List<IntersectingProperties>, string | boolean> = stringRecordProperty;
-    unionCollectionItemPropertyNameIteratee; // $ExpectType string
+    const unionShallowPropertyIteratee: _.Iteratee<_.List<Intersecting>, string | boolean> = shallowProperty;
+    unionShallowPropertyIteratee; // $ExpectType string
 
-    const unionCollectionPropertyNameIteratee: _.Iteratee<StringRecord[] | _.Dictionary<StringRecord>, string> = stringRecordProperty;
-    unionCollectionPropertyNameIteratee; // $ExpectType string
+    const collectionShallowPropertyIteratee: _.Iteratee<StringRecord[] | _.Dictionary<StringRecord>, string> = shallowProperty;
+    collectionShallowPropertyIteratee; // $ExpectType string
 
-    const anyPropertyNameteratee: _.Iteratee<any, string> = stringRecordProperty;
-    anyPropertyNameteratee; // $ExpectType string
+    const anyShallowPropertyIteratee: _.Iteratee<any, string> = shallowProperty;
+    anyShallowPropertyIteratee; // $ExpectType string
 
-    // property paths
-    const listPropertyPathIteratee: _.Iteratee<_.List<StringRecord>, string> = stringRecordPropertyPath;
-    listPropertyPathIteratee; // $ExpectType (string | number)[]
+    // deep properties
+    const listDeepPropertyIteratee: _.Iteratee<_.List<StringRecord>, string> = deepProperty;
+    listDeepPropertyIteratee; // $ExpectType (string | number)[]
 
-    const dictionaryPropertyPathIteratee: _.Iteratee<_.Dictionary<StringRecord>, string> = stringRecordPropertyPath;
-    dictionaryPropertyPathIteratee; // $ExpectType (string | number)[]
+    const dictionaryDeepPropertyIteratee: _.Iteratee<_.Dictionary<StringRecord>, string> = deepProperty;
+    dictionaryDeepPropertyIteratee; // $ExpectType (string | number)[]
 
-    const unionCollectionItemPropertyPathIteratee: _.Iteratee<_.List<IntersectingProperties>, string | boolean> = stringRecordPropertyPath;
-    unionCollectionItemPropertyPathIteratee; // $ExpectType (string | number)[]
+    const unionDeepPropertyIteratee: _.Iteratee<_.List<Intersecting>, string | boolean> = deepProperty;
+    unionDeepPropertyIteratee; // $ExpectType (string | number)[]
 
-    const unionCollectionPropertyPathIteratee: _.Iteratee<StringRecord[] | _.Dictionary<StringRecord>, string> = stringRecordPropertyPath;
-    unionCollectionPropertyPathIteratee; // $ExpectType (string | number)[]
+    const collectionDeepPropertyIteratee: _.Iteratee<StringRecord[] | _.Dictionary<StringRecord>, string> = deepProperty;
+    collectionDeepPropertyIteratee; // $ExpectType (string | number)[]
 
-    const anyPropertyPathIteratee: _.Iteratee<any, string> = stringRecordPropertyPath;
-    if (_.isArray(anyPropertyPathIteratee)) {
-        anyPropertyPathIteratee; // $ExpectType (string | number)[]
+    const anyDeepPropertyIteratee: _.Iteratee<any, string> = deepProperty;
+    if (_.isArray(anyDeepPropertyIteratee)) {
+        anyDeepPropertyIteratee; // $ExpectType (string | number)[]
     }
 
     // identity
@@ -895,1026 +903,1022 @@ declare const extractChainTypes: ChainTypeExtractor;
     const dictionaryIdentityIteratee: _.Iteratee<_.Dictionary<StringRecord>, string> = null;
     dictionaryIdentityIteratee; // $ExpectType null
 
-    const unionCollectionItemIdentityIteratee: _.Iteratee<_.List<IntersectingProperties>, string | boolean> = undefined;
-    unionCollectionItemIdentityIteratee; // $ExpectType undefined
+    const unionIdentityIteratee: _.Iteratee<_.List<Intersecting>, string | boolean> = undefined;
+    unionIdentityIteratee; // $ExpectType undefined
 
-    const unionCollectionIdentityIteratee: _.Iteratee<StringRecord[] | _.Dictionary<StringRecord>, string> = null;
-    unionCollectionIdentityIteratee; // $ExpectType null
+    const collectionIdentityIteratee: _.Iteratee<StringRecord[] | _.Dictionary<StringRecord>, string> = null;
+    collectionIdentityIteratee; // $ExpectType null
 
     const anyIdentityIteratee: _.Iteratee<any, string> = undefined;
     anyIdentityIteratee; // $ExpectType undefined
 }
 
 // IterateeResult
-declare const functionIterateeResult: _.IterateeResult<() => string, StringRecord>;
-functionIterateeResult; // $ExpectType string
+declare const functionResult: _.IterateeResult<() => string, StringRecord>;
+functionResult; // $ExpectType string
 
-declare const partialObjectIterateeResult: _.IterateeResult<Partial<StringRecord>, StringRecord>;
-partialObjectIterateeResult; // $ExpectType boolean
+declare const matcherResult: _.IterateeResult<Partial<StringRecord>, StringRecord>;
+matcherResult; // $ExpectType boolean
 
-declare const knownPropertyNameIterateeResult: _.IterateeResult<typeof stringRecordProperty, IntersectingProperties>;
-knownPropertyNameIterateeResult; // $ExpectType string | boolean
+declare const knownShallowPropertyResult: _.IterateeResult<typeof shallowProperty, Intersecting>;
+knownShallowPropertyResult; // $ExpectType string | StringRecord
 
-declare const unknownPropertyNameIterateeResult: _.IterateeResult<typeof stringRecordProperty, NonIntersectingProperties>;
-unknownPropertyNameIterateeResult; // $ExpectType any
+declare const unknownShallowPropertyResult: _.IterateeResult<typeof shallowProperty, NonIntersecting>;
+unknownShallowPropertyResult; // $ExpectType any
 
-declare const propertyPathIterateeResult: _.IterateeResult<_.EnumerableKey[], StringRecord>;
-propertyPathIterateeResult; // $ExpectType any
+declare const deepPropertyResult: _.IterateeResult<_.EnumerableKey[], StringRecord>;
+deepPropertyResult; // $ExpectType any
 
-declare const nullIdentityIterateeResult: _.IterateeResult<null, StringRecord>;
-nullIdentityIterateeResult; // $ExpectType StringRecord
+declare const nullResult: _.IterateeResult<null, StringRecord>;
+nullResult; // $ExpectType StringRecord
 
-declare const undefinedIdentityIterateeResult: _.IterateeResult<undefined, StringRecord>;
-undefinedIdentityIterateeResult; // $ExpectType StringRecord
+declare const undefinedResult: _.IterateeResult<undefined, StringRecord>;
+undefinedResult; // $ExpectType StringRecord
 
-// Collections
+/*************************************
+ * Combinatorial Tests - Collections *
+ *************************************/
 
 // each, forEach
 {
     // lists - each
-    _.each(stringRecordAugmentedList, stringRecordAugmentedListVoidIterator); // $ExpectType StringRecordAugmentedList
-    _(stringRecordAugmentedList).each(stringRecordAugmentedListVoidIterator, context); // $ExpectType StringRecordAugmentedList
-    _.chain(stringRecordAugmentedList).each(stringRecordAugmentedListVoidIterator); // // $ExpectType _Chain<StringRecordAugmentedList, StringRecordAugmentedList>
+    _.each(augmentedList, augmentedListIterator); // $ExpectType AugmentedList
+    _(augmentedList).each(augmentedListIterator, context); // $ExpectType AugmentedList
+    _.chain(augmentedList).each(augmentedListIterator); // // $ExpectType _Chain<AugmentedList, AugmentedList>
 
     // lists - forEach
-    _.forEach(stringRecordAugmentedList, stringRecordAugmentedListVoidIterator, context); // $ExpectType StringRecordAugmentedList
-    _(stringRecordAugmentedList).forEach(stringRecordAugmentedListVoidIterator); // $ExpectType StringRecordAugmentedList
-    _.chain(stringRecordAugmentedList).forEach(stringRecordAugmentedListVoidIterator, context); // // $ExpectType _Chain<StringRecordAugmentedList, StringRecordAugmentedList>
+    _.forEach(augmentedList, augmentedListIterator, context); // $ExpectType AugmentedList
+    _(augmentedList).forEach(augmentedListIterator); // $ExpectType AugmentedList
+    _.chain(augmentedList).forEach(augmentedListIterator, context); // // $ExpectType _Chain<AugmentedList, AugmentedList>
 
     // dictionaries - each
-    _.each(stringRecordExplicitDictionary, stringRecordExplicitDictionaryVoidIterator, context); // $ExpectType StringRecordExplicitDictionary
-    _(stringRecordExplicitDictionary).each(stringRecordExplicitDictionaryVoidIterator); // $ExpectType StringRecordExplicitDictionary
-    _.chain(stringRecordExplicitDictionary).each(stringRecordExplicitDictionaryVoidIterator, context); // // $ExpectType _Chain<StringRecord, StringRecordExplicitDictionary>
+    _.each(explicitDictionary, explicitDictionaryIterator, context); // $ExpectType ExplicitDictionary
+    _(explicitDictionary).each(explicitDictionaryIterator); // $ExpectType ExplicitDictionary
+    _.chain(explicitDictionary).each(explicitDictionaryIterator, context); // // $ExpectType _Chain<StringRecord, ExplicitDictionary>
 
     // dictionaries - forEach
-    _.forEach(stringRecordExplicitDictionary, stringRecordExplicitDictionaryVoidIterator); // $ExpectType StringRecordExplicitDictionary
-    _(stringRecordExplicitDictionary).forEach(stringRecordExplicitDictionaryVoidIterator, context); // $ExpectType StringRecordExplicitDictionary
-    _.chain(stringRecordExplicitDictionary).forEach(stringRecordExplicitDictionaryVoidIterator); // // $ExpectType _Chain<StringRecord, StringRecordExplicitDictionary>
+    _.forEach(explicitDictionary, explicitDictionaryIterator); // $ExpectType ExplicitDictionary
+    _(explicitDictionary).forEach(explicitDictionaryIterator, context); // $ExpectType ExplicitDictionary
+    _.chain(explicitDictionary).forEach(explicitDictionaryIterator); // // $ExpectType _Chain<StringRecord, ExplicitDictionary>
 
     // unioned list types with similar items - each
-    _.each(stringRecordListUnion, stringRecordListUnionVoidIterator); // $ExpectType List<StringRecord> | StringRecord[]
-    _(stringRecordListUnion).each(stringRecordListUnionVoidIterator); // $ExpectType List<StringRecord> | StringRecord[]
-    _.chain(stringRecordListUnion).each(stringRecordListUnionVoidIterator); // // $ExpectType _Chain<StringRecord, List<StringRecord> | StringRecord[]>
+    _.each(recordListUnion, recordListUnionIterator); // $ExpectType List<StringRecord> | StringRecord[]
+    _(recordListUnion).each(recordListUnionIterator); // $ExpectType List<StringRecord> | StringRecord[]
+    _.chain(recordListUnion).each(recordListUnionIterator); // // $ExpectType _Chain<StringRecord, List<StringRecord> | StringRecord[]>
 
     // unioned list types with similar items - forEach
-    _.forEach(stringRecordListUnion, stringRecordListUnionVoidIterator); // $ExpectType List<StringRecord> | StringRecord[]
-    _(stringRecordListUnion).forEach(stringRecordListUnionVoidIterator); // $ExpectType List<StringRecord> | StringRecord[]
-    _.chain(stringRecordListUnion).forEach(stringRecordListUnionVoidIterator); // // $ExpectType _Chain<StringRecord, List<StringRecord> | StringRecord[]>
+    _.forEach(recordListUnion, recordListUnionIterator); // $ExpectType List<StringRecord> | StringRecord[]
+    _(recordListUnion).forEach(recordListUnionIterator); // $ExpectType List<StringRecord> | StringRecord[]
+    _.chain(recordListUnion).forEach(recordListUnionIterator); // // $ExpectType _Chain<StringRecord, List<StringRecord> | StringRecord[]>
 
     // any - each
-    _.each(anyValue, anyCollectionVoidIterator); // $ExpectType any
-    _(anyValue).each(anyCollectionVoidIterator, context); // $ExpectType any
-    _.chain(anyValue).each(anyCollectionVoidIterator); // // $ExpectType _Chain<any, any>
+    _.each(anyValue, anyCollectionIterator); // $ExpectType any
+    _(anyValue).each(anyCollectionIterator, context); // $ExpectType any
+    _.chain(anyValue).each(anyCollectionIterator); // // $ExpectType _Chain<any, any>
 
     // any - forEach
-    _.forEach(anyValue, anyCollectionVoidIterator); // $ExpectType any
-    _(anyValue).forEach(anyCollectionVoidIterator, context); // $ExpectType any
-    _.chain(anyValue).forEach(anyCollectionVoidIterator); // // $ExpectType _Chain<any, any>
+    _.forEach(anyValue, anyCollectionIterator); // $ExpectType any
+    _(anyValue).forEach(anyCollectionIterator, context); // $ExpectType any
+    _.chain(anyValue).forEach(anyCollectionIterator); // // $ExpectType _Chain<any, any>
 }
 
 // map, collect
 {
     // function iteratee - lists - map
-    _.map(stringRecordList, stringRecordListValueIterator, context); // $ExpectType string[]
-    _(stringRecordList).map(stringRecordListValueIterator, context); // $ExpectType string[]
-    extractChainTypes(_.chain(stringRecordList).map(stringRecordListValueIterator, context)); // $ExpectType ChainType<string[], string>
+    _.map(recordList, recordListSelector, context); // $ExpectType string[]
+    _(recordList).map(recordListSelector, context); // $ExpectType string[]
+    extractChainTypes(_.chain(recordList).map(recordListSelector, context)); // $ExpectType ChainType<string[], string>
 
     // function iteratee - lists - collect
-    _.collect(stringRecordList, stringRecordListValueIterator, context); // $ExpectType string[]
-    _(stringRecordList).collect(stringRecordListValueIterator, context); // $ExpectType string[]
-    extractChainTypes(_.chain(stringRecordList).collect(stringRecordListValueIterator, context)); // $ExpectType ChainType<string[], string>
+    _.collect(recordList, recordListSelector, context); // $ExpectType string[]
+    _(recordList).collect(recordListSelector, context); // $ExpectType string[]
+    extractChainTypes(_.chain(recordList).collect(recordListSelector, context)); // $ExpectType ChainType<string[], string>
 
     // function iteratee - dictionaries - map
-    _.map(stringRecordDictionary, stringRecordDictionaryValueIterator, context); // $ExpectType string[]
-    _(stringRecordDictionary).map(stringRecordDictionaryValueIterator, context); // $ExpectType string[]
-    extractChainTypes(_.chain(stringRecordDictionary).map(stringRecordDictionaryValueIterator, context)); // $ExpectType ChainType<string[], string>
+    _.map(recordDictionary, recordDictionarySelector, context); // $ExpectType string[]
+    _(recordDictionary).map(recordDictionarySelector, context); // $ExpectType string[]
+    extractChainTypes(_.chain(recordDictionary).map(recordDictionarySelector, context)); // $ExpectType ChainType<string[], string>
 
     // function iteratee - dictionaries - collect
-    _.collect(stringRecordDictionary, stringRecordDictionaryValueIterator, context); // $ExpectType string[]
-    _(stringRecordDictionary).collect(stringRecordDictionaryValueIterator, context); // $ExpectType string[]
-    extractChainTypes(_.chain(stringRecordDictionary).collect(stringRecordDictionaryValueIterator, context)); // $ExpectType ChainType<string[], string>
+    _.collect(recordDictionary, recordDictionarySelector, context); // $ExpectType string[]
+    _(recordDictionary).collect(recordDictionarySelector, context); // $ExpectType string[]
+    extractChainTypes(_.chain(recordDictionary).collect(recordDictionarySelector, context)); // $ExpectType ChainType<string[], string>
 
     // function iteratee - strings - map
-    _.map(simpleString, stringListValueIterator, context); // $ExpectType number[]
-    _(simpleString).map(stringListValueIterator, context); // $ExpectType number[]
-    extractChainTypes(_.chain(simpleString).map(stringListValueIterator, context)); // $ExpectType ChainType<number[], number>
+    _.map(stringValue, stringIterator, context); // $ExpectType number[]
+    _(stringValue).map(stringIterator, context); // $ExpectType number[]
+    extractChainTypes(_.chain(stringValue).map(stringIterator, context)); // $ExpectType ChainType<number[], number>
 
     // function iteratee - strings - collect
-    _.collect(simpleString, stringListValueIterator, context); // $ExpectType number[]
-    _(simpleString).collect(stringListValueIterator, context); // $ExpectType number[]
-    extractChainTypes(_.chain(simpleString).collect(stringListValueIterator, context)); // $ExpectType ChainType<number[], number>
+    _.collect(stringValue, stringIterator, context); // $ExpectType number[]
+    _(stringValue).collect(stringIterator, context); // $ExpectType number[]
+    extractChainTypes(_.chain(stringValue).collect(stringIterator, context)); // $ExpectType ChainType<number[], number>
 
     // function iteratee - any - map
-    _.map(anyValue, stringRecordListValueIterator, context); // $ExpectType string[]
-    _(anyValue).map(stringRecordListValueIterator, context); // $ExpectType string[]
-    extractChainTypes(_.chain(anyValue).map(stringRecordListValueIterator, context)); // $ExpectType ChainType<string[], string>
+    _.map(anyValue, recordListSelector, context); // $ExpectType string[]
+    _(anyValue).map(recordListSelector, context); // $ExpectType string[]
+    extractChainTypes(_.chain(anyValue).map(recordListSelector, context)); // $ExpectType ChainType<string[], string>
 
     // function iteratee - any - collect
-    _.collect(anyValue, stringRecordListValueIterator, context); // $ExpectType string[]
-    _(anyValue).collect(stringRecordListValueIterator, context); // $ExpectType string[]
-    extractChainTypes(_.chain(anyValue).collect(stringRecordListValueIterator, context)); // $ExpectType ChainType<string[], string>
+    _.collect(anyValue, recordListSelector, context); // $ExpectType string[]
+    _(anyValue).collect(recordListSelector, context); // $ExpectType string[]
+    extractChainTypes(_.chain(anyValue).collect(recordListSelector, context)); // $ExpectType ChainType<string[], string>
 
     // matcher iteratee - lists - map
-    _.map(stringRecordList, partialStringRecord); // $ExpectType boolean[]
-    _(stringRecordList).map(partialStringRecord); // $ExpectType boolean[]
-    extractChainTypes(_.chain(stringRecordList).map(partialStringRecord)); // $ExpectType ChainType<boolean[], boolean>
+    _.map(recordList, matcher); // $ExpectType boolean[]
+    _(recordList).map(matcher); // $ExpectType boolean[]
+    extractChainTypes(_.chain(recordList).map(matcher)); // $ExpectType ChainType<boolean[], boolean>
 
     // matcher iteratee - lists - collect
-    _.collect(stringRecordList, partialStringRecord); // $ExpectType boolean[]
-    _(stringRecordList).collect(partialStringRecord); // $ExpectType boolean[]
-    extractChainTypes(_.chain(stringRecordList).collect(partialStringRecord)); // $ExpectType ChainType<boolean[], boolean>
+    _.collect(recordList, matcher); // $ExpectType boolean[]
+    _(recordList).collect(matcher); // $ExpectType boolean[]
+    extractChainTypes(_.chain(recordList).collect(matcher)); // $ExpectType ChainType<boolean[], boolean>
 
     // matcher iteratee - dictionaries - map
-    _.map(stringRecordDictionary, partialStringRecord); // $ExpectType boolean[]
-    _(stringRecordDictionary).map(partialStringRecord); // $ExpectType boolean[]
-    extractChainTypes(_.chain(stringRecordDictionary).map(partialStringRecord)); // $ExpectType ChainType<boolean[], boolean>
+    _.map(recordDictionary, matcher); // $ExpectType boolean[]
+    _(recordDictionary).map(matcher); // $ExpectType boolean[]
+    extractChainTypes(_.chain(recordDictionary).map(matcher)); // $ExpectType ChainType<boolean[], boolean>
 
     // matcher iteratee - dictionaries - collect
-    _.collect(stringRecordDictionary, partialStringRecord); // $ExpectType boolean[]
-    _(stringRecordDictionary).collect(partialStringRecord); // $ExpectType boolean[]
-    extractChainTypes(_.chain(stringRecordDictionary).collect(partialStringRecord)); // $ExpectType ChainType<boolean[], boolean>
+    _.collect(recordDictionary, matcher); // $ExpectType boolean[]
+    _(recordDictionary).collect(matcher); // $ExpectType boolean[]
+    extractChainTypes(_.chain(recordDictionary).collect(matcher)); // $ExpectType ChainType<boolean[], boolean>
 
     // matcher iteratee - any (see #33479) - map
-    _.map(anyValue, partialStringRecord); // $ExpectType boolean[]
-    _(anyValue).map(partialStringRecord); // $ExpectType boolean[]
-    extractChainTypes(_.chain(anyValue).map(partialStringRecord)); // $ExpectType ChainType<boolean[], boolean>
+    _.map(anyValue, matcher); // $ExpectType boolean[]
+    _(anyValue).map(matcher); // $ExpectType boolean[]
+    extractChainTypes(_.chain(anyValue).map(matcher)); // $ExpectType ChainType<boolean[], boolean>
 
     // matcher iteratee - any (see #33479) - collect
-    _.collect(anyValue, partialStringRecord); // $ExpectType boolean[]
-    _(anyValue).collect(partialStringRecord); // $ExpectType boolean[]
-    extractChainTypes(_.chain(anyValue).collect(partialStringRecord)); // $ExpectType ChainType<boolean[], boolean>
+    _.collect(anyValue, matcher); // $ExpectType boolean[]
+    _(anyValue).collect(matcher); // $ExpectType boolean[]
+    extractChainTypes(_.chain(anyValue).collect(matcher)); // $ExpectType ChainType<boolean[], boolean>
 
     // shallow property iteratee with a non-nullable single type - lists - map
-    _.map(stringRecordList, stringRecordProperty); // $ExpectType string[]
-    _(stringRecordList).map(stringRecordProperty); // $ExpectType string[]
-    extractChainTypes(_.chain(stringRecordList).map(stringRecordProperty)); // $ExpectType ChainType<string[], string>
+    _.map(recordList, shallowProperty); // $ExpectType string[]
+    _(recordList).map(shallowProperty); // $ExpectType string[]
+    extractChainTypes(_.chain(recordList).map(shallowProperty)); // $ExpectType ChainType<string[], string>
 
     // shallow property iteratee with a non-nullable single type - lists - collect
-    _.collect(stringRecordList, stringRecordProperty); // $ExpectType string[]
-    _(stringRecordList).collect(stringRecordProperty); // $ExpectType string[]
-    extractChainTypes(_.chain(stringRecordList).collect(stringRecordProperty)); // $ExpectType ChainType<string[], string>
+    _.collect(recordList, shallowProperty); // $ExpectType string[]
+    _(recordList).collect(shallowProperty); // $ExpectType string[]
+    extractChainTypes(_.chain(recordList).collect(shallowProperty)); // $ExpectType ChainType<string[], string>
 
     // shallow property iteratee with a non-nullable single type - dictionaries - map
-    _.map(stringRecordDictionary, stringRecordProperty); // $ExpectType string[]
-    _(stringRecordDictionary).map(stringRecordProperty); // $ExpectType string[]
-    extractChainTypes(_.chain(stringRecordDictionary).map(stringRecordProperty)); // $ExpectType ChainType<string[], string>
+    _.map(recordDictionary, shallowProperty); // $ExpectType string[]
+    _(recordDictionary).map(shallowProperty); // $ExpectType string[]
+    extractChainTypes(_.chain(recordDictionary).map(shallowProperty)); // $ExpectType ChainType<string[], string>
 
     // shallow property iteratee with a non-nullable single type - dictionaries - collect
-    _.collect(stringRecordDictionary, stringRecordProperty); // $ExpectType string[]
-    _(stringRecordDictionary).collect(stringRecordProperty); // $ExpectType string[]
-    extractChainTypes(_.chain(stringRecordDictionary).collect(stringRecordProperty)); // $ExpectType ChainType<string[], string>
+    _.collect(recordDictionary, shallowProperty); // $ExpectType string[]
+    _(recordDictionary).collect(shallowProperty); // $ExpectType string[]
+    extractChainTypes(_.chain(recordDictionary).collect(shallowProperty)); // $ExpectType ChainType<string[], string>
 
     // shallow property iteratee with other types - lists - map
-    _.map(stringRecordOrUndefinedList, stringRecordProperty); // $ExpectType any[]
-    _.map(intersectingPropertiesList, stringRecordProperty); // $ExpectType (string | boolean)[]
-    _.map(nonIntersectingPropertiesList, stringRecordProperty); // $ExpectType any[]
+    _.map(maybeRecordList, shallowProperty); // $ExpectType any[]
+    _.map(intersectingPropertiesList, shallowProperty); // $ExpectType (string | StringRecord)[]
+    _.map(nonIntersectingList, shallowProperty); // $ExpectType any[]
 
     // shallow property iteratee with other types - lists - collect
-    _.collect(stringRecordOrUndefinedList, stringRecordProperty); // $ExpectType any[]
-    _.collect(intersectingPropertiesList, stringRecordProperty); // $ExpectType (string | boolean)[]
-    _.collect(nonIntersectingPropertiesList, stringRecordProperty); // $ExpectType any[]
+    _.collect(maybeRecordList, shallowProperty); // $ExpectType any[]
+    _.collect(intersectingPropertiesList, shallowProperty); // $ExpectType (string | StringRecord)[]
+    _.collect(nonIntersectingList, shallowProperty); // $ExpectType any[]
 
     // shallow property iteratee - any (see #33479) - map
-    _.map(anyValue, stringRecordProperty); // $ExpectType any[]
-    _(anyValue).map(stringRecordProperty); // $ExpectType any[]
-    extractChainTypes(_.chain(anyValue).map(stringRecordProperty)); // $ExpectType ChainType<any[], any>
+    _.map(anyValue, shallowProperty); // $ExpectType any[]
+    _(anyValue).map(shallowProperty); // $ExpectType any[]
+    extractChainTypes(_.chain(anyValue).map(shallowProperty)); // $ExpectType ChainType<any[], any>
 
     // shallow property iteratee - any (see #33479) - collect
-    _.collect(anyValue, stringRecordProperty); // $ExpectType any[]
-    _(anyValue).collect(stringRecordProperty); // $ExpectType any[]
-    extractChainTypes(_.chain(anyValue).collect(stringRecordProperty)); // $ExpectType ChainType<any[], any>
+    _.collect(anyValue, shallowProperty); // $ExpectType any[]
+    _(anyValue).collect(shallowProperty); // $ExpectType any[]
+    extractChainTypes(_.chain(anyValue).collect(shallowProperty)); // $ExpectType ChainType<any[], any>
 
     // deep property iteratee - lists - map
-    _.map(stringRecordList, stringRecordPropertyPath); // $ExpectType any[]
-    _(stringRecordList).map(stringRecordPropertyPath); // $ExpectType any[]
-    extractChainTypes(_.chain(stringRecordList).map(stringRecordPropertyPath)); // $ExpectType ChainType<any[], any>
+    _.map(recordList, deepProperty); // $ExpectType any[]
+    _(recordList).map(deepProperty); // $ExpectType any[]
+    extractChainTypes(_.chain(recordList).map(deepProperty)); // $ExpectType ChainType<any[], any>
 
     // deep property iteratee - lists - collect
-    _.collect(stringRecordList, stringRecordPropertyPath); // $ExpectType any[]
-    _(stringRecordList).collect(stringRecordPropertyPath); // $ExpectType any[]
-    extractChainTypes(_.chain(stringRecordList).collect(stringRecordPropertyPath)); // $ExpectType ChainType<any[], any>
+    _.collect(recordList, deepProperty); // $ExpectType any[]
+    _(recordList).collect(deepProperty); // $ExpectType any[]
+    extractChainTypes(_.chain(recordList).collect(deepProperty)); // $ExpectType ChainType<any[], any>
 
     // deep property iteratee - dictionaries - map
-    _.map(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType any[]
-    _(stringRecordDictionary).map(stringRecordPropertyPath); // $ExpectType any[]
-    extractChainTypes(_.chain(stringRecordDictionary).map(stringRecordPropertyPath)); // $ExpectType ChainType<any[], any>
+    _.map(recordDictionary, deepProperty); // $ExpectType any[]
+    _(recordDictionary).map(deepProperty); // $ExpectType any[]
+    extractChainTypes(_.chain(recordDictionary).map(deepProperty)); // $ExpectType ChainType<any[], any>
 
     // deep property iteratee - dictionaries - collect
-    _.collect(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType any[]
-    _(stringRecordDictionary).collect(stringRecordPropertyPath); // $ExpectType any[]
-    extractChainTypes(_.chain(stringRecordDictionary).collect(stringRecordPropertyPath)); // $ExpectType ChainType<any[], any>
+    _.collect(recordDictionary, deepProperty); // $ExpectType any[]
+    _(recordDictionary).collect(deepProperty); // $ExpectType any[]
+    extractChainTypes(_.chain(recordDictionary).collect(deepProperty)); // $ExpectType ChainType<any[], any>
 
     // deep property iteratee - any - map
-    _.map(anyValue, stringRecordPropertyPath); // $ExpectType any[]
-    _(anyValue).map(stringRecordPropertyPath); // $ExpectType any[]
-    extractChainTypes(_.chain(anyValue).map(stringRecordPropertyPath)); // $ExpectType ChainType<any[], any>
+    _.map(anyValue, deepProperty); // $ExpectType any[]
+    _(anyValue).map(deepProperty); // $ExpectType any[]
+    extractChainTypes(_.chain(anyValue).map(deepProperty)); // $ExpectType ChainType<any[], any>
 
     // deep property iteratee - any - collect
-    _.collect(anyValue, stringRecordPropertyPath); // $ExpectType any[]
-    _(anyValue).collect(stringRecordPropertyPath); // $ExpectType any[]
-    extractChainTypes(_.chain(anyValue).collect(stringRecordPropertyPath)); // $ExpectType ChainType<any[], any>
+    _.collect(anyValue, deepProperty); // $ExpectType any[]
+    _(anyValue).collect(deepProperty); // $ExpectType any[]
+    extractChainTypes(_.chain(anyValue).collect(deepProperty)); // $ExpectType ChainType<any[], any>
 }
 
 // reduce, foldl, inject
 {
-    const stringMemo = '';
-    const dictionaryMemo: _.Dictionary<number> = {};
-
     // constant primitive memo and memo-type result - lists - reduce
-    _.reduce(stringRecordList, stringRecordListMemoIterator, stringMemo); // $ExpectType string
-    _.reduce(stringRecordList, stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    _(stringRecordList).reduce(stringRecordListMemoIterator, stringMemo); // $ExpectType string
-    _(stringRecordList).reduce(stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    extractChainTypes(_.chain(stringRecordList).reduce(stringRecordListMemoIterator, stringMemo)); // $ExpectType ChainType<string, string>
-    extractChainTypes(_.chain(stringRecordList).reduce(stringRecordPartialMemoIterator, stringMemo, context)); // $ExpectType ChainType<string, string>
+    _.reduce(recordList, recordListStringReducer, stringValue); // $ExpectType string
+    _.reduce(recordList, recordStringReducer, stringValue, context); // $ExpectType string
+    _(recordList).reduce(recordListStringReducer, stringValue); // $ExpectType string
+    _(recordList).reduce(recordStringReducer, stringValue, context); // $ExpectType string
+    extractChainTypes(_.chain(recordList).reduce(recordListStringReducer, stringValue)); // $ExpectType ChainType<string, string>
+    extractChainTypes(_.chain(recordList).reduce(recordStringReducer, stringValue, context)); // $ExpectType ChainType<string, string>
 
     // constant primitive memo and memo-type result - foldl
-    _.foldl(stringRecordList, stringRecordListMemoIterator, stringMemo); // $ExpectType string
-    _.foldl(stringRecordList, stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    _(stringRecordList).foldl(stringRecordListMemoIterator, stringMemo); // $ExpectType string
-    _(stringRecordList).foldl(stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    extractChainTypes(_.chain(stringRecordList).foldl(stringRecordListMemoIterator, stringMemo)); // $ExpectType ChainType<string, string>
-    extractChainTypes(_.chain(stringRecordList).foldl(stringRecordPartialMemoIterator, stringMemo, context)); // $ExpectType ChainType<string, string>
+    _.foldl(recordList, recordListStringReducer, stringValue); // $ExpectType string
+    _.foldl(recordList, recordStringReducer, stringValue, context); // $ExpectType string
+    _(recordList).foldl(recordListStringReducer, stringValue); // $ExpectType string
+    _(recordList).foldl(recordStringReducer, stringValue, context); // $ExpectType string
+    extractChainTypes(_.chain(recordList).foldl(recordListStringReducer, stringValue)); // $ExpectType ChainType<string, string>
+    extractChainTypes(_.chain(recordList).foldl(recordStringReducer, stringValue, context)); // $ExpectType ChainType<string, string>
 
     // constant primitive memo and memo-type result - inject
-    _.inject(stringRecordList, stringRecordListMemoIterator, stringMemo); // $ExpectType string
-    _.inject(stringRecordList, stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    _(stringRecordList).inject(stringRecordListMemoIterator, stringMemo); // $ExpectType string
-    _(stringRecordList).inject(stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    extractChainTypes(_.chain(stringRecordList).inject(stringRecordListMemoIterator, stringMemo)); // $ExpectType ChainType<string, string>
-    extractChainTypes(_.chain(stringRecordList).inject(stringRecordPartialMemoIterator, stringMemo, context)); // $ExpectType ChainType<string, string>
+    _.inject(recordList, recordListStringReducer, stringValue); // $ExpectType string
+    _.inject(recordList, recordStringReducer, stringValue, context); // $ExpectType string
+    _(recordList).inject(recordListStringReducer, stringValue); // $ExpectType string
+    _(recordList).inject(recordStringReducer, stringValue, context); // $ExpectType string
+    extractChainTypes(_.chain(recordList).inject(recordListStringReducer, stringValue)); // $ExpectType ChainType<string, string>
+    extractChainTypes(_.chain(recordList).inject(recordStringReducer, stringValue, context)); // $ExpectType ChainType<string, string>
 
     // constant primitive memo and memo-type result - dictionaries - reduce
-    _.reduce(stringRecordDictionary, stringRecordDictionaryMemoIterator, stringMemo); // $ExpectType string
-    _.reduce(stringRecordDictionary, stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    _(stringRecordDictionary).reduce(stringRecordDictionaryMemoIterator, stringMemo); // $ExpectType string
-    _(stringRecordDictionary).reduce(stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    extractChainTypes(_.chain(stringRecordDictionary).reduce(stringRecordDictionaryMemoIterator, stringMemo)); // $ExpectType ChainType<string, string>
-    extractChainTypes(_.chain(stringRecordDictionary).reduce(stringRecordPartialMemoIterator, stringMemo, context)); // $ExpectType ChainType<string, string>
+    _.reduce(recordDictionary, recordDictionaryStringReducer, stringValue); // $ExpectType string
+    _.reduce(recordDictionary, recordStringReducer, stringValue, context); // $ExpectType string
+    _(recordDictionary).reduce(recordDictionaryStringReducer, stringValue); // $ExpectType string
+    _(recordDictionary).reduce(recordStringReducer, stringValue, context); // $ExpectType string
+    extractChainTypes(_.chain(recordDictionary).reduce(recordDictionaryStringReducer, stringValue)); // $ExpectType ChainType<string, string>
+    extractChainTypes(_.chain(recordDictionary).reduce(recordStringReducer, stringValue, context)); // $ExpectType ChainType<string, string>
 
     // constant primitive memo and memo-type result - dictionaries - foldl
-    _.foldl(stringRecordDictionary, stringRecordDictionaryMemoIterator, stringMemo); // $ExpectType string
-    _.foldl(stringRecordDictionary, stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    _(stringRecordDictionary).foldl(stringRecordDictionaryMemoIterator, stringMemo); // $ExpectType string
-    _(stringRecordDictionary).foldl(stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    extractChainTypes(_.chain(stringRecordDictionary).foldl(stringRecordDictionaryMemoIterator, stringMemo)); // $ExpectType ChainType<string, string>
-    extractChainTypes(_.chain(stringRecordDictionary).foldl(stringRecordPartialMemoIterator, stringMemo, context)); // $ExpectType ChainType<string, string>
+    _.foldl(recordDictionary, recordDictionaryStringReducer, stringValue); // $ExpectType string
+    _.foldl(recordDictionary, recordStringReducer, stringValue, context); // $ExpectType string
+    _(recordDictionary).foldl(recordDictionaryStringReducer, stringValue); // $ExpectType string
+    _(recordDictionary).foldl(recordStringReducer, stringValue, context); // $ExpectType string
+    extractChainTypes(_.chain(recordDictionary).foldl(recordDictionaryStringReducer, stringValue)); // $ExpectType ChainType<string, string>
+    extractChainTypes(_.chain(recordDictionary).foldl(recordStringReducer, stringValue, context)); // $ExpectType ChainType<string, string>
 
     // constant primitive memo and memo-type result - dictionaries - inject
-    _.inject(stringRecordDictionary, stringRecordDictionaryMemoIterator, stringMemo); // $ExpectType string
-    _.inject(stringRecordDictionary, stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    _(stringRecordDictionary).inject(stringRecordDictionaryMemoIterator, stringMemo); // $ExpectType string
-    _(stringRecordDictionary).inject(stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    extractChainTypes(_.chain(stringRecordDictionary).inject(stringRecordDictionaryMemoIterator, stringMemo)); // $ExpectType ChainType<string, string>
-    extractChainTypes(_.chain(stringRecordDictionary).inject(stringRecordPartialMemoIterator, stringMemo, context)); // $ExpectType ChainType<string, string>
+    _.inject(recordDictionary, recordDictionaryStringReducer, stringValue); // $ExpectType string
+    _.inject(recordDictionary, recordStringReducer, stringValue, context); // $ExpectType string
+    _(recordDictionary).inject(recordDictionaryStringReducer, stringValue); // $ExpectType string
+    _(recordDictionary).inject(recordStringReducer, stringValue, context); // $ExpectType string
+    extractChainTypes(_.chain(recordDictionary).inject(recordDictionaryStringReducer, stringValue)); // $ExpectType ChainType<string, string>
+    extractChainTypes(_.chain(recordDictionary).inject(recordStringReducer, stringValue, context)); // $ExpectType ChainType<string, string>
 
     // object memo and memo-type result - strings - reduce
-    _.reduce(simpleString, stringListMemoIterator, dictionaryMemo); // $ExpectType Dictionary<number>
-    _.reduce(simpleString, stringListMemoIterator, dictionaryMemo, context); // $ExpectType Dictionary<number>
-    _(simpleString).reduce(stringListMemoIterator, dictionaryMemo); // $ExpectType Dictionary<number>
-    _(simpleString).reduce(stringListMemoIterator, dictionaryMemo, context); // $ExpectType Dictionary<number>
-    extractChainTypes(_.chain(simpleString).reduce(stringListMemoIterator, dictionaryMemo)); // $ExpectType ChainType<Dictionary<number>, number>
-    extractChainTypes(_.chain(simpleString).reduce(stringListMemoIterator, dictionaryMemo, context)); // $ExpectType ChainType<Dictionary<number>, number>
+    _.reduce(stringValue, dictionaryStringReducer, numberDictionary); // $ExpectType Dictionary<number>
+    _.reduce(stringValue, dictionaryStringReducer, numberDictionary, context); // $ExpectType Dictionary<number>
+    _(stringValue).reduce(dictionaryStringReducer, numberDictionary); // $ExpectType Dictionary<number>
+    _(stringValue).reduce(dictionaryStringReducer, numberDictionary, context); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(stringValue).reduce(dictionaryStringReducer, numberDictionary)); // $ExpectType ChainType<Dictionary<number>, number>
+    extractChainTypes(_.chain(stringValue).reduce(dictionaryStringReducer, numberDictionary, context)); // $ExpectType ChainType<Dictionary<number>, number>
 
     // object memo and memo-type result - strings - foldl
-    _.foldl(simpleString, stringListMemoIterator, dictionaryMemo); // $ExpectType Dictionary<number>
-    _.foldl(simpleString, stringListMemoIterator, dictionaryMemo, context); // $ExpectType Dictionary<number>
-    _(simpleString).foldl(stringListMemoIterator, dictionaryMemo); // $ExpectType Dictionary<number>
-    _(simpleString).foldl(stringListMemoIterator, dictionaryMemo, context); // $ExpectType Dictionary<number>
-    extractChainTypes(_.chain(simpleString).foldl(stringListMemoIterator, dictionaryMemo)); // $ExpectType ChainType<Dictionary<number>, number>
-    extractChainTypes(_.chain(simpleString).foldl(stringListMemoIterator, dictionaryMemo, context)); // $ExpectType ChainType<Dictionary<number>, number>
+    _.foldl(stringValue, dictionaryStringReducer, numberDictionary); // $ExpectType Dictionary<number>
+    _.foldl(stringValue, dictionaryStringReducer, numberDictionary, context); // $ExpectType Dictionary<number>
+    _(stringValue).foldl(dictionaryStringReducer, numberDictionary); // $ExpectType Dictionary<number>
+    _(stringValue).foldl(dictionaryStringReducer, numberDictionary, context); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(stringValue).foldl(dictionaryStringReducer, numberDictionary)); // $ExpectType ChainType<Dictionary<number>, number>
+    extractChainTypes(_.chain(stringValue).foldl(dictionaryStringReducer, numberDictionary, context)); // $ExpectType ChainType<Dictionary<number>, number>
 
     // object memo and memo-type result - strings - inject
-    _.inject(simpleString, stringListMemoIterator, dictionaryMemo); // $ExpectType Dictionary<number>
-    _.inject(simpleString, stringListMemoIterator, dictionaryMemo, context); // $ExpectType Dictionary<number>
-    _(simpleString).inject(stringListMemoIterator, dictionaryMemo); // $ExpectType Dictionary<number>
-    _(simpleString).inject(stringListMemoIterator, dictionaryMemo, context); // $ExpectType Dictionary<number>
-    extractChainTypes(_.chain(simpleString).inject(stringListMemoIterator, dictionaryMemo)); // $ExpectType ChainType<Dictionary<number>, number>
-    extractChainTypes(_.chain(simpleString).inject(stringListMemoIterator, dictionaryMemo, context)); // $ExpectType ChainType<Dictionary<number>, number>
+    _.inject(stringValue, dictionaryStringReducer, numberDictionary); // $ExpectType Dictionary<number>
+    _.inject(stringValue, dictionaryStringReducer, numberDictionary, context); // $ExpectType Dictionary<number>
+    _(stringValue).inject(dictionaryStringReducer, numberDictionary); // $ExpectType Dictionary<number>
+    _(stringValue).inject(dictionaryStringReducer, numberDictionary, context); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(stringValue).inject(dictionaryStringReducer, numberDictionary)); // $ExpectType ChainType<Dictionary<number>, number>
+    extractChainTypes(_.chain(stringValue).inject(dictionaryStringReducer, numberDictionary, context)); // $ExpectType ChainType<Dictionary<number>, number>
 
     // no memo and collection type result - strings - reduce
-    _.reduce(simpleString, stringListSelfMemoIterator); // $ExpectType string | undefined
-    _(simpleString).reduce(stringListSelfMemoIterator); // $ExpectType string | undefined
-    extractChainTypes(_.chain(simpleString).reduce(stringListSelfMemoIterator)); // $ExpectType ChainType<string | undefined, string>
+    _.reduce(stringValue, stringStringReducer); // $ExpectType string | undefined
+    _(stringValue).reduce(stringStringReducer); // $ExpectType string | undefined
+    extractChainTypes(_.chain(stringValue).reduce(stringStringReducer)); // $ExpectType ChainType<string | undefined, string>
 
     // no memo and collection type result - strings - foldl
-    _.foldl(simpleString, stringListSelfMemoIterator); // $ExpectType string | undefined
-    _(simpleString).foldl(stringListSelfMemoIterator); // $ExpectType string | undefined
-    extractChainTypes(_.chain(simpleString).foldl(stringListSelfMemoIterator)); // $ExpectType ChainType<string | undefined, string>
+    _.foldl(stringValue, stringStringReducer); // $ExpectType string | undefined
+    _(stringValue).foldl(stringStringReducer); // $ExpectType string | undefined
+    extractChainTypes(_.chain(stringValue).foldl(stringStringReducer)); // $ExpectType ChainType<string | undefined, string>
 
     // no memo and collection type result - strings - inject
-    _.inject(simpleString, stringListSelfMemoIterator); // $ExpectType string | undefined
-    _(simpleString).inject(stringListSelfMemoIterator); // $ExpectType string | undefined
-    extractChainTypes(_.chain(simpleString).inject(stringListSelfMemoIterator)); // $ExpectType ChainType<string | undefined, string>
+    _.inject(stringValue, stringStringReducer); // $ExpectType string | undefined
+    _(stringValue).inject(stringStringReducer); // $ExpectType string | undefined
+    extractChainTypes(_.chain(stringValue).inject(stringStringReducer)); // $ExpectType ChainType<string | undefined, string>
 
     // constant primitive memo and type union result - lists - reduce
-    _.reduce(stringRecordList, resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    _(stringRecordList).reduce(resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    extractChainTypes(_.chain(stringRecordList).reduce(resultUnionPartialMemoIterator, stringMemo)); // $ExpectType ChainType<string | StringRecord, string>
+    _.reduce(recordList, recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    _(recordList).reduce(recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    extractChainTypes(_.chain(recordList).reduce(recordUnionReducer, stringValue)); // $ExpectType ChainType<string | StringRecord, string>
 
     // constant primitive memo and type union result - foldl
-    _.foldl(stringRecordList, resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    _(stringRecordList).foldl(resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    extractChainTypes(_.chain(stringRecordList).foldl(resultUnionPartialMemoIterator, stringMemo)); // $ExpectType ChainType<string | StringRecord, string>
+    _.foldl(recordList, recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    _(recordList).foldl(recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    extractChainTypes(_.chain(recordList).foldl(recordUnionReducer, stringValue)); // $ExpectType ChainType<string | StringRecord, string>
 
     // constant primitive memo and type union result - inject
-    _.inject(stringRecordList, resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    _(stringRecordList).inject(resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    extractChainTypes(_.chain(stringRecordList).inject(resultUnionPartialMemoIterator, stringMemo)); // $ExpectType ChainType<string | StringRecord, string>
+    _.inject(recordList, recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    _(recordList).inject(recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    extractChainTypes(_.chain(recordList).inject(recordUnionReducer, stringValue)); // $ExpectType ChainType<string | StringRecord, string>
 
     // constant primitive memo and type union result - dictionaries - reduce
-    _.reduce(stringRecordDictionary, resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    _(stringRecordDictionary).reduce(resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    extractChainTypes(_.chain(stringRecordDictionary).reduce(resultUnionPartialMemoIterator, stringMemo)); // $ExpectType ChainType<string | StringRecord, string>
+    _.reduce(recordDictionary, recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    _(recordDictionary).reduce(recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    extractChainTypes(_.chain(recordDictionary).reduce(recordUnionReducer, stringValue)); // $ExpectType ChainType<string | StringRecord, string>
 
     // constant primitive memo and type union result - dictionaries - foldl
-    _.foldl(stringRecordDictionary, resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    _(stringRecordDictionary).foldl(resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    extractChainTypes(_.chain(stringRecordDictionary).foldl(resultUnionPartialMemoIterator, stringMemo)); // $ExpectType ChainType<string | StringRecord, string>
+    _.foldl(recordDictionary, recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    _(recordDictionary).foldl(recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    extractChainTypes(_.chain(recordDictionary).foldl(recordUnionReducer, stringValue)); // $ExpectType ChainType<string | StringRecord, string>
 
     // constant primitive memo and type union result - dictionaries - inject
-    _.inject(stringRecordDictionary, resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    _(stringRecordDictionary).inject(resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    extractChainTypes(_.chain(stringRecordDictionary).inject(resultUnionPartialMemoIterator, stringMemo)); // $ExpectType ChainType<string | StringRecord, string>
+    _.inject(recordDictionary, recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    _(recordDictionary).inject(recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    extractChainTypes(_.chain(recordDictionary).inject(recordUnionReducer, stringValue)); // $ExpectType ChainType<string | StringRecord, string>
 
     // no memo and union type result - strings - reduce
-    _.reduce(simpleString, resultUnionStringListMemoIterator); // $ExpectType string | number | undefined
-    _(simpleString).reduce(resultUnionStringListMemoIterator); // $ExpectType string | number | undefined
-    extractChainTypes(_.chain(simpleString).reduce(resultUnionStringListMemoIterator)); // $ExpectType ChainType<string | number | undefined, string>
+    _.reduce(stringValue, unionStringReducer); // $ExpectType string | number | undefined
+    _(stringValue).reduce(unionStringReducer); // $ExpectType string | number | undefined
+    extractChainTypes(_.chain(stringValue).reduce(unionStringReducer)); // $ExpectType ChainType<string | number | undefined, string>
 
     // no memo and union type result - strings - foldl
-    _.foldl(simpleString, resultUnionStringListMemoIterator); // $ExpectType string | number | undefined
-    _(simpleString).foldl(resultUnionStringListMemoIterator); // $ExpectType string | number | undefined
-    extractChainTypes(_.chain(simpleString).foldl(resultUnionStringListMemoIterator)); // $ExpectType ChainType<string | number | undefined, string>
+    _.foldl(stringValue, unionStringReducer); // $ExpectType string | number | undefined
+    _(stringValue).foldl(unionStringReducer); // $ExpectType string | number | undefined
+    extractChainTypes(_.chain(stringValue).foldl(unionStringReducer)); // $ExpectType ChainType<string | number | undefined, string>
 
     // no memo and union type result - strings - inject
-    _.inject(simpleString, resultUnionStringListMemoIterator); // $ExpectType string | number | undefined
-    _(simpleString).inject(resultUnionStringListMemoIterator); // $ExpectType string | number | undefined
-    extractChainTypes(_.chain(simpleString).inject(resultUnionStringListMemoIterator)); // $ExpectType ChainType<string | number | undefined, string>
+    _.inject(stringValue, unionStringReducer); // $ExpectType string | number | undefined
+    _(stringValue).inject(unionStringReducer); // $ExpectType string | number | undefined
+    extractChainTypes(_.chain(stringValue).inject(unionStringReducer)); // $ExpectType ChainType<string | number | undefined, string>
 }
 
 // reduceRight, foldr
 {
-    const stringMemo = '';
-    const dictionaryMemo: _.Dictionary<number> = {};
-
     // constant primitive memo and memo-type result - lists - reduceRight
-    _.reduceRight(stringRecordList, stringRecordListMemoIterator, stringMemo); // $ExpectType string
-    _.reduceRight(stringRecordList, stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    _(stringRecordList).reduceRight(stringRecordListMemoIterator, stringMemo); // $ExpectType string
-    _(stringRecordList).reduceRight(stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    extractChainTypes(_.chain(stringRecordList).reduceRight(stringRecordListMemoIterator, stringMemo)); // $ExpectType ChainType<string, string>
-    extractChainTypes(_.chain(stringRecordList).reduceRight(stringRecordPartialMemoIterator, stringMemo, context)); // $ExpectType ChainType<string, string>
+    _.reduceRight(recordList, recordListStringReducer, stringValue); // $ExpectType string
+    _.reduceRight(recordList, recordStringReducer, stringValue, context); // $ExpectType string
+    _(recordList).reduceRight(recordListStringReducer, stringValue); // $ExpectType string
+    _(recordList).reduceRight(recordStringReducer, stringValue, context); // $ExpectType string
+    extractChainTypes(_.chain(recordList).reduceRight(recordListStringReducer, stringValue)); // $ExpectType ChainType<string, string>
+    extractChainTypes(_.chain(recordList).reduceRight(recordStringReducer, stringValue, context)); // $ExpectType ChainType<string, string>
 
     // constant primitive memo and memo-type result - foldr
-    _.foldr(stringRecordList, stringRecordListMemoIterator, stringMemo); // $ExpectType string
-    _.foldr(stringRecordList, stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    _(stringRecordList).foldr(stringRecordListMemoIterator, stringMemo); // $ExpectType string
-    _(stringRecordList).foldr(stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    extractChainTypes(_.chain(stringRecordList).foldr(stringRecordListMemoIterator, stringMemo)); // $ExpectType ChainType<string, string>
-    extractChainTypes(_.chain(stringRecordList).foldr(stringRecordPartialMemoIterator, stringMemo, context)); // $ExpectType ChainType<string, string>
+    _.foldr(recordList, recordListStringReducer, stringValue); // $ExpectType string
+    _.foldr(recordList, recordStringReducer, stringValue, context); // $ExpectType string
+    _(recordList).foldr(recordListStringReducer, stringValue); // $ExpectType string
+    _(recordList).foldr(recordStringReducer, stringValue, context); // $ExpectType string
+    extractChainTypes(_.chain(recordList).foldr(recordListStringReducer, stringValue)); // $ExpectType ChainType<string, string>
+    extractChainTypes(_.chain(recordList).foldr(recordStringReducer, stringValue, context)); // $ExpectType ChainType<string, string>
 
     // constant primitive memo and memo-type result - dictionaries - reduceRight
-    _.reduceRight(stringRecordDictionary, stringRecordDictionaryMemoIterator, stringMemo); // $ExpectType string
-    _.reduceRight(stringRecordDictionary, stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    _(stringRecordDictionary).reduceRight(stringRecordDictionaryMemoIterator, stringMemo); // $ExpectType string
-    _(stringRecordDictionary).reduceRight(stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    extractChainTypes(_.chain(stringRecordDictionary).reduceRight(stringRecordDictionaryMemoIterator, stringMemo)); // $ExpectType ChainType<string, string>
-    extractChainTypes(_.chain(stringRecordDictionary).reduceRight(stringRecordPartialMemoIterator, stringMemo, context)); // $ExpectType ChainType<string, string>
+    _.reduceRight(recordDictionary, recordDictionaryStringReducer, stringValue); // $ExpectType string
+    _.reduceRight(recordDictionary, recordStringReducer, stringValue, context); // $ExpectType string
+    _(recordDictionary).reduceRight(recordDictionaryStringReducer, stringValue); // $ExpectType string
+    _(recordDictionary).reduceRight(recordStringReducer, stringValue, context); // $ExpectType string
+    extractChainTypes(_.chain(recordDictionary).reduceRight(recordDictionaryStringReducer, stringValue)); // $ExpectType ChainType<string, string>
+    extractChainTypes(_.chain(recordDictionary).reduceRight(recordStringReducer, stringValue, context)); // $ExpectType ChainType<string, string>
 
     // constant primitive memo and memo-type result - dictionaries - foldr
-    _.foldr(stringRecordDictionary, stringRecordDictionaryMemoIterator, stringMemo); // $ExpectType string
-    _.foldr(stringRecordDictionary, stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    _(stringRecordDictionary).foldr(stringRecordDictionaryMemoIterator, stringMemo); // $ExpectType string
-    _(stringRecordDictionary).foldr(stringRecordPartialMemoIterator, stringMemo, context); // $ExpectType string
-    extractChainTypes(_.chain(stringRecordDictionary).foldr(stringRecordDictionaryMemoIterator, stringMemo)); // $ExpectType ChainType<string, string>
-    extractChainTypes(_.chain(stringRecordDictionary).foldr(stringRecordPartialMemoIterator, stringMemo, context)); // $ExpectType ChainType<string, string>
+    _.foldr(recordDictionary, recordDictionaryStringReducer, stringValue); // $ExpectType string
+    _.foldr(recordDictionary, recordStringReducer, stringValue, context); // $ExpectType string
+    _(recordDictionary).foldr(recordDictionaryStringReducer, stringValue); // $ExpectType string
+    _(recordDictionary).foldr(recordStringReducer, stringValue, context); // $ExpectType string
+    extractChainTypes(_.chain(recordDictionary).foldr(recordDictionaryStringReducer, stringValue)); // $ExpectType ChainType<string, string>
+    extractChainTypes(_.chain(recordDictionary).foldr(recordStringReducer, stringValue, context)); // $ExpectType ChainType<string, string>
 
     // object memo and memo-type result - strings - reduceRight
-    _.reduceRight(simpleString, stringListMemoIterator, dictionaryMemo); // $ExpectType Dictionary<number>
-    _.reduceRight(simpleString, stringListMemoIterator, dictionaryMemo, context); // $ExpectType Dictionary<number>
-    _(simpleString).reduceRight(stringListMemoIterator, dictionaryMemo); // $ExpectType Dictionary<number>
-    _(simpleString).reduceRight(stringListMemoIterator, dictionaryMemo, context); // $ExpectType Dictionary<number>
-    extractChainTypes(_.chain(simpleString).reduceRight(stringListMemoIterator, dictionaryMemo)); // $ExpectType ChainType<Dictionary<number>, number>
-    extractChainTypes(_.chain(simpleString).reduceRight(stringListMemoIterator, dictionaryMemo, context)); // $ExpectType ChainType<Dictionary<number>, number>
+    _.reduceRight(stringValue, dictionaryStringReducer, numberDictionary); // $ExpectType Dictionary<number>
+    _.reduceRight(stringValue, dictionaryStringReducer, numberDictionary, context); // $ExpectType Dictionary<number>
+    _(stringValue).reduceRight(dictionaryStringReducer, numberDictionary); // $ExpectType Dictionary<number>
+    _(stringValue).reduceRight(dictionaryStringReducer, numberDictionary, context); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(stringValue).reduceRight(dictionaryStringReducer, numberDictionary)); // $ExpectType ChainType<Dictionary<number>, number>
+    extractChainTypes(_.chain(stringValue).reduceRight(dictionaryStringReducer, numberDictionary, context)); // $ExpectType ChainType<Dictionary<number>, number>
 
     // object memo and memo-type result - strings - foldr
-    _.foldr(simpleString, stringListMemoIterator, dictionaryMemo); // $ExpectType Dictionary<number>
-    _.foldr(simpleString, stringListMemoIterator, dictionaryMemo, context); // $ExpectType Dictionary<number>
-    _(simpleString).foldr(stringListMemoIterator, dictionaryMemo); // $ExpectType Dictionary<number>
-    _(simpleString).foldr(stringListMemoIterator, dictionaryMemo, context); // $ExpectType Dictionary<number>
-    extractChainTypes(_.chain(simpleString).foldr(stringListMemoIterator, dictionaryMemo)); // $ExpectType ChainType<Dictionary<number>, number>
-    extractChainTypes(_.chain(simpleString).foldr(stringListMemoIterator, dictionaryMemo, context)); // $ExpectType ChainType<Dictionary<number>, number>
+    _.foldr(stringValue, dictionaryStringReducer, numberDictionary); // $ExpectType Dictionary<number>
+    _.foldr(stringValue, dictionaryStringReducer, numberDictionary, context); // $ExpectType Dictionary<number>
+    _(stringValue).foldr(dictionaryStringReducer, numberDictionary); // $ExpectType Dictionary<number>
+    _(stringValue).foldr(dictionaryStringReducer, numberDictionary, context); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(stringValue).foldr(dictionaryStringReducer, numberDictionary)); // $ExpectType ChainType<Dictionary<number>, number>
+    extractChainTypes(_.chain(stringValue).foldr(dictionaryStringReducer, numberDictionary, context)); // $ExpectType ChainType<Dictionary<number>, number>
 
     // no memo and collection type result - strings - reduceRight
-    _.reduceRight(simpleString, stringListSelfMemoIterator); // $ExpectType string | undefined
-    _(simpleString).reduceRight(stringListSelfMemoIterator); // $ExpectType string | undefined
-    extractChainTypes(_.chain(simpleString).reduceRight(stringListSelfMemoIterator)); // $ExpectType ChainType<string | undefined, string>
+    _.reduceRight(stringValue, stringStringReducer); // $ExpectType string | undefined
+    _(stringValue).reduceRight(stringStringReducer); // $ExpectType string | undefined
+    extractChainTypes(_.chain(stringValue).reduceRight(stringStringReducer)); // $ExpectType ChainType<string | undefined, string>
 
     // no memo and collection type result - strings - foldr
-    _.foldr(simpleString, stringListSelfMemoIterator); // $ExpectType string | undefined
-    _(simpleString).foldr(stringListSelfMemoIterator); // $ExpectType string | undefined
-    extractChainTypes(_.chain(simpleString).foldr(stringListSelfMemoIterator)); // $ExpectType ChainType<string | undefined, string>
+    _.foldr(stringValue, stringStringReducer); // $ExpectType string | undefined
+    _(stringValue).foldr(stringStringReducer); // $ExpectType string | undefined
+    extractChainTypes(_.chain(stringValue).foldr(stringStringReducer)); // $ExpectType ChainType<string | undefined, string>
 
     // constant primitive memo and type union result - lists - reduceRight
-    _.reduceRight(stringRecordList, resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    _(stringRecordList).reduceRight(resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    extractChainTypes(_.chain(stringRecordList).reduceRight(resultUnionPartialMemoIterator, stringMemo)); // $ExpectType ChainType<string | StringRecord, string>
+    _.reduceRight(recordList, recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    _(recordList).reduceRight(recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    extractChainTypes(_.chain(recordList).reduceRight(recordUnionReducer, stringValue)); // $ExpectType ChainType<string | StringRecord, string>
 
     // constant primitive memo and type union result - lists - foldr
-    _.foldl(stringRecordList, resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    _(stringRecordList).foldl(resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    extractChainTypes(_.chain(stringRecordList).foldl(resultUnionPartialMemoIterator, stringMemo)); // $ExpectType ChainType<string | StringRecord, string>
+    _.foldl(recordList, recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    _(recordList).foldl(recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    extractChainTypes(_.chain(recordList).foldl(recordUnionReducer, stringValue)); // $ExpectType ChainType<string | StringRecord, string>
 
     // constant primitive memo and type union result - dictionaries - reduceRight
-    _.reduceRight(stringRecordDictionary, resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    _(stringRecordDictionary).reduceRight(resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    extractChainTypes(_.chain(stringRecordDictionary).reduceRight(resultUnionPartialMemoIterator, stringMemo)); // $ExpectType ChainType<string | StringRecord, string>
+    _.reduceRight(recordDictionary, recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    _(recordDictionary).reduceRight(recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    extractChainTypes(_.chain(recordDictionary).reduceRight(recordUnionReducer, stringValue)); // $ExpectType ChainType<string | StringRecord, string>
 
     // constant primitive memo and type union result - dictionaries - foldr
-    _.foldr(stringRecordDictionary, resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    _(stringRecordDictionary).foldr(resultUnionPartialMemoIterator, stringMemo); // $ExpectType string | StringRecord
-    extractChainTypes(_.chain(stringRecordDictionary).foldr(resultUnionPartialMemoIterator, stringMemo)); // $ExpectType ChainType<string | StringRecord, string>
+    _.foldr(recordDictionary, recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    _(recordDictionary).foldr(recordUnionReducer, stringValue); // $ExpectType string | StringRecord
+    extractChainTypes(_.chain(recordDictionary).foldr(recordUnionReducer, stringValue)); // $ExpectType ChainType<string | StringRecord, string>
 
     // no memo and union type result - strings - reduceRight
-    _.reduceRight(simpleString, resultUnionStringListMemoIterator); // $ExpectType string | number | undefined
-    _(simpleString).reduceRight(resultUnionStringListMemoIterator); // $ExpectType string | number | undefined
-    extractChainTypes(_.chain(simpleString).reduceRight(resultUnionStringListMemoIterator)); // $ExpectType ChainType<string | number | undefined, string>
+    _.reduceRight(stringValue, unionStringReducer); // $ExpectType string | number | undefined
+    _(stringValue).reduceRight(unionStringReducer); // $ExpectType string | number | undefined
+    extractChainTypes(_.chain(stringValue).reduceRight(unionStringReducer)); // $ExpectType ChainType<string | number | undefined, string>
 
     // no memo and union type result - strings - foldr
-    _.foldr(simpleString, resultUnionStringListMemoIterator); // $ExpectType string | number | undefined
-    _(simpleString).foldr(resultUnionStringListMemoIterator); // $ExpectType string | number | undefined
-    extractChainTypes(_.chain(simpleString).foldr(resultUnionStringListMemoIterator)); // $ExpectType ChainType<string | number | undefined, string>
+    _.foldr(stringValue, unionStringReducer); // $ExpectType string | number | undefined
+    _(stringValue).foldr(unionStringReducer); // $ExpectType string | number | undefined
+    extractChainTypes(_.chain(stringValue).foldr(unionStringReducer)); // $ExpectType ChainType<string | number | undefined, string>
 }
 
 // find, detect
 {
     // function iteratee - lists - find
-    _.find(stringRecordList, stringRecordListBooleanIterator, context); // $ExpectType StringRecordOrUndefined
-    _(stringRecordList).find(stringRecordListBooleanIterator, context); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordList).find(stringRecordListBooleanIterator, context)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.find(recordList, recordListTester, context); // $ExpectType StringRecord | undefined
+    _(recordList).find(recordListTester, context); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(recordList).find(recordListTester, context)); // $ExpectType ChainType<StringRecord | undefined, never>
 
     // function iteratee - lists - detect
-    _.detect(stringRecordList, stringRecordListBooleanIterator, context); // $ExpectType StringRecordOrUndefined
-    _(stringRecordList).detect(stringRecordListBooleanIterator, context); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordList).detect(stringRecordListBooleanIterator, context)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.detect(recordList, recordListTester, context); // $ExpectType StringRecord | undefined
+    _(recordList).detect(recordListTester, context); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(recordList).detect(recordListTester, context)); // $ExpectType ChainType<StringRecord | undefined, never>
 
     // function iteratee - dictionaries - find
-    _.find(stringRecordDictionary, stringRecordDictionaryBooleanIterator, context); // $ExpectType StringRecordOrUndefined
-    _(stringRecordDictionary).find(stringRecordDictionaryBooleanIterator, context); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordDictionary).find(stringRecordDictionaryBooleanIterator, context)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.find(recordDictionary, recordDictionaryTester, context); // $ExpectType StringRecord | undefined
+    _(recordDictionary).find(recordDictionaryTester, context); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(recordDictionary).find(recordDictionaryTester, context)); // $ExpectType ChainType<StringRecord | undefined, never>
 
     // function iteratee - dictionaries - detect
-    _.detect(stringRecordDictionary, stringRecordDictionaryBooleanIterator, context); // $ExpectType StringRecordOrUndefined
-    _(stringRecordDictionary).detect(stringRecordDictionaryBooleanIterator, context); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordDictionary).detect(stringRecordDictionaryBooleanIterator, context)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.detect(recordDictionary, recordDictionaryTester, context); // $ExpectType StringRecord | undefined
+    _(recordDictionary).detect(recordDictionaryTester, context); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(recordDictionary).detect(recordDictionaryTester, context)); // $ExpectType ChainType<StringRecord | undefined, never>
 
     // function iteratee - strings - find
-    _.find(simpleString, stringListBooleanIterator, context); // $ExpectType string | undefined
-    _(simpleString).find(stringListBooleanIterator, context); // $ExpectType string | undefined
-    extractChainTypes(_.chain(simpleString).find(stringListBooleanIterator, context)); // $ExpectType ChainType<string | undefined, string>
+    _.find(stringValue, stringTester, context); // $ExpectType string | undefined
+    _(stringValue).find(stringTester, context); // $ExpectType string | undefined
+    extractChainTypes(_.chain(stringValue).find(stringTester, context)); // $ExpectType ChainType<string | undefined, string>
 
     // function iteratee - strings - detect
-    _.detect(simpleString, stringListBooleanIterator, context); // $ExpectType string | undefined
-    _(simpleString).detect(stringListBooleanIterator, context); // $ExpectType string | undefined
-    extractChainTypes(_.chain(simpleString).detect(stringListBooleanIterator, context)); // $ExpectType ChainType<string | undefined, string>
+    _.detect(stringValue, stringTester, context); // $ExpectType string | undefined
+    _(stringValue).detect(stringTester, context); // $ExpectType string | undefined
+    extractChainTypes(_.chain(stringValue).detect(stringTester, context)); // $ExpectType ChainType<string | undefined, string>
 
     // function iteratee - any - find
-    _.find(anyValue, stringRecordPartialBooleanIterator, context); // $ExpectType any
-    _(anyValue).find(stringRecordPartialBooleanIterator, context); // $ExpectType any
-    extractChainTypes(_.chain(anyValue).find(stringRecordPartialBooleanIterator, context)); // $ExpectType ChainType<any, any>
+    _.find(anyValue, recordTester, context); // $ExpectType any
+    _(anyValue).find(recordTester, context); // $ExpectType any
+    extractChainTypes(_.chain(anyValue).find(recordTester, context)); // $ExpectType ChainType<any, any>
 
     // function iteratee - any - detect
-    _.detect(anyValue, stringRecordPartialBooleanIterator, context); // $ExpectType any
-    _(anyValue).detect(stringRecordPartialBooleanIterator, context); // $ExpectType any
-    extractChainTypes(_.chain(anyValue).detect(stringRecordPartialBooleanIterator, context)); // $ExpectType ChainType<any, any>
+    _.detect(anyValue, recordTester, context); // $ExpectType any
+    _(anyValue).detect(recordTester, context); // $ExpectType any
+    extractChainTypes(_.chain(anyValue).detect(recordTester, context)); // $ExpectType ChainType<any, any>
 
     // matcher iteratee - lists - find
-    _.find(stringRecordList, partialStringRecord); // $ExpectType StringRecordOrUndefined
-    _(stringRecordList).find(partialStringRecord); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordList).find(partialStringRecord)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.find(recordList, matcher); // $ExpectType StringRecord | undefined
+    _(recordList).find(matcher); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(recordList).find(matcher)); // $ExpectType ChainType<StringRecord | undefined, never>
 
     // matcher iteratee - dictionaries - detect
-    _.detect(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecordOrUndefined
-    _(stringRecordDictionary).detect(partialStringRecord); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordDictionary).detect(partialStringRecord)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.detect(recordDictionary, matcher); // $ExpectType StringRecord | undefined
+    _(recordDictionary).detect(matcher); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(recordDictionary).detect(matcher)); // $ExpectType ChainType<StringRecord | undefined, never>
 
     // shallow property iteratee - dictionaries - find
-    _.find(stringRecordDictionary, stringRecordProperty); // $ExpectType StringRecordOrUndefined
-    _(stringRecordDictionary).find(stringRecordProperty); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordDictionary).find(stringRecordProperty)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.find(recordDictionary, shallowProperty); // $ExpectType StringRecord | undefined
+    _(recordDictionary).find(shallowProperty); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(recordDictionary).find(shallowProperty)); // $ExpectType ChainType<StringRecord | undefined, never>
 
     // shallow property iteratee - lists - detect
-    _.detect(stringRecordList, stringRecordProperty); // $ExpectType StringRecordOrUndefined
-    _(stringRecordList).detect(stringRecordProperty); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordList).detect(stringRecordProperty)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.detect(recordList, shallowProperty); // $ExpectType StringRecord | undefined
+    _(recordList).detect(shallowProperty); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(recordList).detect(shallowProperty)); // $ExpectType ChainType<StringRecord | undefined, never>
 
     // deep property iteratee - lists - find
-    _.find(stringRecordList, stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
-    _(stringRecordList).find(stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordList).find(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.find(recordList, deepProperty); // $ExpectType StringRecord | undefined
+    _(recordList).find(deepProperty); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(recordList).find(deepProperty)); // $ExpectType ChainType<StringRecord | undefined, never>
 
     // deep property iteratee - dictionaries - detect
-    _.detect(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
-    _(stringRecordDictionary).detect(stringRecordPropertyPath); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordDictionary).detect(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.detect(recordDictionary, deepProperty); // $ExpectType StringRecord | undefined
+    _(recordDictionary).detect(deepProperty); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(recordDictionary).detect(deepProperty)); // $ExpectType ChainType<StringRecord | undefined, never>
 
     // identity iteratee - dictionaries - find
-    _.find(simpleNumberDictionary); // $ExpectType number | undefined
-    _(simpleNumberDictionary).find(); // $ExpectType number | undefined
-    extractChainTypes(_.chain(simpleNumberDictionary).find()); // $ExpectType ChainType<number | undefined, never>
+    _.find(numberDictionary); // $ExpectType number | undefined
+    _(numberDictionary).find(); // $ExpectType number | undefined
+    extractChainTypes(_.chain(numberDictionary).find()); // $ExpectType ChainType<number | undefined, never>
 
     // identity iteratee - lists - detect
-    _.detect(simpleStringList); // $ExpectType string | undefined
-    _(simpleStringList).detect(); // $ExpectType string | undefined
-    extractChainTypes(_.chain(simpleStringList).detect()); // $ExpectType ChainType<string | undefined, string>
+    _.detect(stringList); // $ExpectType string | undefined
+    _(stringList).detect(); // $ExpectType string | undefined
+    extractChainTypes(_.chain(stringList).detect()); // $ExpectType ChainType<string | undefined, string>
 }
 
 // filter, select
 {
     // function iteratee - lists - filter
-    _.filter(stringRecordList, stringRecordListBooleanIterator, context); // $ExpectType StringRecord[]
-    _(stringRecordList).filter(stringRecordListBooleanIterator, context); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).filter(stringRecordListBooleanIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.filter(recordList, recordListTester, context); // $ExpectType StringRecord[]
+    _(recordList).filter(recordListTester, context); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).filter(recordListTester, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // function iteratee - lists - select
-    _.select(stringRecordList, stringRecordListBooleanIterator, context); // $ExpectType StringRecord[]
-    _(stringRecordList).select(stringRecordListBooleanIterator, context); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).select(stringRecordListBooleanIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.select(recordList, recordListTester, context); // $ExpectType StringRecord[]
+    _(recordList).select(recordListTester, context); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).select(recordListTester, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // function iteratee - dictionaries - filter
-    _.filter(stringRecordDictionary, stringRecordDictionaryBooleanIterator, context); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).filter(stringRecordDictionaryBooleanIterator, context); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).filter(stringRecordDictionaryBooleanIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.filter(recordDictionary, recordDictionaryTester, context); // $ExpectType StringRecord[]
+    _(recordDictionary).filter(recordDictionaryTester, context); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordDictionary).filter(recordDictionaryTester, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // function iteratee - dictionaries - select
-    _.select(stringRecordDictionary, stringRecordDictionaryBooleanIterator, context); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).select(stringRecordDictionaryBooleanIterator, context); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).select(stringRecordDictionaryBooleanIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.select(recordDictionary, recordDictionaryTester, context); // $ExpectType StringRecord[]
+    _(recordDictionary).select(recordDictionaryTester, context); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordDictionary).select(recordDictionaryTester, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // function iteratee - strings - filter
-    _.filter(simpleString, stringListBooleanIterator, context); // $ExpectType string[]
-    _(simpleString).filter(stringListBooleanIterator, context); // $ExpectType string[]
-    extractChainTypes(_.chain(simpleString).filter(stringListBooleanIterator, context)); // $ExpectType ChainType<string[], string>
+    _.filter(stringValue, stringTester, context); // $ExpectType string[]
+    _(stringValue).filter(stringTester, context); // $ExpectType string[]
+    extractChainTypes(_.chain(stringValue).filter(stringTester, context)); // $ExpectType ChainType<string[], string>
 
     // function iteratee - strings - select
-    _.select(simpleString, stringListBooleanIterator, context); // $ExpectType string[]
-    _(simpleString).select(stringListBooleanIterator, context); // $ExpectType string[]
-    extractChainTypes(_.chain(simpleString).select(stringListBooleanIterator, context)); // $ExpectType ChainType<string[], string>
+    _.select(stringValue, stringTester, context); // $ExpectType string[]
+    _(stringValue).select(stringTester, context); // $ExpectType string[]
+    extractChainTypes(_.chain(stringValue).select(stringTester, context)); // $ExpectType ChainType<string[], string>
 
     // function iteratee - any - filter
-    _.filter(anyValue, stringRecordPartialBooleanIterator, context); // $ExpectType any[]
-    _(anyValue).filter(stringRecordPartialBooleanIterator, context); // $ExpectType any[]
-    extractChainTypes(_.chain(anyValue).filter(stringRecordPartialBooleanIterator, context)); // $ExpectType ChainType<any[], any>
+    _.filter(anyValue, recordTester, context); // $ExpectType any[]
+    _(anyValue).filter(recordTester, context); // $ExpectType any[]
+    extractChainTypes(_.chain(anyValue).filter(recordTester, context)); // $ExpectType ChainType<any[], any>
 
     // function iteratee - any - select
-    _.select(anyValue, stringRecordPartialBooleanIterator, context); // $ExpectType any[]
-    _(anyValue).select(stringRecordPartialBooleanIterator, context); // $ExpectType any[]
-    extractChainTypes(_.chain(anyValue).select(stringRecordPartialBooleanIterator, context)); // $ExpectType ChainType<any[], any>
+    _.select(anyValue, recordTester, context); // $ExpectType any[]
+    _(anyValue).select(recordTester, context); // $ExpectType any[]
+    extractChainTypes(_.chain(anyValue).select(recordTester, context)); // $ExpectType ChainType<any[], any>
 
     // matcher iteratee - lists - filter
-    _.filter(stringRecordList, partialStringRecord); // $ExpectType StringRecord[]
-    _(stringRecordList).filter(partialStringRecord); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).filter(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.filter(recordList, matcher); // $ExpectType StringRecord[]
+    _(recordList).filter(matcher); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).filter(matcher)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // matcher iteratee - dictionaries - select
-    _.select(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).select(partialStringRecord); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).select(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.select(recordDictionary, matcher); // $ExpectType StringRecord[]
+    _(recordDictionary).select(matcher); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordDictionary).select(matcher)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // shallow property iteratee - dictionaries - filter
-    _.filter(stringRecordDictionary, stringRecordProperty); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).filter(stringRecordProperty); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).filter(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.filter(recordDictionary, shallowProperty); // $ExpectType StringRecord[]
+    _(recordDictionary).filter(shallowProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordDictionary).filter(shallowProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // shallow property iteratee - lists - select
-    _.select(stringRecordList, stringRecordProperty); // $ExpectType StringRecord[]
-    _(stringRecordList).select(stringRecordProperty); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).select(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.select(recordList, shallowProperty); // $ExpectType StringRecord[]
+    _(recordList).select(shallowProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).select(shallowProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // deep property iteratee - lists - filter
-    _.filter(stringRecordList, stringRecordPropertyPath); // $ExpectType StringRecord[]
-    _(stringRecordList).filter(stringRecordPropertyPath); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).filter(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.filter(recordList, deepProperty); // $ExpectType StringRecord[]
+    _(recordList).filter(deepProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).filter(deepProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // deep property iteratee - dictionaries - select
-    _.select(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).select(stringRecordPropertyPath); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).select(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.select(recordDictionary, deepProperty); // $ExpectType StringRecord[]
+    _(recordDictionary).select(deepProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordDictionary).select(deepProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // identity iteratee - dictionaries - filter
-    _.filter(simpleNumberDictionary); // $ExpectType number[]
-    _(simpleNumberDictionary).filter(); // $ExpectType number[]
-    extractChainTypes(_.chain(simpleNumberDictionary).filter()); // $ExpectType ChainType<number[], number>
+    _.filter(numberDictionary); // $ExpectType number[]
+    _(numberDictionary).filter(); // $ExpectType number[]
+    extractChainTypes(_.chain(numberDictionary).filter()); // $ExpectType ChainType<number[], number>
 
     // identity iteratee - lists - select
-    _.select(simpleStringList); // $ExpectType string[]
-    _(simpleStringList).select(); // $ExpectType string[]
-    extractChainTypes(_.chain(simpleStringList).select()); // $ExpectType ChainType<string[], string>
+    _.select(stringList); // $ExpectType string[]
+    _(stringList).select(); // $ExpectType string[]
+    extractChainTypes(_.chain(stringList).select()); // $ExpectType ChainType<string[], string>
 }
 
 // where
 {
     // non-intersecting type union - lists
-    _.where(nonIntersectingPropertiesList, partialStringRecord); // $ExpectType NonIntersectingProperties[]
-    _(nonIntersectingPropertiesList).where(partialStringRecord); // $ExpectType NonIntersectingProperties[]
-    extractChainTypes(_.chain(nonIntersectingPropertiesList).where(partialStringRecord)); // $ExpectType ChainType<NonIntersectingProperties[], NonIntersectingProperties>
+    _.where(nonIntersectingList, matcher); // $ExpectType NonIntersecting[]
+    _(nonIntersectingList).where(matcher); // $ExpectType NonIntersecting[]
+    extractChainTypes(_.chain(nonIntersectingList).where(matcher)); // $ExpectType ChainType<NonIntersecting[], NonIntersecting>
 
     // simple type - dictionaries
-    _.where(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).where(partialStringRecord); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).where(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.where(recordDictionary, matcher); // $ExpectType StringRecord[]
+    _(recordDictionary).where(matcher); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordDictionary).where(matcher)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // any
-    _.where(anyValue, partialStringRecord); // $ExpectType any[]
-    _(anyValue).where(partialStringRecord); // $ExpectType any[]
-    extractChainTypes(_.chain(anyValue).where(partialStringRecord)); // $ExpectType ChainType<any[], any>
+    _.where(anyValue, matcher); // $ExpectType any[]
+    _(anyValue).where(matcher); // $ExpectType any[]
+    extractChainTypes(_.chain(anyValue).where(matcher)); // $ExpectType ChainType<any[], any>
 }
 
 // findWhere
 {
     // non-intersecting type union - lists
-    _.findWhere(nonIntersectingPropertiesList, partialStringRecord); // $ExpectType StringRecord | NonIntersectingStringRecord | undefined
-    _(nonIntersectingPropertiesList).findWhere(partialStringRecord); // $ExpectType StringRecord | NonIntersectingStringRecord | undefined
-    extractChainTypes(_.chain(nonIntersectingPropertiesList).findWhere(partialStringRecord)); // $ExpectType ChainType<StringRecord | NonIntersectingStringRecord | undefined, never>
+    _.findWhere(nonIntersectingList, matcher); // $ExpectType StringRecord | NonIntersectingRecord | undefined
+    _(nonIntersectingList).findWhere(matcher); // $ExpectType StringRecord | NonIntersectingRecord | undefined
+    extractChainTypes(_.chain(nonIntersectingList).findWhere(matcher)); // $ExpectType ChainType<StringRecord | NonIntersectingRecord | undefined, never>
 
     // simple type - dictionaries
-    _.findWhere(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecordOrUndefined
-    _(stringRecordDictionary).findWhere(partialStringRecord); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordDictionary).findWhere(partialStringRecord)); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.findWhere(recordDictionary, matcher); // $ExpectType StringRecord | undefined
+    _(recordDictionary).findWhere(matcher); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(recordDictionary).findWhere(matcher)); // $ExpectType ChainType<StringRecord | undefined, never>
 
     // any
-    _.findWhere(anyValue, partialStringRecord); // $ExpectType any
-    _(anyValue).findWhere(partialStringRecord); // $ExpectType any
-    extractChainTypes(_.chain(anyValue).findWhere(partialStringRecord)); // $ExpectType ChainType<any, any>
+    _.findWhere(anyValue, matcher); // $ExpectType any
+    _(anyValue).findWhere(matcher); // $ExpectType any
+    extractChainTypes(_.chain(anyValue).findWhere(matcher)); // $ExpectType ChainType<any, any>
 }
 
 // reject
 {
     // function iteratee - lists
-    _.reject(stringRecordList, stringRecordListBooleanIterator, context); // $ExpectType StringRecord[]
-    _(stringRecordList).reject(stringRecordListBooleanIterator, context); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).reject(stringRecordListBooleanIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.reject(recordList, recordListTester, context); // $ExpectType StringRecord[]
+    _(recordList).reject(recordListTester, context); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).reject(recordListTester, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // function iteratee - dictionaries
-    _.reject(stringRecordDictionary, stringRecordDictionaryBooleanIterator, context); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).reject(stringRecordDictionaryBooleanIterator, context); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).reject(stringRecordDictionaryBooleanIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.reject(recordDictionary, recordDictionaryTester, context); // $ExpectType StringRecord[]
+    _(recordDictionary).reject(recordDictionaryTester, context); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordDictionary).reject(recordDictionaryTester, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // function iteratee - strings
-    _.reject(simpleString, stringListBooleanIterator, context); // $ExpectType string[]
-    _(simpleString).reject(stringListBooleanIterator, context); // $ExpectType string[]
-    extractChainTypes(_.chain(simpleString).reject(stringListBooleanIterator, context)); // $ExpectType ChainType<string[], string>
+    _.reject(stringValue, stringTester, context); // $ExpectType string[]
+    _(stringValue).reject(stringTester, context); // $ExpectType string[]
+    extractChainTypes(_.chain(stringValue).reject(stringTester, context)); // $ExpectType ChainType<string[], string>
 
     // function iteratee - any
-    _.reject(anyValue, stringRecordPartialBooleanIterator, context); // $ExpectType any[]
-    _(anyValue).reject(stringRecordPartialBooleanIterator, context); // $ExpectType any[]
-    extractChainTypes(_.chain(anyValue).reject(stringRecordPartialBooleanIterator, context)); // $ExpectType ChainType<any[], any>
+    _.reject(anyValue, recordTester, context); // $ExpectType any[]
+    _(anyValue).reject(recordTester, context); // $ExpectType any[]
+    extractChainTypes(_.chain(anyValue).reject(recordTester, context)); // $ExpectType ChainType<any[], any>
 
     // matcher iteratee - lists
-    _.reject(stringRecordList, partialStringRecord); // $ExpectType StringRecord[]
-    _(stringRecordList).reject(partialStringRecord); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).reject(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.reject(recordList, matcher); // $ExpectType StringRecord[]
+    _(recordList).reject(matcher); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).reject(matcher)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // shallow property iteratee - dictionaries
-    _.reject(stringRecordDictionary, stringRecordProperty); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).reject(stringRecordProperty); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).reject(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.reject(recordDictionary, shallowProperty); // $ExpectType StringRecord[]
+    _(recordDictionary).reject(shallowProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordDictionary).reject(shallowProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // deep property iteratee - lists
-    _.reject(stringRecordList, stringRecordPropertyPath); // $ExpectType StringRecord[]
-    _(stringRecordList).reject(stringRecordPropertyPath); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).reject(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.reject(recordList, deepProperty); // $ExpectType StringRecord[]
+    _(recordList).reject(deepProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).reject(deepProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // identity iteratee - dictionaries
-    _.reject(simpleNumberDictionary); // $ExpectType number[]
-    _(simpleNumberDictionary).reject(); // $ExpectType number[]
-    extractChainTypes(_.chain(simpleNumberDictionary).reject()); // $ExpectType ChainType<number[], number>
+    _.reject(numberDictionary); // $ExpectType number[]
+    _(numberDictionary).reject(); // $ExpectType number[]
+    extractChainTypes(_.chain(numberDictionary).reject()); // $ExpectType ChainType<number[], number>
 }
 
 // every, all
 {
     // function iteratee - lists - every
-    _.every(stringRecordList, stringRecordListBooleanIterator); // $ExpectType boolean
-    _(stringRecordList).every(stringRecordListBooleanIterator, context); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).every(stringRecordListBooleanIterator)); // $ExpectType ChainType<boolean, never>
+    _.every(recordList, recordListTester); // $ExpectType boolean
+    _(recordList).every(recordListTester, context); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).every(recordListTester)); // $ExpectType ChainType<boolean, never>
 
     // function iteratee - lists - all
-    _.all(stringRecordList, stringRecordListBooleanIterator, context); // $ExpectType boolean
-    _(stringRecordList).all(stringRecordListBooleanIterator); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).all(stringRecordListBooleanIterator, context)); // $ExpectType ChainType<boolean, never>
+    _.all(recordList, recordListTester, context); // $ExpectType boolean
+    _(recordList).all(recordListTester); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).all(recordListTester, context)); // $ExpectType ChainType<boolean, never>
 
     // function iteratee - dictionaries - every
-    _.every(stringRecordDictionary, stringRecordDictionaryBooleanIterator, context); // $ExpectType boolean
-    _(stringRecordDictionary).every(stringRecordDictionaryBooleanIterator); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordDictionary).every(stringRecordDictionaryBooleanIterator, context)); // $ExpectType ChainType<boolean, never>
+    _.every(recordDictionary, recordDictionaryTester, context); // $ExpectType boolean
+    _(recordDictionary).every(recordDictionaryTester); // $ExpectType boolean
+    extractChainTypes(_.chain(recordDictionary).every(recordDictionaryTester, context)); // $ExpectType ChainType<boolean, never>
 
     // function iteratee - dictionaries - all
-    _.all(stringRecordDictionary, stringRecordDictionaryBooleanIterator); // $ExpectType boolean
-    _(stringRecordDictionary).all(stringRecordDictionaryBooleanIterator, context); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordDictionary).all(stringRecordDictionaryBooleanIterator)); // $ExpectType ChainType<boolean, never>
+    _.all(recordDictionary, recordDictionaryTester); // $ExpectType boolean
+    _(recordDictionary).all(recordDictionaryTester, context); // $ExpectType boolean
+    extractChainTypes(_.chain(recordDictionary).all(recordDictionaryTester)); // $ExpectType ChainType<boolean, never>
 
     // matcher iteratee - lists - every
-    _.every(stringRecordList, partialStringRecord); // $ExpectType boolean
-    _(stringRecordList).every(partialStringRecord); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).every(partialStringRecord)); // $ExpectType ChainType<boolean, never>
+    _.every(recordList, matcher); // $ExpectType boolean
+    _(recordList).every(matcher); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).every(matcher)); // $ExpectType ChainType<boolean, never>
 
     // matcher iteratee - lists - all
-    _.all(stringRecordList, partialStringRecord); // $ExpectType boolean
-    _(stringRecordList).all(partialStringRecord); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).all(partialStringRecord)); // $ExpectType ChainType<boolean, never>
+    _.all(recordList, matcher); // $ExpectType boolean
+    _(recordList).all(matcher); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).all(matcher)); // $ExpectType ChainType<boolean, never>
 
     // matcher iteratee - dictionaries - every
-    _.every(stringRecordDictionary, partialStringRecord); // $ExpectType boolean
-    _(stringRecordDictionary).every(partialStringRecord); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordDictionary).every(partialStringRecord)); // $ExpectType ChainType<boolean, never>
+    _.every(recordDictionary, matcher); // $ExpectType boolean
+    _(recordDictionary).every(matcher); // $ExpectType boolean
+    extractChainTypes(_.chain(recordDictionary).every(matcher)); // $ExpectType ChainType<boolean, never>
 
     // matcher iteratee - dictionaries - all
-    _.all(stringRecordDictionary, partialStringRecord); // $ExpectType boolean
-    _(stringRecordDictionary).all(partialStringRecord); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordDictionary).all(partialStringRecord)); // $ExpectType ChainType<boolean, never>
+    _.all(recordDictionary, matcher); // $ExpectType boolean
+    _(recordDictionary).all(matcher); // $ExpectType boolean
+    extractChainTypes(_.chain(recordDictionary).all(matcher)); // $ExpectType ChainType<boolean, never>
 
     // property name iterator - lists - every
-    _.every(stringRecordList, stringRecordProperty); // $ExpectType boolean
-    _(stringRecordList).every(stringRecordProperty); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).every(stringRecordProperty)); // $ExpectType ChainType<boolean, never>
+    _.every(recordList, shallowProperty); // $ExpectType boolean
+    _(recordList).every(shallowProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).every(shallowProperty)); // $ExpectType ChainType<boolean, never>
 
     // property name iterator - lists - all
-    _.all(stringRecordList, stringRecordProperty); // $ExpectType boolean
-    _(stringRecordList).all(stringRecordProperty); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).all(stringRecordProperty)); // $ExpectType ChainType<boolean, never>
+    _.all(recordList, shallowProperty); // $ExpectType boolean
+    _(recordList).all(shallowProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).all(shallowProperty)); // $ExpectType ChainType<boolean, never>
 
     // property name iterator - dictionaries - every
-    _.every(stringRecordDictionary, stringRecordProperty); // $ExpectType boolean
-    _(stringRecordDictionary).every(stringRecordProperty); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordDictionary).every(stringRecordProperty)); // $ExpectType ChainType<boolean, never>
+    _.every(recordDictionary, shallowProperty); // $ExpectType boolean
+    _(recordDictionary).every(shallowProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(recordDictionary).every(shallowProperty)); // $ExpectType ChainType<boolean, never>
 
     // property name iterator - dictionaries - all
-    _.all(stringRecordDictionary, stringRecordProperty); // $ExpectType boolean
-    _(stringRecordDictionary).all(stringRecordProperty); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordDictionary).all(stringRecordProperty)); // $ExpectType ChainType<boolean, never>
+    _.all(recordDictionary, shallowProperty); // $ExpectType boolean
+    _(recordDictionary).all(shallowProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(recordDictionary).all(shallowProperty)); // $ExpectType ChainType<boolean, never>
 
     // property path iterator - lists - every
-    _.every(stringRecordList, stringRecordPropertyPath); // $ExpectType boolean
-    _(stringRecordList).every(stringRecordPropertyPath); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).every(stringRecordPropertyPath)); // $ExpectType ChainType<boolean, never>
+    _.every(recordList, deepProperty); // $ExpectType boolean
+    _(recordList).every(deepProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).every(deepProperty)); // $ExpectType ChainType<boolean, never>
 
     // property path iterator - lists - all
-    _.all(stringRecordList, stringRecordPropertyPath); // $ExpectType boolean
-    _(stringRecordList).all(stringRecordPropertyPath); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).all(stringRecordPropertyPath)); // $ExpectType ChainType<boolean, never>
+    _.all(recordList, deepProperty); // $ExpectType boolean
+    _(recordList).all(deepProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).all(deepProperty)); // $ExpectType ChainType<boolean, never>
 
     // property path iterator - dictionaries - every
-    _.every(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType boolean
-    _(stringRecordDictionary).every(stringRecordPropertyPath); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordDictionary).every(stringRecordPropertyPath)); // $ExpectType ChainType<boolean, never>
+    _.every(recordDictionary, deepProperty); // $ExpectType boolean
+    _(recordDictionary).every(deepProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(recordDictionary).every(deepProperty)); // $ExpectType ChainType<boolean, never>
 
     // property path iterator - dictionaries - all
-    _.all(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType boolean
-    _(stringRecordDictionary).all(stringRecordPropertyPath); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordDictionary).all(stringRecordPropertyPath)); // $ExpectType ChainType<boolean, never>
+    _.all(recordDictionary, deepProperty); // $ExpectType boolean
+    _(recordDictionary).all(deepProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(recordDictionary).all(deepProperty)); // $ExpectType ChainType<boolean, never>
 
     // identity iterator - lists - every
-    _.every(simpleBooleanList); // $ExpectType boolean
-    _(simpleBooleanList).every(); // $ExpectType boolean
-    extractChainTypes(_.chain(simpleBooleanList).every()); // $ExpectType ChainType<boolean, never>
+    _.every(booleanList); // $ExpectType boolean
+    _(booleanList).every(); // $ExpectType boolean
+    extractChainTypes(_.chain(booleanList).every()); // $ExpectType ChainType<boolean, never>
 
     // identity iterator - lists - all
-    _.all(simpleBooleanList); // $ExpectType boolean
-    _(simpleBooleanList).all(); // $ExpectType boolean
-    extractChainTypes(_.chain(simpleBooleanList).all()); // $ExpectType ChainType<boolean, never>
+    _.all(booleanList); // $ExpectType boolean
+    _(booleanList).all(); // $ExpectType boolean
+    extractChainTypes(_.chain(booleanList).all()); // $ExpectType ChainType<boolean, never>
 
     // identity iterator - dictionaries - every
-    _.every(simpleBooleanDictionary); // $ExpectType boolean
-    _(simpleBooleanDictionary).every(); // $ExpectType boolean
-    extractChainTypes(_.chain(simpleBooleanDictionary).every()); // $ExpectType ChainType<boolean, never>
+    _.every(booleanDictionary); // $ExpectType boolean
+    _(booleanDictionary).every(); // $ExpectType boolean
+    extractChainTypes(_.chain(booleanDictionary).every()); // $ExpectType ChainType<boolean, never>
 
     // identity iterator - dictionaries - all
-    _.all(simpleBooleanDictionary); // $ExpectType boolean
-    _(simpleBooleanDictionary).all(); // $ExpectType boolean
-    extractChainTypes(_.chain(simpleBooleanDictionary).all()); // $ExpectType ChainType<boolean, never>
+    _.all(booleanDictionary); // $ExpectType boolean
+    _(booleanDictionary).all(); // $ExpectType boolean
+    extractChainTypes(_.chain(booleanDictionary).all()); // $ExpectType ChainType<boolean, never>
 }
 
 // some, any
 {
     // function iteratee - lists - some
-    _.some(stringRecordList, stringRecordListBooleanIterator); // $ExpectType boolean
-    _(stringRecordList).some(stringRecordListBooleanIterator, context); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).some(stringRecordListBooleanIterator)); // $ExpectType ChainType<boolean, never>
+    _.some(recordList, recordListTester); // $ExpectType boolean
+    _(recordList).some(recordListTester, context); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).some(recordListTester)); // $ExpectType ChainType<boolean, never>
 
     // function iteratee - lists - any
-    _.any(stringRecordList, stringRecordListBooleanIterator, context); // $ExpectType boolean
-    _(stringRecordList).any(stringRecordListBooleanIterator); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).any(stringRecordListBooleanIterator, context)); // $ExpectType ChainType<boolean, never>
+    _.any(recordList, recordListTester, context); // $ExpectType boolean
+    _(recordList).any(recordListTester); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).any(recordListTester, context)); // $ExpectType ChainType<boolean, never>
 
     // function iteratee - dictionaries - some
-    _.some(stringRecordDictionary, stringRecordDictionaryBooleanIterator, context); // $ExpectType boolean
-    _(stringRecordDictionary).some(stringRecordDictionaryBooleanIterator); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordDictionary).some(stringRecordDictionaryBooleanIterator, context)); // $ExpectType ChainType<boolean, never>
+    _.some(recordDictionary, recordDictionaryTester, context); // $ExpectType boolean
+    _(recordDictionary).some(recordDictionaryTester); // $ExpectType boolean
+    extractChainTypes(_.chain(recordDictionary).some(recordDictionaryTester, context)); // $ExpectType ChainType<boolean, never>
 
     // function iteratee - dictionaries - any
-    _.any(stringRecordDictionary, stringRecordDictionaryBooleanIterator); // $ExpectType boolean
-    _(stringRecordDictionary).any(stringRecordDictionaryBooleanIterator, context); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordDictionary).any(stringRecordDictionaryBooleanIterator)); // $ExpectType ChainType<boolean, never>
+    _.any(recordDictionary, recordDictionaryTester); // $ExpectType boolean
+    _(recordDictionary).any(recordDictionaryTester, context); // $ExpectType boolean
+    extractChainTypes(_.chain(recordDictionary).any(recordDictionaryTester)); // $ExpectType ChainType<boolean, never>
 
     // matcher iteratee - lists - some
-    _.some(stringRecordList, partialStringRecord); // $ExpectType boolean
-    _(stringRecordList).some(partialStringRecord); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).some(partialStringRecord)); // $ExpectType ChainType<boolean, never>
+    _.some(recordList, matcher); // $ExpectType boolean
+    _(recordList).some(matcher); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).some(matcher)); // $ExpectType ChainType<boolean, never>
 
     // matcher iteratee - lists - any
-    _.any(stringRecordList, partialStringRecord); // $ExpectType boolean
-    _(stringRecordList).any(partialStringRecord); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).any(partialStringRecord)); // $ExpectType ChainType<boolean, never>
+    _.any(recordList, matcher); // $ExpectType boolean
+    _(recordList).any(matcher); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).any(matcher)); // $ExpectType ChainType<boolean, never>
 
     // matcher iteratee - dictionaries - some
-    _.some(stringRecordDictionary, partialStringRecord); // $ExpectType boolean
-    _(stringRecordDictionary).some(partialStringRecord); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordDictionary).some(partialStringRecord)); // $ExpectType ChainType<boolean, never>
+    _.some(recordDictionary, matcher); // $ExpectType boolean
+    _(recordDictionary).some(matcher); // $ExpectType boolean
+    extractChainTypes(_.chain(recordDictionary).some(matcher)); // $ExpectType ChainType<boolean, never>
 
     // matcher iteratee - dictionaries - any
-    _.any(stringRecordDictionary, partialStringRecord); // $ExpectType boolean
-    _(stringRecordDictionary).any(partialStringRecord); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordDictionary).any(partialStringRecord)); // $ExpectType ChainType<boolean, never>
+    _.any(recordDictionary, matcher); // $ExpectType boolean
+    _(recordDictionary).any(matcher); // $ExpectType boolean
+    extractChainTypes(_.chain(recordDictionary).any(matcher)); // $ExpectType ChainType<boolean, never>
 
     // property name iterator - lists - some
-    _.some(stringRecordList, stringRecordProperty); // $ExpectType boolean
-    _(stringRecordList).some(stringRecordProperty); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).some(stringRecordProperty)); // $ExpectType ChainType<boolean, never>
+    _.some(recordList, shallowProperty); // $ExpectType boolean
+    _(recordList).some(shallowProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).some(shallowProperty)); // $ExpectType ChainType<boolean, never>
 
     // property name iterator - lists - any
-    _.any(stringRecordList, stringRecordProperty); // $ExpectType boolean
-    _(stringRecordList).any(stringRecordProperty); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).any(stringRecordProperty)); // $ExpectType ChainType<boolean, never>
+    _.any(recordList, shallowProperty); // $ExpectType boolean
+    _(recordList).any(shallowProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).any(shallowProperty)); // $ExpectType ChainType<boolean, never>
 
     // property name iterator - dictionaries - some
-    _.some(stringRecordDictionary, stringRecordProperty); // $ExpectType boolean
-    _(stringRecordDictionary).some(stringRecordProperty); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordDictionary).some(stringRecordProperty)); // $ExpectType ChainType<boolean, never>
+    _.some(recordDictionary, shallowProperty); // $ExpectType boolean
+    _(recordDictionary).some(shallowProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(recordDictionary).some(shallowProperty)); // $ExpectType ChainType<boolean, never>
 
     // property name iterator - dictionaries - any
-    _.any(stringRecordDictionary, stringRecordProperty); // $ExpectType boolean
-    _(stringRecordDictionary).any(stringRecordProperty); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordDictionary).any(stringRecordProperty)); // $ExpectType ChainType<boolean, never>
+    _.any(recordDictionary, shallowProperty); // $ExpectType boolean
+    _(recordDictionary).any(shallowProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(recordDictionary).any(shallowProperty)); // $ExpectType ChainType<boolean, never>
 
     // property path iterator - lists - some
-    _.some(stringRecordList, stringRecordPropertyPath); // $ExpectType boolean
-    _(stringRecordList).some(stringRecordPropertyPath); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).some(stringRecordPropertyPath)); // $ExpectType ChainType<boolean, never>
+    _.some(recordList, deepProperty); // $ExpectType boolean
+    _(recordList).some(deepProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).some(deepProperty)); // $ExpectType ChainType<boolean, never>
 
     // property path iterator - lists - any
-    _.any(stringRecordList, stringRecordPropertyPath); // $ExpectType boolean
-    _(stringRecordList).any(stringRecordPropertyPath); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).any(stringRecordPropertyPath)); // $ExpectType ChainType<boolean, never>
+    _.any(recordList, deepProperty); // $ExpectType boolean
+    _(recordList).any(deepProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).any(deepProperty)); // $ExpectType ChainType<boolean, never>
 
     // property path iterator - dictionaries - some
-    _.some(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType boolean
-    _(stringRecordDictionary).some(stringRecordPropertyPath); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordDictionary).some(stringRecordPropertyPath)); // $ExpectType ChainType<boolean, never>
+    _.some(recordDictionary, deepProperty); // $ExpectType boolean
+    _(recordDictionary).some(deepProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(recordDictionary).some(deepProperty)); // $ExpectType ChainType<boolean, never>
 
     // property path iterator - dictionaries - any
-    _.any(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType boolean
-    _(stringRecordDictionary).any(stringRecordPropertyPath); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordDictionary).any(stringRecordPropertyPath)); // $ExpectType ChainType<boolean, never>
+    _.any(recordDictionary, deepProperty); // $ExpectType boolean
+    _(recordDictionary).any(deepProperty); // $ExpectType boolean
+    extractChainTypes(_.chain(recordDictionary).any(deepProperty)); // $ExpectType ChainType<boolean, never>
 
     // identity iterator - lists - some
-    _.some(simpleBooleanList); // $ExpectType boolean
-    _(simpleBooleanList).some(); // $ExpectType boolean
-    extractChainTypes(_.chain(simpleBooleanList).some()); // $ExpectType ChainType<boolean, never>
+    _.some(booleanList); // $ExpectType boolean
+    _(booleanList).some(); // $ExpectType boolean
+    extractChainTypes(_.chain(booleanList).some()); // $ExpectType ChainType<boolean, never>
 
     // identity iterator - lists - any
-    _.any(simpleBooleanList); // $ExpectType boolean
-    _(simpleBooleanList).any(); // $ExpectType boolean
-    extractChainTypes(_.chain(simpleBooleanList).any()); // $ExpectType ChainType<boolean, never>
+    _.any(booleanList); // $ExpectType boolean
+    _(booleanList).any(); // $ExpectType boolean
+    extractChainTypes(_.chain(booleanList).any()); // $ExpectType ChainType<boolean, never>
 
     // identity iterator - dictionaries - some
-    _.some(simpleBooleanDictionary); // $ExpectType boolean
-    _(simpleBooleanDictionary).some(); // $ExpectType boolean
-    extractChainTypes(_.chain(simpleBooleanDictionary).some()); // $ExpectType ChainType<boolean, never>
+    _.some(booleanDictionary); // $ExpectType boolean
+    _(booleanDictionary).some(); // $ExpectType boolean
+    extractChainTypes(_.chain(booleanDictionary).some()); // $ExpectType ChainType<boolean, never>
 
     // identity iterator - dictionaries - any
-    _.any(simpleBooleanDictionary); // $ExpectType boolean
-    _(simpleBooleanDictionary).any(); // $ExpectType boolean
-    extractChainTypes(_.chain(simpleBooleanDictionary).any()); // $ExpectType ChainType<boolean, never>
+    _.any(booleanDictionary); // $ExpectType boolean
+    _(booleanDictionary).any(); // $ExpectType boolean
+    extractChainTypes(_.chain(booleanDictionary).any()); // $ExpectType ChainType<boolean, never>
 }
 
 // contains, include, includes
 {
     // no index - lists - contains
-    _.contains(stringRecordList, stringRecordList[0]); // $ExpectType boolean
-    _(stringRecordList).contains(stringRecordList[0]); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).contains(stringRecordList[0])); // $ExpectType ChainType<boolean, never>
+    _.contains(recordList, recordList[0]); // $ExpectType boolean
+    _(recordList).contains(recordList[0]); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).contains(recordList[0])); // $ExpectType ChainType<boolean, never>
 
     // no index - lists - include
-    _.include(stringRecordList, stringRecordList[0]); // $ExpectType boolean
-    _(stringRecordList).include(stringRecordList[0]); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).include(stringRecordList[0])); // $ExpectType ChainType<boolean, never>
+    _.include(recordList, recordList[0]); // $ExpectType boolean
+    _(recordList).include(recordList[0]); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).include(recordList[0])); // $ExpectType ChainType<boolean, never>
 
     // no index - lists - includes
-    _.includes(stringRecordList, stringRecordList[0]); // $ExpectType boolean
-    _(stringRecordList).includes(stringRecordList[0]); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).includes(stringRecordList[0])); // $ExpectType ChainType<boolean, never>
+    _.includes(recordList, recordList[0]); // $ExpectType boolean
+    _(recordList).includes(recordList[0]); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).includes(recordList[0])); // $ExpectType ChainType<boolean, never>
 
     // no index - dictionaries - contains
-    _.contains(stringRecordDictionary, stringRecordList[0]); // $ExpectType boolean
-    _(stringRecordDictionary).contains(stringRecordList[0]); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordDictionary).contains(stringRecordList[0])); // $ExpectType ChainType<boolean, never>
+    _.contains(recordDictionary, recordList[0]); // $ExpectType boolean
+    _(recordDictionary).contains(recordList[0]); // $ExpectType boolean
+    extractChainTypes(_.chain(recordDictionary).contains(recordList[0])); // $ExpectType ChainType<boolean, never>
 
     // no index - dictionaries - include
-    _.include(stringRecordDictionary, stringRecordList[0]); // $ExpectType boolean
-    _(stringRecordDictionary).include(stringRecordList[0]); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordDictionary).include(stringRecordList[0])); // $ExpectType ChainType<boolean, never>
+    _.include(recordDictionary, recordList[0]); // $ExpectType boolean
+    _(recordDictionary).include(recordList[0]); // $ExpectType boolean
+    extractChainTypes(_.chain(recordDictionary).include(recordList[0])); // $ExpectType ChainType<boolean, never>
 
     // no index - dictionaries - includes
-    _.includes(stringRecordDictionary, stringRecordList[0]); // $ExpectType boolean
-    _(stringRecordDictionary).includes(stringRecordList[0]); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordDictionary).includes(stringRecordList[0])); // $ExpectType ChainType<boolean, never>
+    _.includes(recordDictionary, recordList[0]); // $ExpectType boolean
+    _(recordDictionary).includes(recordList[0]); // $ExpectType boolean
+    extractChainTypes(_.chain(recordDictionary).includes(recordList[0])); // $ExpectType ChainType<boolean, never>
 
     // with index - contains
-    _.contains(stringRecordList, stringRecordList[0], simpleNumber); // $ExpectType boolean
-    _(stringRecordList).contains(stringRecordList[0], simpleNumber); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).contains(stringRecordList[0], simpleNumber)); // $ExpectType ChainType<boolean, never>
+    _.contains(recordList, recordList[0], numberValue); // $ExpectType boolean
+    _(recordList).contains(recordList[0], numberValue); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).contains(recordList[0], numberValue)); // $ExpectType ChainType<boolean, never>
 
     // with index - include
-    _.include(stringRecordList, stringRecordList[0], simpleNumber); // $ExpectType boolean
-    _(stringRecordList).include(stringRecordList[0], simpleNumber); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).include(stringRecordList[0], simpleNumber)); // $ExpectType ChainType<boolean, never>
+    _.include(recordList, recordList[0], numberValue); // $ExpectType boolean
+    _(recordList).include(recordList[0], numberValue); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).include(recordList[0], numberValue)); // $ExpectType ChainType<boolean, never>
 
     // with index - includes
-    _.includes(stringRecordList, stringRecordList[0], simpleNumber); // $ExpectType boolean
-    _(stringRecordList).includes(stringRecordList[0], simpleNumber); // $ExpectType boolean
-    extractChainTypes(_.chain(stringRecordList).includes(stringRecordList[0], simpleNumber)); // $ExpectType ChainType<boolean, never>
+    _.includes(recordList, recordList[0], numberValue); // $ExpectType boolean
+    _(recordList).includes(recordList[0], numberValue); // $ExpectType boolean
+    extractChainTypes(_.chain(recordList).includes(recordList[0], numberValue)); // $ExpectType ChainType<boolean, never>
 }
 
 // invoke
 {
     // function without parameters
-    _.invoke(noParameterFunctionRecordList, stringRecordProperty); // $ExpectType any[]
-    _(noParameterFunctionRecordList).invoke(stringRecordProperty); // $ExpectType any[]
-    extractChainTypes(_.chain(noParameterFunctionRecordList).invoke(stringRecordProperty)); // $ExpectType ChainType<any[], any>
+    _.invoke(noParametersRecordList, shallowProperty); // $ExpectType any[]
+    _(noParametersRecordList).invoke(shallowProperty); // $ExpectType any[]
+    extractChainTypes(_.chain(noParametersRecordList).invoke(shallowProperty)); // $ExpectType ChainType<any[], any>
 
     // function with parameters
-    _.invoke(twoParameterFunctionRecordDictionary, stringRecordProperty, simpleNumber, simpleString); // $ExpectType any[]
-    _(twoParameterFunctionRecordDictionary).invoke(stringRecordProperty, simpleNumber, simpleString); // $ExpectType any[]
-    extractChainTypes(_.chain(twoParameterFunctionRecordDictionary).invoke(stringRecordProperty, simpleNumber, simpleString)); // $ExpectType ChainType<any[], any>
+    _.invoke(twoParametersRecordDictionary, shallowProperty, numberValue, stringValue); // $ExpectType any[]
+    _(twoParametersRecordDictionary).invoke(shallowProperty, numberValue, stringValue); // $ExpectType any[]
+    extractChainTypes(_.chain(twoParametersRecordDictionary).invoke(shallowProperty, numberValue, stringValue)); // $ExpectType ChainType<any[], any>
 }
 
 // pluck
 {
     // shallow property iteratee with a non-nullable single type - lists
-    _.pluck(stringRecordList, stringRecordProperty); // $ExpectType string[]
-    _(stringRecordList).pluck(stringRecordProperty); // $ExpectType string[]
-    extractChainTypes(_.chain(stringRecordList).pluck(stringRecordProperty)); // $ExpectType ChainType<string[], string>
+    _.pluck(recordList, shallowProperty); // $ExpectType string[]
+    _(recordList).pluck(shallowProperty); // $ExpectType string[]
+    extractChainTypes(_.chain(recordList).pluck(shallowProperty)); // $ExpectType ChainType<string[], string>
 
     // shallow property iteratee with a non-nullable single type - dictionaries
-    _.pluck(stringRecordDictionary, stringRecordProperty); // $ExpectType string[]
-    _(stringRecordDictionary).pluck(stringRecordProperty); // $ExpectType string[]
-    extractChainTypes(_.chain(stringRecordDictionary).pluck(stringRecordProperty)); // $ExpectType ChainType<string[], string>
+    _.pluck(recordDictionary, shallowProperty); // $ExpectType string[]
+    _(recordDictionary).pluck(shallowProperty); // $ExpectType string[]
+    extractChainTypes(_.chain(recordDictionary).pluck(shallowProperty)); // $ExpectType ChainType<string[], string>
 
     // shallow property iteratee with other types - lists
-    _.pluck(stringRecordOrUndefinedList, stringRecordProperty); // $ExpectType any[]
-    _.pluck(intersectingPropertiesList, stringRecordProperty); // $ExpectType (string | boolean)[]
-    _.pluck(nonIntersectingPropertiesList, stringRecordProperty) // $ExpectType any[]
-    _.pluck(anyValue, stringRecordProperty); // $ExpectType any[]
+    _.pluck(maybeRecordList, shallowProperty); // $ExpectType any[]
+    _.pluck(intersectingPropertiesList, shallowProperty); // $ExpectType (string | StringRecord)[]
+    _.pluck(nonIntersectingList, shallowProperty) // $ExpectType any[]
+    _.pluck(anyValue, shallowProperty); // $ExpectType any[]
 }
 
 // max
 {
     // function iteratee - lists
-    _.max(numberRecordList, numberRecordListValueIterator); // $ExpectType number | NumberRecord
-    _.max(numberRecordList, numberRecordListValueIterator, context); // $ExpectType number | NumberRecord
-    _(numberRecordList).max(numberRecordListValueIterator); // $ExpectType number | NumberRecord
-    _(numberRecordList).max(numberRecordListValueIterator, context); // $ExpectType number | NumberRecord
-    extractChainTypes(_.chain(numberRecordList).max(numberRecordListValueIterator)); // $ExpectType ChainType<number | NumberRecord, never>
-    extractChainTypes(_.chain(numberRecordList).max(numberRecordListValueIterator, context)); // $ExpectType ChainType<number | NumberRecord, never>
+    _.max(numberRecordList, numberRecordListSelector); // $ExpectType number | NumberRecord
+    _.max(numberRecordList, numberRecordListSelector, context); // $ExpectType number | NumberRecord
+    _(numberRecordList).max(numberRecordListSelector); // $ExpectType number | NumberRecord
+    _(numberRecordList).max(numberRecordListSelector, context); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordList).max(numberRecordListSelector)); // $ExpectType ChainType<number | NumberRecord, never>
+    extractChainTypes(_.chain(numberRecordList).max(numberRecordListSelector, context)); // $ExpectType ChainType<number | NumberRecord, never>
 
     // function iteratee - dictionaries
-    _.max(numberRecordDictionary, numberRecordDictionaryValueIterator); // $ExpectType number | NumberRecord
-    _.max(numberRecordDictionary, numberRecordDictionaryValueIterator, context); // $ExpectType number | NumberRecord
-    _(numberRecordDictionary).max(numberRecordDictionaryValueIterator); // $ExpectType number | NumberRecord
-    _(numberRecordDictionary).max(numberRecordDictionaryValueIterator, context); // $ExpectType number | NumberRecord
-    extractChainTypes(_.chain(numberRecordDictionary).max(numberRecordDictionaryValueIterator)); // $ExpectType ChainType<number | NumberRecord, never>
-    extractChainTypes(_.chain(numberRecordDictionary).max(numberRecordDictionaryValueIterator, context)); // $ExpectType ChainType<number | NumberRecord, never>
+    _.max(numberRecordDictionary, numberRecordDictionarySelector); // $ExpectType number | NumberRecord
+    _.max(numberRecordDictionary, numberRecordDictionarySelector, context); // $ExpectType number | NumberRecord
+    _(numberRecordDictionary).max(numberRecordDictionarySelector); // $ExpectType number | NumberRecord
+    _(numberRecordDictionary).max(numberRecordDictionarySelector, context); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordDictionary).max(numberRecordDictionarySelector)); // $ExpectType ChainType<number | NumberRecord, never>
+    extractChainTypes(_.chain(numberRecordDictionary).max(numberRecordDictionarySelector, context)); // $ExpectType ChainType<number | NumberRecord, never>
 
     // shallow property iteratee - lists
-    _.max(numberRecordList, stringRecordProperty); // $ExpectType number | NumberRecord
-    _(numberRecordList).max(stringRecordProperty); // $ExpectType number | NumberRecord
-    extractChainTypes(_.chain(numberRecordList).max(stringRecordProperty)); // $ExpectType ChainType<number | NumberRecord, never>
+    _.max(numberRecordList, shallowProperty); // $ExpectType number | NumberRecord
+    _(numberRecordList).max(shallowProperty); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordList).max(shallowProperty)); // $ExpectType ChainType<number | NumberRecord, never>
 
     // shallow property iteratee - dictionaries
-    _.max(numberRecordDictionary, stringRecordProperty); // $ExpectType number | NumberRecord
-    _(numberRecordDictionary).max(stringRecordProperty); // $ExpectType number | NumberRecord
-    extractChainTypes(_.chain(numberRecordDictionary).max(stringRecordProperty)); // $ExpectType ChainType<number | NumberRecord, never>
+    _.max(numberRecordDictionary, shallowProperty); // $ExpectType number | NumberRecord
+    _(numberRecordDictionary).max(shallowProperty); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordDictionary).max(shallowProperty)); // $ExpectType ChainType<number | NumberRecord, never>
 
     // deep property iteratee - lists
-    _.max(numberRecordList, stringRecordPropertyPath); // $ExpectType number | NumberRecord
-    _(numberRecordList).max(stringRecordPropertyPath); // $ExpectType number | NumberRecord
-    extractChainTypes(_.chain(numberRecordList).max(stringRecordPropertyPath)); // $ExpectType ChainType<number | NumberRecord, never>
+    _.max(numberRecordList, deepProperty); // $ExpectType number | NumberRecord
+    _(numberRecordList).max(deepProperty); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordList).max(deepProperty)); // $ExpectType ChainType<number | NumberRecord, never>
 
     // deep property iteratee - dictionaries
-    _.max(numberRecordDictionary, stringRecordPropertyPath); // $ExpectType number | NumberRecord
-    _(numberRecordDictionary).max(stringRecordPropertyPath); // $ExpectType number | NumberRecord
-    extractChainTypes(_.chain(numberRecordDictionary).max(stringRecordPropertyPath)); // $ExpectType ChainType<number | NumberRecord, never>
+    _.max(numberRecordDictionary, deepProperty); // $ExpectType number | NumberRecord
+    _(numberRecordDictionary).max(deepProperty); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordDictionary).max(deepProperty)); // $ExpectType ChainType<number | NumberRecord, never>
 
     // identity iteratee - lists
     _.max(numberList); // $ExpectType number
@@ -1930,40 +1934,40 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
 // min
 {
     // function iteratee - lists
-    _.min(numberRecordList, numberRecordListValueIterator); // $ExpectType number | NumberRecord
-    _.min(numberRecordList, numberRecordListValueIterator, context); // $ExpectType number | NumberRecord
-    _(numberRecordList).min(numberRecordListValueIterator); // $ExpectType number | NumberRecord
-    _(numberRecordList).min(numberRecordListValueIterator, context); // $ExpectType number | NumberRecord
-    extractChainTypes(_.chain(numberRecordList).min(numberRecordListValueIterator)); // $ExpectType ChainType<number | NumberRecord, never>
-    extractChainTypes(_.chain(numberRecordList).min(numberRecordListValueIterator, context)); // $ExpectType ChainType<number | NumberRecord, never>
+    _.min(numberRecordList, numberRecordListSelector); // $ExpectType number | NumberRecord
+    _.min(numberRecordList, numberRecordListSelector, context); // $ExpectType number | NumberRecord
+    _(numberRecordList).min(numberRecordListSelector); // $ExpectType number | NumberRecord
+    _(numberRecordList).min(numberRecordListSelector, context); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordList).min(numberRecordListSelector)); // $ExpectType ChainType<number | NumberRecord, never>
+    extractChainTypes(_.chain(numberRecordList).min(numberRecordListSelector, context)); // $ExpectType ChainType<number | NumberRecord, never>
 
     // function iteratee - dictionaries
-    _.min(numberRecordDictionary, numberRecordDictionaryValueIterator); // $ExpectType number | NumberRecord
-    _.min(numberRecordDictionary, numberRecordDictionaryValueIterator, context); // $ExpectType number | NumberRecord
-    _(numberRecordDictionary).min(numberRecordDictionaryValueIterator); // $ExpectType number | NumberRecord
-    _(numberRecordDictionary).min(numberRecordDictionaryValueIterator, context); // $ExpectType number | NumberRecord
-    extractChainTypes(_.chain(numberRecordDictionary).min(numberRecordDictionaryValueIterator)); // $ExpectType ChainType<number | NumberRecord, never>
-    extractChainTypes(_.chain(numberRecordDictionary).min(numberRecordDictionaryValueIterator, context)); // $ExpectType ChainType<number | NumberRecord, never>
+    _.min(numberRecordDictionary, numberRecordDictionarySelector); // $ExpectType number | NumberRecord
+    _.min(numberRecordDictionary, numberRecordDictionarySelector, context); // $ExpectType number | NumberRecord
+    _(numberRecordDictionary).min(numberRecordDictionarySelector); // $ExpectType number | NumberRecord
+    _(numberRecordDictionary).min(numberRecordDictionarySelector, context); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordDictionary).min(numberRecordDictionarySelector)); // $ExpectType ChainType<number | NumberRecord, never>
+    extractChainTypes(_.chain(numberRecordDictionary).min(numberRecordDictionarySelector, context)); // $ExpectType ChainType<number | NumberRecord, never>
 
     // shallow property iteratee - lists
-    _.min(numberRecordList, stringRecordProperty); // $ExpectType number | NumberRecord
-    _(numberRecordList).min(stringRecordProperty); // $ExpectType number | NumberRecord
-    extractChainTypes(_.chain(numberRecordList).min(stringRecordProperty)); // $ExpectType ChainType<number | NumberRecord, never>
+    _.min(numberRecordList, shallowProperty); // $ExpectType number | NumberRecord
+    _(numberRecordList).min(shallowProperty); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordList).min(shallowProperty)); // $ExpectType ChainType<number | NumberRecord, never>
 
     // shallow property iteratee - dictionaries
-    _.min(numberRecordDictionary, stringRecordProperty); // $ExpectType number | NumberRecord
-    _(numberRecordDictionary).min(stringRecordProperty); // $ExpectType number | NumberRecord
-    extractChainTypes(_.chain(numberRecordDictionary).min(stringRecordProperty)); // $ExpectType ChainType<number | NumberRecord, never>
+    _.min(numberRecordDictionary, shallowProperty); // $ExpectType number | NumberRecord
+    _(numberRecordDictionary).min(shallowProperty); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordDictionary).min(shallowProperty)); // $ExpectType ChainType<number | NumberRecord, never>
 
     // deep property iteratee - lists
-    _.min(numberRecordList, stringRecordPropertyPath); // $ExpectType number | NumberRecord
-    _(numberRecordList).min(stringRecordPropertyPath); // $ExpectType number | NumberRecord
-    extractChainTypes(_.chain(numberRecordList).min(stringRecordPropertyPath)); // $ExpectType ChainType<number | NumberRecord, never>
+    _.min(numberRecordList, deepProperty); // $ExpectType number | NumberRecord
+    _(numberRecordList).min(deepProperty); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordList).min(deepProperty)); // $ExpectType ChainType<number | NumberRecord, never>
 
     // deep property iteratee - dictionaries
-    _.min(numberRecordDictionary, stringRecordPropertyPath); // $ExpectType number | NumberRecord
-    _(numberRecordDictionary).min(stringRecordPropertyPath); // $ExpectType number | NumberRecord
-    extractChainTypes(_.chain(numberRecordDictionary).min(stringRecordPropertyPath)); // $ExpectType ChainType<number | NumberRecord, never>
+    _.min(numberRecordDictionary, deepProperty); // $ExpectType number | NumberRecord
+    _(numberRecordDictionary).min(deepProperty); // $ExpectType number | NumberRecord
+    extractChainTypes(_.chain(numberRecordDictionary).min(deepProperty)); // $ExpectType ChainType<number | NumberRecord, never>
 
     // identity iteratee - lists
     _.min(numberList); // $ExpectType number
@@ -1979,441 +1983,443 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
 // sortBy
 {
     // function iteratee - lists
-    _.sortBy(stringRecordList, stringRecordListValueIterator); // $ExpectType StringRecord[]
-    _(stringRecordList).sortBy(stringRecordListValueIterator, context); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).sortBy(stringRecordListValueIterator)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.sortBy(recordList, recordListSelector); // $ExpectType StringRecord[]
+    _(recordList).sortBy(recordListSelector, context); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).sortBy(recordListSelector)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // function iteratee - dictionaries
-    _.sortBy(stringRecordDictionary, stringRecordDictionaryValueIterator, context); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).sortBy(stringRecordDictionaryValueIterator); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).sortBy(stringRecordDictionaryValueIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.sortBy(recordDictionary, recordDictionarySelector, context); // $ExpectType StringRecord[]
+    _(recordDictionary).sortBy(recordDictionarySelector); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordDictionary).sortBy(recordDictionarySelector, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // matcher iteratee - lists
-    _.sortBy(stringRecordList, partialStringRecord); // $ExpectType StringRecord[]
-    _(stringRecordList).sortBy(partialStringRecord); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).sortBy(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.sortBy(recordList, matcher); // $ExpectType StringRecord[]
+    _(recordList).sortBy(matcher); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).sortBy(matcher)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // matcher iteratee - dictionaries
-    _.sortBy(stringRecordDictionary, partialStringRecord); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).sortBy(partialStringRecord); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).sortBy(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.sortBy(recordDictionary, matcher); // $ExpectType StringRecord[]
+    _(recordDictionary).sortBy(matcher); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordDictionary).sortBy(matcher)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // shallow property iteratee - lists
-    _.sortBy(stringRecordList, stringRecordProperty); // $ExpectType StringRecord[]
-    _(stringRecordList).sortBy(stringRecordProperty); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).sortBy(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.sortBy(recordList, shallowProperty); // $ExpectType StringRecord[]
+    _(recordList).sortBy(shallowProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).sortBy(shallowProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // shallow property iteratee - dictionaries
-    _.sortBy(stringRecordDictionary, stringRecordProperty); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).sortBy(stringRecordProperty); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).sortBy(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.sortBy(recordDictionary, shallowProperty); // $ExpectType StringRecord[]
+    _(recordDictionary).sortBy(shallowProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordDictionary).sortBy(shallowProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // deep property iteratee - lists
-    _.sortBy(stringRecordList, stringRecordPropertyPath); // $ExpectType StringRecord[]
-    _(stringRecordList).sortBy(stringRecordPropertyPath); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).sortBy(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.sortBy(recordList, deepProperty); // $ExpectType StringRecord[]
+    _(recordList).sortBy(deepProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).sortBy(deepProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // deep property iteratee - dictionaries
-    _.sortBy(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).sortBy(stringRecordPropertyPath); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).sortBy(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.sortBy(recordDictionary, deepProperty); // $ExpectType StringRecord[]
+    _(recordDictionary).sortBy(deepProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordDictionary).sortBy(deepProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // identity iteratee - lists
-    _.sortBy(stringRecordList); // $ExpectType StringRecord[]
-    _(stringRecordList).sortBy(); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).sortBy()); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.sortBy(recordList); // $ExpectType StringRecord[]
+    _(recordList).sortBy(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).sortBy()); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // identity iteratee - dictionaries
-    _.sortBy(stringRecordDictionary); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).sortBy(); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).sortBy()); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.sortBy(recordDictionary); // $ExpectType StringRecord[]
+    _(recordDictionary).sortBy(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordDictionary).sortBy()); // $ExpectType ChainType<StringRecord[], StringRecord>
 }
 
 // groupBy
 {
     // function iteratee - lists
-    _.groupBy(stringRecordList, stringRecordListValueIterator, context); // $ExpectType Dictionary<StringRecord[]>
-    _(stringRecordList).groupBy(stringRecordListValueIterator, context); // $ExpectType Dictionary<StringRecord[]>
-    _.chain(stringRecordList).groupBy(stringRecordListValueIterator, context); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
+    _.groupBy(recordList, recordListSelector, context); // $ExpectType Dictionary<StringRecord[]>
+    _(recordList).groupBy(recordListSelector, context); // $ExpectType Dictionary<StringRecord[]>
+    _.chain(recordList).groupBy(recordListSelector, context); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
 
     // function iteratee - dictionaries
-    _.groupBy(stringRecordDictionary, stringRecordDictionaryValueIterator, context); // $ExpectType Dictionary<StringRecord[]>
-    _(stringRecordDictionary).groupBy(stringRecordDictionaryValueIterator, context); // $ExpectType Dictionary<StringRecord[]>
-    _.chain(stringRecordDictionary).groupBy(stringRecordDictionaryValueIterator, context); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
+    _.groupBy(recordDictionary, recordDictionarySelector, context); // $ExpectType Dictionary<StringRecord[]>
+    _(recordDictionary).groupBy(recordDictionarySelector, context); // $ExpectType Dictionary<StringRecord[]>
+    _.chain(recordDictionary).groupBy(recordDictionarySelector, context); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
 
     // matcher iteratee - lists
-    _.groupBy(stringRecordList, partialStringRecord); // $ExpectType Dictionary<StringRecord[]>
-    _(stringRecordList).groupBy(partialStringRecord); // $ExpectType Dictionary<StringRecord[]>
-    _.chain(stringRecordList).groupBy(partialStringRecord); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
+    _.groupBy(recordList, matcher); // $ExpectType Dictionary<StringRecord[]>
+    _(recordList).groupBy(matcher); // $ExpectType Dictionary<StringRecord[]>
+    _.chain(recordList).groupBy(matcher); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
 
     // matcher iteratee - dictionaries
-    _.groupBy(stringRecordDictionary, partialStringRecord); // $ExpectType Dictionary<StringRecord[]>
-    _(stringRecordDictionary).groupBy(partialStringRecord); // $ExpectType Dictionary<StringRecord[]>
-    _.chain(stringRecordDictionary).groupBy(partialStringRecord); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
+    _.groupBy(recordDictionary, matcher); // $ExpectType Dictionary<StringRecord[]>
+    _(recordDictionary).groupBy(matcher); // $ExpectType Dictionary<StringRecord[]>
+    _.chain(recordDictionary).groupBy(matcher); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
 
     // shallow property iteratee - lists
-    _.groupBy(stringRecordList, stringRecordProperty); // $ExpectType Dictionary<StringRecord[]>
-    _(stringRecordList).groupBy(stringRecordProperty); // $ExpectType Dictionary<StringRecord[]>
-    _.chain(stringRecordList).groupBy(stringRecordProperty); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
+    _.groupBy(recordList, shallowProperty); // $ExpectType Dictionary<StringRecord[]>
+    _(recordList).groupBy(shallowProperty); // $ExpectType Dictionary<StringRecord[]>
+    _.chain(recordList).groupBy(shallowProperty); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
 
     // shallow property iteratee - dictionaries
-    _.groupBy(stringRecordDictionary, stringRecordProperty); // $ExpectType Dictionary<StringRecord[]>
-    _(stringRecordDictionary).groupBy(stringRecordProperty); // $ExpectType Dictionary<StringRecord[]>
-    _.chain(stringRecordDictionary).groupBy(stringRecordProperty); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
+    _.groupBy(recordDictionary, shallowProperty); // $ExpectType Dictionary<StringRecord[]>
+    _(recordDictionary).groupBy(shallowProperty); // $ExpectType Dictionary<StringRecord[]>
+    _.chain(recordDictionary).groupBy(shallowProperty); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
 
     // deep property iteratee - lists
-    _.groupBy(stringRecordList, stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord[]>
-    _(stringRecordList).groupBy(stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord[]>
-    _.chain(stringRecordList).groupBy(stringRecordPropertyPath); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
+    _.groupBy(recordList, deepProperty); // $ExpectType Dictionary<StringRecord[]>
+    _(recordList).groupBy(deepProperty); // $ExpectType Dictionary<StringRecord[]>
+    _.chain(recordList).groupBy(deepProperty); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
 
     // deep property iteratee - dictionaries
-    _.groupBy(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord[]>
-    _(stringRecordDictionary).groupBy(stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord[]>
-    _.chain(stringRecordDictionary).groupBy(stringRecordPropertyPath); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
+    _.groupBy(recordDictionary, deepProperty); // $ExpectType Dictionary<StringRecord[]>
+    _(recordDictionary).groupBy(deepProperty); // $ExpectType Dictionary<StringRecord[]>
+    _.chain(recordDictionary).groupBy(deepProperty); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
 
     // identity iteratee - lists
-    _.groupBy(stringRecordList); // $ExpectType Dictionary<StringRecord[]>
-    _(stringRecordList).groupBy(); // $ExpectType Dictionary<StringRecord[]>
-    _.chain(stringRecordList).groupBy(); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
+    _.groupBy(recordList); // $ExpectType Dictionary<StringRecord[]>
+    _(recordList).groupBy(); // $ExpectType Dictionary<StringRecord[]>
+    _.chain(recordList).groupBy(); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
 
     // identity iteratee - dictionaries
-    _.groupBy(stringRecordDictionary); // $ExpectType Dictionary<StringRecord[]>
-    _(stringRecordDictionary).groupBy(); // $ExpectType Dictionary<StringRecord[]>
-    _.chain(stringRecordDictionary).groupBy(); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
+    _.groupBy(recordDictionary); // $ExpectType Dictionary<StringRecord[]>
+    _(recordDictionary).groupBy(); // $ExpectType Dictionary<StringRecord[]>
+    _.chain(recordDictionary).groupBy(); // // $ExpectType _Chain<StringRecord[], Dictionary<StringRecord[]>>
 }
 
 // indexBy
 {
     // function iteratee - lists
-    _.indexBy(stringRecordList, stringRecordListValueIterator); // $ExpectType Dictionary<StringRecord>
-    _(stringRecordList).indexBy(stringRecordListValueIterator, context); // $ExpectType Dictionary<StringRecord>
-    extractChainTypes(_.chain(stringRecordList).indexBy(stringRecordListValueIterator)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+    _.indexBy(recordList, recordListSelector); // $ExpectType Dictionary<StringRecord>
+    _(recordList).indexBy(recordListSelector, context); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(recordList).indexBy(recordListSelector)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
     // function iteratee - dictionaries
-    _.indexBy(stringRecordDictionary, stringRecordDictionaryValueIterator, context); // $ExpectType Dictionary<StringRecord>
-    _(stringRecordDictionary).indexBy(stringRecordDictionaryValueIterator); // $ExpectType Dictionary<StringRecord>
-    extractChainTypes(_.chain(stringRecordDictionary).indexBy(stringRecordDictionaryValueIterator, context)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+    _.indexBy(recordDictionary, recordDictionarySelector, context); // $ExpectType Dictionary<StringRecord>
+    _(recordDictionary).indexBy(recordDictionarySelector); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(recordDictionary).indexBy(recordDictionarySelector, context)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
     // matcher iteratee - lists
-    _.indexBy(stringRecordList, partialStringRecord); // $ExpectType Dictionary<StringRecord>
-    _(stringRecordList).indexBy(partialStringRecord); // $ExpectType Dictionary<StringRecord>
-    extractChainTypes(_.chain(stringRecordList).indexBy(partialStringRecord)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+    _.indexBy(recordList, matcher); // $ExpectType Dictionary<StringRecord>
+    _(recordList).indexBy(matcher); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(recordList).indexBy(matcher)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
     // matcher iteratee - dictionaries
-    _.indexBy(stringRecordDictionary, partialStringRecord); // $ExpectType Dictionary<StringRecord>
-    _(stringRecordDictionary).indexBy(partialStringRecord); // $ExpectType Dictionary<StringRecord>
-    extractChainTypes(_.chain(stringRecordDictionary).indexBy(partialStringRecord)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+    _.indexBy(recordDictionary, matcher); // $ExpectType Dictionary<StringRecord>
+    _(recordDictionary).indexBy(matcher); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(recordDictionary).indexBy(matcher)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
     // shallow property iteratee - lists
-    _.indexBy(stringRecordList, stringRecordProperty); // $ExpectType Dictionary<StringRecord>
-    _(stringRecordList).indexBy(stringRecordProperty); // $ExpectType Dictionary<StringRecord>
-    extractChainTypes(_.chain(stringRecordList).indexBy(stringRecordProperty)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+    _.indexBy(recordList, shallowProperty); // $ExpectType Dictionary<StringRecord>
+    _(recordList).indexBy(shallowProperty); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(recordList).indexBy(shallowProperty)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
     // shallow property iteratee - dictionaries
-    _.indexBy(stringRecordDictionary, stringRecordProperty); // $ExpectType Dictionary<StringRecord>
-    _(stringRecordDictionary).indexBy(stringRecordProperty); // $ExpectType Dictionary<StringRecord>
-    extractChainTypes(_.chain(stringRecordDictionary).indexBy(stringRecordProperty)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+    _.indexBy(recordDictionary, shallowProperty); // $ExpectType Dictionary<StringRecord>
+    _(recordDictionary).indexBy(shallowProperty); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(recordDictionary).indexBy(shallowProperty)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
     // deep property iteratee - lists
-    _.indexBy(stringRecordList, stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord>
-    _(stringRecordList).indexBy(stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord>
-    extractChainTypes(_.chain(stringRecordList).indexBy(stringRecordPropertyPath)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+    _.indexBy(recordList, deepProperty); // $ExpectType Dictionary<StringRecord>
+    _(recordList).indexBy(deepProperty); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(recordList).indexBy(deepProperty)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
     // deep property iteratee - dictionaries
-    _.indexBy(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord>
-    _(stringRecordDictionary).indexBy(stringRecordPropertyPath); // $ExpectType Dictionary<StringRecord>
-    extractChainTypes(_.chain(stringRecordDictionary).indexBy(stringRecordPropertyPath)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+    _.indexBy(recordDictionary, deepProperty); // $ExpectType Dictionary<StringRecord>
+    _(recordDictionary).indexBy(deepProperty); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(recordDictionary).indexBy(deepProperty)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
     // identity iteratee - lists
-    _.indexBy(stringRecordList); // $ExpectType Dictionary<StringRecord>
-    _(stringRecordList).indexBy(); // $ExpectType Dictionary<StringRecord>
-    extractChainTypes(_.chain(stringRecordList).indexBy()); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+    _.indexBy(recordList); // $ExpectType Dictionary<StringRecord>
+    _(recordList).indexBy(); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(recordList).indexBy()); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
     // identity iteratee - dictionaries
-    _.indexBy(stringRecordDictionary); // $ExpectType Dictionary<StringRecord>
-    _(stringRecordDictionary).indexBy(); // $ExpectType Dictionary<StringRecord>
-    extractChainTypes(_.chain(stringRecordDictionary).indexBy()); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+    _.indexBy(recordDictionary); // $ExpectType Dictionary<StringRecord>
+    _(recordDictionary).indexBy(); // $ExpectType Dictionary<StringRecord>
+    extractChainTypes(_.chain(recordDictionary).indexBy()); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 }
 
 // countBy
 {
     // function iteratee - lists
-    _.countBy(stringRecordList, stringRecordListValueIterator); // $ExpectType Dictionary<number>
-    _(stringRecordList).countBy(stringRecordListValueIterator, context); // $ExpectType Dictionary<number>
-    extractChainTypes(_.chain(stringRecordList).countBy(stringRecordListValueIterator)); // $ExpectType ChainType<Dictionary<number>, number>
+    _.countBy(recordList, recordListSelector); // $ExpectType Dictionary<number>
+    _(recordList).countBy(recordListSelector, context); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(recordList).countBy(recordListSelector)); // $ExpectType ChainType<Dictionary<number>, number>
 
     // function iteratee - dictionaries
-    _.countBy(stringRecordDictionary, stringRecordDictionaryValueIterator, context); // $ExpectType Dictionary<number>
-    _(stringRecordDictionary).countBy(stringRecordDictionaryValueIterator); // $ExpectType Dictionary<number>
-    extractChainTypes(_.chain(stringRecordDictionary).countBy(stringRecordDictionaryValueIterator, context)); // $ExpectType ChainType<Dictionary<number>, number>
+    _.countBy(recordDictionary, recordDictionarySelector, context); // $ExpectType Dictionary<number>
+    _(recordDictionary).countBy(recordDictionarySelector); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(recordDictionary).countBy(recordDictionarySelector, context)); // $ExpectType ChainType<Dictionary<number>, number>
 
     // matcher iteratee - lists
-    _.countBy(stringRecordList, partialStringRecord); // $ExpectType Dictionary<number>
-    _(stringRecordList).countBy(partialStringRecord); // $ExpectType Dictionary<number>
-    extractChainTypes(_.chain(stringRecordList).countBy(partialStringRecord)); // $ExpectType ChainType<Dictionary<number>, number>
+    _.countBy(recordList, matcher); // $ExpectType Dictionary<number>
+    _(recordList).countBy(matcher); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(recordList).countBy(matcher)); // $ExpectType ChainType<Dictionary<number>, number>
 
     // matcher iteratee - dictionaries
-    _.countBy(stringRecordDictionary, partialStringRecord); // $ExpectType Dictionary<number>
-    _(stringRecordDictionary).countBy(partialStringRecord); // $ExpectType Dictionary<number>
-    extractChainTypes(_.chain(stringRecordDictionary).countBy(partialStringRecord)); // $ExpectType ChainType<Dictionary<number>, number>
+    _.countBy(recordDictionary, matcher); // $ExpectType Dictionary<number>
+    _(recordDictionary).countBy(matcher); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(recordDictionary).countBy(matcher)); // $ExpectType ChainType<Dictionary<number>, number>
 
     // shallow property iteratee - lists
-    _.countBy(stringRecordList, stringRecordProperty); // $ExpectType Dictionary<number>
-    _(stringRecordList).countBy(stringRecordProperty); // $ExpectType Dictionary<number>
-    extractChainTypes(_.chain(stringRecordList).countBy(stringRecordProperty)); // $ExpectType ChainType<Dictionary<number>, number>
+    _.countBy(recordList, shallowProperty); // $ExpectType Dictionary<number>
+    _(recordList).countBy(shallowProperty); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(recordList).countBy(shallowProperty)); // $ExpectType ChainType<Dictionary<number>, number>
 
     // shallow property iteratee - dictionaries
-    _.countBy(stringRecordDictionary, stringRecordProperty); // $ExpectType Dictionary<number>
-    _(stringRecordDictionary).countBy(stringRecordProperty); // $ExpectType Dictionary<number>
-    extractChainTypes(_.chain(stringRecordDictionary).countBy(stringRecordProperty)); // $ExpectType ChainType<Dictionary<number>, number>
+    _.countBy(recordDictionary, shallowProperty); // $ExpectType Dictionary<number>
+    _(recordDictionary).countBy(shallowProperty); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(recordDictionary).countBy(shallowProperty)); // $ExpectType ChainType<Dictionary<number>, number>
 
     // deep property iteratee - lists
-    _.countBy(stringRecordList, stringRecordPropertyPath); // $ExpectType Dictionary<number>
-    _(stringRecordList).countBy(stringRecordPropertyPath); // $ExpectType Dictionary<number>
-    extractChainTypes(_.chain(stringRecordList).countBy(stringRecordPropertyPath)); // $ExpectType ChainType<Dictionary<number>, number>
+    _.countBy(recordList, deepProperty); // $ExpectType Dictionary<number>
+    _(recordList).countBy(deepProperty); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(recordList).countBy(deepProperty)); // $ExpectType ChainType<Dictionary<number>, number>
 
     // deep property iteratee - dictionaries
-    _.countBy(stringRecordDictionary, stringRecordPropertyPath); // $ExpectType Dictionary<number>
-    _(stringRecordDictionary).countBy(stringRecordPropertyPath); // $ExpectType Dictionary<number>
-    extractChainTypes(_.chain(stringRecordDictionary).countBy(stringRecordPropertyPath)); // $ExpectType ChainType<Dictionary<number>, number>
+    _.countBy(recordDictionary, deepProperty); // $ExpectType Dictionary<number>
+    _(recordDictionary).countBy(deepProperty); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(recordDictionary).countBy(deepProperty)); // $ExpectType ChainType<Dictionary<number>, number>
 
     // identity iteratee - lists
-    _.countBy(stringRecordList); // $ExpectType Dictionary<number>
-    _(stringRecordList).countBy(); // $ExpectType Dictionary<number>
-    extractChainTypes(_.chain(stringRecordList).countBy()); // $ExpectType ChainType<Dictionary<number>, number>
+    _.countBy(recordList); // $ExpectType Dictionary<number>
+    _(recordList).countBy(); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(recordList).countBy()); // $ExpectType ChainType<Dictionary<number>, number>
 
     // identity iteratee - dictionaries
-    _.countBy(stringRecordDictionary); // $ExpectType Dictionary<number>
-    _(stringRecordDictionary).countBy(); // $ExpectType Dictionary<number>
-    extractChainTypes(_.chain(stringRecordDictionary).countBy()); // $ExpectType ChainType<Dictionary<number>, number>
+    _.countBy(recordDictionary); // $ExpectType Dictionary<number>
+    _(recordDictionary).countBy(); // $ExpectType Dictionary<number>
+    extractChainTypes(_.chain(recordDictionary).countBy()); // $ExpectType ChainType<Dictionary<number>, number>
 }
 
 // shuffle
 {
     // lists
-    _.shuffle(stringRecordList); // $ExpectType StringRecord[]
-    _(stringRecordList).shuffle(); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).shuffle()); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.shuffle(recordList); // $ExpectType StringRecord[]
+    _(recordList).shuffle(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).shuffle()); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // dictionaries
-    _.shuffle(stringRecordDictionary); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).shuffle(); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).shuffle()); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.shuffle(recordDictionary); // $ExpectType StringRecord[]
+    _(recordDictionary).shuffle(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordDictionary).shuffle()); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // strings
-    _.shuffle(simpleString); // $ExpectType string[]
-    _(simpleString).shuffle(); // $ExpectType string[]
-    extractChainTypes(_.chain(simpleString).shuffle()); // $ExpectType ChainType<string[], string>
+    _.shuffle(stringValue); // $ExpectType string[]
+    _(stringValue).shuffle(); // $ExpectType string[]
+    extractChainTypes(_.chain(stringValue).shuffle()); // $ExpectType ChainType<string[], string>
 }
 
 // sample
 {
     // without n - lists
-    _.sample(stringRecordList); // $ExpectType StringRecordOrUndefined
-    _(stringRecordList).sample(); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordList).sample()); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.sample(recordList); // $ExpectType StringRecord | undefined
+    _(recordList).sample(); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(recordList).sample()); // $ExpectType ChainType<StringRecord | undefined, never>
 
     // without n - dictionaries
-    _.sample(stringRecordDictionary); // $ExpectType StringRecordOrUndefined
-    _(stringRecordDictionary).sample(); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordDictionary).sample()); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.sample(recordDictionary); // $ExpectType StringRecord | undefined
+    _(recordDictionary).sample(); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(recordDictionary).sample()); // $ExpectType ChainType<StringRecord | undefined, never>
 
     // without n - strings
-    _.sample(simpleString); // $ExpectType string | undefined
-    _(simpleString).sample(); // $ExpectType string | undefined
-    extractChainTypes(_.chain(simpleString).sample()); // $ExpectType ChainType<string | undefined, string>
+    _.sample(stringValue); // $ExpectType string | undefined
+    _(stringValue).sample(); // $ExpectType string | undefined
+    extractChainTypes(_.chain(stringValue).sample()); // $ExpectType ChainType<string | undefined, string>
 
     // with n - lists
-    _.sample(stringRecordList, simpleNumber); // $ExpectType StringRecord[]
-    _(stringRecordList).sample(simpleNumber); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).sample(simpleNumber)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.sample(recordList, numberValue); // $ExpectType StringRecord[]
+    _(recordList).sample(numberValue); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).sample(numberValue)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // with n - dictionaries
-    _.sample(stringRecordDictionary, simpleNumber); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).sample(simpleNumber); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).sample(simpleNumber)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.sample(recordDictionary, numberValue); // $ExpectType StringRecord[]
+    _(recordDictionary).sample(numberValue); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordDictionary).sample(numberValue)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // with n - strings
-    _.sample(simpleString, simpleNumber); // $ExpectType string[]
-    _(simpleString).sample(simpleNumber); // $ExpectType string[]
-    extractChainTypes(_.chain(simpleString).sample(simpleNumber)); // $ExpectType ChainType<string[], string>
+    _.sample(stringValue, numberValue); // $ExpectType string[]
+    _(stringValue).sample(numberValue); // $ExpectType string[]
+    extractChainTypes(_.chain(stringValue).sample(numberValue)); // $ExpectType ChainType<string[], string>
 }
 
 // toArray
 {
     // lists
-    _.toArray(stringRecordList); // $ExpectType StringRecord[]
-    _(stringRecordList).toArray(); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).toArray()); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.toArray(recordList); // $ExpectType StringRecord[]
+    _(recordList).toArray(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).toArray()); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // dictionaries
-    _.toArray(stringRecordDictionary); // $ExpectType StringRecord[]
-    _(stringRecordDictionary).toArray(); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordDictionary).toArray()); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.toArray(recordDictionary); // $ExpectType StringRecord[]
+    _(recordDictionary).toArray(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordDictionary).toArray()); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // strings
-    _.toArray(simpleString); // $ExpectType string[]
-    _(simpleString).toArray(); // $ExpectType string[]
-    extractChainTypes(_.chain(simpleString).toArray()); // $ExpectType ChainType<string[], string>
+    _.toArray(stringValue); // $ExpectType string[]
+    _(stringValue).toArray(); // $ExpectType string[]
+    extractChainTypes(_.chain(stringValue).toArray()); // $ExpectType ChainType<string[], string>
 }
 
 // size
 {
     // lists
-    _.size(stringRecordList); // $ExpectType number
-    _(stringRecordList).size(); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).size()); // $ExpectType ChainType<number, never>
+    _.size(recordList); // $ExpectType number
+    _(recordList).size(); // $ExpectType number
+    extractChainTypes(_.chain(recordList).size()); // $ExpectType ChainType<number, never>
 
     // dictionaries
-    _.size(stringRecordDictionary); // $ExpectType number
-    _(stringRecordDictionary).size(); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordDictionary).size()); // $ExpectType ChainType<number, never>
+    _.size(recordDictionary); // $ExpectType number
+    _(recordDictionary).size(); // $ExpectType number
+    extractChainTypes(_.chain(recordDictionary).size()); // $ExpectType ChainType<number, never>
 
     // strings
-    _.size(simpleString); // $ExpectType number
-    _(simpleString).size(); // $ExpectType number
-    extractChainTypes(_.chain(simpleString).size()); // $ExpectType ChainType<number, never>
+    _.size(stringValue); // $ExpectType number
+    _(stringValue).size(); // $ExpectType number
+    extractChainTypes(_.chain(stringValue).size()); // $ExpectType ChainType<number, never>
 }
 
 // partition
 {
     // function iteratee - lists
-    _.partition(stringRecordList, stringRecordListBooleanIterator); // $ExpectType [StringRecord[], StringRecord[]]
-    _.partition(stringRecordList, stringRecordListBooleanIterator, context); // $ExpectType [StringRecord[], StringRecord[]]
-    _(stringRecordList).partition(stringRecordListBooleanIterator); // $ExpectType [StringRecord[], StringRecord[]]
-    _(stringRecordList).partition(stringRecordListBooleanIterator, context); // $ExpectType [StringRecord[], StringRecord[]]
-    extractChainTypes(_.chain(stringRecordList).partition(stringRecordListBooleanIterator)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
-    extractChainTypes(_.chain(stringRecordList).partition(stringRecordListBooleanIterator, context)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
+    _.partition(recordList, recordListTester); // $ExpectType [StringRecord[], StringRecord[]]
+    _.partition(recordList, recordListTester, context); // $ExpectType [StringRecord[], StringRecord[]]
+    _(recordList).partition(recordListTester); // $ExpectType [StringRecord[], StringRecord[]]
+    _(recordList).partition(recordListTester, context); // $ExpectType [StringRecord[], StringRecord[]]
+    extractChainTypes(_.chain(recordList).partition(recordListTester)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
+    extractChainTypes(_.chain(recordList).partition(recordListTester, context)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
 
     // function iteratee - dictionaries
-    _.partition(stringRecordDictionary, stringRecordDictionaryBooleanIterator); // $ExpectType [StringRecord[], StringRecord[]]
-    _.partition(stringRecordDictionary, stringRecordDictionaryBooleanIterator, context); // $ExpectType [StringRecord[], StringRecord[]]
-    _(stringRecordDictionary).partition(stringRecordDictionaryBooleanIterator); // $ExpectType [StringRecord[], StringRecord[]]
-    _(stringRecordDictionary).partition(stringRecordDictionaryBooleanIterator, context); // $ExpectType [StringRecord[], StringRecord[]]
-    extractChainTypes(_.chain(stringRecordDictionary).partition(stringRecordDictionaryBooleanIterator)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
-    extractChainTypes(_.chain(stringRecordDictionary).partition(stringRecordDictionaryBooleanIterator, context)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
+    _.partition(recordDictionary, recordDictionaryTester); // $ExpectType [StringRecord[], StringRecord[]]
+    _.partition(recordDictionary, recordDictionaryTester, context); // $ExpectType [StringRecord[], StringRecord[]]
+    _(recordDictionary).partition(recordDictionaryTester); // $ExpectType [StringRecord[], StringRecord[]]
+    _(recordDictionary).partition(recordDictionaryTester, context); // $ExpectType [StringRecord[], StringRecord[]]
+    extractChainTypes(_.chain(recordDictionary).partition(recordDictionaryTester)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
+    extractChainTypes(_.chain(recordDictionary).partition(recordDictionaryTester, context)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
 
     // function iteratee - strings
-    _.partition(simpleString, stringListBooleanIterator); // $ExpectType [string[], string[]]
-    _.partition(simpleString, stringListBooleanIterator, context); // $ExpectType [string[], string[]]
-    _(simpleString).partition(stringListBooleanIterator); // $ExpectType [string[], string[]]
-    _(simpleString).partition(stringListBooleanIterator, context); // $ExpectType [string[], string[]]
-    extractChainTypes(_.chain(simpleString).partition(stringListBooleanIterator)); // $ExpectType ChainType<[string[], string[]], string[]>
-    extractChainTypes(_.chain(simpleString).partition(stringListBooleanIterator, context)); // $ExpectType ChainType<[string[], string[]], string[]>
+    _.partition(stringValue, stringTester); // $ExpectType [string[], string[]]
+    _.partition(stringValue, stringTester, context); // $ExpectType [string[], string[]]
+    _(stringValue).partition(stringTester); // $ExpectType [string[], string[]]
+    _(stringValue).partition(stringTester, context); // $ExpectType [string[], string[]]
+    extractChainTypes(_.chain(stringValue).partition(stringTester)); // $ExpectType ChainType<[string[], string[]], string[]>
+    extractChainTypes(_.chain(stringValue).partition(stringTester, context)); // $ExpectType ChainType<[string[], string[]], string[]>
 
     // matcher iteratee - lists
-    _.partition(stringRecordList, partialStringRecord); // $ExpectType [StringRecord[], StringRecord[]]
-    _(stringRecordList).partition(partialStringRecord); // $ExpectType [StringRecord[], StringRecord[]]
-    extractChainTypes(_.chain(stringRecordList).partition(partialStringRecord)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
+    _.partition(recordList, matcher); // $ExpectType [StringRecord[], StringRecord[]]
+    _(recordList).partition(matcher); // $ExpectType [StringRecord[], StringRecord[]]
+    extractChainTypes(_.chain(recordList).partition(matcher)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
 
     // shallow property iteratee - dictionaries
-    _.partition(stringRecordDictionary, stringRecordProperty); // $ExpectType [StringRecord[], StringRecord[]]
-    _(stringRecordDictionary).partition(stringRecordProperty); // $ExpectType [StringRecord[], StringRecord[]]
-    extractChainTypes(_.chain(stringRecordDictionary).partition(stringRecordProperty)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
+    _.partition(recordDictionary, shallowProperty); // $ExpectType [StringRecord[], StringRecord[]]
+    _(recordDictionary).partition(shallowProperty); // $ExpectType [StringRecord[], StringRecord[]]
+    extractChainTypes(_.chain(recordDictionary).partition(shallowProperty)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
 
     // deep property iteratee - lists
-    _.partition(stringRecordList, stringRecordPropertyPath); // $ExpectType [StringRecord[], StringRecord[]]
-    _(stringRecordList).partition(stringRecordPropertyPath); // $ExpectType [StringRecord[], StringRecord[]]
-    extractChainTypes(_.chain(stringRecordList).partition(stringRecordPropertyPath)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
+    _.partition(recordList, deepProperty); // $ExpectType [StringRecord[], StringRecord[]]
+    _(recordList).partition(deepProperty); // $ExpectType [StringRecord[], StringRecord[]]
+    extractChainTypes(_.chain(recordList).partition(deepProperty)); // $ExpectType ChainType<[StringRecord[], StringRecord[]], StringRecord[]>
 
     // identity iteratee - dictionaries
-    _.partition(simpleNumberDictionary); // $ExpectType [number[], number[]]
-    _(simpleNumberDictionary).partition(); // $ExpectType [number[], number[]]
-    extractChainTypes(_.chain(simpleNumberDictionary).partition()); // $ExpectType ChainType<[number[], number[]], number[]>
+    _.partition(numberDictionary); // $ExpectType [number[], number[]]
+    _(numberDictionary).partition(); // $ExpectType [number[], number[]]
+    extractChainTypes(_.chain(numberDictionary).partition()); // $ExpectType ChainType<[number[], number[]], number[]>
 }
 
-// Arrays
+/********************************
+ * Combinatorial Tests - Arrays *
+ ********************************/
 
 // first, head, take
 {
     // without n - first
-    _.first(stringRecordList); // $ExpectType StringRecordOrUndefined
-    _(stringRecordList).first(); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordList).first()); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.first(recordList); // $ExpectType StringRecord | undefined
+    _(recordList).first(); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(recordList).first()); // $ExpectType ChainType<StringRecord | undefined, never>
 
     // without n - head
-    _.head(stringRecordList); // $ExpectType StringRecordOrUndefined
-    _(stringRecordList).head(); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordList).head()); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.head(recordList); // $ExpectType StringRecord | undefined
+    _(recordList).head(); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(recordList).head()); // $ExpectType ChainType<StringRecord | undefined, never>
 
     // without n - take
-    _.take(stringRecordList); // $ExpectType StringRecordOrUndefined
-    _(stringRecordList).take(); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordList).take()); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.take(recordList); // $ExpectType StringRecord | undefined
+    _(recordList).take(); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(recordList).take()); // $ExpectType ChainType<StringRecord | undefined, never>
 
     // with n - first
-    _.first(stringRecordList, simpleNumber); // $ExpectType StringRecord[]
-    _(stringRecordList).first(simpleNumber); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).first(simpleNumber)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.first(recordList, numberValue); // $ExpectType StringRecord[]
+    _(recordList).first(numberValue); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).first(numberValue)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // with n - head
-    _.head(stringRecordList, simpleNumber); // $ExpectType StringRecord[]
-    _(stringRecordList).head(simpleNumber); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).head(simpleNumber)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.head(recordList, numberValue); // $ExpectType StringRecord[]
+    _(recordList).head(numberValue); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).head(numberValue)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // with n - take
-    _.take(stringRecordList, simpleNumber); // $ExpectType StringRecord[]
-    _(stringRecordList).take(simpleNumber); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).take(simpleNumber)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.take(recordList, numberValue); // $ExpectType StringRecord[]
+    _(recordList).take(numberValue); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).take(numberValue)); // $ExpectType ChainType<StringRecord[], StringRecord>
 }
 
 // initial
 {
     // without n
-    _.initial(stringRecordList); // $ExpectType StringRecord[]
-    _(stringRecordList).initial(); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).initial()); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.initial(recordList); // $ExpectType StringRecord[]
+    _(recordList).initial(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).initial()); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // with n
-    _.initial(stringRecordList, simpleNumber); // $ExpectType StringRecord[]
-    _(stringRecordList).initial(simpleNumber); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).initial(simpleNumber)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.initial(recordList, numberValue); // $ExpectType StringRecord[]
+    _(recordList).initial(numberValue); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).initial(numberValue)); // $ExpectType ChainType<StringRecord[], StringRecord>
 }
 
 // last
 {
     // without n
-    _.last(stringRecordList); // $ExpectType StringRecordOrUndefined
-    _(stringRecordList).last(); // $ExpectType StringRecordOrUndefined
-    extractChainTypes(_.chain(stringRecordList).last()); // $ExpectType ChainType<StringRecordOrUndefined, never>
+    _.last(recordList); // $ExpectType StringRecord | undefined
+    _(recordList).last(); // $ExpectType StringRecord | undefined
+    extractChainTypes(_.chain(recordList).last()); // $ExpectType ChainType<StringRecord | undefined, never>
 
     // with n
-    _.last(stringRecordList, simpleNumber); // $ExpectType StringRecord[]
-    _(stringRecordList).last(simpleNumber); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).last(simpleNumber)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.last(recordList, numberValue); // $ExpectType StringRecord[]
+    _(recordList).last(numberValue); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).last(numberValue)); // $ExpectType ChainType<StringRecord[], StringRecord>
 }
 
 // rest, tail, drop
 {
     // without n - rest
-    _.rest(stringRecordList); // $ExpectType StringRecord[]
-    _(stringRecordList).rest(); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).rest()); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.rest(recordList); // $ExpectType StringRecord[]
+    _(recordList).rest(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).rest()); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // without n - tail
-    _.tail(stringRecordList); // $ExpectType StringRecord[]
-    _(stringRecordList).tail(); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).tail()); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.tail(recordList); // $ExpectType StringRecord[]
+    _(recordList).tail(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).tail()); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // without n - drop
-    _.drop(stringRecordList); // $ExpectType StringRecord[]
-    _(stringRecordList).drop(); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).drop()); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.drop(recordList); // $ExpectType StringRecord[]
+    _(recordList).drop(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).drop()); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // with n - rest
-    _.rest(stringRecordList, simpleNumber); // $ExpectType StringRecord[]
-    _(stringRecordList).rest(simpleNumber); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).rest(simpleNumber)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.rest(recordList, numberValue); // $ExpectType StringRecord[]
+    _(recordList).rest(numberValue); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).rest(numberValue)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // with n - tail
-    _.tail(stringRecordList, simpleNumber); // $ExpectType StringRecord[]
-    _(stringRecordList).tail(simpleNumber); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).tail(simpleNumber)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.tail(recordList, numberValue); // $ExpectType StringRecord[]
+    _(recordList).tail(numberValue); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).tail(numberValue)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // with n - drop
-    _.drop(stringRecordList, simpleNumber); // $ExpectType StringRecord[]
-    _(stringRecordList).drop(simpleNumber); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).drop(simpleNumber)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.drop(recordList, numberValue); // $ExpectType StringRecord[]
+    _(recordList).drop(numberValue); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).drop(numberValue)); // $ExpectType ChainType<StringRecord[], StringRecord>
 }
 
 // compact
@@ -2432,14 +2438,14 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
 // flatten
 {
     // one dimension, deep
-    _.flatten(stringRecordList); // $ExpectType StringRecord[]
-    _(stringRecordList).flatten(); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).flatten()); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.flatten(recordList); // $ExpectType StringRecord[]
+    _(recordList).flatten(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).flatten()); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // one dimension, shallow
-    _.flatten(stringRecordList, true); // $ExpectType StringRecord[]
-    _(stringRecordList).flatten(true); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).flatten(true)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.flatten(recordList, true); // $ExpectType StringRecord[]
+    _(recordList).flatten(true); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).flatten(true)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // two dimensions, deep
     _.flatten(level2RecordList); // $ExpectType StringRecord[]
@@ -2482,203 +2488,203 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     extractChainTypes(_.chain(level2StringList).flatten()); // $ExpectType ChainType<string[], string>
 
     // string lists, shallow
-    _.flatten(simpleStringArray, true); // $ExpectType string[]
-    _(simpleStringArray).flatten(true); // $ExpectType string[]
-    extractChainTypes(_.chain(simpleStringArray).flatten(true)); // $ExpectType ChainType<string[], string>
+    _.flatten(stringArray, true); // $ExpectType string[]
+    _(stringArray).flatten(true); // $ExpectType string[]
+    extractChainTypes(_.chain(stringArray).flatten(true)); // $ExpectType ChainType<string[], string>
 
-    _.flatten(simpleStringList, true); // $ExpectType string[]
-    _(simpleStringList).flatten(true); // $ExpectType string[]
-    extractChainTypes(_.chain(simpleStringList).flatten(true)); // $ExpectType ChainType<string[], string>
+    _.flatten(stringList, true); // $ExpectType string[]
+    _(stringList).flatten(true); // $ExpectType string[]
+    extractChainTypes(_.chain(stringList).flatten(true)); // $ExpectType ChainType<string[], string>
 
     // type unions, deep
-    _.flatten(level2NonIntersectingPropertiesList); // $ExpectType NonIntersectingProperties[]
-    _(level2NonIntersectingPropertiesList).flatten(); // $ExpectType NonIntersectingProperties[]
-    extractChainTypes(_.chain(level2NonIntersectingPropertiesList).flatten()); // $ExpectType ChainType<NonIntersectingProperties[], NonIntersectingProperties>
+    _.flatten(level2NonIntersectingList); // $ExpectType NonIntersecting[]
+    _(level2NonIntersectingList).flatten(); // $ExpectType NonIntersecting[]
+    extractChainTypes(_.chain(level2NonIntersectingList).flatten()); // $ExpectType ChainType<NonIntersecting[], NonIntersecting>
 
     // type unions, shallow
-    _.flatten(level2NonIntersectingPropertiesList, true); // $ExpectType NonIntersectingProperties[]
-    _(level2NonIntersectingPropertiesList).flatten(true); // $ExpectType NonIntersectingProperties[]
-    extractChainTypes(_.chain(level2NonIntersectingPropertiesList).flatten(true)); // $ExpectType ChainType<NonIntersectingProperties[], NonIntersectingProperties>
+    _.flatten(level2NonIntersectingList, true); // $ExpectType NonIntersecting[]
+    _(level2NonIntersectingList).flatten(true); // $ExpectType NonIntersecting[]
+    extractChainTypes(_.chain(level2NonIntersectingList).flatten(true)); // $ExpectType ChainType<NonIntersecting[], NonIntersecting>
 }
 
 // without
 {
     // lists
-    _.without(stringRecordList, stringRecordList[0], stringRecordList[1]); // $ExpectType StringRecord[]
-    _(stringRecordList).without(stringRecordList[0], stringRecordList[1]); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).without(stringRecordList[0], stringRecordList[1])); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.without(recordList, recordList[0], recordList[1]); // $ExpectType StringRecord[]
+    _(recordList).without(recordList[0], recordList[1]); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).without(recordList[0], recordList[1])); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // strings
-    _.without(simpleString, simpleString[0], simpleString[1]); // $ExpectType string[]
-    _(simpleString).without(simpleString[0], simpleString[1]); // $ExpectType string[]
-    extractChainTypes(_.chain(simpleString).without(simpleString[0], simpleString[1])); // $ExpectType ChainType<string[], string>
+    _.without(stringValue, stringValue[0], stringValue[1]); // $ExpectType string[]
+    _(stringValue).without(stringValue[0], stringValue[1]); // $ExpectType string[]
+    extractChainTypes(_.chain(stringValue).without(stringValue[0], stringValue[1])); // $ExpectType ChainType<string[], string>
 }
 
 // union
 {
     // lists
     _.union(...recordListArray); // $ExpectType StringRecord[]
-    _(stringRecordList).union(...recordListArray); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).union(...recordListArray)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _(recordList).union(...recordListArray); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).union(...recordListArray)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // list and array mix
-    _.union(simpleStringList, simpleStringArray, simpleStringList); // $ExpectType string[]
-    _(simpleStringList).union(simpleStringArray, simpleStringList); // $ExpectType string[]
-    extractChainTypes(_.chain(simpleStringList).union(simpleStringArray, simpleStringList)); // $ExpectType ChainType<string[], string>
+    _.union(stringList, stringArray, stringList); // $ExpectType string[]
+    _(stringList).union(stringArray, stringList); // $ExpectType string[]
+    extractChainTypes(_.chain(stringList).union(stringArray, stringList)); // $ExpectType ChainType<string[], string>
 }
 
 // intersection
 {
     // lists
     _.intersection(...recordListArray); // $ExpectType StringRecord[]
-    _(stringRecordList).intersection(...recordListArray); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).intersection(...recordListArray)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _(recordList).intersection(...recordListArray); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).intersection(...recordListArray)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // list and array mix
-    _.intersection(simpleStringList, simpleStringArray, simpleStringList); // $ExpectType string[]
-    _(simpleStringList).intersection(simpleStringArray, simpleStringList); // $ExpectType string[]
-    extractChainTypes(_.chain(simpleStringList).intersection(simpleStringArray, simpleStringList)); // $ExpectType ChainType<string[], string>
+    _.intersection(stringList, stringArray, stringList); // $ExpectType string[]
+    _(stringList).intersection(stringArray, stringList); // $ExpectType string[]
+    extractChainTypes(_.chain(stringList).intersection(stringArray, stringList)); // $ExpectType ChainType<string[], string>
 }
 
 // difference
 {
     // lists
-    _.difference(stringRecordList, ...recordListArray); // $ExpectType StringRecord[]
-    _(stringRecordList).difference(...recordListArray); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).difference(...recordListArray)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.difference(recordList, ...recordListArray); // $ExpectType StringRecord[]
+    _(recordList).difference(...recordListArray); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).difference(...recordListArray)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // list and array mix
-    _.intersection(simpleStringList, simpleStringArray, simpleStringList); // $ExpectType string[]
-    _(simpleStringList).intersection(simpleStringArray, simpleStringList); // $ExpectType string[]
-    extractChainTypes(_.chain(simpleStringList).intersection(simpleStringArray, simpleStringList)); // $ExpectType ChainType<string[], string>
+    _.intersection(stringList, stringArray, stringList); // $ExpectType string[]
+    _(stringList).intersection(stringArray, stringList); // $ExpectType string[]
+    extractChainTypes(_.chain(stringList).intersection(stringArray, stringList)); // $ExpectType ChainType<string[], string>
 }
 
 // uniq, unique
 {
     // not sorted - identity iteratee - uniq
-    _.uniq(stringRecordList); // $ExpectType StringRecord[]
-    _(stringRecordList).uniq(); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).uniq()); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.uniq(recordList); // $ExpectType StringRecord[]
+    _(recordList).uniq(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).uniq()); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // not sorted - identity iteratee - unique
-    _.unique(stringRecordList); // $ExpectType StringRecord[]
-    _(stringRecordList).unique(); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).unique()); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.unique(recordList); // $ExpectType StringRecord[]
+    _(recordList).unique(); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).unique()); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // not sorted - function iteratee - uniq
-    _.uniq(stringRecordList, stringRecordListValueIterator); // $ExpectType StringRecord[]
-    _.uniq(stringRecordList, stringRecordListValueIterator, context); // $ExpectType StringRecord[]
-    _(stringRecordList).uniq(stringRecordListValueIterator); // $ExpectType StringRecord[]
-    _(stringRecordList).uniq(stringRecordListValueIterator, context); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).uniq(stringRecordListValueIterator)); // $ExpectType ChainType<StringRecord[], StringRecord>
-    extractChainTypes(_.chain(stringRecordList).uniq(stringRecordListValueIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.uniq(recordList, recordListSelector); // $ExpectType StringRecord[]
+    _.uniq(recordList, recordListSelector, context); // $ExpectType StringRecord[]
+    _(recordList).uniq(recordListSelector); // $ExpectType StringRecord[]
+    _(recordList).uniq(recordListSelector, context); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).uniq(recordListSelector)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    extractChainTypes(_.chain(recordList).uniq(recordListSelector, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // not sorted - function iteratee - unique
-    _.unique(stringRecordList, stringRecordListValueIterator); // $ExpectType StringRecord[]
-    _.unique(stringRecordList, stringRecordListValueIterator, context); // $ExpectType StringRecord[]
-    _(stringRecordList).unique(stringRecordListValueIterator); // $ExpectType StringRecord[]
-    _(stringRecordList).unique(stringRecordListValueIterator, context); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).unique(stringRecordListValueIterator)); // $ExpectType ChainType<StringRecord[], StringRecord>
-    extractChainTypes(_.chain(stringRecordList).unique(stringRecordListValueIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.unique(recordList, recordListSelector); // $ExpectType StringRecord[]
+    _.unique(recordList, recordListSelector, context); // $ExpectType StringRecord[]
+    _(recordList).unique(recordListSelector); // $ExpectType StringRecord[]
+    _(recordList).unique(recordListSelector, context); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).unique(recordListSelector)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    extractChainTypes(_.chain(recordList).unique(recordListSelector, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // not sorted - matcher iteratee - uniq
-    _.uniq(stringRecordList, partialStringRecord); // $ExpectType StringRecord[]
-    _(stringRecordList).uniq(partialStringRecord); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).uniq(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.uniq(recordList, matcher); // $ExpectType StringRecord[]
+    _(recordList).uniq(matcher); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).uniq(matcher)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // not sorted - matcher iteratee - unique
-    _.unique(stringRecordList, partialStringRecord); // $ExpectType StringRecord[]
-    _(stringRecordList).unique(partialStringRecord); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).unique(partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.unique(recordList, matcher); // $ExpectType StringRecord[]
+    _(recordList).unique(matcher); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).unique(matcher)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // not sorted - shallow property iteratee - uniq
-    _.uniq(stringRecordList, stringRecordProperty); // $ExpectType StringRecord[]
-    _(stringRecordList).uniq(stringRecordProperty); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).uniq(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.uniq(recordList, shallowProperty); // $ExpectType StringRecord[]
+    _(recordList).uniq(shallowProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).uniq(shallowProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // not sorted - shallow property iteratee - unique
-    _.unique(stringRecordList, stringRecordProperty); // $ExpectType StringRecord[]
-    _(stringRecordList).unique(stringRecordProperty); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).unique(stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.unique(recordList, shallowProperty); // $ExpectType StringRecord[]
+    _(recordList).unique(shallowProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).unique(shallowProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // not sorted - deep property iteratee - uniq
-    _.uniq(stringRecordList, stringRecordPropertyPath); // $ExpectType StringRecord[]
-    _(stringRecordList).uniq(stringRecordPropertyPath); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).uniq(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.uniq(recordList, deepProperty); // $ExpectType StringRecord[]
+    _(recordList).uniq(deepProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).uniq(deepProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // not sorted - deep property iteratee - unique
-    _.unique(stringRecordList, stringRecordPropertyPath); // $ExpectType StringRecord[]
-    _(stringRecordList).unique(stringRecordPropertyPath); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).unique(stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.unique(recordList, deepProperty); // $ExpectType StringRecord[]
+    _(recordList).unique(deepProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).unique(deepProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // sorted - identity iteratee - uniq
-    _.uniq(stringRecordList, true); // $ExpectType StringRecord[]
-    _(stringRecordList).uniq(true); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).uniq(true)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.uniq(recordList, true); // $ExpectType StringRecord[]
+    _(recordList).uniq(true); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).uniq(true)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // sorted - identity iteratee - unique
-    _.unique(stringRecordList, true); // $ExpectType StringRecord[]
-    _(stringRecordList).unique(true); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).unique(true)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.unique(recordList, true); // $ExpectType StringRecord[]
+    _(recordList).unique(true); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).unique(true)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // sorted - function iteratee - uniq
-    _.uniq(stringRecordList, true, stringRecordListValueIterator); // $ExpectType StringRecord[]
-    _.uniq(stringRecordList, true, stringRecordListValueIterator, context); // $ExpectType StringRecord[]
-    _(stringRecordList).uniq(true, stringRecordListValueIterator); // $ExpectType StringRecord[]
-    _(stringRecordList).uniq(true, stringRecordListValueIterator, context); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).uniq(true, stringRecordListValueIterator)); // $ExpectType ChainType<StringRecord[], StringRecord>
-    extractChainTypes(_.chain(stringRecordList).uniq(true, stringRecordListValueIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.uniq(recordList, true, recordListSelector); // $ExpectType StringRecord[]
+    _.uniq(recordList, true, recordListSelector, context); // $ExpectType StringRecord[]
+    _(recordList).uniq(true, recordListSelector); // $ExpectType StringRecord[]
+    _(recordList).uniq(true, recordListSelector, context); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).uniq(true, recordListSelector)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    extractChainTypes(_.chain(recordList).uniq(true, recordListSelector, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // sorted - function iteratee - unique
-    _.unique(stringRecordList, true, stringRecordListValueIterator); // $ExpectType StringRecord[]
-    _.unique(stringRecordList, true, stringRecordListValueIterator, context); // $ExpectType StringRecord[]
-    _(stringRecordList).unique(true, stringRecordListValueIterator); // $ExpectType StringRecord[]
-    _(stringRecordList).unique(true, stringRecordListValueIterator, context); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).unique(true, stringRecordListValueIterator)); // $ExpectType ChainType<StringRecord[], StringRecord>
-    extractChainTypes(_.chain(stringRecordList).unique(true, stringRecordListValueIterator, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.unique(recordList, true, recordListSelector); // $ExpectType StringRecord[]
+    _.unique(recordList, true, recordListSelector, context); // $ExpectType StringRecord[]
+    _(recordList).unique(true, recordListSelector); // $ExpectType StringRecord[]
+    _(recordList).unique(true, recordListSelector, context); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).unique(true, recordListSelector)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    extractChainTypes(_.chain(recordList).unique(true, recordListSelector, context)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // sorted - matcher iteratee - uniq
-    _.uniq(stringRecordList, true, partialStringRecord); // $ExpectType StringRecord[]
-    _(stringRecordList).uniq(true, partialStringRecord); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).uniq(true, partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.uniq(recordList, true, matcher); // $ExpectType StringRecord[]
+    _(recordList).uniq(true, matcher); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).uniq(true, matcher)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // sorted - matcher iteratee - unique
-    _.unique(stringRecordList, true, partialStringRecord); // $ExpectType StringRecord[]
-    _(stringRecordList).unique(true, partialStringRecord); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).unique(true, partialStringRecord)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.unique(recordList, true, matcher); // $ExpectType StringRecord[]
+    _(recordList).unique(true, matcher); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).unique(true, matcher)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // sorted - shallow property iteratee - uniq
-    _.uniq(stringRecordList, true, stringRecordProperty); // $ExpectType StringRecord[]
-    _(stringRecordList).uniq(true, stringRecordProperty); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).uniq(true, stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.uniq(recordList, true, shallowProperty); // $ExpectType StringRecord[]
+    _(recordList).uniq(true, shallowProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).uniq(true, shallowProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // sorted - shallow property iteratee - unique
-    _.unique(stringRecordList, true, stringRecordProperty); // $ExpectType StringRecord[]
-    _(stringRecordList).unique(true, stringRecordProperty); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).unique(true, stringRecordProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.unique(recordList, true, shallowProperty); // $ExpectType StringRecord[]
+    _(recordList).unique(true, shallowProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).unique(true, shallowProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // sorted - deep property iteratee - uniq
-    _.uniq(stringRecordList, true, stringRecordPropertyPath); // $ExpectType StringRecord[]
-    _(stringRecordList).uniq(true, stringRecordPropertyPath); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).uniq(true, stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.uniq(recordList, true, deepProperty); // $ExpectType StringRecord[]
+    _(recordList).uniq(true, deepProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).uniq(true, deepProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 
     // sorted - deep property iteratee - unique
-    _.unique(stringRecordList, true, stringRecordPropertyPath); // $ExpectType StringRecord[]
-    _(stringRecordList).unique(true, stringRecordPropertyPath); // $ExpectType StringRecord[]
-    extractChainTypes(_.chain(stringRecordList).unique(true, stringRecordPropertyPath)); // $ExpectType ChainType<StringRecord[], StringRecord>
+    _.unique(recordList, true, deepProperty); // $ExpectType StringRecord[]
+    _(recordList).unique(true, deepProperty); // $ExpectType StringRecord[]
+    extractChainTypes(_.chain(recordList).unique(true, deepProperty)); // $ExpectType ChainType<StringRecord[], StringRecord>
 }
 
 // zip
 {
     // multiple arguments
-    _.zip(simpleStringList, simpleNumberList, stringRecordList); // $ExpectType any[][]
-    _(simpleStringList).zip(simpleNumberList, stringRecordList); // $ExpectType any[][]
-    extractChainTypes(_.chain(simpleStringList).zip(simpleNumberList, stringRecordList)); // $ExpectType ChainType<any[][], any[]>
+    _.zip(stringList, numberList, recordList); // $ExpectType any[][]
+    _(stringList).zip(numberList, recordList); // $ExpectType any[][]
+    extractChainTypes(_.chain(stringList).zip(numberList, recordList)); // $ExpectType ChainType<any[][], any[]>
 
     // single arguments
-    _.zip(simpleStringList); // $ExpectType any[][]
-    _(simpleStringList).zip(); // $ExpectType any[][]
-    extractChainTypes(_.chain(simpleStringList).zip()); // $ExpectType ChainType<any[][], any[]>
+    _.zip(stringList); // $ExpectType any[][]
+    _(stringList).zip(); // $ExpectType any[][]
+    extractChainTypes(_.chain(stringList).zip()); // $ExpectType ChainType<any[][], any[]>
 }
 
 // unzip
@@ -2697,9 +2703,9 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
 // object
 {
     // key and value lists
-    _.object(simpleStringList, simpleNumberList); // $ExpectType Dictionary<number | undefined>
-    _(simpleStringList).object(simpleNumberList); // $ExpectType Dictionary<number | undefined>
-    extractChainTypes(_.chain(simpleStringList).object(simpleNumberList)); // $ExpectType ChainType<Dictionary<number | undefined>, number | undefined>
+    _.object(stringList, numberList); // $ExpectType Dictionary<number | undefined>
+    _(stringList).object(numberList); // $ExpectType Dictionary<number | undefined>
+    extractChainTypes(_.chain(stringList).object(numberList)); // $ExpectType ChainType<Dictionary<number | undefined>, number | undefined>
 
     // tuple lists
     _.object(tupleList); // $ExpectType Dictionary<number>
@@ -2712,229 +2718,229 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     extractChainTypes(_.chain(level2UnionList).object()); // $ExpectType ChainType<Dictionary<string | number>, string | number>
 
     // non-nested lists
-    _.object(stringRecordList); // $ExpectError
-    _(stringRecordList).object(); // $ExpectType Dictionary<never>
-    extractChainTypes(_.chain(stringRecordList).object()); // $ExpectType ChainType<Dictionary<never>, never>
+    _.object(recordList); // $ExpectError
+    _(recordList).object(); // $ExpectType Dictionary<never>
+    extractChainTypes(_.chain(recordList).object()); // $ExpectType ChainType<Dictionary<never>, never>
 }
 
 // chunk
 {
-    const length = 2;
-
     // lists
-    _.chunk(stringRecordList, length); // $ExpectType StringRecord[][]
-    _(stringRecordList).chunk(length); // $ExpectType StringRecord[][]
-    extractChainTypes(_.chain(stringRecordList).chunk(length)); // $ExpectType ChainType<StringRecord[][], StringRecord[]>
+    _.chunk(recordList, numberValue); // $ExpectType StringRecord[][]
+    _(recordList).chunk(numberValue); // $ExpectType StringRecord[][]
+    extractChainTypes(_.chain(recordList).chunk(numberValue)); // $ExpectType ChainType<StringRecord[][], StringRecord[]>
 
     // strings
-    _.chunk(simpleString, length); // $ExpectType string[][]
-    _(simpleString).chunk(length); // $ExpectType string[][]
-    extractChainTypes(_.chain(simpleString).chunk(length)); // $ExpectType ChainType<string[][], string[]>
+    _.chunk(stringValue, numberValue); // $ExpectType string[][]
+    _(stringValue).chunk(numberValue); // $ExpectType string[][]
+    extractChainTypes(_.chain(stringValue).chunk(numberValue)); // $ExpectType ChainType<string[][], string[]>
 }
 
 // indexOf
 {
     // not sorted, from zero
-    _.indexOf(stringRecordList, stringRecordList[0]); // $ExpectType number
-    _(stringRecordList).indexOf(stringRecordList[0]); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).indexOf(stringRecordList[0])); // $ExpectType ChainType<number, never>
+    _.indexOf(recordList, recordList[0]); // $ExpectType number
+    _(recordList).indexOf(recordList[0]); // $ExpectType number
+    extractChainTypes(_.chain(recordList).indexOf(recordList[0])); // $ExpectType ChainType<number, never>
 
     // sorted
-    _.indexOf(stringRecordList, stringRecordList[0], true); // $ExpectType number
-    _(stringRecordList).indexOf(stringRecordList[0], true); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).indexOf(stringRecordList[0], true)); // $ExpectType ChainType<number, never>
+    _.indexOf(recordList, recordList[0], true); // $ExpectType number
+    _(recordList).indexOf(recordList[0], true); // $ExpectType number
+    extractChainTypes(_.chain(recordList).indexOf(recordList[0], true)); // $ExpectType ChainType<number, never>
 
     // from index
-    _.indexOf(stringRecordList, stringRecordList[0], simpleNumber); // $ExpectType number
-    _(stringRecordList).indexOf(stringRecordList[0], simpleNumber); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).indexOf(stringRecordList[0], simpleNumber)); // $ExpectType ChainType<number, never>
+    _.indexOf(recordList, recordList[0], numberValue); // $ExpectType number
+    _(recordList).indexOf(recordList[0], numberValue); // $ExpectType number
+    extractChainTypes(_.chain(recordList).indexOf(recordList[0], numberValue)); // $ExpectType ChainType<number, never>
 }
 
 // lastIndexOf
 {
     // from zero
-    _.lastIndexOf(stringRecordList, stringRecordList[0]); // $ExpectType number
-    _(stringRecordList).lastIndexOf(stringRecordList[0]); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).lastIndexOf(stringRecordList[0])); // $ExpectType ChainType<number, never>
+    _.lastIndexOf(recordList, recordList[0]); // $ExpectType number
+    _(recordList).lastIndexOf(recordList[0]); // $ExpectType number
+    extractChainTypes(_.chain(recordList).lastIndexOf(recordList[0])); // $ExpectType ChainType<number, never>
 
     // from index
-    _.lastIndexOf(stringRecordList, stringRecordList[0], simpleNumber); // $ExpectType number
-    _(stringRecordList).lastIndexOf(stringRecordList[0], simpleNumber); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).lastIndexOf(stringRecordList[0], simpleNumber)); // $ExpectType ChainType<number, never>
+    _.lastIndexOf(recordList, recordList[0], numberValue); // $ExpectType number
+    _(recordList).lastIndexOf(recordList[0], numberValue); // $ExpectType number
+    extractChainTypes(_.chain(recordList).lastIndexOf(recordList[0], numberValue)); // $ExpectType ChainType<number, never>
 }
 
 // findIndex
 {
     // function iteratee
-    _.findIndex(stringRecordList, stringRecordListBooleanIterator); // $ExpectType number
-    _.findIndex(stringRecordList, stringRecordListBooleanIterator, context); // $ExpectType number
-    _(stringRecordList).findIndex(stringRecordListBooleanIterator); // $ExpectType number
-    _(stringRecordList).findIndex(stringRecordListBooleanIterator, context); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).findIndex(stringRecordListBooleanIterator)); // $ExpectType ChainType<number, never>
-    extractChainTypes(_.chain(stringRecordList).findIndex(stringRecordListBooleanIterator, context)); // $ExpectType ChainType<number, never>
+    _.findIndex(recordList, recordListTester); // $ExpectType number
+    _.findIndex(recordList, recordListTester, context); // $ExpectType number
+    _(recordList).findIndex(recordListTester); // $ExpectType number
+    _(recordList).findIndex(recordListTester, context); // $ExpectType number
+    extractChainTypes(_.chain(recordList).findIndex(recordListTester)); // $ExpectType ChainType<number, never>
+    extractChainTypes(_.chain(recordList).findIndex(recordListTester, context)); // $ExpectType ChainType<number, never>
 
     // matcher iteratee
-    _.findIndex(stringRecordList, partialStringRecord); // $ExpectType number
-    _(stringRecordList).findIndex(partialStringRecord); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).findIndex(partialStringRecord)); // $ExpectType ChainType<number, never>
+    _.findIndex(recordList, matcher); // $ExpectType number
+    _(recordList).findIndex(matcher); // $ExpectType number
+    extractChainTypes(_.chain(recordList).findIndex(matcher)); // $ExpectType ChainType<number, never>
 
     // shallow property iteratee
-    _.findIndex(stringRecordList, stringRecordProperty); // $ExpectType number
-    _(stringRecordList).findIndex(stringRecordProperty); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).findIndex(stringRecordProperty)); // $ExpectType ChainType<number, never>
+    _.findIndex(recordList, shallowProperty); // $ExpectType number
+    _(recordList).findIndex(shallowProperty); // $ExpectType number
+    extractChainTypes(_.chain(recordList).findIndex(shallowProperty)); // $ExpectType ChainType<number, never>
 
     // deep property iteratee
-    _.findIndex(stringRecordList, stringRecordPropertyPath); // $ExpectType number
-    _(stringRecordList).findIndex(stringRecordPropertyPath); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).findIndex(stringRecordPropertyPath)); // $ExpectType ChainType<number, never>
+    _.findIndex(recordList, deepProperty); // $ExpectType number
+    _(recordList).findIndex(deepProperty); // $ExpectType number
+    extractChainTypes(_.chain(recordList).findIndex(deepProperty)); // $ExpectType ChainType<number, never>
 
     // identity iteratee
-    _.findIndex(stringRecordList); // $ExpectType number
-    _(stringRecordList).findIndex(); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).findIndex()); // $ExpectType ChainType<number, never>
+    _.findIndex(recordList); // $ExpectType number
+    _(recordList).findIndex(); // $ExpectType number
+    extractChainTypes(_.chain(recordList).findIndex()); // $ExpectType ChainType<number, never>
 }
 
 // findLastIndex
 {
     // function iteratee
-    _.findLastIndex(stringRecordList, stringRecordListBooleanIterator); // $ExpectType number
-    _.findLastIndex(stringRecordList, stringRecordListBooleanIterator, context); // $ExpectType number
-    _(stringRecordList).findLastIndex(stringRecordListBooleanIterator); // $ExpectType number
-    _(stringRecordList).findLastIndex(stringRecordListBooleanIterator, context); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).findLastIndex(stringRecordListBooleanIterator)); // $ExpectType ChainType<number, never>
-    extractChainTypes(_.chain(stringRecordList).findLastIndex(stringRecordListBooleanIterator, context)); // $ExpectType ChainType<number, never>
+    _.findLastIndex(recordList, recordListTester); // $ExpectType number
+    _.findLastIndex(recordList, recordListTester, context); // $ExpectType number
+    _(recordList).findLastIndex(recordListTester); // $ExpectType number
+    _(recordList).findLastIndex(recordListTester, context); // $ExpectType number
+    extractChainTypes(_.chain(recordList).findLastIndex(recordListTester)); // $ExpectType ChainType<number, never>
+    extractChainTypes(_.chain(recordList).findLastIndex(recordListTester, context)); // $ExpectType ChainType<number, never>
 
     // matcher iteratee
-    _.findLastIndex(stringRecordList, partialStringRecord); // $ExpectType number
-    _(stringRecordList).findLastIndex(partialStringRecord); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).findLastIndex(partialStringRecord)); // $ExpectType ChainType<number, never>
+    _.findLastIndex(recordList, matcher); // $ExpectType number
+    _(recordList).findLastIndex(matcher); // $ExpectType number
+    extractChainTypes(_.chain(recordList).findLastIndex(matcher)); // $ExpectType ChainType<number, never>
 
     // shallow property iteratee
-    _.findLastIndex(stringRecordList, stringRecordProperty); // $ExpectType number
-    _(stringRecordList).findLastIndex(stringRecordProperty); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).findLastIndex(stringRecordProperty)); // $ExpectType ChainType<number, never>
+    _.findLastIndex(recordList, shallowProperty); // $ExpectType number
+    _(recordList).findLastIndex(shallowProperty); // $ExpectType number
+    extractChainTypes(_.chain(recordList).findLastIndex(shallowProperty)); // $ExpectType ChainType<number, never>
 
     // deep property iteratee
-    _.findLastIndex(stringRecordList, stringRecordPropertyPath); // $ExpectType number
-    _(stringRecordList).findLastIndex(stringRecordPropertyPath); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).findLastIndex(stringRecordPropertyPath)); // $ExpectType ChainType<number, never>
+    _.findLastIndex(recordList, deepProperty); // $ExpectType number
+    _(recordList).findLastIndex(deepProperty); // $ExpectType number
+    extractChainTypes(_.chain(recordList).findLastIndex(deepProperty)); // $ExpectType ChainType<number, never>
 
     // identity iteratee
-    _.findLastIndex(stringRecordList); // $ExpectType number
-    _(stringRecordList).findLastIndex(); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).findLastIndex()); // $ExpectType ChainType<number, never>
+    _.findLastIndex(recordList); // $ExpectType number
+    _(recordList).findLastIndex(); // $ExpectType number
+    extractChainTypes(_.chain(recordList).findLastIndex()); // $ExpectType ChainType<number, never>
 }
 
 // sortedIndex
 {
     // identity iteratee
-    _.sortedIndex(simpleStringList, simpleString); // $ExpectType number
-    _(simpleStringList).sortedIndex(simpleString); // $ExpectType number
-    extractChainTypes(_.chain(simpleStringList).sortedIndex(simpleString)); // $ExpectType ChainType<number, never>
+    _.sortedIndex(stringList, stringValue); // $ExpectType number
+    _(stringList).sortedIndex(stringValue); // $ExpectType number
+    extractChainTypes(_.chain(stringList).sortedIndex(stringValue)); // $ExpectType ChainType<number, never>
 
     // function iteratee
-    _.sortedIndex(stringRecordList, stringRecordList[0], stringRecordOptionalListValueIterator); // $ExpectType number
-    _.sortedIndex(stringRecordList, stringRecordList[0], stringRecordOptionalListValueIterator, context); // $ExpectType number
-    _(stringRecordList).sortedIndex(stringRecordList[0], stringRecordOptionalListValueIterator); // $ExpectType number
-    _(stringRecordList).sortedIndex(stringRecordList[0], stringRecordOptionalListValueIterator, context); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).sortedIndex(stringRecordList[0], stringRecordOptionalListValueIterator)); // $ExpectType ChainType<number, never>
-    extractChainTypes(_.chain(stringRecordList).sortedIndex(stringRecordList[0], stringRecordOptionalListValueIterator, context)); // $ExpectType ChainType<number, never>
+    _.sortedIndex(recordList, recordList[0], recordMaybeListSelector); // $ExpectType number
+    _.sortedIndex(recordList, recordList[0], recordMaybeListSelector, context); // $ExpectType number
+    _(recordList).sortedIndex(recordList[0], recordMaybeListSelector); // $ExpectType number
+    _(recordList).sortedIndex(recordList[0], recordMaybeListSelector, context); // $ExpectType number
+    extractChainTypes(_.chain(recordList).sortedIndex(recordList[0], recordMaybeListSelector)); // $ExpectType ChainType<number, never>
+    extractChainTypes(_.chain(recordList).sortedIndex(recordList[0], recordMaybeListSelector, context)); // $ExpectType ChainType<number, never>
 
     // matcher iteratee
-    _.sortedIndex(stringRecordList, stringRecordList[0], partialStringRecord); // $ExpectType number
-    _(stringRecordList).sortedIndex(stringRecordList[0], partialStringRecord); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).sortedIndex(stringRecordList[0], partialStringRecord)); // $ExpectType ChainType<number, never>
+    _.sortedIndex(recordList, recordList[0], matcher); // $ExpectType number
+    _(recordList).sortedIndex(recordList[0], matcher); // $ExpectType number
+    extractChainTypes(_.chain(recordList).sortedIndex(recordList[0], matcher)); // $ExpectType ChainType<number, never>
 
     // shallow property iteratee
-    _.sortedIndex(stringRecordList, stringRecordList[0], stringRecordProperty); // $ExpectType number
-    _(stringRecordList).sortedIndex(stringRecordList[0], stringRecordProperty); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).sortedIndex(stringRecordList[0], stringRecordProperty)); // $ExpectType ChainType<number, never>
+    _.sortedIndex(recordList, recordList[0], shallowProperty); // $ExpectType number
+    _(recordList).sortedIndex(recordList[0], shallowProperty); // $ExpectType number
+    extractChainTypes(_.chain(recordList).sortedIndex(recordList[0], shallowProperty)); // $ExpectType ChainType<number, never>
 
     // deep property iteratee
-    _.sortedIndex(stringRecordList, stringRecordList[0], stringRecordPropertyPath); // $ExpectType number
-    _(stringRecordList).sortedIndex(stringRecordList[0], stringRecordPropertyPath); // $ExpectType number
-    extractChainTypes(_.chain(stringRecordList).sortedIndex(stringRecordList[0], stringRecordPropertyPath)); // $ExpectType ChainType<number, never>
+    _.sortedIndex(recordList, recordList[0], deepProperty); // $ExpectType number
+    _(recordList).sortedIndex(recordList[0], deepProperty); // $ExpectType number
+    extractChainTypes(_.chain(recordList).sortedIndex(recordList[0], deepProperty)); // $ExpectType ChainType<number, never>
 }
 
 // range
 {
     // only stop
-    _.range(simpleNumber); // $ExpectType number[]
-    _(simpleNumber).range(); // $ExpectType number[]
-    extractChainTypes(_.chain(simpleNumber).range()); // $ExpectType ChainType<number[], number>
+    _.range(numberValue); // $ExpectType number[]
+    _(numberValue).range(); // $ExpectType number[]
+    extractChainTypes(_.chain(numberValue).range()); // $ExpectType ChainType<number[], number>
 
     // start and stop
-    _.range(simpleNumber, simpleNumber); // $ExpectType number[]
-    _(simpleNumber).range(simpleNumber); // $ExpectType number[]
-    extractChainTypes(_.chain(simpleNumber).range(simpleNumber)); // $ExpectType ChainType<number[], number>
+    _.range(numberValue, numberValue); // $ExpectType number[]
+    _(numberValue).range(numberValue); // $ExpectType number[]
+    extractChainTypes(_.chain(numberValue).range(numberValue)); // $ExpectType ChainType<number[], number>
 
     // stop and step
-    _.range(simpleNumber, undefined, simpleNumber); // $ExpectType number[]
-    _(simpleNumber).range(undefined, simpleNumber); // $ExpectType number[]
-    extractChainTypes(_.chain(simpleNumber).range(undefined, simpleNumber)); // $ExpectType ChainType<number[], number>
+    _.range(numberValue, undefined, numberValue); // $ExpectType number[]
+    _(numberValue).range(undefined, numberValue); // $ExpectType number[]
+    extractChainTypes(_.chain(numberValue).range(undefined, numberValue)); // $ExpectType ChainType<number[], number>
 
     // start, stop, and step
-    _.range(simpleNumber, simpleNumber, simpleNumber); // $ExpectType number[]
-    _(simpleNumber).range(simpleNumber, simpleNumber); // $ExpectType number[]
-    extractChainTypes(_.chain(simpleNumber).range(simpleNumber, simpleNumber)); // $ExpectType ChainType<number[], number>
+    _.range(numberValue, numberValue, numberValue); // $ExpectType number[]
+    _(numberValue).range(numberValue, numberValue); // $ExpectType number[]
+    extractChainTypes(_.chain(numberValue).range(numberValue, numberValue)); // $ExpectType ChainType<number[], number>
 }
 
-// Objects
+/*********************************
+ * Combinatorial Tests - Objects *
+ *********************************/
 
 // mapObject
 {
     // function iteratee - objects
-    _.mapObject(mixedTypeRecord, mixedTypeRecordValueIterator, context); // $ExpectType { a: string; b: string; c: string; }
-    _(mixedTypeRecord).mapObject(mixedTypeRecordValueIterator, context); // $ExpectType { a: string; b: string; c: string; }
-    extractChainTypes(_.chain(mixedTypeRecord).mapObject(mixedTypeRecordValueIterator, context)); // $ExpectType ChainType<{ a: string; b: string; c: string; }, string>
+    _.mapObject(mixedTypeRecord, mixedTypeSelector, context); // $ExpectType { a: string; b: string; c: string; }
+    _(mixedTypeRecord).mapObject(mixedTypeSelector, context); // $ExpectType { a: string; b: string; c: string; }
+    extractChainTypes(_.chain(mixedTypeRecord).mapObject(mixedTypeSelector, context)); // $ExpectType ChainType<{ a: string; b: string; c: string; }, string>
 
     // function iteratee - dictionaries
-    _.mapObject(stringRecordDictionary, stringRecordDictionaryValueIterator, context); // $ExpectType { [x: string]: string; }
-    _(stringRecordDictionary).mapObject(stringRecordDictionaryValueIterator, context); // $ExpectType { [x: string]: string; }
-    extractChainTypes(_.chain(stringRecordDictionary).mapObject(stringRecordDictionaryValueIterator, context)); // $ExpectType ChainType<{ [x: string]: string; }, string>
+    _.mapObject(recordDictionary, recordDictionarySelector, context); // $ExpectType { [x: string]: string; }
+    _(recordDictionary).mapObject(recordDictionarySelector, context); // $ExpectType { [x: string]: string; }
+    extractChainTypes(_.chain(recordDictionary).mapObject(recordDictionarySelector, context)); // $ExpectType ChainType<{ [x: string]: string; }, string>
 
     // function iteratee - any
-    _.mapObject(anyValue, stringRecordDictionaryValueIterator, context); // $ExpectType { [x: string]: string; }
-    _(anyValue).mapObject(stringRecordDictionaryValueIterator, context); // $ExpectType { [x: string]: string; }
-    extractChainTypes(_.chain(anyValue).mapObject(stringRecordDictionaryValueIterator, context)); // $ExpectType ChainType<{ [x: string]: string; }, string>
+    _.mapObject(anyValue, recordDictionarySelector, context); // $ExpectType { [x: string]: string; }
+    _(anyValue).mapObject(recordDictionarySelector, context); // $ExpectType { [x: string]: string; }
+    extractChainTypes(_.chain(anyValue).mapObject(recordDictionarySelector, context)); // $ExpectType ChainType<{ [x: string]: string; }, string>
 
     // matcher iteratee - objects
-    _.mapObject(mixedTypeRecord, partialStringRecord); // $ExpectType { a: boolean; b: boolean; c: boolean; }
-    _(mixedTypeRecord).mapObject(partialStringRecord); // $ExpectType { a: boolean; b: boolean; c: boolean; }
-    extractChainTypes(_.chain(mixedTypeRecord).mapObject(partialStringRecord)); // $ExpectType ChainType<{ a: boolean; b: boolean; c: boolean; }, boolean>
+    _.mapObject(mixedTypeRecord, matcher); // $ExpectType { a: boolean; b: boolean; c: boolean; }
+    _(mixedTypeRecord).mapObject(matcher); // $ExpectType { a: boolean; b: boolean; c: boolean; }
+    extractChainTypes(_.chain(mixedTypeRecord).mapObject(matcher)); // $ExpectType ChainType<{ a: boolean; b: boolean; c: boolean; }, boolean>
 
     // matcher iteratee - any
-    _.mapObject(anyValue, partialStringRecord); // $ExpectType { [x: string]: boolean; }
-    _(anyValue).mapObject(partialStringRecord); // $ExpectType { [x: string]: boolean; }
-    extractChainTypes(_.chain(anyValue).mapObject(partialStringRecord)); // $ExpectType ChainType<{ [x: string]: boolean; }, boolean>
+    _.mapObject(anyValue, matcher); // $ExpectType { [x: string]: boolean; }
+    _(anyValue).mapObject(matcher); // $ExpectType { [x: string]: boolean; }
+    extractChainTypes(_.chain(anyValue).mapObject(matcher)); // $ExpectType ChainType<{ [x: string]: boolean; }, boolean>
 
     // shallow property iteratee - objects
-    _.mapObject(mixedTypeRecord, stringRecordProperty); // $ExpectType { a: string; b: any; c: any; }
-    _(mixedTypeRecord).mapObject(stringRecordProperty); // $ExpectType { a: string; b: any; c: any; }
-    extractChainTypes(_.chain(mixedTypeRecord).mapObject(stringRecordProperty)); // $ExpectType ChainType<{ a: string; b: any; c: any; }, any>
+    _.mapObject(mixedTypeRecord, shallowProperty); // $ExpectType { a: string; b: any; c: any; }
+    _(mixedTypeRecord).mapObject(shallowProperty); // $ExpectType { a: string; b: any; c: any; }
+    extractChainTypes(_.chain(mixedTypeRecord).mapObject(shallowProperty)); // $ExpectType ChainType<{ a: string; b: any; c: any; }, any>
 
     // shallow property iteratee - any
-    _.mapObject(anyValue, stringRecordProperty); // $ExpectType { [x: string]: any; }
-    _(anyValue).mapObject(stringRecordProperty); // $ExpectType { [x: string]: any; }
-    extractChainTypes(_.chain(anyValue).mapObject(stringRecordProperty)); // $ExpectType ChainType<{ [x: string]: any; }, any>
+    _.mapObject(anyValue, shallowProperty); // $ExpectType { [x: string]: any; }
+    _(anyValue).mapObject(shallowProperty); // $ExpectType { [x: string]: any; }
+    extractChainTypes(_.chain(anyValue).mapObject(shallowProperty)); // $ExpectType ChainType<{ [x: string]: any; }, any>
 
     // deep property iteratee - objects
-    _.mapObject(mixedTypeRecord, stringRecordPropertyPath); // $ExpectType { a: any; b: any; c: any; }
-    _(mixedTypeRecord).mapObject(stringRecordPropertyPath); // $ExpectType { a: any; b: any; c: any; }
-    extractChainTypes(_.chain(mixedTypeRecord).mapObject(stringRecordPropertyPath)); // $ExpectType ChainType<{ a: any; b: any; c: any; }, any>
+    _.mapObject(mixedTypeRecord, deepProperty); // $ExpectType { a: any; b: any; c: any; }
+    _(mixedTypeRecord).mapObject(deepProperty); // $ExpectType { a: any; b: any; c: any; }
+    extractChainTypes(_.chain(mixedTypeRecord).mapObject(deepProperty)); // $ExpectType ChainType<{ a: any; b: any; c: any; }, any>
 
     // deep property iteratee - any
-    _.mapObject(anyValue, stringRecordPropertyPath); // $ExpectType { [x: string]: any; }
-    _(anyValue).mapObject(stringRecordPropertyPath); // $ExpectType { [x: string]: any; }
-    extractChainTypes(_.chain(anyValue).mapObject(stringRecordPropertyPath)); // $ExpectType ChainType<{ [x: string]: any; }, any>
+    _.mapObject(anyValue, deepProperty); // $ExpectType { [x: string]: any; }
+    _(anyValue).mapObject(deepProperty); // $ExpectType { [x: string]: any; }
+    extractChainTypes(_.chain(anyValue).mapObject(deepProperty)); // $ExpectType ChainType<{ [x: string]: any; }, any>
 }
 
 // pairs
 {
     // dictionaries
-    _.pairs(stringRecordDictionary); // $ExpectType [string, StringRecord][]
-    _(stringRecordDictionary).pairs(); // $ExpectType [string, StringRecord][]
-    extractChainTypes(_.chain(stringRecordDictionary).pairs()); // $ExpectType ChainType<[string, StringRecord][], [string, StringRecord]>
+    _.pairs(recordDictionary); // $ExpectType [string, StringRecord][]
+    _(recordDictionary).pairs(); // $ExpectType [string, StringRecord][]
+    extractChainTypes(_.chain(recordDictionary).pairs()); // $ExpectType ChainType<[string, StringRecord][], [string, StringRecord]>
 
     // objects
     _.pairs(mixedTypeRecord); // $ExpectType ["a" | "b" | "c", any][]
@@ -2950,34 +2956,34 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
 // findKey
 {
     // function iteratee - objects
-    _.findKey(mixedTypeRecord, mixedTypeRecordBooleanIterator, context); // $ExpectType "a" | "b" | "c" | undefined
-    _(mixedTypeRecord).findKey(mixedTypeRecordBooleanIterator, context); // $ExpectType "a" | "b" | "c" | undefined
-    extractChainTypes(_.chain(mixedTypeRecord).findKey(mixedTypeRecordBooleanIterator, context)); // $ExpectType ChainType<"a" | "b" | "c" | undefined, string>
+    _.findKey(mixedTypeRecord, mixedTypeTester, context); // $ExpectType "a" | "b" | "c" | undefined
+    _(mixedTypeRecord).findKey(mixedTypeTester, context); // $ExpectType "a" | "b" | "c" | undefined
+    extractChainTypes(_.chain(mixedTypeRecord).findKey(mixedTypeTester, context)); // $ExpectType ChainType<"a" | "b" | "c" | undefined, string>
 
     // function iteratee - dictionaries
-    _.findKey(stringRecordDictionary, stringRecordDictionaryBooleanIterator, context); // $ExpectType string | undefined
-    _(stringRecordDictionary).findKey(stringRecordDictionaryBooleanIterator, context); // $ExpectType string | undefined
-    extractChainTypes(_.chain(stringRecordDictionary).findKey(stringRecordDictionaryBooleanIterator, context)); // $ExpectType ChainType<string | undefined, string>
+    _.findKey(recordDictionary, recordDictionaryTester, context); // $ExpectType string | undefined
+    _(recordDictionary).findKey(recordDictionaryTester, context); // $ExpectType string | undefined
+    extractChainTypes(_.chain(recordDictionary).findKey(recordDictionaryTester, context)); // $ExpectType ChainType<string | undefined, string>
 
     // function iteratee - any
-    _.findKey(anyValue, stringRecordDictionaryBooleanIterator, context); // $ExpectType string | undefined
-    _(anyValue).findKey(stringRecordDictionaryBooleanIterator, context); // $ExpectType string | undefined
-    extractChainTypes(_.chain(anyValue).findKey(stringRecordDictionaryBooleanIterator, context)); // $ExpectType ChainType<string | undefined, string>
+    _.findKey(anyValue, recordDictionaryTester, context); // $ExpectType string | undefined
+    _(anyValue).findKey(recordDictionaryTester, context); // $ExpectType string | undefined
+    extractChainTypes(_.chain(anyValue).findKey(recordDictionaryTester, context)); // $ExpectType ChainType<string | undefined, string>
 
     // matcher iteratee - objects
-    _.findKey(mixedTypeRecord, partialStringRecord); // $ExpectType "a" | "b" | "c" | undefined
-    _(mixedTypeRecord).findKey(partialStringRecord); // $ExpectType "a" | "b" | "c" | undefined
-    extractChainTypes(_.chain(mixedTypeRecord).findKey(partialStringRecord)); // $ExpectType ChainType<"a" | "b" | "c" | undefined, string>
+    _.findKey(mixedTypeRecord, matcher); // $ExpectType "a" | "b" | "c" | undefined
+    _(mixedTypeRecord).findKey(matcher); // $ExpectType "a" | "b" | "c" | undefined
+    extractChainTypes(_.chain(mixedTypeRecord).findKey(matcher)); // $ExpectType ChainType<"a" | "b" | "c" | undefined, string>
 
     // shallow property iteratee - objects
-    _.findKey(mixedTypeRecord, stringRecordProperty); // $ExpectType "a" | "b" | "c" | undefined
-    _(mixedTypeRecord).findKey(stringRecordProperty); // $ExpectType "a" | "b" | "c" | undefined
-    extractChainTypes(_.chain(mixedTypeRecord).findKey(stringRecordProperty)); // $ExpectType ChainType<"a" | "b" | "c" | undefined, string>
+    _.findKey(mixedTypeRecord, shallowProperty); // $ExpectType "a" | "b" | "c" | undefined
+    _(mixedTypeRecord).findKey(shallowProperty); // $ExpectType "a" | "b" | "c" | undefined
+    extractChainTypes(_.chain(mixedTypeRecord).findKey(shallowProperty)); // $ExpectType ChainType<"a" | "b" | "c" | undefined, string>
 
     // deep property iteratee - objects
-    _.findKey(mixedTypeRecord, stringRecordPropertyPath); // $ExpectType "a" | "b" | "c" | undefined
-    _(mixedTypeRecord).findKey(stringRecordPropertyPath); // $ExpectType "a" | "b" | "c" | undefined
-    extractChainTypes(_.chain(mixedTypeRecord).findKey(stringRecordPropertyPath)); // $ExpectType ChainType<"a" | "b" | "c" | undefined, string>
+    _.findKey(mixedTypeRecord, deepProperty); // $ExpectType "a" | "b" | "c" | undefined
+    _(mixedTypeRecord).findKey(deepProperty); // $ExpectType "a" | "b" | "c" | undefined
+    extractChainTypes(_.chain(mixedTypeRecord).findKey(deepProperty)); // $ExpectType ChainType<"a" | "b" | "c" | undefined, string>
 
     // identity iteratee - objects
     _.findKey(mixedTypeRecord); // $ExpectType "a" | "b" | "c" | undefined
@@ -3019,39 +3025,39 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     extractChainTypes(_.chain(anyValue).pick<'a' | 'b'>('a', ['b'])); // $ExpectType ChainType<Pick<any, "a" | "b">, any>
 
     // generic strings - record
-    _.pick(mixedTypeRecord, simpleString); // $ExpectType Partial<MixedTypeRecord>
-    _(mixedTypeRecord).pick(simpleString); // $ExpectType Partial<MixedTypeRecord>
-    extractChainTypes(_.chain(mixedTypeRecord).pick(simpleString)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingStringRecord | undefined>
+    _.pick(mixedTypeRecord, stringValue); // $ExpectType Partial<MixedTypeRecord>
+    _(mixedTypeRecord).pick(stringValue); // $ExpectType Partial<MixedTypeRecord>
+    extractChainTypes(_.chain(mixedTypeRecord).pick(stringValue)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingRecord | undefined>
 
     // generic strings - any
-    _.pick(anyValue, simpleString); // $ExpectType Pick<any, string>
-    _(anyValue).pick(simpleString); // $ExpectType Pick<any, string>
-    extractChainTypes(_.chain(anyValue).pick(simpleString)); // $ExpectType ChainType<Pick<any, string>, any>
+    _.pick(anyValue, stringValue); // $ExpectType Pick<any, string>
+    _(anyValue).pick(stringValue); // $ExpectType Pick<any, string>
+    extractChainTypes(_.chain(anyValue).pick(stringValue)); // $ExpectType ChainType<Pick<any, string>, any>
 
     // generic string arrays - record
-    _.pick(mixedTypeRecord, simpleStringArray); // $ExpectType Partial<MixedTypeRecord>
-    _(mixedTypeRecord).pick(simpleStringArray); // $ExpectType Partial<MixedTypeRecord>
-    extractChainTypes(_.chain(mixedTypeRecord).pick(simpleStringArray)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingStringRecord | undefined>
+    _.pick(mixedTypeRecord, stringArray); // $ExpectType Partial<MixedTypeRecord>
+    _(mixedTypeRecord).pick(stringArray); // $ExpectType Partial<MixedTypeRecord>
+    extractChainTypes(_.chain(mixedTypeRecord).pick(stringArray)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingRecord | undefined>
 
     // generic string arrays - any
-    _.pick(anyValue, simpleStringArray); // $ExpectType Pick<any, string>
-    _(anyValue).pick(simpleStringArray); // $ExpectType Pick<any, string>
-    extractChainTypes(_.chain(anyValue).pick(simpleStringArray)); // $ExpectType ChainType<Pick<any, string>, any>
+    _.pick(anyValue, stringArray); // $ExpectType Pick<any, string>
+    _(anyValue).pick(stringArray); // $ExpectType Pick<any, string>
+    extractChainTypes(_.chain(anyValue).pick(stringArray)); // $ExpectType ChainType<Pick<any, string>, any>
 
     // function - record
-    _.pick(mixedTypeRecord, mixedTypeRecordBooleanIterator); // $ExpectType Partial<MixedTypeRecord>
-    _(mixedTypeRecord).pick(mixedTypeRecordBooleanIterator); // $ExpectType Partial<MixedTypeRecord>
-    extractChainTypes(_.chain(mixedTypeRecord).pick(mixedTypeRecordBooleanIterator)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingStringRecord | undefined>
+    _.pick(mixedTypeRecord, mixedTypeTester); // $ExpectType Partial<MixedTypeRecord>
+    _(mixedTypeRecord).pick(mixedTypeTester); // $ExpectType Partial<MixedTypeRecord>
+    extractChainTypes(_.chain(mixedTypeRecord).pick(mixedTypeTester)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingRecord | undefined>
 
     // function - dictionary
-    _.pick(stringRecordDictionary, stringRecordDictionaryBooleanIterator); // $ExpectType Partial<Dictionary<StringRecord>>
-    _(stringRecordDictionary).pick(stringRecordDictionaryBooleanIterator); // $ExpectType Partial<Dictionary<StringRecord>>
-    extractChainTypes(_.chain(stringRecordDictionary).pick(stringRecordDictionaryBooleanIterator)); // $ExpectType ChainType<Partial<Dictionary<StringRecord>>, StringRecordOrUndefined>
+    _.pick(recordDictionary, recordDictionaryTester); // $ExpectType Partial<Dictionary<StringRecord>>
+    _(recordDictionary).pick(recordDictionaryTester); // $ExpectType Partial<Dictionary<StringRecord>>
+    extractChainTypes(_.chain(recordDictionary).pick(recordDictionaryTester)); // $ExpectType ChainType<Partial<Dictionary<StringRecord>>, StringRecord | undefined>
 
     // function - any
-    _.pick(anyValue, anyBooleanIterator); // $ExpectType Partial<any>
-    _(anyValue).pick(anyBooleanIterator); // $ExpectType Partial<any>
-    extractChainTypes(_.chain(anyValue).pick(anyBooleanIterator)); // $ExpectType ChainType<Partial<any>, any>
+    _.pick(anyValue, anyCollectionTester); // $ExpectType Partial<any>
+    _(anyValue).pick(anyCollectionTester); // $ExpectType Partial<any>
+    extractChainTypes(_.chain(anyValue).pick(anyCollectionTester)); // $ExpectType ChainType<Partial<any>, any>
 }
 
 // omit
@@ -3059,7 +3065,7 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     // constant strings - record
     _.omit(mixedTypeRecord, 'a', 'b', 'notAKey'); // $ExpectType Pick<MixedTypeRecord, "c">
     _(mixedTypeRecord).omit('a', 'b', 'notAKey'); // $ExpectType Pick<MixedTypeRecord, "c">
-    extractChainTypes(_.chain(mixedTypeRecord).omit('a', 'b', 'notAKey')); // $ExpectType ChainType<Pick<MixedTypeRecord, "c">, NonIntersectingProperties>
+    extractChainTypes(_.chain(mixedTypeRecord).omit('a', 'b', 'notAKey')); // $ExpectType ChainType<Pick<MixedTypeRecord, "c">, NonIntersecting>
 
     // constant strings - any
     _.omit(anyValue, 'a', 'b'); // $ExpectType any
@@ -3069,7 +3075,7 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     // constant string arrays - record
     _.omit(mixedTypeRecord, ['a'], ['b', 'notAKey']); // $ExpectType Pick<MixedTypeRecord, "c">
     _(mixedTypeRecord).omit(['a'], ['b', 'notAKey']); // $ExpectType Pick<MixedTypeRecord, "c">
-    extractChainTypes(_.chain(mixedTypeRecord).omit(['a'], ['b', 'notAKey'])); // $ExpectType ChainType<Pick<MixedTypeRecord, "c">, NonIntersectingProperties>
+    extractChainTypes(_.chain(mixedTypeRecord).omit(['a'], ['b', 'notAKey'])); // $ExpectType ChainType<Pick<MixedTypeRecord, "c">, NonIntersecting>
 
     // constant string arrays - any
     _.omit(anyValue, ['a'], ['b']); // $ExpectType any
@@ -3080,7 +3086,7 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     // constant strings and string arrays - record
     _.omit<MixedTypeRecord, 'a' | 'b' | 'notAKey'>(mixedTypeRecord, 'a', ['b'], 'notAKey'); // $ExpectType Pick<MixedTypeRecord, "c">
     _(mixedTypeRecord).omit<'a' | 'b' | 'notAKey'>('a', ['b'], 'notAKey'); // $ExpectType Pick<MixedTypeRecord, "c">
-    extractChainTypes(_.chain(mixedTypeRecord).omit<'a' | 'b' | 'notAKey'>('a', ['b'], 'notAKey')); // $ExpectType ChainType<Pick<MixedTypeRecord, "c">, NonIntersectingProperties>
+    extractChainTypes(_.chain(mixedTypeRecord).omit<'a' | 'b' | 'notAKey'>('a', ['b'], 'notAKey')); // $ExpectType ChainType<Pick<MixedTypeRecord, "c">, NonIntersecting>
 
     // constant strings and string arrays - any
     _.omit<any, 'a' | 'b'>(anyValue, 'a', ['b']); // $ExpectType any
@@ -3088,39 +3094,39 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     extractChainTypes(_.chain(anyValue).omit<'a' | 'b'>('a', ['b'])); // $ExpectType ChainType<any, any>
 
     // generic strings - record
-    _.omit(mixedTypeRecord, simpleString); // $ExpectType Partial<MixedTypeRecord>
-    _(mixedTypeRecord).omit(simpleString); // $ExpectType Partial<MixedTypeRecord>
-    extractChainTypes(_.chain(mixedTypeRecord).omit(simpleString)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingStringRecord | undefined>
+    _.omit(mixedTypeRecord, stringValue); // $ExpectType Partial<MixedTypeRecord>
+    _(mixedTypeRecord).omit(stringValue); // $ExpectType Partial<MixedTypeRecord>
+    extractChainTypes(_.chain(mixedTypeRecord).omit(stringValue)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingRecord | undefined>
 
     // generic strings - any
-    _.omit(anyValue, simpleString); // $ExpectType any
-    _(anyValue).omit(simpleString); // $ExpectType any
-    extractChainTypes(_.chain(anyValue).omit(simpleString)); // $ExpectType ChainType<any, any>
+    _.omit(anyValue, stringValue); // $ExpectType any
+    _(anyValue).omit(stringValue); // $ExpectType any
+    extractChainTypes(_.chain(anyValue).omit(stringValue)); // $ExpectType ChainType<any, any>
 
     // generic string arrays - record
-    _.omit(mixedTypeRecord, simpleStringArray); // $ExpectType Partial<MixedTypeRecord>
-    _(mixedTypeRecord).omit(simpleStringArray); // $ExpectType Partial<MixedTypeRecord>
-    extractChainTypes(_.chain(mixedTypeRecord).omit(simpleStringArray)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingStringRecord | undefined>
+    _.omit(mixedTypeRecord, stringArray); // $ExpectType Partial<MixedTypeRecord>
+    _(mixedTypeRecord).omit(stringArray); // $ExpectType Partial<MixedTypeRecord>
+    extractChainTypes(_.chain(mixedTypeRecord).omit(stringArray)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingRecord | undefined>
 
     // generic string arrays - any
-    _.omit(anyValue, simpleStringArray); // $ExpectType any
-    _(anyValue).omit(simpleStringArray); // $ExpectType any
-    extractChainTypes(_.chain(anyValue).omit(simpleStringArray)); // $ExpectType ChainType<any, any>
+    _.omit(anyValue, stringArray); // $ExpectType any
+    _(anyValue).omit(stringArray); // $ExpectType any
+    extractChainTypes(_.chain(anyValue).omit(stringArray)); // $ExpectType ChainType<any, any>
 
     // function - record
-    _.omit(mixedTypeRecord, mixedTypeRecordBooleanIterator); // $ExpectType Partial<MixedTypeRecord>
-    _(mixedTypeRecord).omit(mixedTypeRecordBooleanIterator); // $ExpectType Partial<MixedTypeRecord>
-    extractChainTypes(_.chain(mixedTypeRecord).omit(mixedTypeRecordBooleanIterator)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingStringRecord | undefined>
+    _.omit(mixedTypeRecord, mixedTypeTester); // $ExpectType Partial<MixedTypeRecord>
+    _(mixedTypeRecord).omit(mixedTypeTester); // $ExpectType Partial<MixedTypeRecord>
+    extractChainTypes(_.chain(mixedTypeRecord).omit(mixedTypeTester)); // $ExpectType ChainType<Partial<MixedTypeRecord>, number | StringRecord | NonIntersectingRecord | undefined>
 
     // function - dictionary
-    _.omit(stringRecordDictionary, stringRecordDictionaryBooleanIterator); // $ExpectType Partial<Dictionary<StringRecord>>
-    _(stringRecordDictionary).omit(stringRecordDictionaryBooleanIterator); // $ExpectType Partial<Dictionary<StringRecord>>
-    extractChainTypes(_.chain(stringRecordDictionary).omit(stringRecordDictionaryBooleanIterator)); // $ExpectType ChainType<Partial<Dictionary<StringRecord>>, StringRecordOrUndefined>
+    _.omit(recordDictionary, recordDictionaryTester); // $ExpectType Partial<Dictionary<StringRecord>>
+    _(recordDictionary).omit(recordDictionaryTester); // $ExpectType Partial<Dictionary<StringRecord>>
+    extractChainTypes(_.chain(recordDictionary).omit(recordDictionaryTester)); // $ExpectType ChainType<Partial<Dictionary<StringRecord>>, StringRecord | undefined>
 
     // function - any
-    _.omit(anyValue, anyBooleanIterator); // $ExpectType Partial<any>
-    _(anyValue).omit(anyBooleanIterator); // $ExpectType Partial<any>
-    extractChainTypes(_.chain(anyValue).omit(anyBooleanIterator)); // $ExpectType ChainType<Partial<any>, any>
+    _.omit(anyValue, anyCollectionTester); // $ExpectType Partial<any>
+    _(anyValue).omit(anyCollectionTester); // $ExpectType Partial<any>
+    extractChainTypes(_.chain(anyValue).omit(anyCollectionTester)); // $ExpectType ChainType<Partial<any>, any>
 }
 
 // isEqual
@@ -3169,7 +3175,7 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
 {
     if (_.isObject(anyValue)) {
         anyValue; // $ExpectType Dictionary<any> & object
-        anyValue.propertyName; // $ExpectType any
+        anyValue.shallowProperty; // $ExpectType any
         anyValue[3]; // $ExpectType any
         _.map(anyValue, i => i); // $ExpectType any[]
         _.isFunction(anyValue) ? anyValue : neverValue; // $ExpectType Function
@@ -3178,7 +3184,7 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _.isObject(stringy) ? stringy : neverValue // $ExpectType StringRecord
     _.isObject(maybeStringArray) ? maybeStringArray : neverValue; // $ExpectType string[]
     _.isObject(maybeFunction) ? maybeFunction : neverValue; // $ExpectType () => void
-    _.isObject(simpleString) ? simpleString : neverValue; // $ExpectType never
+    _.isObject(stringValue) ? stringValue : neverValue; // $ExpectType never
 
     _(anyValue).isObject(); // $ExpectType boolean
     extractChainTypes(_.chain(anyValue).isObject()); // $ExpectType ChainType<boolean, never>
@@ -3269,23 +3275,25 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     extractChainTypes(_.chain(anyValue).isUndefined()); // $ExpectType ChainType<boolean, never>
 }
 
-// OOP Style
+/*****************************
+ * Combinatorial Tests - OOP *
+ *****************************/
 
 // underscore
 {
     // lists
-    extractUnderscoreTypes(_(stringRecordAugmentedList)); // $ExpectType UnderscoreType<StringRecordAugmentedList, StringRecord>
-    extractUnderscoreTypes(_(stringRecordList)); // $ExpectType UnderscoreType<List<StringRecord>, StringRecord>
+    extractUnderscoreTypes(_(augmentedList)); // $ExpectType UnderscoreType<AugmentedList, StringRecord>
+    extractUnderscoreTypes(_(recordList)); // $ExpectType UnderscoreType<List<StringRecord>, StringRecord>
 
     // dictionaries
-    extractUnderscoreTypes(_(stringRecordExplicitDictionary)); // $ExpectType UnderscoreType<StringRecordExplicitDictionary, StringRecord>
-    extractUnderscoreTypes(_(stringRecordDictionary)); // $ExpectType UnderscoreType<Dictionary<StringRecord>, StringRecord>
+    extractUnderscoreTypes(_(explicitDictionary)); // $ExpectType UnderscoreType<ExplicitDictionary, StringRecord>
+    extractUnderscoreTypes(_(recordDictionary)); // $ExpectType UnderscoreType<Dictionary<StringRecord>, StringRecord>
 
     // strings
-    extractUnderscoreTypes(_(simpleString)); // $ExpectType UnderscoreType<string, string>
+    extractUnderscoreTypes(_(stringValue)); // $ExpectType UnderscoreType<string, string>
 
     // non-collections
-    extractUnderscoreTypes(_(simpleNumber)); // $ExpectType UnderscoreType<number, never>
+    extractUnderscoreTypes(_(numberValue)); // $ExpectType UnderscoreType<number, never>
 
     // mixed non-collections and collections
     extractUnderscoreTypes(_(mixedIterabilityValue)); // $ExpectType UnderscoreType<number | number[], number>
@@ -3301,18 +3309,18 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
 // verify that the object type given to underscore is returned by value
 {
     // lists
-    _(stringRecordAugmentedList).value(); // $ExpectType StringRecordAugmentedList
-    _(stringRecordList).value(); // $ExpectType List<StringRecord>
+    _(augmentedList).value(); // $ExpectType AugmentedList
+    _(recordList).value(); // $ExpectType List<StringRecord>
 
     // dictionaries
-    _(stringRecordExplicitDictionary).value(); // $ExpectType StringRecordExplicitDictionary
-    _(stringRecordDictionary).value(); // $ExpectType Dictionary<StringRecord>
+    _(explicitDictionary).value(); // $ExpectType ExplicitDictionary
+    _(recordDictionary).value(); // $ExpectType Dictionary<StringRecord>
 
     // strings
-    _(simpleString).value(); // $ExpectType string
+    _(stringValue).value(); // $ExpectType string
 
     // non-collections
-    _(simpleNumber).value(); // $ExpectType number
+    _(numberValue).value(); // $ExpectType number
 
     // mixed non-collections and collections
     _(mixedIterabilityValue).value(); // $ExpectType number | number[]
@@ -3324,31 +3332,33 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
     _(neverValue).value(); // $ExpectType never
 }
 
-// Chaining
+/**********************************
+ * Combinatorial Tests - Chaining *
+ **********************************/
 
 // chain
 // verify that the right chain item and value types are yielded by calls to chain
 // these tests also check to make sure that _.chain() and _().chain() yield the same types
 {
     // lists
-    extractChainTypes(_.chain(stringRecordAugmentedList)); // $ExpectType ChainType<StringRecordAugmentedList, StringRecord>
-    extractChainTypes(_(stringRecordAugmentedList).chain()); // $ExpectType ChainType<StringRecordAugmentedList, StringRecord>
-    extractChainTypes(_.chain(stringRecordList)); // $ExpectType ChainType<List<StringRecord>, StringRecord>
-    extractChainTypes(_(stringRecordList).chain()); // $ExpectType ChainType<List<StringRecord>, StringRecord>
+    extractChainTypes(_.chain(augmentedList)); // $ExpectType ChainType<AugmentedList, StringRecord>
+    extractChainTypes(_(augmentedList).chain()); // $ExpectType ChainType<AugmentedList, StringRecord>
+    extractChainTypes(_.chain(recordList)); // $ExpectType ChainType<List<StringRecord>, StringRecord>
+    extractChainTypes(_(recordList).chain()); // $ExpectType ChainType<List<StringRecord>, StringRecord>
 
     // dictionaries
-    extractChainTypes(_.chain(stringRecordExplicitDictionary)); // $ExpectType ChainType<StringRecordExplicitDictionary, StringRecord>
-    extractChainTypes(_(stringRecordExplicitDictionary).chain()); // $ExpectType ChainType<StringRecordExplicitDictionary, StringRecord>
-    extractChainTypes(_.chain(stringRecordDictionary)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
-    extractChainTypes(_(stringRecordDictionary).chain()); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+    extractChainTypes(_.chain(explicitDictionary)); // $ExpectType ChainType<ExplicitDictionary, StringRecord>
+    extractChainTypes(_(explicitDictionary).chain()); // $ExpectType ChainType<ExplicitDictionary, StringRecord>
+    extractChainTypes(_.chain(recordDictionary)); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
+    extractChainTypes(_(recordDictionary).chain()); // $ExpectType ChainType<Dictionary<StringRecord>, StringRecord>
 
     // strings
-    extractChainTypes(_.chain(simpleString)); // $ExpectType ChainType<string, string>
-    extractChainTypes(_(simpleString).chain()); // $ExpectType ChainType<string, string>
+    extractChainTypes(_.chain(stringValue)); // $ExpectType ChainType<string, string>
+    extractChainTypes(_(stringValue).chain()); // $ExpectType ChainType<string, string>
 
     // non-collections
-    extractChainTypes(_.chain(simpleNumber)); // $ExpectType ChainType<number, never>
-    extractChainTypes(_(simpleNumber).chain()); // $ExpectType ChainType<number, never>
+    extractChainTypes(_.chain(numberValue)); // $ExpectType ChainType<number, never>
+    extractChainTypes(_(numberValue).chain()); // $ExpectType ChainType<number, never>
 
     // mixed non-collections and collections
     extractChainTypes(_.chain(mixedIterabilityValue)); // $ExpectType ChainType<number | number[], number>
@@ -3367,18 +3377,18 @@ undefinedIdentityIterateeResult; // $ExpectType StringRecord
 // verify that the object type given to chain is returned by value
 {
     // lists
-    _.chain(stringRecordAugmentedList).value(); // $ExpectType StringRecordAugmentedList
-    _.chain(stringRecordList).value(); // $ExpectType List<StringRecord>
+    _.chain(augmentedList).value(); // $ExpectType AugmentedList
+    _.chain(recordList).value(); // $ExpectType List<StringRecord>
 
     // dictionaries
-    _.chain(stringRecordExplicitDictionary).value(); // $ExpectType StringRecordExplicitDictionary
-    _.chain(stringRecordDictionary).value(); // $ExpectType Dictionary<StringRecord>
+    _.chain(explicitDictionary).value(); // $ExpectType ExplicitDictionary
+    _.chain(recordDictionary).value(); // $ExpectType Dictionary<StringRecord>
 
     // strings
-    _.chain(simpleString).value(); // $ExpectType string
+    _.chain(stringValue).value(); // $ExpectType string
 
     // non-collections
-    _.chain(simpleNumber).value(); // $ExpectType number
+    _.chain(numberValue).value(); // $ExpectType number
 
     // mixed non-collections and collections
     _.chain(mixedIterabilityValue).value(); // $ExpectType number | number[]

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -25,7 +25,7 @@ interface ExplicitDictionary extends _.Dictionary<StringRecord> {
 }
 
 declare const shallowProperty: 'a';
-declare const deepProperty: string[];
+declare const deepProperty: ['a', 'length'];
 declare const matcher: Partial<StringRecord>;
 declare const recordTester: (value: StringRecord) => boolean;
 declare const recordStringReducer: (prev: string, value: StringRecord) => string;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45201#issuecomment-669716675

This is the second of three planned cleanup PRs for #45201 and includes the following changes:

- Shortens most touched lines in index.d.ts to 80 characters or less.
- Removes a few redundant value types in `_Chain` that the linter and I missed.
- Shortens test variable names.
- Moves test variables to the top of the file so they can be reused outside of combinatorial tests and adds more prominent headers to test groups.
- Updates all common test variables to `declare const`.
- Removes a few variables declared within the scopes of specific functions and replaces them with references to common variables.
- Makes a few minor updates to summary comment text.

No logic changes are made in this PR. `IntersectingMixedTypeRecord` is consolidated with `MixedTypeRecord`, and `StringRecordOrUndefined` is dropped in favor of using `StringRecord | undefined`.

As an additional item of cleanup, I'm going to claim that this fixes #7931 even though #45304 is actually what fixed it since I'd like to close that issue and I didn't know about the effect that the word "fix" has back when I was doing that PR.