### PR TITLE
[prop-types] narrow down oneOf array generic to infer actual contents of array

### DIFF
--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -67,7 +67,7 @@ export const element: Requireable<ReactElementLike>;
 export const symbol: Requireable<symbol>;
 export const elementType: Requireable<ReactComponentLike>;
 export function instanceOf<T>(expectedClass: new (...args: any[]) => T): Requireable<T>;
-export function oneOf<T>(types: ReadonlyArray<T>): Requireable<T>;
+export function oneOf<T extends boolean | number | object | string | symbol>(types: ReadonlyArray<T>): Requireable<T>;
 export function oneOfType<T extends Validator<any>>(types: T[]): Requireable<NonNullable<InferType<T>>>;
 export function arrayOf<T>(type: Validator<T>): Requireable<T[]>;
 export function objectOf<T>(type: Validator<T>): Requireable<{ [K in keyof any]: T; }>;

--- a/types/prop-types/prop-types-tests.ts
+++ b/types/prop-types/prop-types-tests.ts
@@ -65,9 +65,9 @@ const propTypes: PropTypesMap = {
     string: PropTypes.string.isRequired,
     symbol: PropTypes.symbol.isRequired,
     instanceOf: PropTypes.instanceOf(TestClass).isRequired,
-    oneOf: PropTypes.oneOf<'a' | 'b' | 'c'>(['a', 'b', 'c']).isRequired,
+    oneOf: PropTypes.oneOf(['a', 'b', 'c']).isRequired,
     oneOfType: PropTypes.oneOfType(arrayOfTypes).isRequired,
-    numberOrFalse: PropTypes.oneOfType([PropTypes.oneOf<false>([false]), PropTypes.number]).isRequired,
+    numberOrFalse: PropTypes.oneOfType([PropTypes.oneOf([false]), PropTypes.number]).isRequired,
     // The generic function type (() => any) is assignable to ReactNode because ReactNode extends the empty object type {}
     // Which widens the array literal of validators to just Array<Requireable<() => any>>
     // It's too risky to change ReactNode to exclude {} even though it's invalid, as it's required for children-as-function props to work
@@ -97,10 +97,9 @@ const propTypesWithoutAnnotation = {
     string: PropTypes.string.isRequired,
     symbol: PropTypes.symbol.isRequired,
     instanceOf: PropTypes.instanceOf(TestClass).isRequired,
-    // required generic specification because of array type widening
-    oneOf: PropTypes.oneOf<'a' | 'b' | 'c'>(['a', 'b', 'c']).isRequired,
+    oneOf: PropTypes.oneOf(['a', 'b', 'c']).isRequired,
     oneOfType: PropTypes.oneOfType(arrayOfTypes).isRequired,
-    numberOrFalse: PropTypes.oneOfType([PropTypes.oneOf<false>([false]), PropTypes.number]).isRequired,
+    numberOrFalse: PropTypes.oneOfType([PropTypes.oneOf([false]), PropTypes.number]).isRequired,
     nodeOrRenderFn: PropTypes.oneOfType([PropTypes.node, PropTypes.func] as [PropTypes.Requireable<ReactNode>, PropTypes.Requireable<() => any>]),
     arrayOf: PropTypes.arrayOf(PropTypes.bool.isRequired).isRequired,
     objectOf: PropTypes.objectOf(PropTypes.number.isRequired).isRequired,


### PR DESCRIPTION
## Description

So we can do this from js:

```js
  foo: PropTypes.oneOf(['a', 'b'])
```

and type of foo will be inferred to:

```ts
  Validator<'a' | 'b'>
```

rather than:

```ts
  Validator<string>
```

without using `as const` (not possible in js) or having to explicitly provide the generic type (cumbersome in js)

### Before
![type-narrow-before](https://user-images.githubusercontent.com/758244/90307231-21e1f900-def6-11ea-9fac-8d6c789b972c.png)

### After
![type-narrow-after](https://user-images.githubusercontent.com/758244/90307234-23abbc80-def6-11ea-8179-a12307b3aa05.png)

## Template

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/TypeScript/issues/30680#issuecomment-568223968 https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43422
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
