### PR TITLE
feat(json-parse-helpfulerror): new definition

### DIFF
--- a/types/json-parse-helpfulerror/index.d.ts
+++ b/types/json-parse-helpfulerror/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for json-parse-helpfulerror 1.0
+// Project: https://github.com/smikes/json-parse-helpfulerror
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyp
+
+/**
+ * Converts a JavaScript Object Notation (JSON) string into an object.
+ * @param text A valid JSON string.
+ * @param reviver A function that transforms the results. This function is called for each member of the object.
+ * If a member contains nested objects, the nested objects are transformed before the parent object is.
+ */
+export function parse(text: string, reviver?: (this: any, key: string, value: any) => any): any;

--- a/types/json-parse-helpfulerror/json-parse-helpfulerror-tests.ts
+++ b/types/json-parse-helpfulerror/json-parse-helpfulerror-tests.ts
@@ -1,0 +1,38 @@
+import jph = require('json-parse-helpfulerror');
+import { parse } from 'json-parse-helpfulerror';
+
+const invalidJSON = "{'foo': 3}";
+const validJSON = '{"1": 1, "2": 2, "3": {"4": 4, "5": {"6": 6}}}';
+
+try {
+    JSON.parse(invalidJSON);
+} catch (error) {
+    //
+}
+try {
+    jph.parse(invalidJSON);
+} catch (error) {
+    //
+}
+try {
+    JSON.parse(validJSON, (key, value) => {
+        return value;
+    });
+} catch (error) {
+    //
+}
+
+try {
+    jph.parse(validJSON, (key, value) => {
+        return value;
+    });
+} catch (error) {
+    ///
+}
+try {
+    parse(validJSON, (key, value) => {
+        return value;
+    });
+} catch (error) {
+    //
+}

--- a/types/json-parse-helpfulerror/tsconfig.json
+++ b/types/json-parse-helpfulerror/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "json-parse-helpfulerror-tests.ts"
+    ]
+}

--- a/types/json-parse-helpfulerror/tslint.json
+++ b/types/json-parse-helpfulerror/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- definition file
- tests

https://www.npmjs.com/package/json-parse-helpfulerror
https://github.com/smikes/json-parse-helpfulerror#use

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.