### PR TITLE
react-d3-graph - updated Node's size property to reflect latest version @2.5.0

### DIFF
--- a/types/react-d3-graph/index.d.ts
+++ b/types/react-d3-graph/index.d.ts
@@ -17,7 +17,7 @@ export interface NodeLevelNodeConfiguration {
     fontColor: string;
     opacity: number;
     renderLabel: boolean;
-    size: number;
+    size: number | {width: number; height: number};
     strokeColor: string;
     strokeWidth: number;
     svg: string;
@@ -31,7 +31,7 @@ export interface GraphLevelNodeConfiguration<N extends GraphNode> {
     fontColor: string;
     opacity: number;
     renderLabel: boolean;
-    size: number;
+    size: number | {width: number; height: number};
     strokeColor: string;
     strokeWidth: number;
     svg: string;

--- a/types/react-d3-graph/index.d.ts
+++ b/types/react-d3-graph/index.d.ts
@@ -17,7 +17,7 @@ export interface NodeLevelNodeConfiguration {
     fontColor: string;
     opacity: number;
     renderLabel: boolean;
-    size: number | {width: number; height: number};
+    size: number | {width: number; height: number;};
     strokeColor: string;
     strokeWidth: number;
     svg: string;
@@ -31,7 +31,7 @@ export interface GraphLevelNodeConfiguration<N extends GraphNode> {
     fontColor: string;
     opacity: number;
     renderLabel: boolean;
-    size: number | {width: number; height: number};
+    size: number | {width: number; height: number;};
     strokeColor: string;
     strokeWidth: number;
     svg: string;

--- a/types/react-d3-graph/index.d.ts
+++ b/types/react-d3-graph/index.d.ts
@@ -17,7 +17,7 @@ export interface NodeLevelNodeConfiguration {
     fontColor: string;
     opacity: number;
     renderLabel: boolean;
-    size: number | {width: number; height: number;};
+    size: number | { width: number; height: number; };
     strokeColor: string;
     strokeWidth: number;
     svg: string;
@@ -31,7 +31,7 @@ export interface GraphLevelNodeConfiguration<N extends GraphNode> {
     fontColor: string;
     opacity: number;
     renderLabel: boolean;
-    size: number | {width: number; height: number;};
+    size: number | { width: number; height: number; };
     strokeColor: string;
     strokeWidth: number;
     svg: string;


### PR DESCRIPTION
Updated types to reflect changes in react-d3-graph@2.5.0 -
An option was added that allowed passing a {width, height} object to customize a Node's size.

This feature was added in version @2.5.0 and can be seen in this commit under its `changelog.md` file https://github.com/danielcaldas/react-d3-graph/commit/b476ef5bfff01a15813a201d2f08d450d5e288ae#diff-4ac32a78649ca5bdd8e0ba38b7006a1e
