### PR TITLE
update(papaparse): minor changes and v5.2 bump

### DIFF
--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for PapaParse v5.0
+// Type definitions for PapaParse 5.2
 // Project: https://github.com/mholt/PapaParse
 // Definitions by: Pedro Flemming <https://github.com/torpedro>
 //                 Rain Shen <https://github.com/rainshen49>
@@ -9,8 +9,8 @@
 //                 3af <https://github.com/3af>
 //                 Janne Liuhtonen <https://github.com/jliuhtonen>
 //                 Raphaël Barbazza <https://github.com/rbarbazz>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
 
 /// <reference types="node" />
 
@@ -27,20 +27,20 @@ export const parse: {
 /**
  * Unparses javascript data objects and returns a csv string
  */
-export const unparse: (data: Array<Object> | Array<Array<any>> | UnparseObject, config?: UnparseConfig) => string;
+export function unparse(data: object[] | any[][] | UnparseObject, config?: UnparseConfig): string;
 
 /**
  * Read-Only Properties
  */
 // An array of characters that are not allowed as delimiters.
-export const BAD_DELIMETERS: Array<string>;
+export const BAD_DELIMETERS: string[];
 
 // The true delimiter. Invisible. ASCII code 30. Should be doing the job we strangely rely upon commas and tabs for.
-declare type RECORD_SEP_TYPE = '';
+export type RECORD_SEP_TYPE = '';
 export const RECORD_SEP = '';
 
 // Also sometimes used as a delimiting character. ASCII code 31.
-declare type UNIT_SEP_TYPE = '';
+export type UNIT_SEP_TYPE = '';
 export const UNIT_SEP = '';
 
 // Whether or not the browser supports HTML5 Web Workers. If false, worker: true will have no effect.
@@ -51,11 +51,11 @@ export const WORKERS_SUPPORTED: boolean;
 export let SCRIPT_PATH: string;
 
 // When passed to Papa Parse a Readable stream is returned.
-declare type NODE_STREAM_INPUT_TYPE = 1;
+export type NODE_STREAM_INPUT_TYPE = 1;
 export const NODE_STREAM_INPUT = 1;
 
 // The possible values for the ParseConfig property delimitersToGuess
-declare type GuessableDelimiters = ',' | '\t' | '|' | ';' | RECORD_SEP_TYPE | UNIT_SEP_TYPE;
+export type GuessableDelimiters = ',' | '\t' | '|' | ';' | RECORD_SEP_TYPE | UNIT_SEP_TYPE;
 
 /**
  * Configurable Properties
@@ -124,10 +124,16 @@ export interface ParseConfig<T = any> {
 }
 
 export interface UnparseConfig {
-    quotes?: boolean | boolean[]; // default: false
+    quotes?: boolean | boolean[] | ((value: any) => boolean); // default: false
     quoteChar?: string; // default: '"'
     escapeChar?: string; // default: '"'
     delimiter?: string; // default: ","
+    /**
+     * If defined and the download property is true,
+     * a POST request will be made instead of a GET request and the passed argument will be set as the body of the request.
+     * @default undefined
+     */
+    downloadRequestBody?: boolean;
     header?: boolean; // default: true
     newline?: string; // default: "\r\n"
     skipEmptyLines?: boolean | 'greedy'; // default: false
@@ -135,8 +141,8 @@ export interface UnparseConfig {
 }
 
 export interface UnparseObject {
-    fields: Array<any>;
-    data: string | Array<any>;
+    fields: any[];
+    data: string | any[];
 }
 
 export interface ParseError {
@@ -150,20 +156,19 @@ export interface ParseMeta {
     delimiter: string; // Delimiter used
     linebreak: string; // Line break sequence used
     aborted: boolean; // Whether process was aborted
-    fields: Array<string>; // Array of field names
+    fields: string[]; // Array of field names
     truncated: boolean; // Whether preview consumed all input
     cursor: number;
 }
 
 /**
- * @interface ParseResult
- *
  * data: is an array of rows. If header is false, rows are arrays; otherwise they are objects of data keyed by the field name.
  * errors: is an array of errors
- * meta: contains extra information about the parse, such as delimiter used, the newline sequence, whether the process was aborted, etc. Properties in this object are not guaranteed to exist in all situations
+ * meta: contains extra information about the parse, such as delimiter used, the newline sequence, whether the process was aborted, etc.
+ * Properties in this object are not guaranteed to exist in all situations
  */
 export interface ParseResult<T> {
-    data: Array<T>;
-    errors: Array<ParseError>;
+    data: T[];
+    errors: ParseError[];
     meta: ParseMeta;
 }

--- a/types/papaparse/papaparse-tests.ts
+++ b/types/papaparse/papaparse-tests.ts
@@ -1,11 +1,10 @@
 import Papa = require('papaparse');
-import { ParseConfig, UnparseConfig, UnparseObject, ParseError, ParseMeta, ParseResult } from 'papaparse';
 import { Readable } from 'stream';
 
 /**
  * Parsing
  */
-var res = Papa.parse('3,3,3');
+const res = Papa.parse('3,3,3');
 
 res.errors[0].code;
 
@@ -13,7 +12,7 @@ Papa.parse('3,3,3', {
     delimiter: ';',
     comments: false,
     trimHeaders: false,
-    step: function (results, p) {
+    step(results, p) {
         p.abort();
         results.data.length;
     },
@@ -44,16 +43,18 @@ Papa.parse('4;4;4', {
     delimitersToGuess: ['\t', Papa.UNIT_SEP],
 });
 
-var file = new File(null, null, null);
+const file = new File(["foo"], "foo.txt", {
+    type: "text/plain",
+  });
 
 Papa.parse(file, {
-    transform: function (value, field) {},
-    transformHeader: function (header, index) {
+    transform(value, field) {},
+    transformHeader(header, index) {
         return header;
     },
-    complete: function (a, b) {
+    complete(a, b) {
         a.meta.fields;
-        b.name;
+        if (b) b.name;
     },
 });
 
@@ -73,19 +74,19 @@ readable.pipe(papaStream);
 
 // generic
 Papa.parse<string>('a,b,c', {
-    step: function (a) {
+    step(a) {
         a.data[0];
     },
 });
 
 Papa.parse<string>('a,b,c', {
-    chunk: function (a) {
+    chunk(a) {
         a.data[0];
     },
 });
 
 Papa.parse<[string, string, string]>('a,b,c', {
-    complete: function (a) {
+    complete(a) {
         a.data[0][0];
         a.data[0][1];
         a.data[0][2];
@@ -121,6 +122,16 @@ Papa.unparse(
     },
     { newline: '\n' },
 );
+Papa.unparse(
+    {
+        fields: ['3'],
+        data: [],
+    },
+    {
+        downloadRequestBody: true,
+        quotes: value => typeof value === 'string',
+    },
+);
 
 /**
  * Properties
@@ -131,7 +142,7 @@ Papa.LocalChunkSize;
 /**
  * Parser
  */
-var parser = new Papa.Parser({});
+const parser = new Papa.Parser({});
 parser.getCharIndex();
 parser.abort();
 parser.parse('', 0, false);

--- a/types/papaparse/tsconfig.json
+++ b/types/papaparse/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/papaparse/tslint.json
+++ b/types/papaparse/tslint.json
@@ -1,23 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "array-type": false,
-        "ban-types": false,
-        "callable-types": false,
-        "dt-header": false,
-        "max-line-length": false,
-        "no-consecutive-blank-lines": false,
-        "no-redundant-jsdoc": false,
-        "no-redundant-jsdoc-2": false,
-        "no-var-keyword": false,
-        "object-literal-shorthand": false,
-        "only-arrow-functions": false,
-        "prefer-const": false,
-        "prefer-declare-function": false,
-        "prefer-method-signature": false,
-        "semicolon": false,
-        "space-before-function-paren": false,
-        "strict-export-declare-modifiers": false,
-        "trim-file": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
- v5.1 and v5.2 changes: `downloadRequestBody` and `quotes` as a
 function
- remove exclusion rules and rewrite definition to fix pending linter
  problems
- maintainer added
- version bump

https://github.com/mholt/PapaParse/compare/5.0.2...5.2.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.