### PR TITLE
Improves robust-point-in-polygon's Return Type using Union Type of Possible Values Instead of number

### DIFF
--- a/types/robust-point-in-polygon/index.d.ts
+++ b/types/robust-point-in-polygon/index.d.ts
@@ -5,5 +5,5 @@
 
 type Point = [number, number];
 
-declare function robustPointInPolygon(vs: Point[], point: Point): number;
+declare function robustPointInPolygon(vs: Point[], point: Point): -1 | 0 | 1;
 export = robustPointInPolygon;


### PR DESCRIPTION
The return type of `robustPointInPolygon` is documented as being in the set `-1`, `0`, `1` but it is currently defined as `number`

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mikolalysenko/robust-point-in-polygon#api

The API is documented as

> **Returns** An integer which determines the position of `point` relative to `polygon`.  This has the following interpretation:
>
> * `-1` if `point` is contained inside `loop`
> * `0` if `point` is on the boundary of `loop`
> * `1` if `point` is outside `loop`
