### PR TITLE
feat(git-parse): new definition

### DIFF
--- a/types/git-parse/git-parse-tests.ts
+++ b/types/git-parse/git-parse-tests.ts
@@ -1,0 +1,30 @@
+/// <reference types="node" />
+
+import { gitToJs, checkoutCommit, gitDiff, gitPull } from 'git-parse';
+
+const repoPath = '.';
+const commitsPromise = gitToJs(repoPath);
+
+commitsPromise.then(commits => console.log(JSON.stringify(commits, null, 2)));
+
+async () => {
+    try {
+        await checkoutCommit('.', 'invalidHash');
+        const parsedRepo = await gitToJs(repoPath);
+    } catch (e) {
+        //
+    }
+};
+
+gitToJs('/some_crazy_directory_that_does_not_exist/asdfasdfasdfasdfxxxx').catch(() => {
+    //
+});
+gitToJs(repoPath).then(data => {
+    console.log(data);
+});
+
+gitDiff(repoPath, '3bbdbc5').then(diff => console.log(diff));
+
+gitPull(repoPath)
+    .then(() => console.log('Done'))
+    .catch(err => console.log(err));

--- a/types/git-parse/index.d.ts
+++ b/types/git-parse/index.d.ts
@@ -1,0 +1,64 @@
+// Type definitions for git-parse 1.0
+// Project: https://github.com/wayfair/git-parse#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * A utility which generates an array of javascript objects representing the current branch of a local git repository's commit history.
+ * Returns a promise which resolves with a list of objects describing git commits on the current branch.
+ */
+export function gitToJs(repoPath: string, options?: GitToJsOptions): Promise<GitCommit[]>;
+
+/**
+ * Checks out a commit given its repo and hash.
+ * @async
+ */
+export function checkoutCommit(pathToRepo: string, hash: string, options?: CheckoutCommmitOptions): Promise<void>;
+
+/**
+ * Pulls a repo given its path.
+ * @async
+ */
+export function gitPull(pathToRepo: string): Promise<void>;
+
+/**
+ * Returns a git diff given a path to the repo, a commit,
+ * an optional second commit, and an optional file.
+ */
+export function gitDiff(pathToRepo: string, commitHash1: string, commitHash2?: string, file?: string): Promise<string>;
+
+// types
+
+export interface FileModification {
+    path: string;
+    linesAdded?: number;
+    linesDeleted?: number;
+}
+
+export interface FileRename {
+    oldPath: string;
+    newPath: string;
+}
+
+/**
+ *  Object representing the current branch of a local git repository's commit history
+ */
+export interface GitCommit {
+    hash: string;
+    authorName: string;
+    authorEmail: string;
+    date: string;
+    message: string;
+    filesAdded: FileModification[];
+    filesDeleted: FileModification[];
+    filesModified: FileModification[];
+    filesRenamed: FileRename[];
+}
+
+export interface GitToJsOptions {
+    sinceCommit?: string;
+}
+
+export interface CheckoutCommmitOptions {
+    force?: boolean;
+}

--- a/types/git-parse/tsconfig.json
+++ b/types/git-parse/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "git-parse-tests.ts"
+    ]
+}

--- a/types/git-parse/tslint.json
+++ b/types/git-parse/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- definition file
- tests

https://www.npmjs.com/package/git-parse
https://github.com/wayfair/git-parse#api

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](htps://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.