### PR TITLE
[@types/webpack-dev-middleware] Make publicPath Option Optional

### DIFF
--- a/types/webpack-dev-middleware/index.d.ts
+++ b/types/webpack-dev-middleware/index.d.ts
@@ -62,7 +62,7 @@ declare namespace WebpackDevMiddleware {
          */
         mimeTypes?: MimeTypeMap | OverrideMimeTypeMap | null;
         /** The public path that the middleware is bound to */
-        publicPath: string;
+        publicPath?: string;
         /** Allows users to provide a custom reporter to handle logging within the module */
         reporter?: Reporter | null;
         /** Instructs the module to enable or disable the server-side rendering mode */

--- a/types/webpack-dev-middleware/webpack-dev-middleware-tests.ts
+++ b/types/webpack-dev-middleware/webpack-dev-middleware-tests.ts
@@ -3,8 +3,15 @@ import webpack = require('webpack');
 import webpackDevMiddleware = require('webpack-dev-middleware');
 
 const compiler = webpack({});
+const compilerWithPublicPath = webpack({
+    output: {
+        publicPath: '/assets/'
+    }
+});
 
 let webpackDevMiddlewareInstance = webpackDevMiddleware(compiler);
+
+webpackDevMiddlewareInstance = webpackDevMiddleware(compilerWithPublicPath, {});
 
 webpackDevMiddlewareInstance = webpackDevMiddleware(compiler, {
     logLevel: 'silent',


### PR DESCRIPTION
## Reasoning
[According to the documentation](https://github.com/webpack/webpack-dev-middleware#publicpath), `publicPath` already has a default value. Since the `options` object is already optional and the `publicPath` already has a default, it would make more sense to make this property optional. That way, developers can simply include the properties that they want to set.

## Checklist
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/webpack-dev-middleware
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

~~_From what I saw in the previous iteration of the test file, there didn't appear to be anything new to add._~~