### PR TITLE
[metascraper] Add types for metascraper

### DIFF
--- a/types/metascraper-address/index.d.ts
+++ b/types/metascraper-address/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for metascraper-address 1.0
+// Project: https://github.com/goodhood-eu/metascraper-address#readme
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare function getData(): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-address/metascraper-address-tests.ts
+++ b/types/metascraper-address/metascraper-address-tests.ts
@@ -1,0 +1,9 @@
+import metascraper = require('metascraper');
+import metascraperAddress = require('metascraper-address');
+
+const html = 'example';
+const url = 'https://example.org';
+
+metascraper([metascraperAddress()])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-address/package.json
+++ b/types/metascraper-address/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-address/tsconfig.json
+++ b/types/metascraper-address/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-address-tests.ts"
+    ]
+}

--- a/types/metascraper-address/tslint.json
+++ b/types/metascraper-address/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-amazon/index.d.ts
+++ b/types/metascraper-amazon/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for metascraper-amazon 5.14
+// Project: https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-amazon
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare function getData(): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-amazon/metascraper-amazon-tests.ts
+++ b/types/metascraper-amazon/metascraper-amazon-tests.ts
@@ -1,0 +1,9 @@
+import metascraper = require('metascraper');
+import metascraperAmazon = require('metascraper-amazon');
+
+const html = 'example';
+const url = 'https://example.org';
+
+metascraper([metascraperAmazon()])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-amazon/package.json
+++ b/types/metascraper-amazon/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-amazon/tsconfig.json
+++ b/types/metascraper-amazon/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-amazon-tests.ts"
+    ]
+}

--- a/types/metascraper-amazon/tslint.json
+++ b/types/metascraper-amazon/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-audio/index.d.ts
+++ b/types/metascraper-audio/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for metascraper-audio 5.14
+// Project: https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-audio
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare function getData(): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-audio/metascraper-audio-tests.ts
+++ b/types/metascraper-audio/metascraper-audio-tests.ts
@@ -1,0 +1,9 @@
+import metascraper = require('metascraper');
+import metascraperAudio = require('metascraper-audio');
+
+const html = 'example';
+const url = 'https://example.org';
+
+metascraper([metascraperAudio()])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-audio/package.json
+++ b/types/metascraper-audio/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-audio/tsconfig.json
+++ b/types/metascraper-audio/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-audio-tests.ts"
+    ]
+}

--- a/types/metascraper-audio/tslint.json
+++ b/types/metascraper-audio/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-author/index.d.ts
+++ b/types/metascraper-author/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for metascraper-author 5.14
+// Project: https://metascraper.js.org
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare function getData(): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-author/metascraper-author-tests.ts
+++ b/types/metascraper-author/metascraper-author-tests.ts
@@ -1,0 +1,9 @@
+import metascraper = require('metascraper');
+import metascraperAuthor = require('metascraper-author');
+
+const html = 'example';
+const url = 'https://example.org';
+
+metascraper([metascraperAuthor()])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-author/package.json
+++ b/types/metascraper-author/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-author/tsconfig.json
+++ b/types/metascraper-author/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-author-tests.ts"
+    ]
+}

--- a/types/metascraper-author/tslint.json
+++ b/types/metascraper-author/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-clearbit/index.d.ts
+++ b/types/metascraper-clearbit/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for metascraper-clearbit 5.14
+// Project: https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-clearbit
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import * as http from 'http';
+
+import metascraper = require('metascraper');
+
+declare namespace getData {
+    interface Options {
+        /** Any option provided here will passed to `got#options`. */
+        gotOpts?: http.ClientRequestArgs;
+    }
+}
+
+declare function getData(options?: getData.Options): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-clearbit/metascraper-clearbit-tests.ts
+++ b/types/metascraper-clearbit/metascraper-clearbit-tests.ts
@@ -1,0 +1,19 @@
+import metascraper = require('metascraper');
+import metascraperClearbit = require('metascraper-clearbit');
+
+const html = 'example';
+const url = 'https://example.org';
+
+const options: metascraperClearbit.Options = {
+    gotOpts: {
+        timeout: 10000,
+    },
+};
+
+metascraper([metascraperClearbit()])({ html, url }).then(data => {
+    data;
+});
+
+metascraper([metascraperClearbit(options)])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-clearbit/package.json
+++ b/types/metascraper-clearbit/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-clearbit/tsconfig.json
+++ b/types/metascraper-clearbit/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-clearbit-tests.ts"
+    ]
+}

