### PR TITLE
update(svg-sprite): remove Winston dependency and version bump

### DIFF
--- a/types/svg-sprite/index.d.ts
+++ b/types/svg-sprite/index.d.ts
@@ -1,9 +1,8 @@
-// Type definitions for svg-sprite
+// Type definitions for svg-sprite 1.5
 // Project: https://github.com/jkphl/svg-sprite
 // Definitions by: Qubo <https://github.com/tkqubo>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
-
 /// <reference types="node" />
 import File = require('vinyl');
 import { Logger } from 'winston';
@@ -24,7 +23,7 @@ declare namespace sprite {
          * @param name The "local" part of the file path, possibly including subdirectories which will get traversed to CSS selectors using the shape.id.separator configuration option.
          * @param svg SVG file content.
          */
-        add(file: string | File, name: string, svg: string): SVGSpriter;
+        add(file: string | File, name: string | null, svg: string): SVGSpriter;
         /**
          * Registering source SVG files
          * @param file Absolute path to the SVG file or a vinyl file object carrying all the necessary values (the following arguments are ignored then).
@@ -32,7 +31,8 @@ declare namespace sprite {
         add(file: File): SVGSpriter;
         /**
          * Triggering the sprite compilation
-         * @param config Configuration object setting the output mode parameters for a single compilation run. If omitted, the mode property of the main configuration used for the constructor will be used.
+         * @param config Configuration object setting the output mode parameters for a single compilation run.
+         * If omitted, the mode property of the main configuration used for the constructor will be used.
          * @param callback Callback triggered when the compilation has finished.
          */
         compile(config: Config, callback: CompileCallback): SVGSpriter;
@@ -58,7 +58,7 @@ declare namespace sprite {
         /**
          * Logging verbosity or custom logger
          */
-        log?: string | Logger;
+        log?: null | '' | 'info' | 'verbose' | 'debug' | Logger;
         /**
          * SVG shape configuration
          */
@@ -139,19 +139,19 @@ declare namespace sprite {
         /**
          * List of transformations / optimizations
          */
-        transform?: (string | CustomConfigurationTransform | CustomCallbackTransform)[];
+        transform?: string[] | CustomConfigurationTransform[] | CustomCallbackTransform[];
         /**
          * Path to YAML file with meta / accessibility data
          */
-        meta?: string;
+        meta?: string | null;
         /**
          * Path to YAML file with extended alignment data
          */
-        align?: string;
+        align?: string | null;
         /**
          * Output directory for optimized intermediate SVG shapes
          */
-        dest?: string;
+        dest?: string | null;
     }
 
     /**
@@ -159,7 +159,7 @@ declare namespace sprite {
      */
     interface CustomConfigurationTransform {
         [transformationName: string]: {
-            plugins?: { [transformationName: string]: boolean }[];
+            plugins?: Array<{ [transformationName: string]: boolean }>;
         };
     }
 
@@ -174,7 +174,7 @@ declare namespace sprite {
              * @param sprite SVG spriter
              * @param callback Callback
              */
-            (shape: any, sprite: SVGSpriter, callback: Function): any;
+            (shape: any, sprite: SVGSpriter, callback: (error: Error | null) => void): any;
         };
     }
 
@@ -242,7 +242,7 @@ declare namespace sprite {
         defs?: DefsAndSymbolSpecificModeConfig | boolean;
         symbol?: DefsAndSymbolSpecificModeConfig | boolean;
         stack?: ModeConfig | boolean;
-        [customConfigName: string]: ModeConfig | boolean;
+        [customConfigName: string]: ModeConfig | boolean | undefined;
     }
 
     interface ModeConfig {

--- a/types/svg-sprite/index.d.ts
+++ b/types/svg-sprite/index.d.ts
@@ -160,7 +160,7 @@ declare namespace sprite {
     interface CustomConfigurationTransform {
         [transformationName: string]: {
             plugins?: { [transformationName: string]: boolean }[];
-        }
+        };
     }
 
     /**
@@ -175,7 +175,7 @@ declare namespace sprite {
              * @param callback Callback
              */
             (shape: any, sprite: SVGSpriter, callback: Function): any;
-        }
+        };
     }
 
     interface Svg {

--- a/types/svg-sprite/svg-sprite-tests.ts
+++ b/types/svg-sprite/svg-sprite-tests.ts
@@ -1,326 +1,311 @@
-
 import SVGSpriter = require('svg-sprite');
 import * as fs from 'fs';
 
 var config: SVGSpriter.Config;
-
 
 //
 // README.md
 //
 
 // Create spriter instance (see below for `config` examples)
-var spriter       = new SVGSpriter(config);
+var spriter = new SVGSpriter(config);
 
 // Add SVG source files — the manual way ...
-spriter.add('assets/svg-1.svg', null, fs.readFileSync('assets/svg-1.svg', {encoding: 'utf-8'}));
-spriter.add('assets/svg-2.svg', null, fs.readFileSync('assets/svg-2.svg', {encoding: 'utf-8'}));
+spriter.add('assets/svg-1.svg', null, fs.readFileSync('assets/svg-1.svg', { encoding: 'utf-8' }));
+spriter.add('assets/svg-2.svg', null, fs.readFileSync('assets/svg-2.svg', { encoding: 'utf-8' }));
 /* ... */
 
 // Compile the sprite
-spriter.compile(function(error: any, result: any) {
+spriter.compile(function (error: any, result: any) {
     /* ... Write `result` files to disk or do whatever with them ... */
 });
 
 // General configuration options
 
-config                      = {
-    dest                    : '.',                      // Main output directory
-    log                     : null,                     // Logging verbosity (default: no logging)
-    shape                   : {                         // SVG shape related options
-        id                  : {                         // SVG shape ID related options
-            separator       : '--',                     // Separator for directory name traversal
-            generator       : function(svg: string) { /*...*/ return ''; },   // SVG shape ID generator callback
-            pseudo          : '~'                       // File name separator for shape states (e.g. ':hover')
+config = {
+    dest: '.', // Main output directory
+    log: null, // Logging verbosity (default: no logging)
+    shape: {
+        // SVG shape related options
+        id: {
+            // SVG shape ID related options
+            separator: '--', // Separator for directory name traversal
+            generator(svg: string) {
+                /*...*/ return '';
+            }, // SVG shape ID generator callback
+            pseudo: '~', // File name separator for shape states (e.g. ':hover')
         },
-        dimension           : {                         // Dimension related options
-            maxWidth        : 2000,                     // Max. shape width
-            maxHeight       : 2000,                     // Max. shape height
-            precision       : 2,                        // Floating point precision
-            attributes      : false,                    // Width and height attributes on embedded shapes
+        dimension: {
+            // Dimension related options
+            maxWidth: 2000, // Max. shape width
+            maxHeight: 2000, // Max. shape height
+            precision: 2, // Floating point precision
+            attributes: false, // Width and height attributes on embedded shapes
         },
-        spacing             : {                         // Spacing related options
-            padding         : 0,                        // Padding around all shapes
-            box             : 'content'                 // Padding strategy (similar to CSS `box-sizing`)
+        spacing: {
+            // Spacing related options
+            padding: 0, // Padding around all shapes
+            box: 'content', // Padding strategy (similar to CSS `box-sizing`)
         },
-        transform           : ['svgo'],                 // List of transformations / optimizations
-        meta                : null,                     // Path to YAML file with meta / accessibility data
-        align               : null,                     // Path to YAML file with extended alignment data
-        dest                : null                      // Output directory for optimized intermediate SVG shapes
+        transform: ['svgo'], // List of transformations / optimizations
+        meta: null, // Path to YAML file with meta / accessibility data
+        align: null, // Path to YAML file with extended alignment data
+        dest: null, // Output directory for optimized intermediate SVG shapes
     },
-    svg                     : {                         // General options for created SVG files
-        xmlDeclaration      : true,                     // Add XML declaration to SVG sprite
-        doctypeDeclaration  : true,                     // Add DOCTYPE declaration to SVG sprite
-        namespaceIDs        : true,                     // Add namespace token to all IDs in SVG shapes
-        dimensionAttributes : true                      // Width and height attributes on the sprite
+    svg: {
+        // General options for created SVG files
+        xmlDeclaration: true, // Add XML declaration to SVG sprite
+        doctypeDeclaration: true, // Add DOCTYPE declaration to SVG sprite
+        namespaceIDs: true, // Add namespace token to all IDs in SVG shapes
+        dimensionAttributes: true, // Width and height attributes on the sprite
     },
-    variables               : {}                        // Custom Mustache templating variables and functions
+    variables: {}, // Custom Mustache templating variables and functions
 };
 
 // Output modes
 
-config                  = {
-    mode                    : {
-    css                 : true,     // Create a «css» sprite
-    view                : true,     // Create a «view» sprite
-    defs                : true,     // Create a «defs» sprite
-    symbol              : true,     // Create a «symbol» sprite
-    stack               : true      // Create a «stack» sprite
-}
+config = {
+    mode: {
+        css: true, // Create a «css» sprite
+        view: true, // Create a «view» sprite
+        defs: true, // Create a «defs» sprite
+        symbol: true, // Create a «symbol» sprite
+        stack: true, // Create a «stack» sprite
+    },
 };
 
-config                  = {
+config = {
     mode: {
         css: {
             // Configuration for the «css» sprite
             // ...
-        }
-    }
+        },
+    },
 };
 
 // Common mode properties
 
-config                  = {
-    mode                    : {
-        mode1              : {
-    dest            : "<mode>",                     // Mode specific output directory
-        prefix          : "svg-%s",                     // Prefix for CSS selectors
-        dimensions      : "-dims",                      // Suffix for dimension CSS selectors
-        sprite          : "svg/sprite.<mode>.svg",       // Sprite path and name
-    bust            : true,                   // Cache busting (mode dependent default value)
-        render          : {                             // Stylesheet rendering definitions
-        /* -------------------------------------------
-         css         : false,                        // CSS stylesheet options
-         scss        : false,                        // Sass stylesheet options
-         less        : false,                        // LESS stylesheet options
-         styl        : false                         // Stylus stylesheet options
-         <custom>    : ...                           // Custom stylesheet options
-         ------------------------------------------- */
+config = {
+    mode: {
+        mode1: {
+            dest: '<mode>', // Mode specific output directory
+            prefix: 'svg-%s', // Prefix for CSS selectors
+            dimensions: '-dims', // Suffix for dimension CSS selectors
+            sprite: 'svg/sprite.<mode>.svg', // Sprite path and name
+            bust: true, // Cache busting (mode dependent default value)
+            render: {
+                // Stylesheet rendering definitions
+                /* -------------------------------------------
+                css         : false,                        // CSS stylesheet options
+                scss        : false,                        // Sass stylesheet options
+                less        : false,                        // LESS stylesheet options
+                styl        : false                         // Stylus stylesheet options
+                <custom>    : ...                           // Custom stylesheet options
+                ------------------------------------------- */
+            },
+            example: false, // Create an HTML example document
+        },
     },
-    example         : false                         // Create an HTML example document
-}
-}
 };
 
 // Basic examples
 
 // A.) Standalone sprite
 
-config                  = {
-    mode                    : {
-    inline              : true,     // Prepare for inline embedding
-    symbol              : true      // Create a «symbol» sprite
-}
+config = {
+    mode: {
+        inline: true, // Prepare for inline embedding
+        symbol: true, // Create a «symbol» sprite
+    },
 };
 
 // B.) CSS sprite with Sass resource
 
-config                  = {
-    mode                    : {
-    css                 : {         // Create a «css» sprite
-    render          : {
-        scss        : true      // Render a Sass stylesheet
-    }
-}
-}
+config = {
+    mode: {
+        css: {
+            // Create a «css» sprite
+            render: {
+                scss: true, // Render a Sass stylesheet
+            },
+        },
+    },
 };
 
 // C.) Multiple sprites
 
-config                  = {
-    mode                    : {
-    defs                : true,
-    symbol              : true,
-    stack               : true
-}
+config = {
+    mode: {
+        defs: true,
+        symbol: true,
+        stack: true,
+    },
 };
 
 // D.) No sprite at all
 
-config                  = {
-    shape                   : {
-    dest                : 'path/to/out/dir'
-}
+config = {
+    shape: {
+        dest: 'path/to/out/dir',
+    },
 };
-
-
 
 //
 // docs/configuration.md
 //
 
 config = {
-    shape               : {
-        id              : {                         // SVG shape ID related options
-            separator   : '--',                     // Separator for directory name traversal
-            generator   : function(svg: string) { /*...*/ return ''; },   // SVG shape ID generator callback
-            pseudo      : '~',                      // File name separator for shape states (e.g. ':hover')
-            whitespace  : '_'                       // Whitespace replacement for shape IDs
+    shape: {
+        id: {
+            // SVG shape ID related options
+            separator: '--', // Separator for directory name traversal
+            generator(svg: string) {
+                /*...*/ return '';
+            }, // SVG shape ID generator callback
+            pseudo: '~', // File name separator for shape states (e.g. ':hover')
+            whitespace: '_', // Whitespace replacement for shape IDs
         },
-        dimension       : {                         // Dimension related options
-            maxWidth    : 2000,                     // Max. shape width
-            maxHeight   : 2000,                     // Max. shape height
-            precision   : 2,                        // Floating point precision
-            attributes  : false,                    // Width and height attributes on embedded shapes
+        dimension: {
+            // Dimension related options
+            maxWidth: 2000, // Max. shape width
+            maxHeight: 2000, // Max. shape height
+            precision: 2, // Floating point precision
+            attributes: false, // Width and height attributes on embedded shapes
         },
-        spacing         : {                         // Spacing related options
-            padding     : 0,                        // Padding around all shapes
-            box         : 'content'                 // Padding strategy (similar to CSS `box-sizing`)
+        spacing: {
+            // Spacing related options
+            padding: 0, // Padding around all shapes
+            box: 'content', // Padding strategy (similar to CSS `box-sizing`)
         },
-        transform       : ['svgo'],                 // List of transformations / optimizations
-        meta            : null,                     // Path to YAML file with meta / accessibility data
-        align           : null,                     // Path to YAML file with extended alignment data
-        dest            : null                      // Output directory for optimized intermediate SVG shapes
-    }
+        transform: ['svgo'], // List of transformations / optimizations
+        meta: null, // Path to YAML file with meta / accessibility data
+        align: null, // Path to YAML file with extended alignment data
+        dest: null, // Output directory for optimized intermediate SVG shapes
+    },
 };
 
-config = // SVGO transformation with default configuration
-{
-    shape               : {
-        transform       : ['svgo']
+config = {
+    shape: {
+        transform: ['svgo'],
         /* ... */
-    }
+    },
 };
 
-config = // Equivalent transformation to ['svgo']
-{
-    shape               : {
-        transform       : [
-            {svgo       : {}}
-        ]
+config = {
+    shape: {
+        transform: [{ svgo: {} }],
         /* ... */
-    }
+    },
 };
 
-config = // SVGO transformation with custom plugin configuration
-{
-    shape               : {
-        transform       : [
-            {svgo       : {
-                plugins : [
-                    {transformsWithOnePath: true},
-                    {moveGroupAttrsToElems: false}
-                ]
-            }}
-        ]
+config = {
+    shape: {
+        transform: [
+            {
+                svgo: {
+                    plugins: [{ transformsWithOnePath: true }, { moveGroupAttrsToElems: false }],
+                },
+            },
+        ],
         /* ... */
-    }
+    },
 };
 
-config = // SVGO transformation with custom plugin configuration
-{
-    shape               : {
-        transform       : [
-            {custom     :
-
-                /**
-                 * Custom callback transformation
-                 *
-                 * @param {SVGShape} shape              SVG shape object
-                 * @param {SVGSpriter} spriter          SVG spriter
-                 * @param {Function} callback           Callback
-                 * @return {void}
-                 */
-                    function(shape, sprite, callback) {
+config = {
+    shape: {
+        transform: [
+            {
+                custom(shape, sprite, callback) {
                     /* ... */
                     callback(null);
-                }
-            }
-        ]
+                },
+            },
+        ],
         /* ... */
-    }
+    },
 };
 
-config = // Custom global post-processing transformation
-{
-    svg                 : {
-        transform       : [
+config = {
+    svg: {
+        transform: [
             /**
              * Custom sprite SVG transformation
              *
-             * @param {String} svg                  Sprite SVG
-             * @return {String}                     Processed SVG
+             * @param svg                  Sprite SVG
+             * @return                     Processed SVG
              */
-                function(svg) {
-                /* ... */
-                return svg;
-            },
+            (svg /* ... */) => svg,
 
             /* ... */
-        ]
-    }
+        ],
+    },
 };
 
 config = {
-    variables   : {
-        now     : +new Date(),
-        png     : function() {
-            return function(sprite: any, render: any) {
-                return render(sprite).split('.svg').join('.png');
-            }
-        }
-    }
-};
-
-config = // Activate the «css» mode with default configuration
-{
-    mode            : {
-        css         : true
-    }
-};
-
-config = // Equivalent: Provide an empty configuration object
-{
-    mode            : {
-        css         : {}
-    }
-};
-
-config = // Multiple sprites of the same output mode
-{
-    mode            : {
-        sprite1     : {
-            mode    : 'css'     // Sprite with «css» mode
+    variables: {
+        now: +new Date(),
+        png() {
+            return (sprite: any, render: any) => render(sprite).split('.svg').join('.png');
         },
-        sprite2     : {
-            mode    : 'css'     // Another sprite with «css» mode
-        }
-    }
+    },
 };
 
 config = {
-    mode                : {
-        css             : {
-            example     : true
-        }
-    }
+    mode: {
+        css: true,
+    },
 };
 
 config = {
-    mode                : {
-        css             : {
-            example     : {}
-        }
-    }
+    mode: {
+        css: {},
+    },
 };
 
 config = {
-    mode                : {
-        css             : {
-            render      : {
-                css     : {
-                    template    : 'path/to/template.html',  // relative to current working directory
-                    dest        : 'path/to/demo.html'       // relative to current output directory
-                }
-            }
-        }
-    }
+    mode: {
+        sprite1: {
+            mode: 'css', // Sprite with «css» mode
+        },
+        sprite2: {
+            mode: 'css', // Another sprite with «css» mode
+        },
+    },
 };
 
 config = {
-    mode                : {
-        css             : {
-            example     : false
-        }
-    }
+    mode: {
+        css: {
+            example: true,
+        },
+    },
+};
+
+config = {
+    mode: {
+        css: {
+            example: {},
+        },
+    },
+};
+
+config = {
+    mode: {
+        css: {
+            render: {
+                css: {
+                    template: 'path/to/template.html', // relative to current working directory
+                    dest: 'path/to/demo.html', // relative to current output directory
+                },
+            },
+        },
+    },
+};
+
+config = {
+    mode: {
+        css: {
+            example: false,
+        },
+    },
 };

--- a/types/svg-sprite/svg-sprite-tests.ts
+++ b/types/svg-sprite/svg-sprite-tests.ts
@@ -1,24 +1,11 @@
 import SVGSpriter = require('svg-sprite');
 import * as fs from 'fs';
 
-var config: SVGSpriter.Config;
+let config: SVGSpriter.Config;
 
 //
 // README.md
 //
-
-// Create spriter instance (see below for `config` examples)
-var spriter = new SVGSpriter(config);
-
-// Add SVG source files — the manual way ...
-spriter.add('assets/svg-1.svg', null, fs.readFileSync('assets/svg-1.svg', { encoding: 'utf-8' }));
-spriter.add('assets/svg-2.svg', null, fs.readFileSync('assets/svg-2.svg', { encoding: 'utf-8' }));
-/* ... */
-
-// Compile the sprite
-spriter.compile(function (error: any, result: any) {
-    /* ... Write `result` files to disk or do whatever with them ... */
-});
 
 // General configuration options
 
@@ -61,6 +48,29 @@ config = {
     },
     variables: {}, // Custom Mustache templating variables and functions
 };
+
+// Create spriter instance (see below for `config` examples)
+const spriter = new SVGSpriter(config);
+
+// Add SVG source files — the manual way ...
+spriter.add('assets/svg-1.svg', null, fs.readFileSync('assets/svg-1.svg', { encoding: 'utf-8' }));
+spriter.add('assets/svg-2.svg', null, fs.readFileSync('assets/svg-2.svg', { encoding: 'utf-8' }));
+/* ... */
+
+// Compile the sprite
+spriter.compile((error: any, result: any) => {
+    /* ... Write `result` files to disk or do whatever with them ... */
+});
+
+// Add SVG source files — the manual way ...
+spriter.add('assets/svg-1.svg', null, fs.readFileSync('assets/svg-1.svg', { encoding: 'utf-8' }));
+spriter.add('assets/svg-2.svg', null, fs.readFileSync('assets/svg-2.svg', { encoding: 'utf-8' }));
+/* ... */
+
+// Compile the sprite
+spriter.compile((error: any, result: any) => {
+    /* ... Write `result` files to disk or do whatever with them ... */
+});
 
 // Output modes
 
@@ -308,4 +318,25 @@ config = {
             example: false,
         },
     },
+};
+
+// logging
+
+config = {
+    log: null,
+};
+config = {
+    log: undefined,
+};
+config = {
+    log: '',
+};
+config = {
+    log: 'info',
+};
+config = {
+    log: 'verbose',
+};
+config = {
+    log: 'debug',
 };

--- a/types/svg-sprite/tsconfig.json
+++ b/types/svg-sprite/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/svg-sprite/tslint.json
+++ b/types/svg-sprite/tslint.json
@@ -1,18 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "array-type": false,
-        "ban-types": false,
-        "dt-header": false,
-        "max-line-length": false,
-        "no-consecutive-blank-lines": false,
-        "no-redundant-jsdoc-2": false,
-        "no-var-keyword": false,
-        "object-literal-shorthand": false,
-        "one-line": false,
-        "only-arrow-functions": false,
-        "prefer-const": false,
-        "semicolon": false,
-        "trim-file": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
- remove direct dependency from Winston package - rewritten to export
logger definition - just 4 methods need to be defined on the custom
logger
- minor changes in definition, backward compatible, to match default DT
linting configuration
- version bump
- maintainer added
- test amended for configuration object

https://github.com/jkphl/svg-sprite#table-of-contents
https://github.com/jkphl/svg-sprite/blob/master/docs/configuration.md#logging
https://github.com/jkphl/svg-sprite/blob/master/docs/configuration.md#custom-callback-transformation-function-values

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.