### PR TITLE
feat(parse-conflict-json): new definition

### DIFF
--- a/types/parse-conflict-json/index.d.ts
+++ b/types/parse-conflict-json/index.d.ts
@@ -1,0 +1,36 @@
+// Type definitions for parse-conflict-json 1.1
+// Project: https://github.com/npm/parse-conflict-json#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference types="node" />
+
+/**
+ * Parse a JSON string that has git merge conflicts, resolving if possible.
+ * If the JSON is valid, it just does JSON.parse as normal.
+ * If either side of the conflict is invalid JSON, then an error is thrown for that.
+ */
+declare function parseConflictJSON(
+    text: string,
+    reviver?: (this: any, key: string, value: any) => any,
+    prefer?: parseConflictJSON.Prefer,
+): any;
+
+declare namespace parseConflictJSON {
+    /**
+     * returns true if the data looks like a conflicted diff file
+     */
+    function isDiff(text: string): boolean;
+
+    /**
+     * If prefer is set to theirs, then the vaules of theirs and ours are switched in the resolver function.
+     * (Ie, we'll apply their changes on top of our object, rather than the other way around.)
+     * Parse the conflicted file into 3 pieces: ours, theirs, and parent
+     * Get the diff from parent to ours.
+     * Apply each change of that diff to theirs.
+     * If any change in the diff set cannot be applied (ie, because they changed an object into a non-object and we changed a field on that object),
+     * then replace the object at the specified path with the object at the path in ours.
+     */
+    type Prefer = 'theirs' | 'ours';
+}
+
+export = parseConflictJSON;

--- a/types/parse-conflict-json/parse-conflict-json-tests.ts
+++ b/types/parse-conflict-json/parse-conflict-json-tests.ts
@@ -1,0 +1,12 @@
+import parseConflictJson = require('parse-conflict-json');
+import fs = require('fs');
+
+const data = fs.readFileSync('tsconfig.json', 'utf8');
+
+parseConflictJson.isDiff(data); // $ExpectType boolean
+parseConflictJson.isDiff(JSON.stringify({})); // $ExpectType boolean
+
+parseConflictJson(data); // $ExpectType any
+parseConflictJson(data, (name, value) => value); // $ExpectType any
+parseConflictJson(data, (name, value) => value, 'theirs'); // $ExpectType any
+parseConflictJson(data, (name, value) => value, 'ours'); // $ExpectType any

--- a/types/parse-conflict-json/tsconfig.json
+++ b/types/parse-conflict-json/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "parse-conflict-json-tests.ts"
+    ]
+}

--- a/types/parse-conflict-json/tslint.json
+++ b/types/parse-conflict-json/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Small module to work with JSON files:
- definition file
- tests

https://github.com/npm/parse-conflict-json
https://github.com/npm/parse-conflict-json#usage

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.