### PR TITLE
Update Koa-webpack to 6.0 and add missing types for koa state

### DIFF
--- a/types/koa-webpack/index.d.ts
+++ b/types/koa-webpack/index.d.ts
@@ -13,7 +13,7 @@ import webpackDevMiddleware = require('webpack-dev-middleware');
 import webpackHotClient = require('webpack-hot-client');
 
 declare function koaWebpack(
-    options?: koaWebpack.Options
+    options?: koaWebpack.Options,
 ): Promise<Koa.Middleware & koaWebpack.CombinedWebpackMiddleware>;
 
 declare namespace koaWebpack {

--- a/types/koa-webpack/index.d.ts
+++ b/types/koa-webpack/index.d.ts
@@ -8,14 +8,13 @@
 // TypeScript Version: 2.3
 
 import Koa = require('koa');
-import MemoryFileSystem = require('memory-fs');
 import webpack = require('webpack');
 import webpackDevMiddleware = require('webpack-dev-middleware');
 import webpackHotClient = require('webpack-hot-client');
 
 declare module 'koa' {
     interface DefaultState {
-        fs: MemoryFileSystem;
+        fs: webpackDevMiddleware.Options['fs'];
         stats: webpack.Stats;
     }
 }

--- a/types/koa-webpack/index.d.ts
+++ b/types/koa-webpack/index.d.ts
@@ -8,9 +8,17 @@
 // TypeScript Version: 2.3
 
 import Koa = require('koa');
+import MemoryFileSystem = require('memory-fs');
 import webpack = require('webpack');
 import webpackDevMiddleware = require('webpack-dev-middleware');
 import webpackHotClient = require('webpack-hot-client');
+
+declare module 'koa' {
+    interface DefaultState {
+        fs: MemoryFileSystem;
+        stats: webpack.Stats;
+    }
+}
 
 declare function koaWebpack(
     options?: koaWebpack.Options,

--- a/types/koa-webpack/index.d.ts
+++ b/types/koa-webpack/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for koa-webpack 5.0
+// Type definitions for koa-webpack 6.0
 // Project: https://github.com/shellscape/koa-webpack
 // Definitions by: Luka Maljic <https://github.com/malj>
 //                 Lee Benson <https://github.com/leebenson>

--- a/types/koa-webpack/koa-webpack-tests.ts
+++ b/types/koa-webpack/koa-webpack-tests.ts
@@ -6,6 +6,18 @@ const app = new Koa();
 const config: webpack.Configuration = {};
 const compiler = webpack(config);
 
+app.use(ctx => {
+    // $ExpectType MemoryFileSystem
+    ctx.state.fs;
+    ctx.body = ctx.state.fs.createReadStream('file.js');
+});
+
+app.use(ctx => {
+    // $ExpectType Stats
+    ctx.state.stats;
+    ctx.body = ctx.state.stats.toJson();
+});
+
 // Using the middleware
 koaWebpack({
     compiler,

--- a/types/koa-webpack/koa-webpack-tests.ts
+++ b/types/koa-webpack/koa-webpack-tests.ts
@@ -7,9 +7,9 @@ const config: webpack.Configuration = {};
 const compiler = webpack(config);
 
 app.use(ctx => {
-    // $ExpectType MemoryFileSystem
+    // $ExpectType MemoryFileSystem | undefined
     ctx.state.fs;
-    ctx.body = ctx.state.fs.createReadStream('file.js');
+    ctx.body = ctx.state.fs!.createReadStream('file.js');
 });
 
 app.use(ctx => {

--- a/types/koa-webpack/koa-webpack-tests.ts
+++ b/types/koa-webpack/koa-webpack-tests.ts
@@ -38,24 +38,23 @@ koaWebpack({
         port: 0,
         reload: true,
         server: undefined,
-        stats: { context: process.cwd() }
-    }
-})
-    .then((middleware) => {
-        app.use(middleware);
+        stats: { context: process.cwd() },
+    },
+}).then(middleware => {
+    app.use(middleware);
 
-        // Accessing the underlying middleware
-        middleware.devMiddleware.close();
-        middleware.devMiddleware.invalidate();
-        middleware.devMiddleware.waitUntilValid();
-        middleware.devMiddleware.getFilenameFromUrl('/public/index.html');
-        middleware.devMiddleware.fileSystem;
-        middleware.hotClient.close();
-        middleware.hotClient.options;
-        middleware.hotClient.server;
+    // Accessing the underlying middleware
+    middleware.devMiddleware.close();
+    middleware.devMiddleware.invalidate();
+    middleware.devMiddleware.waitUntilValid();
+    middleware.devMiddleware.getFilenameFromUrl('/public/index.html');
+    middleware.devMiddleware.fileSystem;
+    middleware.hotClient.close();
+    middleware.hotClient.options;
+    middleware.hotClient.server;
 
-        // close the middleware
-        middleware.close(() => {
-            console.log('closed');
-        });
+    // close the middleware
+    middleware.close(() => {
+        console.log('closed');
     });
+});


### PR DESCRIPTION
This adds types for the injected Koa state propertis `fs` and `state`.

Since `koa-webpack` recently released 6.0 without really breaking changes, the version was updated as well.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/shellscape/koa-webpack/compare/v6.0.0..v5.3.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.