### PR TITLE
[jest-environment-puppeteer] Allow jest 26 and extend from jest-environment-node

### DIFF
--- a/types/jest-environment-puppeteer/index.d.ts
+++ b/types/jest-environment-puppeteer/index.d.ts
@@ -1,16 +1,14 @@
-// Type definitions for jest-environment-puppeteer 4.3
+// Type definitions for jest-environment-puppeteer 4.4
 // Project: https://github.com/smooth-code/jest-puppeteer/tree/master/packages/jest-environment-puppeteer
 // Definitions by: Josh Goldberg <https://github.com/joshuakgoldberg>
 //                 Ifiok Jr. <https://github.com/ifiokjr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.4
+// TypeScript Version: 3.8
 
-import { JestEnvironment } from '@jest/environment';
-import { JestFakeTimers as FakeTimers } from '@jest/fake-timers';
-import { Circus, Global as GlobalType, Config } from '@jest/types';
-import { ModuleMocker } from 'jest-mock';
+import NodeEnvironment = require('jest-environment-node');
+import { Global as GlobalType } from '@jest/types';
 import { Browser, Page, BrowserContext } from 'puppeteer';
-import { Script, Context } from 'vm';
+import { Context } from 'vm';
 
 interface JestPuppeteer {
     /**
@@ -49,12 +47,6 @@ interface JestPuppeteer {
     debug(): Promise<void>;
 }
 
-interface Timer {
-    id: number;
-    ref: () => Timer;
-    unref: () => Timer;
-}
-
 interface Global extends GlobalType.Global {
     browser: Browser;
     context: Context;
@@ -63,26 +55,8 @@ interface Global extends GlobalType.Global {
 }
 
 /** Note: TestEnvironment is sandboxed. Each test suite will trigger setup/teardown in their own TestEnvironment. */
-declare class PuppeteerEnvironment implements JestEnvironment {
-  context: Context | null;
-  fakeTimers: FakeTimers<Timer> | null;
+declare class PuppeteerEnvironment extends NodeEnvironment {
   global: Global;
-  moduleMocker: ModuleMocker | null;
-  constructor(config: Config.ProjectConfig);
-
-  /**
-   * Setup runs when the environment is being spun up, generally before each test suite
-   * You should always call `await super.setup()` in here
-   */
-  setup(): Promise<void>;
-
-  /**
-   * Teardowns runs as the environment is being torn down, generally after each test suite.
-   * You should always call `await super.tearDown()` in here
-   */
-  teardown(): Promise<void>;
-  runScript(script: Script): any;
-  handleTestEvent?(event: Circus.Event, state: Circus.State): void;
 }
 
 declare global {

--- a/types/jest-environment-puppeteer/jest-environment-puppeteer-tests.ts
+++ b/types/jest-environment-puppeteer/jest-environment-puppeteer-tests.ts
@@ -26,7 +26,7 @@ class CustomJestEnvironment extends JestEnvironmentPuppeteer {
         await super.teardown();
     }
 
-    runScript(script: Script) {
+    runScript(script: Script): any {
         return super.runScript(script);
     }
 

--- a/types/jest-environment-puppeteer/package.json
+++ b/types/jest-environment-puppeteer/package.json
@@ -1,9 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@jest/environment": "^24",
-        "@jest/fake-timers": "^24",
-        "@jest/types": "^24",
-        "jest-mock": "^24"
+        "@jest/types": ">=24 && <=26",
+        "jest-environment-node": ">=24 && <=26"
     }
 }


### PR DESCRIPTION
The source code of `jest-environment-puppeteer` also extends `jest-environment-node`, so I feel it makes sense that the types do the same. https://github.com/smooth-code/jest-puppeteer/blob/master/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js

Also the package `jest-environment-puppeteer` has [no dependency](https://github.com/smooth-code/jest-puppeteer/blob/master/packages/jest-environment-puppeteer/package.json#L23..L28) on `jest-environment-node` and works with whatever version is available. This is why I opted to widen the range and allow v24, v25 and v26 of jest packages.
Jest v26 is using `import type ...` in their types so I had to up the ts version to 3.8.


I do get a suggestion in the test `The JavaScript module exports a property named 'setup', which is missing from the declaration module.` and also DangerJs is reporting it as a comment somewhere down this thread. This is because I removed the methods, because they are defined upstream in `jest-environment-node`. So how to handle reexports? Ignore the suggestion? Or add it to the definition to silence the suggestion?

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/smooth-code/jest-puppeteer/blob/master/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
