### PR TITLE
[googlemaps] Update to TypeScript 3.8

### DIFF
--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -18,7 +18,7 @@
 //                 Justin Poehnelt <https://github.com/jpoehnelt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// TypeScript Version: 3.0
+// TypeScript Version: 3.8
 
 /*
 The MIT License


### PR DESCRIPTION
Fix error with [empty tuple](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/47066#issuecomment-682491735). Thanks to @simonhaenisch.
