### PR TITLE
[should-sinon] Augment spy call objects too

### DIFF
--- a/types/should-sinon/index.d.ts
+++ b/types/should-sinon/index.d.ts
@@ -8,7 +8,7 @@ import * as s from 'sinon';
 import should = require('should');
 
 declare module 'sinon' {
-    interface SinonSpy {
+    interface SinonSpyCallApi {
         should: ShouldSinonAssertion;
     }
     interface ShouldSinonAssertion extends should.Assertion {

--- a/types/should-sinon/should-sinon-tests.ts
+++ b/types/should-sinon/should-sinon-tests.ts
@@ -11,3 +11,14 @@ callback.should.be.calledThrice();
 callback.should.be.calledTwice();
 callback.should.be.calledWith(1, 2, 3);
 callback.should.be.neverCalledWith(1, 2, 3);
+
+callback.firstCall.should.be.alwaysCalledOn(obj);
+callback.firstCall.should.be.alwaysCalledWith(1, 2, 3);
+callback.firstCall.should.have.callCount(0);
+callback.firstCall.should.be.called();
+callback.firstCall.should.be.calledOn(obj);
+callback.firstCall.should.be.calledOnce();
+callback.firstCall.should.be.calledThrice();
+callback.firstCall.should.be.calledTwice();
+callback.firstCall.should.be.calledWith(1, 2, 3);
+callback.firstCall.should.be.neverCalledWith(1, 2, 3);


### PR DESCRIPTION
In Sinon, there are two types of spy-related data: spy objects and spy call objects.

- A [spy](https://sinonjs.org/releases/v9.0.3/spies/) object contains the entire history of the spy.
    - In `@types/sinon`, these are represented by the [`SinonSpy`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/93d8f9d7102925e1a39852627465a44a0ff670cf/types/sinon/index.d.ts#L167) interface.
- A [spy call](https://sinonjs.org/releases/v9.0.3/spy-call/) object represents a single individual call within the history.
    - In `@types/sinon`, these are represented by the [`SinonSpyCall`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/93d8f9d7102925e1a39852627465a44a0ff670cf/types/sinon/index.d.ts#L130) interface.

Spy call objects can be accessed using properties and methods on a spy object, including:

- `SinonSpyCall.firstCall`
- `SinonSpyCall.secondCall`
- `SinonSpyCall.getCall(n)`
- ...

Spy objects and spy call objects share many properties and methods. `@types/sinon` reflects this by declaring the [`SinonSpyCallApi`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/93d8f9d7102925e1a39852627465a44a0ff670cf/types/sinon/index.d.ts#L30) interface, which is extended by `SinonSpy` and `SinonSpyCall`.

In fact, assertion methods added by should-sinon are also available on spy call objects (see [`should-sinon.js`](https://github.com/shouldjs/sinon/blob/master/should-sinon.js)). However, `@types/sinon-should` previously declared these methods directly on the `SinonSpy` interface. This made them unavailable to spy call objects.

This PR resolves this issue by augmenting the `SinonSpyCallApi` interface instead of `SinonSpy`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

