### PR TITLE
Add types for heft-jest package

### DIFF
--- a/types/heft-jest/heft-jest-tests.ts
+++ b/types/heft-jest/heft-jest-tests.ts
@@ -1,0 +1,5 @@
+/// <reference types=".">
+
+class X { }
+
+mocked(X).mockClear();

--- a/types/heft-jest/heft-jest-tests.ts
+++ b/types/heft-jest/heft-jest-tests.ts
@@ -1,5 +1,5 @@
 /// <reference types=".">
 
-class X { }
+class X {}
 
 mocked(X).mockClear();

--- a/types/heft-jest/index.d.ts
+++ b/types/heft-jest/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for heft-jest 1.0
 // Project: https://github.com/octogonz/heft-jest
 // Definitions by: Pete Gonzalez <https://github.com/octogonz>
+//                 Ian Clanton-Thuon <https://github.com/iclanton>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.5
 

--- a/types/heft-jest/index.d.ts
+++ b/types/heft-jest/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for heft-jest 1.0
+// Project: https://github.com/octogonz/heft-jest
+// Definitions by: Pete Gonzalez <https://github.com/octogonz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="jest" />
+
+
+declare namespace mocked {
+  // Todo - fill out this definition in the next release.
+  type Mocked<T> = any;
+}
+
+/**
+ * This is a global equivalent of the mocked() API from ts-jest:
+ * https://kulshekhar.github.io/ts-jest/user/test-helpers
+ */
+declare function mocked<T>(item: T, deep?: false): mocked.Mocked<T>;
+declare function mocked<T>(item: T, deep: true): mocked.Mocked<T>;

--- a/types/heft-jest/index.d.ts
+++ b/types/heft-jest/index.d.ts
@@ -2,13 +2,13 @@
 // Project: https://github.com/octogonz/heft-jest
 // Definitions by: Pete Gonzalez <https://github.com/octogonz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
 
 /// <reference types="jest" />
 
-
 declare namespace mocked {
-  // Todo - fill out this definition in the next release.
-  type Mocked<T> = any;
+    // Todo - fill out this definition in the next release.
+    type Mocked<T> = any;
 }
 
 /**

--- a/types/heft-jest/package.json
+++ b/types/heft-jest/package.json
@@ -1,6 +1,0 @@
-{
-  "private": true,
-  "dependencies": {
-      "jest": "*"
-  }
-}

--- a/types/heft-jest/package.json
+++ b/types/heft-jest/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+      "jest": "*"
+  }
+}

--- a/types/heft-jest/tsconfig.json
+++ b/types/heft-jest/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+      "module": "commonjs",
+      "lib": [
+          "es6"
+      ],
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictFunctionTypes": true,
+      "strictNullChecks": true,
+      "baseUrl": "../",
+      "typeRoots": [
+          "../"
+      ],
+      "types": [],
+      "esModuleInterop": true,
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+      "index.d.ts",
+      "heft-jest-tests.ts"
+  ]
+}

--- a/types/heft-jest/tsconfig.json
+++ b/types/heft-jest/tsconfig.json
@@ -1,24 +1,23 @@
 {
-  "compilerOptions": {
-      "module": "commonjs",
-      "lib": [
-          "es6"
-      ],
-      "noImplicitAny": true,
-      "noImplicitThis": true,
-      "strictFunctionTypes": true,
-      "strictNullChecks": true,
-      "baseUrl": "../",
-      "typeRoots": [
-          "../"
-      ],
-      "types": [],
-      "esModuleInterop": true,
-      "noEmit": true,
-      "forceConsistentCasingInFileNames": true
-  },
-  "files": [
-      "index.d.ts",
-      "heft-jest-tests.ts"
-  ]
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "heft-jest-tests.ts"
+    ]
 }

--- a/types/heft-jest/tslint.json
+++ b/types/heft-jest/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
