### PR TITLE
hapi__hapi: request payload any

### DIFF
--- a/types/hapi__hapi/index.d.ts
+++ b/types/hapi__hapi/index.d.ts
@@ -492,9 +492,8 @@ export interface Request extends Podium {
 
     /**
      * The request payload based on the route payload.output and payload.parse settings.
-     * TODO check this typing and add references / links.
      */
-    readonly payload: stream.Readable | Buffer | string | object;
+    readonly payload: any;
 
     /**
      * Plugin-specific state. Provides a place to store and pass request-level plugin data. The plugins is an object where each key is a plugin name and the value is the state.


### PR DESCRIPTION
request payload `any` instead of `stream.Readable | Buffer | string | object`