### PR TITLE
update(graphlib): setGraph should take an any

### DIFF
--- a/types/graphlib/graphlib-tests.ts
+++ b/types/graphlib/graphlib-tests.ts
@@ -7,6 +7,7 @@ function test_graph() {
     directed: true,
     multigraph: true
   });
+  g.setGraph({});
   g.setEdge('a', 'b');
   g.setEdge('a', 'b', 1.023, 'test');
   g.setEdge({ v: 'a', w: 'b', name: 'test' }, 1.023);

--- a/types/graphlib/index.d.ts
+++ b/types/graphlib/index.d.ts
@@ -362,7 +362,7 @@ declare module "graphlib" {
          * @argument label - label value.
          * @returns the graph, allowing this to be chained with other functions.
          */
-        setGraph(label: string): Graph;
+        setGraph(label: any): Graph;
 
         /**
          * Gets the graph label.


### PR DESCRIPTION
dagred3 assumes/requires that callers use an object as the graph label
rather than a simple string.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://dagrejs.github.io/project/dagre-d3/latest/demo/arrows.html (the first line of the demo)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
