### PR TITLE
rebass__forms: adding the missing StyledSystem.FontWeightProps interface

### DIFF
--- a/types/rebass__forms/index.d.ts
+++ b/types/rebass__forms/index.d.ts
@@ -19,6 +19,7 @@ interface BoxKnownProps
         StyledSystem.SpaceProps,
         StyledSystem.LayoutProps,
         StyledSystem.FontSizeProps,
+        StyledSystem.FontWeightProps,
         StyledSystem.ColorProps,
         StyledSystem.FlexProps,
         StyledSystem.OrderProps,

--- a/types/rebass__forms/rebass__forms-tests.tsx
+++ b/types/rebass__forms/rebass__forms-tests.tsx
@@ -4,7 +4,7 @@ import { Label, Input, Select, Textarea, Radio, Checkbox, Slider, Switch } from 
 
 export default () => (
     <>
-        <Label htmlFor="name">Name</Label>
+        <Label fontWeight='bold' fontSize={1} htmlFor="name">Bold Name</Label>
         <Input id="name" name="name" defaultValue="Jane Doe" />
 
         <Label htmlFor="location">Location</Label>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- The Label is defined here: <https://github.com/rebassjs/rebass/blob/cf6cf963ea0f736ec899bba401175ed062eca3c8/packages/forms/src/index.js#L37>
- And Flex is defined here: <https://github.com/rebassjs/rebass/blob/master/packages/reflexbox/src/index.js#L47>
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)