### PR TITLE
[speedtest-net] Add types for speedtest-net

### DIFF
--- a/types/speedtest-net/index.d.ts
+++ b/types/speedtest-net/index.d.ts
@@ -1,0 +1,223 @@
+// Type definitions for speedtest-net 2.1
+// Project: https://github.com/ddsol/speedtest.net#readme
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace exec {
+    type CancelFunction = (setCancelHandler?: symbol, newHandler?: () => void) => boolean | void;
+    type ProgressFunction = (event?: SpeedTestEvent) => void;
+
+    interface BaseEvent {
+        type: 'config' | 'log' | 'testStart' | 'ping' | 'download' | 'upload' | 'result';
+    }
+
+    /** Sent when the test is in the upload phase. */
+    interface UploadEvent extends BaseEvent {
+        /** Indicates the overall progress of the test as a fraction (0 to 1). */
+        progress: number;
+        timestamp: Date;
+        type: 'upload';
+        upload: DownloadUploadData;
+    }
+
+    interface DownloadEvent extends BaseEvent {
+        download: DownloadUploadData;
+        /** Indicates the overall progress of the test as a fraction (0 to 1). */
+        progress: number;
+        timestamp: Date;
+        type: 'download';
+    }
+
+    interface DownloadUploadData {
+        /** Bytes per second. */
+        bandwidth: number;
+        bytes: number;
+        elapsed: number;
+        /** Indicates the progress of the current test. */
+        progress?: number;
+    }
+
+    interface PingData {
+        /** Milliseconds */
+        jitter: number;
+        /** Milliseconds */
+        latency: number;
+        progress?: number;
+    }
+
+    /** Sent when the test is in the ping phase. */
+    interface PingEvent extends BaseEvent {
+        ping: PingData;
+        /** Indicates the overall progress of the test as a fraction (0 to 1). */
+        progress: number;
+        timestamp: Date;
+        type: 'ping';
+    }
+
+    interface SuiteData {
+        global: {
+            dynamic: {
+                download: {
+                    isScalingEnabled: boolean;
+                    maxThreadCount: number;
+                };
+                stableStop: {
+                    isEnabled: boolean;
+                };
+            };
+            engine: {
+                isUploadFirst: boolean;
+                packetSizeBytes: number;
+                testDurationSeconds: number;
+                threadCount: number;
+            };
+        };
+        testStage: {
+            latency: {
+                pingCount: number;
+            };
+            upload: {
+                isClientPrimaryMeasureMethod: boolean;
+                isServerUploadEnabled: boolean;
+            };
+        };
+    }
+
+    interface AppData {
+        ispName: string;
+        license: {
+            message: string;
+            version: string;
+        };
+        licenseKey: string;
+        resultFormat: string;
+        saveTestResultUrl: string;
+        traceLevel: number;
+    }
+
+    /**
+     * This event is only sent when the `verbosity` is 2 or greater. It contains
+     * a bunch of information about the test.
+     */
+    interface ConfigEvent extends BaseEvent {
+        app: AppData;
+        /** Indicates the overall progress of the test as a fraction (0 to 1). */
+        progress: number;
+        servers: ServerData[];
+        suite: SuiteData;
+        type: 'config';
+    }
+
+    /**
+     * These are various log messages. Only sent when `verbosity` is 1 or
+     * greater. Higher verbosity leads to more messages. That's all I know.
+     */
+    interface LogEvent extends BaseEvent {
+        /** Levels include `info` and `warning` and may include others. */
+        level: string;
+        message: string;
+        /** Indicates the overall progress of the test as a fraction (0 to 1). */
+        progress: number;
+        timestamp: Date;
+        type: 'log';
+    }
+
+    interface ResultEvent extends BaseEvent {
+        download: DownloadUploadData;
+        interface: InterfaceData;
+        isp: string;
+        packetLoss: number;
+        ping: PingData;
+        result: {
+            id: string;
+            url: string;
+        };
+        server: ServerData;
+        timestamp: Date;
+        type: 'result';
+        upload: DownloadUploadData;
+    }
+
+    interface InterfaceData {
+        externalIp: string;
+        internalIp: string;
+        isVpn: boolean;
+        macAddr: string;
+        name: string;
+    }
+
+    interface ServerData {
+        country: string;
+        host: string;
+        host_functional?: string;
+        id: number;
+        ip: string;
+        location: string;
+        name: string;
+        port: number;
+        sponsor?: string;
+    }
+
+    /** This contains information about the test to be run. */
+    interface TestStartEvent extends BaseEvent {
+        interface: InterfaceData;
+        isp: string;
+        /** Indicates the overall progress of the test as a fraction (0 to 1). */
+        progress: number;
+        server: ServerData;
+        timestamp: Date;
+        type: 'testStart';
+    }
+
+    type SpeedTestEvent =
+        | ConfigEvent
+        | DownloadEvent
+        | LogEvent
+        | PingEvent
+        | ResultEvent
+        | TestStartEvent
+        | UploadEvent;
+
+    interface Options {
+        /**
+         * Set to `true` to accept the Ookla GDPR terms. This must be done
+         * (at least) once on the system. If you have not accepted the Ookla
+         * GDPR terms you can read their disclaimer by running the speedtest-net
+         * CLI without the --accept-license option.
+         */
+        acceptGdpr?: boolean;
+        /**
+         * Set to `true` to accept the Ookla EULA, TOS and Privacy policy. This
+         * must be done (at least) once on the system. If you have not accepted
+         * the Ookla license terms, you can view the links to their agreements
+         * by running the speedtest-net CLI without the --accept-license option.
+         */
+        acceptLicense?: boolean;
+        /** Binary executable path of the Ookla speedtest CLI */
+        binary?: string;
+        /** Default '1.0.0' Binary executable version */
+        binaryVersion?: string;
+        /**
+         * A cancellation function created with `speedTest.makeCancel()` to
+         * cancel the test.
+         */
+        cancel?: CancelFunction;
+        /** Server host to connect to */
+        host?: string;
+        /** Function to handle progress events */
+        progress?: ProgressFunction;
+        /** ID of the server to restrict the tests against. */
+        serverId?: string;
+        /** IP of the network interface to bind */
+        sourceIp?: string;
+        /** Log level for `{ type: log }` progress events */
+        verbosity?: number;
+    }
+
+    function makeCancel(): CancelFunction;
+    const defaultBinaryVersion: string;
+}
+
+declare function exec(options?: exec.Options): Promise<exec.ResultEvent>;
+
+export = exec;

