### PR TITLE
types for buffer-to-stream

### DIFF
--- a/types/buffer-to-stream/buffer-to-stream-tests.ts
+++ b/types/buffer-to-stream/buffer-to-stream-tests.ts
@@ -1,0 +1,6 @@
+import toStream = require('buffer-to-stream');
+import { Readable } from 'stream';
+
+const fromString: Readable = toStream('foo');
+const fromBuffer: Readable = toStream(Buffer.from('foo'));
+const withChunkSize: Readable = toStream(Buffer.from('foo'), 30);

--- a/types/buffer-to-stream/index.d.ts
+++ b/types/buffer-to-stream/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for buffer-to-stream 1.0
+// Project: https://github.com/creeperyang/buffer-to-stream#readme
+// Definitions by: tpluscode <https://github.com/tpluscode>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import { Readable } from 'stream';
+
+interface ToStream {
+    (buffer: string | Buffer, chunkSize?: number): Readable;
+}
+
+declare const toStream: ToStream;
+
+export = toStream;

--- a/types/buffer-to-stream/tsconfig.json
+++ b/types/buffer-to-stream/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "buffer-to-stream-tests.ts"
+    ]
+}

--- a/types/buffer-to-stream/tslint.json
+++ b/types/buffer-to-stream/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
