### PR TITLE
[express-serve-static-core]: (re)fix listen callback type (#35883)"

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -2,7 +2,7 @@ import * as express from 'express-serve-static-core';
 
 const app: express.Application = {} as any;
 app.listen(3000);
-app.listen(3000, (err: any) => {
+app.listen(3000, () => {
     // no-op error callback
 });
 

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -5,7 +5,6 @@
 //                 Kacper Polak <https://github.com/kacepe>
 //                 Satana Charuwichitratana <https://github.com/micksatana>
 //                 Sami Jaber <https://github.com/samijaber>
-//                 aereal <https://github.com/aereal>
 //                 Jose Luis Leon <https://github.com/JoseLion>
 //                 David Stephens <https://github.com/dwrss>
 //                 Shin Ando <https://github.com/andoshin11>
@@ -1029,11 +1028,11 @@ export interface Application extends EventEmitter, IRouter, Express.Application 
      *    http.createServer(app).listen(80);
      *    https.createServer({ ... }, app).listen(443);
      */
-    listen(port: number, hostname: string, backlog: number, callback?: (...args: any[]) => void): http.Server;
-    listen(port: number, hostname: string, callback?: (...args: any[]) => void): http.Server;
-    listen(port: number, callback?: (...args: any[]) => void): http.Server;
-    listen(callback?: (...args: any[]) => void): http.Server;
-    listen(path: string, callback?: (...args: any[]) => void): http.Server;
+    listen(port: number, hostname: string, backlog: number, callback?: () => void): http.Server;
+    listen(port: number, hostname: string, callback?: () => void): http.Server;
+    listen(port: number, callback?: () => void): http.Server;
+    listen(callback?: () => void): http.Server;
+    listen(path: string, callback?: () => void): http.Server;
     listen(handle: any, listeningListener?: () => void): http.Server;
 
     router: string;


### PR DESCRIPTION
# Description
_TL;DR: This reverts commit 34f4572c07bc123202555cd3879bef26c53da2b2._

## The `listen` callback arguments argument
In the mentioned commit, arguments to the callback function argument on the `app.prototype.listen` method were added. The `app.prototype.listen`,  as the docs of express say, is passing arguments directly to Node.js `http` server `.listen`.  But turns out that since the beginning of Node.js, that callback does not receive anything as arguments:

* [`node` server types specify this callback without arguments](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/net.d.ts#L185-L193)
* [Listening callback registered on `.listen`](https://github.com/nodejs/node/blob/v14.8.0/lib/net.js#L1406)
* [Listening event emitted](https://github.com/nodejs/node/blob/v14.8.0/lib/net.js#L1350)

Then, in order to prevent devs think that they will receive arguments in that callback (like for instance an error object) when actually no arguments to that callback are sent, I think it should be better to remove those non existing arguments from the type definitions.

## How to catch errors on `listen`
To catch errors raised on listening, as the docs say, you have to register a listener for the 'error' event in the created server

https://nodejs.org/api/net.html#net_server_listen

In that callback, you'll have the `error` object describing what happened as the argument

## Discussion
More context:
https://github.com/DefinitelyTyped/DefinitelyTyped/commit/34f4572c07bc123202555cd3879bef26c53da2b2

## Credits
Thanks to @tsimbalar for raising this issue in a project which lead to this discovery

# Checks
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/commit/34f4572c07bc123202555cd3879bef26c53da2b2
- **N/A** If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.