### PR TITLE
recharts: add allowDuplicatedCategory prop

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -552,6 +552,7 @@ export interface PolarAngleAxisProps extends EventAttributes, Partial<Presentati
     stroke?: string;
     orientation?: 'inner' | 'outer';
     tickFormatter?: TickFormatterFunction;
+    allowDuplicatedCategory?: boolean;
 }
 
 export class PolarAngleAxis extends React.Component<PolarAngleAxisProps> { }
@@ -592,6 +593,7 @@ export interface PolarRadiusAxisProps extends EventAttributes, Partial<Presentat
     domain?: Readonly<[PolarRadiusAxisDomain, PolarRadiusAxisDomain]>;
     scale?: ScaleType | RechartsFunction;
     allowDataOverflow?: boolean;
+    allowDuplicatedCategory?: boolean;
 }
 
 export class PolarRadiusAxis extends React.Component<PolarRadiusAxisProps> { }
@@ -1073,6 +1075,7 @@ export interface YAxisProps extends EventAttributes {
     reversed?: boolean;
     // see label section at http://recharts.org/#/en-US/api/YAxis
     label?: string | number | Label | LabelProps;
+    allowDuplicatedCategory?: boolean;
     stroke?: string;
 }
 

--- a/types/recharts/recharts-tests.tsx
+++ b/types/recharts/recharts-tests.tsx
@@ -5,7 +5,8 @@ import {
     CartesianGrid, Line, LineChart, PieChart, Pie,
     Sector, XAxis, YAxis, Tooltip, ReferenceLine,
     ReferenceArea, ResponsiveContainer, Label, LabelList, Brush,
-    ScatterChart, ZAxis, Legend, Scatter, Bar, BarChart, Text, Area, AreaChart, Customized
+    ScatterChart, ZAxis, Legend, Scatter, Bar, BarChart, Text, Area, AreaChart, Customized,
+    RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar
 } from 'recharts';
 
 interface ComponentState {
@@ -154,7 +155,7 @@ class Component extends React.Component<{}, ComponentState> {
                 <ResponsiveContainer height={300}>
                     <LineChart width={500} height={300} data={data}>
                         <XAxis dataKey="name" label={{ value: "X axis - name" }} />
-                        <YAxis label={{ value: "Y axis" }} />
+                        <YAxis label={{ value: "Y axis" }} allowDuplicatedCategory={false} />
                         <CartesianGrid stroke="#eee" strokeDasharray="5 5" />
                         <Line type="monotone" dataKey="uv" stroke="#8884d8" onClick={this.clickHandler} />
                         <Line type="monotone" dataKey="pv" stroke="#82ca9d" />
@@ -242,6 +243,12 @@ class Component extends React.Component<{}, ComponentState> {
                         <Area type="monotone" dataKey="pv" stroke="#82ca9d" fillOpacity={1} fill="url(#colorPv)" />
                     </AreaChart>
                 </ResponsiveContainer>
+                <RadarChart cx={300} cy={250} outerRadius={150} width={500} height={500} data={data}>
+                    <PolarGrid />
+                    <PolarAngleAxis dataKey="subject" allowDuplicatedCategory={false} />
+                    <PolarRadiusAxis allowDuplicatedCategory={true} />
+                    <Radar name="Mike" dataKey="A" stroke="#8884d8" fill="#8884d8" fillOpacity={0.6} />
+                </RadarChart>
             </div>
         );
     }


### PR DESCRIPTION
XAxis, YAxis, PolarAngleAxis, and PolarRadiusAxis all support the allowDuplicatedCategory prop,
but the existing types only have it specified for XAxis.  Add the prop to YAxis, PolarAngleAxis, and PolarRadiusAxis as well.

See

* https://github.com/recharts/recharts/blob/v1.8.5/src/cartesian/YAxis.js#L13
* https://github.com/recharts/recharts/blob/v1.8.5/src/polar/PolarAngleAxis.js#L50
* https://github.com/recharts/recharts/blob/v1.8.5/src/polar/PolarRadiusAxis.js#L53

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:

* https://github.com/recharts/recharts/blob/v1.8.5/src/cartesian/YAxis.js#L13
* https://github.com/recharts/recharts/blob/v1.8.5/src/polar/PolarAngleAxis.js#L50
* https://github.com/recharts/recharts/blob/v1.8.5/src/polar/PolarRadiusAxis.js#L53

- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
