### PR TITLE
feat: update universalify with proper typings

### DIFF
--- a/types/universalify/index.d.ts
+++ b/types/universalify/index.d.ts
@@ -2,72 +2,20 @@
 // Project: https://github.com/RyanZim/universalify#readme
 // Definitions by: Richie Bendall <https://github.com/Richienb>, Jan Peer Stöcklmair <https://github.com/JPeer264>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.7
 
-/**
- * interfaces with different args length
- * Depending on the arg it should either return
- *  - Promise<T> (no callback as last arg) or
- *  - void (result is in callback -> last arg of function)
- */
-export interface FromCallbackReturn<T> {
-    (callback: (err: any, result?: T) => void): void;
-    (): Promise<T>;
-}
-export interface FromCallbackReturnOne<T, A1> {
-    (arg1: A1, callback: (err: any, result?: T) => void): void;
-    (arg1: A1): Promise<T>;
-}
-export interface FromCallbackReturnTwo<T, A1, A2> {
-    (arg1: A1, arg2: A2, callback: (err: any, result?: T) => void): void;
-    (arg1: A1, arg2: A2): Promise<T>;
-}
-export interface FromCallbackReturnThree<T, A1, A2, A3> {
-    (arg1: A1, arg2: A2, arg3: A3, callback: (err: any, result?: T) => void): void;
-    (arg1: A1, arg2: A2, arg3: A3): Promise<T>;
-}
-export interface FromCallbackReturnFour<T, A1, A2, A3, A4> {
-    (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: (err: any, result?: T) => void): void;
-    (arg1: A1, arg2: A2, arg3: A3, arg4: A4): Promise<T>;
-}
-export interface FromCallbackReturnFive<T, A1, A2, A3, A4, A5> {
-    (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (err: any, result?: T) => void): void;
-    (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5): Promise<T>;
+import { List } from 'ts-toolbelt';
+
+export interface UniversalifyResult<T, A extends any[]> {
+    (...args: List.Append<A, (err: any, result?: T) => void>): void;
+    (...arg1: A): Promise<T>;
 }
 
 /**
  * Returns promise if the last argument is not a callback
  * Returns void and puts the result in the callback, which is the last argument of the function
  */
-export function fromCallback<T>(func: (callback: (err: any, result?: T) => void) => void): FromCallbackReturn<T>;
-export function fromCallback<T, A1>(
-    func: (arg1: A1, callback: (err: any, result?: T) => void) => void,
-): FromCallbackReturnOne<T, A1>;
-export function fromCallback<T, A1, A2>(
-    func: (arg1: A1, arg2: A2, callback: (err: any, result?: T) => void) => void,
-): FromCallbackReturnTwo<T, A1, A2>;
-export function fromCallback<T, A1, A2, A3>(
-    func: (arg1: A1, arg2: A2, arg3: A3, callback: (err: any, result?: T) => void) => void,
-): FromCallbackReturnThree<T, A1, A2, A3>;
-export function fromCallback<T, A1, A2, A3, A4>(
-    func: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: (err: any, result?: T) => void) => void,
-): FromCallbackReturnFour<T, A1, A2, A3, A4>;
-export function fromCallback<T, A1, A2, A3, A4, A5>(
-    func: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (err: any, result?: T) => void) => void,
-): FromCallbackReturnFive<T, A1, A2, A3, A4, A5>;
-
-/**
- * Returns promise if the last argument is not a callback
- * Returns void and puts the result in the callback, which is the last argument of the function
- */
-export function fromPromise<T>(func: () => Promise<T>): FromCallbackReturn<T>;
-export function fromPromise<T, A1>(func: (arg1: A1) => Promise<T>): FromCallbackReturnOne<T, A1>;
-export function fromPromise<T, A1, A2>(func: (arg1: A1, arg2: A2) => Promise<T>): FromCallbackReturnTwo<T, A1, A2>;
-export function fromPromise<T, A1, A2, A3>(
-    func: (arg1: A1, arg2: A2, arg3: A3) => Promise<T>,
-): FromCallbackReturnThree<T, A1, A2, A3>;
-export function fromPromise<T, A1, A2, A3, A4>(
-    func: (arg1: A1, arg2: A2, arg3: A3, arg4: A4) => Promise<T>,
-): FromCallbackReturnFour<T, A1, A2, A3, A4>;
-export function fromPromise<T, A1, A2, A3, A4, A5>(
-    func: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => Promise<T>,
-): FromCallbackReturnFive<T, A1, A2, A3, A4, A5>;
+export function fromCallback<T, A extends any[]>(
+    func: (...args: List.Append<A, (err: any, result?: T) => void>) => void,
+): UniversalifyResult<T, A>;
+export function fromPromise<T, A extends any[]>(func: (...args: A) => Promise<T>): UniversalifyResult<T, A>;

