### PR TITLE
[react-scroll] Add type definition for saveHashHistory option on Links

### DIFF
--- a/types/react-scroll/index.d.ts
+++ b/types/react-scroll/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-scroll 1.5
+// Type definitions for react-scroll 1.8
 // Project: https://github.com/fisshy/react-scroll
 // Definitions by: Ioannis Kokkinidis <https://github.com/sudoplz>
 //                 Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>

--- a/types/react-scroll/modules/components/Link.d.ts
+++ b/types/react-scroll/modules/components/Link.d.ts
@@ -16,6 +16,7 @@ export interface ReactScrollLinkProps {
     onSetActive?(to: string): void;
     onSetInactive?(): void;
     ignoreCancelEvents?: boolean;
+    saveHashHistory?: boolean;
 }
 
 export type LinkProps = ReactScrollLinkProps & React.HTMLProps<HTMLButtonElement>;

--- a/types/react-scroll/test/react-scroll-tests.tsx
+++ b/types/react-scroll/test/react-scroll-tests.tsx
@@ -110,6 +110,17 @@ const linkTest5 = (
     </Link>
 );
 
+const linkTest6 = (
+    <Link
+        to="target"
+        saveHashHistory={true}
+        spy={true}
+        hashSpy={true}
+    >
+        Test 7 (hash history)
+    </Link>
+);
+
 const options = {} as any;
 animateScroll.scrollToTop(options);
 animateScroll.scrollToBottom(options);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/fisshy/react-scroll/pull/433
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
