### PR TITLE
feat(find-duplicated-property-keys): new definition

### DIFF
--- a/types/find-duplicated-property-keys/find-duplicated-property-keys-tests.ts
+++ b/types/find-duplicated-property-keys/find-duplicated-property-keys-tests.ts
@@ -1,0 +1,14 @@
+import findDuplicatedPropertyKeys = require('find-duplicated-property-keys');
+
+const jsonString = '{"name": "Carl", "name": "Carla", "data": 1, "data": [{ "data": 1, "data": 2}]}';
+
+const result = findDuplicatedPropertyKeys(jsonString); // $ExpectType PropertyInfo[]
+
+result.forEach(item => {
+    item.isArray; // $ExpectgType boolean
+    item.key; // $ExpecgtType string
+    item.occurrence; // $ExpectType number
+    item.parent; // $ExpectType PropertyInfo
+    item.propertyPath; // $ExpectType () => string[]
+    item.toString(); // $ExpectType string
+});

--- a/types/find-duplicated-property-keys/index.d.ts
+++ b/types/find-duplicated-property-keys/index.d.ts
@@ -1,0 +1,46 @@
+// Type definitions for find-duplicated-property-keys 1.1
+// Project: https://github.com/SebastianG77/find-duplicated-property-keys#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * A package for detecting all duplicated property keys of a JSON string.
+ * It can either be used as a standalone tool for validating JSON files or as a submodule for other Node.js projects.
+ */
+declare function findDuplicatedPropertyKeys(content: string): findDuplicatedPropertyKeys.PropertyInfo[];
+
+declare namespace findDuplicatedPropertyKeys {
+    interface PropertyInfo {
+        /**
+         *  The key name of the duplicated property
+         */
+        key: string;
+
+        /**
+         * The parent object of a property key
+         */
+        parent: PropertyInfo;
+
+        /**
+         * The number of property keys having the same key and parent object
+         */
+        occurrence: number;
+        /**
+         * Is this property an array
+         */
+        isArray: boolean;
+
+        /**
+         * Returns a list of property keys, which represents the path to the property key of the current object.
+         */
+        propertyPath(): string[];
+
+        /**
+         * Prints the path to the property key. However, since all necessary raw data are also contained by the object,
+         * the result objects can also be represented in any other way if desired.
+         */
+        toString(): string;
+    }
+}
+
+export = findDuplicatedPropertyKeys;

--- a/types/find-duplicated-property-keys/tsconfig.json
+++ b/types/find-duplicated-property-keys/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "find-duplicated-property-keys-tests.ts"
+    ]
+}

--- a/types/find-duplicated-property-keys/tslint.json
+++ b/types/find-duplicated-property-keys/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Definition types for JSON utility
- definition file
- tests

https://github.com/SebastianG77/find-duplicated-property-keys
https://www.npmjs.com/package/find-duplicated-property-keys

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.