### PR TITLE
Add types for @keep-network/tbtc.js

### DIFF
--- a/types/keep-network__tbtc.js/OTHER_FILES.txt
+++ b/types/keep-network__tbtc.js/OTHER_FILES.txt
@@ -1,0 +1,10 @@
+src/BitcoinHelpers.d.ts
+src/Constants.d.ts
+src/EthereumHelpers.d.ts
+src/Redemption.d.ts
+src/CommonTypes.d.ts
+src/Deposit.d.ts
+src/TBTC.d.ts
+src/lib/BitcoinSPV.d.ts
+src/lib/BitcoinTxParser.d.ts
+src/lib/ElectrumClient.d.ts

--- a/types/keep-network__tbtc.js/index.d.ts
+++ b/types/keep-network__tbtc.js/index.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for @keep-network/tbtc.js 0.18
+// Project: https://github.com/keep-network/tbtc.js
+// Definitions by: corollari <https://github.com/corollari>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.8
+
+import TBTC, { getNetworkIdFromArtifact } from "./src/TBTC.js";
+import BitcoinHelpers from "./src/BitcoinHelpers.js";
+import EthereumHelpers from "./src/EthereumHelpers.js";
+export { BitcoinHelpers, EthereumHelpers, getNetworkIdFromArtifact };
+export default TBTC;

--- a/types/keep-network__tbtc.js/keep-network__tbtc.js-tests.ts
+++ b/types/keep-network__tbtc.js/keep-network__tbtc.js-tests.ts
@@ -1,0 +1,18 @@
+import TBTC from '@keep-network/tbtc.js';
+
+const tbtc = TBTC.withConfig({
+    web3: {} as any,
+    bitcoinNetwork: "testnet",
+    electrum: {
+        testnet: {
+            server: "electrumx-server.test.tbtc.network",
+            port: 50002,
+            protocol: "ssl"
+        },
+        testnetWS: {
+            server: "electrumx-server.test.tbtc.network",
+            port: 50003,
+            protocol: "ws"
+        }
+    },
+});

