### PR TITLE
[express] remove constraint that request params must be strings.

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -23,14 +23,13 @@ app.get<express.ParamsArray>('/*', req => {
     req.params.length; // $ExpectType number
 });
 
-// Params can be a custom type that conforms to constraint
-app.get<{ foo: string }>('/:foo', req => {
+// Params can be a custom type
+// NB. out-of-the-box all params are strings, however, other types are allowed to accomadate request validation/coersion middleware
+app.get<{ foo: string, bar: number }>('/:foo/:bar', req => {
     req.params.foo; // $ExpectType string
-    req.params.bar; // $ExpectError
+    req.params.bar; // $ExpectType number
+    req.params.baz; // $ExpectError
 });
-
-// Params cannot be a custom type that does not conform to constraint
-app.get<{ foo: number }>('/:foo', () => {}); // $ExpectError
 
 // Query can be a custom type
 app.get<{}, any, any, {q: string}>('/:foo', req => {

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -47,17 +47,17 @@ export interface ParamsDictionary { [key: string]: string; }
 export type ParamsArray = string[];
 export type Params = ParamsDictionary | ParamsArray;
 
-export interface RequestHandler<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = ParsedQs> {
+export interface RequestHandler<P = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = ParsedQs> {
     // tslint:disable-next-line callable-types (This is extended from and can't extend from a type alias in ts<2.2
     (req: Request<P, ResBody, ReqBody, ReqQuery>, res: Response<ResBody>, next: NextFunction): any;
 }
 
-export type ErrorRequestHandler<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = ParsedQs> =
+export type ErrorRequestHandler<P = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = ParsedQs> =
     (err: any, req: Request<P, ResBody, ReqBody, ReqQuery>, res: Response<ResBody>, next: NextFunction) => any;
 
 export type PathParams = string | RegExp | Array<string | RegExp>;
 
-export type RequestHandlerParams<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = ParsedQs>
+export type RequestHandlerParams<P = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = ParsedQs>
     = RequestHandler<P, ResBody, ReqBody, ReqQuery>
     | ErrorRequestHandler<P, ResBody, ReqBody, ReqQuery>
     | Array<RequestHandler<P>
@@ -65,9 +65,9 @@ export type RequestHandlerParams<P extends Params = ParamsDictionary, ResBody = 
 
 export interface IRouterMatcher<T, Method extends 'all' | 'get' | 'post' | 'put' | 'delete' | 'patch' | 'options' | 'head' = any> {
     // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
-    <P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = ParsedQs>(path: PathParams, ...handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery>>): T;
+    <P = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = ParsedQs>(path: PathParams, ...handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery>>): T;
     // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
-    <P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = ParsedQs>(path: PathParams, ...handlers: Array<RequestHandlerParams<P, ResBody, ReqBody, ReqQuery>>): T;
+    <P = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = ParsedQs>(path: PathParams, ...handlers: Array<RequestHandlerParams<P, ResBody, ReqBody, ReqQuery>>): T;
     (path: PathParams, subApplication: Application): T;
 }
 
@@ -217,7 +217,7 @@ export type Errback = (err: Error) => void;
  *     app.get<ParamsArray>(/user\/(.*)/, (req, res) => res.send(req.params[0]));
  *     app.get<ParamsArray>('/user/*', (req, res) => res.send(req.params[0]));
  */
-export interface Request<P extends Params = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = ParsedQs> extends http.IncomingMessage, Express.Request {
+export interface Request<P = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = ParsedQs> extends http.IncomingMessage, Express.Request {
     /**
      * Return request header.
      *

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -147,26 +147,27 @@ namespace express_tests {
         req.params.length; // $ExpectType number
     });
 
-    // Params can be a custom type that conforms to constraint
-    router.get<{ foo: string }>('/:foo', req => {
+    // Params can be a custom type
+    // NB. out-of-the-box all params are strings, however, other types are allowed to accomadate request validation/coersion middleware
+    router.get<{ foo: string, bar: number }>('/:foo/:bar', req => {
         req.params.foo; // $ExpectType string
-        req.params.bar; // $ExpectError
+        req.params.bar; // $ExpectType number
+        req.params.baz; // $ExpectError
     });
 
-    // Params can be a custom type that conforms to constraint and can be specified via an explicit param type (express-serve-static-core)
-    router.get('/:foo', (req: Request<{ foo: string }>) => {
+    // Params can be a custom type and can be specified via an explicit param type (express-serve-static-core)
+    router.get('/:foo/:bar', (req: Request<{ foo: string, bar: number }>) => {
         req.params.foo; // $ExpectType string
-        req.params.bar; // $ExpectError
+        req.params.bar; // $ExpectType number
+        req.params.baz; // $ExpectError
     });
 
-    // Params can be a custom type that conforms to constraint and can be specified via an explicit param type (express)
-    router.get('/:foo', (req: express.Request<{ foo: string }>) => {
+    // Params can be a custom type and can be specified via an explicit param type (express)
+    router.get('/:foo/:bar', (req: express.Request<{ foo: string, bar: number }>) => {
         req.params.foo; // $ExpectType string
-        req.params.bar; // $ExpectError
+        req.params.bar; // $ExpectType number
+        req.params.baz; // $ExpectError
     });
-
-    // Params cannot be a custom type that does not conform to constraint
-    router.get<{ foo: number }>('/:foo', () => {}); // $ExpectError
 
     // Query can be a custom type
     router.get('/:foo', (req: express.Request<{}, any, any , {q: string}>) => {

--- a/types/express/index.d.ts
+++ b/types/express/index.d.ts
@@ -95,7 +95,7 @@ declare namespace e {
     interface Application extends core.Application { }
     interface CookieOptions extends core.CookieOptions { }
     interface Errback extends core.Errback { }
-    interface ErrorRequestHandler<P extends core.Params = core.ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = core.Query>
+    interface ErrorRequestHandler<P = core.ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = core.Query>
         extends core.ErrorRequestHandler<P, ResBody, ReqBody, ReqQuery> { }
     interface Express extends core.Express { }
     interface Handler extends core.Handler { }
@@ -105,8 +105,8 @@ declare namespace e {
     interface IRouterMatcher<T> extends core.IRouterMatcher<T> { }
     interface MediaType extends core.MediaType { }
     interface NextFunction extends core.NextFunction { }
-    interface Request<P extends core.Params = core.ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = core.Query> extends core.Request<P, ResBody, ReqBody, ReqQuery> { }
-    interface RequestHandler<P extends core.Params = core.ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = core.Query> extends core.RequestHandler<P, ResBody, ReqBody, ReqQuery> { }
+    interface Request<P = core.ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = core.Query> extends core.Request<P, ResBody, ReqBody, ReqQuery> { }
+    interface RequestHandler<P = core.ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = core.Query> extends core.RequestHandler<P, ResBody, ReqBody, ReqQuery> { }
     interface RequestParamHandler extends core.RequestParamHandler { }
     export interface Response<ResBody = any> extends core.Response<ResBody> { }
     interface Router extends core.Router { }


### PR DESCRIPTION
Loosening this constraint was discussed in the [original PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37718#issuecomment-524028607) that added the generics, but it seems to never have happened.
cc: @OliverJAsh @Bene-Graham @davidje13 

It's possible that middleware is used that would make alterations to the request params and their types before the request handler is executed.
This changes allows for the manual/explicit defining in these cases, while maintaining the default of a `ParamsDictionary` for the standard use case.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [ ] **N/A** Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] **N/A** If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] **N/A** If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
