### PR TITLE
[humanize-duration] Add missing `count` property to `UnitTranslationOptions`

### DIFF
--- a/types/humanize-duration/humanize-duration-tests.ts
+++ b/types/humanize-duration/humanize-duration-tests.ts
@@ -71,8 +71,8 @@ const shortEnglishHumanizer = humanizeDuration.humanizer({
   languages: {
     shortEn: {
       d: () => "d",
-      h: () => "h",
-      m: () => "m",
+      h: (count) => count === 1 ? "hour" : "hours",
+      m: (count) => count === 1 ? "minute" : "minutes",
       mo: () => "mo",
       ms: () => "ms",
       s: () => "s",
@@ -81,6 +81,8 @@ const shortEnglishHumanizer = humanizeDuration.humanizer({
     },
   },
 });
+
+shortEnglishHumanizer(5400000);  // '1 hour, 30 minutes'
 
 shortEnglishHumanizer(15600000);  // '4 h, 20 m'
 

--- a/types/humanize-duration/index.d.ts
+++ b/types/humanize-duration/index.d.ts
@@ -31,14 +31,14 @@ declare namespace HumanizeDuration {
   }
 
   interface UnitTranslationOptions {
-    y?: () => string;
-    mo?: () => string;
-    w?: () => string;
-    d?: () => string;
-    h?: () => string;
-    m?: () => string;
-    s?: () => string;
-    ms?: () => string;
+    y?: (count?: number) => string;
+    mo?: (count?: number) => string;
+    w?: (count?: number) => string;
+    d?: (count?: number) => string;
+    h?: (count?: number) => string;
+    m?: (count?: number) => string;
+    s?: (count?: number) => string;
+    ms?: (count?: number) => string;
   }
 
   interface Options {


### PR DESCRIPTION
Add missing `count` property to `UnitTranslationOptions`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/EvanHahn/HumanizeDuration.js/blob/master/humanize-duration.js#L206-L230