### PR TITLE
[prosemirror-view] Fix EditorView.setProps to no longer require state

### DIFF
--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -275,7 +275,7 @@ export class EditorView<S extends Schema = any> {
    * given as argument. Equivalent to `view.update(Object.assign({},
    * view.props, props))`.
    */
-  setProps(props: DirectEditorProps<S>): void;
+  setProps(props: Partial<DirectEditorProps<S>>): void;
   /**
    * Update the editor's `state` prop, without touching any of the
    * other props.

--- a/types/prosemirror-view/prosemirror-view-tests.ts
+++ b/types/prosemirror-view/prosemirror-view-tests.ts
@@ -22,6 +22,7 @@ nodeDecoration.spec.a; // $ExpectType number
 const res1_1 = new view.EditorView({} as any, {} as any);
 const res1_2: { pos: number, inside: number } = res1_1.posAtCoords({ left: 0, top: 0})!;
 const res1_3: boolean = res1_1.editable;
+res1_1.setProps({ scrollThreshold: 42 });
 
 const res2_1: view.EditorProps = {} as any;
 const res2_plugin = new state.Plugin({});


### PR DESCRIPTION
Hi, the type of `EditorView.setProps` currently requires the `state` to be set. The [documentation](https://prosemirror.net/docs/ref/#view.EditorView.setProps) might be somewhat vague, but if you look at the [code](https://github.com/ProseMirror/prosemirror-view/blob/master/src/index.js#L102) it is clear that all props should be optional.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ProseMirror/prosemirror-view/blob/master/src/index.js#L102
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
