### PR TITLE
[cometd] add getTransportTypes method

### DIFF
--- a/types/cometd/cometd-tests.ts
+++ b/types/cometd/cometd-tests.ts
@@ -65,6 +65,7 @@ const timeSyncSubscription = cometd.addListener("/foo/bar", () => {
 });
 
 cometd.unregisterTransport("websocket");
+const transportTypes = cometd.getTransportTypes();
 
 // Handshaking
 // ===========

--- a/types/cometd/index.d.ts
+++ b/types/cometd/index.d.ts
@@ -185,6 +185,13 @@ export class CometD {
     unregisterTransports(): void;
 
     /**
+     * Gets all registered transport types.
+     *
+     * @return an array of all registered transport types
+     */
+    getTransportTypes(): string[];
+
+    /**
      * Configures and establishes the Bayeux communication with the Bayeux server via a handshake
      * and a subsequent connect.
      *


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
    ```js
    const client = new CometD();
    client.unregisterTransport("websocket");
    client.unregisterTransport("callback-polling");

    const result = client.getTransportTypes();

    expect(result).toEqual(["long-polling"]);
    ```
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/cometd/cometd-javascript/blob/360cf1df8baea9ea0234138a0ff21f03be5738ff/cometd.js#L2619-L2624>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

