### PR TITLE
add type declarations for ioredis.getrangeBuffer

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -276,6 +276,9 @@ declare namespace IORedis {
         getrange(key: KeyType, start: number, end: number, callback: Callback<string>): void;
         getrange(key: KeyType, start: number, end: number): Promise<string>;
 
+        getrangeBuffer(key: KeyType, start: number, end: number, callback: Callback<Buffer>): void;
+        getrangeBuffer(key: KeyType, start: number, end: number): Promise<Buffer>;
+
         substr(key: KeyType, start: number, end: number, callback: Callback<string>): void;
         substr(key: KeyType, start: number, end: number): Promise<string>;
 
@@ -995,6 +998,8 @@ declare namespace IORedis {
         setrange(key: KeyType, offset: number, value: ValueType, callback?: Callback<number>): Pipeline;
 
         getrange(key: KeyType, start: number, end: number, callback?: Callback<string>): Pipeline;
+
+        getrangeBuffer(key: KeyType, start: number, end: number, callback?: Callback<Buffer>): Pipeline;
 
         substr(key: KeyType, start: number, end: number, callback?: Callback<string>): Pipeline;
 

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -17,6 +17,9 @@ const cbNumber = (err: Error | null, result: any) => {
 redis.set('foo', 'bar');
 redis.get('foo', cb);
 
+redis.getrangeBuffer("foo", 0, 1, cb);
+redis.getrangeBuffer("foo", 0, 1).then(b => cb(null, b));
+
 // Static check that returned value is always a number
 redis.del('foo', 'bar').then(result => result * 1);
 
@@ -313,6 +316,7 @@ pipeline.hset('hash', 'foo', 4);
 pipeline.hget('hash', 'foo');
 pipeline.hsetBuffer('hash', 'fooBuffer', 4);
 pipeline.hgetBuffer('hash', 'fooBuffer');
+pipeline.getrangeBuffer('foo', 0, 1);
 pipeline.exec((err, results) => {
     // `err` is always null, and `results` is an array of responses
     // corresponding to the sequence of queued commands.


### PR DESCRIPTION
Adds type declarations for the "Buffer" version of getrange: [redis.getrangeBuffer](https://www.npmjs.com/package/ioredis#handle-binary-data)

The getrangeBuffer function (and all the command functions) is generated here: https://github.com/luin/ioredis/blob/f275bc24de3825f80415a69ff227a45251dd1a3b/lib/commander.ts#L61-L67

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/ioredis#handle-binary-data and https://github.com/luin/ioredis/blob/f275bc24de3825f80415a69ff227a45251dd1a3b/lib/commander.ts#L61-L67
- ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~

