### PR TITLE
feat(mongodb): Narrow sort array values to 1 or -1

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -2567,7 +2567,7 @@ export class GridFSBucketReadStream extends Readable {
 
 /** https://mongodb.github.io/node-mongodb-native/3.1/api/GridFSBucketReadStream.html */
 export interface GridFSBucketReadStreamOptions {
-    sort?: SortValues;
+    sort?: Array<[string, SortValues]> | SortOptionObject<T>;
     skip?: number;
     start?: number;
     end?: number;

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -2172,7 +2172,7 @@ export interface FindOperatorsUnordered {
 /** http://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#findOne */
 export interface FindOneOptions<T> {
     limit?: number;
-    sort?: Array<[string, 1 | -1]> | SortOptionObject<T>;
+    sort?: Array<[string, SortValues]> | SortOptionObject<T>;
     projection?: SchemaMember<T, ProjectionOperators | number | boolean | any>;
     /**
      * @deprecated Use options.projection instead

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -31,6 +31,7 @@
 //                 HitkoDev <https://github.com/HitkoDev>
 //                 TJT <https://github.com/Celend>
 //                 Julien TASSIN <https://github.com/jtassin>
+//                 Guy Ellis <https://github.com/guyellis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.2
 
@@ -2171,7 +2172,7 @@ export interface FindOperatorsUnordered {
 /** http://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#findOne */
 export interface FindOneOptions<T> {
     limit?: number;
-    sort?: Array<[string, number]> | SortOptionObject<T>;
+    sort?: Array<[string, 1 | -1]> | SortOptionObject<T>;
     projection?: SchemaMember<T, ProjectionOperators | number | boolean | any>;
     /**
      * @deprecated Use options.projection instead

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -2384,7 +2384,7 @@ export class Cursor<T = Default> extends Readable {
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#snapshot */
     snapshot(snapshot: object): Cursor<T>;
     /** http://mongodb.github.io/node-mongodb-native/3.6/api/Cursor.html#sort */
-    sort(keyOrList: string | Array<[string, number]> | SortOptionObject<T>, direction?: number): Cursor<T>;
+    sort(keyOrList: string | Array<[string, SortValues]> | SortOptionObject<T>, direction?: SortValues): Cursor<T>;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#stream */
     stream(options?: { transform?: (document: T) => any }): Cursor<T>;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#toArray */
@@ -2567,7 +2567,7 @@ export class GridFSBucketReadStream extends Readable {
 
 /** https://mongodb.github.io/node-mongodb-native/3.1/api/GridFSBucketReadStream.html */
 export interface GridFSBucketReadStreamOptions {
-    sort?: number;
+    sort?: SortValues;
     skip?: number;
     start?: number;
     end?: number;

--- a/types/mongodb/test/collection/findX.ts
+++ b/types/mongodb/test/collection/findX.ts
@@ -39,6 +39,15 @@ async function run() {
     sort: {stringField: -1, text: {$meta: 'textScore'}, notExistingField: -1}
   });
 
+  // 2nd element of sort sub-array can only be 1 or -1
+  await collectionT.findOne({}, {
+    projection: {
+      stringField: {$meta: 'textScore'},
+      fruitTags: {$min: 'fruitTags'},
+      max: {$max: ['$max', 0]},
+    },
+    sort: [['stringField', -1], ['numberField', 1]],
+  });
 
   // collection.findX<T>() generic tests
   interface Bag {

--- a/types/mongodb/test/collection/findX.ts
+++ b/types/mongodb/test/collection/findX.ts
@@ -47,7 +47,7 @@ async function run() {
       max: {$max: ['$max', 0]},
     },
     sort: [['stringField', -1], ['numberField', 1]],
-  }
+  };
 
   // Error path: expect error if sort sub-array not 1 or -1
   // $ExpectError

--- a/types/mongodb/test/collection/findX.ts
+++ b/types/mongodb/test/collection/findX.ts
@@ -1,4 +1,4 @@
-import { connect, MongoError, Cursor } from 'mongodb';
+import { connect, MongoError, Cursor, FindOneOptions } from 'mongodb';
 import { connectionString } from '../index';
 
 // collection.findX tests
@@ -39,15 +39,19 @@ async function run() {
     sort: {stringField: -1, text: {$meta: 'textScore'}, notExistingField: -1}
   });
 
-  // 2nd element of sort sub-array can only be 1 or -1
-  await collectionT.findOne({}, {
+  // Happy path: 2nd element of sort sub-array can only be 1 or -1
+  const findOptions: FindOneOptions<TestModel> =  {
     projection: {
       stringField: {$meta: 'textScore'},
       fruitTags: {$min: 'fruitTags'},
       max: {$max: ['$max', 0]},
     },
     sort: [['stringField', -1], ['numberField', 1]],
-  });
+  }
+
+  // Error path: expect error if sort sub-array not 1 or -1
+  // $ExpectError
+  findOptions.sort = [['stringField', -5], ['numberField', 'i am a string']];
 
   // collection.findX<T>() generic tests
   interface Bag {


### PR DESCRIPTION
Purpose of this change: To the best of my understanding the sort sub-array can only have `1` or `-1` as the 2nd element to indicate `asc` or `desc` for the sort option. Narrowing this from `number` to `1 | -1` will provide value to developers using this by helping them get this value correct the first time.

Reviewers: If you feel this needs a new test please can you drop a note describing briefly where I'd put this and what its scope would be and I'll take a crack at doing this.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
