### PR TITLE
[serverless] Support provider.environment as a string

### DIFF
--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -44,7 +44,7 @@ declare namespace Aws {
         rolePermissionsBoundary?: string;
         cfnRole?: string;
         versionFunctions?: boolean;
-        environment?: Environment;
+        environment?: Environment | string;
         endpointType?: 'regional' | 'edge' | 'private';
         apiKeys?: string[];
         apiGateway?: ApiGateway;


### PR DESCRIPTION
According to [documentation](https://www.serverless.com/framework/docs/providers/aws/guide/variables/) `provider.environmen` should be an object. But it also could be loaded from .yml file using .yml syntax: 
```yaml
  ...
  provider:
    environment: ${file/env.yml}
  ...
```

This PR extends a definition of the Provider interface.

It changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [documentation](https://www.serverless.com/framework/docs/providers/aws/guide/variables/)
