### PR TITLE
Add definitions for `json-schema-generator`

### DIFF
--- a/types/json-schema-generator/index.d.ts
+++ b/types/json-schema-generator/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for json-schema-generator 2.0
+// Project: https://github.com/krg7880/json-schema-generator
+// Definitions by: Marcell Toth <https://github.com/marcelltoth>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import type { JSONSchema4 } from 'json-schema';
+
+/*~ Note that ES6 modules cannot directly export callable functions.
+ *~ This file should be imported using the CommonJS-style:
+ *~   import x = require('someLibrary');
+ *~
+ *~ Refer to the documentation to understand common
+ *~ workarounds for this limitation of ES6 modules.
+ */
+
+/*~ This declaration specifies that the function
+ *~ is the exported object from the file
+ */
+
+export = generate;
+
+/*~ This example shows how to have multiple overloads for your function */
+declare function generate(schema: object): JSONSchema4;

--- a/types/json-schema-generator/index.d.ts
+++ b/types/json-schema-generator/index.d.ts
@@ -7,7 +7,7 @@ import { JSONSchema4 } from 'json-schema';
 
 export = jsonToSchema;
 
-/** 
+/**
  * JSON schema generated based on draft-v4 of the specification.
-*/
+ */
 declare function jsonToSchema(schema: object): JSONSchema4;

--- a/types/json-schema-generator/index.d.ts
+++ b/types/json-schema-generator/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Marcell Toth <https://github.com/marcelltoth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import type { JSONSchema4 } from 'json-schema';
+import { JSONSchema4 } from 'json-schema';
 
 /*~ Note that ES6 modules cannot directly export callable functions.
  *~ This file should be imported using the CommonJS-style:

--- a/types/json-schema-generator/index.d.ts
+++ b/types/json-schema-generator/index.d.ts
@@ -5,19 +5,9 @@
 
 import { JSONSchema4 } from 'json-schema';
 
-/*~ Note that ES6 modules cannot directly export callable functions.
- *~ This file should be imported using the CommonJS-style:
- *~   import x = require('someLibrary');
- *~
- *~ Refer to the documentation to understand common
- *~ workarounds for this limitation of ES6 modules.
- */
+export = jsonToSchema;
 
-/*~ This declaration specifies that the function
- *~ is the exported object from the file
- */
-
-export = generate;
-
-/*~ This example shows how to have multiple overloads for your function */
-declare function generate(schema: object): JSONSchema4;
+/** 
+ * JSON schema generated based on draft-v4 of the specification.
+*/
+declare function jsonToSchema(schema: object): JSONSchema4;

--- a/types/json-schema-generator/json-schema-generator-tests.ts
+++ b/types/json-schema-generator/json-schema-generator-tests.ts
@@ -1,0 +1,6 @@
+import generate = require("json-schema-generator");
+
+const obj = generate({a: 4});
+
+ // @ts-expect-error
+const withString = generate("{a: 4}");

--- a/types/json-schema-generator/json-schema-generator-tests.ts
+++ b/types/json-schema-generator/json-schema-generator-tests.ts
@@ -1,6 +1,5 @@
 import generate = require("json-schema-generator");
 
-const obj = generate({a: 4});
+const obj = generate({a: 4}); // $ExpectType JSONSchema4
 
- // @ts-expect-error
-const withString = generate("{a: 4}");
+const withString = generate("{a: 4}"); // $ExpectError

--- a/types/json-schema-generator/json-schema-generator-tests.ts
+++ b/types/json-schema-generator/json-schema-generator-tests.ts
@@ -1,5 +1,5 @@
-import generate = require("json-schema-generator");
+import jsonToSchema = require("json-schema-generator");
 
-const obj = generate({a: 4}); // $ExpectType JSONSchema4
+const obj = jsonToSchema({a: 4}); // $ExpectType JSONSchema4
 
-const withString = generate("{a: 4}"); // $ExpectError
+const withString = jsonToSchema("{a: 4}"); // $ExpectError

--- a/types/json-schema-generator/tsconfig.json
+++ b/types/json-schema-generator/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "json-schema-generator-tests.ts"
+    ]
+}

--- a/types/json-schema-generator/tslint.json
+++ b/types/json-schema-generator/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

