### PR TITLE
[@types/react-native-canvas] Fix case of CanvasRenderingContext2D#lineCap

### DIFF
--- a/types/react-native-canvas/index.d.ts
+++ b/types/react-native-canvas/index.d.ts
@@ -43,7 +43,7 @@ export interface CanvasRenderingContext2D {
     font: string;
     globalAlpha: number;
     globalCompositionOperation: string;
-    linecap: string;
+    lineCap: string;
     lineDashOffset: number;
     lineJoin: string;
     lineWidth: number;

--- a/types/react-native-canvas/react-native-canvas-tests.tsx
+++ b/types/react-native-canvas/react-native-canvas-tests.tsx
@@ -41,6 +41,9 @@ class CanvasTest extends React.Component {
 
         context.fillStyle = 'purple';
         context.fillRect(0, 0, 100, 100);
+        context.lineCap = 'round';
+        context.strokeStyle = 'blue';
+        context.strokeRect(0, 0, 100, 100);
 
         const { width } = context.measureText('yo');
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/iddan/react-native-canvas/blob/983aa21d6eef86c108cd3b15b87ca373ffe221f4/src/CanvasRenderingContext2D.js#L9
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
