### PR TITLE
refactor(webidl2): Match AST class inheritance

### DIFF
--- a/types/webidl2/index.d.ts
+++ b/types/webidl2/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for webidl2 23.12
+// Type definitions for webidl2 23.13
 // Project: https://github.com/w3c/webidl2.js#readme
 // Definitions by: Kagama Sascha Rosylight <https://github.com/saschanaz>
 //                 ExE Boss <https://github.com/ExE-Boss>
@@ -10,23 +10,32 @@ export as namespace WebIDL2;
 export function parse(str: string, options?: ParseOptions): IDLRootType[];
 
 export type IDLRootType =
-    | InterfaceType
-    | InterfaceMixinType
-    | NamespaceType
     | CallbackType
+    | CallbackInterfaceType
     | DictionaryType
     | EnumType
-    | TypedefType
-    | IncludesType;
+    | IncludesType
+    | InterfaceMixinType
+    | InterfaceType
+    | NamespaceType
+    | TypedefType;
+
+export type IDLCallbackInterfaceMemberType = ConstantMemberType | OperationMemberType;
 
 export type IDLInterfaceMemberType =
-    | OperationMemberType
-    | ConstructorMemberType
     | AttributeMemberType
     | ConstantMemberType
-    | DeclarationMemberType;
+    | ConstructorMemberType
+    | DeclarationMemberType
+    | OperationMemberType;
 
-export type IDLNamespaceMemberType = OperationMemberType | AttributeMemberType;
+export type IDLInterfaceMixinMemberType =
+    | AttributeMemberType
+    | ConstantMemberType
+    | (DeclarationMemberType & { type: "stringifier" })
+    | OperationMemberType;
+
+export type IDLNamespaceMemberType = AttributeMemberType | OperationMemberType;
 
 export type IDLTypeDescription = SingleTypeDescription | UnionTypeDescription;
 
@@ -45,7 +54,7 @@ export class WebIDLParseError extends Error {
         line: number;
         sourceName?: string;
         input: string;
-        tokens: ValueDescription[];
+        tokens: Token[];
     });
 
     name: "WebIDLParseError";
@@ -62,18 +71,47 @@ export class WebIDLParseError extends Error {
     /** a short peek at the text at the point where the error happened */
     input: string;
     /** the five tokens at the point of error, as understood by the tokeniser */
-    tokens: ValueDescription[];
+    tokens: Token[];
 }
 
