### PR TITLE
[pcm-volume] add typing

### DIFF
--- a/types/pcm-volume/index.d.ts
+++ b/types/pcm-volume/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for pcm-volume 1.0
+// Project: https://github.com/reneraab/pcm-volume
+// Definitions by: Matthew Peveler <https://github.com/MasterOdin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import * as stream from "stream";
+
+declare class Volume extends stream.Transform {
+    setVolume(volume: number): void;
+}
+
+export = Volume;

--- a/types/pcm-volume/index.d.ts
+++ b/types/pcm-volume/index.d.ts
@@ -5,9 +5,9 @@
 
 /// <reference types="node" />
 
-import * as stream from "stream";
+import { Transform } from "stream";
 
-declare class Volume extends stream.Transform {
+declare class Volume extends Transform {
     setVolume(volume: number): void;
 }
 

--- a/types/pcm-volume/pcm-volume-tests.ts
+++ b/types/pcm-volume/pcm-volume-tests.ts
@@ -1,0 +1,16 @@
+import fs = require('fs');
+import Volume = require('pcm-volume');
+
+const readable = fs.createReadStream('music.pcm');
+const writable = fs.createWriteStream('final.pcm');
+
+// Create a volume instance
+const volume = new Volume();
+
+// Wait 5s, then change the volume to 50%
+setTimeout(() => {
+  volume.setVolume(0.5);
+}, 2000);
+
+readable.pipe(volume); // pipe PCM data to volume
+volume.pipe(writable); // pipe transformed PCM data to file

--- a/types/pcm-volume/tsconfig.json
+++ b/types/pcm-volume/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "pcm-volume-tests.ts"
+    ]
+}

--- a/types/pcm-volume/tslint.json
+++ b/types/pcm-volume/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Adds typing for the [pcm-volume](https://www.npmjs.com/package/pcm-volume) module.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.