### PR TITLE
[@types/rdf-js] Make Term.equals() accept TermLike object instead of Term

### DIFF
--- a/types/rdf-js/index.d.ts
+++ b/types/rdf-js/index.d.ts
@@ -8,7 +8,6 @@
 
 /// <reference types="node" />
 
-import * as stream from "stream";
 import { EventEmitter } from "events";
 
 /* Data Model Interfaces */
@@ -23,6 +22,16 @@ import { EventEmitter } from "events";
  * @see DefaultGraph
  */
 export type Term = NamedNode | BlankNode | Literal | Variable | DefaultGraph;
+/**
+ * Contains an object which looks like an RDF/JS term to allow external Term extensions.
+ * @see Term
+ */
+export interface TermLike {
+    /**
+     * Contains string constant to distinguish different Term types.
+     */
+    readonly termType: string;
+}
 
 /**
  * Contains an IRI.
@@ -41,7 +50,7 @@ export interface NamedNode<Iri extends string = string> {
      * @param other The term to compare with.
      * @return True if and only if other has termType "NamedNode" and the same `value`.
      */
-    equals(other: Term | null | undefined): boolean;
+    equals(other: TermLike | null | undefined): boolean;
 }
 
 /**
@@ -64,7 +73,7 @@ export interface BlankNode {
      * @param other The term to compare with.
      * @return True if and only if other has termType "BlankNode" and the same `value`.
      */
-    equals(other: Term | null | undefined): boolean;
+    equals(other: TermLike | null | undefined): boolean;
 }
 
 /**
@@ -95,7 +104,7 @@ export interface Literal {
      * @return True if and only if other has termType "Literal"
      *                   and the same `value`, `language`, and `datatype`.
      */
-    equals(other: Term | null | undefined): boolean;
+    equals(other: TermLike | null | undefined): boolean;
 }
 
 /**
@@ -115,7 +124,7 @@ export interface Variable {
      * @param other The term to compare with.
      * @return True if and only if other has termType "Variable" and the same `value`.
      */
-    equals(other: Term | null | undefined): boolean;
+    equals(other: TermLike | null | undefined): boolean;
 }
 
 /**
@@ -136,7 +145,7 @@ export interface DefaultGraph {
      * @param other The term to compare with.
      * @return True if and only if other has termType "DefaultGraph".
      */
-    equals(other: Term | null | undefined): boolean;
+    equals(other: TermLike | null | undefined): boolean;
 }
 
 /**

--- a/types/rdf-js/rdf-js-tests.ts
+++ b/types/rdf-js/rdf-js-tests.ts
@@ -1,5 +1,5 @@
 import { BlankNode, DataFactory, Dataset, DatasetCore, DatasetCoreFactory, DatasetFactory, DefaultGraph, Literal,
-  NamedNode, Quad, BaseQuad, Sink, Source, Store, Stream, Term, Variable, Quad_Graph } from "rdf-js";
+  NamedNode, Quad, BaseQuad, Sink, Source, Store, Stream, Term, TermLike, Variable, Quad_Graph } from "rdf-js";
 import { EventEmitter } from "events";
 
 function test_terms() {
@@ -54,6 +54,24 @@ function test_terms() {
     let defaultGraphEqual: boolean = defaultGraph.equals(someTerm);
     defaultGraphEqual = defaultGraph.equals(null);
     defaultGraphEqual = defaultGraph.equals(undefined);
+}
+
+function test_customTermEquality() {
+    interface Wildcard {
+        termType: 'Wildcard';
+        value: '*';
+        equals(term: TermLike | null | undefined): boolean;
+    }
+
+    const wildcard: Wildcard = <any> {};
+    const iri: NamedNode = <any> {};
+    const term: Term = <any> {};
+
+    let wildcardEqual = wildcard.equals(wildcard);
+    wildcardEqual = wildcard.equals(iri);
+    wildcardEqual = iri.equals(wildcard);
+    wildcardEqual = wildcard.equals(term);
+    wildcardEqual = term.equals(wildcard);
 }
 
 function test_quads() {


### PR DESCRIPTION
Change `Term.equals()` signature to accept `TermLike` object instead of `Term`.
This allows RDF/JS-dependent projects to define custom term-like types
and keep equality comparison type-safe.

Example term-like type: `Wildcard` from SPARQL.js
https://github.com/RubenVerborgh/SPARQL.js/blob/master/lib/Wildcard.js

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Example term-like type: `Wildcard` from SPARQL.js: https://github.com/RubenVerborgh/SPARQL.js/blob/master/lib/Wildcard.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
