### PR TITLE
Allow extra properties in when calling `createTag`.

### DIFF
--- a/types/select2/index.d.ts
+++ b/types/select2/index.d.ts
@@ -213,7 +213,7 @@ export interface Options<Result = DataFormat | GroupedDataFormat, RemoteResult =
     width?: string;
 
     // Not in https://select2.org/configuration/options-api
-    createTag?: (params: SearchOptions) => IdTextPair | null;
+    createTag?: (params: SearchOptions) => (IdTextPair & Record<string, any>) | null;
     insertTag?: (data: Array<OptionData | IdTextPair>, tag: IdTextPair) => void;
 }
 


### PR DESCRIPTION
Relates to upcoming changes in https://github.com/microsoft/TypeScript/pull/40311.

See  https://github.com/microsoft/TypeScript/pull/40311#issuecomment-685340412 for details on potential breakage.