### PR TITLE
[metaget] Add types for metaget

### DIFF
--- a/types/metaget/index.d.ts
+++ b/types/metaget/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for metaget 1.0
+// Project: https://github.com/mrvautin/metaget#readme
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface Options {
+    headers?: Record<string, any>;
+    timeout?: number;
+}
+
+export type Result = Record<string, string>;
+
+export type Callback<T> = (error: Error | null, data: Result) => T;
+
+export function fetch<T>(uri: string, userArgs: Options, callback: Callback<T>): Promise<T>;
+export function fetch<T>(uri: string, callback: Callback<T>): Promise<T>;
+export function fetch(uri: string, userArgs?: Options): Promise<Result>;

--- a/types/metaget/metaget-tests.ts
+++ b/types/metaget/metaget-tests.ts
@@ -1,0 +1,10 @@
+import * as metaget from 'metaget';
+
+metaget.fetch('https://wordpress.com').then(response => {
+    response; // $ExpectType Record<string, string>
+});
+
+metaget.fetch('https://wordpress.com', (error, response) => {
+    error; // $ExpectType Error | null
+    response; // $ExpectType Record<string, string>
+});

--- a/types/metaget/tsconfig.json
+++ b/types/metaget/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metaget-tests.ts"
+    ]
+}

--- a/types/metaget/tslint.json
+++ b/types/metaget/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
