### PR TITLE
feat(react-select): add missing `defaultTheme` export

### DIFF
--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -16,6 +16,7 @@ export default StateManager;
 export * from './src/types';
 export { createFilter } from './src/filters';
 export { mergeStyles, Styles, StylesConfig } from './src/styles';
+export { defaultTheme } from './src/theme';
 
 export { NonceProvider } from './src/NonceProvider';
 export { Props, FormatOptionLabelMeta } from './src/Select';

--- a/types/react-select/test/examples/Popout.tsx
+++ b/types/react-select/test/examples/Popout.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { Button } from '../AtlaskitDummy';
 
-import Select from 'react-select';
-import { colors } from 'react-select/src/theme';
+import Select, { defaultTheme } from 'react-select';
 import { stateOptions } from '../data';
+
+const { colors } = defaultTheme;
 
 const selectStyles = {
   control: (provided: any) => ({ ...provided, minWidth: 240, margin: 8 }),


### PR DESCRIPTION
This fixes danger bot warnings about the export missing in the DT
definition, see e.g.:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46790#issuecomment-674129586

https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/index.js#L11

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Provide a URL to documentation or source code which provides context for the suggested changes