### PR TITLE
update(imagemin-webp): v6 update and minor tweaks

### DIFF
--- a/types/imagemin-webp/imagemin-webp-tests.ts
+++ b/types/imagemin-webp/imagemin-webp-tests.ts
@@ -4,6 +4,7 @@ import imageminWebp = require('imagemin-webp');
 imagemin(['*.webp'], {
     plugins: [
         imageminWebp(),
+        imageminWebp({}),
         imageminWebp({
             crop: {
                 height: 20,
@@ -14,6 +15,21 @@ imagemin(['*.webp'], {
             preset: 'photo',
             metadata: 'all',
             lossless: true,
+            alphaQuality: 50,
+            autoFilter: true,
+            filter: 50,
+            method: 0,
+            nearLossless: 50,
+            quality: 50,
+            resize: {
+                width: 100,
+                height: 100,
+            },
+            sharpness: 4,
+            size: 1024,
+            sns: 50,
         }),
     ],
 });
+
+imageminWebp(); // $ExpectType Plugin

--- a/types/imagemin-webp/index.d.ts
+++ b/types/imagemin-webp/index.d.ts
@@ -1,10 +1,14 @@
 // Type definitions for imagemin-webp 5.1
 // Project: https://github.com/imagemin/imagemin-webp#readme
 // Definitions by: Brett M <https://github.com/brettm12345>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { Plugin } from 'imagemin';
 
+/**
+ * WebP imagemin plugin
+ */
 declare function imageminWebp(options?: imageminWebp.Options): Plugin;
 
 declare namespace imageminWebp {
@@ -92,10 +96,6 @@ declare namespace imageminWebp {
          * A list of metadata to copy from the input to the output if present.
          */
         metadata?: Metadata | Metadata[];
-        /**
-         * Buffer to optimize.
-         */
-        buffer?: Buffer;
     }
 }
 


### PR DESCRIPTION
- remove 'buffer' options, is not an option - it's just reference in the
  README about the outcome input argument type (Buffer)
- JSDoc comments
- tests amended
- v6 bump
- maintainer added

https://github.com/imagemin/imagemin-webp/compare/v5.1.0...v6.0.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.