--- a/types/metascraper-clearbit/tslint.json
+++ b/types/metascraper-clearbit/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-date/index.d.ts
+++ b/types/metascraper-date/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for metascraper-date 5.14
+// Project: https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-date
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare function getData(): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-date/metascraper-date-tests.ts
+++ b/types/metascraper-date/metascraper-date-tests.ts
@@ -1,0 +1,9 @@
+import metascraper = require('metascraper');
+import metascraperDate = require('metascraper-date');
+
+const html = 'example';
+const url = 'https://example.org';
+
+metascraper([metascraperDate()])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-date/package.json
+++ b/types/metascraper-date/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-date/tsconfig.json
+++ b/types/metascraper-date/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-date-tests.ts"
+    ]
+}

--- a/types/metascraper-date/tslint.json
+++ b/types/metascraper-date/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-description/index.d.ts
+++ b/types/metascraper-description/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for metascraper-description 5.14
+// Project: https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-description
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare namespace getData {
+    interface Options {
+        /** Truncate the value extracted to a maximum size (default: `300`). */
+        truncateLength?: number;
+    }
+}
+
+declare function getData(options?: getData.Options): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-description/metascraper-description-tests.ts
+++ b/types/metascraper-description/metascraper-description-tests.ts
@@ -1,0 +1,17 @@
+import metascraper = require('metascraper');
+import metascraperDescription = require('metascraper-description');
+
+const html = 'example';
+const url = 'https://example.org';
+
+const options: metascraperDescription.Options = {
+    truncateLength: 150,
+};
+
+metascraper([metascraperDescription()])({ html, url }).then(data => {
+    data;
+});
+
+metascraper([metascraperDescription(options)])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-description/package.json
+++ b/types/metascraper-description/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-description/tsconfig.json
+++ b/types/metascraper-description/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-description-tests.ts"
+    ]
+}

--- a/types/metascraper-description/tslint.json
+++ b/types/metascraper-description/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-iframe/index.d.ts
+++ b/types/metascraper-iframe/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for metascraper-iframe 5.14
+// Project: https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-iframe
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare function getData(): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-iframe/metascraper-iframe-tests.ts
+++ b/types/metascraper-iframe/metascraper-iframe-tests.ts
@@ -1,0 +1,9 @@
+import metascraper = require('metascraper');
+import metascraperIframe = require('metascraper-iframe');
+
+const html = 'example';
+const url = 'https://example.org';
+
+metascraper([metascraperIframe()])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-iframe/package.json
+++ b/types/metascraper-iframe/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-iframe/tsconfig.json
+++ b/types/metascraper-iframe/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-iframe-tests.ts"
+    ]
+}

--- a/types/metascraper-iframe/tslint.json
+++ b/types/metascraper-iframe/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-image/index.d.ts
+++ b/types/metascraper-image/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for metascraper-image 5.14
+// Project: https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-image
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare function getData(): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-image/metascraper-image-tests.ts
+++ b/types/metascraper-image/metascraper-image-tests.ts
@@ -1,0 +1,9 @@
+import metascraper = require('metascraper');
+import metascraperImage = require('metascraper-image');
+
+const html = 'example';
+const url = 'https://example.org';
+
+metascraper([metascraperImage()])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-image/package.json
+++ b/types/metascraper-image/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-image/tsconfig.json
+++ b/types/metascraper-image/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-image-tests.ts"
+    ]
+}

