### PR TITLE
feat(user-idle-observer): new definition

### DIFF
--- a/types/user-idle-observer/index.d.ts
+++ b/types/user-idle-observer/index.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for user-idle-observer 1.0
+// Project: https://github.com/vladagurets/user-idle-observer#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace userIDLEObserver;
+
+/**
+ * This lib allows you to track user inactivity time.
+ */
+declare function userIDLEObserver(opts?: userIDLEObserver.Options): userIDLEObserver.UserIDLEObserver;
+
+declare namespace userIDLEObserver {
+    /**
+     * observer options
+     */
+    interface Options {
+        /**
+         * fire callback on user inactivity time in ms
+         * @default 3_000
+         */
+        idleTime?: number;
+        /**
+         * callback that will triger after opts.idleTime of user's IDLE
+         * @default console.log
+         */
+        cb?: Callback;
+        /**
+         * @default ["mousemove", "mousedown", "keydown", "scroll", "touchstart", "resize", "visibilitychange"]
+         */
+        listeners?: Array<keyof WindowEventMap>;
+    }
+
+    interface UserIDLEObserver {
+        /**
+         * destroy observer instance
+         */
+        destroy(): void;
+    }
+
+    type Callback = (time: number) => void;
+}
+
+export = userIDLEObserver;

--- a/types/user-idle-observer/tsconfig.json
+++ b/types/user-idle-observer/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "DOM"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "user-idle-observer-tests.ts"
+    ]
+}

--- a/types/user-idle-observer/tslint.json
+++ b/types/user-idle-observer/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/user-idle-observer/user-idle-observer-tests.ts
+++ b/types/user-idle-observer/user-idle-observer-tests.ts
@@ -1,0 +1,15 @@
+import IDLEObserver = require('user-idle-observer');
+
+const observer = IDLEObserver({
+    idleTime: 5000,
+    cb: time => {
+        console.log(`User was innactive for ${time}ms`);
+    },
+    listeners: ['mousemove', 'mousedown', 'keydown'],
+});
+
+IDLEObserver();
+IDLEObserver({});
+IDLEObserver({
+    cb: console.log,
+});


### PR DESCRIPTION
Simple lib tracking client side user inactivity
- definition file
- tests

https://www.npmjs.com/package/user-idle-observer
https://github.com/vladagurets/user-idle-observer#example

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.