### PR TITLE
[@types/react-native] ScrollView's getScrollResponder should return ScrollResponderMixin ra…

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -6836,7 +6836,7 @@ export class ScrollView extends ScrollViewBase {
      * implement this method so that they can be composed while providing access
      * to the underlying scroll responder's methods.
      */
-    getScrollResponder(): JSX.Element;
+    getScrollResponder(): ScrollResponderMixin;
 
     getScrollableNode(): any;
 

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -601,7 +601,14 @@ class ScrollerListComponentTest extends React.Component<{}, { dataSource: ListVi
     scrollView: ScrollView | null = null;
 
     testNativeMethods() {
-        this.scrollView && this.scrollView.setNativeProps({ scrollEnabled: false });
+        if (this.scrollView) {
+            this.scrollView.setNativeProps({ scrollEnabled: false });
+
+            // Dummy values for scroll dimenions changes
+            this.scrollView.getScrollResponder().scrollResponderZoomTo({
+                x: 0, y: 0, width: 300, height: 500, animated: true
+            })
+        }
     }
 
     render() {


### PR DESCRIPTION
ScrollView's getScrollResponder should return ScrollResponderMixin, *not* JSX Element.

I believe this case and can be seen in source code here.

https://github.com/facebook/react-native/blob/206ea36253146727b5c858ddf37d7ec2fb2e12ef/Libraries/Components/ScrollView/ScrollView.js#L678

If there is an alternate type though depending on platform, would love for someone to chime in

Please fill in this template.

- [ X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ X] Test the change in your own code. (Compile and run.)
- [ X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [X ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

