### PR TITLE
Fix 'resolve()' calls for 'memcached'

### DIFF
--- a/types/aframe/test/aframe-io-tests.ts
+++ b/types/aframe/test/aframe-io-tests.ts
@@ -534,7 +534,7 @@ AFRAME.registerComponent('audioanalyser-waveform', {
             var normLevel;
             normLevel = levels[RINGCOUNT - index - 1] + 0.01; // Avoid scaling by 0.
             const lineMaterial = ring.material as THREE.LineBasicMaterial;
-            lineMaterial.color.setHSL(colors[index], 1, normLevel);
+            (lineMaterial.color as THREE.Color).setHSL(colors[index], 1, normLevel);
             lineMaterial.linewidth = normLevel * 3;
             lineMaterial.opacity = normLevel;
             ring.scale.z = normLevel;

--- a/types/async-stream-emitter/async-stream-emitter-tests.ts
+++ b/types/async-stream-emitter/async-stream-emitter-tests.ts
@@ -26,7 +26,7 @@ const emitter = new AsyncStreamEmitter<string>();
 
 // Utility function.
 function wait(duration: number) {
-    return new Promise(resolve => {
+    return new Promise<void>(resolve => {
         setTimeout(() => {
             resolve();
         }, duration);

--- a/types/fetch-mock/index.d.ts
+++ b/types/fetch-mock/index.d.ts
@@ -586,8 +586,8 @@ declare namespace fetchMock {
              * implementation.
              */
             Promise?: new (executor: (
-                resolve: () => void,
-                reject: () => void,
+                resolve: (value: Response | PromiseLike<Response>) => void,
+                reject: (reason?: any) => void,
             ) => void) => Promise<Response>;
 
             /**

--- a/types/graphql-relay/graphql-relay-tests.ts
+++ b/types/graphql-relay/graphql-relay-tests.ts
@@ -79,7 +79,7 @@ conn.pageInfo.hasPreviousPage = true;
 conn.pageInfo.startCursor = "s";
 // connectionFromPromisedArray is similar to connectionFromArray, but it takes a promise that resolves to an array, and returns a promise that resolves to the expected shape by connectionType.
 const conn2 = connectionFromPromisedArray(new Promise<number[]>((resolve) => {
-    resolve();
+    resolve([]);
 }), {
         after: "a",
         before: "b",

--- a/types/listr/listr-tests.ts
+++ b/types/listr/listr-tests.ts
@@ -13,7 +13,7 @@ const tasks = new Listr<Context>([
             return new Listr([
                 {
                     title: 'Checking git status',
-                    task: () => new Promise(resolve => resolve())
+                    task: () => new Promise<string>(resolve => resolve(''))
                         .then(result => {
                         if (result !== '') {
                             throw new Error('Unclean working tree. Commit or stash changes first.');
@@ -22,7 +22,7 @@ const tasks = new Listr<Context>([
                 },
                 {
                     title: 'Checking remote history',
-                    task: () => new Promise(resolve => resolve())
+                    task: () => new Promise<string>(resolve => resolve(''))
                         .then(result => {
                         if (result !== '0') {
                             throw new Error('Remote history differ. Please pull changes.');
@@ -35,7 +35,7 @@ const tasks = new Listr<Context>([
     },
     {
         title: 'Install package dependencies with Yarn',
-        task: (ctx, task) => new Promise(resolve => resolve())
+        task: (ctx, task) => new Promise<void>(resolve => resolve())
             .catch(() => {
                 ctx.yarn = false;
 
@@ -45,15 +45,15 @@ const tasks = new Listr<Context>([
     {
         title: 'Install package dependencies with npm',
         enabled: ctx => ctx.yarn === false,
-        task: () => new Promise(resolve => resolve())
+        task: () => new Promise<void>(resolve => resolve())
     },
     {
         title: 'Run tests',
-        task: () => new Promise(resolve => resolve())
+        task: () => new Promise<void>(resolve => resolve())
     },
     {
         title: 'Publish package',
-        task: () => new Promise(resolve => resolve())
+        task: () => new Promise<void>(resolve => resolve())
     }
 ]);
 
@@ -128,7 +128,7 @@ const tasks5 = new Listr([
 const tasks6 = new Listr([
     {
         title: 'Install package dependencies with Yarn',
-        task: (ctx, task) => new Promise(resolve => resolve())
+        task: (ctx, task) => new Promise<void>(resolve => resolve())
             .catch(() => {
                 ctx.yarn = false;
 
@@ -138,7 +138,7 @@ const tasks6 = new Listr([
     {
         title: 'Install package dependencies with npm',
         enabled: ctx => ctx.yarn === false,
-        task: () => new Promise(resolve => resolve())
+        task: () => new Promise<void>(resolve => resolve())
     }
 ]);
 

--- a/types/memcached/memcached-tests.ts
+++ b/types/memcached/memcached-tests.ts
@@ -161,13 +161,13 @@ function test_cas() {
     const value = 'casvalue';
 
     Promise.resolve()
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.set(key, value, 0, function() {
             isCommandData(this);
             resolve();
         });
     }))
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.gets(key, function(err, data) {
             isCommandData(this);
             memcached.cas(key, value, data.cas, 0, function(err, result) {
@@ -177,7 +177,7 @@ function test_cas() {
             });
         });
     }))
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.cas(key, value, '99', 0, function(err, result) {
             isCommandData(this);
             assert(!result);
@@ -193,19 +193,19 @@ function test_replace() {
     const value = 'replacevalue';
 
     Promise.resolve()
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.set(key, value, 0, () => {
             resolve();
         });
     }))
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.replace(key, value, 0, function(err, result) {
             assert(result);
             isCommandData(this);
             resolve();
         });
     }))
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.replace('noexistss', value, 0, function(err, result) {
             assert(!result);
             isCommandData(this);
@@ -220,14 +220,14 @@ function test_add() {
     const value = 'addvalue';
 
     Promise.resolve()
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.add(key, value, 0, function(err, result) {
             assert(result);
             isCommandData(this);
             resolve();
         });
     }))
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.add(key, value, 0, function(err, result) {
             assert(!result);
             isCommandData(this);
@@ -242,13 +242,13 @@ function test_append() {
     const value = 'appendvalue';
 
     Promise.resolve()
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.set(key, value, 0, (err, result) => {
             isBoolean(result);
             resolve();
         });
     }))
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.append(key, value, (err, result) => {
             isBoolean(result);
             resolve();
@@ -261,13 +261,13 @@ function test_prepend() {
     const key = 'prependkey';
     const value = 'prependvalue';
     Promise.resolve()
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.set(key, value, 0, (err, result) => {
             isBoolean(result);
             resolve();
         });
     }))
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.prepend(key, value, function(err, result) {
             isBoolean(result);
             isCommandData(this);
@@ -282,20 +282,20 @@ function test_incr() {
     const value = 2;
 
     Promise.resolve()
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.set(key, value, 0, (err, result) => {
             isBoolean(result);
             resolve();
         });
     }))
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.incr(key, value, function(err, result) {
             assert.deepStrictEqual(result, 4);
             isCommandData(this);
             resolve();
         });
     }))
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.incr('noexists', value, function(err, result) {
             assert.deepStrictEqual(result, false);
             isCommandData(this);
@@ -309,21 +309,21 @@ function test_decr() {
     const key = 'decrkey';
     const value = 2;
     Promise.resolve()
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.set(key, value, 0, function(err, result) {
             isCommandData(this);
             isBoolean(result);
             resolve();
         });
     }))
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.decr(key, value, function(err, result) {
             assert.deepStrictEqual(result, 0);
             isCommandData(this);
             resolve();
         });
     }))
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.decr('noexists', value, function(err, result) {
             assert.deepStrictEqual(result, false);
             isCommandData(this);
@@ -337,13 +337,13 @@ function test_decr_2() {
     const key = 'delkey';
     const value = 'delvalue';
     Promise.resolve()
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.set(key, value, 0, (err, result) => {
             isBoolean(result);
             resolve();
         });
     }))
-    .then(() => new Promise(resolve => {
+    .then(() => new Promise<void>(resolve => {
         memcached.del(key, function(err, result) {
             isBoolean(result);
             isCommandData(this);

--- a/types/mirrorx/mirrorx-tests.ts
+++ b/types/mirrorx/mirrorx-tests.ts
@@ -13,7 +13,7 @@ mirror.model({
     },
     effects: {
         async incrementAsync() {
-            await new Promise((resolve, reject) => {
+            await new Promise<void>((resolve, reject) => {
                 setTimeout(() => {
                     resolve();
                 }, 1000);

--- a/types/nightmare/nightmare-tests.ts
+++ b/types/nightmare/nightmare-tests.ts
@@ -398,7 +398,7 @@ new Nightmare({ gotoTimeout: 10000 })
 new Nightmare({ executionTimeout: 1000 })
   .goto("https//google.com")
   .evaluate(() => {
-    new Promise((resolve, reject) => {
+    new Promise<void>((resolve, reject) => {
       setTimeout(() => {
         resolve()
       }, 2000)

--- a/types/node-wit/node-wit-tests.ts
+++ b/types/node-wit/node-wit-tests.ts
@@ -4,7 +4,7 @@ const wit = new Wit({
     accessToken: "",
     actions: {
         send(request: WitRequest, response: WitResponse) {
-            return new Promise((resolve, reject) => {
+            return new Promise<void>((resolve, reject) => {
                 console.log(response.text);
                 console.log(request.entities);
                 resolve();

--- a/types/polka/polka-tests.ts
+++ b/types/polka/polka-tests.ts
@@ -11,7 +11,7 @@ const middleware: Polka.Middleware<any, MyResponse, any, any> = async (req, res,
 
     res.send({ foo: 'bar' });
 
-    await new Promise((resolve, reject) => resolve());
+    await new Promise<void>((resolve, reject) => resolve());
     next();
 };
 

--- a/types/react-router-guard/test/checkAuth.ts
+++ b/types/react-router-guard/test/checkAuth.ts
@@ -1,5 +1,5 @@
 export default function checkAuth(): Promise<any> {
     return new Promise((resolve, reject) => {
-        resolve();
+        resolve(undefined);
     });
 }

--- a/types/react-virtualized/react-virtualized-tests.tsx
+++ b/types/react-virtualized/react-virtualized-tests.tsx
@@ -537,7 +537,7 @@ export class InfiniteLoaderExample extends PureComponent<any, any> {
 
         let promiseResolver: () => void;
 
-        return new Promise(resolve => {
+        return new Promise<void>(resolve => {
             promiseResolver = resolve;
         });
     }

--- a/types/react-window-infinite-loader/react-window-infinite-loader-tests.tsx
+++ b/types/react-window-infinite-loader/react-window-infinite-loader-tests.tsx
@@ -11,7 +11,7 @@ const loadMoreItems = (startIndex: number, stopIndex: number) => {
     for (let index = startIndex; index <= stopIndex; index++) {
         itemStatusMap[index] = LOADING;
     }
-    return new Promise(resolve =>
+    return new Promise<void>(resolve =>
         setTimeout(() => {
             for (let index = startIndex; index <= stopIndex; index++) {
                 itemStatusMap[index] = LOADED;

--- a/types/redux-form/v4/redux-form-tests.tsx
+++ b/types/redux-form/v4/redux-form-tests.tsx
@@ -176,7 +176,7 @@ namespace SumbitValidation {
   export const fields = ['username', 'password'];
 
   const submit = (values: any, dispatch: any) => {
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
       setTimeout(() => {
         if (['john', 'paul', 'george', 'ringo'].indexOf(values.username) === -1) {
           reject({username: 'User does not exist', _error: 'Login failed!'});

--- a/types/redux-form/v5/redux-form-tests.tsx
+++ b/types/redux-form/v5/redux-form-tests.tsx
@@ -176,7 +176,7 @@ namespace SumbitValidation {
   export const fields = ['username', 'password'];
 
   const submit = (values: any, dispatch: any) => {
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
       setTimeout(() => {
         if (['john', 'paul', 'george', 'ringo'].indexOf(values.username) === -1) {
           reject({username: 'User does not exist', _error: 'Login failed!'});

--- a/types/snapsvg/test/4.ts
+++ b/types/snapsvg/test/4.ts
@@ -27,7 +27,7 @@
 
   // Animate all elements in set
   function animateTest() {
-    return new Promise(resolve => {
+    return new Promise<void>(resolve => {
       rectSet.animate({
         x: 50
       }, 500, mina.bounce, resolve);
@@ -36,7 +36,7 @@
 
   // Animate elements individually
   function animateMultipleTest() {
-    return new Promise(resolve => {
+    return new Promise<void>(resolve => {
       rectSet.animate(
         [{ x: 100 }, 500, mina.linear],
         [{ x: 100 }, 1000, mina.linear],
@@ -49,7 +49,7 @@
   // Animate elements individually
   function forEachTest() {
     const colors = ['red', 'green', 'blue'];
-    return new Promise(resolve => {
+    return new Promise<void>(resolve => {
       rectSet.forEach((element, idx) => { 
         element.attr({
           fill: colors[idx] || '#aaa'
@@ -61,7 +61,7 @@
 
   // Exclude rect4 from set
   function excludeTest() {
-    return new Promise(resolve => {
+    return new Promise<void>(resolve => {
       rectSet.exclude(rect4);
       rectSet.animate({
         x: 150
@@ -84,7 +84,7 @@
 
   // Clear set. Rectangles should not go back to x=0
   function clearTest() {
-    return new Promise(resolve => {
+    return new Promise<void>(resolve => {
       rectSet.clear();
 
       // SHOULD NOT WORK

--- a/types/stream-demux/stream-demux-tests.ts
+++ b/types/stream-demux/stream-demux-tests.ts
@@ -55,7 +55,7 @@ const demux = new StreamDemux<string>();
 
 // Utility function for using setTimeout() with async/await.
 function wait(duration: number) {
-    return new Promise(resolve => {
+    return new Promise<void>(resolve => {
         setTimeout(() => {
             resolve();
         }, duration);

--- a/types/system-task/system-task-tests.ts
+++ b/types/system-task/system-task-tests.ts
@@ -6,7 +6,7 @@ const REQUIREASYNCEPROCESS = true;
 const DEMOASSET = {
   name: 'DEMO ASSET',
   async execute(message: string) {
-    return new Promise((res) => {
+    return new Promise<void>((res) => {
       setTimeout(() => {
         console.log(`Done with ${message}`);
         res();

--- a/types/undertaker/undertaker-tests.ts
+++ b/types/undertaker/undertaker-tests.ts
@@ -15,7 +15,7 @@ taker.task("task2", () => {
 });
 
 taker.task("task3", () => {
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
         // do things
         resolve(); // when everything is done
     });

--- a/types/xml/xml-tests.ts
+++ b/types/xml/xml-tests.ts
@@ -114,7 +114,7 @@ test('supports stream interface', t => {
         t.is(stanza, results.shift());
     });
 
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
         xmlStream.on('close', () => {
             t.same(results, []);
             resolve();
@@ -145,7 +145,7 @@ test('streams end properly', t => {
         t.ok(gotData);
     });
 
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
         xmlStream.on('close',  () => {
             t.ok(gotData);
             resolve();


### PR DESCRIPTION
These are backwards-compatible fixes for tests ins various DT projects in advance of merging https://github.com/microsoft/TypeScript/pull/39817. In most cases this is changing untyped `new Promise` to `new Promise<void>` for cases where the tests explicitly call `resolve()`.

The following are the projects explicitly affected by the above change:

  - [x] `memcached` - `Expected 1 arguments, but got 0`. These may be due to incorrect calls to `resolve` in the tests and if so are the kind of error this PR is intended to catch.
  - [x] `system-task` - `Expected 1 arguments, but got 0`
  - [x] `async-stream-emitter` - `Expected 1 arguments, but got 0`
  - [x] `graphql-relay` - `Expected 1 arguments, but got 0`
  - [x] `node-wit` - `Expected 1 arguments, but got 0`
  - [x] `react-window-infinite-loader` - `Expected 1 arguments, but got 0`
  - [x] `stream-demux` - `Expected 1 arguments, but got 0`
  - [x] `undertaker` - `Expected 1 arguments, but got 0`
  - [x] `xml` - `Expected 1 arguments, but got 0`
  - [x] `listr` - `Expected 1 arguments, but got 0`
  - [x] `mirrorx` - `Expected 1 arguments, but got 0`
  - [x] `nightmare` - `Expected 1 arguments, but got 0`
  - [x] `polka` - `Expected 1 arguments, but got 0`
  - [x] `react-router-guard` - `Expected 1 arguments, but got 0`
  - [x] `redux-form/v4` - `Expected 1 arguments, but got 0`
  - [x] `redux-form/v5` - `Expected 1 arguments, but got 0`
  - [x] `snapsvg` - `Argument of type (value: unknown) => void' is not assignable to a parameter of type '() => void'`. Seems like the kind of error this PR is intended to produce.
  - [x] `react-virtualized` - `Type '(value: unknown) => void' is not assignable to type '() => void'`. Seems like the kind of error this PR is intended to produce.
  - [x] `fetch-mock` - Seems like the type specified to be assignable to `PromiseConstructor` is wrong and needs to be addressed in `fetch-mock`.

This PR will stay in draft form until fixes for all of the above projects have been added.