### PR TITLE
[urijs] Fix argument type for search/query

### DIFF
--- a/types/urijs/index.d.ts
+++ b/types/urijs/index.d.ts
@@ -212,8 +212,8 @@ interface URI {
     preventInvalidHostname(val: boolean): URI;
 
     query(): string;
-    query(qry: string | URI.QueryDataMap | ((qryObject: URI.QueryDataMap) => URI.QueryDataMap)): URI;
-    query(qry: boolean): URI.QueryDataMap;
+    query(qry: string | URI.QueryDataMap | ((qryObject: URI.QueryDataMap) => (URI.QueryDataMap | undefined))): URI;
+    query(v: boolean): URI.QueryDataMap;
 
     readable(): string;
     relativeTo(path: string): URI;
@@ -229,8 +229,8 @@ interface URI {
     scheme(): string;
     scheme(protocol: string): URI;
     search(): string;
-    search(qry: string | URI.QueryDataMap | ((qryObject: URI.QueryDataMap) => URI.QueryDataMap)): URI;
-    search(qry: boolean): URI.QueryDataMap;
+    search(qry: string | URI.QueryDataMap | ((qryObject: URI.QueryDataMap) => (URI.QueryDataMap | undefined))): URI;
+    search(v: boolean): URI.QueryDataMap;
     segment(): string[];
     segment(segments: string[] | string): URI;
     segment(position: number): string | undefined;

--- a/types/urijs/test/urijs-dom.test.ts
+++ b/types/urijs/test/urijs-dom.test.ts
@@ -249,4 +249,6 @@ declare var $: (arg?: any) => JQuery;
     const u = new URI('mailto:mail@example.org');
     u.query(qs => qs);
     u.search(qs => qs);
+    u.query(() => undefined);
+    u.search(() => undefined);
 }

--- a/types/urijs/test/urijs-nodejs.test.ts
+++ b/types/urijs/test/urijs-nodejs.test.ts
@@ -254,4 +254,6 @@ declare var $: (arg?: any) => JQuery;
     const u = new URI('mailto:mail@example.org');
     u.query(qs => qs);
     u.search(qs => qs);
+    u.query(() => undefined);
+    u.search(() => undefined);
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://medialize.github.io/URI.js/docs.html#accessors-search
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

In the doc there are 2 use cases if a function is passed in: 
(From https://medialize.github.io/URI.js/docs.html#accessors-search)
```js
// overwrite data through callback
uri.search(function(data) {
  return { hello : "world" };
});
// uri == "http://example.org/bar/world.html?hello=world"

// augment data through callback
uri.search(function(data) {
  data.foo = "bar";
});
// uri == "http://example.org/bar/world.html?hello=world&foo=bar"
```

Current signature only covers 1st use case but not the 2nd one