### PR TITLE
[node-hid]: add optional arguments to "devices"

### DIFF
--- a/types/node-hid/index.d.ts
+++ b/types/node-hid/index.d.ts
@@ -36,5 +36,5 @@ export class HID extends EventEmitter {
     write(values: number[] | Buffer): number;
     setNonBlocking(no_block: boolean): void;
 }
-export function devices(): Device[];
+export function devices(vid?: number, pid?: number): Device[];
 export function setDriverType(type: 'hidraw' | 'libusb'): void;


### PR DESCRIPTION
The node-hid `devices` function accepts [two optional arguments](https://github.com/node-hid/node-hid/blob/master/src/HID.cc#L545)

@todbot