### PR TITLE
Enhance langmap types

### DIFF
--- a/types/langmap/index.d.ts
+++ b/types/langmap/index.d.ts
@@ -1,11 +1,21 @@
 // Type definitions for langmap 0.0
 // Project: https://github.com/mozilla/language-mapping-list
 // Definitions by: Gábor Balogh <https://github.com/grabofus>
+//                 Remco Haszing <https://github.com/remcohaszing>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
-import { LanguageMappingList } from './types';
+declare const langmap: langmap.LanguageMappingList;
 
-declare const langmap: LanguageMappingList;
+declare namespace langmap {
+    interface Language {
+        englishName: string;
+        nativeName: string;
+    }
+
+    interface LanguageMappingList {
+        [language: string]: Language;
+    }
+}
 
 export = langmap;

--- a/types/langmap/langmap-tests.ts
+++ b/types/langmap/langmap-tests.ts
@@ -1,13 +1,12 @@
-// tslint:disable:no-duplicate-imports
+import * as langmap from 'langmap';
 
-import langmap1 from 'langmap';
-import * as langmap2 from 'langmap';
+// $ExpectType LanguageMappingList
+langmap;
 
-const val1 = langmap1['en-US']; // { nativeName: string, englishName: string }
-const val2 = langmap2['en-US']; // { nativeName: string, englishName: string }
+// $ExpectType Language
+const value = langmap['en-US'];
 
-val1.englishName;
-val1.nativeName;
-
-val2.englishName;
-val2.nativeName;
+// $ExpectType string
+value.englishName;
+// $ExpectType string
+value.nativeName;

--- a/types/langmap/tsconfig.json
+++ b/types/langmap/tsconfig.json
@@ -4,7 +4,6 @@
         "lib": [
             "es6"
         ],
-        "esModuleInterop": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/langmap/types.d.ts
+++ b/types/langmap/types.d.ts
@@ -1,8 +1,0 @@
-export interface Language {
-    englishName: string;
-    nativeName: string;
-}
-
-export interface LanguageMappingList {
-    [language: string]: Language;
-}


### PR DESCRIPTION
- Types are exported in the index, as `types.d.ts` doesn’t map to an existing JavaScript file.
- `esModuleInterop` was removed from `tsconfig.json` for correctness.
- Tests were changed not to use `esModuleInterop` and to use `$ExpectType` annotations.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mozilla/language-mapping-list
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.