### PR TITLE
Add first polycrc module definition type

### DIFF
--- a/types/polycrc/index.d.ts
+++ b/types/polycrc/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for polycrc 0.1
+// Project: https://github.com/latysheff/node-polycrc#readme
+// Definitions by: Emmanuel <https://github.com/emmanuelm41>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+export class CRC {
+    constructor(width: number, poly: number, xor_in: number, xor_out: number, reflect: boolean);
+    calculate(buffer: Buffer): number;
+    calculate_no_table(buffer: Buffer): number;
+    gen_table(): Int32Array;
+    print_table(): string;
+}
+
+export function crc(
+    width: number,
+    poly: number,
+    xor_in: number,
+    xor_out: number,
+    reflect: boolean,
+): (buffer: Buffer) => number;
+
+export const crc1: CRC;
+export const crc6: CRC;
+export const crc8: CRC;
+export const crc10: CRC;
+export const crc16: CRC;
+export const crc24: CRC;
+export const crc32: CRC;
+export const crc32c: CRC;

--- a/types/polycrc/polycrc-tests.ts
+++ b/types/polycrc/polycrc-tests.ts
@@ -1,0 +1,16 @@
+import * as polycrc from 'polycrc';
+
+const crc1 = new polycrc.CRC(1, 0x01, 0x00, 0x00, false);
+const crc6 = new polycrc.CRC(6, 0x2f, 0x00, 0x00, false);
+const crc8 = new polycrc.CRC(8, 0x07, 0x00, 0x00, false);
+const crc10 = new polycrc.CRC(10, 0x233, 0x0000, 0x0000, false);
+const crc16 = new polycrc.CRC(16, 0x8005, 0x0000, 0x0000, true);
+const crc24 = new polycrc.CRC(24, 0x864cfb, 0xb704ce, 0x000000, false);
+const crc32 = new polycrc.CRC(32, 0x04c11db7, 0xffffffff, 0xffffffff, true);
+const crc32c = new polycrc.CRC(32, 0x1edc6f41, 0xffffffff, 0xffffffff, true);
+
+polycrc.crc(16, 0x04c11db7, 0x00000000, 0xffffffff, false)(Buffer.from('0203', 'hex'));
+polycrc.crc(32, 0x04c11db7, 0x00000000, 0xffffffff, false)(Buffer.from('0203', 'hex'));
+
+crc16.calculate(Buffer.from('0203', 'hex'));
+crc32.calculate(Buffer.from('0203', 'hex'));

--- a/types/polycrc/tsconfig.json
+++ b/types/polycrc/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "polycrc-tests.ts"
+    ]
+}

--- a/types/polycrc/tslint.json
+++ b/types/polycrc/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Create the first definition file for polycrc module

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
