### PR TITLE
Add missing types to react-native-webrtc

### DIFF
--- a/types/react-native-webrtc/index.d.ts
+++ b/types/react-native-webrtc/index.d.ts
@@ -35,6 +35,14 @@ export type RTCIceConnectionState =
     | "disconnected"
     | "closed";
 
+export type RTCPeerConnectionState =
+    | "new"
+    | "connecting"
+    | "connected"
+    | "disconnected"
+    | "failed"
+    | "closed";
+
 export class MediaStreamTrack {
     private _enabled: boolean;
 
@@ -123,12 +131,13 @@ export interface EventOnAddStream {
 export class RTCPeerConnection {
     localDescription: RTCSessionDescriptionType;
     remoteDescription: RTCSessionDescriptionType;
+    connectionState: RTCPeerConnectionState;
 
     signalingState: RTCSignalingState;
     private privateiceGatheringState: RTCIceGatheringState;
     private privateiceConnectionState: RTCIceConnectionState;
 
-    onconnectionstatechange: () => void | undefined;
+    onconnectionstatechange: (event: Event) => void | undefined;
     onicecandidate: (event: EventOnCandidate) => void | undefined;
     onicecandidateerror: (error: Error) => void | undefined;
     oniceconnectionstatechange: (
@@ -154,9 +163,9 @@ export class RTCPeerConnection {
 
     removeStream(stream: MediaStream): void;
 
-    createOffer(): Promise<RTCSessionDescriptionType>;
+    createOffer(options?: RTCOfferOptions): Promise<RTCSessionDescriptionType>;
 
-    createAnswer(): Promise<RTCSessionDescriptionType>;
+    createAnswer(options?: RTCAnswerOptions): Promise<RTCSessionDescriptionType>;
 
     setConfiguration(configuration: RTCPeerConnectionConfiguration): void;
 
@@ -252,3 +261,14 @@ export interface RTCViewProps {
 }
 
 export class RTCView extends Component<RTCViewProps, any> {}
+
+export interface RTCOfferOptions {
+    iceRestart?: boolean;
+    offerToReceiveAudio?: boolean;
+    offerToReceiveVideo?: boolean;
+    voiceActivityDetection?: boolean;
+}
+
+export interface RTCAnswerOptions {
+    voiceActivityDetection?: boolean;
+}


### PR DESCRIPTION
There are several type definitions that are missing from `react-native-webrtc`. Some of them are actually required by a project that I am working on, so rather than sprinkling `//@ts-ignore` throughout my project, I decided to update the type definitions themselves. I don't think this PR is comprehensive - there are likely still type definitions missing for this library. This PR at least adds some critical ones to get RTCPeerConnections talking with each other properly though.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection
https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/createOffer
https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/createAnswer
https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/onconnectionstatechange
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.