### PR TITLE
[react-table] Removed groupByBoundary & added leafRows

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -565,7 +565,6 @@ export type UseGroupByColumnOptions<D extends object> = Partial<{
     Aggregated: Renderer<CellProps<D>>;
     disableGroupBy: boolean;
     defaultCanGroupBy: boolean;
-    groupByBoundary: boolean;
 }>;
 
 export interface UseGroupByInstanceProps<D extends object> {
@@ -599,6 +598,7 @@ export interface UseGroupByRowProps<D extends object> {
     groupByVal: string;
     values: Record<IdType<D>, AggregatedValue>;
     subRows: Array<Row<D>>;
+    leafRows: Array<Row<D>>;
     depth: number;
     id: string;
     index: number;

--- a/types/react-table/react-table-tests.tsx
+++ b/types/react-table/react-table-tests.tsx
@@ -396,9 +396,6 @@ function Table({ columns, data, updateMyData, skipPageReset = false }: Table<Dat
             hooks.allColumns.push(columns => [
                 {
                     id: 'selection',
-                    // Make this column a groupByBoundary. This ensures that groupBy columns
-                    // are placed after it
-                    groupByBoundary: true,
                     // The header can use the table's getToggleAllRowsSelectedProps method
                     // to render a checkbox
                     Header: ({ getToggleAllRowsSelectedProps }: HeaderProps<Data>) => (
@@ -597,9 +594,6 @@ const Component = (props: {}) => {
     const columns: Array<Column<Data>> = [
         {
             id: 'selection',
-            // Make this column a groupByBoundary. This ensures that groupBy columns
-            // are placed after it
-            groupByBoundary: true,
             // The header can use the table's getToggleAllRowsSelectedProps method
             // to render a checkbox
             Header: ({ getToggleAllRowsSelectedProps }: HeaderProps<Data>) => (


### PR DESCRIPTION
1. Removed `groupByBoundary` not used anywhere in react-table
2. Added `leafRows` definition, reference - https://github.com/tannerlinsley/react-table/blob/master/src/plugin-hooks/useGroupBy.js#L318
