### PR TITLE
Add type definitions for email-check package

### DIFF
--- a/types/email-check/email-check-tests.ts
+++ b/types/email-check/email-check-tests.ts
@@ -1,0 +1,9 @@
+import emailCheck = require('email-check');
+
+const checkWithoutOptions: Promise<boolean> = emailCheck('recipient@email.com');
+
+const options: emailCheck.EmailCheckOptions = { from: 'sender@email.com', host: 'email.com', timeout: 10000 };
+const checkWithOptions: Promise<boolean> = emailCheck('recipient@email.com', options);
+
+const partialOptions: emailCheck.EmailCheckOptions = { from: 'sender@email.com' };
+const checkWithPartialOptions: Promise<boolean> = emailCheck('recipient@email.com', partialOptions);

--- a/types/email-check/index.d.ts
+++ b/types/email-check/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for email-check 1.1
+// Project: https://github.com/pensierinmusica/email-check
+// Definitions by: Luke Jones <https://github.com/luke-j>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace emailCheck {
+    interface EmailCheckOptions {
+        from?: string;
+        host?: string;
+        timeout?: number;
+    }
+}
+
+declare function emailCheck(email: string, options?: emailCheck.EmailCheckOptions): Promise<boolean>;
+
+export = emailCheck;

--- a/types/email-check/tsconfig.json
+++ b/types/email-check/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "files": [
+        "index.d.ts",
+        "email-check-tests.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/email-check/tslint.json
+++ b/types/email-check/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.