### PR TITLE
Add cast.framework.ui.Controls and dependent classes and enums.

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.ui.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.ui.d.ts
@@ -4,6 +4,7 @@ import {
     MediaInformation,
     MediaCategory,
     QueueData,
+    Image,
 } from './cast.framework.messages';
 import { CastReceiverContext } from './cast.framework';
 
@@ -19,7 +20,7 @@ export enum State {
     LOADING = 'loading',
     BUFFERING = 'buffering',
     PAUSED = 'paused',
-    PLAYING = 'playing'
+    PLAYING = 'playing',
 }
 
 export enum PlayerDataEventType {
@@ -315,4 +316,378 @@ export class PlayerData {
      * Provide the time a break is skipable - relative to current playback time. Undefined if not skippable.
      */
     whenSkippable?: number;
+}
+
+/**
+ * Touch Controls. Provides interface for configuring controls on
+ * touch-enabled devices.
+ */
+export class Controls {
+    static getInstance(): Controls;
+
+    /**
+     * Displays button in the specified slot.
+     *
+     * Throws `non-null Error` if slot or button name is incorrect.
+     *
+     * @param slot
+     * @param button
+     */
+    assignButton(slot: ControlsSlot, button: ControlsButton): void;
+
+    /**
+     * Remove all buttons assigned by default from slots.
+     */
+    clearDefaultSlotAssignments(): void;
+
+    /**
+     * For audio applications only. Returns height in pixels of
+     * the area above the controls where application can render
+     * content without being overlapped by Cast SDK UI elements.
+     * CSS variable `--cast-controls-safe-area-height` can be
+     * used instead of this method.
+     *
+     * @returns height of safe area in px.
+     */
+    getSafeAreaHeight(): number;
+
+    /**
+     * Set Media Browse content for users to discover more
+     * contents from your receiver.
+     *
+     * @param browseContent
+     */
+    setBrowseContent(browseContent?: BrowseContent): void;
+}
+
+export class BrowseContent {
+    /**
+     * @param browseItems Array of non-null cast.framework.ui.BrowseItem
+     * List of browse items. Maximum items count is 30. Excess items will
+     * be truncated. Value must not be null
+     * @param title Title of the list
+     */
+    constructor(browseItems: BrowseItem[], title?: string);
+
+    /**
+     * List of browse items. Maximum items count is 30. Excess items will
+     * be truncated.
+     */
+    items: BrowseItem[];
+
+    /**
+     * Aspect ratio of all images in the media browse carousel. It's highly
+     * recommended to have browse item image provided in
+     * BrowseContentItem#image matching targetAspectRatio value. If image
+     * is too narrow/tall, it will be pillarboxed. If image is too wide/short,
+     * it will be letterboxed.
+     */
+    targetAspectRation?: BrowseImageAspectRatio;
+
+    /**
+     * Title of the list.
+     */
+    title?: string;
+}
+
+export class BrowseItem {
+    /**
+     * @param entity Content entity information.
+     * @param title Main text of the browse item.
+     * @param subtitle Secondary text of the element. Both title and subtitle
+     * can be provided, but at least one of them is required.
+     * @param image Image displayed for browse item. Value must not be null.
+     */
+    constructor(entity: string, title?: string, subtitle?: string, image?: Image);
+
+    /**
+     * Content duration in seconds. If provided, duration indicator will be
+     * displayed over media browse item image. For example, if duration = 150,
+     * label will be 2:30. If duration is 0, no label will be displayed.
+     */
+    duration?: number;
+
+    /**
+     * Content entity information.
+     */
+    entity: string;
+
+    /**
+     * Image displayed for browse item. It's highly recommended to have image
+     * aspect ratio matching BrowseContent#targetAspectRatio value. If image
+     * is too narrow/tall, it will be pillarboxed. If image is too wide/short,
+     * it will be letterboxed.
+     */
+    image?: Image;
+
+    /**
+     * Type of placeholder that will be used if image is not available for the
+     * browse item.
+     */
+    imageType?: BrowseImageType;
+
+    /**
+     * Additional badge to be displayed over the browse item image.
+     */
+    mediaBadge?: BrowseMediaBadge;
+
+    /**
+     * Secondary text of the element. Both title and subtitle can be provided,
+     * but at least one of them is required.
+     */
+    subtitle?: string;
+
+    /**
+     * Main text of the browse item.
+     */
+    title?: string;
+}
+
+/**
+ * Aspect ratio of all images in the media browse carousel.
+ */
+export enum BrowseImageAspectRatio {
+    /**
+     * Square images.
+     */
+    SQUARE_1_TO_1 = 'SQUARE_1_TO_1',
+
+    /**
+     * Portrait orientation images with 2:3 aspect ratio. UI
+     * for portrait orientation is not final and is a subject
+     * to change.
+     */
+    PORTRAIT_2_TO_3 = 'PORTRAIT_2_TO_3',
+
+    /**
+     * Landscape orientation images with 16:9 aspect ratio.
+     */
+    LANDSCAPE_16_TO_9 = 'LANDSCAPE_16_TO_9',
+}
+
+/**
+ * Type of placeholder that will be used if image is not
+ * available for the browse item.
+ */
+export enum BrowseImageType {
+    /**
+     * A playlist that consists of songs by a specific
+     * music artist or band, or radio seeded by an artist
+     * or band.
+     */
+    ARTIST = 'ARTIST',
+
+    /**
+     * An audio book.
+     */
+    AUDIO_BOOK = 'AUDIO_BOOK',
+
+    /**
+     * Episode of a TV show.
+     */
+    EPISODE = 'EPISODE',
+
+    /**
+     * A movie.
+     */
+    MOVIE = 'MOVIE',
+
+    /**
+     * A playlist that consists of songs from a specific
+     * music album or radio seeded by album.
+     */
+    MUSIC_ALBUM = 'MUSIC_ALBUM',
+
+    /**
+     * A music genre.
+     */
+    MUSIC_GENRE = 'MUSIC_GENRE',
+
+    /**
+     * A music mix seeded by genre.
+     */
+    MUSIC_MIX = 'MUSIC_MIX',
+
+    /**
+     * A song track or radio seeded by the track.
+     */
+    MUSIC_TRACK = 'MUSIC_TRACK',
+
+    /**
+     * News audio or video.
+     */
+    NEWS = 'NEWS',
+
+    /**
+     * An image.
+     */
+    PHOTO = 'PHOTO',
+
+    /**
+     * A playlist publicly available or radio seeded by playlist.
+     * Playlists always contain a finite and defined set of songs.
+     */
+    PLAYLIST = 'PLAYLIST',
+
+    /**
+     * A podcast series.
+     */
+    PODCAST = 'PODCAST',
+
+    /**
+     * A radio station. This could be a terrestrial or an internet
+     * radio station.
+     */
+    RADIO_STATION = 'RADIO_STATION',
+
+    /**
+     * A TV show.
+     */
+    TV_SHOW = 'TV_SHOW',
+
+    /**
+     * A single video.
+     */
+    VIDEO = 'VIDEO',
+}
+
+/**
+ * Badge that will be displayed on top of the browse item image.
+ */
+export enum BrowseMediaBadge {
+    /**
+     * LIVE indicator badge. Should be used if stream is a live
+     * content.
+     */
+    LIVE = 'LIVE',
+}
+
+/**
+ * Predefined buttons for the Media Controls overlay
+ */
+export enum ControlsButton {
+    /**
+     * Turn on/off closed captions.
+     */
+    CAPTIONS = 'captions',
+
+    /**
+     * Dislike butoon.
+     */
+    DISLIKE = 'dislike',
+
+    /**
+     * Like button.
+     */
+    LIKE = 'like',
+
+    /**
+     * Clear slot from any buttons.
+     */
+    NO_BUTTON = 'no-button',
+
+    /**
+     * Go to the next item in queue.
+     */
+    QUEUE_NEXT = 'queue-next',
+
+    /**
+     * Go to the previous item in queue.
+     */
+    QUEUE_PREV = 'queue-prev',
+
+    /**
+     * Toggle repeat mode.
+     */
+    REPEAT = 'repeat',
+
+    /**
+     * Seek 10 seconds backward.
+     */
+    SEEK_BACKWARD_10 = 'seek-backward-10',
+
+    /**
+     * Seek 15 seconds backward.
+     */
+    SEEK_BACKWARD_15 = 'seek-backward-15',
+
+    /**
+     * Seek 30 seconds backward.
+     */
+    SEEK_BACKWARD_30 = 'seek-backward-30',
+
+    /**
+     * Seek 10 seconds forward.
+     */
+    SEEK_FORWARD_10 = 'seek-forward-10',
+
+    /**
+     * Seek 15 seconds forward.
+     */
+    SEEK_FORWARD_15 = 'seek-forward-15',
+
+    /**
+     * Seek 30 seconds forward.
+     */
+    SEEK_FORWARD_30 = 'seek-forward-30',
+
+    /**
+     * Toggle shuffle mode.
+     */
+    SHUFFLE = 'shuffle',
+
+    /**
+     * Undocumented
+     */
+    SLEEP_TIMER = 'sleep-timer',
+}
+
+export enum ControlsSlot {
+    /**
+     * Side left slot. Deprecated, use SLOT_SECONDARY_1 instead.
+     *
+     * @deprecated
+     */
+    SLOT_1 = 'slot-1',
+
+    /**
+     * Center left slot. Deprecated, use SLOT_PRIMARY_1 instead.
+     *
+     * @deprecated
+     */
+    SLOT_2 = 'slot-2',
+
+    /**
+     * Center right slot. Deprecated, use SLOT_PRIMARY_2 instead.
+     *
+     * @deprecated
+     */
+    SLOT_3 = 'slot-3',
+
+    /**
+     * Side right slot. Deprecated, use SLOT_SECONDARY_2 instead.
+     *
+     * @deprecated
+     */
+    SLOT_4 = 'slot-4',
+
+    /**
+     * Center left slot. Placed to the left of the play/pause button.
+     */
+    SLOT_PRIMARY_1 = 'slot-primary-1',
+
+    /**
+     * Center right slot. Placed to the right of the play/pause button.
+     */
+    SLOT_PRIMARY_2 = 'slot-primary-2',
+
+    /**
+     * Side left slot. Aligned to the left edge of the screen.
+     */
+    SLOT_SECONDARY_1 = 'slot-secondary-1',
+
+    /**
+     * Side right slot. Aligned to the right edge of the screen.
+     */
+    SLOT_SECONDARY_2 = 'slot-secondary-2',
 }

--- a/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
+++ b/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
@@ -199,3 +199,8 @@ debugLogger.error(
     'Track could not be reported',
     cast.framework.CastReceiverContext.getInstance().getPlayerManager().getMediaInformation(),
 );
+
+const controls = cast.framework.ui.Controls.getInstance();
+
+controls.assignButton(cast.framework.ui.ControlsSlot.SLOT_SECONDARY_1, cast.framework.ui.ControlsButton.LIKE);
+controls.assignButton(cast.framework.ui.ControlsSlot.SLOT_SECONDARY_2, cast.framework.ui.ControlsButton.DISLIKE);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
    - BrowseContent https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.ui.BrowseContent
    - BrowseImageAspectRatio https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.ui#.BrowseImageAspectRatio
    - BrowseImageType https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.ui#.BrowseImageType
    - BrowseItem https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.ui.BrowseItem
    - BrowseMediaBadge https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.ui#.BrowseMediaBadge
    - Controls https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.ui.Controls
    - ControlsButton https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.ui#.ControlsButton
    - ControlsSlot https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.ui#.ControlsSlot
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
