### PR TITLE
@types/react-transition-group RefElement default value is not work

### DIFF
--- a/types/react-transition-group/CSSTransition.d.ts
+++ b/types/react-transition-group/CSSTransition.d.ts
@@ -40,6 +40,6 @@ export type CSSTransitionProps<Ref extends undefined | HTMLElement = undefined> 
     classNames?: string | CSSTransitionClassNames;
 };
 
-declare class CSSTransition<Ref extends undefined | HTMLElement> extends Component<CSSTransitionProps<Ref>> {}
+declare class CSSTransition<Ref extends undefined | HTMLElement = undefined> extends Component<CSSTransitionProps<Ref>> {}
 
 export default CSSTransition;

--- a/types/react-transition-group/CSSTransition.d.ts
+++ b/types/react-transition-group/CSSTransition.d.ts
@@ -13,7 +13,7 @@ export interface CSSTransitionClassNames {
     exitDone?: string;
 }
 
-export type CSSTransitionProps<Ref extends undefined | HTMLElement = undefined> = TransitionProps<Ref> & {
+export type CSSTransitionProps<Ref extends undefined | HTMLElement> = TransitionProps<Ref> & {
     /**
      * The animation `classNames` applied to the component as it enters or exits.
      * A single name can be provided and it will be suffixed for each stage: e.g.

--- a/types/react-transition-group/Transition.d.ts
+++ b/types/react-transition-group/Transition.d.ts
@@ -196,7 +196,7 @@ interface EndListenerProps<Ref extends undefined | HTMLElement> extends BaseTran
     addEndListener: EndHandler<Ref>;
 }
 
-export type TransitionProps<RefElement extends undefined | HTMLElement = undefined> =
+export type TransitionProps<RefElement extends undefined | HTMLElement> =
     | TimeoutProps<RefElement>
     | EndListenerProps<RefElement>;
 
@@ -241,6 +241,6 @@ export type TransitionProps<RefElement extends undefined | HTMLElement = undefin
  * ```
  *
  */
-declare class Transition<RefElement extends HTMLElement | undefined> extends Component<TransitionProps<RefElement>> {}
+declare class Transition<RefElement extends HTMLElement | undefined = undefined> extends Component<TransitionProps<RefElement>> {}
 
 export default Transition;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-transition-group/Transition.d.ts>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
