### PR TITLE
[firefox-webext-browser] Narrowed message and storage types

### DIFF
--- a/types/firefox-webext-browser/index.d.ts
+++ b/types/firefox-webext-browser/index.d.ts
@@ -15,6 +15,11 @@ interface Window {
     browser: typeof browser;
 }
 
+/** courtesy of https://github.com/sindresorhus/type-fest */
+export type JsonObject = {[Key in string]?: JsonValue};
+export interface JsonArray extends Array<JsonValue> {}
+export type JsonValue = string | number | boolean | null | JsonObject | JsonArray;
+
 /** Not allowed in: Content scripts, Devtools pages */
 declare namespace browser._manifest {
     /* _manifest types */

--- a/types/firefox-webext-browser/index.d.ts
+++ b/types/firefox-webext-browser/index.d.ts
@@ -2146,7 +2146,7 @@ declare namespace browser.extension {
      * @deprecated Please use `runtime.onMessage`.
      */
     const onRequest:
-        | WebExtEvent<(request: any, sender: runtime.MessageSender, sendResponse: (response?: any) => void) => void>
+        | WebExtEvent<(request: JsonObject, sender: runtime.MessageSender, sendResponse: (response?: any) => void) => void>
         | undefined;
 
     /**
@@ -2156,7 +2156,7 @@ declare namespace browser.extension {
      * @deprecated Please use `runtime.onMessageExternal`.
      */
     const onRequestExternal:
-        | WebExtEvent<(request: any, sender: runtime.MessageSender, sendResponse: (response?: any) => void) => void>
+        | WebExtEvent<(request: JsonObject, sender: runtime.MessageSender, sendResponse: (response?: any) => void) => void>
         | undefined;
 }
 
@@ -3256,7 +3256,7 @@ declare namespace browser.runtime {
         /** This property will **only** be present on ports passed to onConnect/onConnectExternal listeners. */
         sender?: MessageSender;
         error?: Error;
-        onMessage: WebExtEvent<(response: object) => void>;
+        onMessage: WebExtEvent<(response: JsonObject) => void>;
         onDisconnect: WebExtEvent<(port: Port) => void>;
     }
 
@@ -3462,12 +3462,12 @@ declare namespace browser.runtime {
     /**
      * Sends a single message to event listeners within your extension/app or a different extension/app. Similar to `runtime.connect` but only sends a single message, with an optional response. If sending to your extension, the `runtime.onMessage` event will be fired in each page, or `runtime.onMessageExternal`, if a different extension. Note that extensions cannot send messages to content scripts using this method. To send messages to content scripts, use `tabs.sendMessage`.
      */
-    function sendMessage(message: any, options?: _SendMessageOptions): Promise<any>;
+    function sendMessage(message: any, options?: _SendMessageOptions): Promise<JsonObject | undefined>;
     /**
      * Sends a single message to event listeners within your extension/app or a different extension/app. Similar to `runtime.connect` but only sends a single message, with an optional response. If sending to your extension, the `runtime.onMessage` event will be fired in each page, or `runtime.onMessageExternal`, if a different extension. Note that extensions cannot send messages to content scripts using this method. To send messages to content scripts, use `tabs.sendMessage`.
      * @param extensionId The ID of the extension/app to send the message to. If omitted, the message will be sent to your own extension/app. Required if sending messages from a web page for web messaging.
      */
-    function sendMessage(extensionId: string, message: any, options?: _SendMessageOptions): Promise<any>;
+    function sendMessage(extensionId: string, message: any, options?: _SendMessageOptions): Promise<JsonObject | undefined>;
 
     /**
      * Send a single message to a native application.
@@ -3538,7 +3538,7 @@ declare namespace browser.runtime {
      * @returns Return true from the event listener if you wish to call `sendResponse` after the event listener returns.
      */
     const onMessage: WebExtEvent<(
-        message: any,
+        message: JsonObject,
         sender: MessageSender,
         sendResponse: (response?: any) => void,
     ) => boolean | Promise<any> | void>;
@@ -3550,7 +3550,7 @@ declare namespace browser.runtime {
      * @returns Return true from the event listener if you wish to call `sendResponse` after the event listener returns.
      */
     const onMessageExternal: WebExtEvent<(
-        message: any,
+        message: JsonObject,
         sender: MessageSender,
         sendResponse: (response?: any) => void,
     ) => boolean | Promise<any> | void>;
@@ -7623,12 +7623,12 @@ declare namespace browser.tabs {
      * Sends a single request to the content script(s) in the specified tab, with an optional callback to run when a response is sent back. The `extension.onRequest` event is fired in each content script running in the specified tab for the current extension.
      * @deprecated Please use `runtime.sendMessage`.
      */
-    function sendRequest(tabId: number, request: any, responseCallback?: (response: any) => void): void;
+    function sendRequest(tabId: number, request: any, responseCallback?: (response: JsonObject | undefined) => void): void;
 
     /**
      * Sends a single message to the content script(s) in the specified tab, with an optional callback to run when a response is sent back. The `runtime.onMessage` event is fired in each content script running in the specified tab for the current extension.
      */
-    function sendMessage(tabId: number, message: any, options?: _SendMessageOptions): Promise<any>;
+    function sendMessage(tabId: number, message: any, options?: _SendMessageOptions): Promise<JsonObject | undefined>;
 
     /**
      * Gets the tab that is selected in the specified window.

--- a/types/firefox-webext-browser/index.d.ts
+++ b/types/firefox-webext-browser/index.d.ts
@@ -3572,9 +3572,9 @@ declare namespace browser.storage {
     /* storage types */
     interface StorageChange {
         /** The old value of the item, if there was an old value. */
-        oldValue?: any;
+        oldValue?: JsonValue;
         /** The new value of the item, if there is a new value. */
-        newValue?: any;
+        newValue?: JsonValue;
     }
 
     interface StorageArea {
@@ -3582,7 +3582,7 @@ declare namespace browser.storage {
          * Gets one or more items from storage.
          * @param [keys] A single key to get, list of keys to get, or a dictionary specifying default values (see description of the object). An empty list or object will return an empty result object. Pass in `null` to get the entire contents of storage.
          */
-        get(keys?: string | string[] | { [key: string]: any }): Promise<{ [key: string]: any }>;
+        get(keys?: string | string[] | { [key: string]: any }): Promise<JsonObject>;
         /**
          * Gets the amount of space (in bytes) being used by one or more items.
          * @param [keys] A single key or list of keys to get the total usage for. An empty list will return 0\. Pass in `null` to get the total usage of all of storage.
@@ -3610,7 +3610,7 @@ declare namespace browser.storage {
          * Gets one or more items from storage.
          * @param [keys] A single key to get, list of keys to get, or a dictionary specifying default values (see description of the object). An empty list or object will return an empty result object. Pass in `null` to get the entire contents of storage.
          */
-        get(keys?: string | string[] | { [key: string]: any }): Promise<{ [key: string]: any }>;
+        get(keys?: string | string[] | { [key: string]: any }): Promise<JsonObject>;
         /**
          * Gets the amount of space (in bytes) being used by one or more items.
          * @param [keys] A single key or list of keys to get the total usage for. An empty list will return 0\. Pass in `null` to get the total usage of all of storage.

--- a/types/firefox-webext-browser/index.d.ts
+++ b/types/firefox-webext-browser/index.d.ts
@@ -20,6 +20,11 @@ export type JsonObject = {[Key in string]?: JsonValue};
 export interface JsonArray extends Array<JsonValue> {}
 export type JsonValue = string | number | boolean | null | JsonObject | JsonArray;
 
+/** structured json types */
+type JsonOfString<Key extends string> = Record<Key, JsonValue>;
+type JsonOfStrings<Keys extends string[]> = Record<Keys[number], JsonValue>;
+type JsonOfObject<T extends Record<string | number | symbol, unknown>> = Record<keyof T, JsonValue>;
+
 /** Not allowed in: Content scripts, Devtools pages */
 declare namespace browser._manifest {
     /* _manifest types */
@@ -3582,7 +3587,15 @@ declare namespace browser.storage {
          * Gets one or more items from storage.
          * @param [keys] A single key to get, list of keys to get, or a dictionary specifying default values (see description of the object). An empty list or object will return an empty result object. Pass in `null` to get the entire contents of storage.
          */
-        get(keys?: string | string[] | { [key: string]: any }): Promise<JsonObject>;
+        get<Keys extends string | string[] | { [key: string]: unknown }>(keys?: Keys): Promise<
+        Keys extends string
+            ? JsonOfString<Keys>
+            : Keys extends string[]
+            ? JsonOfStrings<Keys>
+            : Keys extends {[key: string]: unknown}
+            ? JsonOfObject<Keys>
+            : unknown
+    >;
         /**
          * Gets the amount of space (in bytes) being used by one or more items.
          * @param [keys] A single key or list of keys to get the total usage for. An empty list will return 0\. Pass in `null` to get the total usage of all of storage.
@@ -3610,7 +3623,15 @@ declare namespace browser.storage {
          * Gets one or more items from storage.
          * @param [keys] A single key to get, list of keys to get, or a dictionary specifying default values (see description of the object). An empty list or object will return an empty result object. Pass in `null` to get the entire contents of storage.
          */
-        get(keys?: string | string[] | { [key: string]: any }): Promise<JsonObject>;
+        get<Keys extends string | string[] | { [key: string]: unknown }>(keys?: Keys): Promise<
+        Keys extends string
+            ? JsonOfString<Keys>
+            : Keys extends string[]
+            ? JsonOfStrings<Keys>
+            : Keys extends {[key: string]: unknown}
+            ? JsonOfObject<Keys>
+            : unknown
+    >;
         /**
          * Gets the amount of space (in bytes) being used by one or more items.
          * @param [keys] A single key or list of keys to get the total usage for. An empty list will return 0\. Pass in `null` to get the total usage of all of storage.


### PR DESCRIPTION
Authors: @jsmnbom 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Disclaimer: I tried following the testing/compiling steps from the readme but the test file already seems to not work as-is, and `index.d.ts` already contains a lint/compile violation on the `eval` function?

Since the various functions around local/sync storage and background/tabs messaging can _only_ return jsonified objects, I believe they should be typed as such. This prevents you from writing code that e.g. mistakenly assumes a field to be of type Date or some such. I've also added the "smarts" to the storage functions that make them properly predict the structure of the loaded object, which is always derived from the `keys` passed in.
TLDR: `any` is evil.

I'm not 100% sure about some of the `any`s I've changed to `JsonObject`  if they shouldn't also be ` | undefined`, I'll have to read the specs to get a better idea.

I'm putting this PR up half-finished as a starting point, POC, and basis for discussion. I'm lacking some insider knowledge/experience on DefinitelyTyped and this package to be able to get this PR to 100% done, but I assume you can help with that and do the parts you can more easily do yourself than explain to me? :)