--- a/types/keep-network__tbtc.js/keep-network__tbtc.js-tests.ts
+++ b/types/keep-network__tbtc.js/keep-network__tbtc.js-tests.ts
@@ -1,4 +1,4 @@
-import TBTC from '@keep-network/tbtc.js';
+import TBTC from 'keep-network__tbtc.js';
 
 const tbtc = TBTC.withConfig({
     web3: {} as any,

--- a/types/keep-network__tbtc.js/src/BitcoinHelpers.d.ts
+++ b/types/keep-network__tbtc.js/src/BitcoinHelpers.d.ts
@@ -1,0 +1,63 @@
+/// <reference types="node" />
+import type { Proof } from './lib/BitcoinSPV';
+import ElectrumClient from "./lib/ElectrumClient.js";
+import type { Config as ElectrumConfig } from "./lib/ElectrumClient";
+import BN = require("bn.js");
+export type BitcoinNetworkType = "testnet" | "main" | "simnet";
+
+export interface FoundTransaction {
+    transactionID: string;
+    outputPosition: number;
+    value: number;
+}
+export interface ParsedTransaction {
+    version: string;
+    txInVector: string;
+    txOutVector: string;
+    locktime: string;
+}
+export interface SPVProof extends Proof {
+    parsedTransaction: ParsedTransaction;
+}
+export default interface BitcoinHelpers {
+    satoshisPerBtc: BN;
+    Network: {
+        TESTNET: string;
+        MAINNET: string;
+        SIMNET: string;
+    };
+    electrumConfig: ElectrumConfig | null;
+    setElectrumConfig: (newConfig: ElectrumConfig) => void;
+    signatureDER: (r: string, s: string) => Buffer;
+    publicKeyPointToPublicKeyString: (publicKeyX: string, publicKeyY: string) => string;
+    Address: {
+        pubKeyHashFrom: (address: string) => Buffer | null;
+        publicKeyPointToP2WPKHAddress: (publicKeyX: string, publicKeyY: string, bitcoinNetwork: BitcoinNetworkType) => string;
+        pubKeyHashToBech32: (pubKeyHash: string, network: BitcoinNetworkType) => string;
+        publicKeyToP2WPKHAddress: (publicKeyString: string, network: BitcoinNetworkType) => string;
+        toScript: (address: string) => string;
+        toRawScript: (address: string) => Buffer;
+    };
+    withElectrumClient: <T>(block: (client: ElectrumClient) => Promise<T>) => Promise<T>;
+    Transaction: {
+        find: (bitcoinAddress: string, expectedValue: number) => Promise<FoundTransaction>;
+        findScript: (outputScript: string, expectedValue: number) => Promise<FoundTransaction>;
+        findOrWaitFor: (bitcoinAddress: string, expectedValue: number) => Promise<FoundTransaction>;
+        checkForConfirmations: (transactionID: string, requiredConfirmations: number) => Promise<number>;
+        waitForConfirmations: (transactionID: string, requiredConfirmations: number, onReceivedConfirmation: (tx: {
+            transactionID: string;
+            confirmations: number;
+        }) => void) => Promise<number>;
+        estimateFee: (tbtcConstantsContract: any) => Promise<number>;
+        getSPVProof: (transactionID: string, confirmations: number) => Promise<SPVProof>;
+        broadcast: (signedTransaction: string) => Promise<{
+            transactionID: string;
+        }>;
+        addWitnessSignature: (unsignedTransaction: string, inputIndex: number, r: string, s: string, publicKey: string) => string;
+        constructOneInputOneOutputWitnessTransaction(previousOutpoint: string, inputSequence: number, outputValue: number, outputScript: string): string;
+        findAllUnspent: (bitcoinAddress: string) => Promise<FoundTransaction[]>;
+        getBalance: (bitcoinAddress: string) => Promise<number>;
+        findWithClient: (electrumClient: ElectrumClient, receiverScript: string, expectedValue: number) => Promise<FoundTransaction | undefined>;
+        findAllUnspentWithClient: (electrumClient: ElectrumClient, receiverScript: string) => Promise<FoundTransaction[]>;
+    };
+}

--- a/types/keep-network__tbtc.js/src/CommonTypes.d.ts
+++ b/types/keep-network__tbtc.js/src/CommonTypes.d.ts
@@ -1,0 +1,118 @@
+/// <reference types="node" />
+import type { Config as ElectrumConfig } from "./lib/ElectrumClient";
+import type { FoundTransaction, BitcoinNetworkType } from './BitcoinHelpers';
+import BN = require("bn.js");
+import * as net from 'net';
+export class Web3 {
+    constructor(provider: any, net?: net.Socket);
+
+    static modules: any;
+    readonly givenProvider: any;
+    defaultAccount: string | null;
+    defaultBlock: string | number;
+    readonly currentProvider: any;
+    setProvider(provider: any): boolean;
+    BatchRequest: new () => any;
+    static readonly providers: any;
+
+    utils: any;
+    eth: any;
+    shh: any;
+    bzz: any;
+    version: string;
+    static readonly version: string;
+    static readonly utils: any;
+    extend(extension: any): any;
+}
+export type AbiType = 'function' | 'constructor' | 'event' | 'fallback';
+export type StateMutabilityType = 'pure' | 'view' | 'nonpayable' | 'payable';
+export interface AbiInput {
+    name: string;
+    type: string;
+    indexed?: boolean;
+	components?: AbiInput[];
+    internalType?: string;
+}
+export interface AbiOutput {
+    name: string;
+    type: string;
+	components?: AbiOutput[];
+    internalType?: string;
+}
+export interface AbiItem {
+    anonymous?: boolean;
+    constant?: boolean;
+    inputs?: AbiInput[];
+    name?: string;
+    outputs?: AbiOutput[];
+    payable?: boolean;
+    stateMutability?: StateMutabilityType;
+    type: AbiType;
+    gas?: number;
+}
+
+export class Contract {
+    constructor(
+        provider: any,
+        abi: AbiItem[],
+        address?: string,
+        options?: any
+    );
+
+    private _address: string;
+    private _jsonInterface: AbiItem[];
+    defaultAccount: string | null;
+    defaultBlock: string | number;
+    defaultCommon: any;
+    defaultHardfork: any;
+    defaultChain: any;
+    transactionPollingTimeout: number;
+    transactionConfirmationBlocks: number;
+    transactionBlockTimeout: number;
+
+    options: any;
+
+    clone(): Contract;
+
+    methods: any;
+
+    once(
+        event: string,
+        callback: (error: Error, event: any) => void
+    ): void;
+    once(
+        event: string,
+        options: any,
+        callback: (error: Error, event: any) => void
+    ): void;
+
+    events: any;
+
+    getPastEvents(event: string): Promise<any[]>;
+}
+export interface TBTCConfig {
+    web3: Web3;
+    bitcoinNetwork: BitcoinNetworkType;
+    electrum: { [configType: string]: ElectrumConfig };
+}
+export interface RedemptionDetails {
+    utxoValue: BN;
+    redeemerOutputScript: string;
+    requestedFee: BN;
+    outpoint: string;
+    digest: string;
+}
+export interface KeyPoint {
+    x: string;
+    y: string;
+}
+export interface DepositBaseClass {
+    address: string;
+    keepContract: Contract;
+    publicKeyPoint: Promise<KeyPoint>;
+    getCurrentState(): Promise<number>;
+    factory: any;
+    contract: Contract;
+    constructFundingProof(bitcoinTransaction: Omit<FoundTransaction, 'value'>, confirmations: number): Promise<[Buffer, Buffer, Buffer, Buffer, number, Buffer, string, Buffer]>;
+    getLatestRedemptionDetails(): Promise<null | RedemptionDetails>;
+}

--- a/types/keep-network__tbtc.js/src/CommonTypes.d.ts
+++ b/types/keep-network__tbtc.js/src/CommonTypes.d.ts
@@ -30,13 +30,13 @@ export interface AbiInput {
     name: string;
     type: string;
     indexed?: boolean;
-	components?: AbiInput[];
+    components?: AbiInput[];
     internalType?: string;
 }
 export interface AbiOutput {
     name: string;
     type: string;
-	components?: AbiOutput[];
+    components?: AbiOutput[];
     internalType?: string;
 }
 export interface AbiItem {

--- a/types/keep-network__tbtc.js/src/Constants.d.ts
+++ b/types/keep-network__tbtc.js/src/Constants.d.ts
@@ -1,0 +1,21 @@
+import BN = require("bn.js");
+import type { TBTCConfig, Contract } from './CommonTypes';
+declare class Constants {
+    contract: Contract;
+    static withConfig(config: TBTCConfig): Promise<Constants>;
+    BENEFICIARY_REWARD_DIVISOR: BN;
+    SATOSHI_MULTIPLIER: BN;
+    DEPOSIT_TERM: BN;
+    TX_PROOF_DIFFICULTY_FACTOR: BN;
+    REDEMPTION_SIGNATURE_TIMEOUT: BN;
+    INCREASE_FEE_TIMER: BN;
+    REDEMPTION_PROOF_TIMEOUT: BN;
+    MINIMUM_REDEMPTION_FEE: BN;
+    FUNDING_PROOF_TIMEOUT: BN;
+    SIGNING_GROUP_FORMATION_TIMEOUT: BN;
+    COURTESY_CALL_DURATION: BN;
+    AUCTION_DURATION: BN;
+    PERMITTED_FEE_BUMPS: BN;
+    constructor(constants: any, contract: Contract);
+}
+export { Constants };

--- a/types/keep-network__tbtc.js/src/Deposit.d.ts
+++ b/types/keep-network__tbtc.js/src/Deposit.d.ts
@@ -1,0 +1,128 @@
+/// <reference types="node" />
+import { EventEmitter } from "events";
+import { FoundTransaction as BitcoinTransaction } from "./BitcoinHelpers.js";
+import Redemption from "./Redemption.js";
+import BN = require('bn.js');
+import type { TBTCConfig, DepositBaseClass, KeyPoint, RedemptionDetails, Contract } from './CommonTypes';
+export const DepositStates: {
+    START: number;
+    AWAITING_SIGNER_SETUP: number;
+    AWAITING_BTC_FUNDING_PROOF: number;
+    FAILED_SETUP: number;
+    ACTIVE: number;
+    AWAITING_WITHDRAWAL_SIGNATURE: number;
+    AWAITING_WITHDRAWAL_PROOF: number;
+    REDEEMED: number;
+    COURTESY_CALL: number;
+    FRAUD_LIQUIDATION_IN_PROGRESS: number;
+    LIQUIDATION_IN_PROGRESS: number;
+    LIQUIDATED: number;
+};
+export class DepositFactory {
+    config: TBTCConfig;
+    static withConfig(config: TBTCConfig): Promise<DepositFactory>;
+    State: typeof DepositStates;
+    constructor(config: TBTCConfig);
+    availableSatoshiLotSizes(): Promise<any>;
+    withSatoshiLotSize(satoshiLotSize: BN): Promise<Deposit>;
+    withAddress(depositAddress: string): Promise<Deposit>;
+    constantsContract: Contract;
+    systemContract: Contract;
+    tokenContract: Contract;
+    depositTokenContract: Contract;
+    feeRebateTokenContract: Contract;
+    depositContract: Contract;
+    depositLogContract: Contract;
+    depositFactoryContract: Contract;
+    vendingMachineContract: Contract;
+    fundingScriptContract: Contract;
+    resolveContracts(): Promise<void>;
+    createNewDepositContract(lotSize: BN): Promise<{
+        depositAddress: string;
+        keepAddress: string;
+    }>;
+}
+export interface AutoSubmitState {
+    fundingTransaction: Promise<BitcoinTransaction>;
+    fundingConfirmations: Promise<{
+        transaction: BitcoinTransaction;
+        requiredConfirmations: number;
+    }>;
+    proofTransaction: Promise<any>;
+    mintedTBTC: Promise<BN>;
+}
+export interface FundingConfirmations {
+    transaction: BitcoinTransaction;
+    requiredConfirmations: number;
+}
+export default class Deposit implements DepositBaseClass {
+    factory: DepositFactory;
+    address: string;
+    keepContract: Contract;
+    static forLotSize(factory: DepositFactory, satoshiLotSize: BN): Promise<Deposit>;
+    static forAddress(factory: DepositFactory, address: string): Promise<Deposit>;
+    contract: Contract;
+    activeStatePromise: Promise<boolean>;
+    publicKeyPoint: Promise<KeyPoint>;
+    bitcoinAddress: Promise<string>;
+    receivedFundingConfirmationEmitter: EventEmitter;
+    constructor(factory: DepositFactory, depositContract: Contract, keepContract: Contract);
+    _fundingTransaction?: Promise<BitcoinTransaction>;
+    get fundingTransaction(): Promise<BitcoinTransaction>;
+    _fundingConfirmations?: Promise<FundingConfirmations>;
+    get fundingConfirmations(): Promise<FundingConfirmations>;
+    getLotSizeSatoshis(): Promise<BN>;
+    getLotSizeTBTC(): Promise<BN>;
+    getSignerFeeTBTC(): Promise<BN>;
+    getBitcoinAddress(): Promise<string>;
+    getCurrentState(): Promise<number>;
+    getTDT(): Promise<{}>;
+    getFRT(): Promise<{}>;
+    getOwner(): Promise<any>;
+    inVendingMachine(): Promise<boolean>;
+    onBitcoinAddressAvailable(bitcoinAddressHandler: (address: string) => void): void;
+    onActive(activeHandler: (deposit: Deposit) => void): void;
+    onReceivedFundingConfirmation(onReceivedFundingConfirmationHandler: (fundingConfirmation: {
+        transactionID: string;
+        confirmations: number;
+    }) => void): void;
+    mintTBTC(): Promise<string>;
+    qualifyAndMintTBTC(): Promise<BN>;
+    getRedemptionCost(): Promise<BN>;
+    getCurrentRedemption(): Promise<Redemption | null>;
+    requestRedemption(redeemerAddress: string): Promise<Redemption>;
+    getLatestRedemptionDetails(): Promise<RedemptionDetails | null>;
+    autoSubmittingState?: AutoSubmitState;
+    autoSubmit(): AutoSubmitState;
+    autoMint(): AutoSubmitState;
+    findOrWaitForPublicKeyPoint(): Promise<KeyPoint>;
+    waitForActiveState(): Promise<boolean>;
+    readPublishedPubkeyEvent(): Promise<any>;
+    publicKeyPointToBitcoinAddress(publicKeyPoint: KeyPoint): Promise<string>;
+    constructFundingProof(bitcoinTransaction: Omit<BitcoinTransaction, 'value'>, confirmations: number): Promise<[Buffer, Buffer, Buffer, Buffer, number, Buffer, string, Buffer]>;
+    redemptionDetailsFromEvent(redemptionRequestedEventArgs: {
+        _utxoValue: string;
+        _redeemerOutputScript: string;
+        _requestedFee: string;
+        _outpoint: string;
+        _digest: string;
+    }): RedemptionDetails;
+    getCollateralizationPercentage(): Promise<BN>;
+    getInitialCollateralizedPercentage(): Promise<BN>;
+    getUndercollateralizedThresholdPercent(): Promise<BN>;
+    getSeverelyUndercollateralizedThresholdPercent(): Promise<BN>;
+    notifyCourtesyCall(): Promise<void>;
+    exitCourtesyCall(): Promise<void>;
+    notifyCourtesyCallExpired(): Promise<void>;
+    notifyUndercollateralizedLiquidation(): Promise<void>;
+    purchaseSignerBondsAtAuction(): Promise<void>;
+    auctionValue(): Promise<BN>;
+    notifySignerSetupFailed(): Promise<void>;
+    notifyFundingTimedOut(): Promise<void>;
+    notifyCourtesyTimedOut(): Promise<void>;
+    notifyRedemptionSignatureTimedOut(): Promise<void>;
+    notifyRedemptionProofTimeout(): Promise<void>;
+    wasSignatureApproved(digest: string): Promise<boolean>;
+    provideFundingECDSAFraudProof(v: number, r: string, s: string, signedDigest: string, preimage: string): Promise<void>;
+    provideECDSAFraudProof(v: number, r: string, s: string, signedDigest: string, preimage: string): Promise<void>;
+}

--- a/types/keep-network__tbtc.js/src/EthereumHelpers.d.ts
+++ b/types/keep-network__tbtc.js/src/EthereumHelpers.d.ts
@@ -1,0 +1,35 @@
+import type { Contract, Web3 } from './CommonTypes';
+import BN = require("bn.js");
+
+export namespace EthereumHelpers {
+    function isMainnet(web3: Web3): Promise<boolean>;
+    interface ContractCallOptions {
+        from?: string;
+        gasPrice?: string;
+        gas?: number;
+        value?: number | string | BN;
+    }
+    interface ContractCall {
+        send(options: ContractCallOptions, callback?: (err: Error, transactionHash: string) => void): Promise<any>;
+        estimateGas(options: ContractCallOptions, callback?: (err: Error, gas: number) => void): Promise<number>;
+        call(params: any): any;
+    }
+    function readEventFromTransaction(web3: Web3, transaction: any, sourceContract: Contract, eventName: string): {
+        [key: string]: string;
+    };
+    function getEvent(sourceContract: Contract, eventName: string, filter?: any): Promise<any>;
+    function getExistingEvent(source: Contract, eventName: string, filter?: any): Promise<any>;
+    function bytesToRaw(bytesString: string): string;
+    function sendSafely(boundContractMethod: ContractCall, sendParams?: ContractCallOptions, forceSend?: boolean): Promise<any>;
+    interface Artifact {
+        contractName: string;
+        abi: any;
+        networks: {
+            [netId: string]: {
+                address: string;
+            };
+        };
+    }
+    function sendSafelyRetryable(boundContractMethod: ContractCall, sendParams: ContractCallOptions, forceSend: boolean, totalAttempts: number): Promise<any>;
+    function getDeployedContract(artifact: Artifact, web3: Web3, networkId: string): Contract;
+}

--- a/types/keep-network__tbtc.js/src/Redemption.d.ts
+++ b/types/keep-network__tbtc.js/src/Redemption.d.ts
@@ -1,0 +1,31 @@
+/// <reference types="node" />
+import { EventEmitter } from "events";
+import type { DepositBaseClass, RedemptionDetails } from './CommonTypes';
+export interface AutoSubmitState {
+    broadcastTransactionID: Promise<string>;
+    confirmations: Promise<{
+        transactionID: string;
+        requiredConfirmations: number;
+    }>;
+    proofTransaction: Promise<void>;
+}
+export interface UnsignedTransactionDetails {
+    hex: string;
+    digest: string;
+}
+export default class Redemption {
+    deposit: DepositBaseClass;
+    redemptionDetails: Promise<RedemptionDetails>;
+    unsignedTransactionDetails: Promise<UnsignedTransactionDetails>;
+    signedTransaction: Promise<string>;
+    withdrawnEmitter: EventEmitter;
+    receivedConfirmationEmitter: EventEmitter;
+    constructor(deposit: DepositBaseClass, redemptionDetails?: RedemptionDetails);
+    autoSubmittingState?: AutoSubmitState;
+    autoSubmit(): AutoSubmitState;
+    proveWithdrawal(transactionID: string, confirmations: number): Promise<void>;
+    onBitcoinTransactionSigned(transactionHandler: (transaction: string) => void): void;
+    onWithdrawn(withdrawalHandler: (txHash: string) => void): void;
+    onReceivedConfirmation(onReceivedConfirmationHandler: (transactionID: string, confirmations: number) => void): void;
+    getLatestRedemptionDetails(existingRedemptionDetails: RedemptionDetails | undefined): Promise<RedemptionDetails>;
+}

--- a/types/keep-network__tbtc.js/src/TBTC.d.ts
+++ b/types/keep-network__tbtc.js/src/TBTC.d.ts
@@ -1,0 +1,15 @@
+import BN = require("bn.js");
+import { DepositFactory } from "./Deposit.js";
+import { Constants } from "./Constants.js";
+import type { TBTCConfig } from './CommonTypes';
+export default class TBTC {
+    depositFactory: DepositFactory;
+    constants: Constants;
+    config: TBTCConfig;
+    static withConfig(config: TBTCConfig, networkMatchCheck?: boolean): Promise<TBTC>;
+    satoshisPerTbtc: BN;
+    constructor(depositFactory: DepositFactory, constants: Constants, config: TBTCConfig);
+    get Deposit(): DepositFactory;
+    get Constants(): Constants;
+}
+export function getNetworkIdFromArtifact(): string;

--- a/types/keep-network__tbtc.js/src/lib/BitcoinSPV.d.ts
+++ b/types/keep-network__tbtc.js/src/lib/BitcoinSPV.d.ts
@@ -1,0 +1,13 @@
+export class BitcoinSPV {
+    constructor(electrumClient: any);
+    client: any;
+    getTransactionProof(txHash: string, confirmations: number): Proof;
+    verifyMerkleProof(proofHex: string, txHash: string, index: number, blockHeight: number): boolean;
+}
+
+export interface Proof {
+    tx: string;
+    merkleProof: string;
+    txInBlockIndex: string;
+    chainHeaders: string;
+}

--- a/types/keep-network__tbtc.js/src/lib/BitcoinTxParser.d.ts
+++ b/types/keep-network__tbtc.js/src/lib/BitcoinTxParser.d.ts
@@ -1,0 +1,8 @@
+export namespace BitcoinTxParser {
+    export function parse(rawTx: any): {
+        version: any;
+        txInVector: any;
+        txOutVector: any;
+        locktime: any;
+    };
+}

--- a/types/keep-network__tbtc.js/src/lib/ElectrumClient.d.ts
+++ b/types/keep-network__tbtc.js/src/lib/ElectrumClient.d.ts
@@ -1,0 +1,25 @@
+export default class Client {
+    constructor(config: Config);
+    electrumClient: any;
+    connect(): Promise<void>;
+    close(): Promise<void>;
+    latestBlockHeight(): number;
+    getTransaction(txHash: string): any;
+    broadcastTransaction(rawTX: string): string;
+    getUnspentToScript(script: string): any;
+    getBalanceOfScript(script: string): any;
+    onTransactionToScript(script: string, callback: (state: any) => void): any;
+    onNewBlock(callback: (block: any) => void): any;
+    getMerkleRoot(blockHeight: number): string;
+    getHeadersChain(blockHeight: number, confirmations: number): string;
+    getMerkleProof(txHash: string, blockHeight: number): string;
+    findOutputForAddress(txHash: string, address: string): number;
+    getTransactionsForScript(script: string): any;
+}
+
+export interface Config {
+    server: string;
+    port: number;
+    protocol: "ssl" | "tls" | "ws" | "wss";
+    options?: any;
+}

--- a/types/keep-network__tbtc.js/tsconfig.json
+++ b/types/keep-network__tbtc.js/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "keep-network__tbtc.js-tests.ts"
+    ]
+}

--- a/types/keep-network__tbtc.js/tslint.json
+++ b/types/keep-network__tbtc.js/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

### Notes
Essentially I generated the types in this PR following these steps:
- Rewrote the whole package using typescript ([this fork](https://github.com/corollari/tbtc.js))
- Fixed some things to get it to build with full `strict` checks
- Generated the declaration files using the compiler
- Edited them manually in order to get them to comply to the linting rules used in this repo
- Added a short test

I think that some more tests could be added, but given that the types are already checked for correctness by the compiler itself, I don't believe that to be necessary (also I feel like I've already spent too much time on this). Also, some of the types I ended up using are `any` and these could be improved but these are generally confined to internal or uncommonly used parts of the API so I believe that for now these types are already a big improvement over the lack of types.