### PR TITLE
feat(express-simple-locale): new definition

### DIFF
--- a/types/express-simple-locale/express-simple-locale-tests.ts
+++ b/types/express-simple-locale/express-simple-locale-tests.ts
@@ -1,0 +1,19 @@
+import express = require('express');
+import locale = require('express-simple-locale');
+
+const localeMiddlewareOptions = {
+    key: 'userLocale',
+    supportedLocales: ['en', 'fr', 'it', 'es', 'de'],
+    defaultLocale: 'en',
+    cookieName: 'c00ki3z',
+    queryParams: ['locale', 'lang'],
+};
+
+express()
+    .use(locale())
+    .use(locale({}))
+    .use(locale(localeMiddlewareOptions))
+    .use((request, response, next) => {
+        request.userLocale; // $ExpectType string
+        next();
+    });

--- a/types/express-simple-locale/index.d.ts
+++ b/types/express-simple-locale/index.d.ts
@@ -1,0 +1,56 @@
+// Type definitions for express-simple-locale 0.3
+// Project: https://github.com/n26/express-simple-locale#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import express = require('express');
+import { RequestHandler } from 'express';
+
+declare module 'express-serve-static-core' {
+    interface Request {
+        userLocale: locale.ShortLocale;
+    }
+}
+
+/**
+ * A simple Express middleware to guess the short-locale of a user.
+ * It then saves the found locale on the request for further usage.
+ */
+declare function locale(options?: locale.Options): RequestHandler;
+
+declare namespace locale {
+    /**
+     * @see {@link https://github.com/n26/express-simple-locale#options}
+     */
+    interface Options {
+        /**
+         * the key to save locale to on the request
+         * @default 'locale'
+         */
+        key?: string;
+        /**
+         * available locales for the app
+         * @default []
+         */
+        supportedLocales?: string[];
+        /**
+         * locale to fallback to
+         * @default 'en'
+         */
+        defaultLocale?: string;
+        /**
+         * cookie to try getting the locale from
+         * @default 'locale'
+         */
+        cookieName?: string;
+        /**
+         * the query parameter(s) to look the locale from
+         * @default ['locale']
+         */
+        queryParams?: string | string[];
+    }
+
+    /** The short-locale of a user */
+    type ShortLocale = string;
+}
+
+export = locale;

--- a/types/express-simple-locale/tsconfig.json
+++ b/types/express-simple-locale/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "express-simple-locale-tests.ts"
+    ]
+}

--- a/types/express-simple-locale/tslint.json
+++ b/types/express-simple-locale/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Definition types for Express middleware:
- definition file
- tests

https://www.npmjs.com/package/express-simple-locale
https://github.com/n26/express-simple-locale#options

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.