### PR TITLE
Update kap-plugin tests for new conf version

### DIFF
--- a/types/kap-plugin/kap-plugin-tests.ts
+++ b/types/kap-plugin/kap-plugin-tests.ts
@@ -20,7 +20,7 @@ const service: KapShareService<Config> = {
         greeting: { type: 'string', default: true },
     },
     action: async context => {
-        // $ExpectType string | undefined
+        // $ExpectType string
         const name = context.config.get('name');
 
         context.config.get('accessToken');


### PR DESCRIPTION
The new version makes the type of `get` stricter by fixing a `string | <string subtype>` union. This makes the return type of `get` not include `undefined`.