### PR TITLE
[react-lazyload] add prop 'classNamePrefix'

### DIFF
--- a/types/react-lazyload/index.d.ts
+++ b/types/react-lazyload/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-lazyload ver 2.6
+// Type definitions for react-lazyload ver 3.0
 // Project: https://github.com/jasonslyvia/react-lazyload
 // Definitions by: m0a <https://github.com/m0a>
 //                 svobik7 <https://github.com/svobik7>
@@ -21,6 +21,7 @@ export interface LazyLoadProps {
     scrollContainer?: string | Element;
     unmountIfInvisible?: boolean;
     preventLoading?: boolean;
+    classNamePrefix?: string;
 }
 
 export default class LazyLoad extends Component<LazyLoadProps> {
@@ -30,3 +31,5 @@ export default class LazyLoad extends Component<LazyLoadProps> {
 export function lazyload(option: {}): LazyLoad;
 
 export function forceCheck(): void;
+
+export function forceVisible(): void;


### PR DESCRIPTION
Added prop 'classNamePrefix' and function `forceVisible` from new major version of react-lazyload. 
**Docs:** https://www.npmjs.com/package/react-lazyload#classnameprefix

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/react-lazyload#classnameprefix
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.