### PR TITLE
mailparser: Mark email address as possibly being undefined

### DIFF
--- a/types/mailparser/index.d.ts
+++ b/types/mailparser/index.d.ts
@@ -56,7 +56,7 @@ interface EmailAddress {
     /**
      * The email address.
      */
-    address: string;
+    address?: string;
     /**
      * The name part of the email/group.
      */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://github.com/nodemailer/mailparser/blob/master/lib/mail-parser.js#L505. 

That function doesn't always parse an address, the type definition specified that the address would never be undefined.  But it is possible.
