### PR TITLE
[@types/node-schedule] change RecurrenceSpecDateRange's field into optional

### DIFF
--- a/types/node-schedule/index.d.ts
+++ b/types/node-schedule/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>
 //                 Florian Plattner <https://github.com/flowpl>
 //                 Tieu Philippe Khim <https://github.com/spike008t>
+//                 Seohyun Yoon <https://github.com/seohyun0120>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -134,11 +135,11 @@ export interface RecurrenceSpecDateRange {
     /**
      * Starting date in date range.
      */
-    start: Date | string | number;
+    start?: Date | string | number;
     /**
      * Ending date in date range.
      */
-    end: Date | string | number;
+    end?: Date | string | number;
     /**
      * Cron expression string.
      */

--- a/types/node-schedule/node-schedule-tests.ts
+++ b/types/node-schedule/node-schedule-tests.ts
@@ -144,6 +144,8 @@ function testScheduleJob() {
     const startDate: Date = new Date();
     const endDate: Date = new Date(startDate.getDate() + 10000);
     const jobDateRange: nodeSchedule.Job = nodeSchedule.scheduleJob({start: startDate, end: endDate, rule: "* * * * * *"}, callback);
+    const jobDateRangeWithoutEndDate: nodeSchedule.Job = nodeSchedule.scheduleJob({ start: startDate, rule: "* * * * * *" }, callback);
+    const jobDateRangeWithoutStartDate: nodeSchedule.Job = nodeSchedule.scheduleJob({ end: endDate, rule: "* * * * * *" }, callback);
 
     const jobTimestamp: nodeSchedule.Job = nodeSchedule.scheduleJob(Date.now() + 1000, callback);
 }


### PR DESCRIPTION
- interface `RecurrenceSpecDateRange` has four properties (`start`, `end`, `tz`, `rule`). `start` and `end` property should be optional, not required. User can make a schedule option that has `start` and `rule` but no `end`. Vice Versa. (check out [node-schedule 1.3.2](https://github.com/node-schedule/node-schedule/))
- added related tests

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
<<https://github.com/node-schedule/node-schedule/releases/tag/v1.3.2>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.