### PR TITLE
Add type declaration for Parser.assert in parsimmon 1.13

### DIFF
--- a/types/parsimmon/index.d.ts
+++ b/types/parsimmon/index.d.ts
@@ -108,6 +108,13 @@ declare namespace Parsimmon {
          */
         tryParse(input: string): T;
         /**
+         * Passes the result of `parser` to the function `condition`,
+         * which returns a boolean. If the the condition is false, returns
+         * a failed parse with the given `message`. Else it returns the
+         * original result of `parser`.
+         */
+        assert(condition: (result: T) => boolean, message: string): Parser<T>;
+        /**
          * returns a new parser which tries parser, and if it fails uses otherParser.
          */
         or<U>(otherParser: Parser<U>): Parser<T | U>;

--- a/types/parsimmon/parsimmon-tests.ts
+++ b/types/parsimmon/parsimmon-tests.ts
@@ -100,6 +100,8 @@ barPar = fooPar.map((f) => {
 
 strPar = P.string(str);
 
+strPar = strPar.assert((s: string) => s === 'foo', 'reason goes here');
+
 strPar = strPar.contramap((f) => {
     f; // $ExpectType string
     return f.toUpperCase();


### PR DESCRIPTION
This was added in parsimmon 1.13:
https://github.com/jneen/parsimmon/blob/master/CHANGELOG.md#1130-2019-07-25c