### PR TITLE
Add types for package node-ip2region

### DIFF
--- a/types/node-ip2region/index.d.ts
+++ b/types/node-ip2region/index.d.ts
@@ -1,0 +1,80 @@
+// Type definitions for node-ip2region 1.0
+// Project: https://github.com/lionsoul2014/ip2region
+// Definitions by: DCsunset <https://github.com/DefinitelyTyped>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.7
+
+/// <reference types="node" />
+
+type SearchResult = {
+    city: number;
+    region: string;
+} | null;
+
+type SearchCallback = (err: NodeJS.ErrnoException, result: SearchResult) => void;
+
+declare class IP2Region {
+    //#region Static Functions
+
+    // Single Instance
+    static create(dbPath?: string): IP2Region;
+
+    /**
+     * For backward compatibility
+     */
+    static destroy(): void;
+
+    //#endregion
+
+    constructor(options?: { dbPath: string });
+
+    //#region Public Functions
+    /**
+     * Destroy the current file by closing it.
+     */
+    destroy(): void;
+
+    /**
+     * Sync of binarySearch.
+     * @param ip The IP address to search for.
+     * @return A result something like `{ city: 2163, region: '中国|0|广东省|深圳市|阿里云' }`
+     */
+    binarySearchSync(ip: string): SearchResult;
+
+    /**
+     * Async of binarySearch.
+     * @param ip The IP address to search for.
+     * @param callBack The callBack function with two parameters, if successful,
+     * err is null and result is `{ city: 2163, region: '中国|0|广东省|深圳市|阿里云' }`
+     */
+    binarySearch(ip: string, callBack: SearchCallback): void;
+
+    /**
+     * Sync of btreeSearch.
+     * @param ip The IP address to search for.
+     * @return A result something like `{ city: 2163, region: '中国|0|广东省|深圳市|阿里云' }`
+     */
+    btreeSearchSync(ip: string): SearchResult;
+
+    /**
+     * Async of btreeSearch.
+     * @param ip The IP address to search for.
+     * @param callBack The callBack function with two parameters, if successful,
+     * err is null and result is `{ city: 2163, region: '中国|0|广东省|深圳市|阿里云' }`
+     */
+    btreeSearch(ip: string, callBack: SearchCallback): void;
+
+    /**
+     * Sync of MemorySearch.
+     * @param ip
+     */
+    memorySearchSync(ip: string): SearchResult;
+
+    /**
+     * Async of MemorySearch.
+     * @param ip
+     */
+    memorySearch(ip: string, callBack: SearchCallback): void;
+}
+
+export = IP2Region;

--- a/types/node-ip2region/node-ip2region-tests.ts
+++ b/types/node-ip2region/node-ip2region-tests.ts
@@ -1,0 +1,28 @@
+import IP2Region = require('node-ip2region');
+
+const searcher = new IP2Region({
+    dbPath: './db',
+});
+searcher.binarySearch('1.1.1.1', (_err, result) => {
+    result?.city;
+    result?.region;
+});
+let result = searcher.binarySearchSync('1.1.1.1');
+result?.city;
+result?.region;
+searcher.btreeSearch('1.1.1.1', (_err, result) => {
+    result?.city;
+    result?.region;
+});
+result = searcher.btreeSearchSync('1.1.1.1');
+result?.city;
+result?.region;
+searcher.memorySearch('1.1.1.1', (_err, result) => {
+    result?.city;
+    result?.region;
+});
+result = searcher.memorySearchSync('1.1.1.1');
+result?.city;
+result?.region;
+
+searcher.destroy();

--- a/types/node-ip2region/tsconfig.json
+++ b/types/node-ip2region/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "node-ip2region-tests.ts"
+    ]
+}

--- a/types/node-ip2region/tslint.json
+++ b/types/node-ip2region/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
