### PR TITLE
[rn-phone-input]: onChangePhoneNumber argument type should be string

### DIFF
--- a/types/react-native-phone-input/index.d.ts
+++ b/types/react-native-phone-input/index.d.ts
@@ -94,7 +94,7 @@ export interface ReactNativePhoneInputProps<TextComponentType extends React.Comp
     /**
      * Function to be invoked when phone number is changed
      */
-    onChangePhoneNumber?: (number: number) => void;
+    onChangePhoneNumber?: (number: string) => void;
     /**
      * Function to be invoked when country picker is selected
      */


### PR DESCRIPTION
```
<PhoneInput 
  onChangePhoneNumber: (phone) => {
    console.log(typeof phone); // string
  }
/>
```
Now, if i try console `typeof number` it will be string, but in types it's declarated as `number`.
