### PR TITLE
Add richer types for @types/heft-jest

### DIFF
--- a/types/heft-jest/heft-jest-tests.ts
+++ b/types/heft-jest/heft-jest-tests.ts
@@ -3,3 +3,5 @@
 class X {}
 
 mocked(X).mockClear();
+mocked(X).getMockName();
+mocked(X).mock.instances[0];

--- a/types/heft-jest/index.d.ts
+++ b/types/heft-jest/index.d.ts
@@ -9,7 +9,27 @@
 /// <reference path="./mocked.d.ts" />
 
 /**
- * This is a global equivalent of the mocked() API from ts-jest:
+ * Tests can use the `mocked()` function to access additional properties that
+ * Jest adds to a mocked object.
+ *
+ * @remarks
+ *
+ * In the example below, `mockClear()` is not part of the type signature for the
+ * real `SoundPlayer` class.  It is added by Jest.  The `mocked()` function returns
+ * its input object but extends the type signature with these additional members.
+ *
+ * ```ts
+ * jest.mock('./SoundPlayer');
+ * import SoundPlayer from './SoundPlayer';
+ *
+ * // mockClear() is provided by Jest's API:
+ * mocked(SoundPlayer).mockClear();
+ * ```
+ *
+ * Heft's API is based on `mocked()` from `ts-jest`, but provided as a global API
+ * so you don't need to explicitly import it.  For more information, see the `ts-jest`
+ * documentation here:
+ *
  * https://kulshekhar.github.io/ts-jest/user/test-helpers
  */
 declare function mocked<T>(item: T, deep?: false): mocked.MaybeMocked<T>;

--- a/types/heft-jest/index.d.ts
+++ b/types/heft-jest/index.d.ts
@@ -6,15 +6,11 @@
 // TypeScript Version: 3.5
 
 /// <reference types="jest" />
-
-declare namespace mocked {
-    // Todo - fill out this definition in the next release.
-    type Mocked<T> = any;
-}
+/// <reference path="./mocked.d.ts" />
 
 /**
  * This is a global equivalent of the mocked() API from ts-jest:
  * https://kulshekhar.github.io/ts-jest/user/test-helpers
  */
-declare function mocked<T>(item: T, deep?: false): mocked.Mocked<T>;
-declare function mocked<T>(item: T, deep: true): mocked.Mocked<T>;
+declare function mocked<T>(item: T, deep?: false): mocked.MaybeMocked<T>;
+declare function mocked<T>(item: T, deep: true): mocked.MaybeMockedDeep<T>;

--- a/types/heft-jest/mocked.d.ts
+++ b/types/heft-jest/mocked.d.ts
@@ -1,0 +1,60 @@
+// The declarations here are based on this file from the "ts-jest" package:
+// https://github.com/kulshekhar/ts-jest/blob/ac88cd6649c25777f41139b6429980c8a77a38af/src/util/testing.ts
+//
+// The main change was to make every declarations importable, and move them into a global namespace.
+// The original author's LICENSE.md is reproduced below.
+
+// MIT License
+//
+// Copyright (c) 2016-2018
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+declare namespace mocked {
+    type MockableFunction = (...args: any[]) => any;
+    type MethodKeysOf<T> = { [K in keyof T]: T[K] extends MockableFunction ? K : never }[keyof T];
+    type PropertyKeysOf<T> = { [K in keyof T]: T[K] extends MockableFunction ? never : K }[keyof T];
+    type ArgumentsOf<T> = T extends (...args: infer A) => any ? A : never;
+    type ConstructorArgumentsOf<T> = T extends new (...args: infer A) => any ? A : never;
+
+    interface MockWithArgs<T extends MockableFunction> extends jest.MockInstance<ReturnType<T>, ArgumentsOf<T>> {
+        new (...args: ConstructorArgumentsOf<T>): T;
+        (...args: ArgumentsOf<T>): ReturnType<T>;
+    }
+
+    type MaybeMockedConstructor<T> = T extends new (...args: any[]) => infer R
+        ? jest.MockInstance<R, ConstructorArgumentsOf<T>>
+        : {};
+    type MockedFunction<T extends MockableFunction> = MockWithArgs<T> & { [K in keyof T]: T[K] };
+    type MockedFunctionDeep<T extends MockableFunction> = MockWithArgs<T> & MockedObjectDeep<T>;
+    type MockedObject<T> = MaybeMockedConstructor<T> &
+        { [K in MethodKeysOf<T>]: T[K] extends MockableFunction ? MockedFunction<T[K]> : T[K] } &
+        { [K in PropertyKeysOf<T>]: T[K] };
+    type MockedObjectDeep<T> = MaybeMockedConstructor<T> &
+        { [K in MethodKeysOf<T>]: T[K] extends MockableFunction ? MockedFunctionDeep<T[K]> : T[K] } &
+        { [K in PropertyKeysOf<T>]: MaybeMockedDeep<T[K]> };
+
+    type MaybeMockedDeep<T> = T extends MockableFunction
+        ? MockedFunctionDeep<T>
+        : T extends object
+        ? MockedObjectDeep<T>
+        : T;
+
+    type MaybeMocked<T> = T extends MockableFunction ? MockedFunction<T> : T extends object ? MockedObject<T> : T;
+}

--- a/types/heft-jest/tsconfig.json
+++ b/types/heft-jest/tsconfig.json
@@ -1,23 +1,16 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": [
-            "es6"
-        ],
+        "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
+        "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-    "files": [
-        "index.d.ts",
-        "heft-jest-tests.ts"
-    ]
+    "files": ["index.d.ts", "heft-jest-tests.ts"]
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/rushstack/pull/2123
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
