### PR TITLE
fix #43976 - @types/passport-local done callback function should accept any type in info parameter. 

### DIFF
--- a/types/passport-local/index.d.ts
+++ b/types/passport-local/index.d.ts
@@ -23,16 +23,12 @@ interface IStrategyOptionsWithRequest {
     passReqToCallback: true;
 }
 
-interface IVerifyOptions {
-    message: string;
-}
-
 interface VerifyFunctionWithRequest {
     (
         req: express.Request,
         username: string,
         password: string,
-        done: (error: any, user?: any, options?: IVerifyOptions) => void
+        done: (error: any, user?: any, info?: any) => void
     ): void;
 }
 
@@ -40,7 +36,7 @@ interface VerifyFunction {
     (
         username: string,
         password: string,
-        done: (error: any, user?: any, options?: IVerifyOptions) => void
+        done: (error: any, user?: any, info?: any) => void
     ): void;
 }
 

--- a/types/passport-local/passport-local-tests.ts
+++ b/types/passport-local/passport-local-tests.ts
@@ -42,7 +42,7 @@ passport.use(new local.Strategy((username: any, password: any, done: any) => {
         }
 
         if (!user.verifyPassword(password)) {
-            return done(null, false);
+            return done(null, false, { message: 'something wrong', errorCode: 1 });
         }
 
         return done(null, user);
@@ -62,7 +62,7 @@ passport.use(new local.Strategy({
         }
 
         if (!user.verifyPassword(password)) {
-            return done(null, false);
+            return done(null, false, { message: 'something wrong', errorCode: 1 });
         }
 
         return done(null, user);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/43976
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
