### PR TITLE
Add missing vsc-dark-plus style to react-syntax-highlighter package

### DIFF
--- a/types/react-syntax-highlighter/index.d.ts
+++ b/types/react-syntax-highlighter/index.d.ts
@@ -3371,7 +3371,7 @@ declare module "react-syntax-highlighter/dist/cjs/styles/prism" {
     } from "react-syntax-highlighter/dist/cjs/styles/prism/vs";
     export {
         default as vscDarkPlus
-    } from "react-syntax-highlighter/dist/cjs/styles/prism/vsc-dark-plus"
+    } from "react-syntax-highlighter/dist/cjs/styles/prism/vsc-dark-plus";
     export {
         default as xonokai
     } from "react-syntax-highlighter/dist/cjs/styles/prism/xonokai";

--- a/types/react-syntax-highlighter/index.d.ts
+++ b/types/react-syntax-highlighter/index.d.ts
@@ -809,6 +809,9 @@ declare module "react-syntax-highlighter/dist/esm/styles/prism" {
         default as vs
     } from "react-syntax-highlighter/dist/esm/styles/prism/vs";
     export {
+        default as vscDarkPlus
+    } from "react-syntax-highlighter/dist/esm/styles/prism/vsc-dark-plus";
+    export {
         default as xonokai
     } from "react-syntax-highlighter/dist/esm/styles/prism/xonokai";
 }
@@ -919,6 +922,11 @@ declare module "react-syntax-highlighter/dist/esm/styles/prism/twilight" {
 }
 
 declare module "react-syntax-highlighter/dist/esm/styles/prism/vs" {
+    const style: any;
+    export default style;
+}
+
+declare module "react-syntax-highlighter/dist/esm/styles/prism/vsc-dark-plus" {
     const style: any;
     export default style;
 }

--- a/types/react-syntax-highlighter/index.d.ts
+++ b/types/react-syntax-highlighter/index.d.ts
@@ -3370,6 +3370,9 @@ declare module "react-syntax-highlighter/dist/cjs/styles/prism" {
         default as vs
     } from "react-syntax-highlighter/dist/cjs/styles/prism/vs";
     export {
+        default as vscDarkPlus
+    } from "react-syntax-highlighter/dist/cjs/styles/prism/vsc-dark-plus"
+    export {
         default as xonokai
     } from "react-syntax-highlighter/dist/cjs/styles/prism/xonokai";
 }
@@ -3480,6 +3483,11 @@ declare module "react-syntax-highlighter/dist/cjs/styles/prism/twilight" {
 }
 
 declare module "react-syntax-highlighter/dist/cjs/styles/prism/vs" {
+    const style: any;
+    export default style;
+}
+
+declare module "react-syntax-highlighter/dist/cjs/styles/prism/vsc-dark-plus" {
     const style: any;
     export default style;
 }


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed

