### PR TITLE
feat(html-beautify-webpack-plugin): new definition

### DIFF
--- a/types/html-beautify-webpack-plugin/html-beautify-webpack-plugin-tests.ts
+++ b/types/html-beautify-webpack-plugin/html-beautify-webpack-plugin-tests.ts
@@ -1,0 +1,39 @@
+import { Configuration } from 'webpack';
+import HtmlWebpackPlugin = require('html-webpack-plugin');
+import HtmlBeautifyPLugin = require('html-beautify-webpack-plugin');
+
+const config: Configuration = {
+    plugins: [
+        new HtmlWebpackPlugin(),
+        new HtmlBeautifyPLugin({
+            config: {
+                indent_size: 4,
+                html: {
+                    end_with_newline: true,
+                    indent_size: 2,
+                    indent_with_tabs: true,
+                    indent_inner_html: true,
+                    preserve_newlines: true,
+                    unformatted: ['p', 'i', 'b', 'span'],
+                },
+            },
+            replace: [' type="text/javascript"'],
+        }),
+    ],
+};
+
+new HtmlBeautifyPLugin();
+new HtmlBeautifyPLugin({});
+new HtmlBeautifyPLugin({
+    config: {
+        html: {
+            end_with_newline: true,
+            indent_size: 2,
+            indent_with_tabs: true,
+            indent_inner_html: true,
+            preserve_newlines: true,
+            unformatted: ['p', 'i', 'b', 'span'],
+        },
+    },
+    replace: [' type="text/javascript"'],
+});

--- a/types/html-beautify-webpack-plugin/index.d.ts
+++ b/types/html-beautify-webpack-plugin/index.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for html-beautify-webpack-plugin 1.0
+// Project: https://github.com/SeeYouLater/html-beautify-webpack-plugin#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import { Plugin } from 'webpack';
+import { CoreBeautifyOptions, CSSBeautifyOptions, HTMLBeautifyOptions, JSBeautifyOptions } from 'js-beautify';
+
+/**
+ * Beautifier for output of HtmlWebpackPlugin
+ */
+declare class HtmlBeautifyPlugin extends Plugin {
+    options: HtmlBeautifyPlugin.Options;
+    constructor(options?: HtmlBeautifyPlugin.Options, replace?: string[]);
+}
+
+declare namespace HtmlBeautifyPlugin {
+    interface Options {
+        /**
+         * js-beautify's options as object to beautify the output.
+         */
+        config?: HtmlBeautifyConfig;
+        /**
+         * Optional array of items to replace in destination file
+         * @default []
+         */
+        replace?: string[] | ReplaceConfig[];
+    }
+
+    interface HtmlBeautifyConfig extends CoreBeautifyOptions {
+        html?: HTMLBeautifyOptions;
+        js?: JSBeautifyOptions;
+        css?: CSSBeautifyOptions;
+    }
+
+    interface ReplaceConfig {
+        test: string | RegExp;
+        with?: string;
+    }
+}
+
+export = HtmlBeautifyPlugin;

--- a/types/html-beautify-webpack-plugin/tsconfig.json
+++ b/types/html-beautify-webpack-plugin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "html-beautify-webpack-plugin-tests.ts"
+    ]
+}

--- a/types/html-beautify-webpack-plugin/tslint.json
+++ b/types/html-beautify-webpack-plugin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- definition file
- tests

https://www.npmjs.com/package/html-beautify-webpack-plugin
https://github.com/seeyoulater/html-beautify-webpack-plugin


Please note it requires #46933 to be merged first in order to work properly!

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.