### PR TITLE
prosemirror-view - add missing typings to Decoration

### DIFF
--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -108,6 +108,27 @@ export class Decoration<T extends object = { [key: string]: any }> {
    */
   spec: T;
   /**
+   * `true` if this Decoration is an inline Decoration
+   */
+  inline: boolean;
+  /**
+   * Creates a new copy of this Decoration with the `from` and `to`
+   * properties set to the passed values.
+   */
+  copy(from: number, to: number): Decoration<T>;
+  /**
+   * Returns `true` if the other Decoration's type matches this Decoration's
+   * type and if the other's `from` and `to` both match this's `from` and `to`,
+   * adding offset to the values if passed.
+   */
+  eq(other: Decoration<any>, offset?: number): boolean;
+  /**
+   * Maps a Decoration in response to a change in offset, returning either
+   * a new Decoration with updated `from` and `to` properties or `null`
+   * if the Decoration was deleted.
+   */
+  map(mapping: Mapping, offset: number, oldOffset: number): Decoration<T> | null;
+  /**
    * Creates a widget decoration, which is a DOM node that's shown in
    * the document at the given position. It is recommended that you
    * delay rendering the widget by passing a function that will be

--- a/types/prosemirror-view/prosemirror-view-tests.ts
+++ b/types/prosemirror-view/prosemirror-view-tests.ts
@@ -2,12 +2,22 @@ import * as model from 'prosemirror-model';
 import * as schema from 'prosemirror-schema-basic';
 import * as state from 'prosemirror-state';
 import * as view from 'prosemirror-view';
+import * as transform from 'prosemirror-transform';
 
 const { Decoration } = view;
 const decoration = new Decoration();
 
 const plainDecoration = new Decoration<{ a: number }>();
 plainDecoration.spec.a; // $ExpectType number
+plainDecoration.inline; // $ExpectType boolean
+
+const copied = plainDecoration.copy(0, 0);
+copied.spec.a; // $ExpectType number
+
+const mapped = plainDecoration.map(new transform.Mapping(), 0, 0)!;
+mapped.spec.a; // $ExpectType number
+
+const equal = plainDecoration.eq(copied); // $ExpectType boolean
 
 Decoration.widget<{a: number}>(0, (x) => x.dom, { a: '' }); // $ExpectError
 Decoration.widget(0, (x) => x.dom, 'this argument should be an object, not a string!'); // $ExpectError


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ProseMirror/prosemirror-view/blob/b5e930d801293ff043f7ebe29c5e6270558460ed/src/decoration.js#L94
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