--- a/types/metascraper-image/tslint.json
+++ b/types/metascraper-image/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-lang/index.d.ts
+++ b/types/metascraper-lang/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for metascraper-lang 5.14
+// Project: https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-lang
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare function getData(): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-lang/metascraper-lang-tests.ts
+++ b/types/metascraper-lang/metascraper-lang-tests.ts
@@ -1,0 +1,9 @@
+import metascraper = require('metascraper');
+import metascraperLang = require('metascraper-lang');
+
+const html = 'example';
+const url = 'https://example.org';
+
+metascraper([metascraperLang()])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-lang/package.json
+++ b/types/metascraper-lang/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-lang/tsconfig.json
+++ b/types/metascraper-lang/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-lang-tests.ts"
+    ]
+}

--- a/types/metascraper-lang/tslint.json
+++ b/types/metascraper-lang/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-logo-favicon/index.d.ts
+++ b/types/metascraper-logo-favicon/index.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for metascraper-logo-favicon 5.14
+// Project: https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-logo-favicon
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+/// <reference types="node" />
+
+import * as http from 'http';
+import metascraper = require('metascraper');
+
+declare namespace getData {
+    type PickDefaultFunction = (sizes: FaviconSize[]) => FaviconSize;
+    type PickFunction = (sizes: FaviconSize[], pickDefault: PickDefaultFunction) => FaviconSize;
+
+    interface FaviconSize {
+        rel?: string;
+        href: string;
+        sizes?: string;
+        url: string;
+        size: number;
+    }
+
+    interface Options {
+        /** Any option provided here will passed to `got#options`. */
+        gotOpts?: http.ClientRequestArgs;
+        /** Truncate the value extracted to a maximum size (default: `300`). */
+        pickFn?: PickFunction;
+    }
+}
+
+declare function getData(options?: getData.Options): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-logo-favicon/metascraper-logo-favicon-tests.ts
+++ b/types/metascraper-logo-favicon/metascraper-logo-favicon-tests.ts
@@ -1,0 +1,25 @@
+import metascraper = require('metascraper');
+import metascraperLogoFavicon = require('metascraper-logo-favicon');
+
+const html = 'example';
+const url = 'https://example.org';
+
+const pickFn: metascraperLogoFavicon.PickFunction = (sizes, pickDefault) => {
+    const appleTouchIcon = sizes.find(item => item.rel && item.rel.includes('apple'));
+    return appleTouchIcon || pickDefault(sizes);
+};
+
+const options: metascraperLogoFavicon.Options = {
+    pickFn,
+    gotOpts: {
+        timeout: 10000,
+    },
+};
+
+metascraper([metascraperLogoFavicon()])({ html, url }).then(data => {
+    data;
+});
+
+metascraper([metascraperLogoFavicon(options)])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-logo-favicon/package.json
+++ b/types/metascraper-logo-favicon/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-logo-favicon/tsconfig.json
+++ b/types/metascraper-logo-favicon/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-logo-favicon-tests.ts"
+    ]
+}

--- a/types/metascraper-logo-favicon/tslint.json
+++ b/types/metascraper-logo-favicon/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-logo/index.d.ts
+++ b/types/metascraper-logo/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for metascraper-logo 5.14
+// Project: https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-logo
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare function getData(): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-logo/metascraper-logo-tests.ts
+++ b/types/metascraper-logo/metascraper-logo-tests.ts
@@ -1,0 +1,9 @@
+import metascraper = require('metascraper');
+import metascraperLogo = require('metascraper-logo');
+
+const html = 'example';
+const url = 'https://example.org';
+
+metascraper([metascraperLogo()])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-logo/package.json
+++ b/types/metascraper-logo/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-logo/tsconfig.json
+++ b/types/metascraper-logo/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-logo-tests.ts"
+    ]
+}

