### PR TITLE
fix(webidl2): Fix generic IDLTypeDescription type definition

### DIFF
--- a/types/webidl2/index.d.ts
+++ b/types/webidl2/index.d.ts
@@ -37,7 +37,7 @@ export type IDLInterfaceMixinMemberType =
 
 export type IDLNamespaceMemberType = AttributeMemberType | OperationMemberType;
 
-export type IDLTypeDescription = SingleTypeDescription | UnionTypeDescription;
+export type IDLTypeDescription = GenericTypeDescription | SingleTypeDescription | UnionTypeDescription;
 
 export interface ParseOptions {
     /** Boolean indicating whether the result should include EOF node or not. */
@@ -92,10 +92,6 @@ export interface AbstractBase {
 }
 
 export interface AbstractTypeDescription extends AbstractBase {
-    /** Boolean indicating if it is a sequence. Same as generic === "sequence" */
-    sequence: boolean;
-    /** String indicating the generic type (e.g. "Promise", "sequence"). null otherwise. */
-    generic: string | null;
     /** Boolean indicating whether this is nullable or not. */
     nullable: boolean;
     /** The container of this type. */
@@ -111,7 +107,23 @@ export interface AbstractTypeDescription extends AbstractBase {
         | UnionTypeDescription;
 }
 
+export interface GenericTypeDescription extends AbstractTypeDescription {
+    /** String indicating the generic type (e.g. "Promise", "sequence"). The empty string otherwise. */
+    generic: "FrozenArray" | "ObservableArray" | "Promise"| "record" | "sequence";
+    /** Boolean indicating whether this is a union type or not. */
+    union: false;
+    /**
+     * In most cases, this will just be a string with the type name.
+     * If the type is a union, then this contains an array of the types it unites.
+     * If it is a generic type, it contains the IDL type description for the type in the sequence,
+     * the eventual value of the promise, etc.
+     */
+    idlType: IDLTypeDescription[];
+}
+
 export interface SingleTypeDescription extends AbstractTypeDescription {
+    /** String indicating the generic type (e.g. "Promise", "sequence"). The empty string otherwise. */
+    generic: "";
     /** Boolean indicating whether this is a union type or not. */
     union: false;
     /**
@@ -124,6 +136,8 @@ export interface SingleTypeDescription extends AbstractTypeDescription {
 }
 
 export interface UnionTypeDescription extends AbstractTypeDescription {
+    /** String indicating the generic type (e.g. "Promise", "sequence"). The empty string otherwise. */
+    generic: "";
     /** Boolean indicating whether this is a union type or not. */
     union: true;
     /**

--- a/types/webidl2/webidl2-tests.ts
+++ b/types/webidl2/webidl2-tests.ts
@@ -203,13 +203,17 @@ function logArguments(args: webidl2.Argument[]) {
 
 function logIdlType(idlType: webidl2.IDLTypeDescription) {
     console.log(idlType.type);
-    console.log(idlType.generic, idlType.nullable, idlType.sequence, idlType.union);
+    console.log(idlType.generic, idlType.nullable, idlType.union);
 
     if (idlType.union) {
         idlType; // $ExpectType UnionTypeDescription
         for (const t of idlType.idlType) {
             logIdlType(t);
         }
+    } else if (idlType.generic) {
+        idlType; // $ExpectType GenericTypeDescription
+        idlType.generic; // $ExpectType "FrozenArray" | "ObservableArray" | "Promise" | "record" | "sequence"
+        console.log(idlType);
     } else {
         idlType; // $ExpectType SingleTypeDescription
         console.log(idlType);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/w3c/webidl2.js/blob/cb92b7c401612f4771fbedf4627072c128c1c324/lib/productions/type.js#L13> <https://github.com/w3c/webidl2.js/blob/cb92b7c401612f4771fbedf4627072c128c1c324/lib/productions/type.js#L127-L132>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
