### PR TITLE
feat(dashdash): new definition

### DIFF
--- a/types/dashdash/dashdash-tests.ts
+++ b/types/dashdash/dashdash-tests.ts
@@ -1,0 +1,191 @@
+/// <reference types="node" />
+import dashdash = require('dashdash');
+import path = require('path');
+import { format } from 'util';
+
+// api
+const options = [
+    {
+        name: 'version',
+        type: 'bool',
+        help: 'Print tool version and exit.',
+    },
+    {
+        names: ['help', 'h'],
+        type: 'bool',
+        help: 'Print this help and exit.',
+    },
+    {
+        names: ['verbose', 'v'],
+        type: 'arrayOfBool',
+        help: 'Verbose output. Use multiple times for more verbose.',
+    },
+    {
+        names: ['file', 'f'],
+        type: 'string',
+        help: 'File to process',
+        helpArg: 'FILE',
+    },
+];
+
+let opts = dashdash.parse({ options });
+
+console.log('opts:', opts);
+console.log('args:', opts._args);
+
+const parser = dashdash.createParser({ options });
+try {
+    opts = parser.parse(process.argv);
+} catch (e) {
+    console.error('foo: error: %s', e.message);
+    process.exit(1);
+}
+
+console.log('# opts:', opts);
+console.log('# args:', opts._args);
+
+if (opts.help) {
+    const help = parser.help({ includeEnv: true }).trimRight();
+    console.log(`usage: node foo.js [OPTIONS]
+options:
+${help}`);
+    process.exit(0);
+}
+
+/** custom-option-arrayOfCommaSepString.js */ (() => {
+    function parseCommaSepStringNoEmpties(option: any, optstr: any, arg: string) {
+        return arg
+            .trim()
+            .split(/\s*,\s*/g)
+            .filter(part => part);
+    }
+
+    dashdash.addOptionType({
+        name: 'commaSepString',
+        takesArg: true,
+        helpArg: 'STRING',
+        parseArg: parseCommaSepStringNoEmpties,
+    });
+
+    dashdash.addOptionType({
+        name: 'arrayOfCommaSepString',
+        takesArg: true,
+        helpArg: 'STRING',
+        parseArg: parseCommaSepStringNoEmpties,
+        array: true,
+        arrayFlatten: true,
+    });
+
+    const options = [
+        { names: ['single', 's'], type: 'commaSepString' },
+        { names: ['multi', 'm'], type: 'arrayOfCommaSepString' },
+    ];
+
+    try {
+        const opts = dashdash.parse({ options });
+    } catch (e) {
+        console.error('%s: error: %s', path.basename(process.argv[1]), e.message);
+        process.exit(1);
+    }
+
+    console.log('opts.single (-s): %j', opts.single);
+    console.log('opts.multi (-m): %j', opts.multi);
+})();
+
+/** custom-option-duration.js */ (() => {
+    const durationRe = /^([1-9]\d*)([smhd])$/;
+    function parseDuration(option: any, optstr: string, arg: string) {
+        const match = durationRe.exec(arg);
+        if (!match) {
+            throw new Error(format('arg for "%s" is not a valid duration: "%s"', optstr, arg));
+        }
+        const num = parseInt(match[1], 10);
+        const scope = match[2];
+        let t = 0;
+        switch (scope) {
+            case 's':
+                t += num * 1000;
+                break;
+            case 'm':
+                t += num * 60 * 1000;
+                break;
+            case 'h':
+                t += num * 60 * 60 * 1000;
+                break;
+            case 'd':
+                t += num * 24 * 60 * 60 * 1000;
+                break;
+        }
+        return t;
+    }
+
+    dashdash.addOptionType({
+        name: 'duration',
+        takesArg: true,
+        helpArg: 'DURATION',
+        parseArg: parseDuration,
+    });
+
+    const options = [{ names: ['time', 't'], type: 'duration' }];
+
+    try {
+        const opts = dashdash.parse({ options });
+    } catch (e) {
+        console.error('%s: error: %s', path.basename(process.argv[1]), e.message);
+        process.exit(1);
+    }
+
+    if (opts.time) {
+        console.log('duration: %d ms', opts.time);
+    }
+})();
+
+/** custom-option-fruit.js  */ (() => {
+    const fruits = ['apple', 'pear', 'cherry', 'strawberry', 'banana'];
+    function parseFruit(option: any, optstr: string, arg: string) {
+        if (fruits.indexOf(arg) === -1) {
+            throw new Error(format('arg for "%s" is not a known fruit: "%s"', optstr, arg));
+        }
+        return arg;
+    }
+
+    dashdash.addOptionType({
+        name: 'fruit',
+        takesArg: true,
+        helpArg: 'FRUIT',
+        parseArg: parseFruit,
+        default: 'apple',
+    });
+
+    const options = [
+        {
+            names: ['help', 'h'],
+            type: 'bool',
+            help: 'Print this help and exit.',
+        },
+        { names: ['pie', 'p'], type: 'fruit', env: 'FRUIT' },
+    ];
+
+    const parser = dashdash.createParser({ options });
+    try {
+        const opts = parser.parse(process.argv);
+    } catch (e) {
+        console.error('%s: error: %s', path.basename(process.argv[1]), e.message);
+        process.exit(1);
+    }
+
+    if (opts.help) {
+        const help = parser
+            .help({
+                includeEnv: true,
+                includeDefault: true,
+            })
+            .trimRight();
+        console.log(`usage: node custom-option-fruit.js [OPTIONS]
+options:
+${help}`);
+        process.exit(0);
+    }
+
+    console.log('pie fruit: %s', opts.pie);
+})();

