### PR TITLE
Fix html-webpack-plugin definition for templateContent

### DIFF
--- a/types/html-webpack-plugin/html-webpack-plugin-tests.ts
+++ b/types/html-webpack-plugin/html-webpack-plugin-tests.ts
@@ -78,6 +78,15 @@ const optionsArray: HtmlWebpackPlugin.Options[] = [
     {
         template: 'template.html'
     },
+    {
+        templateContent: false
+    },
+    {
+        templateContent: '<html></html>'
+    },
+    {
+        templateContent: () => '<html></html>'
+    },
     // Config from 'favicon' example
     {
         title: 'HtmlWebpackPlugin example',

--- a/types/html-webpack-plugin/index.d.ts
+++ b/types/html-webpack-plugin/index.d.ts
@@ -119,7 +119,7 @@ declare namespace HtmlWebpackPlugin {
          * Allow to use a html string instead of reading from a file.
          * Default: `false`, meaning the `template` option should be used instead.
          */
-        templateContent?: false | string | Promise<string>;
+        templateContent?: false | string | TemplateFunction;
         /**
          * Allows to overwrite the parameters used in the template.
          */


### PR DESCRIPTION
According to the package's documentation at https://github.com/jantimon/html-webpack-plugin#options, `templateContent` is allowed to be `{string|Function|false}` (quoting here), but the type definition was not reflecting that.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jantimon/html-webpack-plugin#options
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
