### PR TITLE
 update(js-beautify): re-export types for CJS and  minor version bump

### DIFF
--- a/types/js-beautify/index.d.ts
+++ b/types/js-beautify/index.d.ts
@@ -1,6 +1,9 @@
-// Type definitions for js_beautify 1.11.0
+// Type definitions for js_beautify 1.13
 // Project: https://github.com/beautify-web/js-beautify/
-// Definitions by: Josh Goldberg <https://github.com/JoshuaKGoldberg>, Hans Windhoff <https://github.com/hansrwindhoff>, Gavin Rehkemper <https://github.com/gavinr/>
+// Definitions by: Josh Goldberg <https://github.com/JoshuaKGoldberg>
+//                 Hans Windhoff <https://github.com/hansrwindhoff>
+//                 Gavin Rehkemper <https://github.com/gavinr/>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface CoreBeautifyOptions {
@@ -80,6 +83,21 @@ interface jsb {
 }
 
 declare var js_beautify: jsb;
+
+// tslint:disable:no-single-declare-module backward compatible change requires this exclusion
+// tslint:disable:no-declare-current-package backward compatible change requires this exclusion
 declare module 'js-beautify' {
+    // re-exports types for CJS without redefinition of the global exports
+    type _CoreBeautifyOptions = CoreBeautifyOptions;
+    type _CSSBeautifyOptions =  CSSBeautifyOptions;
+    type _JSBeautifyOptions = JSBeautifyOptions;
+    type _HTMLBeautifyOptions = HTMLBeautifyOptions;
+    namespace js_beautify {
+        type CoreBeautifyOptions = _CoreBeautifyOptions;
+        type CSSBeautifyOptions = _CSSBeautifyOptions;
+        type JSBeautifyOptions = _JSBeautifyOptions;
+        type HTMLBeautifyOptions = _HTMLBeautifyOptions;
+    }
+
     export = js_beautify;
 }

--- a/types/js-beautify/js-beautify-tests.ts
+++ b/types/js-beautify/js-beautify-tests.ts
@@ -8,9 +8,9 @@ let emptyHTMLOptions: HTMLBeautifyOptions = {};
 let emptyCSSOptions: CSSBeautifyOptions = {};
 let emptyJSOptions: JSBeautifyOptions = {};
 
-var simple: string = js_beautify("console.log('Hello world!');");
+let simple: string = js_beautify("console.log('Hello world!');");
 
-var JSoptions: JSBeautifyOptions = {
+let JSoptions: JSBeautifyOptions = {
     indent_size: 4,
     indent_char: ' ',
     eol: '\n',
@@ -37,7 +37,7 @@ var JSoptions: JSBeautifyOptions = {
     test_output_raw: true,
 };
 
-var HTMLoptions: HTMLBeautifyOptions = {
+let HTMLoptions: HTMLBeautifyOptions = {
     indent_size: 4,
     indent_char: ' ',
     eol: '\n',
@@ -51,7 +51,7 @@ var HTMLoptions: HTMLBeautifyOptions = {
     end_with_newline: false,
 };
 
-var CSSoptions: CSSBeautifyOptions = {
+let CSSoptions: CSSBeautifyOptions = {
     indent_size: 4,
     indent_char: ' ',
     eol: '\n',
@@ -63,6 +63,6 @@ var CSSoptions: CSSBeautifyOptions = {
     end_with_newline: false,
 };
 
-var full: string = js_beautify("console.log('Hello world!');", JSoptions);
+let full: string = js_beautify("console.log('Hello world!');", JSoptions);
 
-var markup: string = js_beautify("function render(){return <div> <img src='.' /></div>}", { ...JSoptions, e4x: true });
+let markup: string = js_beautify("function render(){return <div> <img src='.' /></div>}", { ...JSoptions, e4x: true });

--- a/types/js-beautify/tslint.json
+++ b/types/js-beautify/tslint.json
@@ -1,9 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "dt-header": false,
-        "no-declare-current-package": false,
-        "no-single-declare-module": false,
-        "no-var-keyword": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
[this PR was amended to simplify change in order to get it passed through]

update(js-beautify): re-export types for CJS and  minor rversion bump

I cannot re-use the module types in proper CJS code, this change is
expected to be backward compatible (no code rewwrite required), while
allowing to import required details in CJS ecosystem:

- re-exported types for CJS consumption without rewriting global export
    code
- tests amended
- minor version bump
- mantainer added

https://github.com/beautify-web/js-beautify/compare/v1.11.0...v1.13.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)