### PR TITLE
[@types/enzyme] Add Overload for find Method

### DIFF
--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -649,6 +649,7 @@ function ReactWrapperTest() {
 
     function test_find() {
         elementWrapper = reactWrapper.find('.selector');
+        anotherComponentWrapper = reactWrapper.find<AnotherComponentProps>("AnotherComponent");
         anotherComponentWrapper = reactWrapper.find(AnotherComponent);
         anotherStatelessWrapper = reactWrapper.find(AnotherStatelessComponent);
         reactWrapper = reactWrapper.find({ prop: 'myprop' });

--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -184,6 +184,7 @@ function ShallowWrapperTest() {
         anotherStatelessWrapper = shallowWrapper.find(AnotherStatelessComponent);
         shallowWrapper = shallowWrapper.find({ prop: 'value' });
         elementWrapper = shallowWrapper.find('.selector');
+        anotherComponentWrapper = shallowWrapper.find<AnotherComponentProps>("AnotherComponent");
         // Since AnotherComponent does not have a constructor, it cannot match the
         // previous selector overload of ComponentClass { new(props?, contenxt? ) }
         const s1: EnzymeComponentClass<AnotherComponentProps> = AnotherComponent;
@@ -407,6 +408,7 @@ function ShallowWrapperTest() {
         const props2: AnotherComponentProps = shallowWrapper.find(AnotherComponent).props();
         const props3: AnotherStatelessProps = shallowWrapper.find(AnotherStatelessComponent).props();
         const props4: HTMLAttributes<any> = shallowWrapper.find('.selector').props();
+        const props5: AnotherComponentProps = shallowWrapper.find<AnotherComponentProps>("AnotherComponent").props();
     }
 
     function test_prop() {
@@ -649,8 +651,8 @@ function ReactWrapperTest() {
 
     function test_find() {
         elementWrapper = reactWrapper.find('.selector');
-        anotherComponentWrapper = reactWrapper.find<AnotherComponentProps>("AnotherComponent");
         anotherComponentWrapper = reactWrapper.find(AnotherComponent);
+        anotherComponentWrapper = reactWrapper.find<AnotherComponentProps>("AnotherComponent");
         anotherStatelessWrapper = reactWrapper.find(AnotherStatelessComponent);
         reactWrapper = reactWrapper.find({ prop: 'myprop' });
     }
@@ -849,6 +851,7 @@ function ReactWrapperTest() {
         const props2: AnotherComponentProps = reactWrapper.find(AnotherComponent).props();
         const props3: AnotherStatelessProps = reactWrapper.find(AnotherStatelessComponent).props();
         const props4: HTMLAttributes<any> = reactWrapper.find('.selector').props();
+        const props5: AnotherComponentProps = reactWrapper.find<AnotherComponentProps>("AnotherComponent").props();
     }
 
     function test_prop() {

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -549,6 +549,7 @@ export class ReactWrapper<P = {}, S = {}, C = Component> {
       componentClass: ComponentClass<C2['props']>,
     ): ReactWrapper<C2['props'], C2['state'], C2>;
     find(props: EnzymePropSelector): ReactWrapper<any, any>;
+    find<P2>(componentName: string): ReactWrapper<P2, any>;
     find(selector: string): ReactWrapper<HTMLAttributes, any>;
 
     /**

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -414,6 +414,7 @@ export class ShallowWrapper<P = {}, S = {}, C = Component> {
     ): ShallowWrapper<C2['props'], C2['state'], C2>;
     find(props: EnzymePropSelector): ShallowWrapper<any, any>;
     find(selector: string): ShallowWrapper<HTMLAttributes, any>;
+    find<P2>(componentName: string): ShallowWrapper<P2, any>;
 
     /**
      * Removes nodes in the current wrapper that do not match the provided selector.
@@ -549,8 +550,8 @@ export class ReactWrapper<P = {}, S = {}, C = Component> {
       componentClass: ComponentClass<C2['props']>,
     ): ReactWrapper<C2['props'], C2['state'], C2>;
     find(props: EnzymePropSelector): ReactWrapper<any, any>;
-    find<P2>(componentName: string): ReactWrapper<P2, any>;
     find(selector: string): ReactWrapper<HTMLAttributes, any>;
+    find<P2>(componentName: string): ReactWrapper<P2, any>;
 
     /**
      * Finds every node in the render tree that returns true for the provided predicate function.

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -408,13 +408,12 @@ export class ShallowWrapper<P = {}, S = {}, C = Component> {
      * @param selector The selector to match.
      */
     find<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, never>;
-    find<P2>(component: ComponentType<P2>): ShallowWrapper<P2, any>;
     find<C2 extends Component>(
       componentClass: ComponentClass<C2['props']>,
     ): ShallowWrapper<C2['props'], C2['state'], C2>;
     find(props: EnzymePropSelector): ShallowWrapper<any, any>;
     find(selector: string): ShallowWrapper<HTMLAttributes, any>;
-    find<P2>(componentName: string): ShallowWrapper<P2, any>;
+    find<P2>(component: ComponentType<P2> | string): ShallowWrapper<P2, any>;
 
     /**
      * Removes nodes in the current wrapper that do not match the provided selector.
@@ -545,13 +544,12 @@ export class ReactWrapper<P = {}, S = {}, C = Component> {
      * @param selector The selector to match.
      */
     find<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, never>;
-    find<P2>(component: ComponentType<P2>): ReactWrapper<P2, any>;
     find<C2 extends Component>(
       componentClass: ComponentClass<C2['props']>,
     ): ReactWrapper<C2['props'], C2['state'], C2>;
     find(props: EnzymePropSelector): ReactWrapper<any, any>;
     find(selector: string): ReactWrapper<HTMLAttributes, any>;
-    find<P2>(componentName: string): ReactWrapper<P2, any>;
+    find<P2>(component: ComponentType<P2> | string): ReactWrapper<P2, any>;
 
     /**
      * Finds every node in the render tree that returns true for the provided predicate function.


### PR DESCRIPTION
## Reasoning

Sometimes it's necessary to find React Components in Enzyme by their display name. This PR is to allow developers to do this in TypeScript while testing things like `props()` without getting errors.

~~I read the [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes) section and am anticipating some concerns about the change. This overload is necessary because of the way Enzyme works. Sometimes people need to [find components by display name](https://github.com/enzymejs/enzyme/issues/396#issuecomment-219455265) in order for their tests to work. However, TypeScript has no way of anticipating the correct props from a string alone. Technically, this could be compensated for by updating the `find(selector: string)` overload, but then you're more so reasoning about a `componentName` than an actual `selector` -- at least arguably. That's just the reasoning, of course. Disagreements are welcome.~~

~~Disclaimer: I ran the test and the linter, but neither of the errors make sense because I haven't touched `package.json` (for the former) and I didn't change anything related to React's type definitions (for the latter). I'm hoping the issues are external? But if not, I'm hoping for some help.~~

The new code that was checked in to allow the tests to pass should resolve the crossed-out issues.

## Checklist
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://enzymejs.github.io/enzyme/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
