### PR TITLE
[@wordpress/data] Fix return type of `registerStore`

### DIFF
--- a/types/wordpress__data/index.d.ts
+++ b/types/wordpress__data/index.d.ts
@@ -96,7 +96,7 @@ export interface Store<S, A extends Action = Action> {
 }
 
 export function registerGenericStore(key: string, config: GenericStoreConfig): void;
-export function registerStore<T = {}>(key: string, config: StoreConfig<T>): void;
+export function registerStore<T = {}>(key: string, config: StoreConfig<T>): Store<T>;
 
 //
 // Registry

--- a/types/wordpress__data/wordpress__data-tests.tsx
+++ b/types/wordpress__data/wordpress__data-tests.tsx
@@ -13,6 +13,7 @@ interface FooBar {
     bar: number;
 }
 
+// $ExpectType Store<FooBar>
 data.registerStore<FooBar>('foo', {
     reducer(state = { foo: 'foo', bar: 21 }, action) {
         return state;

--- a/types/wordpress__data/wordpress__data-tests.tsx
+++ b/types/wordpress__data/wordpress__data-tests.tsx
@@ -13,7 +13,7 @@ interface FooBar {
     bar: number;
 }
 
-// $ExpectType Store<FooBar>
+// $ExpectType Store<FooBar, AnyAction>
 data.registerStore<FooBar>('foo', {
     reducer(state = { foo: 'foo', bar: 21 }, action) {
         return state;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.wordpress.org/block-editor/packages/packages-data/#registering-a-store
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

