### PR TITLE
[lodash] Update definition of omitBy to correctly preserve original type information

### DIFF
--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -1951,7 +1951,7 @@ declare module "../index" {
          * _.omitBy(object, _.isNumber);
          * // => { 'b': '2' }
          */
-        omitBy<T>(object: Dictionary<T> | null | undefined, predicate?: ValueKeyIteratee<T>): Dictionary<T>;
+        omitBy<T extends object>(object: T | null | undefined, predicate: ValueKeyIteratee<T[K]>): {[K in keyof T]?: T[K]};
         /**
          * @see _.omitBy
          */
@@ -1959,7 +1959,7 @@ declare module "../index" {
         /**
          * @see _.omitBy
          */
-        omitBy<T extends object>(object: T | null | undefined, predicate: ValueKeyIteratee<T[keyof T]>): PartialObject<T>;
+        omitBy<T>(object: Dictionary<T> | null | undefined, predicate?: ValueKeyIteratee<T>): Dictionary<T>;
     }
     interface Collection<T> {
         /**

--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -1951,7 +1951,7 @@ declare module "../index" {
          * _.omitBy(object, _.isNumber);
          * // => { 'b': '2' }
          */
-        omitBy<T extends object>(object: T | null | undefined, predicate: ValueKeyIteratee<T[K]>): {[K in keyof T]?: T[K]};
+        omitBy<T extends object>(object: T | null | undefined, predicate: ValueKeyIteratee<T[keyof T]>): {[K in keyof T]?: T[K]};
         /**
          * @see _.omitBy
          */


### PR DESCRIPTION
Reflect the fact that a function that omits keys of an object can only return an object with keys that form part of a subset of the original keys. Also definition is reordered so the most common case (this one) is taken first.

Example:

I have an object that has some predefined keys, this function only allows for keys to be removed, so the resulting object keys is always a sub-set of the original object keys, this was not being reflected properly:

### Original behavior:
![image](https://user-images.githubusercontent.com/12591112/92280540-9b528300-eec7-11ea-93f1-e76976a71237.png)

![image](https://user-images.githubusercontent.com/12591112/92280563-a2799100-eec7-11ea-88a4-33e973de4c0e.png)

Notice how `result` which is the result of using `omitBy` in `myObject` lost all of is type information and is just a `Dictionary<>` 


### After this change:
![image](https://user-images.githubusercontent.com/12591112/92280693-ff754700-eec7-11ea-97db-317934d2b27b.png)

![image](https://user-images.githubusercontent.com/12591112/92280624-cd63e500-eec7-11ea-85e2-fd2a7bf4a7b8.png)

Notice how `result` which is the result of using `omitBy` in `myObject` has a type which indicates that it contains at most all of its original keys, and each key may or may not be there


If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: [https://lodash.com/docs/4.17.15#omitBy](https://lodash.com/docs/4.17.15#omitBy)
