### PR TITLE
fix(mongodb): Fix incorrect return type for calling Cursor.find with options

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1102,12 +1102,12 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
     estimatedDocumentCount(query?: FilterQuery<TSchema>, options?: MongoCountPreferences): Promise<number>;
     estimatedDocumentCount(query: FilterQuery<TSchema>, options: MongoCountPreferences, callback: MongoCallback<number>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#find */
-    find<T = TSchema>(query?: FilterQuery<TSchema>): Cursor<TSchema>;
-    find<T = TSchema>(query: FilterQuery<TSchema>, options?: FindOneOptions<T>): Cursor<TSchema>;
+    find<T = TSchema>(query?: FilterQuery<TSchema>): Cursor<T>;
+    find<T = TSchema>(query: FilterQuery<TSchema>, options?: FindOneOptions<T extends TSchema ? TSchema : T>): Cursor<T>;
     /** http://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#findOne */
-    findOne<T = TSchema>(filter: FilterQuery<TSchema>, callback: MongoCallback<T | null>): void;
-    findOne<T = TSchema>(filter: FilterQuery<TSchema>, options?: FindOneOptions<T>): Promise<TSchema | null>;
-    findOne<T = TSchema>(filter: FilterQuery<TSchema>, options: FindOneOptions<T>, callback: MongoCallback<TSchema | null>): void;
+    findOne<T = TSchema>(filter: FilterQuery<TSchema>, callback: MongoCallback<T extends TSchema ? TSchema : T | null>): void;
+    findOne<T = TSchema>(filter: FilterQuery<TSchema>, options?: FindOneOptions<T extends TSchema ? TSchema : T>): Promise<T | null>;
+    findOne<T = TSchema>(filter: FilterQuery<TSchema>, options: FindOneOptions<T extends TSchema ? TSchema : T>, callback: MongoCallback<T extends TSchema ? TSchema : T | null>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#findOneAndDelete */
     findOneAndDelete(filter: FilterQuery<TSchema>, callback: MongoCallback<FindAndModifyWriteOpResultObject<TSchema>>): void;
     findOneAndDelete(filter: FilterQuery<TSchema>, options?: FindOneAndDeleteOption<TSchema>): Promise<FindAndModifyWriteOpResultObject<TSchema>>;

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1102,12 +1102,12 @@ export interface Collection<TSchema extends { [key: string]: any } = DefaultSche
     estimatedDocumentCount(query?: FilterQuery<TSchema>, options?: MongoCountPreferences): Promise<number>;
     estimatedDocumentCount(query: FilterQuery<TSchema>, options: MongoCountPreferences, callback: MongoCallback<number>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#find */
-    find<T = TSchema>(query?: FilterQuery<TSchema>): Cursor<T>;
-    find<T = TSchema>(query: FilterQuery<TSchema>, options?: FindOneOptions<T>): Cursor<T>;
+    find<T = TSchema>(query?: FilterQuery<TSchema>): Cursor<TSchema>;
+    find<T = TSchema>(query: FilterQuery<TSchema>, options?: FindOneOptions<T>): Cursor<TSchema>;
     /** http://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#findOne */
     findOne<T = TSchema>(filter: FilterQuery<TSchema>, callback: MongoCallback<T | null>): void;
-    findOne<T = TSchema>(filter: FilterQuery<TSchema>, options?: FindOneOptions<T>): Promise<T | null>;
-    findOne<T = TSchema>(filter: FilterQuery<TSchema>, options: FindOneOptions<T>, callback: MongoCallback<T | null>): void;
+    findOne<T = TSchema>(filter: FilterQuery<TSchema>, options?: FindOneOptions<T>): Promise<TSchema | null>;
+    findOne<T = TSchema>(filter: FilterQuery<TSchema>, options: FindOneOptions<T>, callback: MongoCallback<TSchema | null>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#findOneAndDelete */
     findOneAndDelete(filter: FilterQuery<TSchema>, callback: MongoCallback<FindAndModifyWriteOpResultObject<TSchema>>): void;
     findOneAndDelete(filter: FilterQuery<TSchema>, options?: FindOneAndDeleteOption<TSchema>): Promise<FindAndModifyWriteOpResultObject<TSchema>>;

--- a/types/mongodb/test/cursor.ts
+++ b/types/mongodb/test/cursor.ts
@@ -34,10 +34,27 @@ async function run() {
     .stream();
 
   collection.find().project({});
-  collection.find().project({notExistingField: 1});
-  collection.find().sort({'fruitTags.name': -1, numberField: -1, notExistingField: -1});
+  collection.find().project({notExistingField: 1, });
   collection.find().sort({text: {$meta: 'textScore'}, notExistingField: -1});
   collection.find().sort({});
+
+  interface TypedDoc {
+    name: string;
+    age: number;
+    tag: {
+      name: string;
+    }
+  }
+  const typedCollection = db.collection<TypedDoc>('test')
+  typedCollection.find({name: 'name'}, {}).map(x => x.tag)
+  typedCollection.find({'tag.name': 'name'}, {})
+  typedCollection.find({'tag.name': 'name'}, {projection: {name: 1, max: {$max: []}}})
+    .sort({score: {$meta: 'textScore'}})
+    .map(x => x.tag)
+
+  typedCollection.find().project({name: 1})
+  typedCollection.find().project({notExistingField: 1})
+  typedCollection.find().project({max: {$max: []}})
 
   for await (const item of cursor) {
     item.foo; // $ExpectType number

--- a/types/mongodb/test/cursor.ts
+++ b/types/mongodb/test/cursor.ts
@@ -48,7 +48,7 @@ async function run() {
   const typedCollection = db.collection<TypedDoc>('test');
   typedCollection.find({name: 'name'}, {}).map(x => x.tag);
   typedCollection.find({'tag.name': 'name'}, {});
-  typedCollection.find({'tag.name': 'name'}, {projection: {name: 1, max: {$max: []}}})
+  typedCollection.find({'tag.name': 'name'}, {projection: {'tag.name': 1, max: {$max: []}}})
     .sort({score: {$meta: 'textScore'}})
     .map(x => x.tag);
   typedCollection.find({'tag.name': 'name'}, {projection: {name: 1, max: {$max: []}}}).toArray().then(docs => {

--- a/types/mongodb/test/cursor.ts
+++ b/types/mongodb/test/cursor.ts
@@ -43,18 +43,27 @@ async function run() {
     age: number;
     tag: {
       name: string;
-    }
+    };
   }
-  const typedCollection = db.collection<TypedDoc>('test')
-  typedCollection.find({name: 'name'}, {}).map(x => x.tag)
-  typedCollection.find({'tag.name': 'name'}, {})
+  const typedCollection = db.collection<TypedDoc>('test');
+  typedCollection.find({name: 'name'}, {}).map(x => x.tag);
+  typedCollection.find({'tag.name': 'name'}, {});
   typedCollection.find({'tag.name': 'name'}, {projection: {name: 1, max: {$max: []}}})
     .sort({score: {$meta: 'textScore'}})
-    .map(x => x.tag)
+    .map(x => x.tag);
+  typedCollection.find({'tag.name': 'name'}, {projection: {name: 1, max: {$max: []}}}).toArray().then(docs => {
+    return docs.map(x => x.tag);
+  });
 
-  typedCollection.find().project({name: 1})
-  typedCollection.find().project({notExistingField: 1})
-  typedCollection.find().project({max: {$max: []}})
+  // override the collection type
+  typedCollection.find<{name2: string, age2: number}>({name: '123'}, {projection: {age2: 1}})
+    .map(x => x.name2 && x.age2);
+  typedCollection.find({name: '123'}, {projection: {age: 1}})
+    .map(x => x.tag);
+
+  typedCollection.find().project({name: 1});
+  typedCollection.find().project({notExistingField: 1});
+  typedCollection.find().project({max: {$max: []}});
 
   for await (const item of cursor) {
     item.foo; // $ExpectType number


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.