### PR TITLE
add types for rdf-loaders

### DIFF
--- a/types/rdf-loader-code/arguments.d.ts
+++ b/types/rdf-loader-code/arguments.d.ts
@@ -1,0 +1,21 @@
+import { Loader } from 'rdf-loaders-registry';
+import { NamedNode } from 'rdf-js';
+import LoaderRegistry = require('rdf-loaders-registry');
+
+interface Options {
+    property?: NamedNode;
+    context?: any;
+    variables?: Map<string, any>;
+    basePath?: string;
+}
+
+declare namespace loader {
+    type Arguments = unknown[] | [Record<string, any>];
+}
+
+type ArgumentsLoader = Loader<loader.Arguments, Options> & {
+    register(registry: LoaderRegistry): void;
+};
+
+declare const loader: ArgumentsLoader;
+export = loader;

--- a/types/rdf-loader-code/ecmaScript.d.ts
+++ b/types/rdf-loader-code/ecmaScript.d.ts
@@ -1,0 +1,15 @@
+import { Loader } from 'rdf-loaders-registry';
+import LoaderRegistry = require('rdf-loaders-registry');
+
+interface Options {
+    basePath?: string;
+    context?: unknown;
+}
+
+type EcmaScriptLoader = Loader<unknown, Options> & {
+    register(registry: LoaderRegistry): void;
+};
+
+declare const loader: EcmaScriptLoader;
+
+export = loader;

--- a/types/rdf-loader-code/ecmaScriptLiteral.d.ts
+++ b/types/rdf-loader-code/ecmaScriptLiteral.d.ts
@@ -1,0 +1,15 @@
+import { Loader } from 'rdf-loaders-registry';
+import LoaderRegistry = require('rdf-loaders-registry');
+
+interface Options {
+    variables?: Map<string, any>;
+    context?: unknown;
+}
+
+type EcmaScriptLiteralLoader = Loader<string, Options> & {
+    register(registry: LoaderRegistry): void;
+};
+
+declare const loader: EcmaScriptLiteralLoader;
+
+export = loader;

--- a/types/rdf-loader-code/index.d.ts
+++ b/types/rdf-loader-code/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for rdf-loader-code 0.3
+// Project: https://github.com/zazuko/rdf-loader-code
+// Definitions by: tpluscode <https://github.com/tpluscode>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.4
+
+export {};

--- a/types/rdf-loader-code/rdf-loader-code-tests.ts
+++ b/types/rdf-loader-code/rdf-loader-code-tests.ts
@@ -1,0 +1,43 @@
+import { GraphPointer } from 'clownface';
+import LoaderRegistry = require('rdf-loaders-registry');
+import ArgumentsLoader = require('rdf-loader-code/arguments');
+import EcmaScriptLoader = require('rdf-loader-code/ecmaScript');
+import EcmaScriptLiteralLoader = require('rdf-loader-code/ecmaScriptLiteral');
+import { Arguments } from 'rdf-loader-code/arguments';
+import { NamedNode } from 'rdf-js';
+
+const node: GraphPointer = <any> {};
+const registry = new LoaderRegistry();
+
+const variables = new Map();
+variables.set('name', 'World');
+
+async function ecmaScript() {
+  EcmaScriptLoader.register(registry);
+
+  registry.load<unknown, typeof EcmaScriptLoader>(node, {
+    basePath: '/temp',
+    context: {}
+  });
+}
+
+async function ecmaScriptLiteral() {
+  EcmaScriptLiteralLoader.register(registry);
+
+  const literal: string | null = await registry.load<string, typeof EcmaScriptLiteralLoader>(node, {
+    variables,
+    context: {}
+  });
+}
+
+async function argumentsLoader() {
+  ArgumentsLoader.register(registry);
+
+  const property: NamedNode = <any> {};
+  const args: unknown[] | [Record<string, any>] | null = await registry.load<Arguments, typeof ArgumentsLoader>(node, {
+    basePath: '/temp',
+    context: {},
+    variables,
+    property
+  });
+}

--- a/types/rdf-loader-code/tsconfig.json
+++ b/types/rdf-loader-code/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "rdf-loader-code-tests.ts"
+    ]
+}

