### PR TITLE
feat(postcss-focus-within): new definition

### DIFF
--- a/types/postcss-focus-within/index.d.ts
+++ b/types/postcss-focus-within/index.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for postcss-focus-within 4.0
+// Project: https://github.com/csstools/postcss-focus-within#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import { Plugin } from 'postcss';
+
+/**
+ * PostCSS Focus Within lets you use the `:focus-within` pseudo-class in CSS,
+ * following the Selectors Level 4 specification.
+ */
+declare namespace focusWithin {
+    /**
+     * @see {@link https://github.com/csstools/postcss-focus-within#options}
+     */
+    interface Options {
+        /**
+         * The preserve option defines whether the original selector should remain.
+         * By default, the original selector is preserved.
+         * @default true
+         */
+        preserve?: boolean;
+        /**
+         * The replaceWith option defines the selector to replace `:focus-within`.
+         * By default, the replacement selector is `[focus-within]`.
+         * @default `[focus-within]`
+         */
+        replaceWith?: string;
+    }
+
+    type FocusWithin = Plugin<Options>;
+}
+
+declare const focusWithin: focusWithin.FocusWithin;
+
+export = focusWithin;

--- a/types/postcss-focus-within/package.json
+++ b/types/postcss-focus-within/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "^7.0.32"
+    }
+}

--- a/types/postcss-focus-within/postcss-focus-within-tests.ts
+++ b/types/postcss-focus-within/postcss-focus-within-tests.ts
@@ -1,0 +1,11 @@
+import postcssFocusWithin = require('postcss-focus-within');
+import postcss = require('postcss');
+
+postcssFocusWithin.process('.some-css {}');
+
+postcss([
+    postcssFocusWithin({
+        preserve: false,
+        replaceWith: `[focus-witin]`,
+    }),
+]).process('.some-css {}' /*, processOptions */);

--- a/types/postcss-focus-within/tsconfig.json
+++ b/types/postcss-focus-within/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "postcss-focus-within-tests.ts"
+    ]
+}

--- a/types/postcss-focus-within/tslint.json
+++ b/types/postcss-focus-within/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Defnition for PostCSS module:
- definition file
- tests

https://www.npmjs.com/package/postcss-focus-within
https://github.com/csstools/postcss-focus-within#options

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.