### PR TITLE
Update type definitions for express-brute

### DIFF
--- a/types/express-brute/express-brute-tests.ts
+++ b/types/express-brute/express-brute-tests.ts
@@ -1,14 +1,34 @@
-import express = require("express");
-import ExpressBrute = require("express-brute");
+import express = require('express');
+import ExpressBrute = require('express-brute');
 
 var store = new ExpressBrute.MemoryStore();
-store = new ExpressBrute.MemoryStore({ prefix: "prefix" });
-store.set("key", "value", 0, (error: any) => { });
-store.get("key", (error: any, data: Object) => { });
-store.reset("key", (error: any) => { });
+store = new ExpressBrute.MemoryStore({ prefix: 'prefix' });
+store.set('key', 'value', 0, (error: any) => {});
+store.get('key', (error: any, data: Object) => {});
+store.reset('key', (error: any) => {});
 
 var app = express();
 var bruteforce = new ExpressBrute(store);
-app.post("/auth", bruteforce.prevent, (req, res, next) => {
-    res.send("Success!");
+app.post('/auth', bruteforce.prevent, (req, res, next) => {
+    res.send('Success!');
+});
+
+app.get(
+    '/expensive',
+    bruteforce.getMiddleware({
+        key(req, res, next) {
+            // prevent too many attempts for the same username
+            next(req.body.username);
+        },
+        failCallback: (req, res, next, nextValidRequestDate) => {
+            res.status(429).send(`Try again at ${nextValidRequestDate.toDateString()}`);
+        },
+    }),
+    (req, res, next) => {
+        res.send('Success!');
+    },
+);
+
+app.post('/expensive', bruteforce.getMiddleware({ failCallback: ExpressBrute.FailMark }), (req, res, next) => {
+    res.send('Success!');
 });


### PR DESCRIPTION
Most of these changes make the types more specific (e.g. `Function` -> `(req: express.Request, res: express.Response, next: express.NextFunction, nextValidRequestDate: Date) => void`).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/express-brute
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
