### PR TITLE
add types for package jsreport

### DIFF
--- a/types/jsreport/index.d.ts
+++ b/types/jsreport/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for jsreport 2.9
+// Project: https://github.com/jsreport/jsreport
+// Definitions by: pofider <https://github.com/jsreport>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// import all availible types for jsreport included extensions
+import JsReportChromePdf = require('jsreport-chrome-pdf');
+import JsReportJsRender = require('jsreport-jsrender');
+import JReportHtmlToXlsx = require('jsreport-html-to-xlsx');
+import JsReportXlsx = require('jsreport-xlsx');
+
+// just reexport types from core
+import JsReport = require('jsreport-core');
+export = JsReport;

--- a/types/jsreport/index.d.ts
+++ b/types/jsreport/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for jsreport 2.9
 // Project: https://github.com/jsreport/jsreport
-// Definitions by: pofider <https://github.com/jsreport>
+// Definitions by: pofider <https://github.com/pofider>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // import all availible types for jsreport included extensions

--- a/types/jsreport/jsreport-tests.ts
+++ b/types/jsreport/jsreport-tests.ts
@@ -1,0 +1,26 @@
+import JsReport = require('jsreport');
+import fs = require('fs');
+
+const jsreport = JsReport();
+
+jsreport.beforeRenderListeners.add('test', (req, res) => {
+    console.log('input', req.template.content);
+});
+
+(async () => {
+    await jsreport.init();
+    await jsreport.documentStore.collection('settings').update({}, { $set: { foo: 1 } });
+    const res = await jsreport.render({
+        template: {
+            content: "<h1>{{foo}}</h1>",
+            engine: 'handlebars',
+            recipe: 'chrome-pdf',
+            chrome: {
+                landscape: true
+            }
+        },
+        data: { foo: "hello2" }
+    });
+    fs.writeFileSync('./types/test/test.pdf', res.content);
+    process.exit(0);
+})();

--- a/types/jsreport/tsconfig.json
+++ b/types/jsreport/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jsreport-tests.ts"
+    ]
+}

--- a/types/jsreport/tslint.json
+++ b/types/jsreport/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