--- a/types/rdf-loader-code/tslint.json
+++ b/types/rdf-loader-code/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/rdf-loaders-registry/index.d.ts
+++ b/types/rdf-loaders-registry/index.d.ts
@@ -1,0 +1,36 @@
+// Type definitions for rdf-loaders-registry 0.2
+// Project: https://github.com/zazuko/rdf-loaders-registry
+// Definitions by: tpluscode <https://github.com/tpluscode>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.4
+
+import { NamedNode } from 'rdf-js';
+import { GraphPointer } from 'clownface';
+
+declare namespace LoaderRegistry {
+    type LoadOptions<T extends Record<string, any> = {}> = T & {
+        loaderRegistry: LoaderRegistry;
+    };
+
+    interface Loader<T, TOptions = {}> {
+        (node: GraphPointer, options: LoadOptions<TOptions>): T | Promise<T>;
+    }
+}
+
+declare class LoaderRegistry {
+    _literalLoaders: Map<string, any>;
+    _nodeLoaders: Map<string, any>;
+
+    registerLiteralLoader(datatype: string | NamedNode, loader: LoaderRegistry.Loader<any, any>): void;
+    registerNodeLoader(type: string | NamedNode, loader: LoaderRegistry.Loader<any, any>): void;
+    load<
+        T extends any = unknown,
+        // tslint:disable-next-line:no-unnecessary-generics
+        TLoader extends LoaderRegistry.Loader<T, TOptions> = LoaderRegistry.Loader<T>,
+        TOptions = TLoader extends LoaderRegistry.Loader<T, infer U> ? U : {}>(
+            node: GraphPointer,
+            options?: TOptions): Promise<T | null>;
+    loader(node: GraphPointer): LoaderRegistry.Loader<any, any> | null;
+}
+
+export = LoaderRegistry;

--- a/types/rdf-loaders-registry/rdf-loaders-registry-tests.ts
+++ b/types/rdf-loaders-registry/rdf-loaders-registry-tests.ts
@@ -1,0 +1,49 @@
+import { NamedNode } from 'rdf-js';
+import { GraphPointer } from 'clownface';
+import LoaderRegistry = require('rdf-loaders-registry');
+
+const registry: LoaderRegistry = new LoaderRegistry();
+const node: GraphPointer = <any> {};
+
+type IntegerLoader = LoaderRegistry.Loader<number>;
+interface Nebula {
+  label: string;
+  distance: number;
+}
+type NebulaLoader = LoaderRegistry.Loader<Nebula, { bar: string }>;
+
+async function basicLoading() {
+  const integer: NamedNode = <any> {};
+  const nebula: NamedNode = <any> {};
+
+  const integerLoader: IntegerLoader = (numberNode: GraphPointer): number => {
+    return 0;
+  };
+
+  const nebulaLoader: NebulaLoader = async (term: GraphPointer, { loaderRegistry, bar }): Promise<Nebula> => {
+    return {
+      label: bar,
+      distance: await loaderRegistry.load<number>(term) || 0
+    };
+  };
+
+  registry.registerLiteralLoader(integer, integerLoader);
+  registry.registerNodeLoader(nebula, nebulaLoader);
+
+  const result: Nebula | null = await registry.load<Nebula>(node);
+}
+
+async function loadWithSpecificLoaderInferOptionType() {
+  const result: Nebula | null = await registry.load<Nebula, NebulaLoader>(node, { bar: 'baz'});
+  // $ExpectError
+  await registry.load<Nebula, NebulaLoader>(node, {});
+  // $ExpectError
+  await registry.load<Nebula, NebulaLoader>(node, { bar: 5 });
+}
+
+async function wrongLoaderForType() {
+  // $ExpectError
+  await registry.load<string, NebulaLoader>(node);
+}
+
+const nebulaLoader: NebulaLoader | null = registry.loader(node);

--- a/types/rdf-loaders-registry/tsconfig.json
+++ b/types/rdf-loaders-registry/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "rdf-loaders-registry-tests.ts"
+    ]
+}

--- a/types/rdf-loaders-registry/tslint.json
+++ b/types/rdf-loaders-registry/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.