--- a/types/metascraper-logo/tslint.json
+++ b/types/metascraper-logo/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-media-provider/index.d.ts
+++ b/types/metascraper-media-provider/index.d.ts
@@ -1,0 +1,42 @@
+// Type definitions for metascraper-media-provider 5.14
+// Project: https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-media-provider
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare namespace getData {
+    type OnErrorFunction = (url: string, error: Error) => void;
+    type GetProxyFunction = (data: GetProxyData) => string;
+
+    interface GetProxyData {
+        url: string;
+        retryCount: number;
+    }
+
+    interface Options {
+        /**
+         * It specifies cache based on file system to be used by
+         * [youtube-dl](https://github.com/microlinkhq/metascraper/blob/master/packages/metascraper-media-provider/youtube-dl).
+         */
+        cacheDir?: string;
+        /**
+         * It will be called to determinate if a proxy should be used for
+         * resolving the next request URL.
+         */
+        getProxy?: GetProxyFunction;
+        /** A function to be called when something wrong happens. */
+        onError?: OnErrorFunction;
+        /**
+         * The maximum time allowed to wait until considering the request as
+         * timed out. Default is `30000`.
+         */
+        timeout?: number;
+        /** It specifies a custom user agent. */
+        userAgent?: string;
+    }
+}
+
+declare function getData(options?: getData.Options): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-media-provider/metascraper-media-provider-tests.ts
+++ b/types/metascraper-media-provider/metascraper-media-provider-tests.ts
@@ -1,0 +1,30 @@
+import metascraper = require('metascraper');
+import metascraperMediaProvider = require('metascraper-media-provider');
+
+const html = 'example';
+const url = 'https://example.org';
+
+const getProxy: metascraperMediaProvider.GetProxyFunction = data => {
+    return data.url;
+};
+
+const onError: metascraperMediaProvider.OnErrorFunction = (url, error) => {
+    url; // $ExpectType string
+    error; // $ExpectType Error
+};
+
+const options: metascraperMediaProvider.Options = {
+    cacheDir: '/tmp/cache',
+    getProxy,
+    onError,
+    timeout: 10000,
+    userAgent: 'MyUserAgent 1.0',
+};
+
+metascraper([metascraperMediaProvider()])({ html, url }).then(data => {
+    data;
+});
+
+metascraper([metascraperMediaProvider(options)])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-media-provider/package.json
+++ b/types/metascraper-media-provider/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-media-provider/tsconfig.json
+++ b/types/metascraper-media-provider/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-media-provider-tests.ts"
+    ]
+}

--- a/types/metascraper-media-provider/tslint.json
+++ b/types/metascraper-media-provider/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-publisher/index.d.ts
+++ b/types/metascraper-publisher/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for metascraper-publisher 5.14
+// Project: https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-publisher
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare function getData(): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-publisher/metascraper-publisher-tests.ts
+++ b/types/metascraper-publisher/metascraper-publisher-tests.ts
@@ -1,0 +1,9 @@
+import metascraper = require('metascraper');
+import metascraperPublisher = require('metascraper-publisher');
+
+const html = 'example';
+const url = 'https://example.org';
+
+metascraper([metascraperPublisher()])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-publisher/package.json
+++ b/types/metascraper-publisher/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-publisher/tsconfig.json
+++ b/types/metascraper-publisher/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-publisher-tests.ts"
+    ]
+}

--- a/types/metascraper-publisher/tslint.json
+++ b/types/metascraper-publisher/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-readability/index.d.ts
+++ b/types/metascraper-readability/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for metascraper-readability 5.14
+// Project: https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-readability
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare function getData(): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-readability/metascraper-readability-tests.ts
+++ b/types/metascraper-readability/metascraper-readability-tests.ts
@@ -1,0 +1,9 @@
+import metascraper = require('metascraper');
+import metascraperReadability = require('metascraper-readability');
+
+const html = 'example';
+const url = 'https://example.org';
+
+metascraper([metascraperReadability()])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-readability/package.json
+++ b/types/metascraper-readability/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-readability/tsconfig.json
+++ b/types/metascraper-readability/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-readability-tests.ts"
+    ]
+}

