### PR TITLE
Remove potentially unnecessary `content` property.

### DIFF
--- a/types/baidu-app/baidu-app-tests.ts
+++ b/types/baidu-app/baidu-app-tests.ts
@@ -1825,7 +1825,6 @@
         onShareAppMessage() {
             return {
                 title: '智能小程序示例',
-                content: '世界很复杂，百度更懂你',
                 path: '/pages/openShare/openShare?key=value'
             };
         }


### PR DESCRIPTION
Removed the `content` property from the example code. The property appears not to be documented, and is likely a result of copy/paste on the subsequent example. If this is incorrect, it may be better to change the actual type declarations.

Found from upcoming changes in microsoft/TypeScript#40311.

See microsoft/TypeScript#40311 (comment) for details on potential breakage.