### PR TITLE
[is-number] Changed return type of isNumber to boolean

### DIFF
--- a/types/is-number/index.d.ts
+++ b/types/is-number/index.d.ts
@@ -11,4 +11,4 @@ export = is_number;
  * @param num Any value that should be tested for being a number
  * @returns true if the parameter is a valid number, otherwise false
  */
-declare function is_number(num: any): num is number | string;
+declare function is_number(num: any): boolean;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The previous return type gave an error ("Property 'split' does not exist on type 'never'.  TS2339") when the following code is compiled with TypeScript 3.9.7:

const s = "13:09:42";
if (isNumber(s)) {
  console.log(`${s} hours`);
} else {
  const hours = s.split(":");
  console.log(`${hours} hours`);
}