### PR TITLE
Pin ical's rrule dependency to 2.6.4

### DIFF
--- a/types/ical/package.json
+++ b/types/ical/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "rrule": ">=2.3.0"
+        "rrule": "2.6.4"
     }
 }


### PR DESCRIPTION
[rrule 2.6.5 is broken, so the authors deprecated it in favour of 2.6.4](https://www.npmjs.com/package/rrule)

Unblocks changes to ical.
