### PR TITLE
[ramda] fix: let `map` & `values` work correctly with unions

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -971,8 +971,8 @@ export function lte(a: number, b: number): boolean;
 export function lte(a: number): (b: number) => boolean;
 
 /**
- * If `T` is a union, `T[keyof T]` (analogue to below) contains the object keys that are common across the union (i.e., an intersection).
- * Because we want to include all keys, including those that occur in some, but not all members of the union, we first define `KeyOfUnion`.
+ * If `T` is a union, `T[keyof T]` (analogue to below) contains the types of object values that are common across the union (i.e., an intersection).
+ * Because we want to include the types of all values, including those that occur in some, but not all members of the union, we first define `ValueOfUnion`.
  * @see https://stackoverflow.com/a/60085683
  */
 type ValueOfUnion<T> = T extends infer U ? U[keyof U] : never;

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -971,12 +971,19 @@ export function lte(a: number, b: number): boolean;
 export function lte(a: number): (b: number) => boolean;
 
 /**
+ * If `T` is a union, `T[keyof T]` (analogue to below) contains the object keys that are common across the union (i.e., an intersection).
+ * Because we want to include all keys, including those that occur in some, but not all members of the union, we first define `KeyOfUnion`.
+ * @see https://stackoverflow.com/a/60085683
+ */
+type ValueOfUnion<T> = T extends infer U ? U[keyof U] : never;
+
+/**
  * Returns a new list, constructed by applying the supplied function to every element of the supplied list.
  */
 export function map<T, U>(fn: (x: T) => U, list: readonly T[]): U[];
 export function map<T, U>(fn: (x: T) => U): (list: readonly T[]) => U[];
-export function map<T, U>(fn: (x: T[keyof T & keyof U]) => U[keyof T & keyof U], list: T): U;
-export function map<T, U>(fn: (x: T[keyof T & keyof U]) => U[keyof T & keyof U]): (list: T) => U;
+export function map<T, U>(fn: (x: T[keyof T & keyof U] | ValueOfUnion<T>) => U[keyof T & keyof U], list: T): U;
+export function map<T, U>(fn: (x: T[keyof T & keyof U] | ValueOfUnion<T>) => U[keyof T & keyof U]): (list: T) => U;
 export function map<T, U>(fn: (x: T) => U, obj: Functor<T>): Functor<U>; // used in functors
 export function map<T, U>(fn: (x: T) => U): (obj: Functor<T>) => Functor<U>; // used in functors
 

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -58,6 +58,7 @@ import {
     Reduced,
     SafePred,
     ValueOfRecord,
+    ValueOfUnion
 } from "./tools";
 
 export * from './tools';
@@ -969,13 +970,6 @@ export function lte(__: Placeholder, b: number): (a: number) => boolean;
 export function lte(__: Placeholder): (b: number, a: number) => boolean;
 export function lte(a: number, b: number): boolean;
 export function lte(a: number): (b: number) => boolean;
-
-/**
- * If `T` is a union, `T[keyof T]` (analogue to below) contains the types of object values that are common across the union (i.e., an intersection).
- * Because we want to include the types of all values, including those that occur in some, but not all members of the union, we first define `ValueOfUnion`.
- * @see https://stackoverflow.com/a/60085683
- */
-type ValueOfUnion<T> = T extends infer U ? U[keyof U] : never;
 
 /**
  * Returns a new list, constructed by applying the supplied function to every element of the supplied list.
@@ -2065,7 +2059,7 @@ export function useWith(fn: ((...a: readonly any[]) => any), transformers: Array
  * Note that the order of the output array is not guaranteed across
  * different JS platforms.
  */
