### PR TITLE
fix(pull-stream): `pull` function supports parameters of type Duplex(…

### DIFF
--- a/types/pull-stream/index.d.ts
+++ b/types/pull-stream/index.d.ts
@@ -58,6 +58,10 @@ declare namespace pull {
     type Duplex<In, Out> = DuplexSource<In> & DuplexSink<Out>;
     type DuplexThrough<In, Out> = DuplexSource<In> & DuplexSink<Out>;
 
+    type PossibleSource<T> = Source<T> | DuplexSource<T>;
+    type PossibleSink<T> = Sink<T> | DuplexSink<T>;
+    type PossibleThrough<In, Out> = Through<In, Out> | DuplexThrough<In, Out>;
+
     const count: typeof countImport;
     const empty: typeof emptyImport;
     const error: typeof errorImport;
@@ -90,146 +94,150 @@ declare namespace pull {
  */
 declare function pull(): void;
 
-declare function pull<Out>(source: pull.Source<Out>): pull.Source<Out>;
-declare function pull<In, Out>(source: pull.Source<In>, t1: pull.Through<In, Out>): pull.Source<Out>;
+declare function pull<Out>(source: pull.PossibleSource<Out>): pull.Source<Out>;
+declare function pull<In, Out>(source: pull.PossibleSource<In>, t1: pull.PossibleThrough<In, Out>): pull.Source<Out>;
 declare function pull<In, P1, Out>(
-    source: pull.Source<In>,
-    t1: pull.Through<In, P1>,
-    t2: pull.Through<P1, Out>,
+    source: pull.PossibleSource<In>,
+    t1: pull.PossibleThrough<In, P1>,
+    t2: pull.PossibleThrough<P1, Out>,
 ): pull.Source<Out>;
 declare function pull<In, P1, P2, Out>(
-    source: pull.Source<In>,
-    t1: pull.Through<In, P1>,
-    t2: pull.Through<P1, P2>,
-    t3: pull.Through<P2, Out>,
+    source: pull.PossibleSource<In>,
+    t1: pull.PossibleThrough<In, P1>,
+    t2: pull.PossibleThrough<P1, P2>,
+    t3: pull.PossibleThrough<P2, Out>,
 ): pull.Source<Out>;
 declare function pull<In, P1, P2, P3, Out>(
-    source: pull.Source<In>,
-    t1: pull.Through<In, P1>,
-    t2: pull.Through<P1, P2>,
-    t3: pull.Through<P2, P3>,
-    t4: pull.Through<P3, Out>,
+    source: pull.PossibleSource<In>,
+    t1: pull.PossibleThrough<In, P1>,
+    t2: pull.PossibleThrough<P1, P2>,
+    t3: pull.PossibleThrough<P2, P3>,
+    t4: pull.PossibleThrough<P3, Out>,
 ): pull.Source<Out>;
 declare function pull<In, P1, P2, P3, P4, Out>(
-    source: pull.Source<In>,
-    t1: pull.Through<In, P1>,
-    t2: pull.Through<P1, P2>,
-    t3: pull.Through<P2, P3>,
-    t4: pull.Through<P3, P4>,
-    t5: pull.Through<P4, Out>,
+    source: pull.PossibleSource<In>,
+    t1: pull.PossibleThrough<In, P1>,
+    t2: pull.PossibleThrough<P1, P2>,
+    t3: pull.PossibleThrough<P2, P3>,
+    t4: pull.PossibleThrough<P3, P4>,
+    t5: pull.PossibleThrough<P4, Out>,
 ): pull.Source<Out>;
 declare function pull<In, P1, P2, P3, P4, P5, Out>(
-    source: pull.Source<In>,
-    t1: pull.Through<In, P1>,
-    t2: pull.Through<P1, P2>,
-    t3: pull.Through<P2, P3>,
-    t4: pull.Through<P3, P4>,
-    t5: pull.Through<P4, P5>,
-    t6: pull.Through<P5, Out>,
+    source: pull.PossibleSource<In>,
+    t1: pull.PossibleThrough<In, P1>,
+    t2: pull.PossibleThrough<P1, P2>,
+    t3: pull.PossibleThrough<P2, P3>,
+    t4: pull.PossibleThrough<P3, P4>,
+    t5: pull.PossibleThrough<P4, P5>,
+    t6: pull.PossibleThrough<P5, Out>,
 ): pull.Source<Out>;
 
 declare function pull<In, Out>(t1: pull.Through<In, Out>): pull.Through<In, Out>;
-declare function pull<In, P1, Out>(t1: pull.Through<In, P1>, t2: pull.Through<P1, Out>): pull.Through<In, Out>;
+declare function pull<In, P1, Out>(t1: pull.Through<In, P1>, t2: pull.PossibleThrough<P1, Out>): pull.Through<In, Out>;
 declare function pull<In, P1, P2, Out>(
     t1: pull.Through<In, P1>,
-    t2: pull.Through<P1, P2>,
-    t3: pull.Through<P2, Out>,
+    t2: pull.PossibleThrough<P1, P2>,
+    t3: pull.PossibleThrough<P2, Out>,
 ): pull.Through<In, Out>;
 declare function pull<In, P1, P2, P3, Out>(
     t1: pull.Through<In, P1>,
-    t2: pull.Through<P1, P2>,
-    t3: pull.Through<P2, P3>,
-    t4: pull.Through<P3, Out>,
+    t2: pull.PossibleThrough<P1, P2>,
+    t3: pull.PossibleThrough<P2, P3>,
+    t4: pull.PossibleThrough<P3, Out>,
 ): pull.Through<In, Out>;
 declare function pull<In, P1, P2, P3, P4, Out>(
     t1: pull.Through<In, P1>,
-    t2: pull.Through<P1, P2>,
-    t3: pull.Through<P2, P3>,
-    t4: pull.Through<P3, P4>,
-    t5: pull.Through<P4, Out>,
+    t2: pull.PossibleThrough<P1, P2>,
+    t3: pull.PossibleThrough<P2, P3>,
+    t4: pull.PossibleThrough<P3, P4>,
+    t5: pull.PossibleThrough<P4, Out>,
 ): pull.Through<In, Out>;
 declare function pull<In, P1, P2, P3, P4, P5, Out>(
     t1: pull.Through<In, P1>,
-    t2: pull.Through<P1, P2>,
-    t3: pull.Through<P2, P3>,
-    t4: pull.Through<P3, P4>,
-    t5: pull.Through<P4, P5>,
-    t6: pull.Through<P5, Out>,
+    t2: pull.PossibleThrough<P1, P2>,
+    t3: pull.PossibleThrough<P2, P3>,
+    t4: pull.PossibleThrough<P3, P4>,
+    t5: pull.PossibleThrough<P4, P5>,
+    t6: pull.PossibleThrough<P5, Out>,
 ): pull.Through<In, Out>;
 
-declare function pull<In>(sink: pull.Sink<In>): pull.Sink<In>;
-declare function pull<In, Out>(t1: pull.Through<In, Out>, sink: pull.Sink<Out>): pull.Sink<In>;
+declare function pull<In>(sink: pull.PossibleSink<In>): pull.Sink<In>;
+declare function pull<In, Out>(t1: pull.PossibleThrough<In, Out>, sink: pull.PossibleSink<Out>): pull.Sink<In>;
 declare function pull<In, P1, Out>(
-    t1: pull.Through<In, P1>,
-    t2: pull.Through<P1, Out>,
-    sink: pull.Sink<Out>,
+    t1: pull.PossibleThrough<In, P1>,
+    t2: pull.PossibleThrough<P1, Out>,
+    sink: pull.PossibleSink<Out>,
 ): pull.Sink<In>;
 declare function pull<In, P1, P2, Out>(
-    t1: pull.Through<In, P1>,
-    t2: pull.Through<P1, P2>,
-    t3: pull.Through<P2, Out>,
-    sink: pull.Sink<Out>,
+    t1: pull.PossibleThrough<In, P1>,
+    t2: pull.PossibleThrough<P1, P2>,
+    t3: pull.PossibleThrough<P2, Out>,
+    sink: pull.PossibleSink<Out>,
 ): pull.Sink<In>;
 declare function pull<In, P1, P2, P3, Out>(
-    t1: pull.Through<In, P1>,
-    t2: pull.Through<P1, P2>,
-    t3: pull.Through<P2, P3>,
-    t4: pull.Through<P3, Out>,
-    sink: pull.Sink<Out>,
+    t1: pull.PossibleThrough<In, P1>,
+    t2: pull.PossibleThrough<P1, P2>,
+    t3: pull.PossibleThrough<P2, P3>,
+    t4: pull.PossibleThrough<P3, Out>,
+    sink: pull.PossibleSink<Out>,
 ): pull.Sink<In>;
 declare function pull<In, P1, P2, P3, P4, Out>(
-    t1: pull.Through<In, P1>,
-    t2: pull.Through<P1, P2>,
-    t3: pull.Through<P2, P3>,
-    t4: pull.Through<P3, P4>,
-    t5: pull.Through<P4, Out>,
-    sink: pull.Sink<Out>,
+    t1: pull.PossibleThrough<In, P1>,
+    t2: pull.PossibleThrough<P1, P2>,
+    t3: pull.PossibleThrough<P2, P3>,
+    t4: pull.PossibleThrough<P3, P4>,
+    t5: pull.PossibleThrough<P4, Out>,
+    sink: pull.PossibleSink<Out>,
 ): pull.Sink<In>;
 declare function pull<In, P1, P2, P3, P4, P5, Out>(
-    t1: pull.Through<In, P1>,
-    t2: pull.Through<P1, P2>,
-    t3: pull.Through<P2, P3>,
-    t4: pull.Through<P3, P4>,
-    t5: pull.Through<P4, P5>,
-    t6: pull.Through<P5, Out>,
-    sink: pull.Sink<Out>,
+    t1: pull.PossibleThrough<In, P1>,
+    t2: pull.PossibleThrough<P1, P2>,
+    t3: pull.PossibleThrough<P2, P3>,
+    t4: pull.PossibleThrough<P3, P4>,
+    t5: pull.PossibleThrough<P4, P5>,
+    t6: pull.PossibleThrough<P5, Out>,
+    sink: pull.PossibleSink<Out>,
 ): pull.Sink<In>;
 
-declare function pull<InOut>(source: pull.Source<InOut>, sink: pull.Sink<InOut>): void;
-declare function pull<In, Out>(source: pull.Source<In>, t1: pull.Through<In, Out>, sink: pull.Sink<Out>): void;
+declare function pull<InOut>(source: pull.PossibleSource<InOut>, sink: pull.PossibleSink<InOut>): void;
+declare function pull<In, Out>(
+    source: pull.PossibleSource<In>,
+    t1: pull.PossibleThrough<In, Out>,
+    sink: pull.PossibleSink<Out>,
+): void;
 declare function pull<In, P1, Out>(
-    source: pull.Source<In>,
-    t1: pull.Through<In, P1>,
-    t2: pull.Through<P1, Out>,
-    sink: pull.Sink<Out>,
+    source: pull.PossibleSource<In>,
+    t1: pull.PossibleThrough<In, P1>,
+    t2: pull.PossibleThrough<P1, Out>,
+    sink: pull.PossibleSink<Out>,
 ): void;
 declare function pull<In, P1, P2, Out>(
-    source: pull.Source<In>,
-    t1: pull.Through<In, P1>,
-    t2: pull.Through<P1, P2>,
-    t3: pull.Through<P2, Out>,
-    sink: pull.Sink<Out>,
+    source: pull.PossibleSource<In>,
+    t1: pull.PossibleThrough<In, P1>,
+    t2: pull.PossibleThrough<P1, P2>,
+    t3: pull.PossibleThrough<P2, Out>,
+    sink: pull.PossibleSink<Out>,
 ): void;
 declare function pull<In, P1, P2, P3, Out>(
-    source: pull.Source<In>,
-    t1: pull.Through<In, P1>,
-    t2: pull.Through<P1, P2>,
-    t3: pull.Through<P2, P3>,
-    t4: pull.Through<P3, Out>,
-    sink: pull.Sink<Out>,
+    source: pull.PossibleSource<In>,
+    t1: pull.PossibleThrough<In, P1>,
+    t2: pull.PossibleThrough<P1, P2>,
+    t3: pull.PossibleThrough<P2, P3>,
+    t4: pull.PossibleThrough<P3, Out>,
+    sink: pull.PossibleSink<Out>,
 ): void;
 declare function pull<In, P1, P2, P3, P4, Out>(
-    source: pull.Source<In>,
-    t1: pull.Through<In, P1>,
-    t2: pull.Through<P1, P2>,
-    t3: pull.Through<P2, P3>,
-    t4: pull.Through<P3, P4>,
-    t5: pull.Through<P4, Out>,
-    sink: pull.Sink<Out>,
+    source: pull.PossibleSource<In>,
+    t1: pull.PossibleThrough<In, P1>,
+    t2: pull.PossibleThrough<P1, P2>,
+    t3: pull.PossibleThrough<P2, P3>,
+    t4: pull.PossibleThrough<P3, P4>,
+    t5: pull.PossibleThrough<P4, Out>,
+    sink: pull.PossibleSink<Out>,
 ): void;
 
 declare function pull(
-    ...pullStreams: ReadonlyArray<pull.Source<any> | pull.Sink<any> | pull.Through<any, any>>
+    ...pullStreams: ReadonlyArray<pull.PossibleSource<any> | pull.PossibleSink<any> | pull.PossibleThrough<any, any>>
 ): pull.Source<any> | pull.Sink<any> | pull.Through<any, any> | void;
 
 export = pull;

--- a/types/pull-stream/pull-stream-tests.ts
+++ b/types/pull-stream/pull-stream-tests.ts
@@ -8,6 +8,19 @@ let source: pull.Source<string> = (end, cb) => {};
 let through: pull.Through<string, string> = source => source;
 let sink: pull.Sink<string> = source => {};
 
+const duplexSource = {
+    source,
+};
+
+const duplexSink = {
+    sink,
+};
+
+const duplexThrough: pull.DuplexThrough<string, string> = {
+    source: (end, cb) => {},
+    sink: source => source,
+};
+
 function voidFunc(): void {}
 
 type Void = ReturnType<typeof voidFunc>;
@@ -15,24 +28,64 @@ type Void = ReturnType<typeof voidFunc>;
 // Start with source and end with sink
 let nothing: Void;
 nothing = pull();
+
 nothing = pull(source, sink);
+nothing = pull(duplexSource, duplexSink);
+
 nothing = pull(source, through, sink);
+nothing = pull(duplexSource, through, duplexSink);
+
 nothing = pull(source, through, through, sink);
+nothing = pull(duplexSource, through, through, duplexSink);
+nothing = pull(duplexSource, through, through, through, duplexSink);
+nothing = pull(duplexSource, through, through, through, through, duplexSink);
 
 // Start with source
 source = pull(source);
+source = pull(duplexSource);
+
 source = pull(source, through);
-source = pull(source, through, through);
+source = pull(duplexSource, through);
+source = pull(duplexSource, duplexThrough);
+
+source = pull(source, duplexThrough, through);
+source = pull(duplexSource, duplexThrough, through);
+source = pull(source, duplexThrough, through, through);
+source = pull(duplexSource, duplexThrough, through, through);
+source = pull(source, duplexThrough, through, through, through, through);
+source = pull(duplexSource, duplexThrough, through, through, through, through);
+source = pull(source, duplexThrough, through, through, through, through, through);
+source = pull(duplexSource, duplexThrough, through, through, through, through, through);
 
 // End with sink
 sink = pull(sink);
+sink = pull(duplexSink);
+
 sink = pull(through, sink);
-sink = pull(through, through, sink);
+sink = pull(duplexThrough, sink);
+sink = pull(duplexThrough, duplexSink);
+
+sink = pull(through, duplexThrough, sink);
+sink = pull(through, duplexThrough, duplexSink);
+sink = pull(through, duplexThrough, through, sink);
+sink = pull(through, duplexThrough, through, duplexSink);
+sink = pull(through, duplexThrough, through, through, sink);
+sink = pull(through, duplexThrough, through, through, duplexSink);
+sink = pull(through, duplexThrough, through, through, through, sink);
+sink = pull(through, duplexThrough, through, through, through, duplexSink);
+sink = pull(through, duplexThrough, through, through, through, through, sink);
+sink = pull(through, duplexThrough, through, through, through, through, duplexSink);
 
 // Through only
 through = pull(through);
-through = pull(through, through);
+through = pull(through, duplexThrough);
+
 through = pull(through, through, through);
+through = pull(through, duplexThrough, through);
+through = pull(through, duplexThrough, duplexThrough);
+through = pull(through, through, through, duplexThrough);
+through = pull(through, through, through, through, duplexThrough);
+through = pull(through, through, through, through, through, duplexThrough);
 
 const numberSource: pull.Source<number> = (end, cb) => {};
 const parseNumber: pull.Through<string, number> = source => numberSource;


### PR DESCRIPTION
…`{source, sink}`).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jacobbubu/DefinitelyTyped/issues/2
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.