### PR TITLE
[meteor-mdg-validated-method] Add ThisType annotation

### DIFF
--- a/types/meteor-mdg-validated-method/meteor-mdg-validated-method-tests.ts
+++ b/types/meteor-mdg-validated-method/meteor-mdg-validated-method-tests.ts
@@ -201,7 +201,27 @@ new ValidatedMethod({
 });
 
 // method can access its name
-// TODO "slice" call is needed here because this method actually returns `Return<() => TName> & string` and I don't know why
-// (the `& string` was something I added so you can at least use the name in weird situations like this, but I don't get why TName isn't getting resolved there - it's clearly known by now!)
-// $ExpectType string
-methodReturnsName.call().slice();
+// $ExpectType "methodReturnsName"
+methodReturnsName.call();
+
+// method has all expected "this" properties
+new ValidatedMethod({
+    name: 'methodThatUsesThis',
+    validate: null,
+    run() {
+        // $ExpectType "methodThatUsesThis"
+        this.name;
+        // $ExpectType boolean
+        this.isSimulation;
+        // $ExpectType string | null
+        this.userId;
+        // $ExpectType void
+        this.setUserId("test");
+        // $ExpectType Connection
+        this.connection;
+        // $ExpectType string
+        this.randomSeed();
+        // $ExpectType void
+        this.unblock();
+    }
+});


### PR DESCRIPTION
`run` and `validate` now have strongly typed `this`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/meteor/meteor/blob/devel/packages/ddp-common/method_invocation.js>, <https://docs.meteor.com/api/methods.html#Meteor-methods>, <https://github.com/meteor/validated-method/blob/master/validated-method.js#L89>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.