### PR TITLE
Add cast.debug types

### DIFF
--- a/types/chromecast-caf-receiver/cast.debug.d.ts
+++ b/types/chromecast-caf-receiver/cast.debug.d.ts
@@ -1,0 +1,79 @@
+import { LoggerLevel } from './cast.framework';
+
+export as namespace debug;
+
+/**
+ * The Web Receiver SDK provides another option for developers to easily debug your Web Receiver app by using CastDebugLogger API and a companion
+ * Command and Control (CaC) Tool to capture logs.
+ *
+ * Requires including the CAF Receiver Logger tag.
+ */
+export class CastDebugLogger {
+    static getInstance(): CastDebugLogger;
+
+    /**
+     * The loggerLevelByEvents config takes cast.framework.events.EventType and cast.framework.events.category to specify the events to be logged.
+     *
+     * @example
+     * ```ts
+     * cast.debug.CastDebugLogger.getInstance().loggerLevelByEvents = {
+     *   'cast.framework.events.category.CORE': cast.framework.LoggerLevel.INFO,
+     *   'cast.framework.events.EventType.MEDIA_STATUS': cast.framework.LoggerLevel.DEBUG
+     * }
+     * ```
+     */
+    loggerLevelByEvents: Record<string, LoggerLevel>;
+
+    /**
+     * You can control which messages appear on the debug overlay by setting the log level in loggerLevelByTags for each custom tag. For example,
+     * enabling a custom tag with log level cast.framework.LoggerLevel.DEBUG would display all messages added with error, warn, info, and debug
+     * log messages. Another example is that enabling a custom tag with WARNING level would only display error and warn log messages.
+     *
+     * The loggerLevelByTags config is optional. If a custom tag is not configured for its logger level, all log messages will display on the
+     * debug overlay.
+     */
+    loggerLevelByTags?: Record<string, LoggerLevel>;
+
+    /**
+     * Clear log messages on the overlay provided by CastDebugLogger.
+     */
+    clearDebugLogs(): void;
+
+    /**
+     * Enable debug logger and show a 'DEBUG MODE' overlay at top left corner.
+     *
+     * @example
+     * ```ts
+     * cast.debug.CastDebugLogger.getInstance().loggerLevelByEvents = {
+     *   'cast.framework.events.category.CORE': cast.framework.LoggerLevel.INFO,
+     *   'cast.framework.events.EventType.MEDIA_STATUS': cast.framework.LoggerLevel.DEBUG
+     * }
+     * ```
+     */
+    setEnabled(enabled: boolean): void;
+
+    /**
+     * Toggle the debug overlay provided by CastDebugLogger
+     */
+    showDebugLogs(show: boolean): void;
+
+    /**
+     * Log method. Lowest priority
+     */
+    debug(customTag: string, ...message: any[]): void;
+
+    /**
+     * Log method. Highest priority
+     */
+    error(customTag: string, ...message: any[]): void;
+
+    /**
+     * Log method. Third highest priority
+     */
+    info(customTag: string, ...message: any[]): void;
+
+    /**
+     * Log method. Second highest priority
+     */
+    warn(customTag: string, ...message: any[]): void;
+}

--- a/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
+++ b/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
@@ -3,10 +3,8 @@ import {
     LoadRequestData,
     StreamType,
     HlsSegmentFormat,
-    Track,
     TrackType,
     MessageType,
-    RequestData,
 } from 'chromecast-caf-receiver/cast.framework.messages';
 import { DetailedErrorCode, EventType } from 'chromecast-caf-receiver/cast.framework.events';
 
@@ -145,12 +143,10 @@ cast.framework.CastReceiverContext.getInstance().addEventListener(
 );
 
 // send custom message to specific sender
-cast.framework.CastReceiverContext.getInstance()
-    .sendCustomMessage('custom-namespace', 'sender-id', {});
+cast.framework.CastReceiverContext.getInstance().sendCustomMessage('custom-namespace', 'sender-id', {});
 
 // broadcast custom message to all connected senders
-cast.framework.CastReceiverContext.getInstance()
-    .sendCustomMessage('custom-namespace', undefined, {});
+cast.framework.CastReceiverContext.getInstance().sendCustomMessage('custom-namespace', undefined, {});
 
 const loadingError = new cast.framework.events.ErrorEvent(DetailedErrorCode.LOAD_FAILED, 'Loading failed!');
 
@@ -186,3 +182,20 @@ cast.framework.CastReceiverContext.getInstance()
     .addEventListener(cast.framework.events.EventType.BITRATE_CHANGED, bitrateChangedEvent => {
         const bitrate = bitrateChangedEvent.totalBitrate;
     });
+
+// CastDebugLogger
+const debugLogger = cast.debug.CastDebugLogger.getInstance();
+
+debugLogger.loggerLevelByEvents = {
+    'cast.framework.events.category.CORE': cast.framework.LoggerLevel.WARNING,
+};
+
+debugLogger.setEnabled(true);
+
+debugLogger.showDebugLogs(true);
+
+debugLogger.error(
+    'REPORTING',
+    'Track could not be reported',
+    cast.framework.CastReceiverContext.getInstance().getPlayerManager().getMediaInformation(),
+);

--- a/types/chromecast-caf-receiver/index.d.ts
+++ b/types/chromecast-caf-receiver/index.d.ts
@@ -6,6 +6,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
+/// <reference path="./cast.debug.d.ts" />
 /// <reference path="./cast.framework.d.ts" />
 /// <reference path="./cast.framework.breaks.d.ts" />
 /// <reference path="./cast.framework.events.d.ts" />
@@ -13,6 +14,7 @@
 /// <reference path="./cast.framework.system.d.ts" />
 /// <reference path="./cast.framework.ui.d.ts" />
 
+import * as debug from './cast.debug';
 import * as framework from './cast.framework';
 import { PlayerDataChangedEvent } from './cast.framework.ui';
 import { Event as SystemEvent } from './cast.framework.system';
@@ -40,10 +42,13 @@ import {
 } from './cast.framework.events';
 
 export as namespace cast;
-export { framework };
+export { debug, framework };
 
 declare global {
-    const cast: { framework: typeof framework };
+    const cast: {
+        debug: typeof debug;
+        framework: typeof framework;
+    };
 
     type EventHandler = (event: Event) => void;
     type SystemEventHandler = (event: SystemEvent) => void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/cast/docs/debugging/cast_debug_logger
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

Though the use of cast.debug requires a new tag, I saw no way to extend the definition of `global.cast` if both type packages were used. Also, it is not possible to use the logger without using the receiver.
