### PR TITLE
Adjust react-router `withRouter` to accept partial `RouteComponentProps` for more flexibility

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -20,6 +20,8 @@
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 //                 Nicholas Hehr <https://github.com/HipsterBrown>
 //                 Pawel Fajfer <https://github.com/pawfa>
+//                 Nathan Weber <https://github.com/nweber-gh>
+//                 Bryan Wain <https://github.com/bdwain>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -152,6 +154,12 @@ export interface WithRouterStatics<C extends React.ComponentType<any>> {
 // you will see a bunch of errors from TypeScript. The current workaround is to use withRouter() as a function call
 // on a separate line instead of as a decorator.
 export function withRouter<P extends RouteComponentProps<any>, C extends React.ComponentType<P>>(
+    component: C & React.ComponentType<P>,
+): React.ComponentClass<Omit<P, keyof RouteComponentProps<any>> & WithRouterProps<C>> & WithRouterStatics<C>;
+
+// Add a `Partial` as an overload so that components are capable of defining their shape instead
+// of the HOC forcing a shape onto components.
+export function withRouter<P extends Partial<RouteComponentProps<any>>, C extends React.ComponentType<P>>(
     component: C & React.ComponentType<P>,
 ): React.ComponentClass<Omit<P, keyof RouteComponentProps<any>> & WithRouterProps<C>> & WithRouterStatics<C>;
 

--- a/types/react-router/test/WithRouter.tsx
+++ b/types/react-router/test/WithRouter.tsx
@@ -2,16 +2,61 @@ import * as React from 'react';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { StaticContext } from 'react-router';
 
