### PR TITLE
ndjson: Update definitions to 2.0

### DIFF
--- a/types/ndjson/index.d.ts
+++ b/types/ndjson/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ndjson 1.5
+// Type definitions for ndjson 2.0
 // Project: https://github.com/maxogden/ndjson
 // Definitions by: Junxiao Shi <https://github.com/yoursunny>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -13,7 +13,5 @@ export interface ParseOptions {
 }
 
 export function parse(opts?: ParseOptions): ThroughStream;
-
-export function serialize(opts?: DuplexOptions): Transform;
 
 export function stringify(opts?: DuplexOptions): Transform;

--- a/types/ndjson/ndjson-tests.ts
+++ b/types/ndjson/ndjson-tests.ts
@@ -8,8 +8,7 @@ fs.createReadStream("data.txt")
   .pipe(parser)
   .on("data", (obj) => undefined);
 
-let serialize = ndjson.serialize();
-serialize = ndjson.stringify({ encoding: "ascii" });
-serialize.on("data", (line) => undefined);
-serialize.write({ foo: "bar" });
-serialize.end();
+const stream = ndjson.stringify({ encoding: "ascii" });
+stream.on("data", (line) => undefined);
+stream.write({ foo: "bar" });
+stream.end();


### PR DESCRIPTION
serialize was removed. It was an alias to stringify anyway.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Link](https://github.com/ndjson/ndjson.js/commit/dbc6ce28791930c85a0b724677543158df02aa34#diff-168726dbe96b3ce427e7fedce31bb0bc)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
