### PR TITLE
Handle any in Lodash's PartialDeep

### DIFF
--- a/types/lodash/common/common.d.ts
+++ b/types/lodash/common/common.d.ts
@@ -250,9 +250,9 @@ declare module "../index" {
         flush(): void;
     }
 
-    type PartialDeep<T> = {
-        [P in keyof T]?: PartialDeep<T[P]>;
-    };
+    type PartialDeep<T> = T extends object ? {
+        [P in keyof T]?: PartialDeep<T[P]>
+    } : T;
 
     // For backwards compatibility
     type LoDashImplicitArrayWrapper<T> = LoDashImplicitWrapper<T[]>;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5661,10 +5661,10 @@ fp.now(); // $ExpectType number
     const literalsArray: Array<"a" | "b"> = ["a", "b"];
     const roLiteralsArray: ReadonlyArray<"a" | "b"> = literalsArray;
 
-    _.pick(obj1, "a"); // $ExpectType PartialDeep<AbcObject>
-    _.pick(obj1, 0, "a"); // $ExpectType PartialDeep<AbcObject>
-    _.pick(obj1, ["b", 1], 0, "a"); // $ExpectType PartialDeep<AbcObject>
-    _.pick(obj1, readonlyArray); // $ExpectType PartialDeep<AbcObject>
+    _.pick(obj1, "a"); // $ExpectType { a?: number | undefined; b?: string | undefined; c?: boolean | undefined; }
+    _.pick(obj1, 0, "a"); // $ExpectType { a?: number | undefined; b?: string | undefined; c?: boolean | undefined; }
+    _.pick(obj1, ["b", 1], 0, "a"); // $ExpectType { a?: number | undefined; b?: string | undefined; c?: boolean | undefined; }
+    _.pick(obj1, readonlyArray); // $ExpectType { a?: number | undefined; b?: string | undefined; c?: boolean | undefined; }
     _.pick(obj2, "a", "b"); // $ExpectType Pick<AbcObject, "a" | "b">
     // We can't use ExpectType here because typescript keeps changing what order the types appear.
     let result1: Pick<AbcObject, "a" | "b">;


### PR DESCRIPTION
Enforce that `PartialDeep<any>` is `any`

Inspired from https://github.com/Microsoft/TypeScript/issues/30082#issuecomment-467028447

For reference, there are some more complex implementations available in some libraries: (see [here](https://github.com/krzkaczor/ts-essentials/blob/master/lib/types.ts#L31-L54) and [here](https://github.com/sindresorhus/type-fest/blob/master/source/partial-deep.d.ts)).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - Addresses issues: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25758, https://github.com/DefinitelyTyped/DefinitelyTyped/issues/32204
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
    - Not sure how to test that 