### PR TITLE
[googlemaps] Improve type annotation for addDomListener 

### DIFF
--- a/types/googlemaps/reference/event.d.ts
+++ b/types/googlemaps/reference/event.d.ts
@@ -5,10 +5,17 @@ declare namespace google.maps {
          * calling removeListener(handle) for the handle that is returned by this
          * function.
          */
-        function addDomListener(
+        function addDomListener<K extends keyof DocumentEventMap>(
             instance: object,
-            eventName: string,
-            handler: (event: Event) => void,
+            eventName: K,
+            handler: (event: DocumentEventMap[K]) => void,
+            capture?: boolean,
+        ): MapsEventListener;
+
+        function addDomListener<K extends keyof WindowEventMap>(
+            instance: object,
+            eventName: K,
+            handler: (event: WindowEventMap[K]) => void,
             capture?: boolean,
         ): MapsEventListener;
 
@@ -16,10 +23,17 @@ declare namespace google.maps {
          * Wrapper around addDomListener that removes the listener after the first
          * event.
          */
-        function addDomListenerOnce(
+        function addDomListenerOnce<K extends keyof DocumentEventMap>(
             instance: object,
-            eventName: string,
-            handler: (event: Event) => void,
+            eventName: K,
+            handler: (event: DocumentEventMap[K]) => void,
+            capture?: boolean,
+        ): MapsEventListener;
+
+        function addDomListenerOnce<K extends keyof WindowEventMap>(
+            instance: object,
+            eventName: K,
+            handler: (event: WindowEventMap[K]) => void,
             capture?: boolean,
         ): MapsEventListener;
 

--- a/types/googlemaps/test/reference/event-tests.ts
+++ b/types/googlemaps/test/reference/event-tests.ts
@@ -1,0 +1,15 @@
+import event = google.maps.event;
+
+event.addDomListener({}, 'click', (e: MouseEvent) => {
+    e; // $ExpectType MouseEvent
+});
+
+event.addDomListener({}, 'keydown', (e: KeyboardEvent) => {
+    e; // $ExpectType KeyboardEvent
+});
+
+event.addDomListener({}, 'load', (e: Event) => {
+    e; // $ExpectType Event
+});
+
+export {};

--- a/types/googlemaps/test/reference/event-tests.ts
+++ b/types/googlemaps/test/reference/event-tests.ts
@@ -1,14 +1,14 @@
 import event = google.maps.event;
 
-event.addDomListener({}, 'click', (e: MouseEvent) => {
+event.addDomListener({}, 'click', (e) => {
     e; // $ExpectType MouseEvent
 });
 
-event.addDomListener({}, 'keydown', (e: KeyboardEvent) => {
+event.addDomListener({}, 'keydown', (e) => {
     e; // $ExpectType KeyboardEvent
 });
 
-event.addDomListener({}, 'load', (e: Event) => {
+event.addDomListener({}, 'load', (e) => {
     e; // $ExpectType Event
 });
 

--- a/types/googlemaps/tsconfig.json
+++ b/types/googlemaps/tsconfig.json
@@ -20,6 +20,7 @@
     "files": [
         "index.d.ts",
         "test/reference/info-window-tests.ts",
+        "test/reference/event-tests.ts",
         "test/reference/max-zoom-tests.ts",
         "googlemaps-tests.ts"
     ]


### PR DESCRIPTION
# Reason

When using `google.maps.event.addDomListener` and specifying a particular eventName, e.g. `keydown`, an error is shown if we type the function as 

```ts
    google.maps.event.addDomListener(
      someThing,
      "keydown",
      (event: KeyboardEvent) => {
        if (event.code === "Enter" || event.code === "Space") {
          ...
        }
      }
    );

```

This is because currently [google.maps.event.addDomListener](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/googlemaps/reference/event.d.ts#L11) types it as `Event`. 

My understanding of this is because a function of `KeyboardEvent => void` is not a subtype of `Event => void`. 

Google maps documentation specifies that `addDomListener` listener [handles it according
to the browser's DOM event model](https://developers.google.com/maps/documentation/javascript/events).

So I looked at how typescript solves it for [addEventListeners within lib.dom.ts](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L4880), I think we can use a similar approach.

# Housekeeping 
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - [google maps documentation](https://developers.google.com/maps/documentation/javascript/events)
   - [example lib.dom.ts addEventListener](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L4880)
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

# Problems/Questions

1. Lint is failing for me for another file within `googlemaps` unrelated to my changes (even on the master branch)
![Screen Shot 2020-08-27 at 9 24 07 am](https://user-images.githubusercontent.com/3787885/91381671-4da49d80-e86b-11ea-80b1-adcc3f9accd5.png)

❓ Should I raise an issue for this? Or maybe it's just failing on my machine

2. Based on the Google Map docs, I've opted to use the [DocumentEventMap](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L4404-L4411) and [WindowEventMap](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L18331-L18429). I _think_ this should cover the use cases for users using `addDomListener`, but am happy to be corrected.

3. Any other concerns/things I should do, please let me know.