### PR TITLE
[prosemirror-inputrules] Fix type of return value from inputRules

### DIFF
--- a/types/prosemirror-inputrules/index.d.ts
+++ b/types/prosemirror-inputrules/index.d.ts
@@ -52,7 +52,7 @@ export class InputRule<S extends Schema = any> {
  */
 export function inputRules<S extends Schema = any>(config: {
   rules: Array<InputRule<S>>;
-}): Plugin<S>;
+}): Plugin<unknown, S>;
 /**
  * This is a command that will undo an input rule, if applying such a
  * rule was the last thing that the user did.


### PR DESCRIPTION
The type of `Plugin` in `prosemirror-state` has two arguments, the second of which is the schema:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/867ab9307d482e06745a2b328ad09b11e74579c4/types/prosemirror-state/index.d.ts#L86

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
