### PR TITLE
Upgrade types for express-actuator@1.6.1

### DIFF
--- a/types/express-actuator/express-actuator-tests.ts
+++ b/types/express-actuator/express-actuator-tests.ts
@@ -14,10 +14,16 @@ function actuatorTest() {
     app.use(actuator({ infoGitMode: 'full' }));
     app.use(actuator({ infoDateFormat: 'YYYY-DD-MM' }));
     app.use(actuator({
-      infoBuildOptions: {
-        string: '123',
-        bool: true,
-        number: 1
-      }
+        infoBuildOptions: {
+            string: '123',
+            bool: true,
+            number: 1
+        }
+    }));
+    app.use(actuator({
+        customEndpoints: [{
+            id: 'dependencies',
+            controller: (req, res) => {}
+        }]
     }));
 }

--- a/types/express-actuator/index.d.ts
+++ b/types/express-actuator/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for express-actuator 1.6.1
+// Type definitions for express-actuator 1.6
 // Project: https://www.npmjs.org/package/express-actuator
 // Definitions by:  Eduardo Silva <https://github.com/etruta>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/express-actuator/index.d.ts
+++ b/types/express-actuator/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for express-actuator 1.6
+// Type definitions for express-actuator 1.6.1
 // Project: https://www.npmjs.org/package/express-actuator
 // Definitions by:  Eduardo Silva <https://github.com/etruta>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -34,6 +34,27 @@ declare namespace actuator {
          * @summary Extra Options to pass to info build output.
          */
         infoBuildOptions?: Record<string, any>;
+
+        /**
+         * @summary Custom endpoints
+         */
+        customEndpoints?: CustomEndpoint[];
+    }
+
+    interface CustomEndpoint {
+        /**
+         * @summary Used as endpoint `/id` or `${basePath}/id`
+         */
+        id: string;
+
+        /**
+         * @summary Controller to be called when accessing this endpoint
+         */
+        controller: CustomControllerMethod;
+    }
+
+    interface CustomControllerMethod {
+        (req?: any, res?: any): void;
     }
 }
 


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rcruzper/express-actuator/releases
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)