### PR TITLE
[ember-data] Adapter headers should be overwriteable with a getter

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -1259,14 +1259,6 @@ export namespace DS {
          */
         host: string;
         /**
-         * Some APIs require HTTP headers, e.g. to provide an API
-         * key. Arbitrary headers can be set as key/value pairs on the
-         * `RESTAdapter`'s `headers` object and Ember Data will send them
-         * along with each ajax request. For dynamic headers see [headers
-         * customization](/api/data/classes/DS.RESTAdapter.html#toc_headers-customization).
-         */
-        headers: {};
-        /**
          * Called by the store in order to fetch the JSON for a given
          * type and ID.
          */
@@ -1495,6 +1487,20 @@ export namespace DS {
          * Determines the pathname for a given type.
          */
         pathForType<K extends keyof ModelRegistry>(modelName: K): string;
+    }
+
+    // Instead of declaring `headers as a property we now declare it in an
+    // interface. This works around the issue noted here with TypeScript 4:
+    // https://github.com/microsoft/TypeScript/issues/40220
+    interface RESTAdapter {
+        /**
+         * Some APIs require HTTP headers, e.g. to provide an API
+         * key. Arbitrary headers can be set as key/value pairs on the
+         * `RESTAdapter`'s `headers` object and Ember Data will send them
+         * along with each ajax request. For dynamic headers see [headers
+         * customization](/api/data/classes/DS.RESTAdapter.html#toc_headers-customization).
+         */
+        headers: {};
     }
     /**
      * ## Using Embedded Records

--- a/types/ember-data/test/adapter.ts
+++ b/types/ember-data/test/adapter.ts
@@ -29,6 +29,15 @@ const AuthTokenHeader = DS.JSONAPIAdapter.extend({
     })
 });
 
+// Ensure that we are allowed to overwrite headers with a getter
+class GetterHeader extends DS.JSONAPIAdapter {
+    get headers() {
+        return {
+            'CUSTOM_HEADER': 'Some header value'
+        };
+    }
+}
+
 const UseAjax = DS.JSONAPIAdapter.extend({
     query(store: DS.Store, type: string, query: object) {
         const url = 'https://api.example.com/my-api';

--- a/types/ember-data/tsconfig.json
+++ b/types/ember-data/tsconfig.json
@@ -5,6 +5,7 @@
             "es6",
             "dom"
         ],
+        "target": "es5",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,


### PR DESCRIPTION
Instead of being declared as a property we now declare it in an
interface. This works around the issue noted here with TypeScript 4:
https://github.com/microsoft/TypeScript/issues/40220

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- ~Provide a URL to documentation or source code which provides context for the suggested changes~
- ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~
