### PR TITLE
Add types for bemmer@1.1

### DIFF
--- a/types/bemmer/bemmer-tests.ts
+++ b/types/bemmer/bemmer-tests.ts
@@ -1,0 +1,22 @@
+import bemmer from 'bemmer';
+
+// $ExpectType Builder
+bemmer.createBuilder('cn1', 'cn2', 'cn3');
+
+// $ExpectType Builder
+bemmer.create('cn1', 'cn2', 'cn3');
+
+// $ExpectType Builder
+const builder = bemmer.createBuilder('singleClassName');
+
+// $ExpectType string
+builder('test');
+
+// $ExpectType string
+builder('test', { foo: true });
+
+// $ExpectType string
+builder('test', { foo: 100, baz: 'stuff' });
+
+// $ExpectType boolean
+bemmer.isBuilder(builder);

--- a/types/bemmer/index.d.ts
+++ b/types/bemmer/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for bemmer 1.1
+// Project: https://github.com/axross/bemmer
+// Definitions by: Nathan <https://github.com/nweber-gh>
+//                 Bryan <https://github.com/bdwain>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface Builder {
+    (classname?: string, modifiers?: { [index: string]: any }): string;
+}
+
+export function createBuilder(...classnames: string[]): Builder;
+export function create(...classnames: string[]): Builder;
+export function isBuilder(target: any): target is Builder;

--- a/types/bemmer/tsconfig.json
+++ b/types/bemmer/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "bemmer-tests.ts"
+    ]
+}

--- a/types/bemmer/tslint.json
+++ b/types/bemmer/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
