### PR TITLE
[yandex-money-sdk] OperationHistoryOptions: label is optional parameter

### DIFF
--- a/types/yandex-money-sdk/index.d.ts
+++ b/types/yandex-money-sdk/index.d.ts
@@ -44,7 +44,7 @@ declare namespace YandexMoneySDK {
 
         interface OperationHistoryOptions {
             type: string;
-            label: string;
+            label?: string;
             from?: string|Date;
             till?: string|Date;
             start_record?: string;


### PR DESCRIPTION
Documentation here https://yandex.ru/dev/money/doc/dg/reference/operation-history-docpage/
All params for this API call are optional.