### PR TITLE
fix(gamedig): add new givenPortOnly query option

### DIFF
--- a/types/gamedig/gamedig-tests.ts
+++ b/types/gamedig/gamedig-tests.ts
@@ -2,7 +2,13 @@ import Gamedig = require("gamedig");
 
 Gamedig.query({
   type: "tf2",
-  host: "127.0.0.1"
+  host: "127.0.0.1",
+  port: 27015,
+  maxAttempts: 1,
+  socketTimeout: 2000,
+  attemptTimeout: 10000,
+  givenPortOnly: true,
+  debug: false
 }, (error, state) => {
   if (error) throw error();
 

--- a/types/gamedig/index.d.ts
+++ b/types/gamedig/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for Gamedig 2.0
+// Type definitions for Gamedig 2.0.23
 // Project: https://github.com/sonicsnes/node-gamedig
 // Definitions by: Ivan Sieder <https://github.com/ivansieder>
 //                 Marco Vockner <https://github.com/marcopixel>
+//                 Pascal Sthamer <https://github.com/p4sca1>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export type Type =
@@ -292,6 +293,7 @@ export interface QueryOptions {
     maxAttempts?: number;
     socketTimeout?: number;
     attemptTimeout?: number;
+    givenPortOnly?: boolean;
     debug?: boolean;
 }
 

--- a/types/gamedig/index.d.ts
+++ b/types/gamedig/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Gamedig 2.0.23
+// Type definitions for Gamedig 2.0
 // Project: https://github.com/sonicsnes/node-gamedig
 // Definitions by: Ivan Sieder <https://github.com/ivansieder>
 //                 Marco Vockner <https://github.com/marcopixel>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gamedig/node-gamedig/commit/a362d1d11303796188296b60d66584551333b0c8
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
