### PR TITLE
Plotly.js update traces types list and start splitting data types

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -22,7 +22,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as _d3 from 'd3';
+import { BoxPlotData } from './lib/traces/box';
+import { ViolinData } from './lib/traces/violin';
+
 export as namespace Plotly;
+export { BoxPlotData, ViolinData };
 
 export interface StaticPlots {
     resize(root: Root): void;
@@ -1060,7 +1064,7 @@ export type PlotType =
     | 'volume'
     | 'waterfall';
 
-export type Data = Partial<PlotData>;
+export type Data = Partial<PlotData> | Partial<BoxPlotData> | Partial<ViolinData>;
 export type Color =
     | string
     | number

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for plotly.js 1.50
+// Type definitions for plotly.js 1.54
 // Project: https://plot.ly/javascript/, https://github.com/plotly/plotly.js
 // Definitions by: Chris Gervang <https://github.com/chrisgervang>
 //                 Martin Duparc <https://github.com/martinduparc>
@@ -1013,31 +1013,52 @@ export type ErrorBar = Partial<ErrorOptions> &
 export type Dash = 'solid' | 'dot' | 'dash' | 'longdash' | 'dashdot' | 'longdashdot';
 export type PlotType =
     | 'bar'
+    | 'barpolar'
     | 'box'
     | 'candlestick'
+    | 'carpet'
     | 'choropleth'
+    | 'choroplethmapbox'
+    | 'cone'
     | 'contour'
+    | 'contourcarpet'
+    | 'contourgl'
+    | 'densitymapbox'
+    | 'funnel'
+    | 'funnelarea'
     | 'heatmap'
+    | 'heatmapgl'
     | 'histogram'
+    | 'histogram2d'
+    | 'histogram2dcontour'
+    | 'image'
     | 'indicator'
+    | 'isosurface'
     | 'mesh3d'
     | 'ohlc'
+    | 'parcats'
     | 'parcoords'
     | 'pie'
     | 'pointcloud'
+    | 'sankey'
     | 'scatter'
     | 'scatter3d'
+    | 'scattercarpet'
     | 'scattergeo'
     | 'scattergl'
+    | 'scattermapbox'
     | 'scatterpolar'
+    | 'scatterpolargl'
     | 'scatterternary'
+    | 'splom'
+    | 'streamtube'
     | 'sunburst'
     | 'surface'
+    | 'table'
     | 'treemap'
-    | 'waterfall'
-    | 'funnel'
-    | 'funnelarea'
-    | 'scattermapbox';
+    | 'violin'
+    | 'volume'
+    | 'waterfall';
 
 export type Data = Partial<PlotData>;
 export type Color =

--- a/types/plotly.js/lib/traces/box.d.ts
+++ b/types/plotly.js/lib/traces/box.d.ts
@@ -1,0 +1,33 @@
+import { PlotData, Color, MarkerSymbol } from '../../index';
+import { ScatterSelectedMarker } from './scatter';
+
+// See https://github.com/plotly/plotly.js/blob/master/src/traces/box/attributes.js
+export interface BoxPlotData extends PlotData {
+    type: 'box';
+    x0: any;
+    y0: any;
+    width: number;
+    quartilemethod: 'linear' | 'exclusive' | 'inclusive';
+    boxpoints: 'all' | 'outliers' | 'suspectedoutliers' | false;
+    jitter: number;
+    pointpos: number;
+    marker: Partial<{
+        outliercolor: Color;
+        symbol: MarkerSymbol;
+        opacity: number;
+        size: number;
+        color: Color;
+        line: Partial<{
+            color: Color;
+            width: number;
+            outliercolor: Color;
+            outlierwidth: number;
+        }>;
+    }>;
+
+    offsetgroup: string;
+    alignmentgroup: string;
+
+    selected: ScatterSelectedMarker;
+    unselected: ScatterSelectedMarker;
+}

--- a/types/plotly.js/lib/traces/scatter.d.ts
+++ b/types/plotly.js/lib/traces/scatter.d.ts
@@ -1,0 +1,9 @@
+import { Color } from '../../index';
+
+export interface ScatterSelectedMarker {
+    marker: Partial<{
+        opacity: number;
+        color: Color;
+    }>;
+    textfont: { color: Color };
+}

--- a/types/plotly.js/lib/traces/violin.d.ts
+++ b/types/plotly.js/lib/traces/violin.d.ts
@@ -1,0 +1,58 @@
+import { BoxPlotData } from './box';
+import { Color } from '../..';
+
+// See https://github.com/plotly/plotly.js/blob/master/src/traces/violin/attributes.js
+export interface ViolinData {
+    type: 'violin';
+
+    x: BoxPlotData['x'];
+    y: BoxPlotData['y'];
+    x0: BoxPlotData['x0'];
+    y0: BoxPlotData['y0'];
+    name: BoxPlotData['name'];
+
+    opacity: number; // Missing from the list of attributes
+
+    orientation: BoxPlotData['orientation'];
+    bandwidth: number;
+    scalegroup: string;
+    scalemode: 'width' | 'count';
+    spanmode: 'soft' | 'hard' | 'manual';
+    span: any[];
+    line: Partial<{
+        color: Color;
+        width: number;
+    }>;
+    fillcolor: Color;
+    points: BoxPlotData['boxpoints'];
+    jitter: BoxPlotData['jitter'];
+    pointpos: BoxPlotData['pointpos'];
+    width: BoxPlotData['width'];
+    marker: BoxPlotData['marker'];
+    text: BoxPlotData['text'];
+    hovertext: BoxPlotData['hovertext'];
+    hovertemplate: BoxPlotData['hovertemplate'];
+    box: Partial<{
+        visible: boolean;
+        width: number;
+        fillcolor: Color;
+        line: Partial<{
+            color: Color;
+            width: number;
+        }>;
+    }>;
+    meanline: Partial<{
+        visible: boolean;
+        color: Color;
+        width: number;
+    }>;
+    side: 'both' | 'positive' | 'negative';
+
+    offsetgroup: BoxPlotData['offsetgroup'];
+    alignmentgroup: BoxPlotData['alignmentgroup'];
+
+    selected: BoxPlotData['selected'];
+    unselected: BoxPlotData['unselected'];
+
+    hoveron: 'violins' | 'points' | 'kde' | 'all' | string;
+}

--- a/types/plotly.js/test/core-tests.ts
+++ b/types/plotly.js/test/core-tests.ts
@@ -1,5 +1,5 @@
 import * as Plotly from 'plotly.js/lib/core';
-import { Datum, ScatterData, Layout, PlotlyHTMLElement, newPlot, PlotData } from 'plotly.js/lib/core';
+import { Datum, ScatterData, Layout, newPlot, PlotData, ViolinData } from 'plotly.js/lib/core';
 
 const graphDiv = '#test';
 
@@ -30,6 +30,23 @@ const graphDiv = '#test';
         },
     };
     Plotly.newPlot(graphDiv, data, layout);
