### PR TITLE
[node] Add missing `getFips` to `crypto`

### DIFF
--- a/types/node/v10/ts3.1/crypto.d.ts
+++ b/types/node/v10/ts3.1/crypto.d.ts
@@ -228,6 +228,7 @@ declare module "crypto" {
     function publicDecrypt(public_key: string | RsaPublicKey, buffer: Buffer | NodeJS.TypedArray | DataView): Buffer;
     function getCiphers(): string[];
     function getCurves(): string[];
+    function getFips(): 1 | 0;
     function getHashes(): string[];
     class ECDH {
         static convertKey(

--- a/types/node/v11/ts3.1/crypto.d.ts
+++ b/types/node/v11/ts3.1/crypto.d.ts
@@ -379,6 +379,7 @@ declare module "crypto" {
     function publicDecrypt(public_key: RsaPublicKey | KeyLike, buffer: Binary): Buffer;
     function getCiphers(): string[];
     function getCurves(): string[];
+    function getFips(): 1 | 0;
     function getHashes(): string[];
     class ECDH {
         private constructor();

--- a/types/node/v12/ts3.1/crypto.d.ts
+++ b/types/node/v12/ts3.1/crypto.d.ts
@@ -402,6 +402,7 @@ declare module "crypto" {
     function privateEncrypt(private_key: RsaPrivateKey | KeyLike, buffer: NodeJS.ArrayBufferView): Buffer;
     function getCiphers(): string[];
     function getCurves(): string[];
+    function getFips(): 1 | 0;
     function getHashes(): string[];
     class ECDH {
         private constructor();

--- a/types/node/v13/ts3.1/crypto.d.ts
+++ b/types/node/v13/ts3.1/crypto.d.ts
@@ -403,6 +403,7 @@ declare module "crypto" {
     function privateEncrypt(private_key: RsaPrivateKey | KeyLike, buffer: NodeJS.ArrayBufferView): Buffer;
     function getCiphers(): string[];
     function getCurves(): string[];
+    function getFips(): 1 | 0;
     function getHashes(): string[];
     class ECDH {
         private constructor();


### PR DESCRIPTION
Fixed https://github.com/DefinitelyTyped/DefinitelyTyped/issues/46952

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v13.x/api/crypto.html#crypto_crypto_getfips
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
