### PR TITLE
fix(infra): correct artefact in non-needed-packages

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -2845,12 +2845,6 @@
             "asOfVersion": "1.0.0"
         },
         {
-            "libraryName": "@material/ripple",
-            "typingsPackageName": "material__ripple",
-            "sourceRepoURL": "https://github.com/material-components/material-components-web/tree/master/packages/mdc-ripple",
-            "asOfVersion": "1.0.0"
-        },
-        {
             "libraryName": "@material/checkbox",
             "typingsPackageName": "material__checkbox",
             "sourceRepoURL": "https://github.com/material-components/material-components-web/tree/master/packages/mdc-checkbox",
@@ -2938,6 +2932,12 @@
             "libraryName": "@material/radio",
             "typingsPackageName": "material__radio",
             "sourceRepoURL": "https://github.com/material-components/material-components-web/tree/master/packages/mdc-radio",
+            "asOfVersion": "1.0.0"
+        },
+        {
+            "libraryName": "@material/ripple",
+            "typingsPackageName": "material__ripple",
+            "sourceRepoURL": "https://github.com/material-components/material-components-web/tree/master/packages/mdc-ripple",
             "asOfVersion": "1.0.0"
         },
         {


### PR DESCRIPTION
Someone's added entry manually, so it gets resorted when removing a
package, making a change non-focused one.
This fixes that sorting issue.

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.