### PR TITLE
react-instantsearch: fix typing of connectCurrentRefinements

### DIFF
--- a/types/react-instantsearch-core/index.d.ts
+++ b/types/react-instantsearch-core/index.d.ts
@@ -131,7 +131,7 @@ export type ConnectorProvided<TProvided> = TProvided & {
  */
 export function createConnector<TProvided = {}, TExposed = {}>(
   connectorDesc: ConnectorDescription<TProvided, TExposed>
-): ((stateless: React.StatelessComponent<ConnectorProvided<TProvided>>) => React.ComponentClass<TExposed>) &
+): ((stateless: React.FunctionComponent<ConnectorProvided<TProvided>>) => React.ComponentClass<TExposed>) &
   (<TProps extends Partial<ConnectorProvided<TProvided>>>(
     Composed: React.ComponentType<TProps>
   ) => ConnectedComponentClass<TProps, ConnectorProvided<TProvided>, TExposed>);
@@ -185,7 +185,7 @@ export interface AutocompleteExposed {
 }
 
 // tslint:disable-next-line:no-unnecessary-generics
-export function connectAutoComplete<TDoc = BasicDoc>(stateless: React.StatelessComponent<AutocompleteProvided<TDoc>>): React.ComponentClass<AutocompleteExposed>;
+export function connectAutoComplete<TDoc = BasicDoc>(stateless: React.FunctionComponent<AutocompleteProvided<TDoc>>): React.ComponentClass<AutocompleteExposed>;
 export function connectAutoComplete<Props extends AutocompleteProvided<TDoc>, TDoc = BasicDoc>(
   Composed: React.ComponentType<Props>
 ): ConnectedComponentClass<Props, AutocompleteProvided<TDoc>, AutocompleteExposed>;
