### PR TITLE
[sha256-file] Add types for sha256-file

### DIFF
--- a/types/sha256-file/index.d.ts
+++ b/types/sha256-file/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for sha256-file 1.0
+// Project: https://github.com/so-ta/sha256-file
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace sha256File {
+    type CallbackFunction = (error: Error | null, sum: string) => void;
+}
+
+declare function sha256File(filename: string, callback: sha256File.CallbackFunction): void;
+declare function sha256File(filename: string): string;
+
+export = sha256File;

--- a/types/sha256-file/sha256-file-tests.ts
+++ b/types/sha256-file/sha256-file-tests.ts
@@ -1,0 +1,8 @@
+import sha256File = require('sha256-file');
+
+sha256File('./path/to/a_file'); // $ExpectType string
+
+sha256File('./path/to/a_file', (error, sum) => {
+    error; // $ExpectType Error | null
+    sum; // $ExpectType string
+});

--- a/types/sha256-file/tsconfig.json
+++ b/types/sha256-file/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "sha256-file-tests.ts"
+    ]
+}

--- a/types/sha256-file/tslint.json
+++ b/types/sha256-file/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
