### PR TITLE
fix(styled-components): remove insections on resulting StyledComponentProps

### DIFF
--- a/types/styled-components/ts3.7/index.d.ts
+++ b/types/styled-components/ts3.7/index.d.ts
@@ -54,12 +54,24 @@ export type StyledComponentProps<
 > =
     // Distribute O if O is a union type
     O extends object
-    ? WithOptionalTheme<
-        LooseOmit<Merge<ReactDefaultizedProps<C, React.ComponentPropsWithRef<C>>, O>, A> &
-            Partial<LoosePick<Merge<React.ComponentPropsWithRef<C>, O>, A>>,
-          T
-      > &
-          WithChildrenIfReactComponentClass<C>
+    ?
+        C extends React.ComponentType<any>
+        ?
+            WithOptionalTheme<
+                Omit<ReactDefaultizedProps<C, React.ComponentPropsWithRef<C>> & O, A> &
+                    Partial<Pick<React.ComponentPropsWithRef<C> & O, A>>,
+                T
+            > &
+                WithChildrenIfReactComponentClass<C>
+        :
+            // Merge prop types if host component.
+            // See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46850
+            WithOptionalTheme<
+                LooseOmit<Merge<ReactDefaultizedProps<C, React.ComponentPropsWithRef<C>>, O>, A> &
+                    Partial<LoosePick<Merge<React.ComponentPropsWithRef<C>, O>, A>>,
+                T
+            > &
+                WithChildrenIfReactComponentClass<C>
     : never;
 
 // Because of React typing quirks, when getting props from a React.ComponentClass,

--- a/types/styled-components/ts3.7/index.d.ts
+++ b/types/styled-components/ts3.7/index.d.ts
@@ -55,8 +55,8 @@ export type StyledComponentProps<
     // Distribute O if O is a union type
     O extends object
     ? WithOptionalTheme<
-          Omit<ReactDefaultizedProps<C, React.ComponentPropsWithRef<C>> & O, A> &
-              Partial<Pick<React.ComponentPropsWithRef<C> & O, A>>,
+        LooseOmit<Merge<ReactDefaultizedProps<C, React.ComponentPropsWithRef<C>>, O>, A> &
+            Partial<LoosePick<Merge<React.ComponentPropsWithRef<C>, O>, A>>,
           T
       > &
           WithChildrenIfReactComponentClass<C>
@@ -307,6 +307,11 @@ export type ThemedCssFunction<T extends object> = BaseThemedCssFunction<
 
 // Helper type operators
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+type Merge<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
+type LooseOmit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+type LoosePick<T, K extends keyof any> = {
+    [P in Extract<K, keyof T>]: T[P];
+};
 type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, "theme"> & {
     theme?: T;
 };

--- a/types/styled-components/ts3.7/test/index.tsx
+++ b/types/styled-components/ts3.7/test/index.tsx
@@ -1162,7 +1162,7 @@ function unionTest() {
     };
 
     const StyledReadable = styled(Readable)`
-        font-size: ${props => props.kind === 'book' ? 16 : 14}
+        font-size: ${props => props.kind === 'book' ? 16 : 14};
     `;
 
     // undesired, fix was reverted because of https://github.com/Microsoft/TypeScript/issues/30663
@@ -1186,6 +1186,8 @@ function unionTest2() {
     <C foo={123} bar="foobar" />; // $ExpectError
 }
 
+// Allow merging of props on host components.
+// See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46850
 function unionTest3() {
     // Can occur when working with styled-system
     // and any html props
@@ -1193,12 +1195,24 @@ function unionTest3() {
         color: number | string | Array<string | number | null> | { [x: string]: string | number; [x: number]: string | number; } | null;
     }
 
-    const C = styled.p<Props>``;
+    const C1 = styled.p<Props>``;
 
-    <C color="test" />;
-    <C color={2} />;
-    <C color={["test", null, 2]} />;
-    <C color={null} />;
-    <C color={{ foo: "bar" }} />;
-    <C color={{ 1: "foo" }} />;
+    <C1 color="test" />;
+    <C1 color={2} />;
+    <C1 color={["test", null, 2]} />;
+    <C1 color={null} />;
+    <C1 color={{ foo: "bar" }} />;
+    <C1 color={{ 1: "foo" }} />;
+
+    const C2 = ({ color }: { color: string }) => {
+        return <React.Fragment>{color.endsWith('green')}</React.Fragment>;
+    };
+
+    const S = styled(C2)<{ color: number }>``;
+
+    <C2 color="green" />;
+    <C2 color={123} />; // $ExpectError
+
+    // This would cause a runtime error.
+    <S color={123} />; // $ExpectError
 }

--- a/types/styled-components/ts3.7/test/index.tsx
+++ b/types/styled-components/ts3.7/test/index.tsx
@@ -1188,7 +1188,7 @@ function unionTest2() {
 
 function unionTest3() {
     // Can occur when working with styled-system
-    // and the `color` prop.
+    // and any html props
     interface Props {
         color: number | string | Array<string | number | null> | { [x: string]: string | number; [x: number]: string | number; } | null;
     }

--- a/types/styled-components/ts3.7/test/index.tsx
+++ b/types/styled-components/ts3.7/test/index.tsx
@@ -1185,3 +1185,20 @@ function unionTest2() {
     <C />; // $ExpectError
     <C foo={123} bar="foobar" />; // $ExpectError
 }
+
+function unionTest3() {
+    // Can occur when working with styled-system
+    // and the `color` prop.
+    interface Props {
+        color: number | string | Array<string | number | null> | { [x: string]: string | number; [x: number]: string | number; } | null;
+    }
+
+    const C = styled.p<Props>``;
+
+    <C color="test" />;
+    <C color={2} />;
+    <C color={["test", null, 2]} />;
+    <C color={null} />;
+    <C color={{ foo: "bar" }} />;
+    <C color={{ 1: "foo" }} />;
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

When using `styled-system` with `styled-components` the `color` property commonly gets overwritten. By default `color` on JSX intrinsic elements are typed as `color?: string`. But with styled-system the prop can support `string | number | symbol | null` along with an array of those types or a keyed object of those types (see `ColorProps` from `styled-system`).

Currently before this change, `color` would come back typed as:

```
string | (string & (string | number | symbol | null)[]) | (string & {
    [x: string]: string | number | symbol | undefined;
    [x: number]: string | number | symbol | undefined;
}) | undefined
```

After this change the `color` type comes back as:

```
string | number | symbol | (string | number | symbol | null)[] | {
[x: string]: string | number | symbol | undefined;
[x: number]: string | number | symbol | undefined;
} | null | undefined
```

Without this change the following fails.

```tsx
function unionTest3() {
    // Can occur when working with styled-system
    // and the `color` prop.
    interface Props {
        color: number | string | Array<string | number | null> | { [x: string]: string | number; [x: number]: string | number; } | null;
    }

    const C = styled.p<Props>``;

    <C color={2} />;  // Fails
    <C color={["test", null, 2]} />; // Fails
    <C color={null} />; // Fails
    <C color={{ foo: "bar" }} />; // Fails
    <C color={{ 1: "foo" }} />; // Fails
}
```

This removes an incorrect intersecting of prop types.