+interface TPartialProps extends Partial<RouteComponentProps> {
+    username: string;
+}
+
+const PartialComponentFunction = (props: TPartialProps) => (
+    props.location
+        ? <h2>Welcome {props.username} from {props.location.pathname}</h2>
+        : <h2>Welcome {props.username}</h2>
+);
+
+const PartialFunctionComponent: React.FunctionComponent<TPartialProps> = props => (
+    <h2>Welcome {props.username}</h2>
+);
+
+class PartialComponentClass extends React.Component<TPartialProps> {
+    render() {
+        return <h2>Welcome {this.props.username}</h2>;
+    }
+}
+
+const TestComponent = () => (
+    <PartialComponentFunction username="foobar" />
+);
+
+const PartialWithRouterComponentFunction = withRouter(PartialComponentFunction);
+const PartialWithRouterFunctionComponent = withRouter(PartialFunctionComponent);
+const PartialWithRouterComponentClass = withRouter(PartialComponentClass);
+PartialWithRouterComponentClass.WrappedComponent; // $ExpectType typeof PartialComponentClass
+
+// can use unwrapped component with partials
+{
+    type FooProps = { username: string } & Partial<RouteComponentProps>;
+
+    const FooComp: React.FC<FooProps> = props => {
+        props.location; // $ExpectType Location<UnknownFacade> | undefined
+        props.history; // $ExpectType History<UnknownFacade> | undefined
+
+        return <div>user: {props.username}</div>;
+    };
+
+    const RoutedFoo = withRouter(FooComp);
+
+    <FooComp username="Joe" />;
+}
+
 interface TOwnProps extends RouteComponentProps {
     username: string;
 }
 
 const ComponentFunction = (props: TOwnProps) => (
-    <h2>Welcome {props.username}</h2>
+    <h2>Welcome {props.username} from {props.location.pathname}</h2>
 );
 
 const FunctionComponent: React.FunctionComponent<TOwnProps> = props => (
-  <h2>Welcome {props.username}</h2>
+    <h2>Welcome {props.username}</h2>
 );
 
 class ComponentClass extends React.Component<TOwnProps> {
@@ -56,7 +101,7 @@ const WithRouterTestClass2 = () => <WithRouterComponentClass username="John" wra
 
     type SomethingToRead = (Book | Magazine) & RouteComponentProps<{}, StaticContext, State>;
 
-    const Readable: React.SFC<SomethingToRead> = props => {
+    const Readable: React.FC<SomethingToRead> = props => {
         props.location.state; // $ExpectType State
         props.history.location.state; // $ExpectType State
 


### PR DESCRIPTION
The `withRouter` function requires that the component being decorated extends `RouteComponentProps`. This can be a frustrating implementor experience as it is fine to decorate a component that *does not* require the props from `RouteComponentProps`.

e.g.,
```
const FooComponent = () => <span>Hello World</span>;

const WrappedComponent = withRouter(FooComponent);
```

This example should be acceptable (and it functionally works) but today we get a TypeScript error that `RouteComponentProps` are not part of the props signature.

An example using classes.

```
import * as React from 'react';
import { withRouter, RouteComponentProps } from 'react-router'

class WithPartial extends React.Component<Partial<RouteComponentProps>> {}
class WithRequired extends React.Component<RouteComponentProps> {}

withRouter(WithPartial); // error
withRouter(WithRequired);
```

https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQokscA3nAO7AwAWGEArjCxQANJgFCAwiUgA7LLJgAFYmHQBfOERLlKeGAFpig4WTp1cAGzToA6l25LksYMktwsADyGyAJumx9ADppcAh5RQAeJxc3SL4TULkFZVVUAD501nULa1Q7B2wAR35gSl8PbwV-TCoYEJlwlPiJLCSmxRUINSyWHLpOHgShKAAKex4YmFdLAEoaOAB6RY8oYigBwtaxid4sErKsX3m6IA

This is particularly frustrating when the *undecorated* version of the component is used, as you get an error if you don't provide all of the `RouteComponentProps` even though your component does not use them.

e.g.,
```
// this is what you have to do today
const FooComponent: React.FC<RouteComponentProps> = (props) => <span>Hello World</span>;
const WrappedComponent = withRouter(FooComponent);

const UsingUnwrappedComponent = () => <FooComponent />; // error
const UsingWrappedComponent = () => <WrappedComponent />;
```

Proposal: Allow the `RouteComponentProps` to be partial, indicating that the decorated component can have the props but that the props are optional.

e.g.,
```
const PartialPropsComponent: React.FC<Partial<RouteComponentProps>> = (props) => (
  props.location
    ? <span>{props.location.pathname}</span>
    : <span>no location available</span<
);

const WrappedPartial = withRouter(PartialPropsComponent);

const RequiredPropsComponent: React.FC<RouteComponentProps> = (props) => (
  <span>{props.location.pathname}</span>
);

const WrappedRequired = withRouter(RequiredPropsComponent);

const TestComp1 = () => <PartialPropsComponent />;
const TestComp2 = () => <WrappedPartial />;

const TestComp3 = () => <RequiredPropsComponent />; // error
const TestComp4 = () => <WrappedRequired />;
```

This change unlocks the ability for the component to decide whether or not it requires the props to be provided.

_The existing behavior, where `RouteComponentProps` are *not* marked as `Partial<>` in the implementing component, will continue to work as it does today._

_Note: This does not appear to be an issue if you type the props on a FunctionComponent instead of using `React.FC`, thereby allowing `withRouter` to infer the type of the React element. See thread for more information. The description has been updated to reflect using `React.FC`._

e.g.,

```
import * as React from 'react';
import { withRouter, RouteComponentProps } from 'react-router'

const C1: React.FC<Partial<RouteComponentProps>> = (props) => <div />
const C2 = (props: Partial<RouteComponentProps>) => <div />;

withRouter(C1); // error
withRouter(C2); // no error
```

https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQokscA3nAO7AwAWGEArjCxQANJgFCAwiUgA7LLJgAFYmHQBfOERLlKeGAFpig4WTp1cEWaniSAjAC5MVGADoAYpIA8S5LGDIADZefCbS4FYKyqqoAHyxcAC8cAAUYDEAlEkJXgAmwABucAD0sRZWNnCSAExJqekQak6+-kEhEljhclEqjXFZiTn5RaX0dJw8oUJQKfYZ9BO8HTM183RAA

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
