### PR TITLE
Add RDF* support to rdf-js

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -24,7 +24,7 @@ export type PrefixedToIri = (suffix: string) => NamedNode;
 export class NamedNode<Iri extends string = string> implements RDF.NamedNode<Iri> {
     readonly termType: "NamedNode";
     readonly value: Iri;
-    constructor(iri: string);
+    constructor(iri: Iri);
     readonly id: string;
     toJSON(): {};
     equals(other: RDF.Term): boolean;

--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -21,9 +21,9 @@ export interface Prefixes<I = RDF.NamedNode> {
 export type Term = NamedNode | BlankNode | Literal | Variable | DefaultGraph;
 export type PrefixedToIri = (suffix: string) => NamedNode;
 
-export class NamedNode implements RDF.NamedNode {
+export class NamedNode<Iri extends string = string> implements RDF.NamedNode<Iri> {
     readonly termType: "NamedNode";
-    readonly value: string;
+    readonly value: Iri;
     constructor(iri: string);
     readonly id: string;
     toJSON(): {};
@@ -83,6 +83,8 @@ export type Quad_Graph = DefaultGraph | NamedNode | BlankNode | Variable;
 
 export class BaseQuad implements RDF.BaseQuad {
     constructor(subject: Term, predicate: Term, object: Term, graph?: Term);
+    termType: 'Quad';
+    value: '';
     subject: Term;
     predicate: Term;
     object: Term;
@@ -104,7 +106,7 @@ export class Quad extends BaseQuad implements RDF.Quad {
 export class Triple extends Quad implements RDF.Quad {}
 
 export namespace DataFactory {
-    function namedNode(value: string): NamedNode;
+    function namedNode<Iri extends string = string>(value: Iri): NamedNode<Iri>;
     function blankNode(value?: string): BlankNode;
     function literal(value: string | number, languageOrDatatype?: string | RDF.NamedNode): Literal;
     function variable(value: string): Variable;

--- a/types/rdf-ext/lib/DataFactory.d.ts
+++ b/types/rdf-ext/lib/DataFactory.d.ts
@@ -27,7 +27,7 @@ declare class DataFactoryExt  {
     PrefixMap: typeof PrefixMap;
   };
   static factory: typeof DataFactoryExt;
-  static namedNode(value: string): NamedNodeExt;
+  static namedNode<Iri extends string = string>(value: Iri): NamedNodeExt<Iri>;
   static blankNode(value?: string): BlankNodeExt;
   static literal(value: string, languageOrDatatype?: string | NamedNode): LiteralExt;
   static variable(value: string): VariableExt;

--- a/types/rdf-ext/lib/NamedNode.d.ts
+++ b/types/rdf-ext/lib/NamedNode.d.ts
@@ -1,7 +1,7 @@
 import { NamedNode, Term } from "rdf-js";
 import { PropType } from './_PropType';
 
-interface NamedNodeExt extends NamedNode {
+interface NamedNodeExt<Iri extends string = string> extends NamedNode<Iri> {
   toCanonical(): string;
   toJSON(): {
     value: PropType<NamedNode, 'value'>;

--- a/types/rdf-ext/lib/Quad.d.ts
+++ b/types/rdf-ext/lib/Quad.d.ts
@@ -7,6 +7,8 @@ import VariableExt = require('./Variable');
 import DefaultGraphExt = require('./DefaultGraph');
 
 interface QuadExt extends Quad {
+  termType: 'Quad';
+  value: '';
   subject: NamedNodeExt | BlankNodeExt | VariableExt;
   predicate: NamedNodeExt | VariableExt;
   object: NamedNodeExt | LiteralExt | BlankNodeExt | VariableExt;

--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -264,10 +264,7 @@ export interface DataFactory<OutQuad extends BaseQuad = Quad, InQuad extends Bas
      * @return A new instance of NamedNode.
      * @see NamedNode
      */
-    // TODO: This could be changed into a Generic method that returns a NamedNode constained to the
-    //       given `value` - but note that that would be a breaking change. See commit
-    //       16d29e86cd6fe34e6ac6f53bba6ba1a1988d7401.
-    namedNode(value: string): NamedNode;
+    namedNode<Iri extends string = string>(value: Iri): NamedNode<Iri>;
 
     /**
      * @param value The optional blank node identifier.

--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -252,7 +252,7 @@ export interface Quad extends BaseQuad {
      * @param other The term to compare with.
      * @return True if and only if the argument is a) of the same type b) has all components equal.
      */
-    equals(other: BaseQuad | Term | null | undefined): boolean;
+    equals(other: Term | null | undefined): boolean;
 }
 
 /**

--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -211,7 +211,7 @@ export interface BaseQuad {
    * @param other The term to compare with.
    * @return True if and only if the argument is a) of the same type b) has all components equal.
    */
-  equals(other: BaseQuad | Term | null | undefined): boolean;
+  equals(other: Term | null | undefined): boolean;
 }
 
 /**

--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for the RDFJS specification 3.0
+// Type definitions for the RDFJS specification 4.0
 // Project: https://github.com/rdfjs/representation-task-force
 // Definitions by: Ruben Taelman <https://github.com/rubensworks>
 //                 Laurens Rietveld <https://github.com/LaurensRietveld>
@@ -15,14 +15,15 @@ import { EventEmitter } from "events";
 /* https://rdf.js.org/data-model-spec/ */
 
 /**
- * Contains an Iri, RDF blank Node, RDF literal, variable name, or a default graph
+ * Contains an Iri, RDF blank Node, RDF literal, variable name, default graph, or a quad
  * @see NamedNode
  * @see BlankNode
  * @see Literal
  * @see Variable
  * @see DefaultGraph
+ * @see Quad
  */
-export type Term = NamedNode | BlankNode | Literal | Variable | DefaultGraph;
+export type Term = NamedNode | BlankNode | Literal | Variable | DefaultGraph | BaseQuad;
 
 /**
  * Contains an IRI.
@@ -145,7 +146,7 @@ export interface DefaultGraph {
  * @see BlankNode
  * @see Variable
  */
-export type Quad_Subject = NamedNode | BlankNode | Variable;
+export type Quad_Subject = NamedNode | BlankNode | Quad | Variable;
 
 /**
  * The predicate, which is a NamedNode or Variable.
@@ -161,7 +162,7 @@ export type Quad_Predicate = NamedNode | Variable;
  * @see BlankNode
  * @see Variable
  */
-export type Quad_Object = NamedNode | Literal | BlankNode | Variable;
+export type Quad_Object = NamedNode | Literal | BlankNode | Quad | Variable;
 
 /**
  * The named graph, which is a DefaultGraph, NamedNode, BlankNode or Variable.
@@ -176,6 +177,15 @@ export type Quad_Graph = DefaultGraph | NamedNode | BlankNode | Variable;
  * An RDF quad, taking any Term in its positions, containing the subject, predicate, object and graph terms.
  */
 export interface BaseQuad {
+  /**
+   * Contains the constant "Quad".
+   */
+  termType: "Quad";
+  /**
+   * Contains an empty string as constant value.
+   */
+  value: "";
+
   /**
    * The subject.
    * @see Quad_Subject
@@ -201,13 +211,22 @@ export interface BaseQuad {
    * @param other The term to compare with.
    * @return True if and only if the argument is a) of the same type b) has all components equal.
    */
-  equals(other: BaseQuad | null | undefined): boolean;
+  equals(other: BaseQuad | Term | null | undefined): boolean;
 }
 
 /**
  * An RDF quad, containing the subject, predicate, object and graph terms.
  */
 export interface Quad extends BaseQuad {
+    /**
+     * Contains the constant "Quad".
+     */
+    termType: "Quad";
+    /**
+     * Contains an empty string as constant value.
+     */
+    value: "";
+
     /**
      * The subject.
      * @see Quad_Subject
@@ -233,7 +252,7 @@ export interface Quad extends BaseQuad {
      * @param other The term to compare with.
      * @return True if and only if the argument is a) of the same type b) has all components equal.
      */
-    equals(other: BaseQuad | null | undefined): boolean;
+    equals(other: BaseQuad | Term | null | undefined): boolean;
 }
 
 /**

--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -219,15 +219,6 @@ export interface BaseQuad {
  */
 export interface Quad extends BaseQuad {
     /**
-     * Contains the constant "Quad".
-     */
-    termType: "Quad";
-    /**
-     * Contains an empty string as constant value.
-     */
-    value: "";
-
-    /**
      * The subject.
      * @see Quad_Subject
      */

--- a/types/rdf-js/rdf-js-tests.ts
+++ b/types/rdf-js/rdf-js-tests.ts
@@ -69,6 +69,11 @@ function test_datafactory() {
     const dataFactory: DataFactory = <any> {};
 
     const namedNode: NamedNode = dataFactory.namedNode('http://example.org');
+    const constantValue: 'http://example.org' = dataFactory.namedNode('http://example.org').value;
+    // $ExpectError
+    const otherConstantValue: 'http://not-example.org' = dataFactory.namedNode('http://example.org').value;
+    // $ExpectError
+    const otherConstantNamedNode: NamedNode<'http://not-example.org'> = dataFactory.namedNode('http://example.org');
 
     const blankNode1: BlankNode = dataFactory.blankNode('b1');
     const blankNode2: BlankNode = dataFactory.blankNode();

--- a/types/rdf-js/rdf-js-tests.ts
+++ b/types/rdf-js/rdf-js-tests.ts
@@ -92,6 +92,54 @@ function test_datafactory() {
     const hasBnode = quad.predicate.termType === "BlankNode";
 }
 
+function test_datafactory_star() {
+    const dataFactory: DataFactory = <any> {};
+
+    // Compose the triple "<<ex:bob ex:age 23>> ex:certainty 0.9."
+    const quadBobAge: Quad = dataFactory.quad(
+        dataFactory.namedNode('ex:bob'),
+        dataFactory.namedNode('ex:age'),
+        dataFactory.literal('23'),
+    );
+    const quadBobAgeCertainty: Quad = dataFactory.quad(
+        quadBobAge,
+        dataFactory.namedNode('ex:certainty'),
+        dataFactory.literal('0.9'),
+    );
+
+    // Decompose the triple
+    if (quadBobAgeCertainty.subject.termType === 'Quad') {
+        const quadBobAge2: Quad = quadBobAgeCertainty.subject;
+
+        const equalToSelf: boolean = quadBobAge2.equals(quadBobAge);
+        const notEqualToOtherType: boolean = quadBobAge2.equals(dataFactory.namedNode('ex:something:else'));
+    }
+}
+
+function test_datafactory_star_basequad() {
+    const dataFactory: DataFactory<BaseQuad> = <any> {};
+
+    // Compose the triple "<<ex:bob ex:age 23>> ex:certainty 0.9."
+    const quadBobAge: BaseQuad = dataFactory.quad(
+        dataFactory.namedNode('ex:bob'),
+        dataFactory.namedNode('ex:age'),
+        dataFactory.literal('23'),
+    );
+    const quadBobAgeCertainty: BaseQuad = dataFactory.quad(
+        quadBobAge,
+        dataFactory.namedNode('ex:certainty'),
+        dataFactory.literal('0.9'),
+    );
+
+    // Decompose the triple
+    if (quadBobAgeCertainty.subject.termType === 'Quad') {
+        const quadBobAge2: BaseQuad = quadBobAgeCertainty.subject;
+
+        const equalToSelf: boolean = quadBobAge2.equals(quadBobAge);
+        const notEqualToOtherType: boolean = quadBobAge2.equals(dataFactory.namedNode('ex:something:else'));
+    }
+}
+
 function test_stream() {
     const stream: Stream = <any> {};
     const quad: Quad | null = stream.read();


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rdfjs/data-model-spec/pull/165
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Tested this in several libraries already to make sure the typings work as intended.

Since all of this is a breaking change to the typings, I've also applied the breaking change that was needed for https://github.com/DefinitelyTyped/DefinitelyTyped/commit/16d29e86cd6fe34e6ac6f53bba6ba1a1988d7401 by @Vinnl.