### PR TITLE
Added missing property types to MicroModalConfig for Micromodal package

### DIFF
--- a/types/micromodal/index.d.ts
+++ b/types/micromodal/index.d.ts
@@ -18,8 +18,8 @@ export interface MicroModalConfig {
 
     /** Custom data attribute to close modal. Default is data-micromodal-close. */
     closeTrigger?: string;
-    
-    /** Custom class to be applied when modal is open. Default class is is-open */
+
+    /** Custom class to be applied when modal is open. Default class is is-open. */
     openClass?: string;
 
     /** This disables scrolling on the page while the modal is open. The default value is false. */
@@ -27,14 +27,16 @@ export interface MicroModalConfig {
 
     /** Disable auto focus on first focusable element. Default is false */
     disableFocus?: boolean;
-    
-     /**
-     * Set this to true if using css animations to open the modal. This allows it to wait for the animation to finish before focusing on an element inside the modal. Default is false
+
+    /**
+     * Set this to true if using css animations to open the modal.
+     * This allows it to wait for the animation to finish before focusing on an element inside the modal. Default is false
      */
     awaitOpenAnimation?: boolean;
 
     /**
-     * Set this to true if using css animations to hide the modal. This allows it to wait for the animation to finish before removing it from the DOM. Default is false
+     * Set this to true if using css animations to hide the modal.
+     * This allows it to wait for the animation to finish before removing it from the DOM. Default is false
      */
     awaitCloseAnimation?: boolean;
 

--- a/types/micromodal/index.d.ts
+++ b/types/micromodal/index.d.ts
@@ -18,16 +18,23 @@ export interface MicroModalConfig {
 
     /** Custom data attribute to close modal. Default is data-micromodal-close. */
     closeTrigger?: string;
+    
+    /** Custom class to be applied when modal is open. Default class is is-open */
+    openClass?: string;
 
     /** This disables scrolling on the page while the modal is open. The default value is false. */
     disableScroll?: boolean;
 
     /** Disable auto focus on first focusable element. Default is false */
     disableFocus?: boolean;
+    
+     /**
+     * Set this to true if using css animations to open the modal. This allows it to wait for the animation to finish before focusing on an element inside the modal. Default is false
+     */
+    awaitOpenAnimation?: boolean;
 
     /**
-     * Set this to true if using css animations to hide the modal. This allows it to wait for the animation to
-     * finish before removing it from the DOM. Default is false
+     * Set this to true if using css animations to hide the modal. This allows it to wait for the animation to finish before removing it from the DOM. Default is false
      */
     awaitCloseAnimation?: boolean;
 

--- a/types/micromodal/micromodal-tests.ts
+++ b/types/micromodal/micromodal-tests.ts
@@ -5,8 +5,10 @@ const config: MicroModalConfig = {
     onClose: (modal) => { console.log(modal!.id); },
     openTrigger: 'data-modal-open',
     closeTrigger: 'data-modal-close',
+    openClass: "opened",
     disableScroll: true,
     disableFocus: true,
+    awaitOpenAnimation: true,
     awaitCloseAnimation: true,
     debugMode: true
 };


### PR DESCRIPTION
Added missing openClass & awaitOpenAnimation properties and descriptions to the MicroModalConfig interface.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://micromodal.now.sh/#configuration>>