--- a/types/dashdash/index.d.ts
+++ b/types/dashdash/index.d.ts
@@ -1,0 +1,342 @@
+// Type definitions for dashdash 1.14
+// Project: https://github.com/trentm/node-dashdash#readme
+// Definitions by: Adam Voss <https://github.com/adamvoss>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export class Parser {
+    /**  Allow interspersed arguments. @default true */
+    interpersed: boolean;
+
+    /** Don't allow unknown flags. @default true */
+    allowUnknown: boolean;
+
+    constructor(config: ParserConfiguration);
+
+    /**  Return a string suitable for a Bash completion file for this tool. */
+    bashCompletion(args: BashCompletionConfiguration): string;
+
+    /**
+     * Return help output for the current options.
+     *
+     * E.g.: if the current options are:
+     *      [{names: ['help', 'h'], type: 'bool', help: 'Show help and exit.'}]
+     * then this would return:
+     *      '  -h, --help     Show help and exit.\n'
+     */
+    help(config?: HelpConfiguration): string;
+
+    /** Parse options from the given argv. */
+    parse(inputs?: string[] | ParsingConfiguration): Results;
+}
+
+/**
+ * Add a new option type.
+ */
+export function addOptionType(optionType: OptionType): void;
+
+export function bashCompletionFromOptions(args: BashCompletionConfiguration): string;
+
+export function bashCompletionSpecFromOptions(args: BashCompletionSpecConfiguration): string;
+
+export function createParser(config: ParserConfiguration): Parser;
+
+export function getOptionType(name: string): OptionType;
+
+/**
+ * Parse argv with the given options.
+ *
+ * @param config A merge of all the available fields from
+ *      `dashdash.Parser` and `dashdash.Parser.parse`: options, interspersed,
+ *      argv, env, slice.
+ */
+export function parse(config: ParsingConfiguration): Results;
+
+export interface Results {
+    [key: string]: any;
+    _order: Arg[];
+    _args: string[];
+}
+
+export interface Arg {
+    name: string;
+    value: any;
+    from: string;
+}
+
+/**
+ * Return a synopsis string for the given option spec.
+ *
+ * Examples:
+ *      > synopsisFromOpt({names: ['help', 'h'], type: 'bool'});
+ *      '[ --help | -h ]'
+ *      > synopsisFromOpt({name: 'file', type: 'string', helpArg: 'FILE'});
+ *      '[ --file=FILE ]'
+ */
+export function synopsisFromOpt(o: Option): string;
+
+export type Option = OptionWithoutAliases | OptionWithAliases;
+
+export interface ParsingConfiguration {
+    /**
+     * The argv to parse. Defaults to `process.argv`.
+     */
+    argv?: string[];
+
+    /**
+     * The index into argv at which options/args begin.  Default is 2, as appropriate for `process.argv`.
+     */
+    slice?: number;
+
+    /**
+     * The env to use for 'env' entries in the option specs. Defaults to `process.env`.
+     */
+    env?: any; // NodeJS.ProcessEnv;
+
+    options?: Array<Option | Group>;
+}
+
+export interface ParserConfiguration {
+    /**
+     * Array of option specs.
+     */
+    options: Array<Option | Group>;
+
+    /**
+     * Whether to throw on unknown options.
+     * If false, then unknown args are included in the _args array.
+     * Default: false
+     */
+    allowUnknown?: boolean;
+
+    /**
+     * Whether to allow interspersed arguments (non-options) and options.
+     *
+     * E.g.:
+     *   node tool.js arg1 arg2 -v
+     *
+     * '-v' is after some args here. If `interspersed: false` then '-v'
+     *  would not be parsed out. Note that regardless of `interspersed`
+     * the presence of '--' will stop option parsing, as all good
+     * option parsers should.
+     *
+     * Default: true
+     */
+    interspersed?: boolean;
+}
+
+export interface OptionWithoutAliases extends OptionBase {
+    /**
+     * The option name
+     */
+    name: string;
+}
+
+export interface OptionWithAliases extends OptionBase {
+    /**
+     * The option name and aliases. The first name (if more than one given) is the key for the parsed `opts` object.
+     */
+    names: string[];
+}
+
+export interface OptionBase {
+    /**
+     * One of: bool, string, number, integer, positiveInteger, arrayOfBool, arrayOfString,
+     * arrayOfNumber, arrayOfInteger, arrayOfPositiveInteger, arrayOfDate,
+     * date (epoch seconds, e.g. 1396031701, or ISO 8601 format YYYY-MM-DD[THH:MM:SS[.sss][Z]], e.g. "2014-03-28T18:35:01.489Z").
+     * You can add your own custom option types with `dashdash.addOptionType`
+     * These names attempt to match with asserts on `assert-plus`.
+     */
+    type: string;
+
+    /**
+     * This is used for Bash completion for an option argument.
+     * If not specified, then the value of type is used. Any string may be specified, but only the following values have meaning:
+     *  - none: Provide no completions.
+     *  - file: Bash's default completion (i.e. complete -o default), which includes filenames.
+     *  - Any string FOO for which a function complete_FOO Bash function is defined.
+     * This is for custom completions for a given tool.
+     * Typically these custom functions are provided in the specExtra argument to dashdash.bashCompletionFromOptions().
+     */
+    completionType?: string;
+
+    /**
+     * An environment variable name (or names) that can be used as a fallback for this option.
+     * An environment variable is only used as a fallback, i.e. it is ignored if the associated option is given in `argv`.
+     */
+    env?: string | string[];
+
+    /**
+     * Used for parser.help() output.
+     */
+    help?: string;
+
+    /**
+     * Used in help output as the placeholder for the option argument.
+     */
+    helpArg?: string;
+
+    /**
+     * Set this to false to have that option's help not be text wrapped in <parser>.help() output.
+     */
+    helpWrap?: boolean;
+
+    /**
+     * A default value used for this option, if the option isn't specified in argv.
+     */
+    default?: string;
+
+    /**
+     * If true, help output will not include this option.
+     */
+    hidden?: boolean;
+}
+
+export interface Group {
+    group: string;
+}
+
+export interface OptionType {
+    name: string;
+    /**
+     * Whether this type of option takes an
+     * argument on process.argv. Typically this is true for all but the
+     * "bool" type.
+     */
+    takesArg: boolean;
+    /**
+     * Required iff `takesArg === true`. The string to show in generated help for options of this type.
+     */
+    helpArg?: string;
+    /**
+     * parser that takes a string argument and returns an instance of the
+     * appropriate type, or throws an error if the arg is invalid.
+     */
+    parseArg(option: Option, optstr: string, arg: string): any;
+    /**
+     * Set to true if this is an 'arrayOf' type
+     * that collects multiple usages of the option in process.argv and puts results in an array.
+     */
+    array?: boolean;
+    arrayFlatten?: boolean;
+    /**
+     * Default value for options of this type, if no default is specified in the option type usage.
+     */
+    default?: any;
+    completionType?: any;
+}
+
+export interface BashCompletionConfiguration {
+    /**
+     * The tool name.
+     */
+    name: string;
+
+    /**
+     * The array of dashdash option specs.
+     */
+    options?: Array<Option | Group>;
+
+    /**
+     * Extra Bash code content to add
+     * to the end of the "spec". Typically this is used to append Bash
+     * "complete_TYPE" functions for custom option types.
+     */
+    specExtra?: string;
+
+    /**
+     * Array of completion types for positional args (i.e. non-options).
+     * If not given, positional args will use Bash's 'default' completion.
+     */
+    argtypes?: string[];
+}
+
+export interface BashCompletionSpecConfiguration {
+    /**
+     * The array of dashdash option specs.
+     */
+    options: Array<Option | Group>;
+
+    /**
+     * A context string for the "local cmd*"
+     * vars in the spec. By default it is the empty string. When used to
+     * scope for completion on a *sub-command*.
+     */
+    context?: string;
+
+    /**
+     * By default
+     * hidden options and subcmds are "excluded". Here excluded means they
+     * won't be offered as a completion, but if used, their argument type
+     * will be completed. "Hidden" options and subcmds are ones with the
+     * `hidden: true` attribute to exclude them from default help output.
+     */
+    includeHidden?: boolean;
+
+    /**
+     * Array of completion types for positional args (i.e. non-options).
+     * If not given, positional args will use Bash's 'default' completion.
+     */
+    argtypes?: string[];
+}
+
+export interface HelpConfiguration {
+    /**
+     * Set to a number (for that many spaces) or a string for the literal indent.
+     * Default: 4
+     */
+    indent?: number | string;
+
+    /**
+     * Set to a number (for that many spaces) or a string for the literal indent.
+     * This indent applies to group heading lines, between normal option lines.
+     * Default: half length of `indent`
+     */
+    headingIndent?: number | string;
+
+    /**
+     * By default the names are sorted to put the short opts first (i.e. '-h, --help' preferred to '--help, -h').
+     * Set to 'none' to not do this sorting.
+     * Default: 'length'
+     */
+    nameSort?: string;
+
+    /**
+     * Note that reflow is just done on whitespace so a long token in the option help can overflow maxCol.
+     * Default: 80
+     */
+    maxCol?: number;
+
+    /**
+     * If not set a reasonable value will be determined between minHelpCol and maxHelpCol.
+     */
+    helpCol?: number;
+
+    /**
+     * Default: 20
+     */
+    minHelpCol?: number;
+
+    /**
+     * Default: 40
+     */
+    maxHelpCol?: number;
+
+    /**
+     * Set to `false` to have option `help` strings not be textwrapped to the helpCol..maxCol range.
+     * Default: true
+     */
+    helpWrap?: boolean;
+
+    /**
+     * If the option has associated environment variables (via the env option spec attribute), then append mentioned of those envvars to the help string.
+     * Default: false
+     */
+    includeEnv?: boolean;
+
+    /**
+     * If the option has a default value (via the default option spec attribute, or a default on the option's type), then a "Default: VALUE" string will be appended to the help string.
+     * Default: false
+     */
+    includeDefault?: boolean;
+}

--- a/types/dashdash/tsconfig.json
+++ b/types/dashdash/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "dashdash-tests.ts"
+    ]
+}

--- a/types/dashdash/tslint.json
+++ b/types/dashdash/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Definition types for node-dashdash package:
- definition file
- types

Shout to original author @adamvoss

https://github.com/trentm/node-dashdash
https://github.com/trentm/node-dashdash#usage

Thanks!

Closes: trentm/node-dashdash#37

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.