### PR TITLE
Rename test tasks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       - run: npm install
 
       # Run tests
-      - run: npm run test
+      - run: npm run test-all
 
       - name: "Run Danger"
         env:

--- a/README.md
+++ b/README.md
@@ -338,11 +338,9 @@ For more details, see [dtslint](https://github.com/Microsoft/dtslint#write-tests
 
 ## Verifying
 
-Test your changes by running `npm run lint package-name` where `package-name` is the name of your package.
+Test your changes by running `npm test package-name` where `package-name` is the name of your package.
 
 This script uses [dtslint](https://github.com/microsoft/dtslint) to run the TypeScript compiler against your dts files.
-
-If you're editing an existing package, you should `git add` your changes and then run `npm test` to test your changes on any `@types` packages that depend on the package you changed.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -340,14 +340,15 @@ For more details, see [dtslint](https://github.com/Microsoft/dtslint#write-tests
 
 Test your changes by running `npm run lint package-name` where `package-name` is the name of your package.
 
-This script uses [dtslint](https://github.com/Microsoft/dtslint) to run the TypeScript compiler against your dts files.
+This script uses [dtslint](https://github.com/microsoft/dtslint) to run the TypeScript compiler against your dts files.
 
+If you're editing an existing package, you should `git add` your changes and then run `npm test` to test your changes on any `@types` packages that depend on the package you changed.
 
 ## FAQ
 
 #### What exactly is the relationship between this repository and the `@types` packages on NPM?
 
-The `master` branch is automatically published to the `@types` scope on NPM thanks to [types-publisher](https://github.com/Microsoft/types-publisher).
+The `master` branch is automatically published to the `@types` scope on NPM thanks to [types-publisher](https://github.com/microsoft/DefinitelyTyped-tools).
 
 #### I've submitted a pull request. How long until it is merged?
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,10 +17,10 @@ jobs:
       if [[ $BUILD_REASON == "Schedule" ]]; then git config --global user.email "types@microsoft.com" && git config --global user.name "TypeScript Bot" && npm run update-codeowners; fi
       git checkout -- .
 
-      npm run test
+      npm run test-all
 
 
-    displayName: 'npm run test'
+    displayName: 'npm run test-all
 
 trigger:
 - master

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
       npm run test-all
 
 
-    displayName: 'npm run test-all
+    displayName: 'npm run test-all'
 
 trigger:
 - master

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "compile-scripts": "tsc -p scripts",
         "not-needed": "node scripts/not-needed.js",
         "update-codeowners": "node scripts/update-codeowners.js",
-        "test": "node node_modules/@definitelytyped/dtslint-runner/dist/index.js --path .",
+        "test-all": "node node_modules/@definitelytyped/dtslint-runner/dist/index.js --path .",
+        "test": "dtslint types",
         "lint": "dtslint types",
         "prettier": "prettier"
     },


### PR DESCRIPTION
`npm run lint package-name` &rarr; `npm test package-name`
`npm test` &rarr; `npm run test-all`

Thanks to @mscharlock and @ElizabethSamuel-MSFT for pointing out that this was needed.