@@ -224,7 +224,7 @@ export interface CurrentRefinementsExposed {
 
 export interface CurrentRefinementsProvided {
   /** a function to remove a single filter */
-  refine: (refinement: RefinementValue | RefinementValue[]) => void;
+  refine: (refinement: RefinementValue | RefinementValue[] | Refinement[]) => void;
   /**
    * all the filters, the value is to pass to the refine function for removing all currentrefinements,
    * label is for the display. When existing several refinements for the same atribute name, then you
@@ -237,7 +237,7 @@ export interface CurrentRefinementsProvided {
 }
 
 export function connectCurrentRefinements(
-  stateless: React.StatelessComponent<CurrentRefinementsProvided>
+  stateless: React.FunctionComponent<CurrentRefinementsProvided>
 ): React.ComponentClass<CurrentRefinementsExposed>;
 export function connectCurrentRefinements<TProps extends Partial<CurrentRefinementsProvided>>(
   Composed: React.ComponentType<TProps>
@@ -273,7 +273,7 @@ export interface GeoSearchProvided<THit = any> {
  * https://community.algolia.com/react-instantsearch/connectors/connectGeoSearch.html
  */
 export function connectGeoSearch(
-  stateless: React.StatelessComponent<GeoSearchProvided>
+  stateless: React.FunctionComponent<GeoSearchProvided>
 ): React.ComponentClass<GeoSearchExposed>;
 export function connectGeoSearch<TProps extends Partial<GeoSearchProvided<THit>>, THit>(
   ctor: React.ComponentType<TProps>
@@ -319,7 +319,7 @@ export type HighlightProps<TDoc = any> = HighlightProvided<TDoc> & HighlightPass
  * connectHighlight connector provides the logic to create an highlighter component that will retrieve, parse and render an highlighted attribute from an Algolia hit.
  */
 export function connectHighlight<TDoc = any>(
-  stateless: React.StatelessComponent<HighlightProps<TDoc>>
+  stateless: React.FunctionComponent<HighlightProps<TDoc>>
 ): React.ComponentClass<HighlightPassedThru<TDoc>>;
 export function connectHighlight<TProps extends Partial<HighlightProps<TDoc>>, TDoc>(
   ctor: React.ComponentType<TProps>
@@ -338,7 +338,7 @@ export interface HitsProvided<THit> {
  * https://community.algolia.com/react-instantsearch/connectors/connectHits.html
  */
 // tslint:disable-next-line:no-unnecessary-generics
-export function connectHits<THit = BasicDoc>(stateless: React.StatelessComponent<HitsProvided<THit>>): React.ComponentClass;
+export function connectHits<THit = BasicDoc>(stateless: React.FunctionComponent<HitsProvided<THit>>): React.ComponentClass;
 export function connectHits<TProps extends HitsProvided<THit>, THit>(
   ctor: React.ComponentType<TProps>
 ): ConnectedComponentClass<TProps, HitsProvided<THit>>;
@@ -388,7 +388,7 @@ export interface MenuExposed {
  *
  * https://community.algolia.com/react-instantsearch/connectors/connectMenu.html
  */
-export function connectMenu(stateless: React.StatelessComponent<MenuProvided>): React.ComponentClass<MenuExposed>;
+export function connectMenu(stateless: React.FunctionComponent<MenuProvided>): React.ComponentClass<MenuExposed>;
 export function connectMenu<TProps extends Partial<MenuProvided>>(
   ctor: React.ComponentType<TProps>
 ): ConnectedComponentClass<TProps, MenuProvided, MenuExposed>;
@@ -429,7 +429,7 @@ export interface NumericMenuExposed {
  * https://community.algolia.com/react-instantsearch/connectors/connectNumericMenu.html
  */
 export function connectNumericMenu(
-  stateless: React.StatelessComponent<NumericMenuProvided>
+  stateless: React.FunctionComponent<NumericMenuProvided>
 ): React.ComponentClass<NumericMenuExposed>;
 export function connectNumericMenu<TProps extends Partial<NumericMenuProvided>>(
   ctor: React.ComponentType<TProps>
@@ -487,7 +487,7 @@ export interface RefinementListExposed {
  * https://community.algolia.com/react-instantsearch/connectors/connectRefinementList.html
  */
 export function connectRefinementList(
-  stateless: React.StatelessComponent<RefinementListProvided>
+  stateless: React.FunctionComponent<RefinementListProvided>
 ): React.ComponentClass<RefinementListExposed>;
 export function connectRefinementList<TProps extends Partial<RefinementListProvided>>(
   ctor: React.ComponentType<TProps>
@@ -508,7 +508,7 @@ export interface SearchBoxExposed {
   defaultRefinement?: string;
 }
 export function connectSearchBox(
-  stateless: React.StatelessComponent<SearchBoxProvided>
+  stateless: React.FunctionComponent<SearchBoxProvided>
 ): React.ComponentClass<SearchBoxExposed>;
 export function connectSearchBox<TProps extends Partial<SearchBoxProvided>>(
   ctor: React.ComponentType<TProps>
@@ -542,7 +542,7 @@ export interface StateResultsProvided<TDoc = BasicDoc> {
  *
  * https://community.algolia.com/react-instantsearch/connectors/connectStateResults.html
  */
-export function connectStateResults(stateless: React.StatelessComponent<StateResultsProvided>): React.ComponentClass;
+export function connectStateResults(stateless: React.FunctionComponent<StateResultsProvided>): React.ComponentClass;
 export function connectStateResults<TProps extends Partial<StateResultsProvided<any>>>(
   ctor: React.ComponentType<TProps>
 ): ConnectedComponentClass<TProps, StateResultsProvided>;
@@ -552,7 +552,7 @@ interface StatsProvided {
   processingTimeMS: number;
 }
 
-export function connectStats(stateless: React.StatelessComponent<StatsProvided>): React.ComponentClass;
+export function connectStats(stateless: React.FunctionComponent<StatsProvided>): React.ComponentClass;
 export function connectStats<TProps extends Partial<StatsProvided>>(
   ctor: React.ComponentType<TProps>
 ): ConnectedComponentClass<TProps, StatsProvided>;

--- a/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
+++ b/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
@@ -301,6 +301,18 @@ import {
 };
 
 () => {
+    const MyClearRefinements = ({ refine, items }: CurrentRefinementsProvided) => (
+      <button onClick={() => refine(items)}>
+        clear all
+      </button>
+    );
+
+    const ConnectedClearRefinements = connectCurrentRefinements(MyClearRefinements);
+
+    <ConnectedClearRefinements clearsQuery={true} transformItems={item => item} />;
+};
+
+() => {
   function renderRefinement(label: string, value: Refinement['value'], refine: CurrentRefinementsProvided['refine']) {
     return (
       <button className="badge badge-secondary" onClick={() => refine(value)}>


### PR DESCRIPTION

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://www.algolia.com/doc/api-reference/widgets/clear-refinements/react/?language=usage#full-example>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

