### PR TITLE
[superagent] Response has both 'headers' and 'header'

### DIFF
--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -111,6 +111,7 @@ declare namespace request {
         get(header: string): string;
         get(header: 'Set-Cookie'): string[];
         header: any;
+        headers: any;
         info: boolean;
         links: object;
         noContent: boolean;

--- a/types/superagent/superagent-tests.ts
+++ b/types/superagent/superagent-tests.ts
@@ -206,6 +206,7 @@ request('/search')
         const files: object = res.files;
         const text: string = res.text;
         const contentLength = res.header['content-length'];
+        assert(res.header === res.headers);
         const contentType: string = res.type;
         const charset: string = res.charset;
         const redirects: string[] = res.redirects;


### PR DESCRIPTION
The SuperAgent intro doc uses 'headers': https://visionmedia.github.io/superagent/#request-basics

I tested with superagent v3.x-6.x and both '.header' and '.headers' have
the same value:

```
const superagent = require('superagent');

superagent.get('https://www.google.com').then(res => {
    console.log('header', res.header);
    console.log('headers', res.headers);
});
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (see commit message)
- N/A: If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- N/A: If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
