### PR TITLE
Update types for jest-image-snapshots 4.1.0

### DIFF
--- a/types/jest-image-snapshot/index.d.ts
+++ b/types/jest-image-snapshot/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jest-image-snapshot 3.1
+// Type definitions for jest-image-snapshot 4.1.0
 // Project: https://github.com/americanexpress/jest-image-snapshot#readme
 // Definitions by: Janeene Beeforth <https://github.com/dawnmist>
 //                 erbridge <https://github.com/erbridge>
@@ -7,23 +7,8 @@
 // TypeScript Version: 3.1
 
 /// <reference types="jest" />
-
-/**
- * Options to be passed to the 'pixelmatch' image diffing function.
- */
-export interface PixelmatchOptions {
-    /**
-     * Matching threshold, ranges from 0 to 1.
-     * Smaller values make the comparison more sensitive.
-     * @default 0.1
-     */
-    readonly threshold?: number;
-    /**
-     * If true, disables detecting and ignoring anti-aliased pixels.
-     * @default false
-     */
-    readonly includeAA?: boolean;
-}
+import { PixelmatchOptions } from 'pixelmatch';
+import { Options as SSIMOptions } from 'ssim.js';
 
 export interface MatchImageSnapshotOptions {
     /**
@@ -32,9 +17,15 @@ export interface MatchImageSnapshotOptions {
      */
     allowSizeMismatch?: boolean;
     /**
-     * Custom config passed to 'pixelmatch'
+     * Custom config passed to 'pixelmatch' or 'ssim'
      */
-    customDiffConfig?: PixelmatchOptions;
+    customDiffConfig?: PixelmatchOptions | SSIMOptions;
+    /**
+     * The method by which images are compared.
+     * `pixelmatch` does a pixel by pixel comparison, whereas `ssim` does a structural similarity comparison.
+     * @default 'pixelmatch'
+     */
+    comparisonMethod?: 'pixelmatch' | 'ssim';
     /**
      * Custom snapshots directory.
      * Absolute path of a directory to keep the snapshot in.

--- a/types/jest-image-snapshot/index.d.ts
+++ b/types/jest-image-snapshot/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jest-image-snapshot 4.1.0
+// Type definitions for jest-image-snapshot 4.1
 // Project: https://github.com/americanexpress/jest-image-snapshot#readme
 // Definitions by: Janeene Beeforth <https://github.com/dawnmist>
 //                 erbridge <https://github.com/erbridge>

--- a/types/jest-image-snapshot/package.json
+++ b/types/jest-image-snapshot/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "ssim.js": "^3.1.0"
+    }
+}

--- a/types/jest-image-snapshot/tsconfig.json
+++ b/types/jest-image-snapshot/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/pixelmatch/index.d.ts
+++ b/types/pixelmatch/index.d.ts
@@ -19,50 +19,52 @@ declare function Pixelmatch(
     /** Height of the images. Note that all three images need to have the same dimensions. */
     height: number,
     /** Options. */
-    options?: Options,
+    options?: Pixelmatch.PixelmatchOptions,
 ): number;
 
-type RGBTuple = [number, number, number];
+declare namespace Pixelmatch {
+    type RGBTuple = [number, number, number];
 
-interface Options {
-    /**
-     * Matching threshold, ranges from 0 to 1. Smaller values make the comparison more sensitive.
-     * @default 0.1
-     */
-    readonly threshold?: number;
-    /**
-     * If true, disables detecting and ignoring anti-aliased pixels.
-     * @default false
-     */
-    readonly includeAA?: boolean;
-    /**
-     * Blending factor of unchanged pixels in the diff output.
-     * Ranges from 0 for pure white to 1 for original brightness
-     * @default 0.1
-     */
-    alpha?: number;
-    /**
-     * The color of anti-aliased pixels in the diff output.
-     * @default [255, 255, 0]
-     */
-    aaColor?: RGBTuple;
-    /**
-     * The color of differing pixels in the diff output.
-     * @default [255, 0, 0]
-     */
-    diffColor?: RGBTuple;
-    /**
-     * An alternative color to use for dark on light differences to differentiate between "added" and "removed" parts.
-     * If not provided, all differing pixels use the color specified by `diffColor`.
-     * @default null
-     */
-    diffColorAlt?: RGBTuple;
-    /**
-     * Draw the diff over a transparent background (a mask), rather than over the original image.
-     * Will not draw anti-aliased pixels (if detected)
-     * @default false
-     */
-    diffMask?: boolean;
+    interface PixelmatchOptions {
+        /**
+         * Matching threshold, ranges from 0 to 1. Smaller values make the comparison more sensitive.
+         * @default 0.1
+         */
+        readonly threshold?: number;
+        /**
+         * If true, disables detecting and ignoring anti-aliased pixels.
+         * @default false
+         */
+        readonly includeAA?: boolean;
+        /**
+         * Blending factor of unchanged pixels in the diff output.
+         * Ranges from 0 for pure white to 1 for original brightness
+         * @default 0.1
+         */
+        alpha?: number;
+        /**
+         * The color of anti-aliased pixels in the diff output.
+         * @default [255, 255, 0]
+         */
+        aaColor?: RGBTuple;
+        /**
+         * The color of differing pixels in the diff output.
+         * @default [255, 0, 0]
+         */
+        diffColor?: RGBTuple;
+        /**
+         * An alternative color to use for dark on light differences to differentiate between "added" and "removed" parts.
+         * If not provided, all differing pixels use the color specified by `diffColor`.
+         * @default null
+         */
+        diffColorAlt?: RGBTuple;
+        /**
+         * Draw the diff over a transparent background (a mask), rather than over the original image.
+         * Will not draw anti-aliased pixels (if detected)
+         * @default false
+         */
+        diffMask?: boolean;
+    }
 }
 
 export = Pixelmatch;


### PR DESCRIPTION
`npm test` currently fails due to changes required in `DefinitelyTypes-tools`. See: https://github.com/microsoft/DefinitelyTyped-tools/pull/97

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/americanexpress/jest-image-snapshot/issues/220
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.