### PR TITLE
Update SubmitRequest from sharedb to support CreateOP, DeleteOp and EditOp

### DIFF
--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -119,6 +119,9 @@ declare namespace sharedb {
     type Query = ShareDB.Query;
     type Error = ShareDB.Error;
     type Op = ShareDB.Op;
+    type CreateOp = ShareDB.CreateOp;
+    type DeleteOp = ShareDB.DeleteOp;
+    type EditOp = ShareDB.EditOp;
     type AddNumOp = ShareDB.AddNumOp;
     type ListMoveOp = ShareDB.ListMoveOp;
     type ListInsertOp = ShareDB.ListInsertOp;
@@ -226,7 +229,7 @@ interface SubmitRequest {
     projection: Projection | undefined;
     collection: string;
     id: string;
-    op: sharedb.Op;
+    op: sharedb.CreateOp | sharedb.DeleteOp | sharedb.EditOp;
     options: any;
     start: number;
 

--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -46,11 +46,15 @@ export interface RawOp {
     src: string;
     seq: number;
     v: number;
-    op: Op[];
     m: any;
     c: string;
     d: string;
 }
+
+export type CreateOp = RawOp & { create: {type: string; data: any }; del: undefined; op: undefined; }
+export type DeleteOp = RawOp & { del: boolean; create: undefined; op: undefined; }
+export type EditOp = RawOp & { op: Op[]; create: undefined; del: undefined; }
+
 export type OTType = 'ot-text' | 'ot-json0' | 'ot-json1' | 'ot-text-tp2' | 'rich-text';
 
 export interface Type {

--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -51,7 +51,7 @@ export interface RawOp {
     d: string;
 }
 
-export type CreateOp = RawOp & { create: {type: string; data: any }; del: undefined; op: undefined; };
+export type CreateOp = RawOp & { create: { type: string; data: any }; del: undefined; op: undefined; };
 export type DeleteOp = RawOp & { del: boolean; create: undefined; op: undefined; };
 export type EditOp = RawOp & { op: Op[]; create: undefined; del: undefined; };
 

--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -51,9 +51,9 @@ export interface RawOp {
     d: string;
 }
 
-export type CreateOp = RawOp & { create: {type: string; data: any }; del: undefined; op: undefined; }
-export type DeleteOp = RawOp & { del: boolean; create: undefined; op: undefined; }
-export type EditOp = RawOp & { op: Op[]; create: undefined; del: undefined; }
+export type CreateOp = RawOp & { create: {type: string; data: any }; del: undefined; op: undefined; };
+export type DeleteOp = RawOp & { del: boolean; create: undefined; op: undefined; };
+export type EditOp = RawOp & { op: Op[]; create: undefined; del: undefined; };
 
 export type OTType = 'ot-text' | 'ot-json0' | 'ot-json1' | 'ot-text-tp2' | 'rich-text';
 

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -78,6 +78,9 @@ for (const action of submitRelatedActions) {
             request.snapshot,
             request.ops,
             request.channels,
+            request.op.op,
+            request.op.create,
+            request.op.del,
         );
         callback();
     });

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -1,4 +1,3 @@
-/// <reference types="qunit" />
 import * as ShareDB from 'sharedb';
 import * as http from 'http';
 import * as WebSocket from 'ws';


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [sharedb Op Types](https://github.com/share/sharedb/blob/c8275fb49b76c83dead36e2cee305fd349d40d8e/lib/agent.js#L843-L869)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
