### PR TITLE
[mapbox-gl] brings `setFilter` inline with mapbox documentation 

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -251,7 +251,7 @@ declare namespace mapboxgl {
          */
         queryRenderedFeatures(
             pointOrBox?: PointLike | [PointLike, PointLike],
-            options?: { layers?: string[]; filter?: any[]; validate?: boolean },
+            options?: { layers?: string[]; filter?: any[] } & FilterOptions,
         ): MapboxGeoJSONFeature[];
 
         /**
@@ -269,8 +269,7 @@ declare namespace mapboxgl {
             parameters?: {
                 sourceLayer?: string;
                 filter?: any[];
-                validate?: boolean;
-            },
+            } & FilterOptions,
         ): MapboxGeoJSONFeature[];
 
         setStyle(style: mapboxgl.Style | string, options?: { diff?: boolean; localIdeographFontFamily?: string }): this;
@@ -315,7 +314,7 @@ declare namespace mapboxgl {
 
         getLayer(id: string): mapboxgl.Layer;
 
-        setFilter(layer: string, filter?: any[] | boolean | null, options?: { validate?: boolean }): this;
+        setFilter(layer: string, filter?: any[] | boolean | null, options?: FilterOptions | null): this;
 
         setLayerZoomRange(layerId: string, minzoom: number, maxzoom: number): this;
 
@@ -1645,6 +1644,18 @@ declare namespace mapboxgl {
     export class ErrorEvent extends MapboxEvent {
         type: 'error';
         error: Error;
+    }
+
+    /**
+     * FilterOptions
+     */
+    export interface FilterOptions {
+        /**
+         * Whether to check if the filter conforms to the Mapbox GL Style Specification.
+         * Disabling validation is a performance optimization that should only be used
+         * if you have previously validated the values you will be passing to this function.
+         */
+        validate?: boolean | null;
     }
 
     /**

--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -315,7 +315,7 @@ declare namespace mapboxgl {
 
         getLayer(id: string): mapboxgl.Layer;
 
-        setFilter(layer: string, filter?: any[] | boolean | null): this;
+        setFilter(layer: string, filter?: any[] | boolean | null, options?: { validate?: boolean }): this;
 
         setLayerZoomRange(layerId: string, minzoom: number, maxzoom: number): this;
 

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -268,6 +268,14 @@ map.flyTo({
 const features = map.queryRenderedFeatures([0, 0], { layers: ['custom'], validate: false });
 features; // $ExpectType MapboxGeoJSONFeature[]
 
+// querySourceFeatures
+const features2 = map.querySourceFeatures('some_source', {
+    sourceLayer: 'source_layer',
+    filter: ['all'],
+    validate: null,
+});
+features2; // $ExpectType MapboxGeoJSONFeature[]
+
 /**
  * GeoJSONSource
  */
@@ -824,6 +832,7 @@ expectType<mapboxgl.Map>(map.setFilter('layerId', true));
 expectType<mapboxgl.Map>(map.setFilter('layerId', false));
 
 map.setFilter('layerId', true, { validate: true });
+map.setFilter('layerId', true, { validate: null });
 map.setFilter('layerId', true, {});
 // $ExpectError
 map.setFilter('layerId', true, { some_option: 'some_string' });

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -823,6 +823,11 @@ map.showPadding = false;
 expectType<mapboxgl.Map>(map.setFilter('layerId', true));
 expectType<mapboxgl.Map>(map.setFilter('layerId', false));
 
+map.setFilter('layerId', true, { validate: true });
+map.setFilter('layerId', true, {});
+// $ExpectError
+map.setFilter('layerId', true, { some_option: 'some_string' });
+
 // $ExpectType Map
 map.setMinZoom(5);
 // $ExpectType Map


### PR DESCRIPTION
The map.setFilter command can take in a 3 optional configuration object. Currently the only supported input is a "validate" option. Note that according to the mapbox docs, an empty object is also allowed.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

**If changing an existing definition:**
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [here](https://docs.mapbox.com/mapbox-gl-js/api/map/#map#setfilter)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

