### PR TITLE
Update/axe-webdriverjs

### DIFF
--- a/types/axe-webdriverjs/axe-webdriverjs-tests.ts
+++ b/types/axe-webdriverjs/axe-webdriverjs-tests.ts
@@ -1,10 +1,18 @@
-import { Result, RunOptions, Spec } from "axe-core";
-import { AxeBuilder, AxeAnalysis } from "axe-webdriverjs";
-import { WebDriver } from "selenium-webdriver";
+/// <reference types="node" />
+import { Result, RunOptions, Spec } from 'axe-core';
+import { AxeAnalysis, AxeBuilder, BuilderOptions } from 'axe-webdriverjs';
+import fs = require('fs');
+import { Builder, WebDriver } from 'selenium-webdriver';
 
-const inTest = async (webDriver: WebDriver, source?: string) => {
-    const builderCalled: AxeBuilder = AxeBuilder(webDriver);
-    const builderNewed: AxeBuilder = new AxeBuilder(webDriver);
+const inTest = async (webDriver: WebDriver, source?: string, builderOptions?: BuilderOptions) => {
+    const [builderCalled, builderNewed, ...builders] = [
+        AxeBuilder(webDriver),
+        new AxeBuilder(webDriver),
+        AxeBuilder(webDriver, source),
+        new AxeBuilder(webDriver, source),
+        AxeBuilder(webDriver, source, builderOptions),
+        new AxeBuilder(webDriver, source, builderOptions),
+    ];
 
     const runOptions: RunOptions = {};
     const spec: Spec = {};
@@ -33,3 +41,10 @@ const inTest = async (webDriver: WebDriver, source?: string) => {
     const url: string = analysis.url;
     const violations: Result[] = analysis.violations;
 };
+
+const driver = new Builder().forBrowser('firefox').build();
+const axeSource = fs.readFileSync('./axe-1.0.js', 'utf8');
+const axeBuilderOptions: BuilderOptions = {
+    logIframeErrors: false,
+};
+inTest(driver, axeSource, axeBuilderOptions);

--- a/types/axe-webdriverjs/index.d.ts
+++ b/types/axe-webdriverjs/index.d.ts
@@ -1,10 +1,9 @@
-// Type definitions for axe-webdriverjs 2.1
+// Type definitions for axe-webdriverjs 2.3
 // Project: https://github.com/dequelabs/axe-webdriverjs#readme
 // Definitions by: Joshua Goldberg <https://github.com/JoshuaKGoldberg>
 //                 Tyler Krupicka <https://github.com/tylerkrupicka>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
-
 import { Result, RunOptions, Spec } from "axe-core";
 import { WebDriver } from "selenium-webdriver";
 
@@ -83,7 +82,15 @@ export interface AxeBuilder {
     ): Promise<AxeAnalysis>;
 }
 
+export interface BuilderOptions {
+    /**
+     * Should errors be printed into console
+     * @default true
+     */
+    logIframeErrors?: boolean;
+}
+
 export const AxeBuilder: {
-    (driver: WebDriver, source?: string): AxeBuilder;
-    new (driver: WebDriver): AxeBuilder;
+    (driver: WebDriver, source?: string, builderOptions?: BuilderOptions): AxeBuilder;
+    new (driver: WebDriver, source?: string, builderOptions?: BuilderOptions): AxeBuilder;
 };


### PR DESCRIPTION
This commit:
- adds support for builder options from 2.3 (constructor/function arguments changed)
- bumps version
- simplifies and updates linting setp to DT defaults
- adds mantainer

https://github.com/dequelabs/axe-webdriverjs/commit/b4f24940c714b10e7bf217f8bf4901e6ae35443c#diff-6d186b954a58d5bb740f73d84fe39073
https://github.com/dequelabs/axe-webdriverjs/compare/v2.2.0...v2.3.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.