### PR TITLE
[ioBroker] Add smartName to StateObject definition, add EnumObject definition, fix typo

### DIFF
--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -164,6 +164,12 @@ declare global {
             custom?: undefined;
             // TODO: any other definition for device?
         }
+        interface EnumCommon extends ObjectCommon {
+            // Only states can have common.custom
+            custom?: undefined;
+            /** The IDs of the enum members */
+            members?: string[];
+        }
         interface OtherCommon extends ObjectCommon {
             [propName: string]: ObjectField | undefined;
 
@@ -225,8 +231,16 @@ declare global {
             common?: Partial<OtherCommon>;
         }
 
+        interface EnumObject extends BaseObject {
+            type: 'enum';
+            common: EnumCommon;
+        }
+        interface PartialEnumObject extends Partial<Omit<EnumObject, 'common'>> {
+            common?: Partial<EnumCommon>;
+        }
+
         interface OtherObject extends BaseObject {
-            type: 'adapter' | 'config' | 'enum' | 'group' | 'host' | 'info' | 'instance' | 'meta' | 'script' | 'user';
+            type: 'adapter' | 'config' | 'group' | 'host' | 'info' | 'instance' | 'meta' | 'script' | 'user';
             common: OtherCommon;
         }
         interface PartialOtherObject extends Partial<Omit<OtherObject, 'common'>> {
@@ -234,7 +248,7 @@ declare global {
         }
 
         // Base type for Objects. Should not be used directly
-        type AnyObject = StateObject | ChannelObject | DeviceObject | FolderObject | OtherObject;
+        type AnyObject = StateObject | ChannelObject | DeviceObject | FolderObject | EnumObject | OtherObject;
 
         // For all objects that are exposed to the user we need to tone the strictness down.
         // Otherwise, every operation on objects becomes a pain to work with
@@ -254,8 +268,9 @@ declare global {
             | SettableObjectWorker<ChannelObject>
             | SettableObjectWorker<DeviceObject>
             | SettableObjectWorker<FolderObject>
+            | SettableObjectWorker<EnumObject>
             | SettableObjectWorker<OtherObject>;
-        type PartialObject = PartialStateObject | PartialChannelObject | PartialDeviceObject | PartialFolderObject | PartialOtherObject;
+        type PartialObject = PartialStateObject | PartialChannelObject | PartialDeviceObject | PartialFolderObject | PartialEnumObject | PartialOtherObject;
 
         /** Defines access rights for a single file */
         interface FileACL {

--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -230,7 +230,7 @@ declare global {
             common: OtherCommon;
         }
         interface PartialOtherObject extends Partial<Omit<OtherObject, 'common'>> {
-            common?: Partial<ObjectCommon>;
+            common?: Partial<OtherCommon>;
         }
 
         // Base type for Objects. Should not be used directly

--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -54,14 +54,14 @@ declare global {
             /** Optional comment */
             c?: string;
         }
-        type SettableState = Partial<Omit<State, "val">> & Pick<State, "val">;
+        type SettableState = Partial<Omit<State, 'val'>> & Pick<State, 'val'>;
 
         type Session = any; // TODO: implement
 
         type ObjectType = 'state' | 'channel' | 'device';
         type CommonType = 'number' | 'string' | 'boolean' | 'array' | 'object' | 'mixed' | 'file';
 
-        type Languages = "en" | "de" | "ru" | "pt" | "nl" | "fr" | "it" | "es" | "pl" | "zh-cn";
+        type Languages = 'en' | 'de' | 'ru' | 'pt' | 'nl' | 'fr' | 'it' | 'es' | 'pl' | 'zh-cn';
 
         // Objects are JSON-serializable
         type ObjectField =
@@ -189,7 +189,7 @@ declare global {
             enums?: Record<string, string>;
             type: string; // specified in the derived interfaces
             // Be strict with what we allow here. Read objects overwrite this with any.
-            common: StateCommon | ChannelCommon | DeviceCommon | FolderObject | EnumObject | OtherCommon;
+            common: StateCommon | ChannelCommon | DeviceCommon | EnumCommon | OtherCommon;
             acl?: ObjectACL;
             from?: string;
             ts?: number;

--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -189,7 +189,7 @@ declare global {
             enums?: Record<string, string>;
             type: string; // specified in the derived interfaces
             // Be strict with what we allow here. Read objects overwrite this with any.
-            common: StateCommon | ChannelCommon | DeviceCommon | OtherCommon;
+            common: StateCommon | ChannelCommon | DeviceCommon | FolderObject | EnumObject | OtherCommon;
             acl?: ObjectACL;
             from?: string;
             ts?: number;

--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -61,6 +61,8 @@ declare global {
         type ObjectType = 'state' | 'channel' | 'device';
         type CommonType = 'number' | 'string' | 'boolean' | 'array' | 'object' | 'mixed' | 'file';
 
+        type Languages = "en" | "de" | "ru" | "pt" | "nl" | "fr" | "it" | "es" | "pl" | "zh-cn";
+
         // Objects are JSON-serializable
         type ObjectField =
             | string
@@ -138,6 +140,17 @@ declare global {
 
             /** Custom settings for this state */
             custom?: Record<string, any>;
+
+            /**
+             * Settings for IOT adapters and how the state should be named in e.g. Alexa.
+             * The string "ignore" is a special case, causing the state to be ignored.
+             */
+            smartName?: string | ({ [lang in Languages]?: string; } & {
+                /** Which kind of device this is */
+                smartType?: string | null;
+                /** Which value to set when the ON command is issued */
+                byOn?: string | null;
+            });
         }
         interface ChannelCommon extends ObjectCommon {
             /** description of this channel */

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -503,3 +503,6 @@ if (typeof state.common.smartName === "object") {
     state.common.smartName.de && state.common.smartName.de.toUpperCase();
     state.common.smartName.byOn && state.common.smartName.byOn.toUpperCase();
 }
+
+declare let enumObj: ioBroker.EnumObject;
+enumObj.common.members && enumObj.common.members.map(() => 1);

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -497,3 +497,9 @@ adapter.getObjectAsync('id').then(obj => {
     obj && obj.common && obj.common.alias && obj.common.alias.id;
     obj && obj.common && obj.common.unit && obj.common.workingID;
 });
+
+declare let state: ioBroker.StateObject;
+if (typeof state.common.smartName === "object") {
+    state.common.smartName.de && state.common.smartName.de.toUpperCase();
+    state.common.smartName.byOn && state.common.smartName.byOn.toUpperCase();
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Hidden somewhere in https://github.com/ioBroker/ioBroker.iot/blob/master/lib/alexaSmartHomeV2.js, see linked issues for details.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

fixes: https://github.com/ioBroker/adapter-core/issues/251
fixes: https://github.com/ioBroker/adapter-core/issues/252
fixes: https://github.com/ioBroker/adapter-core/issues/253
