### PR TITLE
fix(clownface): add missing overloads for creating pointers

### DIFF
--- a/types/clownface/clownface-tests.ts
+++ b/types/clownface/clownface-tests.ts
@@ -116,6 +116,9 @@ function testBlankNode() {
     let singleBlank: clownface.AnyPointer<BlankNode, Dataset> = cf.blankNode();
     singleBlank = cf.blankNode('label');
     const multiBlankContext: clownface.AnyPointer<BlankNode[], Dataset> = cf.blankNode([ 'b1', 'b2' ]);
+
+    const fromOther: clownface.AnyPointer<BlankNode, Dataset> = cf.blankNode(singleBlank);
+    const fromMultipleOther: clownface.MultiPointer<BlankNode, Dataset> = cf.blankNode(multiBlankContext);
 }
 
 function testDeleteIn() {
@@ -244,9 +247,12 @@ function testList() {
 function testLiteral() {
     const cf: clownface.AnyPointer<undefined, Dataset> = <any> {};
     let cfOneLit: clownface.AnyPointer<Literal, Dataset> = cf.literal('foo');
-    const cfLiterasl: clownface.AnyPointer<Literal[], Dataset> = cf.literal(['foo', 'bar']);
+    const cfLiterals: clownface.AnyPointer<Literal[], Dataset> = cf.literal(['foo', 'bar']);
     cfOneLit = cf.literal('foo', node);
     cfOneLit = cf.literal('foo', 'en');
+
+    const fromOther: clownface.AnyPointer<Literal, Dataset> = cf.literal(cfOneLit);
+    const fromMultipleOther: clownface.MultiPointer<Literal, Dataset> = cf.literal(cfLiterals);
 }
 
 function testMap() {
@@ -264,6 +270,9 @@ function testNamedNode() {
     let cfSingleNamed: clownface.AnyPointer<NamedNode, Dataset> = cf.namedNode(node);
     cfSingleNamed = cf.namedNode('http://example.com/');
     const cfNamedMany: clownface.AnyPointer<NamedNode[], Dataset> = cf.namedNode(['http://example.com/', 'http://example.org/']);
+
+    const fromOther: clownface.AnyPointer<NamedNode, Dataset> = cf.namedNode(cfSingleNamed);
+    const fromMultipleOther: clownface.MultiPointer<NamedNode, Dataset> = cf.namedNode(cfNamedMany);
 }
 
 function testNode() {
@@ -276,6 +285,11 @@ function testNode() {
     const cfBlank: clownface.AnyPointer<BlankNode, Dataset> = cf.node(null, { type: 'BlankNode' });
     cfLit = cf.node('example', { datatype: node.value });
     cfLit = cf.node('example', { datatype: node });
+
+    const fromOtherNode: clownface.MultiPointer<Term, Dataset> = cf.node(singleTerm);
+    const literalFromOther: clownface.MultiPointer<Literal, Dataset> = cf.node(cfLit);
+
+    const literalFromMultipleOther: clownface.MultiPointer<Literal, Dataset> = cf.node(cfLitMany);
 }
 
 function testOut() {

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -57,7 +57,8 @@ declare namespace clownface {
     node(value: SingleOrOneElementArray<boolean | string | number>, options?: NodeOptions): AnyPointer<Literal, D>;
     node(values: Array<boolean | string | number>, options?: NodeOptions): AnyPointer<Literal[], D>;
 
-    node<X extends Term>(value: SingleOrOneElementArray<X>, options?: NodeOptions): AnyPointer<X, D>;
+    node<X extends Term>(value: SingleOrOneElementArray<X> | AnyPointer<X, D>, options?: NodeOptions): AnyPointer<X, D>;
+    node<X extends Term>(value: MultiPointer<X, D>, options?: NodeOptions): AnyPointer<X[], D>;
     node<X extends Term[]>(values: X, options?: NodeOptions): AnyPointer<X, D>;
 
     node(value: null, options?: NodeOptions): AnyPointer<BlankNode, D>;
@@ -65,14 +66,14 @@ declare namespace clownface {
 
     node(values: Array<boolean | string | number | Term | null>, options?: NodeOptions): AnyPointer<Term[], D>;
 
-    blankNode(value?: SingleOrOneElementArray<string>): AnyPointer<BlankNode, D>;
-    blankNode(values: string[]): AnyPointer<BlankNode[], D>;
+    blankNode(value?: SingleOrOneElementArray<string> | AnyPointer<BlankNode, D>): AnyPointer<BlankNode, D>;
+    blankNode(values: string[] | MultiPointer<BlankNode, D>): AnyPointer<BlankNode[], D>;
 
-    literal(value: SingleOrOneElementArray<boolean | string | number | Term | null>, languageOrDatatype?: string | NamedNode): AnyPointer<Literal, D>;
-    literal(values: Array<boolean | string | number | Term | null>, languageOrDatatype?: string | NamedNode): AnyPointer<Literal[], D>;
+    literal(value: SingleOrOneElementArray<boolean | string | number | Term | null> | AnyPointer<Literal, D>, languageOrDatatype?: string | NamedNode): AnyPointer<Literal, D>;
+    literal(values: Array<boolean | string | number | Term | null> | MultiPointer<Literal, D>, languageOrDatatype?: string | NamedNode): AnyPointer<Literal[], D>;
 
-    namedNode(value: SingleOrOneElementArray<string | NamedNode>): AnyPointer<NamedNode, D>;
-    namedNode(values: Array<string | NamedNode>): AnyPointer<NamedNode[], D>;
+    namedNode(value: SingleOrOneElementArray<string | NamedNode> | AnyPointer<NamedNode, D>): AnyPointer<NamedNode, D>;
+    namedNode(values: Array<string | NamedNode> | MultiPointer<NamedNode, D>): AnyPointer<NamedNode[], D>;
 
     in(predicates?: SingleOrArrayOfTerms<Term>): MultiPointer<T extends undefined ? never : NamedNode | BlankNode, D>;
     out(predicates?: SingleOrArrayOfTerms<Term>): MultiPointer<T extends undefined ? never : Term, D>;


### PR DESCRIPTION
The methods `node`/`blankNode`/`literal` all allow another pointer as argument

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
