### PR TITLE
Add types for NPM pkg 'is-gzip'

### DIFF
--- a/types/is-gzip/index.d.ts
+++ b/types/is-gzip/index.d.ts
@@ -6,4 +6,3 @@
 export = is_gzip;
 
 declare function is_gzip(buf: Buffer | Uint8Array): boolean;
-

--- a/types/is-gzip/index.d.ts
+++ b/types/is-gzip/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for is-gzip 2.0
+// Project: https://github.com/kevva/is-gzip#readme
+// Definitions by: Kit Peters <https://github.com/PopeFelix>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = is_gzip;
+
+declare function is_gzip(buf: Buffer | Uint8Array): boolean;
+

--- a/types/is-gzip/is-gzip-tests.ts
+++ b/types/is-gzip/is-gzip-tests.ts
@@ -1,0 +1,2 @@
+import isGzip from 'is-gzip';
+isGzip(Buffer.from('blah blah'));

--- a/types/is-gzip/is-gzip-tests.ts
+++ b/types/is-gzip/is-gzip-tests.ts
@@ -1,2 +1,3 @@
+/// <reference types="node" />
 import isGzip from 'is-gzip';
 isGzip(Buffer.from('blah blah'));

--- a/types/is-gzip/tsconfig.json
+++ b/types/is-gzip/tsconfig.json
@@ -12,7 +12,7 @@
         "typeRoots": [
             "../"
         ],
-        "types": ["node"],
+        "types": [],
         "esModuleInterop": true,
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/is-gzip/tsconfig.json
+++ b/types/is-gzip/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": ["node"],
+        "esModuleInterop": true,
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "is-gzip-tests.ts"
+    ]
+}

--- a/types/is-gzip/tslint.json
+++ b/types/is-gzip/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ x ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ x ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ x ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ x ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ x ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ x ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.


