### PR TITLE
fix(webidl2): Add missing `parent` fields

### DIFF
--- a/types/webidl2/index.d.ts
+++ b/types/webidl2/index.d.ts
@@ -85,6 +85,17 @@ export interface SingleTypeDescription {
     idlType: string;
     /** A list of extended attributes. */
     extAttrs: ExtendedAttribute[];
+    /** The container of this type. */
+    parent:
+        | UnionTypeDescription
+        | CallbackType
+        | FieldType
+        | TypedefType
+        | OperationMemberType
+        | AttributeMemberType
+        | ConstantMemberType
+        | Argument
+        | DeclarationMemberType;
 }
 
 export interface UnionTypeDescription {
@@ -107,6 +118,17 @@ export interface UnionTypeDescription {
     idlType: IDLTypeDescription[];
     /** A list of extended attributes. */
     extAttrs: ExtendedAttribute[];
+    /** The container of this type. */
+    parent:
+        | UnionTypeDescription
+        | CallbackType
+        | FieldType
+        | TypedefType
+        | OperationMemberType
+        | AttributeMemberType
+        | ConstantMemberType
+        | Argument
+        | DeclarationMemberType;
 }
 
 export interface InterfaceType {
@@ -121,6 +143,8 @@ export interface InterfaceType {
     inheritance: string | null;
     /** A list of extended attributes. */
     extAttrs: ExtendedAttribute[];
+    /** The container of this type. */
+    parent: null;
 }
 
 export interface InterfaceMixinType {
@@ -133,6 +157,8 @@ export interface InterfaceMixinType {
     members: IDLInterfaceMemberType[];
     /** A list of extended attributes. */
     extAttrs: ExtendedAttribute[];
+    /** The container of this type. */
+    parent: null;
 }
 
 export interface NamespaceType {
@@ -145,6 +171,8 @@ export interface NamespaceType {
     members: IDLNamespaceMemberType[];
     /** A list of extended attributes. */
     extAttrs: ExtendedAttribute[];
+    /** The container of this type. */
+    parent: null;
 }
 
 export interface CallbackType {
@@ -157,6 +185,8 @@ export interface CallbackType {
     arguments: Argument[];
     /** A list of extended attributes. */
     extAttrs: ExtendedAttribute[];
+    /** The container of this type. */
+    parent: null;
 }
 
 export interface DictionaryType {
@@ -171,6 +201,8 @@ export interface DictionaryType {
     inheritance: string | null;
     /** A list of extended attributes. */
     extAttrs: ExtendedAttribute[];
+    /** The container of this type. */
+    parent: null;
 }
 
 export type DictionaryMemberType = FieldType;
@@ -187,6 +219,8 @@ export interface FieldType {
     extAttrs: ExtendedAttribute[];
     /** A default value, absent if there is none. */
     default: ValueDescription | null;
+    /** The container of this type. */
+    parent: DictionaryType;
 }
 
 export interface EnumType {
@@ -197,6 +231,8 @@ export interface EnumType {
     values: Array<{ type: "string"; value: string }>;
     /** A list of extended attributes. */
     extAttrs: ExtendedAttribute[];
+    /** The container of this type. */
+    parent: null;
 }
 
 export interface TypedefType {
@@ -207,6 +243,8 @@ export interface TypedefType {
     idlType: IDLTypeDescription;
     /** A list of extended attributes. */
     extAttrs: ExtendedAttribute[];
+    /** The container of this type. */
+    parent: null;
 }
 
 export interface IncludesType {
@@ -217,6 +255,8 @@ export interface IncludesType {
     includes: string;
     /** A list of extended attributes. */
     extAttrs: ExtendedAttribute[];
+    /** The container of this type. */
+    parent: null;
 }
 
 export interface ConstructorMemberType {
@@ -232,7 +272,7 @@ export interface ConstructorMemberType {
 export interface OperationMemberType {
     type: "operation";
     /** Special modifier if exists */
-    special: "getter" | "setter" | "deleter" | "static" | "stringifier";
+    special: "getter" | "setter" | "deleter" | "static" | "stringifier" | null;
     /** An IDL Type of what the operation returns. If a stringifier, may be absent. */
     idlType: IDLTypeDescription | null;
     /** The name of the operation. If a stringifier, may be null. */
@@ -250,7 +290,7 @@ export interface AttributeMemberType {
     /** The attribute's name. */
     name: string;
     /** Special modifier if exists */
-    special: "static" | "stringifier";
+    special: "static" | "stringifier" | null;
     /** True if it's an inherit attribute. */
     inherit: boolean;
     /** True if it's a read-only attribute. */
@@ -275,6 +315,22 @@ export interface ConstantMemberType {
     value: ValueDescription;
     /** A list of extended attributes. */
     extAttrs: ExtendedAttribute[];
+    /** The container of this type. */
+    parent: InterfaceType | InterfaceMixinType;
+}
+
+export interface DeclarationMemberType {
+    type: "iterable" | "maplike" | "setlike";
+    /** An array with one or more IDL Types representing the declared type arguments. */
+    idlType: IDLTypeDescription[];
+    /** Whether the iterable is declared as async. */
+    async: boolean;
+    /** Whether the maplike or setlike is declared as read only. */
+    readonly: boolean;
+    /** A list of extended attributes. */
+    extAttrs: ExtendedAttribute[];
+    /** An array of arguments for the iterable declaration. */
+    arguments: Argument[];
     /** The container of this type. */
     parent: InterfaceType | InterfaceMixinType;
 }
@@ -381,50 +437,52 @@ export type ValueDescription =
 export interface ValueDescriptionString {
     type: "string";
     value: string;
+    /** The container of this type. */
+    parent: FieldType | ConstantMemberType | Argument;
 }
 
 export interface ValueDescriptionNumber {
     type: "number";
     value: string;
+    /** The container of this type. */
+    parent: FieldType | ConstantMemberType | Argument;
 }
 
 export interface ValueDescriptionBoolean {
     type: "boolean";
     value: boolean;
+    /** The container of this type. */
+    parent: FieldType | ConstantMemberType | Argument;
 }
 
 export interface ValueDescriptionNull {
     type: "null";
+    /** The container of this type. */
+    parent: FieldType | ConstantMemberType | Argument;
 }
 
 export interface ValueDescriptionInfinity {
     type: "Infinity";
     negative: boolean;
+    /** The container of this type. */
+    parent: FieldType | ConstantMemberType | Argument;
 }
 
 export interface ValueDescriptionNaN {
     type: "NaN";
+    /** The container of this type. */
+    parent: FieldType | ConstantMemberType | Argument;
 }
 
 export interface ValueDescriptionSequence {
     type: "sequence";
     value: [];
+    /** The container of this type. */
+    parent: FieldType | ConstantMemberType | Argument;
 }
 
 export interface ValueDescriptionDictionary {
     type: "dictionary";
-}
-
-export interface DeclarationMemberType {
-    type: "iterable" | "maplike" | "setlike";
-    /** An array with one or more IDL Types representing the declared type arguments. */
-    idlType: IDLTypeDescription[];
-    /** Whether the iterable is declared as async. */
-    async: boolean;
-    /** Whether the maplike or setlike is declared as read only. */
-    readonly: boolean;
-    /** A list of extended attributes. */
-    extAttrs: ExtendedAttribute[];
-    /** An array of arguments for the iterable declaration. */
-    arguments: Argument[];
+    /** The container of this type. */
+    parent: FieldType | ConstantMemberType | Argument;
 }

--- a/types/webidl2/webidl2-tests.ts
+++ b/types/webidl2/webidl2-tests.ts
@@ -4,6 +4,8 @@ import * as webidl2 from "webidl2";
 const parsed = webidl2.parse("");
 
 for (const rootType of parsed) {
+    rootType.parent; // $ExpectType null
+
     if (rootType.type !== "includes") {
         console.log(rootType.name);
     }
@@ -75,14 +77,17 @@ function logMembers(members: webidl2.IDLInterfaceMemberType[]) {
         switch (member.type) {
             case "constructor":
                 member; // $ExpectType ConstructorMemberType
+                member.parent; // $ExpectType InterfaceType
                 logArguments(member.arguments);
                 break;
             case "operation":
             case "attribute":
+                member.parent; // $ExpectType InterfaceType | InterfaceMixinType | NamespaceType
                 logNamespaceMember(member);
                 break;
             case "const":
                 member; // $ExpectType ConstantMemberType
+                member.parent; // $ExpectType InterfaceType | InterfaceMixinType
                 console.log(member.name);
                 logIdlType(member.idlType);
                 logValueDescription(member.value);
@@ -92,6 +97,7 @@ function logMembers(members: webidl2.IDLInterfaceMemberType[]) {
             case "maplike":
             case "setlike":
                 member; // $ExpectType DeclarationMemberType
+                member.parent; // $ExpectType InterfaceType | InterfaceMixinType
                 member.async; // $ExpectType boolean
                 member.readonly; // $ExpectType boolean
                 console.log(member.readonly);
@@ -117,12 +123,14 @@ function logNamespaceMember(member: webidl2.IDLNamespaceMemberType) {
     switch (member.type) {
         case "operation":
             member; // $ExpectType OperationMemberType
+            member.parent; // $ExpectType InterfaceType | InterfaceMixinType | NamespaceType
             logArguments(member.arguments);
             console.log(member.name);
             console.log(member.special);
             break;
         case "attribute":
             member; // $ExpectType AttributeMemberType
+            member.parent; // $ExpectType InterfaceType | InterfaceMixinType | NamespaceType
             console.log(member.name);
             console.log(member.special, member.readonly, member.inherit);
             break;
@@ -204,6 +212,7 @@ function logIdlType(idlType: webidl2.IDLTypeDescription) {
 }
 
 function logValueDescription(valueDesc: webidl2.ValueDescription) {
+    valueDesc.parent; // $ExpectType FieldType | ConstantMemberType | Argument
     console.log(valueDesc.type);
     switch (valueDesc.type) {
         case "string":


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/w3c/webidl2.js/pull/425>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
