### PR TITLE
[airtable] Support optional error in eachPage `done`

### DIFF
--- a/types/airtable/index.d.ts
+++ b/types/airtable/index.d.ts
@@ -69,7 +69,7 @@ declare global {
         interface Query<TFields extends object> {
             all(): Promise<Records<TFields>>;
             firstPage(): Promise<Records<TFields>>;
-            eachPage(pageCallback: (records: Records<TFields>, next: () => void) => void): Promise<void>;
+            eachPage(pageCallback: (records: Records<TFields>, next: () => void) => void): Promise<string | null>;
         }
 
         interface Record<TFields> {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Airtable/airtable.js/blob/master/lib/query.js#L79
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

No tests for `eachPage` currently exist, but the change is so small that I don't want to figure out how to write them. I just want the type corrected for my personal project. The current tests all continue to pass.