### PR TITLE
WIP: Lodash - fix type of castArray when value is undefined

### DIFF
--- a/types/lodash/common/lang.d.ts
+++ b/types/lodash/common/lang.d.ts
@@ -9,7 +9,23 @@ declare module "../index" {
          * @param value The value to inspect.
          * @return Returns the cast array.
          */
-        castArray<T>(value?: Many<T>): T[];
+        castArray<T>(value: Many<T>): T[];
+
+        /**
+         * @see _.castArray
+         */
+        castArray(value: undefined): [undefined];
+
+        /**
+         * @see _.castArray
+         */
+        castArray(): [];
+
+        /**
+         * @see _.castArray
+         */
+        castArray<T>(value: Many<T> | undefined): T[] | [undefined];
+
     }
 
     interface LoDashImplicitWrapper<TValue> {


### PR DESCRIPTION
This fixes the type of [Lodash `castArray`](https://lodash.com/docs/4.17.15#castArray) when the value is `undefined`. Following the example from the documentation:
```js
_.castArray(1);
// => [1]
 
_.castArray({ 'a': 1 });
// => [{ 'a': 1 }]
 
_.castArray('abc');
// => ['abc']
 
_.castArray(null);
// => [null]
 
_.castArray(undefined); // <--- this fixes this one here
// => [undefined]
 
_.castArray();
// => []
```

It has a different when the value is `undefined` and when it is not provided:

```tsx
function test(value?: string[]) {
  const result = castArray(value)
  //    ^ typed as `string[]` but should be `(string | undefined)[]`
}
```

### TODO

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.