-export function values<T extends object, K extends keyof T>(obj: T): Array<T[K]>;
+export function values<T extends object, K extends keyof T>(obj: T): Array<T[K] | ValueOfUnion<T>>;
 
 /**
  * Returns a list of all the properties, including prototype properties, of the supplied

--- a/types/ramda/test/map-tests.ts
+++ b/types/ramda/test/map-tests.ts
@@ -49,7 +49,10 @@ import * as R from 'ramda';
 
   type KeyOfUnion<T> = T extends infer U ? keyof U : never;
 
-  R.map<A | C, Record<KeyOfUnion<A | C>, void>>(value => {
-    if (typeof value === 'string') console.log(value.toUpperCase());
-  }, { a: 1, b: 2 });
+  // $ExpectType Record<"a" | "b" | "c", void>
+  R.map<A | C, Record<KeyOfUnion<A | C>, void>>(
+    // $ExpectType (value: string | number) => void
+    value => {
+        value;
+    }, { a: 1, b: 2 });
 };

--- a/types/ramda/test/map-tests.ts
+++ b/types/ramda/test/map-tests.ts
@@ -36,9 +36,20 @@ import * as R from 'ramda';
     b: string;
   }
 
+  interface C {
+    b: number;
+    c: string;
+  }
+
   R.map<A, A>(R.inc, { a: 1, b: 2 });
   R.map<A, B>(R.toString, { a: 1, b: 2 });
 
   R.map<A, A>(R.inc)({ a: 1, b: 2 });
   R.map<A, B>(R.toString)({ a: 1, b: 2 });
+
+  type KeyOfUnion<T> = T extends infer U ? keyof U : never;
+
+  R.map<A | C, Record<KeyOfUnion<A | C>, void>>(value => {
+    if (typeof value === 'string') console.log(value.toUpperCase());
+  }, { a: 1, b: 2 });
 };

--- a/types/ramda/test/values-tests.ts
+++ b/types/ramda/test/values-tests.ts
@@ -1,17 +1,32 @@
 import * as R from 'ramda';
 
 () => {
-  interface A {
-    a: string;
-    b: string;
-  }
-  const a1: A = { a: 'something', b: 'else' };
-  const v1 = R.values(a1);
+    interface A {
+        a: string;
+        b: string;
+    }
+    const a1: A = { a: 'something', b: 'else' };
+    const v1 = R.values(a1);
 
-  const a = R.values({ a: 1, b: 2, c: 3 }); // => [1, 2, 3] (number[])
-  const addition = a[0] + a[1];
+    const a = R.values({ a: 1, b: 2, c: 3 }); // => [1, 2, 3] (number[])
+    const addition = a[0] + a[1];
 
-  const b = R.values({ a: 1, b: 'something' }); // b = (string|number)[]
-  const c = R.values({ 1: 3 });
-  // const d = R.values('something');
+    const b = R.values({ a: 1, b: 'something' }); // b = (string|number)[]
+    const c = R.values({ 1: 3 });
+    // const d = R.values('something');
+
+    interface B {
+        a: string;
+        c: number;
+    }
+
+    const d: Array<A | B> = [
+        { a: 'this object is of type A', b: '' },
+        { a: 'this object is of type B', c: 8 },
+    ];
+
+    d.forEach(item => {
+        // $ExpectType (string | number)[]
+        const v = R.values(item);
+    });
 };

--- a/types/ramda/tools.d.ts
+++ b/types/ramda/tools.d.ts
@@ -436,4 +436,11 @@ export type ValueOfRecord<R> =
     ? T
     : never;
 
+/**
+ * If `T` is a union, `T[keyof T]` (cf. `map` and `values` in `index.d.ts`) contains the types of object values that are common across the union (i.e., an intersection).
+ * Because we want to include the types of all values, including those that occur in some, but not all members of the union, we first define `ValueOfUnion`.
+ * @see https://stackoverflow.com/a/60085683
+ */
+export type ValueOfUnion<T> = T extends infer U ? U[keyof U] : never;
+
 export {};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/38173#issuecomment-676221347
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

# Context for the suggested changes

`map` can be used on an object. If the type of this object is a union (e.g. `Teacher | Student`), the argument of the function that is the first argument of `map` was incorrectly typed.

Let’s say `Teacher` and `Student` are defined as follows:

```ts
type Teacher = {
  age: number
  id: string
}
type Student = {
  age: number
  grade: number
}
```

Let’s say `user` is of type `Teacher | Student` and somewhere in our code we have `map(fn, user)`. In this case, the argument of `fn` should be inferred as `number | string`, because `fn` will be called on the values corresponding to `age` and `id`, or `age` and `grade`.

`map` was typed such that the argument of `fn` was a union of all values that occur in *both* `Teacher` and `Student` (i.e., the intersection). In this example, only `age` is common, so the argument had type `number`. This is incorrect, the type should be `number | string`, which is fixed by this PR.