### PR TITLE
[react-scrollspy] Fix type definitions for onUpdate prop

### DIFF
--- a/types/react-scrollspy/index.d.ts
+++ b/types/react-scrollspy/index.d.ts
@@ -29,7 +29,7 @@ export interface ScrollspyProps {
     rootEl?: string;
 
     // Function to be executed when the active item has been updated
-    onUpdate?: (item: string) => void;
+    onUpdate?: (item: HTMLElement) => void;
 
     // ClassName attribute to be passed to the generated <ul /> element
     className?: string;

--- a/types/react-scrollspy/react-scrollspy-tests.tsx
+++ b/types/react-scrollspy/react-scrollspy-tests.tsx
@@ -12,10 +12,16 @@ function TestComponent() {
                 <section id="section-3">section 3</section>
             </div>
 
-            <Scrollspy items={items} currentClassName="is-current">
-                <li><a href="#section-1">section 1</a></li>
-                <li><a href="#section-2">section 2</a></li>
-                <li><a href="#section-3">section 3</a></li>
+            <Scrollspy items={items} currentClassName="is-current" onUpdate={el => console.log(el.id)}>
+                <li>
+                    <a href="#section-1">section 1</a>
+                </li>
+                <li>
+                    <a href="#section-2">section 2</a>
+                </li>
+                <li>
+                    <a href="#section-3">section 3</a>
+                </li>
             </Scrollspy>
         </div>
     );


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

---

Hello! Just ran into this in one of my projects so I figured I would update the typing.

You can see in the source code of React Scrollspy [here](https://github.com/makotot/react-scrollspy/blob/master/src/js/lib/scrollspy.js#L208) that the item passed to the `onUpdate` prop is actually an element rather than a string.
