### PR TITLE
feat(short-css-vars): new definition

### DIFF
--- a/types/short-css-vars/index.d.ts
+++ b/types/short-css-vars/index.d.ts
@@ -1,0 +1,75 @@
+// Type definitions for short-css-vars 1.1
+// Project: https://github.com/godaddy/short-css-vars/packages/short-css-vars#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Each instance keeps track of renamed variables to check for collisions and
+ * to provide a mapping of changed names.
+ *
+ * @classdesc Shorten lengthy CSS variable names
+ */
+declare class ShortCssVars {
+    constructor(options?: ShortCssVars.Options);
+
+    /**
+     * Shortens the name part of a variable string
+     * @param varName - Variable name including -- prefix
+     * @returns short
+     */
+    replaceName(varName: string): string;
+
+    /**
+     * Shortens the names of variables throughout CSS
+     * @param css - Text containing CSS variables
+     * @returns shortened CSS
+     */
+    replaceCss(css: string): string;
+
+    /**
+     * Get a mapping of original names to shortened names
+     *
+     * @example
+     * {
+     *   'long-variable-name-that-defines-a-particular-color': '1vf2dsn'
+     * }
+     * @returns map
+     */
+    getMap(): {
+        [name: string]: string;
+    };
+}
+
+declare namespace ShortCssVars {
+    /**
+     * Optional configurations
+     */
+    interface Options {
+        /**
+         * Custom formatter
+         */
+        formatter?: CustomFormatter;
+        /**
+         * Rule to ignore certain variable names
+         */
+        ignore?: IgnoreType;
+    }
+
+    interface CustomFormatter {
+        /**
+         * Returns a unique hash for a string name.
+         *
+         * @param name - Variable name
+         * @returns encoded hash
+         */
+        (name: string): string;
+    }
+
+    interface CustomIgnore {
+        (name: string): boolean;
+    }
+
+    type IgnoreType = RegExp | string | CustomIgnore;
+}
+
+export = ShortCssVars;

--- a/types/short-css-vars/short-css-vars-tests.ts
+++ b/types/short-css-vars/short-css-vars-tests.ts
@@ -1,0 +1,25 @@
+import { Options } from 'short-css-vars';
+import ShortCssVars = require('short-css-vars');
+
+const input = `:root {
+    --custom-var-one: red;
+    --custom-var-two_EXTRA_1234: 1.2rem;
+  }`;
+
+const ctors = [
+    new ShortCssVars(),
+    new ShortCssVars({}),
+    new ShortCssVars({
+        ignore: () => false,
+    }),
+];
+
+const optionsTests: Options[] = [
+    { ignore: /^.+-one/ },
+    { ignore: name => name.length <= 4 },
+    { formatter: name => name.split('').reverse().join('') },
+];
+const [options] = optionsTests;
+
+const p = new ShortCssVars(options);
+p.replaceCss(input);

--- a/types/short-css-vars/tsconfig.json
+++ b/types/short-css-vars/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "short-css-vars-tests.ts"
+    ]
+}

--- a/types/short-css-vars/tslint.json
+++ b/types/short-css-vars/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- definition file
- tests

https://www.npmjs.com/package/short-css-vars
https://github.com/godaddy/short-css-vars/tree/master/packages/short-css-vars

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.