### PR TITLE
feat(mdv): new definition

### DIFF
--- a/types/mdv/index.d.ts
+++ b/types/mdv/index.d.ts
@@ -1,0 +1,63 @@
+// Type definitions for mdv 1.3
+// Project: https://github.com/Mermade/mdv#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * A tiny markdown validator
+ */
+export function validate(
+    s: string,
+    options: Options & {
+        warnings: true;
+    },
+): ValidateResults & Warnings;
+export function validate(s: string, options?: Options): ValidateResults;
+
+export interface Options {
+    /**
+     * markdown document path
+     */
+    source?: string;
+    /**
+     * enable warnings
+     * @default false
+     */
+    warnings?: boolean;
+    /**
+     * save intermediary html
+     * @default false
+     */
+    save?: boolean;
+}
+
+export interface Anchor {
+    name: string;
+    defined: number;
+    emptyText: number;
+    localRefNoHash: boolean;
+    seen: number;
+}
+
+export interface NonParsedEntry {
+    extension: string;
+    lineEnd: number;
+    lineStart: number;
+    message: string;
+}
+
+export interface ValidateResults {
+    anchorsWithEmptyText: Anchor[];
+    anchorsWithHash: Anchor[];
+    duplicatedAnchors: Anchor[];
+    imagesWithMissingAlt: number;
+    localRefNoHash: Anchor[];
+    missingAnchors: Anchor[];
+    nonParsingExamples: NonParsedEntry[];
+    source: string;
+}
+
+export interface Warnings {
+    anchorsWithNoLinks: Anchor[];
+    codeBlocksWithNoLanguage: number;
+}

--- a/types/mdv/mdv-tests.ts
+++ b/types/mdv/mdv-tests.ts
@@ -1,0 +1,25 @@
+import { Options, Warnings } from 'mdv';
+import mdv = require('mdv');
+
+const options: Options = {
+    source: './some.md',
+    save: true,
+    warnings: false,
+};
+const result = mdv.validate(`# Markdown Validator`, options); // $ExpectType ValidateResults
+// $ExpectType ValidateResults & Warnings
+const warnings: Warnings = mdv.validate('# Markdown Validator', {
+    warnings: true,
+});
+
+result.anchorsWithEmptyText; // $ExpectType Anchor[]
+result.anchorsWithHash; // $ExpectType Anchor[]
+result.duplicatedAnchors; // $ExpectType Anchor[]
+result.imagesWithMissingAlt; // $ExpectType number
+result.localRefNoHash; // $ExpectType Anchor[]
+result.missingAnchors; // $ExpectType Anchor[]
+result.nonParsingExamples; // $ExpectType NonParsedEntry[]
+result.source; // $ExpectType string
+
+warnings.anchorsWithNoLinks; // $ExpectType Anchor[]
+warnings.codeBlocksWithNoLanguage; // $ExpectType number

--- a/types/mdv/tsconfig.json
+++ b/types/mdv/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mdv-tests.ts"
+    ]
+}

--- a/types/mdv/tslint.json
+++ b/types/mdv/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Definition type for Markdown validator:
- definition file
- tests

https://www.npmjs.com/package/mdv
https://github.com/Mermade/mdv#api

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.