### PR TITLE
Add types for jasmine-expect-jsx@3.2 package

### DIFF
--- a/types/jasmine-expect-jsx/index.d.ts
+++ b/types/jasmine-expect-jsx/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for jasmine-expect-jsx 3.2
+// Project: https://github.com/smacker/jasmine-expect-jsx#readme
+// Definitions by: Nathan <https://github.com/nweber-gh>
+//                 Bryan <https://github.com/bdwain>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.2
+
+/// <reference types="jasmine"/>
+
+import * as React from 'react';
+
+declare global {
+    namespace jasmine {
+        interface Matchers<T> {
+            toEqualJSX(element: Expected<T>): boolean;
+            toIncludeJSX(element: Expected<T>): boolean;
+        }
+    }
+}

--- a/types/jasmine-expect-jsx/jasmine-expect-jsx-tests.tsx
+++ b/types/jasmine-expect-jsx/jasmine-expect-jsx-tests.tsx
@@ -1,0 +1,18 @@
+/// <reference types="../jasmine"/>
+/// <reference types="./index"/>
+
+describe('test suite', () => {
+  it('tests toEqualJSX method', () => {
+    const component = (
+      <div>hello world</div>
+    );
+    expect(component).toEqualJSX(<div>hello world</div>);
+  });
+
+  it('tests toIncludeJSX method', () => {
+    const component = (
+      <div><span>hello world</span></div>
+    );
+    expect(component).toIncludeJSX(<span>hello world</span>);
+  });
+});

--- a/types/jasmine-expect-jsx/tsconfig.json
+++ b/types/jasmine-expect-jsx/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "jsx": "preserve",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "jasmine-expect-jsx-tests.tsx"
+    ]
+}

--- a/types/jasmine-expect-jsx/tslint.json
+++ b/types/jasmine-expect-jsx/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.