--- a/types/universalify/index.d.ts
+++ b/types/universalify/index.d.ts
@@ -1,7 +1,73 @@
-// Type definitions for universalify 1.0
+// Type definitions for universalify 2.0
 // Project: https://github.com/RyanZim/universalify#readme
-// Definitions by: Richie Bendall <https://github.com/Richienb>
+// Definitions by: Richie Bendall <https://github.com/Richienb>, Jan Peer Stöcklmair <https://github.com/JPeer264>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export function fromCallback(fn: (...args: any[]) => any): (...args: any[]) => Promise<any> | void;
-export function fromPromise(fn: (...args: any[]) => any): (...args: any[]) => Promise<any> | void;
+/**
+ * interfaces with different args length
+ * Depending on the arg it should either return
+ *  - Promise<T> (no callback as last arg) or
+ *  - void (result is in callback -> last arg of function)
+ */
+export interface FromCallbackReturn<T> {
+    (callback: (err: any, result?: T) => void): void;
+    (): Promise<T>;
+}
+export interface FromCallbackReturnOne<T, A1> {
+    (arg1: A1, callback: (err: any, result?: T) => void): void;
+    (arg1: A1): Promise<T>;
+}
+export interface FromCallbackReturnTwo<T, A1, A2> {
+    (arg1: A1, arg2: A2, callback: (err: any, result?: T) => void): void;
+    (arg1: A1, arg2: A2): Promise<T>;
+}
+export interface FromCallbackReturnThree<T, A1, A2, A3> {
+    (arg1: A1, arg2: A2, arg3: A3, callback: (err: any, result?: T) => void): void;
+    (arg1: A1, arg2: A2, arg3: A3): Promise<T>;
+}
+export interface FromCallbackReturnFour<T, A1, A2, A3, A4> {
+    (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: (err: any, result?: T) => void): void;
+    (arg1: A1, arg2: A2, arg3: A3, arg4: A4): Promise<T>;
+}
+export interface FromCallbackReturnFive<T, A1, A2, A3, A4, A5> {
+    (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (err: any, result?: T) => void): void;
+    (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5): Promise<T>;
+}
+
+/**
+ * Returns promise if the last argument is not a callback
+ * Returns void and puts the result in the callback, which is the last argument of the function
+ */
+export function fromCallback<T>(func: (callback: (err: any, result?: T) => void) => void): FromCallbackReturn<T>;
+export function fromCallback<T, A1>(
+    func: (arg1: A1, callback: (err: any, result?: T) => void) => void,
+): FromCallbackReturnOne<T, A1>;
+export function fromCallback<T, A1, A2>(
+    func: (arg1: A1, arg2: A2, callback: (err: any, result?: T) => void) => void,
+): FromCallbackReturnTwo<T, A1, A2>;
+export function fromCallback<T, A1, A2, A3>(
+    func: (arg1: A1, arg2: A2, arg3: A3, callback: (err: any, result?: T) => void) => void,
+): FromCallbackReturnThree<T, A1, A2, A3>;
+export function fromCallback<T, A1, A2, A3, A4>(
+    func: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: (err: any, result?: T) => void) => void,
+): FromCallbackReturnFour<T, A1, A2, A3, A4>;
+export function fromCallback<T, A1, A2, A3, A4, A5>(
+    func: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (err: any, result?: T) => void) => void,
+): FromCallbackReturnFive<T, A1, A2, A3, A4, A5>;
+
+/**
+ * Returns promise if the last argument is not a callback
+ * Returns void and puts the result in the callback, which is the last argument of the function
+ */
+export function fromPromise<T>(func: () => Promise<T>): FromCallbackReturn<T>;
+export function fromPromise<T, A1>(func: (arg1: A1) => Promise<T>): FromCallbackReturnOne<T, A1>;
+export function fromPromise<T, A1, A2>(func: (arg1: A1, arg2: A2) => Promise<T>): FromCallbackReturnTwo<T, A1, A2>;
+export function fromPromise<T, A1, A2, A3>(
+    func: (arg1: A1, arg2: A2, arg3: A3) => Promise<T>,
+): FromCallbackReturnThree<T, A1, A2, A3>;
+export function fromPromise<T, A1, A2, A3, A4>(
+    func: (arg1: A1, arg2: A2, arg3: A3, arg4: A4) => Promise<T>,
+): FromCallbackReturnFour<T, A1, A2, A3, A4>;
+export function fromPromise<T, A1, A2, A3, A4, A5>(
+    func: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => Promise<T>,
+): FromCallbackReturnFive<T, A1, A2, A3, A4, A5>;

