### PR TITLE
ffprobe definition types.

### DIFF
--- a/types/ffprobe/ffprobe-tests.ts
+++ b/types/ffprobe/ffprobe-tests.ts
@@ -1,6 +1,21 @@
-import * as ffprobe from 'ffprobe';
+import ffprobe = require('ffprobe');
+import ffprobeStatic = require('ffprobe-static');
 
+ffprobe('./file.mp4', { path: ffprobeStatic.path })
+    .then(info => {
+        info; // $ExpectType FFProbeResult
+    })
+    .catch((err: Error) => {
+        err; // $ExpectType Error
+    });
+ffprobe('./file.mp4', { path: ffprobeStatic.path }, (err, info) => {
+    if (err) {
+        err; // $ExpectType Error
+    } else {
+        info; // $ExpectType FFProbeResult
+    }
+});
 (async () => {
-    const result = await ffprobe('/path/to/movie.avi');
-    result; // $ExpectType FFProbeResult
+    // $ExpectType FFProbeResult
+    const result = await ffprobe('/path/to/movie.avi', { path: ffprobeStatic.path });
 })();

--- a/types/ffprobe/ffprobe-tests.ts
+++ b/types/ffprobe/ffprobe-tests.ts
@@ -1,0 +1,6 @@
+import * as ffprobe from 'ffprobe';
+
+(async () => {
+    const result = await ffprobe('/path/to/movie.avi');
+    result; // $ExpectType IFFProbeStream
+})();

--- a/types/ffprobe/ffprobe-tests.ts
+++ b/types/ffprobe/ffprobe-tests.ts
@@ -2,5 +2,5 @@ import * as ffprobe from 'ffprobe';
 
 (async () => {
     const result = await ffprobe('/path/to/movie.avi');
-    result; // $ExpectType IFFProbeStream
+    result; // $ExpectType IFFProbeResult
 })();

--- a/types/ffprobe/ffprobe-tests.ts
+++ b/types/ffprobe/ffprobe-tests.ts
@@ -2,5 +2,5 @@ import * as ffprobe from 'ffprobe';
 
 (async () => {
     const result = await ffprobe('/path/to/movie.avi');
-    result; // $ExpectType IFFProbeResult
+    result; // $ExpectType FFProbeResult
 })();

--- a/types/ffprobe/index.d.ts
+++ b/types/ffprobe/index.d.ts
@@ -70,6 +70,8 @@ declare namespace getInfo {
     }
 }
 
-declare function getInfo(options: getInfo.Options | string): Promise<getInfo.FFProbeResult>;
+declare function getInfo(filePath: string, options: getInfo.Options, cb: (err: Error, info: getInfo.FFProbeResult) => void): void;
+
+declare function getInfo(filePath: string, options: getInfo.Options): Promise<getInfo.FFProbeResult>;
 
 export = getInfo;

--- a/types/ffprobe/index.d.ts
+++ b/types/ffprobe/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ffprobe 1.1.0
+// Type definitions for ffprobe 1.1
 // Project: https://github.com/eugeneware/ffprobe
 // Definitions by: Sergey <https://github.com/SergeyAlexsandrovich>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/ffprobe/index.d.ts
+++ b/types/ffprobe/index.d.ts
@@ -1,5 +1,7 @@
 // Type definitions for ffprobe
+// Project: https://github.com/eugeneware/ffprobe
 // Definitions by: Sergey <https://github.com/SergeyAlexsandrovich>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace getInfo {
 

--- a/types/ffprobe/index.d.ts
+++ b/types/ffprobe/index.d.ts
@@ -1,15 +1,14 @@
-// Type definitions for ffprobe
+// Type definitions for ffprobe 1.1.0
 // Project: https://github.com/eugeneware/ffprobe
 // Definitions by: Sergey <https://github.com/SergeyAlexsandrovich>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace getInfo {
-
-    export interface IOptions {
+    interface Options {
         path: string;
     }
 
-    export interface IFFProbeStream {
+    interface FFProbeStream {
         index: number;
         codec_name: string;
         codec_long_name: string;
@@ -66,13 +65,11 @@ declare namespace getInfo {
         };
     }
 
-    export interface IFFProbeResult {
-        streams: IFFProbeStream[];
+    interface FFProbeResult {
+        streams: FFProbeStream[];
     }
-
 }
 
-declare function getInfo(options: getInfo.IOptions): Promise<getInfo.IFFProbeResult>;
-declare function getInfo(path: string): Promise<getInfo.IFFProbeResult>;
+declare function getInfo(options: getInfo.Options | string): Promise<getInfo.FFProbeResult>;
 
 export = getInfo;

--- a/types/ffprobe/index.d.ts
+++ b/types/ffprobe/index.d.ts
@@ -1,0 +1,75 @@
+// Definitions by: Sergey <https://github.com/SergeyAlexsandrovich>
+
+declare namespace getInfo {
+
+    export interface IOptions {
+        path: string;
+    }
+
+    export interface IFFProbeStream {
+        index: number;
+        codec_name: string;
+        codec_long_name: string;
+        profile: string;
+        codec_type: 'video' | 'audio' | 'images';
+        codec_time_base: string;
+        codec_tag_string: string;
+        codec_tag: string;
+        width?: number;
+        height?: number;
+        coded_width?: number;
+        coded_height?: number;
+        has_b_frames?: number;
+        sample_aspect_ratio?: string;
+        display_aspect_ratio?: string;
+        pix_fmt?: string;
+        level?: number;
+        sample_fmt?: string;
+        sample_rate?: number;
+        channel_layout?: string;
+        channels?: number;
+        bits_per_sample?: number;
+        chroma_location?: string;
+        refs?: number;
+        is_avc?: number;
+        nal_length_size?: number;
+        r_frame_rate: string;
+        avg_frame_rate?: string;
+        time_base?: string;
+        start_pts: number;
+        start_time: number;
+        duration_ts: string;
+        duration: number;
+        bit_rate: number;
+        bits_per_raw_sample?: number;
+        nb_frames: number;
+        disposition: {
+            default: number;
+            dub: number;
+            original: number;
+            comment: number;
+            lyrics: number;
+            karaoke: number;
+            forced: number;
+            hearing_impaired: number;
+            visual_impaired: number;
+            clean_effects: number;
+            attached_pic: number;
+        };
+        tags: {
+            language?: string;
+            handler_name: string;
+            creation_time?: string;
+        };
+    }
+
+    export interface IFFProbeResult {
+        streams: IFFProbeStream[];
+    }
+
+}
+
+declare function getInfo(options: getInfo.IOptions): Promise<getInfo.IFFProbeResult>;
+declare function getInfo(path: string): Promise<getInfo.IFFProbeResult>;
+
+export = getInfo;

--- a/types/ffprobe/index.d.ts
+++ b/types/ffprobe/index.d.ts
@@ -1,3 +1,4 @@
+// Type definitions for ffprobe
 // Definitions by: Sergey <https://github.com/SergeyAlexsandrovich>
 
 declare namespace getInfo {

--- a/types/ffprobe/tsconfig.json
+++ b/types/ffprobe/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ffprobe-tests.ts"
+    ]
+}

--- a/types/ffprobe/tslint.json
+++ b/types/ffprobe/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
