### PR TITLE
@types/auth0 ManagementClient#getUsersInRole overload order

### DIFF
--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -1018,12 +1018,12 @@ export class ManagementClient<A=AppMetadata, U=UserMetadata> {
   addPermissionsInRole(params: ObjectWithId, data: PermissionsData): Promise<void>;
   addPermissionsInRole(params: ObjectWithId, data: PermissionsData, cb: (err: Error) => void): void;
 
-  getUsersInRole(params: ObjectWithId): Promise<User<A, U>[]>;
-  getUsersInRole(params: ObjectWithId, cb: (err: Error, users: User<A, U>[]) => void): void;
-  getUsersInRole(params: GetRoleUsersData): Promise<User<A, U>[]>;
-  getUsersInRole(params: GetRoleUsersData, cb: (err: Error, users: User<A, U>[]) => void): void;
   getUsersInRole(params: GetRoleUsersDataPaged): Promise<UserPage<A, U>>;
   getUsersInRole(params: GetRoleUsersDataPaged, cb: (err: Error, userPage: UserPage<A, U>) => void): void;
+  getUsersInRole(params: GetRoleUsersData): Promise<User<A, U>[]>;
+  getUsersInRole(params: GetRoleUsersData, cb: (err: Error, users: User<A, U>[]) => void): void;
+  getUsersInRole(params: ObjectWithId): Promise<User<A, U>[]>;
+  getUsersInRole(params: ObjectWithId, cb: (err: Error, users: User<A, U>[]) => void): void;
 
     // Rules
   getRules(): Promise<Rule[]>;


### PR DESCRIPTION
Changing the order of @types/auth0 ManagementClient#getUsersInRole's overloads, so the we have the more specific overloads going first than the more generic one.

When we try to mock the current method (with ts-mockito's mock for exemple), the mock matches with the more generic overload and don't try to match with the other ones, this way making unable of mocking a call and returning a `UserPage<A, U>` because the return type of the more generic call is `User<A, U>[]`.

Sample code:

```typescript
before(() => {
  const response: UserPage<AppMetadata, UserMetadata> = {
    users: [],
    limit: 100,
    start: 0,
    total: 100,
    length: 100,
  };
    
  when(ManagementMock.getUsersInRole(anything() as GetRoleUsersDataPaged)).thenResolve(response);
});
```

Error:

```
test/unit/roles/roles.service.spec.ts:128:11 - error TS2345: Argument of type 'UserPage<AppMetadata, UserMetadata>' is not assignable to parameter of type 'User<AppMetadata, UserMetadata>[]'.
  Type 'UserPage<AppMetadata, UserMetadata>' is missing the following properties from type 'User<AppMetadata, UserMetadata>[]': pop, push, concat, join, and 27 more.
```