--- a/types/universalify/package.json
+++ b/types/universalify/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "ts-toolbelt": "^6.15.1"
+    }
+}

--- a/types/universalify/universalify-tests.ts
+++ b/types/universalify/universalify-tests.ts
@@ -1,4 +1,67 @@
-import universalify = require("universalify");
+import universalify = require('universalify');
 
-universalify.fromCallback(() => { }); // $ExpectType (...args: any[]) => void | Promise<any>
-universalify.fromPromise(() => { }); // $ExpectType (...args: any[]) => void | Promise<any>
+// check if no parameter is valid
+const callbackFn = universalify.fromCallback((cb: (err: any, result: number) => void) => {
+    cb(null, 3);
+    cb(null, 'Hello World!'); // $ExpectError
+});
+
+callbackFn((error, result) => {}); // $ExpectType void
+callbackFn(); // $ExpectType Promise<number>
+callbackFn('Hello World!'); // $ExpectError
+callbackFn('Hello World!', 'not a function'); // $ExpectError
+
+const promiseFn = universalify.fromPromise(() => Promise.resolve(3));
+
+promiseFn((error, result) => {}); // $ExpectType void
+promiseFn(); // $ExpectType Promise<number>
+promiseFn('Hello World!'); // $ExpectError
+promiseFn('Hello World!', 'not a function'); // $ExpectError
+
+// check if one parameter is valid
+const callbackFnOne = universalify.fromCallback((arg1: string, cb: (err: any, result: string) => void) => {
+    cb(null, 'Hello World!');
+    cb(null, 3); // $ExpectError
+});
+
+callbackFnOne('Hello World!', (error, result) => {}); // $ExpectType void
+callbackFnOne('Hello World!'); // $ExpectType Promise<string>
+callbackFnOne(); // $ExpectError
+callbackFnOne('Hello World!', 'not a function'); // $ExpectError
+
+const promiseFnOne = universalify.fromPromise((arg1: string) => Promise.resolve('Hello World!'));
+
+promiseFnOne('Hello World!', (error, result) => {}); // $ExpectType void
+promiseFnOne('Hello World!'); // $ExpectType Promise<string>
+promiseFnOne(); // $ExpectError
+promiseFnOne('Hello World!', 'not a function'); // $ExpectError
+
+// check if three parameters are valid
+const callbackFnThree = universalify.fromCallback(
+    (arg1: string, arg2: number, arg3: string, cb: (err: any, result: string) => void) => {
+        cb(null, 'Hello World!');
+        cb(null, 3); // $ExpectError
+    },
+);
+
+callbackFnThree('Hello World!', 3, 'Hello World!', (error, result) => {}); // $ExpectType void
+callbackFnThree('Hello World!', 3, 'Hello World!'); // $ExpectType Promise<string>
+callbackFnThree('Hello World!', 'Not a string', 'Hello World!'); // $ExpectError
+callbackFnThree('Hello World!', 'Not a string', 'Hello World!', (error, result) => {}); // $ExpectError
+callbackFnThree(); // $ExpectError
+callbackFnThree('Not enough values'); // $ExpectError
+callbackFnThree('Not enough values', 0); // $ExpectError
+callbackFnThree('Not enough values', 0, 'Enough values', 'but not a function'); // $ExpectError
+
+const promiseFnThree = universalify.fromPromise((arg1: string, arg2: number, arg3: string) =>
+    Promise.resolve('Hello World!'),
+);
+
+promiseFnThree('Hello World!', 3, 'Hello World!', (error, result) => {}); // $ExpectType void
+promiseFnThree('Hello World!', 3, 'Hello World!'); // $ExpectType Promise<string>
+promiseFnThree('Hello World!', 'Not a string', 'Hello World!'); // $ExpectError
+promiseFnThree('Hello World!', 'Not a string', 'Hello World!', (error, result) => {}); // $ExpectError
+promiseFnThree(); // $ExpectError
+promiseFnThree('Not enough values'); // $ExpectError
+promiseFnThree('Not enough values', 0); // $ExpectError
+promiseFnThree('Not enough values', 0, 'Enough values', 'but not a function'); // $ExpectError


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/RyanZim/universalify

**Note:** Basically the real implementation of the types are now added

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

--- 

I am not really satisfied with the solution `FromCallbackReturn`, `FromCallbackReturnOne`, ... . I wanted to have kinda overloads, but this didn't quite work well with the output of the tests. Maybe you have some suggestions regarding this.
