### PR TITLE
[react-native-background-downloader] Add FAILED and STOPPED states

### DIFF
--- a/types/react-native-background-downloader/index.d.ts
+++ b/types/react-native-background-downloader/index.d.ts
@@ -26,6 +26,8 @@ export enum DownloadTaskState {
   DOWNLOADING = 'DOWNLOADING',
   PAUSED = 'PAUSED',
   DONE = 'DONE',
+  FAILED = 'FAILED',
+  STOPPED = 'STOPPED',
 }
 
 export interface DownloadTask {

--- a/types/react-native-background-downloader/react-native-background-downloader-tests.tsx
+++ b/types/react-native-background-downloader/react-native-background-downloader-tests.tsx
@@ -42,6 +42,13 @@ const taskFuncTest = (task: DownloadTask) => {
         console.log('Task is in state PAUSED');
         break;
       }
+      case DownloadTaskState.FAILED: {
+        console.log('Task is in state FAILED');
+        break;
+      }
+      case DownloadTaskState.STOPPED: {
+        console.log('Task is in state STOPPED');
+      }
     }
 
     // Pause the task


### PR DESCRIPTION
Add [`STOPPED`](https://github.com/EkoLabs/react-native-background-downloader/blob/dc07f4886004e37dede2ecfcf1a0014f7d51ef99/lib/downloadTask.js#L91) and [`FAILED`](https://github.com/EkoLabs/react-native-background-downloader/blob/dc07f4886004e37dede2ecfcf1a0014f7d51ef99/lib/downloadTask.js#L74) to the `DownloadTaskState` enum.

This is my first time contributing to DefinitelyTyped, and one thing I'm not clear on is if I need to bump the version for this change here in the PR or if that happens afterwards. Please let me know and I'd be happy to include that change here.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`STOPPED`](https://github.com/EkoLabs/react-native-background-downloader/blob/dc07f4886004e37dede2ecfcf1a0014f7d51ef99/lib/downloadTask.js#L91), [`FAILED`](https://github.com/EkoLabs/react-native-background-downloader/blob/dc07f4886004e37dede2ecfcf1a0014f7d51ef99/lib/downloadTask.js#L74)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.