### PR TITLE
feat(linear-gradient-parser): new definition

### DIFF
--- a/types/linear-gradient-parser/index.d.ts
+++ b/types/linear-gradient-parser/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for linear-gradient-parser 1.1
+// Project: https://github.com/odedglas/linear-gradient-parser
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Transform a given linear gradient ( String or json ) into css background image property
+ * @param linearGradient - The linear gradient
+ */
+export function getBackground(linearGradient: string | LinearGradient): BackgroundResult;
+
+/**
+ * Builds a linear gradient position attributes for a given angle.
+ */
+export function getGradientCords(angle: number): GradientCoords;
+
+export interface Stop {
+    color: string;
+    opacity?: number;
+    offset: string | number;
+    style?: object;
+}
+
+export interface GradientCoords {
+    x1: string;
+    x2: string;
+    y1?: string;
+    y2?: string;
+}
+
+export interface LinearGradient extends GradientCoords {
+    stops: Stop[];
+    children?: Stop[];
+}
+
+export interface BackgroundResult {
+    background: string;
+    angle: number;
+}

--- a/types/linear-gradient-parser/linear-gradient-parser-tests.ts
+++ b/types/linear-gradient-parser/linear-gradient-parser-tests.ts
@@ -1,0 +1,27 @@
+import parser = require('linear-gradient-parser');
+
+// SVG String input
+const linearGradientString = `
+<linearGradient xmlns="http://www.w3.org/2000/svg" gradientUnits="userSpaceOnUse" x1="17.5001" y1="32" x2="17.5001" y2="2.9711">
+    <stop offset="0" style="stop-color:#FCB3A4"/>
+    <stop offset="1" style="stop-color:#DA5899"/>
+</linearGradient>
+`;
+
+parser.getBackground(linearGradientString); // $ExpectType BackgroundResult
+
+// JSON input test
+const linearGradient = {
+    x1: '17.5001',
+    y1: '32',
+    x2: '17.5001',
+    y2: '2.9711',
+    stops: [
+        { color: '#FCC3A4', offset: '0', opacity: 0.5 },
+        { color: '#AAA899', offset: '1' },
+    ],
+};
+
+parser.getBackground(linearGradient); // $ExpertType $BackgroundResult
+
+parser.getGradientCords(90); // $ExpectType GradientCoords

--- a/types/linear-gradient-parser/tsconfig.json
+++ b/types/linear-gradient-parser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "linear-gradient-parser-tests.ts"
+    ]
+}

--- a/types/linear-gradient-parser/tslint.json
+++ b/types/linear-gradient-parser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Definition types for linear-gradient-parser:
- definition type
- tests

https://github.com/odedglas/linear-gradient-parser
https://www.npmjs.com/package/linear-gradient-parser

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.