### PR TITLE
Added type definitions for addressparser

### DIFF
--- a/types/addressparser/addressparser-tests.ts
+++ b/types/addressparser/addressparser-tests.ts
@@ -1,0 +1,7 @@
+import addressparser = require('addressparser');
+
+const addresses = addressparser('andris <andris@tr.ee>');
+console.log(addresses); // [{name: "andris", address:"andris@tr.ee"}]
+
+const composers = addressparser('Composers:"Bach, Sebastian" <sebu@example.com>, mozart@example.com (Mozzie);');
+console.log(composers); // [{name: "Composers",group: [{address: "sebu@example.com",name: "Bach, Sebastian"},{address: "mozart@example.com",name: "Mozzie"}]}]

--- a/types/addressparser/index.d.ts
+++ b/types/addressparser/index.d.ts
@@ -1,0 +1,43 @@
+// Type definitions for addressparser 1.0
+// Project: https://github.com/nodemailer/addressparser
+// Definitions by: Anton Panov <https://github.com/risedphantom>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+/**
+ * Parses structured e-mail addresses from an address field
+ *
+ * Example:
+ *
+ *    'Name <address@domain>'
+ *
+ * will be converted to
+ *
+ *     [{name: 'Name', address: 'address@domain'}]
+ *
+ * @param str Address field
+ */
+declare function addressparser(str: string): addressparser.EmailAddress[];
+
+declare namespace addressparser {
+    /**
+     * Address details.
+     */
+    interface EmailAddress {
+        /**
+         * The email address.
+         */
+        address: string;
+        /**
+         * The name part of the email/group.
+         */
+        name: string;
+        /**
+         * An array of grouped addresses.
+         */
+        group?: EmailAddress[];
+    }
+}
+
+export = addressparser;

--- a/types/addressparser/tsconfig.json
+++ b/types/addressparser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "baseUrl": "../",
+    "typeRoots": [
+      "../"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts",
+    "addressparser-tests.ts"
+  ]
+}

--- a/types/addressparser/tslint.json
+++ b/types/addressparser/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
