### PR TITLE
[ackee-tracker] add types

### DIFF
--- a/types/ackee-tracker/ackee-tracker-tests.ts
+++ b/types/ackee-tracker/ackee-tracker-tests.ts
@@ -1,0 +1,27 @@
+import * as ackeeTracker from 'ackee-tracker';
+
+ackeeTracker.attributes();
+ackeeTracker.attributes(true);
+
+const instance1 = ackeeTracker.create({
+    server: 'https://example.com',
+    domainId: 'hd11f820-68a1-11e6-8047-79c0c2d9bce0',
+});
+
+const { stop } = instance1.record();
+stop();
+
+ackeeTracker.detect();
+
+const instance2 = ackeeTracker.create(
+    {
+        server: 'https://example.com',
+        domainId: 'hd11f820-68a1-11e6-8047-79c0c2d9bce0',
+    },
+    {
+        ignoreLocalhost: true,
+        detailed: false,
+    },
+);
+
+instance2.record(ackeeTracker.attributes(true));

--- a/types/ackee-tracker/index.d.ts
+++ b/types/ackee-tracker/index.d.ts
@@ -1,39 +1,52 @@
 // Type definitions for ackee-tracker 4.0
 // Project: https://github.com/electerious/ackee-tracker
-// Definitions by: Spencer Elliott <https://github.com/me>
+// Definitions by: Spencer Elliott <https://github.com/elliottsj>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/*~ If this module is a UMD module that exposes a global variable 'myLib' when
- *~ loaded outside a module loader environment, declare that global here.
- *~ Otherwise, delete this declaration.
- */
-export as namespace myLib;
-
-/*~ If this module has methods, declare them as functions like so.
- */
-export function myMethod(a: string): string;
-export function myOtherMethod(a: number): number;
-
-/*~ You can declare types that are available via importing the module */
-export interface someType {
-    name: string;
-    length: number;
-    extras?: string[];
+export interface ServerDetails {
+    server: string;
+    domainId: string;
 }
 
-/*~ You can declare properties of the module using const, let, or var */
-export const myField: number;
-
-/*~ If there are types, properties, or methods inside dotted names
- *~ of the module, declare them inside a 'namespace'.
- */
-export namespace subProp {
-    /*~ For example, given this definition, someone could write:
-     *~   import { subProp } from 'yourModule';
-     *~   subProp.foo();
-     *~ or
-     *~   import * as yourMod from 'yourModule';
-     *~   yourMod.subProp.foo();
+export interface TrackingOptions {
+    /**
+     * Defaults to `true`
      */
-    function foo(): void;
+    ignoreLocalhost?: boolean;
+    /**
+     * Defaults to `false`
+     */
+    detailed?: boolean;
 }
+
+export interface AckeeInstance {
+    record: (attrs?: ReturnType<typeof attributes>) => { stop: () => void };
+}
+
+export interface DefaultData {
+    siteLocation: string;
+    siteReferrer: string;
+}
+
+// Based on https://github.com/bestiejs/platform.js/blob/master/platform.js
+export interface DetailedData {
+    siteLanguage: string;
+    screenWidth: number;
+    screenHeight: number;
+    screenColorDepth: number;
+    deviceName: string | null;
+    deviceManufacturer: string | null;
+    osName: string | null;
+    osVersion: string | null;
+    browserName: string | null;
+    browserVersion: string | null;
+    browserWidth: number;
+    browserHeight: number;
+}
+
+export function create(server: ServerDetails, options?: TrackingOptions): AckeeInstance;
+
+export function attributes(detailed?: false): DefaultData;
+export function attributes(detailed: true): DefaultData & DetailedData;
+
+export function detect(): void;

--- a/types/ackee-tracker/index.d.ts
+++ b/types/ackee-tracker/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for ackee-tracker 4.0
 // Project: https://github.com/electerious/ackee-tracker
-// Definitions by: Spencer Elliott <https://github.com/elliottsj>
+// Definitions by: Pablo Sáez <https://github.com/PabloSzx>
+//                 Spencer Elliott <https://github.com/elliottsj>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface ServerDetails {

--- a/types/ackee-tracker/index.d.ts
+++ b/types/ackee-tracker/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for ackee-tracker 4.0
+// Project: https://github.com/electerious/ackee-tracker
+// Definitions by: Spencer Elliott <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/*~ If this module is a UMD module that exposes a global variable 'myLib' when
+ *~ loaded outside a module loader environment, declare that global here.
+ *~ Otherwise, delete this declaration.
+ */
+export as namespace myLib;
+
+/*~ If this module has methods, declare them as functions like so.
+ */
+export function myMethod(a: string): string;
+export function myOtherMethod(a: number): number;
+
+/*~ You can declare types that are available via importing the module */
+export interface someType {
+    name: string;
+    length: number;
+    extras?: string[];
+}
+
+/*~ You can declare properties of the module using const, let, or var */
+export const myField: number;
+
+/*~ If there are types, properties, or methods inside dotted names
+ *~ of the module, declare them inside a 'namespace'.
+ */
+export namespace subProp {
+    /*~ For example, given this definition, someone could write:
+     *~   import { subProp } from 'yourModule';
+     *~   subProp.foo();
+     *~ or
+     *~   import * as yourMod from 'yourModule';
+     *~   yourMod.subProp.foo();
+     */
+    function foo(): void;
+}

--- a/types/ackee-tracker/tsconfig.json
+++ b/types/ackee-tracker/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ackee-tracker-tests.ts"
+    ]
+}

--- a/types/ackee-tracker/tslint.json
+++ b/types/ackee-tracker/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Mostly taken from https://github.com/electerious/ackee-tracker/pull/17; thank you @PabloSzx