--- a/types/speedtest-net/speedtest-net-tests.ts
+++ b/types/speedtest-net/speedtest-net-tests.ts
@@ -1,0 +1,46 @@
+import speedTest = require('speedtest-net');
+
+speedTest().then(result => {
+    result;
+});
+
+const cancel = speedTest.makeCancel();
+const progress: speedTest.ProgressFunction = event => {
+    if (!event) return;
+
+    switch (event.type) {
+        case 'config': {
+            event.servers; // $ExpectType ServerData[]
+            break;
+        }
+        case 'download': {
+            event.timestamp; // $ExpectType Date
+            break;
+        }
+        case 'log': {
+            event.level; // $ExpectType string
+            break;
+        }
+        case 'ping': {
+            event.ping; // $ExpectType PingData
+            break;
+        }
+        case 'result': {
+            event.isp; // $ExpectType string
+            break;
+        }
+        case 'testStart': {
+            event.interface; // $ExpectType InterfaceData
+            break;
+        }
+        case 'upload': {
+            event.upload; // $ExpectType DownloadUploadData
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+};
+
+speedTest({ acceptLicense: true, acceptGdpr: true, cancel, progress });

--- a/types/speedtest-net/tsconfig.json
+++ b/types/speedtest-net/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "speedtest-net-tests.ts"
+    ]
+}

--- a/types/speedtest-net/tslint.json
+++ b/types/speedtest-net/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
