### PR TITLE
fix(node): Make `ProcessVersions` extend `Dict<string>`

### DIFF
--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -32,7 +32,7 @@ declare module "process" {
                 lts?: string;
             }
 
-            interface ProcessVersions {
+            interface ProcessVersions extends Dict<string> {
                 http_parser: string;
                 node: string;
                 v8: string;

--- a/types/node/test/process.ts
+++ b/types/node/test/process.ts
@@ -20,6 +20,7 @@ import { EventEmitter } from "events";
     process.prependOnceListener("rejectionHandled", (promise: Promise<any>) => { });
     process.on("uncaughtException", (error: Error) => { });
     process.once("uncaughtExceptionMonitor", (error: Error) => { });
+    // tslint:disable-next-line: no-null-undefined-union
     process.addListener("unhandledRejection", (reason: {} | null | undefined, promise: Promise<any>) => { });
     process.once("warning", (warning: Error) => { });
     process.prependListener("message", (message: any, sendHandle: any) => { });
@@ -78,4 +79,9 @@ import { EventEmitter } from "events";
     const heapUsed: number = usage.heapUsed;
     const external: number = usage.external;
     const arrayBuffers: number = usage.arrayBuffers;
+}
+{
+    let strDict: NodeJS.Dict<string>;
+    strDict = process.versions;
+    strDict = p.versions;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46700#issuecomment-673956841>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
