### PR TITLE
Angular: Remove deprecation flag of `which` in JQueryEventObject

### DIFF
--- a/types/angular/jqlite.d.ts
+++ b/types/angular/jqlite.d.ts
@@ -774,7 +774,6 @@ interface BaseJQueryEventObject extends Event {
     pageY: number;
     /**
      * For key or mouse events, this property indicates the specific key or button that was pressed.
-     * @deprecated Use `key` for KeyEvents or `button` for MouseEvents instead.
      * @see {@link https://api.jquery.com/event.which/}
      */
     which: number;


### PR DESCRIPTION
While the DOM's `KeyboardEvent.which` **is** deprecated (https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/which), jQuery's counterpart isn't: https://api.jquery.com/event.which/

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (it doesn't)
- [] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing) (only affects non-ts linting rules)
- [] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. (not making substantial changes)
