### PR TITLE
update(replace-ext): v2 bump

### DIFF
--- a/types/replace-ext/index.d.ts
+++ b/types/replace-ext/index.d.ts
@@ -1,9 +1,14 @@
-// Type definitions for replace-ext 0.0.1
+// Type definitions for replace-ext 2.0
 // Project: https://github.com/wearefractal/replace-ext
 // Definitions by: Deividas Bakanas <https://github.com/DeividasBakanas>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
-declare function replaceExt(npath: string, ext: string): string;
+/**
+ * Replaces the extension from path with extension and returns the updated path string.
+ *
+ * Does not replace the extension if path is not a string or is empty.
+ */
+declare function replaceExt(path: string, extension: string): string;
 
 export = replaceExt;

--- a/types/replace-ext/replace-ext-tests.ts
+++ b/types/replace-ext/replace-ext-tests.ts
@@ -1,5 +1,4 @@
-
 import replaceExt = require('replace-ext');
 
-var path: string = '/some/dir/file.js';
-var npath: string = replaceExt(path, '.coffee');
+const path = '/some/dir/file.js';
+const newPath = replaceExt(path, '.coffee'); // $ExpectType string

--- a/types/replace-ext/tslint.json
+++ b/types/replace-ext/tslint.json
@@ -1,14 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "callable-types": false,
-        "dt-header": false,
-        "no-consecutive-blank-lines": false,
-        "no-inferrable-types": false,
-        "no-redundant-jsdoc": false,
-        "no-var-keyword": false,
-        "prefer-const": false,
-        "prefer-method-signature": false,
-        "trim-file": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
API shape stays same:
- JSDocs added
- default to current DT settings
- version bump
- mantainer added

https://github.com/gulpjs/replace-ext/compare/v0.0.1...v2.0.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.