### PR TITLE
fix(is-hotkey): describe function overload properly

### DIFF
--- a/types/is-hotkey/index.d.ts
+++ b/types/is-hotkey/index.d.ts
@@ -27,8 +27,13 @@ export function isHotkey(
 
 export function isHotkey(
     hotkey: string | ReadonlyArray<string>,
-    options?: HotKeyOptions | KeyboardEvent,
-    event?: KeyboardEvent
+    event: KeyboardEvent
+): boolean;
+
+export function isHotkey(
+    hotkey: string | ReadonlyArray<string>,
+    options: HotKeyOptions,
+    event: KeyboardEvent
 ): boolean;
 
 export function isCodeHotkey(

--- a/types/is-hotkey/is-hotkey-tests.ts
+++ b/types/is-hotkey/is-hotkey-tests.ts
@@ -16,6 +16,9 @@ isHotkey("mod+s", { byKey: true })(event); // $ExpectType boolean
 isHotkey("mod+s", event); // $ExpectType boolean
 isHotkey("mod+s", { byKey: true }, event); // $ExpectType boolean
 
+isHotkey("mod+s"); // $ExpectType (event: KeyboardEvent) => boolean
+isHotkey("mod+s", { byKey: true }); // $ExpectType (event: KeyboardEvent) => boolean
+
 isCodeHotkey("mod+s")(event); // $ExpectType boolean
 isKeyHotkey("mod+s")(event); // $ExpectType boolean
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ianstormtaylor/is-hotkey#api
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

-----

The current types don't allow TypeScript to discriminate between the two function overloads, meaning the two lines added as tests return type `boolean` as they match both function definitions.