### PR TITLE
crypto.generateKeyPair('x25519') and crypto.diffieHellman({ privateKey, publicKey }) support

### DIFF
--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -494,6 +494,28 @@ import { promisify } from 'util';
             type: 'pkcs8',
         },
     }, (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {});
+
+    crypto.generateKeyPair('ed25519', {
+        publicKeyEncoding: {
+            format: 'pem',
+            type: 'spki',
+        },
+        privateKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs8',
+        },
+    }, (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {});
+
+    crypto.generateKeyPair('x25519', {
+        publicKeyEncoding: {
+            format: 'pem',
+            type: 'spki',
+        },
+        privateKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs8',
+        },
+    }, (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {});
 }
 
 {
@@ -550,6 +572,34 @@ import { promisify } from 'util';
             type: 'pkcs8',
         },
     });
+
+    const ed25519Res: Promise<{
+        publicKey: string;
+        privateKey: string;
+    }> = generateKeyPairPromisified('ed25519', {
+        publicKeyEncoding: {
+            format: 'pem',
+            type: 'spki',
+        },
+        privateKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs8',
+        },
+    });
+
+    const x25519Res: Promise<{
+        publicKey: string;
+        privateKey: string;
+    }> = generateKeyPairPromisified('x25519', {
+        publicKeyEncoding: {
+            format: 'pem',
+            type: 'spki',
+        },
+        privateKeyEncoding: {
+            format: 'pem',
+            type: 'pkcs8',
+        },
+    });
 }
 
 {
@@ -601,6 +651,21 @@ import { promisify } from 'util';
     verify.update('some data to sign');
     verify.end();
     verify.verify(publicKey, signature);    // $ExpectType boolean
+}
+
+{
+    // crypto.diffieHellman_test
+    const { privateKey1, publicKey1 } = crypto.generateKeyPairSync('x25519');
+    const privateKeyObject1 = crypto.createPrivateKey({ key: privateKey1 });
+    const publicKeyObject1 = crypto.createPublicKey({ key: publicKey1 });
+
+    const { privateKey2, publicKey2 } = crypto.generateKeyPairSync('x25519');
+    const privateKeyObject2 = crypto.createPrivateKey({ key: privateKey2 });
+    const publicKeyObject2 = crypto.createPublicKey({ key: publicKey2 });
+
+    const sharedSecret1 = crypto.diffieHellman({ privateKeyObject1, publicKeyObject2 });
+    const sharedSecret2 = crypto.diffieHellman({ privateKeyObject2, publicKeyObject1 });
+    assert.equal(sharedSecret1, sharedSecret2)
 }
 
 {

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -655,17 +655,42 @@ import { promisify } from 'util';
 
 {
     // crypto.diffieHellman_test
-    const { privateKey1, publicKey1 } = crypto.generateKeyPairSync('x25519');
-    const privateKeyObject1 = crypto.createPrivateKey({ key: privateKey1 });
-    const publicKeyObject1 = crypto.createPublicKey({ key: publicKey1 });
+    const { privateKey, publicKey } = crypto.generateKeyPairSync('x25519', {
+        publicKeyEncoding: {
+            type: 'spki',
+            format: 'pem',
+        },
+        privateKeyEncoding: {
+            type: 'pkcs8',
+            format: 'pem',
+        },
+    });
+    const privateKeyObject = crypto.createPrivateKey({ key: privateKey });
+    const publicKeyObject = crypto.createPublicKey({ key: publicKey });
 
-    const { privateKey2, publicKey2 } = crypto.generateKeyPairSync('x25519');
-    const privateKeyObject2 = crypto.createPrivateKey({ key: privateKey2 });
-    const publicKeyObject2 = crypto.createPublicKey({ key: publicKey2 });
+    crypto.generateKeyPair(
+        'x25519',
+        {
+            publicKeyEncoding: {
+                type: 'spki',
+                format: 'pem',
+            },
+            privateKeyEncoding: {
+                type: 'pkcs8',
+                format: 'pem',
+            },
+        },
+        (err, publicKey1, privateKey1) => {
+            if (err) console.log(err);
 
-    const sharedSecret1 = crypto.diffieHellman({ privateKeyObject1, publicKeyObject2 });
-    const sharedSecret2 = crypto.diffieHellman({ privateKeyObject2, publicKeyObject1 });
-    assert.equal(sharedSecret1, sharedSecret2)
+            const privateKeyObject1 = crypto.createPrivateKey({ key: privateKey1 });
+            const publicKeyObject1 = crypto.createPublicKey({ key: publicKey1 });
+
+            const sharedSecret1 = crypto.diffieHellman({ privateKey: privateKeyObject, publicKey: publicKeyObject1 });
+            const sharedSecret2 = crypto.diffieHellman({ privateKey: privateKeyObject1, publicKey: publicKeyObject });
+            assert.equal(sharedSecret1, sharedSecret2);
+        },
+    );
 }
 
 {

--- a/types/node/ts3.1/crypto.d.ts
+++ b/types/node/ts3.1/crypto.d.ts
@@ -543,21 +543,21 @@ declare module "crypto" {
 
     interface ED25519KeyPairOptions<PubF extends KeyFormat, PrivF extends KeyFormat> {
         publicKeyEncoding: {
-            type: 'pkcs1' | 'spki';
+            type: 'spki';
             format: PubF;
         };
         privateKeyEncoding: BasePrivateKeyEncodingOptions<PrivF> & {
-            type: 'sec1' | 'pkcs8';
+            type: 'pkcs8';
         };
     }
 
     interface X25519KeyPairOptions<PubF extends KeyFormat, PrivF extends KeyFormat> {
         publicKeyEncoding: {
-            type: 'pkcs1' | 'spki';
+            type: 'spki';
             format: PubF;
         };
         privateKeyEncoding: BasePrivateKeyEncodingOptions<PrivF> & {
-            type: 'sec1' | 'pkcs8';
+            type: 'pkcs8';
         };
     }
 

--- a/types/node/ts3.1/crypto.d.ts
+++ b/types/node/ts3.1/crypto.d.ts
@@ -680,4 +680,14 @@ declare module "crypto" {
      * passed to [`crypto.createPublicKey()`][].
      */
     function verify(algorithm: string | null | undefined, data: NodeJS.ArrayBufferView, key: KeyLike | VerifyKeyWithOptions, signature: NodeJS.ArrayBufferView): boolean;
+
+    /**
+     * Computes the Diffie-Hellman secret based on a privateKey and a publicKey. 
+     * Both keys must have the same asymmetricKeyType, which must be one of 
+     * 'dh' (for Diffie-Hellman), 'ec' (for ECDH), 'x448', or 'x25519' (for ECDH-ES).
+     */
+    function diffieHellman(options: {
+        privateKey: KeyObject;
+        publicKey: KeyObject
+    }): Buffer;
 }

--- a/types/node/ts3.1/crypto.d.ts
+++ b/types/node/ts3.1/crypto.d.ts
@@ -431,7 +431,7 @@ declare module "crypto" {
     /** @deprecated since v10.0.0 */
     const DEFAULT_ENCODING: BufferEncoding;
 
-    type KeyType = 'rsa' | 'dsa' | 'ec' | 'ed25519';
+    type KeyType = 'rsa' | 'dsa' | 'ec' | 'ed25519' | 'x25519';
     type KeyFormat = 'pem' | 'der';
 
     interface BasePrivateKeyEncodingOptions<T extends KeyFormat> {
@@ -449,6 +449,12 @@ declare module "crypto" {
         /**
          * No options.
          */
+    }
+
+    interface X25519KeyPairKeyObjectOptions {
+       /**
+        * No options.
+        */
     }
 
     interface ECKeyPairKeyObjectOptions {
@@ -545,6 +551,16 @@ declare module "crypto" {
         };
     }
 
+    interface X25519KeyPairOptions<PubF extends KeyFormat, PrivF extends KeyFormat> {
+        publicKeyEncoding: {
+            type: 'pkcs1' | 'spki';
+            format: PubF;
+        };
+        privateKeyEncoding: BasePrivateKeyEncodingOptions<PrivF> & {
+            type: 'sec1' | 'pkcs8';
+        };
+    }
+
     interface KeyPairSyncResult<T1 extends string | Buffer, T2 extends string | Buffer> {
         publicKey: T1;
         privateKey: T2;
@@ -574,6 +590,12 @@ declare module "crypto" {
     function generateKeyPairSync(type: 'ed25519', options: ED25519KeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'ed25519', options: ED25519KeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
+    function generateKeyPairSync(type: 'x25519', options: X25519KeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(type: 'x25519', options: X25519KeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(type: 'x25519', options: X25519KeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(type: 'x25519', options: X25519KeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(type: 'x25519', options: X25519KeyPairKeyObjectOptions): KeyPairKeyObjectResult;
+
     function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
     function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
     function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
@@ -597,6 +619,12 @@ declare module "crypto" {
     function generateKeyPair(type: 'ed25519', options: ED25519KeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
     function generateKeyPair(type: 'ed25519', options: ED25519KeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
     function generateKeyPair(type: 'ed25519', options: ED25519KeyPairKeyObjectOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+
+    function generateKeyPair(type: 'x25519', options: X25519KeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
+    function generateKeyPair(type: 'x25519', options: X25519KeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
+    function generateKeyPair(type: 'x25519', options: X25519KeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
+    function generateKeyPair(type: 'x25519', options: X25519KeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
+    function generateKeyPair(type: 'x25519', options: X25519KeyPairKeyObjectOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
 
     namespace generateKeyPair {
         function __promisify__(type: "rsa", options: RSAKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
@@ -622,6 +650,12 @@ declare module "crypto" {
         function __promisify__(type: "ed25519", options: ED25519KeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
         function __promisify__(type: "ed25519", options: ED25519KeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
         function __promisify__(type: "ed25519", options: ED25519KeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+
+        function __promisify__(type: "x25519", options: X25519KeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
+        function __promisify__(type: "x25519", options: X25519KeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
+        function __promisify__(type: "x25519", options: X25519KeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
+        function __promisify__(type: "x25519", options: X25519KeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
+        function __promisify__(type: "x25519", options: X25519KeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
     }
 
     /**

--- a/types/node/ts3.1/crypto.d.ts
+++ b/types/node/ts3.1/crypto.d.ts
@@ -682,8 +682,8 @@ declare module "crypto" {
     function verify(algorithm: string | null | undefined, data: NodeJS.ArrayBufferView, key: KeyLike | VerifyKeyWithOptions, signature: NodeJS.ArrayBufferView): boolean;
 
     /**
-     * Computes the Diffie-Hellman secret based on a privateKey and a publicKey. 
-     * Both keys must have the same asymmetricKeyType, which must be one of 
+     * Computes the Diffie-Hellman secret based on a privateKey and a publicKey.
+     * Both keys must have the same asymmetricKeyType, which must be one of
      * 'dh' (for Diffie-Hellman), 'ec' (for ECDH), 'x448', or 'x25519' (for ECDH-ES).
      */
     function diffieHellman(options: {


### PR DESCRIPTION
Part of #45614

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)

If changing an existing definition:

- [x ] Provide a URL to documentation or source code which provides context for the suggested changes:
    https://nodejs.org/api/crypto.html#crypto_crypto_generatekeypair_type_options_callback
    https://nodejs.org/api/crypto.html#crypto_crypto_diffiehellman_options