--- a/types/metascraper-readability/tslint.json
+++ b/types/metascraper-readability/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-soundcloud/index.d.ts
+++ b/types/metascraper-soundcloud/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for metascraper-soundcloud 5.14
+// Project: https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-soundcloud
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare function getData(): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-soundcloud/metascraper-soundcloud-tests.ts
+++ b/types/metascraper-soundcloud/metascraper-soundcloud-tests.ts
@@ -1,0 +1,9 @@
+import metascraper = require('metascraper');
+import metascraperSoundcloud = require('metascraper-soundcloud');
+
+const html = 'example';
+const url = 'https://example.org';
+
+metascraper([metascraperSoundcloud()])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-soundcloud/package.json
+++ b/types/metascraper-soundcloud/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-soundcloud/tsconfig.json
+++ b/types/metascraper-soundcloud/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-soundcloud-tests.ts"
+    ]
+}

--- a/types/metascraper-soundcloud/tslint.json
+++ b/types/metascraper-soundcloud/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-spotify/index.d.ts
+++ b/types/metascraper-spotify/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for metascraper-spotify 5.14
+// Project: https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-spotify
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare namespace getData {
+    function isValidUrl(config: { url: string }): boolean;
+}
+
+declare function getData(): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-spotify/metascraper-spotify-tests.ts
+++ b/types/metascraper-spotify/metascraper-spotify-tests.ts
@@ -1,0 +1,9 @@
+import metascraper = require('metascraper');
+import metascraperSpotify = require('metascraper-spotify');
+
+const html = 'example';
+const url = 'https://example.org';
+
+metascraper([metascraperSpotify()])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-spotify/package.json
+++ b/types/metascraper-spotify/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-spotify/tsconfig.json
+++ b/types/metascraper-spotify/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-spotify-tests.ts"
+    ]
+}

--- a/types/metascraper-spotify/tslint.json
+++ b/types/metascraper-spotify/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-title/index.d.ts
+++ b/types/metascraper-title/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for metascraper-title 5.14
+// Project: https://metascraper.js.org
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare function getData(): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-title/metascraper-title-tests.ts
+++ b/types/metascraper-title/metascraper-title-tests.ts
@@ -1,0 +1,9 @@
+import metascraper = require('metascraper');
+import metascraperTitle = require('metascraper-title');
+
+const html = 'example';
+const url = 'https://example.org';
+
+metascraper([metascraperTitle()])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-title/package.json
+++ b/types/metascraper-title/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-title/tsconfig.json
+++ b/types/metascraper-title/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-title-tests.ts"
+    ]
+}

--- a/types/metascraper-title/tslint.json
+++ b/types/metascraper-title/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-uol/index.d.ts
+++ b/types/metascraper-uol/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for metascraper-uol 5.14
+// Project: https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-uol
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare namespace getData {
+    function isValidUrl(config: { url: string }): boolean;
+}
+
+declare function getData(): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-uol/metascraper-uol-tests.ts
+++ b/types/metascraper-uol/metascraper-uol-tests.ts
@@ -1,0 +1,9 @@
+import metascraper = require('metascraper');
+import metascraperUol = require('metascraper-uol');
+
+const html = 'example';
+const url = 'https://example.org';
+
+metascraper([metascraperUol()])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-uol/package.json
+++ b/types/metascraper-uol/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-uol/tsconfig.json
+++ b/types/metascraper-uol/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-uol-tests.ts"
+    ]
+}

--- a/types/metascraper-uol/tslint.json
+++ b/types/metascraper-uol/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-url/index.d.ts
+++ b/types/metascraper-url/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for metascraper-url 5.14
+// Project: https://metascraper.js.org
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare function getData(): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-url/metascraper-url-tests.ts
+++ b/types/metascraper-url/metascraper-url-tests.ts
@@ -1,0 +1,9 @@
+import metascraper = require('metascraper');
+import metascraperUrl = require('metascraper-url');
+
+const html = 'example';
+const url = 'https://example.org';
+
+metascraper([metascraperUrl()])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-url/package.json
+++ b/types/metascraper-url/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-url/tsconfig.json
+++ b/types/metascraper-url/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-url-tests.ts"
+    ]
+}

