### PR TITLE
Plotly.js: Add multi-axis support to all x and y references

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -798,12 +798,10 @@ export interface Shape {
     layer: 'below' | 'above';
     type: 'rect' | 'circle' | 'line' | 'path';
     path: string;
-    // x-reference is assigned to the x-values
-    xref: 'x' | 'paper';
+    xref: 'paper' | 'x' | 'x2' | 'x3' | 'x4' | 'x5' | 'x6' | 'x7' | 'x8' | 'x9';
     xsizemode: 'scaled' | 'pixel';
     xanchor: number | string;
-    // y-reference is assigned to the plot paper [0,1]
-    yref: 'paper' | 'y';
+    yref: 'paper' | 'y' | 'y2' | 'y3' | 'y4' | 'y5' | 'y6' | 'y7' | 'y8' | 'y9';
     ysizemode: 'scaled' | 'pixel';
     yanchor: number | string;
     x0: Datum;
@@ -1726,7 +1724,7 @@ export interface Annotations extends Label {
      * for trendline annotations which should continue to indicate
      * the correct trend when zoomed.
      */
-    axref: 'pixel';
+    axref: 'pixel' | 'x' | 'x2' | 'x3' | 'x4' | 'x5' | 'x6' | 'x7' | 'x8' | 'x9';
 
     /**
      * Indicates in what terms the tail of the annotation (ax,ay)
@@ -1736,7 +1734,7 @@ export interface Annotations extends Label {
      * for trendline annotations which should continue to indicate
      * the correct trend when zoomed.
      */
-    ayref: 'pixel';
+    ayref: 'pixel' | 'y' | 'y2' | 'y3' | 'y4' | 'y5' | 'y6' | 'y7' | 'y8' | 'y9';
 
     /**
      * Sets the annotation's x coordinate axis.
@@ -1745,7 +1743,7 @@ export interface Annotations extends Label {
      * the left side of the plotting area in normalized coordinates
      * where 0 (1) corresponds to the left (right) side.
      */
-    xref: 'paper' | 'x';
+    xref: 'paper' | 'x' | 'x2' | 'x3' | 'x4' | 'x5' | 'x6' | 'x7' | 'x8' | 'x9';
 
     /**
      * Sets the annotation's x position.
@@ -1780,7 +1778,7 @@ export interface Annotations extends Label {
      * the bottom of the plotting area in normalized coordinates
      * where 0 (1) corresponds to the bottom (top).
      */
-    yref: 'paper' | 'y';
+    yref: 'paper' | 'y' | 'y2' | 'y3' | 'y4' | 'y5' | 'y6' | 'y7' | 'y8' | 'y9';
 
     /**
      * Sets the annotation's y position.
@@ -1863,8 +1861,8 @@ export interface Image {
     y: number | string;
     xanchor: 'left' | 'center' | 'right';
     yanchor: 'top' | 'middle' | 'bottom';
-    xref: 'paper' | 'x';
-    yref: 'paper' | 'y';
+    xref: 'paper' | 'x' | 'x2' | 'x3' | 'x4' | 'x5' | 'x6' | 'x7' | 'x8' | 'x9';
+    yref: 'paper' | 'y' | 'y2' | 'y3' | 'y4' | 'y5' | 'y6' | 'y7' | 'y8' | 'y9';
 }
 
 export interface Scene {

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -741,25 +741,11 @@ export type Calendar =
     | 'thai'
     | 'ummalqura';
 
-export type AxisName =
-    | 'x'
-    | 'x2'
-    | 'x3'
-    | 'x4'
-    | 'x5'
-    | 'x6'
-    | 'x7'
-    | 'x8'
-    | 'x9'
-    | 'y'
-    | 'y2'
-    | 'y3'
-    | 'y4'
-    | 'y5'
-    | 'y6'
-    | 'y7'
-    | 'y8'
-    | 'y9';
+export type XAxisName = 
+    | 'x' | 'x2' | 'x3' | 'x4' | 'x5' | 'x6' | 'x7' | 'x8' | 'x9' | 'x10' | 'x11';
+export type YAxisName =
+    | 'y' | 'y2' | 'y3' | 'y4' | 'y5' | 'y6' | 'y7' | 'y8' | 'y9' | 'y10' | 'y11';
+export type AxisName = XAxisName | YAxisName;
 
 export interface LayoutAxis extends Axis {
     fixedrange: boolean;
@@ -798,10 +784,10 @@ export interface Shape {
     layer: 'below' | 'above';
     type: 'rect' | 'circle' | 'line' | 'path';
     path: string;
-    xref: 'paper' | 'x' | 'x2' | 'x3' | 'x4' | 'x5' | 'x6' | 'x7' | 'x8' | 'x9';
+    xref: 'paper' | XAxisName;
     xsizemode: 'scaled' | 'pixel';
     xanchor: number | string;
-    yref: 'paper' | 'y' | 'y2' | 'y3' | 'y4' | 'y5' | 'y6' | 'y7' | 'y8' | 'y9';
+    yref: 'paper' | YAxisName;
     ysizemode: 'scaled' | 'pixel';
     yanchor: number | string;
     x0: Datum;
@@ -1724,7 +1710,7 @@ export interface Annotations extends Label {
      * for trendline annotations which should continue to indicate
      * the correct trend when zoomed.
      */
-    axref: 'pixel' | 'x' | 'x2' | 'x3' | 'x4' | 'x5' | 'x6' | 'x7' | 'x8' | 'x9';
+    axref: 'pixel' | XAxisName;
 
     /**
      * Indicates in what terms the tail of the annotation (ax,ay)
@@ -1734,7 +1720,7 @@ export interface Annotations extends Label {
      * for trendline annotations which should continue to indicate
      * the correct trend when zoomed.
      */
-    ayref: 'pixel' | 'y' | 'y2' | 'y3' | 'y4' | 'y5' | 'y6' | 'y7' | 'y8' | 'y9';
+    ayref: 'pixel' | YAxisName;
 
     /**
      * Sets the annotation's x coordinate axis.
@@ -1743,7 +1729,7 @@ export interface Annotations extends Label {
      * the left side of the plotting area in normalized coordinates
      * where 0 (1) corresponds to the left (right) side.
      */
-    xref: 'paper' | 'x' | 'x2' | 'x3' | 'x4' | 'x5' | 'x6' | 'x7' | 'x8' | 'x9';
+    xref: 'paper' | XAxisName;
 
     /**
      * Sets the annotation's x position.
@@ -1778,7 +1764,7 @@ export interface Annotations extends Label {
      * the bottom of the plotting area in normalized coordinates
      * where 0 (1) corresponds to the bottom (top).
      */
-    yref: 'paper' | 'y' | 'y2' | 'y3' | 'y4' | 'y5' | 'y6' | 'y7' | 'y8' | 'y9';
+    yref: 'paper' | YAxisName;
 
     /**
      * Sets the annotation's y position.
@@ -1861,8 +1847,8 @@ export interface Image {
     y: number | string;
     xanchor: 'left' | 'center' | 'right';
     yanchor: 'top' | 'middle' | 'bottom';
-    xref: 'paper' | 'x' | 'x2' | 'x3' | 'x4' | 'x5' | 'x6' | 'x7' | 'x8' | 'x9';
-    yref: 'paper' | 'y' | 'y2' | 'y3' | 'y4' | 'y5' | 'y6' | 'y7' | 'y8' | 'y9';
+    xref: 'paper' | XAxisName;
+    yref: 'paper' | YAxisName;
 }
 
 export interface Scene {

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -741,7 +741,7 @@ export type Calendar =
     | 'thai'
     | 'ummalqura';
 
-export type XAxisName = 
+export type XAxisName =
     | 'x' | 'x2' | 'x3' | 'x4' | 'x5' | 'x6' | 'x7' | 'x8' | 'x9' | 'x10' | 'x11';
 export type YAxisName =
     | 'y' | 'y2' | 'y3' | 'y4' | 'y5' | 'y6' | 'y7' | 'y8' | 'y9' | 'y10' | 'y11';


### PR DESCRIPTION
Plotly.js Shapes, Annotations, and Images can reference any x or y axis but currently Definitely Typed only supports the first axis. I'm not sure if Plotly.js supports >10 axes, but I figure 10 should be enough for almost all use cases.


A few references:
https://plotly.com/javascript/reference/layout/shapes/#layout-shapes-items-shape-xref
https://plotly.com/javascript/reference/layout/annotations/#layout-annotations-items-annotation-axref
https://plotly.com/javascript/reference/layout/images/#layout-images-items-image-yref