### PR TITLE
add dom types to tsconfig

### DIFF
--- a/types/axios-token-interceptor/tsconfig.json
+++ b/types/axios-token-interceptor/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6", "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
axios-token-interceptor itself doesn't need DOM types, but axios, which is a dependency, does.