### PR TITLE
Add types for grant-express 5.3

### DIFF
--- a/types/grant-express/grant-express-tests.ts
+++ b/types/grant-express/grant-express-tests.ts
@@ -1,7 +1,7 @@
 import express = require('express');
 import grant = require('grant-express');
 
-let app = express();
+const app = express();
 
 app.use(
     grant({

--- a/types/grant-express/grant-express-tests.ts
+++ b/types/grant-express/grant-express-tests.ts
@@ -1,0 +1,21 @@
+import express = require('express');
+import grant = require('grant-express');
+
+let app = express();
+
+app.use(
+    grant({
+        defaults: {
+            protocol: 'http',
+            host: 'localhost:8080',
+            transport: 'session',
+            state: true,
+        },
+        google: {
+            key: 'GOOGLE_CLIENT_ID',
+            secret: 'GOOGLE_CLIENT_SECRET',
+            scope: ['profile', 'email'],
+            callback: '/login/google',
+        },
+    }),
+);

--- a/types/grant-express/index.d.ts
+++ b/types/grant-express/index.d.ts
@@ -7,25 +7,28 @@
 
 import express = require('express');
 
-export function grant(providers: { defaults: DefaultOptions } | ProvidersOptions): express.RequestHandler;
+export = grant;
 
-type Provider = string;
+declare function grant(providers: { defaults: grant.DefaultOptions } | grant.ProvidersOptions): express.RequestHandler;
+declare namespace grant {
+    export type Provider = string;
 
-type ProvidersOptions = {
-    [key in Provider]?: GrantOptions;
-};
+    export type ProvidersOptions = {
+        [key in Provider]?: GrantOptions;
+    };
 
-interface DefaultOptions {
-    protocol: 'http' | 'https';
-    host: string;
-    transport: 'querystring' | 'session';
-    state: boolean;
-}
-interface GrantOptions {
-    key: string;
-    secret: string;
-    scope: string[];
-    nonce?: boolean;
-    custom_params?: any;
-    callback: string;
+    export interface DefaultOptions {
+        protocol: 'http' | 'https';
+        host: string;
+        transport: 'querystring' | 'session';
+        state: boolean;
+    }
+    export interface GrantOptions {
+        key: string;
+        secret: string;
+        scope: string[];
+        nonce?: boolean;
+        custom_params?: any;
+        callback: string;
+    }
 }

--- a/types/grant-express/index.d.ts
+++ b/types/grant-express/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by:  Gordon Lau <https://gitlab.com/gordon-tecky>
 //                  Beeno Tung <https://github.com/beenotung>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.9.7
+// TypeScript Version: 3.9
 
 declare module 'grant-express' {
     import express from 'express';

--- a/types/grant-express/index.d.ts
+++ b/types/grant-express/index.d.ts
@@ -1,9 +1,8 @@
-// Type definitions for grant-express 5.2.0
+// Type definitions for grant-express 5.3
 // Project: https://www.npmjs.org/package/grant-express
 // Definitions by:  Gordon Lau <https://gitlab.com/gordon-tecky>
 //                  Beeno Tung <https://github.com/beenotung>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.9
 
 import express = require('express');
 

--- a/types/grant-express/index.d.ts
+++ b/types/grant-express/index.d.ts
@@ -1,5 +1,5 @@
-// Type definitions for express-jwt
-// Project: https://www.npmjs.org/package/express-jwt
+// Type definitions for grant-express 5.2.0
+// Project: https://www.npmjs.org/package/grant-express
 // Definitions by:  Gordon Lau <https://gitlab.com/gordon-tecky>
 //                  Beeno Tung <https://github.com/beenotung>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/grant-express/index.d.ts
+++ b/types/grant-express/index.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for express-jwt
+// Project: https://www.npmjs.org/package/express-jwt
+// Definitions by:  Gordon Lau <https://gitlab.com/gordon-tecky>
+//                  Beeno Tung <https://github.com/beenotung>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.9.7
+
+declare module 'grant-express' {
+    import express from 'express';
+
+    type Provider = string;
+    function grant(providers: { defaults: DefaultOptions } | ProvidersOptions): express.RequestHandler;
+
+    type ProvidersOptions = {
+        [key in Provider]?: GrantOptions;
+    };
+
+    interface DefaultOptions {
+        protocol: 'http' | 'https';
+        host: string;
+        transport: 'querystring' | 'session';
+        state: boolean;
+    }
+    interface GrantOptions {
+        key: string;
+        secret: string;
+        scope: string[];
+        nonce?: boolean;
+        custom_params?: any;
+        callback: string;
+    }
+
+    export = grant;
+}

--- a/types/grant-express/index.d.ts
+++ b/types/grant-express/index.d.ts
@@ -10,19 +10,19 @@ export = grant;
 
 declare function grant(providers: { defaults: grant.DefaultOptions } | grant.ProvidersOptions): express.RequestHandler;
 declare namespace grant {
-    export type Provider = string;
+    type Provider = string;
 
-    export type ProvidersOptions = {
+    type ProvidersOptions = {
         [key in Provider]?: GrantOptions;
     };
 
-    export interface DefaultOptions {
+    interface DefaultOptions {
         protocol: 'http' | 'https';
         host: string;
         transport: 'querystring' | 'session';
         state: boolean;
     }
-    export interface GrantOptions {
+    interface GrantOptions {
         key: string;
         secret: string;
         scope: string[];

--- a/types/grant-express/index.d.ts
+++ b/types/grant-express/index.d.ts
@@ -5,30 +5,27 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.9
 
-declare module 'grant-express' {
-    import express from 'express';
+import express = require('express');
 
-    type Provider = string;
-    function grant(providers: { defaults: DefaultOptions } | ProvidersOptions): express.RequestHandler;
+export function grant(providers: { defaults: DefaultOptions } | ProvidersOptions): express.RequestHandler;
 
-    type ProvidersOptions = {
-        [key in Provider]?: GrantOptions;
-    };
+type Provider = string;
 
-    interface DefaultOptions {
-        protocol: 'http' | 'https';
-        host: string;
-        transport: 'querystring' | 'session';
-        state: boolean;
-    }
-    interface GrantOptions {
-        key: string;
-        secret: string;
-        scope: string[];
-        nonce?: boolean;
-        custom_params?: any;
-        callback: string;
-    }
+type ProvidersOptions = {
+    [key in Provider]?: GrantOptions;
+};
 
-    export = grant;
+interface DefaultOptions {
+    protocol: 'http' | 'https';
+    host: string;
+    transport: 'querystring' | 'session';
+    state: boolean;
+}
+interface GrantOptions {
+    key: string;
+    secret: string;
+    scope: string[];
+    nonce?: boolean;
+    custom_params?: any;
+    callback: string;
 }

--- a/types/grant-express/package.json
+++ b/types/grant-express/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "dependencies": {
+        "express": "^4.17.1",
+        "grant-express": "^5.2.0"
+    }
+}

--- a/types/grant-express/package.json
+++ b/types/grant-express/package.json
@@ -1,7 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "express": "^4.17.1",
-        "grant-express": "^5.2.0"
-    }
-}

--- a/types/grant-express/tsconfig.json
+++ b/types/grant-express/tsconfig.json
@@ -1,14 +1,13 @@
 {
     "compilerOptions": {
-        "esModuleInterop": true,
         "module": "commonjs",
         "lib": [
             "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": true,
         "strictFunctionTypes": true,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/grant-express/tsconfig.json
+++ b/types/grant-express/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "esModuleInterop": true,
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "grant-express-tests.ts"
+    ]
+}

--- a/types/grant-express/tslint.json
+++ b/types/grant-express/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "dt-header": false
+    }
+}

--- a/types/grant-express/tslint.json
+++ b/types/grant-express/tslint.json
@@ -1,0 +1,16 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "callable-types": false,
+        "dt-header": false,
+        "no-redundant-jsdoc": false,
+        "no-var-keyword": false,
+        "only-arrow-functions": false,
+        "prefer-const": false,
+        "prefer-method-signature": false,
+        "semicolon": false,
+        "space-before-function-paren": false,
+        "strict-export-declare-modifiers": false,
+        "trim-file": false
+    }
+}

--- a/types/grant-express/tslint.json
+++ b/types/grant-express/tslint.json
@@ -1,16 +1,1 @@
-{
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "callable-types": false,
-        "dt-header": false,
-        "no-redundant-jsdoc": false,
-        "no-var-keyword": false,
-        "only-arrow-functions": false,
-        "prefer-const": false,
-        "prefer-method-signature": false,
-        "semicolon": false,
-        "space-before-function-paren": false,
-        "strict-export-declare-modifiers": false,
-        "trim-file": false
-    }
-}
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.