### PR TITLE
fix(compression-webpack-plugin): fix result type definition

### DIFF
--- a/types/compression-webpack-plugin/compression-webpack-plugin-tests.ts
+++ b/types/compression-webpack-plugin/compression-webpack-plugin-tests.ts
@@ -58,13 +58,14 @@ const badZlib: Configuration = {
     ]
 };
 
-function customAlgorithm(input: string, options: number, callback: (err: Error, result: Buffer) => void) {
-}
-
 const custom: Configuration = {
     plugins: [
         new CompressionPlugin({
-            algorithm: customAlgorithm,
+            algorithm: (input: string, options: number, callback: (err: Error, result: Buffer) => void) => {},
+            compressionOptions: 5
+        }),
+        new CompressionPlugin({
+            algorithm: (input: string, options: number, callback: (err: Error, result: Uint8Array) => void) => {},
             compressionOptions: 5
         })
     ]

--- a/types/compression-webpack-plugin/index.d.ts
+++ b/types/compression-webpack-plugin/index.d.ts
@@ -19,7 +19,7 @@ declare class CompressionPlugin<O = any> extends Plugin {
 }
 
 declare namespace CompressionPlugin {
-    type AlgorithmCallback = (error: Error | null, result: Buffer) => void;
+    type AlgorithmCallback = (error: Error | null, result: Uint8Array) => void;
     type Algorithm<O> = (source: string, options: O, callback: AlgorithmCallback) => void;
 
     // NOTE: These are the async compression algorithms on the zlib object.


### PR DESCRIPTION
Expand allowed types for result callback to be compatible with patched
version:
https://github.com/webpack-contrib/compression-webpack-plugin/compare/v5.0.1...v5.0.2
https://github.com/webpack-contrib/compression-webpack-plugin/pull/190
https://github.com/gfx/universal-zopfli-js/blob/master/src/index.ts#L87

/cc @vitoyucepi

Thanks!

Fixes: #47230

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)