### PR TITLE
office.js, office-js-preview, copy new APIs to release

### DIFF
--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -885,7 +885,7 @@ declare namespace Office {
          *
          * @remarks
          *
-         * **Requirement set**: TBD
+         * **Requirement set**: DialogApi 1.2
          *
          * You can add multiple event handlers for the specified event type as long as the name of each event handler function is unique.
          *
@@ -1684,8 +1684,6 @@ declare namespace Office {
         /**
          * Delivers a message from the host page, such as a task pane or a UI-less function file, to a dialog that was opened from the page.
          *
-         * @beta
-         *
          * @remarks
          *
          * **Requirement set**: TBD
@@ -1934,8 +1932,6 @@ declare namespace Office {
         DialogMessageReceived,
         /**
          * Triggers when a host page sends a message to a child dialog box with `messageChild`.
-         *
-         * @beta
          */
         DialogParentMessageReceived,
         /**

--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -5121,8 +5121,6 @@ declare namespace Office {
     /**
      * Provides information about the message from the parent page that raised the `DialogParentMessageReceived` event.
      *
-     * @beta
-     *
      * To add an event handler for the `DialogParentMessageReceived` event, use the `addHandlerAsync` method of the
      * {@link Office.UI} object.
      *

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -477,6 +477,101 @@ declare namespace Office {
         value: T;
     }
     /**
+     * Message used in the `onVisibilityModeChanged` invocation.
+     */
+    interface VisibilityModeChangedMessage {
+        /**
+         * Visibility changed state.
+         */
+        visibilityMode: Office.VisibilityMode;
+    }
+    /**
+     * Function type to turn off the event.
+     */
+    type RemoveEventListener = () => Promise<void>;
+    /**
+     * Represents add-in level functionality for operating or configuring various aspects of the add-in.
+     */
+    interface Addin {
+        /**
+         * Sets the startup behavior for the add-in for when the document is opened next time.
+         * @param behavior - Specifies startup behavior of the add-in.
+         */
+        setStartupBehavior(behavior: Office.StartupBehavior): Promise<void>;
+        /**
+         * Gets the current startup behavior for the add-in.
+         */
+        getStartupBehavior(): Promise<Office.StartupBehavior>;
+        /**
+         * Shows the task pane associated with the add-in.
+         * @returns A promise that is resolved when the UI is shown.
+         */
+        showAsTaskpane(): Promise<void>;
+        /**
+         * Hides the task pane.
+         * @returns A promise that is resolved when the UI is hidden.
+         */
+        hide(): Promise<void>;
+        /**
+         * Adds a listener for the `onVisbilityModeChanged` event.
+         * @param listener - The listener function that is called when the event is emitted. This function takes in a message for the receiving component.
+         * @returns A promise that resolves when the listener is added.
+         */
+        onVisibilityModeChanged(
+            listener: (message: VisibilityModeChangedMessage) => void,
+        ): Promise<RemoveEventListener>;
+    }
+    /**
+     * An interface that contains all the functionality provided to manage the state of the OFfice ribbon.
+     */
+    interface Ribbon {
+        /**
+         * Sends a request to Office to update the ribbon.
+         * Note that this API is only to request an update. The actual UI update to the ribbon is controlled by the Office application and hence the exact timing of the ribbon update (or refresh) cannot be determined by the completion of this API.
+         * @param input - Represents the updates to be made to the ribbon. Note that only the changes specified in the input parameter are made.
+         */
+        requestUpdate(input: RibbonUpdaterData): Promise<void>;
+    }
+    /**
+     * Specifies changes to the ribbon, such as the enabled or disabled status of a button.
+     */
+    interface RibbonUpdaterData {
+        /**
+         * Collection of tabs whose state is set with the call of `requestUpdate`.
+         */
+        tabs: Tab[];
+    }
+    /**
+     * Represents an individual tab and the state it should have.
+     */
+    interface Tab {
+        /**
+         * Identifier of the tab as specified in the manifest.
+         */
+        id: string;
+        /**
+         * Specifies the controls in the tab, such as menu items, buttons, etc.
+         */
+        controls?: Control[];
+    }
+    /**
+     * Represents an individual control or command and the state it should have.
+     */
+    interface Control {
+        /**
+         * Identifier of the control as specified in the manifest.
+         */
+        id: string;
+        /**
+         * Indicates whether the control should be visible or hidden. The default is true.
+         */
+        visible?: boolean;
+        /**
+         * Indicates whether the control should be enabled or disabled. The default is true.
+         */
+        enabled?: boolean;
+    } 	
+    /**
      * Represents the runtime environment of the add-in and provides access to key objects of the API. 
      * The current context exists as a property of Office. It is accessed using `Office.context`.
      *
@@ -737,6 +832,23 @@ declare namespace Office {
      * for more information.
      */
     interface UI {
+        /**
+         * Adds an event handler to the object using the specified event type.
+         *
+         * @beta
+         *
+         * @remarks
+         *
+         * **Requirement set**: DialogApi 1.2
+         *
+         * You can add multiple event handlers for the specified event type as long as the name of each event handler function is unique.
+         *
+         * @param eventType Specifies the type of event to add. This must be `Office.EventType.DialogParentMessageReceived`.
+         * @param handler The event handler function to add, whose only parameter is of type {@link Office.DialogParentMessageReceivedEventArgs}.
+         * @param options Optional. Provides an option for preserving context data of any type, unchanged, for use in a callback.
+         * @param callback Optional. A function that is invoked when the handler registration returns, whose only parameter is of type {@link Office.AsyncResult}.
+         */
+        addHandlerAsync(eventType: Office.EventType, handler: (result: DialogParentMessageReceivedEventArgs) => void, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
         * Displays a dialog to show or collect information from the user or to facilitate Web navigation.
         *
@@ -1523,6 +1635,16 @@ declare namespace Office {
          */
         addEventHandler(eventType: Office.EventType, handler: (args: {message: string | boolean} | {error: number}) => void): void;
         /**
+         * Delivers a message from the host page, such as a task pane or a UI-less function file, to a dialog that was opened from the page.
+         *
+         * @remarks
+         *
+         * **Requirement set**: DialogApi 1.2
+         *
+         * @param message Accepts a message from the host page to deliver to the dialog. Anything that can be serialized to a string, including JSON and XML, can be sent.
+         */
+        messageChild(message: string): void;
+        /**
          * FOR INTERNAL USE ONLY. DO NOT CALL IN YOUR CODE.
          */
         sendMessage(name: string): void;
@@ -1761,6 +1883,10 @@ declare namespace Office {
          * Triggers when a dialog sends a message via `messageParent`.
          */
         DialogMessageReceived,
+        /**
+         * Triggers when a host page sends a message to a child dialog box with `messageChild`.
+         */
+        DialogParentMessageReceived,
         /**
          * Triggers when a document-level selection happens.
          * 

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -477,72 +477,45 @@ declare namespace Office {
         value: T;
     }
     /**
-     * Message used in the `onVisibilityModeChanged` invocation.
-     */
-    interface VisibilityModeChangedMessage {
-        /**
-         * Visibility changed state.
-         */
-        visibilityMode: Office.VisibilityMode;
-    }
-    /**
-     * Function type to turn off the event.
-     */
-    type RemoveEventListener = () => Promise<void>;
-    /**
-     * Represents add-in level functionality for operating or configuring various aspects of the add-in.
-     */
-    interface Addin {
-        /**
-         * Sets the startup behavior for the add-in for when the document is opened next time.
-         * @param behavior - Specifies startup behavior of the add-in.
-         */
-        setStartupBehavior(behavior: Office.StartupBehavior): Promise<void>;
-        /**
-         * Gets the current startup behavior for the add-in.
-         */
-        getStartupBehavior(): Promise<Office.StartupBehavior>;
-        /**
-         * Shows the task pane associated with the add-in.
-         * @returns A promise that is resolved when the UI is shown.
-         */
-        showAsTaskpane(): Promise<void>;
-        /**
-         * Hides the task pane.
-         * @returns A promise that is resolved when the UI is hidden.
-         */
-        hide(): Promise<void>;
-        /**
-         * Adds a listener for the `onVisbilityModeChanged` event.
-         * @param listener - The listener function that is called when the event is emitted. This function takes in a message for the receiving component.
-         * @returns A promise that resolves when the listener is added.
-         */
-        onVisibilityModeChanged(
-            listener: (message: VisibilityModeChangedMessage) => void,
-        ): Promise<RemoveEventListener>;
-    }
-    /**
-     * An interface that contains all the functionality provided to manage the state of the OFfice ribbon.
+     * An interface that contains all the functionality provided to manage the state of the Office ribbon.
+	 *
+	 * @remarks
+     *
+     * **Requirement set**: Ribbon 1.1
      */
     interface Ribbon {
         /**
          * Sends a request to Office to update the ribbon.
+		 *
+		 * @remarks
+         *
+         * **Requirement set**: Ribbon 1.1
+		 *
          * Note that this API is only to request an update. The actual UI update to the ribbon is controlled by the Office application and hence the exact timing of the ribbon update (or refresh) cannot be determined by the completion of this API.
+		 *
          * @param input - Represents the updates to be made to the ribbon. Note that only the changes specified in the input parameter are made.
          */
         requestUpdate(input: RibbonUpdaterData): Promise<void>;
     }
     /**
      * Specifies changes to the ribbon, such as the enabled or disabled status of a button.
+	 *
+	 * @remarks
+     *
+     * **Requirement set**: Ribbon 1.1
      */
     interface RibbonUpdaterData {
         /**
          * Collection of tabs whose state is set with the call of `requestUpdate`.
-         */
+		 */
         tabs: Tab[];
     }
     /**
      * Represents an individual tab and the state it should have.
+	 *
+	 * @remarks
+     *
+     * **Requirement set**: Ribbon 1.1
      */
     interface Tab {
         /**
@@ -556,6 +529,10 @@ declare namespace Office {
     }
     /**
      * Represents an individual control or command and the state it should have.
+	 *
+	 * @remarks
+     *
+     * **Requirement set**: Ribbon 1.1
      */
     interface Control {
         /**
@@ -834,8 +811,6 @@ declare namespace Office {
     interface UI {
         /**
          * Adds an event handler to the object using the specified event type.
-         *
-         * @beta
          *
          * @remarks
          *

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -5037,6 +5037,23 @@ declare namespace Office {
         type: EventType;
     }
     /**
+     * Provides information about the message from the parent page that raised the `DialogParentMessageReceived` event.
+     *
+     * To add an event handler for the `DialogParentMessageReceived` event, use the `addHandlerAsync` method of the
+     * {@link Office.UI} object.
+     *
+     */
+    interface DialogParentMessageReceivedEventArgs {
+        /**
+         * Gets the content of the message sent from the parent page, which can be any string or stringified data.
+         */
+        message: string;
+        /**
+         * Get an {@link Office.EventType} enumeration value that identifies the kind of event that was raised.
+         */
+        type: EventType;
+    }
+    /**
      * Represents a slice of a document file. The Slice object is accessed with the `File.getSliceAsync` method.
      */
     interface Slice {

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -476,6 +476,7 @@ declare namespace Office {
         */
         value: T;
     }
+	
     /**
      * An interface that contains all the functionality provided to manage the state of the Office ribbon.
 	 *


### PR DESCRIPTION
Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://review.docs.microsoft.com/en-us/office/dev/add-ins/reference/requirement-sets/ribbon-api-requirement-sets?branch=enable-disable-partial-GA and https://review.docs.microsoft.com/en-us/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets?branch=master
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
