### PR TITLE
feat(mapbox/maki): new definition

### DIFF
--- a/types/mapbox__maki/index.d.ts
+++ b/types/mapbox__maki/index.d.ts
@@ -12,7 +12,7 @@ declare namespace maki {
 }
 
 declare const maki: {
-    /** bject that can be used to organize and display icons in your app or website */
+    /** Object that can be used to organize and display icons in your app or website */
     layouts: {
         all: maki.IconName[];
     };

--- a/types/mapbox__maki/index.d.ts
+++ b/types/mapbox__maki/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for @mapbox/maki 6.2
+// Project: https://github.com/mapbox/maki
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * A pixel-aligned point of interest icon set made for cartographers
+ */
+declare namespace maki {
+    type IconName = string;
+    type SvgContent = string;
+}
+
+declare const maki: {
+    /** bject that can be used to organize and display icons in your app or website */
+    layouts: {
+        all: maki.IconName[];
+    };
+    svgArray: maki.SvgContent[];
+};
+
+export = maki;

--- a/types/mapbox__maki/mapbox__maki-tests.ts
+++ b/types/mapbox__maki/mapbox__maki-tests.ts
@@ -1,0 +1,22 @@
+/// <reference types="node" />
+
+import maki = require('@mapbox/maki');
+import { IconName, SvgContent } from '@mapbox/maki';
+import fs = require('fs');
+
+maki.layouts; // $ExpectType { all: string[]; }
+maki.layouts.all; // $ExpectType string[]
+maki.svgArray; // $ExpectType string[]
+
+// api usage
+
+const files: string[] = [];
+
+files.forEach(fileName => {
+    maki.layouts.all.forEach((icon: IconName) => {
+        fs.readFile(`${__dirname}/icons/${icon}-11.svg`, 'utf8', (err, file) => {
+            console.log(file);
+        });
+    });
+    maki.svgArray.forEach((svg: SvgContent) => console.log(svg));
+});

--- a/types/mapbox__maki/tsconfig.json
+++ b/types/mapbox__maki/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@mapbox/maki": [
+                "mapbox__maki"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mapbox__maki-tests.ts"
+    ]
+}

--- a/types/mapbox__maki/tslint.json
+++ b/types/mapbox__maki/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Definition for Mapbox Maki icons:
- definition file
- tests

https://github.com/mapbox/maki
https://github.com/mapbox/maki#for-developers

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.