+
+    const violinTrace = {
+        name: 'Values',
+        type: 'violin',
+        y: [10, 15, 13, 17],
+        points: 'all',
+        pointpos: -1,
+        marker: { opacity: 0.6 },
+        box: {
+            visible: true,
+            fillcolor: 'yellow',
+        },
+        line: { color: 'black' },
+        opacity: 0.6,
+        meanline: { visible: true },
+    } as ViolinData;
+    Plotly.newPlot(graphDiv, [violinTrace], { title: 'Sales growth' });
 })();
 (() => {
     // deprecated: calling plot again will add new trace(s) to the plot,

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -232,21 +232,31 @@ const graphDiv = '#test';
 (() => {
     // Test the template with practical types.
     // https://plotly.com/javascript/layout-template/
-    const data: Array<Partial<PlotData>> = [{
-        type: 'bar', name: 'bar', text: ['2', '3', '1', '4'], x: ['Jan', 'Feb', 'Mar', 'Apr'], y: [2, 3, 1, 4]
-    }, {
-        type: 'scatter', name: 'scatter', x: [1, 2, 3, 4], y: [2, 4, 1, 5]
-    }];
+    const data: Array<Partial<PlotData>> = [
+        {
+            type: 'bar',
+            name: 'bar',
+            text: ['2', '3', '1', '4'],
+            x: ['Jan', 'Feb', 'Mar', 'Apr'],
+            y: [2, 3, 1, 4],
+        },
+        {
+            type: 'scatter',
+            name: 'scatter',
+            x: [1, 2, 3, 4],
+            y: [2, 4, 1, 5],
+        },
+    ];
     const template: Template = {
         data: {
             bar: { marker: { color: '#3183BD', opacity: 0.7 }, textposition: 'auto' },
             scatter: {
                 mode: 'lines+markers',
                 line: { color: 'red', width: 3 },
-                marker: { color: 'red', size: 8, symbol: 'circle-open' }
-            }
+                marker: { color: 'red', size: 8, symbol: 'circle-open' },
+            },
         },
-        layout: { barmode: 'stack', showlegend: false, xaxis: { tickangle: -45 } }
+        layout: { barmode: 'stack', showlegend: false, xaxis: { tickangle: -45 } },
     };
     const layout: Partial<Layout> = { showlegend: true, title: 'January 2013 Sales Report', template };
     Plotly.newPlot('myDiv', data, layout);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See comments in source code
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

For now only the violin plot is fully implemented as a separate type.
It follows https://github.com/plotly/plotly.js/blob/master/src/traces/violin/attributes.js.

Due to lack of time, the box type implements only a few missing fields (required for the violin type) and otherwise extends PlotData. This is based on https://github.com/plotly/plotly.js/blob/master/src/traces/box/attributes.js.

Ideally, we should start using new type definitions for each trace type instead of bloating `PlotData`.
