### PR TITLE
bonjour: Fix remote service definition

### DIFF
--- a/types/bonjour/bonjour-tests.ts
+++ b/types/bonjour/bonjour-tests.ts
@@ -4,7 +4,7 @@ let bonjourOptions: bonjour.BonjourOptions;
 let bonjourInstance: bonjour.Bonjour;
 
 let serviceOptions: bonjour.ServiceOptions;
-let service: bonjour.Service;
+let service: bonjour.LocalService;
 
 let browserOptions: bonjour.BrowserOptions;
 let browser: bonjour.Browser;
@@ -18,6 +18,6 @@ service = bonjourInstance.publish(serviceOptions);
 
 browserOptions = { protocol: 'tcp', type: 'http' };
 // Look for the server
-browser = bonjourInstance.findOne(browserOptions, (srv: bonjour.Service) => {
+browser = bonjourInstance.findOne(browserOptions, (srv: bonjour.RemoteService) => {
     // You can test here if the found server (srv) name is 'My Website'
 });

--- a/types/bonjour/bonjour-tests.ts
+++ b/types/bonjour/bonjour-tests.ts
@@ -4,7 +4,7 @@ let bonjourOptions: bonjour.BonjourOptions;
 let bonjourInstance: bonjour.Bonjour;
 
 let serviceOptions: bonjour.ServiceOptions;
-let service: bonjour.LocalService;
+let service: bonjour.Service;
 
 let browserOptions: bonjour.BrowserOptions;
 let browser: bonjour.Browser;

--- a/types/bonjour/index.d.ts
+++ b/types/bonjour/index.d.ts
@@ -5,6 +5,8 @@
 
 /// <reference types="node" />
 
+import { RemoteInfo } from 'dgram';
+
 declare function bonjour(opts?: bonjour.BonjourOptions): bonjour.Bonjour;
 export = bonjour;
 declare namespace bonjour {
@@ -23,20 +25,20 @@ declare namespace bonjour {
      * with that service.
      */
     interface Browser extends NodeJS.EventEmitter {
-        services: Service[];
+        services: RemoteService[];
         start(): void;
         update(): void;
         stop(): void;
-        on(event: 'up' | 'down', listener: (service: Service) => void): this;
-        once(event: 'up' | 'down', listener: (service: Service) => void): this;
-        removeListener(event: 'up' | 'down', listener: (service: Service) => void): this;
+        on(event: 'up' | 'down', listener: (service: RemoteService) => void): this;
+        once(event: 'up' | 'down', listener: (service: RemoteService) => void): this;
+        removeListener(event: 'up' | 'down', listener: (service: RemoteService) => void): this;
         removeAllListeners(event?: 'up' | 'down'): this;
     }
     interface BrowserOptions {
         type?: string;
         subtypes?: string[];
         protocol?: string;
-        txt?: Object;
+        txt?: { [key: string]: string };
     }
 
     interface ServiceOptions {
@@ -46,22 +48,29 @@ declare namespace bonjour {
         type: string;
         subtypes?: string[];
         protocol?: 'udp'|'tcp';
-        txt?: Object;
+        txt?: { [key: string]: string };
         probe?: boolean;
     }
 
-    interface Service extends NodeJS.EventEmitter {
+    interface Service {
         name: string;
-        type: string;
-        subtypes: string[];
-        protocol: string;
+        fqdn: string;
         host: string;
         port: number;
-        fqdn: string;
-        txt: Object;
+        type: string;
+        protocol: string;
+        subtypes: string[];
+        txt: { [key: string]: string };
+    }
+    interface RemoteService extends Service {
+        referer: RemoteInfo;
+        rawTxt: Buffer;
+        addresses: string[];
+    }
+    interface LocalService extends Service, NodeJS.EventEmitter {
         published: boolean;
 
-        stop(cb: () => any): void;
+        stop(cb: () => void): void;
         start(): void;
     }
     interface BonjourOptions {
@@ -76,10 +85,10 @@ declare namespace bonjour {
     }
     interface Bonjour {
         (opts?: BonjourOptions): Bonjour;
-        publish(options: ServiceOptions): Service;
+        publish(options: ServiceOptions): LocalService;
         unpublishAll(cb?: () => void): void;
-        find(options: BrowserOptions, onUp?: (service: Service) => void): Browser;
-        findOne(options: BrowserOptions, cb?: (service: Service) => void): Browser;
+        find(options: BrowserOptions, onUp?: (service: RemoteService) => void): Browser;
+        findOne(options: BrowserOptions, cb?: (service: RemoteService) => void): Browser;
         destroy(): void;
     }
 }

--- a/types/bonjour/index.d.ts
+++ b/types/bonjour/index.d.ts
@@ -52,7 +52,7 @@ declare namespace bonjour {
         probe?: boolean;
     }
 
-    interface Service {
+    interface BaseService {
         name: string;
         fqdn: string;
         host: string;
@@ -62,12 +62,12 @@ declare namespace bonjour {
         subtypes: string[];
         txt: { [key: string]: string };
     }
-    interface RemoteService extends Service {
+    interface RemoteService extends BaseService {
         referer: RemoteInfo;
         rawTxt: Buffer;
         addresses: string[];
     }
-    interface LocalService extends Service, NodeJS.EventEmitter {
+    interface Service extends BaseService, NodeJS.EventEmitter {
         published: boolean;
 
         stop(cb: () => void): void;
@@ -85,7 +85,7 @@ declare namespace bonjour {
     }
     interface Bonjour {
         (opts?: BonjourOptions): Bonjour;
-        publish(options: ServiceOptions): LocalService;
+        publish(options: ServiceOptions): Service;
         unpublishAll(cb?: () => void): void;
         find(options: BrowserOptions, onUp?: (service: RemoteService) => void): Browser;
         findOne(options: BrowserOptions, cb?: (service: RemoteService) => void): Browser;


### PR DESCRIPTION
Added definitions for remote service discovery. Moved the common properties to shared interface which is extended by the remote service interface and the existing local service interface which was renamed to `LocalService`. Also made the `txt` property a string to string object map.

This is a breaking change in the definitions.

- The existing `Service` interface was renamed to `LocalService`. (this change isn't strictly necessary and can be undone if required)
- Some signatures were changed to return the new and more correct `RemoteService` interface.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/watson/bonjour/blob/master/lib/browser.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.