### PR TITLE
markdown-to-jsx: add definition for `namedCodesToUnicode` and `disableParsingRawHTML`

### DIFF
--- a/types/markdown-to-jsx/index.d.ts
+++ b/types/markdown-to-jsx/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://probablyup.github.io/markdown-to-jsx
 // Definitions by: Elizabeth Craig <https://github.com/ecraig12345>
 //                 Sun Knudsen <https://github.com/sunknudsen>
+//                 Lasse Kuechler <https://github.com/lkuechler>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -80,6 +81,12 @@ export interface MarkdownOptions {
 
     /** Custom function to generate an HTML id from headings. */
     slugify?: (text: string) => string;
+
+    /** Override named html codes that should be converted to unicode characters. */
+    namedCodesToUnicode?: Record<string, string>;
+
+    /** By default, raw HTML is parsed to JSX. This behavior can be disabled with this option. */
+    disableParsingRawHTML?: boolean;
 }
 
 export function compiler(markdown: string, options?: MarkdownOptions): JSX.Element;

--- a/types/markdown-to-jsx/markdown-to-jsx-tests.tsx
+++ b/types/markdown-to-jsx/markdown-to-jsx-tests.tsx
@@ -145,3 +145,18 @@ render(
 # Header 1
 ## Header 2
 `}</Markdown>;
+
+<Markdown
+    options={{
+        namedCodesToUnicode: {
+            le: '\u2264',
+            ge: '\u2265',
+        },
+    }}
+>
+    This text is &le; than this text.
+</Markdown>;
+
+<Markdown options={{ disableParsingRawHTML: true }}>
+    {"This text has <span>html</span> in it but it won't be rendered"}
+</Markdown>;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/probablyup/markdown-to-jsx#optionsnamedcodestounicode
https://github.com/probablyup/markdown-to-jsx#optionsdisableparsingrawhtml
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