-export interface SingleTypeDescription {
-    /** String indicating where this type is used. Can be null if not applicable. */
+export interface Token {
+    type: string;
+    value: string;
+    trivia: string;
+    line: number;
+    index: number;
+}
+
+export interface AbstractBase {
+    /** String indicating the type of this node. */
     type: string | null;
+    /** The container of this type. */
+    parent: AbstractBase | null;
+    /** A list of extended attributes. */
+    extAttrs: ExtendedAttribute[];
+}
+
+export interface AbstractTypeDescription extends AbstractBase {
     /** Boolean indicating if it is a sequence. Same as generic === "sequence" */
     sequence: boolean;
     /** String indicating the generic type (e.g. "Promise", "sequence"). null otherwise. */
     generic: string | null;
     /** Boolean indicating whether this is nullable or not. */
     nullable: boolean;
+    /** The container of this type. */
+    parent:
+        | Argument
+        | AttributeMemberType
+        | CallbackType
+        | ConstantMemberType
+        | DeclarationMemberType
+        | FieldType
+        | OperationMemberType
+        | TypedefType
+        | UnionTypeDescription;
+}
+
+export interface SingleTypeDescription extends AbstractTypeDescription {
     /** Boolean indicating whether this is a union type or not. */
     union: false;
     /**
@@ -83,30 +121,9 @@ export interface SingleTypeDescription {
      * the eventual value of the promise, etc.
      */
     idlType: string;
-    /** A list of extended attributes. */
-    extAttrs: ExtendedAttribute[];
-    /** The container of this type. */
-    parent:
-        | UnionTypeDescription
-        | CallbackType
-        | FieldType
-        | TypedefType
-        | OperationMemberType
-        | AttributeMemberType
-        | ConstantMemberType
-        | Argument
-        | DeclarationMemberType;
 }
 
-export interface UnionTypeDescription {
-    /** String indicating where this type is used. Can be null if not applicable. */
-    type: string | null;
-    /** Boolean indicating if it is a sequence. Same as generic === "sequence" */
-    sequence: boolean;
-    /** String indicating the generic type (e.g. "Promise", "sequence"). null otherwise. */
-    generic: string | null;
-    /** Boolean indicating whether this is nullable or not. */
-    nullable: boolean;
+export interface UnionTypeDescription extends AbstractTypeDescription {
     /** Boolean indicating whether this is a union type or not. */
     union: true;
     /**
@@ -116,66 +133,46 @@ export interface UnionTypeDescription {
      * the eventual value of the promise, etc.
      */
     idlType: IDLTypeDescription[];
-    /** A list of extended attributes. */
-    extAttrs: ExtendedAttribute[];
-    /** The container of this type. */
-    parent:
-        | UnionTypeDescription
-        | CallbackType
-        | FieldType
-        | TypedefType
-        | OperationMemberType
-        | AttributeMemberType
-        | ConstantMemberType
-        | Argument
-        | DeclarationMemberType;
 }
 
-export interface InterfaceType {
-    type: "interface" | "callback interface";
-    /** The name of the interface */
+export interface AbstractContainer extends AbstractBase {
+    /** The name of the container. */
     name: string;
-    /** A boolean indicating whether it's a partial interface. */
+    /** A boolean indicating whether this container is partial. */
     partial: boolean;
-    /** An array of interface members (attributes, operations, etc.). Empty if there are none. */
+    /** An array of container members (attributes, operations, etc.). Empty if there are none. */
+    members: AbstractBase[];
+}
+
+export interface CallbackInterfaceType extends AbstractContainer {
+    type: "callback interface";
+    members: IDLCallbackInterfaceMemberType[];
+    parent: null;
+}
+
+export interface InterfaceType extends AbstractContainer {
+    type: "interface";
     members: IDLInterfaceMemberType[];
     /** A string giving the name of an interface this one inherits from, null otherwise. */
     inheritance: string | null;
-    /** A list of extended attributes. */
-    extAttrs: ExtendedAttribute[];
-    /** The container of this type. */
     parent: null;
 }
 
-export interface InterfaceMixinType {
+export interface InterfaceMixinType extends AbstractContainer {
     type: "interface mixin";
-    /** The name of the interface mixin */
-    name: string;
-    /** A boolean indicating whether it's a partial interface mixin. */
-    partial: boolean;
-    /** An array of interface members (attributes, operations, etc.). Empty if there are none. */
-    members: IDLInterfaceMemberType[];
-    /** A list of extended attributes. */
-    extAttrs: ExtendedAttribute[];
-    /** The container of this type. */
+    members: IDLInterfaceMixinMemberType[];
+    inheritance: null;
     parent: null;
 }
 
-export interface NamespaceType {
+export interface NamespaceType extends AbstractContainer {
     type: "namespace";
-    /** A boolean indicating whether it's a partial namespace. */
-    partial: boolean;
-    /** The enum's name. */
-    name: string;
-    /** An array of namespace members (attributes, operations). Empty if there are none. */
     members: IDLNamespaceMemberType[];
-    /** A list of extended attributes. */
-    extAttrs: ExtendedAttribute[];
-    /** The container of this type. */
+    inheritance: null;
     parent: null;
 }
 
-export interface CallbackType {
+export interface CallbackType extends AbstractBase {
     type: "callback";
     /** The name of the callback. */
     name: string;
@@ -183,31 +180,20 @@ export interface CallbackType {
     idlType: IDLTypeDescription;
     /** A list of arguments, as in function paramters. */
     arguments: Argument[];
-    /** A list of extended attributes. */
-    extAttrs: ExtendedAttribute[];
-    /** The container of this type. */
     parent: null;
 }
 
-export interface DictionaryType {
+export interface DictionaryType extends AbstractContainer {
     type: "dictionary";
-    /** The dictionary name. */
-    name: string;
-    /** Boolean indicating whether it's a partial dictionary. */
-    partial: boolean;
-    /** An array of members (see below). */
     members: DictionaryMemberType[];
-    /** A string indicating which dictionary is being inherited from, null otherwise. */
+    /** A string giving the name of a dictionary this one inherits from, null otherwise. */
     inheritance: string | null;
-    /** A list of extended attributes. */
-    extAttrs: ExtendedAttribute[];
-    /** The container of this type. */
     parent: null;
 }
 
 export type DictionaryMemberType = FieldType;
 
-export interface FieldType {
+export interface FieldType extends AbstractBase {
     type: "field";
     /** The name of the field. */
     name: string;
@@ -215,61 +201,47 @@ export interface FieldType {
     required: boolean;
     /** An IDL Type describing what field's type. */
     idlType: IDLTypeDescription;
-    /** A list of extended attributes. */
-    extAttrs: ExtendedAttribute[];
     /** A default value, absent if there is none. */
     default: ValueDescription | null;
-    /** The container of this type. */
     parent: DictionaryType;
 }
 
-export interface EnumType {
+export interface EnumType extends AbstractBase {
     type: "enum";
     /** The enum's name. */
     name: string;
     /** An array of values (strings). */
-    values: Array<{ type: "string"; value: string }>;
-    /** A list of extended attributes. */
-    extAttrs: ExtendedAttribute[];
+    values: Array<{ type: "enum-value"; value: string; parent: EnumType }>;
     /** The container of this type. */
     parent: null;
 }
 
-export interface TypedefType {
+export interface TypedefType extends AbstractBase {
     type: "typedef";
     /** The typedef's name. */
     name: string;
     /** An IDL Type describing what typedef's type. */
     idlType: IDLTypeDescription;
-    /** A list of extended attributes. */
-    extAttrs: ExtendedAttribute[];
-    /** The container of this type. */
     parent: null;
 }
 
-export interface IncludesType {
+export interface IncludesType extends AbstractBase {
     type: "includes";
     /** The interface that includes an interface mixin. */
     target: string;
     /** The interface mixin that is being included by the target. */
     includes: string;
-    /** A list of extended attributes. */
-    extAttrs: ExtendedAttribute[];
-    /** The container of this type. */
     parent: null;
 }
 
-export interface ConstructorMemberType {
+export interface ConstructorMemberType extends AbstractBase {
     type: "constructor";
     /** An array of arguments for the constructor operation. */
     arguments: Argument[];
-    /** A list of extended attributes. */
-    extAttrs: ExtendedAttribute[];
-    /** The container of this type. */
     parent: InterfaceType;
 }
 
-export interface OperationMemberType {
+export interface OperationMemberType extends AbstractBase {
     type: "operation";
     /** Special modifier if exists */
     special: "getter" | "setter" | "deleter" | "static" | "stringifier" | null;
@@ -279,13 +251,10 @@ export interface OperationMemberType {
     name: string | null;
     /** An array of arguments for the operation. */
     arguments: Argument[];
-    /** A list of extended attributes. */
-    extAttrs: ExtendedAttribute[];
-    /** The container of this type. */
-    parent: InterfaceType | InterfaceMixinType | NamespaceType;
+    parent: CallbackInterfaceType | InterfaceMixinType | InterfaceType | NamespaceType;
 }
 
-export interface AttributeMemberType {
+export interface AttributeMemberType extends AbstractBase {
     type: "attribute";
     /** The attribute's name. */
     name: string;
@@ -297,13 +266,10 @@ export interface AttributeMemberType {
     readonly: boolean;
     /** An IDL Type for the attribute. */
     idlType: IDLTypeDescription;
-    /** A list of extended attributes. */
-    extAttrs: ExtendedAttribute[];
-    /** The container of this type. */
-    parent: InterfaceType | InterfaceMixinType | NamespaceType;
+    parent: InterfaceMixinType | InterfaceType | NamespaceType;
 }
 
-export interface ConstantMemberType {
+export interface ConstantMemberType extends AbstractBase {
     type: "const";
     /** Whether its type is nullable. */
     nullable: boolean;
@@ -313,13 +279,10 @@ export interface ConstantMemberType {
     name: string;
     /** The constant value */
     value: ValueDescription;
-    /** A list of extended attributes. */
-    extAttrs: ExtendedAttribute[];
-    /** The container of this type. */
-    parent: InterfaceType | InterfaceMixinType;
+    parent: CallbackInterfaceType | InterfaceMixinType | InterfaceType;
 }
 
-export interface DeclarationMemberType {
+export interface DeclarationMemberType extends AbstractBase {
     type: "iterable" | "maplike" | "setlike";
     /** An array with one or more IDL Types representing the declared type arguments. */
     idlType: IDLTypeDescription[];
@@ -327,15 +290,13 @@ export interface DeclarationMemberType {
     async: boolean;
     /** Whether the maplike or setlike is declared as read only. */
     readonly: boolean;
-    /** A list of extended attributes. */
-    extAttrs: ExtendedAttribute[];
     /** An array of arguments for the iterable declaration. */
     arguments: Argument[];
-    /** The container of this type. */
-    parent: InterfaceType | InterfaceMixinType;
+    parent: InterfaceMixinType | InterfaceType;
 }
 
-export interface Argument {
+export interface Argument extends AbstractBase {
+    type: "argument";
     /** A default value, absent if there is none. */
     default: ValueDescription | null;
     /** True if the argument is optional. */
@@ -346,23 +307,21 @@ export interface Argument {
     idlType: IDLTypeDescription;
     /** The argument's name. */
     name: string;
-    /** A list of extended attributes. */
-    extAttrs: ExtendedAttribute[];
-    /** The container of this type. */
     parent: CallbackType | ConstructorMemberType | ExtendedAttribute | OperationMemberType;
 }
 
-export interface ExtendedAttribute {
+export interface ExtendedAttribute extends AbstractBase {
+    type: "extended-attribute";
     /** The extended attribute's name. */
     name: string;
     /** If the extended attribute takes arguments or if its right-hand side does they are listed here. */
     arguments: Argument[];
     /** If there is a right-hand side, this will capture its type and value. */
     rhs: ExtendedAttributeRightHandSide | null;
-    /** The container of this extended attribute. */
     parent: IDLRootType | FieldType | IDLInterfaceMemberType;
 }
 
+// prettier-ignore
 export type ExtendedAttributeRightHandSide =
     | ExtendedAttributeRightHandSideBase
     | ExtendedAttributeRightHandSideList;
@@ -419,9 +378,8 @@ export interface ExtendedAttributeRightHandSideIntegerList {
     value: ExtendedAttributeRightHandSideInteger[];
 }
 
-export interface Token {
-    type: "decimal" | "integer" | "identifier" | "string" | "whitespace" | "other";
-    value: string;
+export interface AbstractValueDescription extends AbstractBase {
+    parent: Argument | ConstantMemberType | FieldType;
 }
 
 export type ValueDescription =
@@ -434,55 +392,39 @@ export type ValueDescription =
     | ValueDescriptionSequence
     | ValueDescriptionDictionary;
 
-export interface ValueDescriptionString {
+export interface ValueDescriptionString extends AbstractValueDescription {
     type: "string";
     value: string;
-    /** The container of this type. */
-    parent: FieldType | ConstantMemberType | Argument;
 }
 
-export interface ValueDescriptionNumber {
+export interface ValueDescriptionNumber extends AbstractValueDescription {
     type: "number";
     value: string;
-    /** The container of this type. */
-    parent: FieldType | ConstantMemberType | Argument;
 }
 
-export interface ValueDescriptionBoolean {
+export interface ValueDescriptionBoolean extends AbstractValueDescription {
     type: "boolean";
     value: boolean;
-    /** The container of this type. */
-    parent: FieldType | ConstantMemberType | Argument;
 }
 
-export interface ValueDescriptionNull {
+export interface ValueDescriptionNull extends AbstractValueDescription {
     type: "null";
-    /** The container of this type. */
-    parent: FieldType | ConstantMemberType | Argument;
 }
 
-export interface ValueDescriptionInfinity {
+export interface ValueDescriptionInfinity extends AbstractValueDescription {
     type: "Infinity";
     negative: boolean;
-    /** The container of this type. */
-    parent: FieldType | ConstantMemberType | Argument;
 }
 
-export interface ValueDescriptionNaN {
+export interface ValueDescriptionNaN extends AbstractValueDescription {
     type: "NaN";
-    /** The container of this type. */
-    parent: FieldType | ConstantMemberType | Argument;
 }
 
-export interface ValueDescriptionSequence {
+export interface ValueDescriptionSequence extends AbstractValueDescription {
     type: "sequence";
     value: [];
-    /** The container of this type. */
-    parent: FieldType | ConstantMemberType | Argument;
 }
 
-export interface ValueDescriptionDictionary {
+export interface ValueDescriptionDictionary extends AbstractValueDescription {
     type: "dictionary";
-    /** The container of this type. */
-    parent: FieldType | ConstantMemberType | Argument;
 }

--- a/types/webidl2/webidl2-tests.ts
+++ b/types/webidl2/webidl2-tests.ts
@@ -28,7 +28,7 @@ for (const rootType of parsed) {
             logNamespaceMembers(rootType.members);
             break;
         case "callback interface":
-            rootType; // $ExpectType InterfaceType
+            rootType; // $ExpectType CallbackInterfaceType
             logMembers(rootType.members);
             console.log(rootType.partial);
             break;
@@ -69,6 +69,7 @@ for (const rootType of parsed) {
             break;
     }
 
+    rootType.extAttrs; // $ExpectType ExtendedAttribute[]
     logExtAttrs(rootType.extAttrs);
 }
 
@@ -81,13 +82,18 @@ function logMembers(members: webidl2.IDLInterfaceMemberType[]) {
                 logArguments(member.arguments);
                 break;
             case "operation":
+                member; // $ExpectType OperationMemberType
+                member.parent; // $ExpectType CallbackInterfaceType | InterfaceMixinType | InterfaceType | NamespaceType
+                logNamespaceMember(member);
+                break;
             case "attribute":
-                member.parent; // $ExpectType InterfaceType | InterfaceMixinType | NamespaceType
+                member; // $ExpectType AttributeMemberType
+                member.parent; // $ExpectType InterfaceMixinType | InterfaceType | NamespaceType
                 logNamespaceMember(member);
                 break;
             case "const":
                 member; // $ExpectType ConstantMemberType
-                member.parent; // $ExpectType InterfaceType | InterfaceMixinType
+                member.parent; // $ExpectType CallbackInterfaceType | InterfaceMixinType | InterfaceType
                 console.log(member.name);
                 logIdlType(member.idlType);
                 logValueDescription(member.value);
@@ -97,7 +103,7 @@ function logMembers(members: webidl2.IDLInterfaceMemberType[]) {
             case "maplike":
             case "setlike":
                 member; // $ExpectType DeclarationMemberType
-                member.parent; // $ExpectType InterfaceType | InterfaceMixinType
+                member.parent; // $ExpectType InterfaceMixinType | InterfaceType
                 member.async; // $ExpectType boolean
                 member.readonly; // $ExpectType boolean
                 console.log(member.readonly);
@@ -123,14 +129,14 @@ function logNamespaceMember(member: webidl2.IDLNamespaceMemberType) {
     switch (member.type) {
         case "operation":
             member; // $ExpectType OperationMemberType
-            member.parent; // $ExpectType InterfaceType | InterfaceMixinType | NamespaceType
+            member.parent; // $ExpectType CallbackInterfaceType | InterfaceMixinType | InterfaceType | NamespaceType
             logArguments(member.arguments);
             console.log(member.name);
             console.log(member.special);
             break;
         case "attribute":
             member; // $ExpectType AttributeMemberType
-            member.parent; // $ExpectType InterfaceType | InterfaceMixinType | NamespaceType
+            member.parent; // $ExpectType InterfaceMixinType | InterfaceType | NamespaceType
             console.log(member.name);
             console.log(member.special, member.readonly, member.inherit);
             break;


### PR DESCRIPTION
This refactors the **webidl2** AST interfaces to use an inheritance chain similar to the actual implementation and the type definitions used by `@types/babel-types` and `@babel/types`.

This also cleans up a lot of duplication in the type definitions.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/w3c/webidl2.js/tree/gh-pages/lib/productions>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
