### PR TITLE
Add Types for package react-native-base64

### DIFF
--- a/types/react-native-base64/index.d.ts
+++ b/types/react-native-base64/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for react-native-base64 0.1
+// Project: https://github.com/eranbo/react-native-base64#readme
+// Definitions by: seongjoojin <https://github.com/seongjoojin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface Base64 {
+    encode: (input: string) => string;
+    decode: (input: string) => string;
+}
+
+declare const base64: Base64;
+export = base64;

--- a/types/react-native-base64/react-native-base64-tests.tsx
+++ b/types/react-native-base64/react-native-base64-tests.tsx
@@ -1,0 +1,4 @@
+import base64 from 'react-native-base64';
+
+base64.encode('Some string to encode to base64');
+base64.decode('SW4gbXkgZXllcywgaW5kaXNwb3NlZA0KSW4gZGlzZ3Vpc2VzIG5vIG9uZSBrbm93cw0KUklQIEND==');

--- a/types/react-native-base64/tsconfig.json
+++ b/types/react-native-base64/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "allowSyntheticDefaultImports": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+  },
+  "files": ["index.d.ts", "react-native-base64-tests.tsx"]
+}

--- a/types/react-native-base64/tslint.json
+++ b/types/react-native-base64/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
