### PR TITLE
feat(express-locale): new definition

### DIFF
--- a/types/express-locale/express-locale-tests.ts
+++ b/types/express-locale/express-locale-tests.ts
@@ -1,0 +1,25 @@
+import express = require('express');
+import createLocaleMiddleware = require('express-locale');
+
+express()
+    .use(createLocaleMiddleware())
+    .use(createLocaleMiddleware({}))
+    .use(
+        createLocaleMiddleware({
+            priority: ['accept-language', 'default', 'custom', 'query'],
+            default: 'en-GB',
+            allowed: ['en-GB'],
+            hostname: { '127.0.0.1': 'nl-BE' },
+            cookie: { name: 'lang' },
+            lookups: {
+                custom: () => 'fr-FR',
+            },
+            map: { en: 'en-CA', fr: 'fr-CA' },
+            query: { name: 'l' },
+            requestProperty: 'locale',
+        }),
+    )
+    .use((req, res) => {
+        res.end(`Request locale: ${req.locale}`);
+    })
+    .listen(3000);

--- a/types/express-locale/index.d.ts
+++ b/types/express-locale/index.d.ts
@@ -1,0 +1,108 @@
+// Type definitions for express-locale 2.0
+// Project: https://github.com/smhg/express-locale#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import express = require('express');
+import { RequestHandler, Request } from 'express';
+
+declare module 'express-serve-static-core' {
+    interface Request {
+        locale: locale.Locale;
+    }
+}
+
+/**
+ * Express middleware to determine the locale identifier of the incomming request.
+ * It returns (only) full locale identifiers based on the middleware's configuration.
+ * Configuration defines possible sources, their order and, optionally, a whitelist.
+ * For performance reasons, on each request, remaining lookups are ignored as soon as a match is found.
+ */
+declare function locale(options?: locale.Options): RequestHandler;
+
+declare namespace locale {
+    /**
+     * @see {@link https://github.com/smhg/express-locale/#configuration}
+     */
+    interface Options {
+        /**
+         * Defines the order of lookups.
+         * The first lookup to return a full locale will be the final result.
+         * @default ['accept-language', 'default']
+         */
+        priority?: string[];
+
+        /**
+         * Add custom lookups or overwrite the default ones
+         * @default undefined
+         */
+        lookups?: {
+            [key: string]: (req: Request) => string;
+        };
+
+        /**
+         * The name of the cookie that contains the locale for the cookie lookup.
+         *
+         * Use with {@link https://github.com/expressjs/cookie-parser|cookie-parser} middleware.
+         *
+         * Note: you are responsible for writing the locale to the cookie.
+         *
+         * @default {name: 'locale'}
+         */
+        cookie?: {
+            [key: string]: unknown;
+        };
+
+        /**
+         * The name of the query string parameter that contains the locale for the query lookup.
+         * @default {name: 'locale'}
+         */
+        query?: {
+            [key: string]: unknown;
+        };
+
+        /**
+         * A mapping of hostnames to locales for the hostname lookup.
+         * @default {}
+         */
+        hostname?: {
+            [locale: string]: string;
+        };
+
+        /**
+         * Maps lookup results that return only a language to a full locale.
+         * @default {}
+         */
+        map?: {
+            [language: string]: string;
+        };
+
+        /**
+         * The default locale for the default lookup.
+         * @default 'en-GB'
+         */
+        default?: string;
+
+        /**
+         * Lookup results are validated against this list of allowed locales if provided.
+         * @default undefined
+         */
+        allowed?: string[];
+
+        /**
+         * By default, the locale is attached to `req.locale` but can be configured with the `requestProperty` option.
+         * @default 'locale'
+         */
+        requestProperty?: string;
+    }
+
+    /**
+     * The locale property on the request object
+     */
+    interface Locale {
+        source: string;
+        language: string;
+        region: string;
+    }
+}
+
+export = locale;

--- a/types/express-locale/tsconfig.json
+++ b/types/express-locale/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "express-locale-tests.ts"
+    ]
+}

--- a/types/express-locale/tslint.json
+++ b/types/express-locale/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Definition types for Express middleware:
- definitioin file
- tests

https://github.com/smhg/express-locale
https://www.npmjs.com/package/express-locale

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [d] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.