### PR TITLE
[urijs] Fix argument type for search/query

### DIFF
--- a/types/urijs/index.d.ts
+++ b/types/urijs/index.d.ts
@@ -212,7 +212,8 @@ interface URI {
     preventInvalidHostname(val: boolean): URI;
 
     query(): string;
-    query(qry: string | URI.QueryDataMap | ((qryObject: URI.QueryDataMap) => (URI.QueryDataMap | undefined))): URI;
+    // tslint:disable-next-line void-return
+    query(qry: string | URI.QueryDataMap | ((qryObject: URI.QueryDataMap) => (URI.QueryDataMap | void))): URI;
     query(v: boolean): URI.QueryDataMap;
 
     readable(): string;
@@ -229,7 +230,8 @@ interface URI {
     scheme(): string;
     scheme(protocol: string): URI;
     search(): string;
-    search(qry: string | URI.QueryDataMap | ((qryObject: URI.QueryDataMap) => (URI.QueryDataMap | undefined))): URI;
+    // tslint:disable-next-line void-return
+    search(qry: string | URI.QueryDataMap | ((qryObject: URI.QueryDataMap) => (URI.QueryDataMap | void))): URI;
     search(v: boolean): URI.QueryDataMap;
     segment(): string[];
     segment(segments: string[] | string): URI;

--- a/types/urijs/test/urijs-dom.test.ts
+++ b/types/urijs/test/urijs-dom.test.ts
@@ -251,4 +251,10 @@ declare var $: (arg?: any) => JQuery;
     u.search(qs => qs);
     u.query(() => undefined);
     u.search(() => undefined);
+    u.query(() => {
+        // Return nothing
+    });
+    u.search(() => {
+        // Return nothing
+    });
 }

--- a/types/urijs/test/urijs-nodejs.test.ts
+++ b/types/urijs/test/urijs-nodejs.test.ts
@@ -256,4 +256,10 @@ declare var $: (arg?: any) => JQuery;
     u.search(qs => qs);
     u.query(() => undefined);
     u.search(() => undefined);
+    u.query(() => {
+        // Return nothing
+    });
+    u.search(() => {
+        // Return nothing
+    });
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://medialize.github.io/URI.js/docs.html#accessors-search
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

My last PR #47099 got incorrect test case thus unable to cover the type that should really be accepted