### PR TITLE
types for @fcostarodrigo/walk

### DIFF
--- a/types/fcostarodrigo__walk/fcostarodrigo__walk-tests.ts
+++ b/types/fcostarodrigo__walk/fcostarodrigo__walk-tests.ts
@@ -1,0 +1,29 @@
+import walk = require('@fcostarodrigo/walk');
+
+async function parameterless() {
+    for await (const file of walk()) {
+        const fileStr: string = file;
+    }
+}
+
+async function pathParam() {
+    for await (const file of walk('foo')) {
+        const fileStr: string = file;
+    }
+}
+
+async function filesAndDirs() {
+    for await (const file of walk('foo', true)) {
+        const fileStr: string = file;
+    }
+}
+
+async function withCallback() {
+    function shouldList(dir: string): boolean {
+        return true;
+    }
+
+    for await (const file of walk('foo', false, shouldList)) {
+        const fileStr: string = file;
+    }
+}

--- a/types/fcostarodrigo__walk/index.d.ts
+++ b/types/fcostarodrigo__walk/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for @fcostarodrigo/walk 5.0
+// Project: https://github.com/fcostarodrigo/walk#readme
+// Definitions by: tpluscode <https://github.com/tpluscode>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface Walk {
+    (path?: string, listFolders?: boolean, walkFolder?: (path: string) => boolean): AsyncIterable<string>;
+}
+
+declare const walk: Walk;
+
+export = walk;

--- a/types/fcostarodrigo__walk/tsconfig.json
+++ b/types/fcostarodrigo__walk/tsconfig.json
@@ -1,0 +1,29 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "esnext.asynciterable"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@fcostarodrigo/walk": [
+                "fcostarodrigo__walk"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "fcostarodrigo__walk-tests.ts"
+    ]
+}

--- a/types/fcostarodrigo__walk/tslint.json
+++ b/types/fcostarodrigo__walk/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