--- a/types/metascraper-url/tslint.json
+++ b/types/metascraper-url/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-video/index.d.ts
+++ b/types/metascraper-video/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for metascraper-video 5.14
+// Project: https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-video
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare function getData(): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-video/metascraper-video-tests.ts
+++ b/types/metascraper-video/metascraper-video-tests.ts
@@ -1,0 +1,9 @@
+import metascraper = require('metascraper');
+import metascraperVideo = require('metascraper-video');
+
+const html = 'example';
+const url = 'https://example.org';
+
+metascraper([metascraperVideo()])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-video/package.json
+++ b/types/metascraper-video/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-video/tsconfig.json
+++ b/types/metascraper-video/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-video-tests.ts"
+    ]
+}

--- a/types/metascraper-video/tslint.json
+++ b/types/metascraper-video/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper-youtube/index.d.ts
+++ b/types/metascraper-youtube/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for metascraper-youtube 5.14
+// Project: https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-youtube
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare namespace getData {
+    function isValidUrl(config: { url: string }): boolean;
+}
+
+declare function getData(): metascraper.Rule;
+
+export = getData;

--- a/types/metascraper-youtube/metascraper-youtube-tests.ts
+++ b/types/metascraper-youtube/metascraper-youtube-tests.ts
@@ -1,0 +1,9 @@
+import metascraper = require('metascraper');
+import metascraperYoutube = require('metascraper-youtube');
+
+const html = 'example';
+const url = 'https://example.org';
+
+metascraper([metascraperYoutube()])({ html, url }).then(data => {
+    data;
+});

--- a/types/metascraper-youtube/package.json
+++ b/types/metascraper-youtube/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/metascraper-youtube/tsconfig.json
+++ b/types/metascraper-youtube/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-youtube-tests.ts"
+    ]
+}

--- a/types/metascraper-youtube/tslint.json
+++ b/types/metascraper-youtube/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/metascraper/index.d.ts
+++ b/types/metascraper/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for metascraper 5.14
+// Project: https://metascraper.js.org
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace metascraper {
+    type Rule = Record<string, any>;
+
+    interface Options {
+        html: string;
+        rules?: Rule[];
+        url: string;
+    }
+}
+
+declare function getData(options: metascraper.Options): Promise<Record<string, string>>;
+declare function metascraper(rules: metascraper.Rule[]): typeof getData;
+
+export = metascraper;

--- a/types/metascraper/metascraper-tests.ts
+++ b/types/metascraper/metascraper-tests.ts
@@ -1,0 +1,3 @@
+import metascraper = require('metascraper');
+
+metascraper([])({ html: '', url: 'https://example.com' });

--- a/types/metascraper/tsconfig.json
+++ b/types/metascraper/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metascraper-tests.ts"
+    ]
+}

--- a/types/metascraper/tslint.json
+++ b/types/metascraper/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/samirrayani__metascraper-shopping/index.d.ts
+++ b/types/samirrayani__metascraper-shopping/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for @samirrayani/metascraper-shopping 1.3
+// Project: https://github.com/samirrayani/metascraper-shopping#readme
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import metascraper = require('metascraper');
+
+declare function getData(): metascraper.Rule;
+
+export = getData;

--- a/types/samirrayani__metascraper-shopping/package.json
+++ b/types/samirrayani__metascraper-shopping/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "metascraper": "^5.14.0"
+    },
+    "private": true
+}

--- a/types/samirrayani__metascraper-shopping/samirrayani__metascraper-shopping-tests.ts
+++ b/types/samirrayani__metascraper-shopping/samirrayani__metascraper-shopping-tests.ts
@@ -1,0 +1,7 @@
+import metascraper = require('metascraper');
+import metascraperShopping = require('@samirrayani/metascraper-shopping');
+
+const html = 'example';
+const url = 'https://example.org';
+
+metascraper([metascraperShopping()])({ html, url });

--- a/types/samirrayani__metascraper-shopping/tsconfig.json
+++ b/types/samirrayani__metascraper-shopping/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "paths": {
+            "@samirrayani/metascraper-shopping": [
+                "samirrayani__metascraper-shopping"
+            ]
+        },
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "samirrayani__metascraper-shopping-tests.ts"
+    ]
+}

--- a/types/samirrayani__metascraper-shopping/tslint.json
+++ b/types/samirrayani__metascraper-shopping/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
