### PR TITLE
chore: Use actions/checkout@v2 for pull requests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: "12"


### PR DESCRIPTION
This changes the CI workflow to use `actions/checkout@v2` for performance reasons. For further updates, see https://github.com/actions/checkout#checkout-v2.

v2 fetches only a single commit by default, that means the checkout will take around 15 seconds instead of ~1.5 minutes!

// cc @RyanCavanaugh @andrewbranch @sandersn