### PR TITLE
add types for more jsreport extensions

### DIFF
--- a/types/jsreport-assets/index.d.ts
+++ b/types/jsreport-assets/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for jsreport-assets 1.7
+// Project: https://github.com/jsreport/jsreport-assets
+// Definitions by: pofider <https://github.com/pofider>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { ExtensionDefinition } from 'jsreport-core';
+
+declare namespace JsReportAssets {
+    interface Configuration {
+        allowedFiles?: string;
+        searchOnDiskIfNotFoundInStore?: boolean;
+        rootUrlForLinks?: string;
+        publicAccessEnabled?: boolean;
+    }
+}
+
+declare function JsReportAssets(cfg?: JsReportAssets.Configuration): ExtensionDefinition;
+
+export = JsReportAssets;

--- a/types/jsreport-assets/jsreport-assets-tests.ts
+++ b/types/jsreport-assets/jsreport-assets-tests.ts
@@ -1,0 +1,11 @@
+import JsReport = require('jsreport-core');
+import JsReportAssets = require('jsreport-assets');
+
+(async () => {
+    const jsreport = JsReport();
+    jsreport.use(JsReportAssets({
+        publicAccessEnabled: true
+    }));
+    await jsreport.init();
+    await jsreport.close();
+})();

--- a/types/jsreport-assets/tsconfig.json
+++ b/types/jsreport-assets/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jsreport-assets-tests.ts"
+    ]
+}

--- a/types/jsreport-assets/tslint.json
+++ b/types/jsreport-assets/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/jsreport-client/index.d.ts
+++ b/types/jsreport-client/index.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for jsreport-client 1.2
+// Project: https://github.com/jsreport/nodejs-client
+// Definitions by: pofider <https://github.com/pofider>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import jsreport = require('jsreport');
+import JsReport = require('jsreport-core');
+import { ServerResponse } from 'http';
+
+declare module 'jsreport-core' {
+    interface ClientRenderResponse extends ServerResponse {
+        body(): Promise<Buffer>;
+    }
+    interface Client {
+        render(req: Partial<Request>, options?: object): Promise<ClientRenderResponse>;
+    }
+}
+
+declare function CreateJsReportClient(url: string, username?: string, password?: string): JsReport.Client;
+export = CreateJsReportClient;

--- a/types/jsreport-client/jsreport-client-tests.ts
+++ b/types/jsreport-client/jsreport-client-tests.ts
@@ -1,0 +1,18 @@
+import JsReport = require('jsreport');
+import Client = require('jsreport-client');
+
+(async () => {
+    const jsreport = JsReport();
+    await jsreport.init();
+
+    const client = Client('http://localhost:5488');
+    await client.render({
+        template: {
+            recipe: 'html',
+            engine: 'none',
+            content: 'html'
+        }
+    });
+
+    await jsreport.close();
+})();

--- a/types/jsreport-client/tsconfig.json
+++ b/types/jsreport-client/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jsreport-client-tests.ts"
+    ]
+}

--- a/types/jsreport-client/tslint.json
+++ b/types/jsreport-client/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/jsreport-core/index.d.ts
+++ b/types/jsreport-core/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for jsreport-core 1.5
 // Project: http://jsreport.net
 // Definitions by: taoqf <https://github.com/taoqf>
+//                 pofider <https://github.com/pofider>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -20,9 +21,13 @@ declare namespace JsReport {
         recipe: Recipe | string;
     }
 
+    interface Options {
+        preview?: boolean;
+    }
+
     interface Request {
         template: Partial<Template>;
-        options: object;
+        options?: Options;
         data: any;
     }
 
@@ -79,6 +84,7 @@ declare namespace JsReport {
         render(options: Partial<Request>): Promise<Response>;
         discover(): Reporter;
         createListenerCollection(): ListenerCollection;
+        close(): Promise<void>;
     }
 
     interface Configuration {

--- a/types/jsreport-docx/index.d.ts
+++ b/types/jsreport-docx/index.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for jsreport-docx 2.8
+// Project: https://github.com/jsreport/jsreport-docx
+// Definitions by: pofider <https://github.com/pofider>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { ExtensionDefinition } from 'jsreport-core';
+
+declare module 'jsreport-core' {
+    interface Template {
+        docx?: JsReportDocx.DocxTemplate;
+    }
+}
+
+declare namespace JsReportDocx {
+    interface Configuration {
+        preview?: {
+            enabled: true;
+            publicUri: string;
+            showWarning: false;
+        };
+    }
+
+    interface DocxTemplate {
+        templateAsetShortid?: string;
+        templateAsset?: {
+            content: string;
+            encoding: string;
+        };
+    }
+}
+
+declare function JSReportDocx(cfg?: JsReportDocx.Configuration): ExtensionDefinition;
+
+export = JSReportDocx;

--- a/types/jsreport-docx/jsreport-docx-tests.ts
+++ b/types/jsreport-docx/jsreport-docx-tests.ts
@@ -1,0 +1,25 @@
+import JsReport = require('jsreport-core');
+import JsReportDocx = require('jsreport-docx');
+
+(async () => {
+    const jsreport = JsReport();
+    jsreport.use(JsReportDocx());
+
+    try {
+        await jsreport.render({
+            template: {
+                content: '',
+                recipe: 'docx',
+                engine: 'handlebars',
+                docx: {
+                    templateAsetShortid: 'aaaa'
+                }
+            }
+        });
+    } catch (e) {
+        // intentional
+    }
+
+    await jsreport.init();
+    await jsreport.close();
+})();

--- a/types/jsreport-docx/tsconfig.json
+++ b/types/jsreport-docx/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jsreport-docx-tests.ts"
+    ]
+}

--- a/types/jsreport-docx/tslint.json
+++ b/types/jsreport-docx/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/jsreport-handlebars/index.d.ts
+++ b/types/jsreport-handlebars/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for jsreport-handlebars 2.1
+// Project: https://github.com/jsreport/jsreport-handlebars
+// Definitions by: pofider <https://github.com/pofider>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { ExtensionDefinition } from 'jsreport-core';
+
+declare function JsReportHandlebars(): ExtensionDefinition;
+
+export = JsReportHandlebars;

--- a/types/jsreport-handlebars/jsreport-handlebars-tests.ts
+++ b/types/jsreport-handlebars/jsreport-handlebars-tests.ts
@@ -1,0 +1,9 @@
+import JsReport = require('jsreport-core');
+import JsReportHandlebars = require('jsreport-handlebars');
+
+(async () => {
+    const jsreport = JsReport();
+    jsreport.use(JsReportHandlebars());
+    await jsreport.init();
+    await jsreport.close();
+})();

--- a/types/jsreport-handlebars/tsconfig.json
+++ b/types/jsreport-handlebars/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jsreport-handlebars-tests.ts"
+    ]
+}

--- a/types/jsreport-handlebars/tslint.json
+++ b/types/jsreport-handlebars/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/jsreport-pdf-utils/index.d.ts
+++ b/types/jsreport-pdf-utils/index.d.ts
@@ -1,0 +1,58 @@
+// Type definitions for jsreport-pdf-utils 1.9
+// Project: https://github.com/jsreport/jsreport-pdf-utils
+// Definitions by: pofider <https://github.com/pofider>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { ExtensionDefinition, Template } from 'jsreport-core';
+
+declare module 'jsreport-core' {
+    interface Template {
+        pdfOperations?: JsReportPdfUtils.PdfOperation[];
+        pdfMeta?: JsReportPdfUtils.PdfMeta;
+        pdfSign?: JsReportPdfUtils.PdfSign;
+        pdfPassword?: JsReportPdfUtils.PdfPassword;
+    }
+}
+
+declare namespace JsReportPdfUtils {
+    interface PdfOperation {
+        type: "merge" | "append" | "prepend";
+        mergeWholeDocument?: boolean;
+        renderForEveryPage?: boolean;
+        templateShortid?: string;
+        template?: Template;
+    }
+
+    interface PdfMeta {
+        title?: string;
+        author?: string;
+        subject?: string;
+        keywords?: string;
+        creator?: string;
+        producer?: string;
+    }
+
+    interface PdfSign {
+        certificateAsset: {
+            contrent: string;
+            encoding: string;
+            password: string;
+        };
+        reason: string;
+    }
+
+    interface PdfPassword {
+        password: string;
+        ownerPassword: string;
+        printing: "HighResolution" | "NotAllowed" | "LowResolution";
+        modifying: boolean;
+        copying: boolean;
+        fillingForms: boolean;
+        contentAccessibility: boolean;
+        documentAssembly: true;
+    }
+}
+
+declare function JSReportPdfUtils(): ExtensionDefinition;
+
+export = JSReportPdfUtils;

--- a/types/jsreport-pdf-utils/jsreport-pdf-utils-tests.ts
+++ b/types/jsreport-pdf-utils/jsreport-pdf-utils-tests.ts
@@ -1,0 +1,25 @@
+import JsReport = require('jsreport-core');
+import JsReportPdfUtils = require('jsreport-pdf-utils');
+
+(async () => {
+    const jsreport = JsReport();
+    jsreport.use(JsReportPdfUtils());
+
+    try {
+        await jsreport.render({
+            template: {
+                content: '',
+                recipe: 'docx',
+                engine: 'handlebars',
+                pdfOperations: [{
+                    type: 'merge'
+                }]
+            }
+        });
+    } catch (e) {
+        // intentional
+    }
+
+    await jsreport.init();
+    await jsreport.close();
+})();

--- a/types/jsreport-pdf-utils/tsconfig.json
+++ b/types/jsreport-pdf-utils/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jsreport-pdf-utils-tests.ts"
+    ]
+}

--- a/types/jsreport-pdf-utils/tslint.json
+++ b/types/jsreport-pdf-utils/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/jsreport-reports/index.d.ts
+++ b/types/jsreport-reports/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for jsreport-reports 2.5
+// Project: https://github.com/jsreport/jsreport-reports
+// Definitions by: pofider <https://github.com/pofider>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { ExtensionDefinition } from 'jsreport-core';
+
+declare module 'jsreport-core' {
+    interface Options {
+        reports?: JsReportReports.ReportsOptions;
+    }
+}
+
+declare namespace JsReportReports {
+    interface Configuration {
+        cleanInterval?: string;
+        cleanTreshold?: string;
+    }
+
+    interface ReportsOptions {
+        save?: boolean;
+        async?: boolean;
+        public?: boolean;
+    }
+}
+
+declare function JsReportReports(cfg?: JsReportReports.Configuration): ExtensionDefinition;
+
+export = JsReportReports;

--- a/types/jsreport-reports/jsreport-reports-tests.ts
+++ b/types/jsreport-reports/jsreport-reports-tests.ts
@@ -1,0 +1,23 @@
+import JsReport = require('jsreport-core');
+import JsReportReports = require('jsreport-reports');
+
+(async () => {
+    const jsreport = JsReport();
+    jsreport.use(JsReportReports());
+
+    await jsreport.render({
+        template: {
+            content: '',
+            recipe: 'html',
+            engine: 'handlebars',
+        },
+        options: {
+            reports: {
+                save: true
+            }
+        }
+    });
+
+    await jsreport.init();
+    await jsreport.close();
+})();

--- a/types/jsreport-reports/tsconfig.json
+++ b/types/jsreport-reports/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jsreport-reports-tests.ts"
+    ]
+}

--- a/types/jsreport-reports/tslint.json
+++ b/types/jsreport-reports/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/jsreport-scripts/index.d.ts
+++ b/types/jsreport-scripts/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for jsreport-scripts 2.6
+// Project: https://github.com/jsreport/jsreport-scripts
+// Definitions by: pofider <https://github.com/pofider>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { ExtensionDefinition } from 'jsreport-core';
+
+declare module 'jsreport-core' {
+    interface Template {
+        scripts?: JsReportScripts.TemplateScript[];
+    }
+}
+
+declare namespace JsReportScripts {
+    interface TemplateScript {
+        shortid?: string;
+        name?: string;
+        content?: string;
+    }
+
+    interface Configuration {
+        allowedModules?: string[] | "*";
+    }
+}
+
+declare function JsReportScripts(cfg?: JsReportScripts.Configuration): ExtensionDefinition;
+
+export = JsReportScripts;

--- a/types/jsreport-scripts/jsreport-scripts-tests.ts
+++ b/types/jsreport-scripts/jsreport-scripts-tests.ts
@@ -1,0 +1,21 @@
+import JsReport = require('jsreport-core');
+import JsReportScripts = require('jsreport-scripts');
+
+(async () => {
+    const jsreport = JsReport();
+    jsreport.use(JsReportScripts());
+
+    await jsreport.render({
+        template: {
+            content: '',
+            recipe: 'html',
+            engine: 'handlebars',
+            scripts: [{
+                content: `function beforeRender(req, res) {}`
+            }]
+        }
+    });
+
+    await jsreport.init();
+    await jsreport.close();
+})();

--- a/types/jsreport-scripts/tsconfig.json
+++ b/types/jsreport-scripts/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jsreport-scripts-tests.ts"
+    ]
+}

--- a/types/jsreport-scripts/tslint.json
+++ b/types/jsreport-scripts/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/jsreport-templates/index.d.ts
+++ b/types/jsreport-templates/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for jsreport-templates 2.4
+// Project: https://github.com/jsreport/jsreport-templates
+// Definitions by: pofider <https://github.com/pofider>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { ExtensionDefinition } from 'jsreport-core';
+
+declare module 'jsreport-core' {
+    interface Template {
+        name?: string;
+    }
+}
+
+declare function JsReportTemplates(): ExtensionDefinition;
+
+export = JsReportTemplates;

--- a/types/jsreport-templates/jsreport-templates-tests.ts
+++ b/types/jsreport-templates/jsreport-templates-tests.ts
@@ -1,0 +1,10 @@
+import JsReport = require('jsreport-core');
+import JsReportTemplates = require('jsreport-templates');
+
+(async () => {
+    const jsreport = JsReport();
+    jsreport.use(JsReportTemplates());
+
+    await jsreport.init();
+    await jsreport.close();
+})();

--- a/types/jsreport-templates/tsconfig.json
+++ b/types/jsreport-templates/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jsreport-templates-tests.ts"
+    ]
+}

--- a/types/jsreport-templates/tslint.json
+++ b/types/jsreport-templates/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/jsreport/index.d.ts
+++ b/types/jsreport/index.d.ts
@@ -4,9 +4,16 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // import all availible types for jsreport included extensions
+import JsReportAssets = require('jsreport-assets');
 import JsReportChromePdf = require('jsreport-chrome-pdf');
-import JsReportJsRender = require('jsreport-jsrender');
+import JsReportDocx = require('jsreport-docx');
+import JsReportHandlebars = require('jsreport-handlebars');
 import JReportHtmlToXlsx = require('jsreport-html-to-xlsx');
+import JsReportJsRender = require('jsreport-jsrender');
+import JReportPdfUtils = require('jsreport-pdf-utils');
+import JsReportReports = require('jsreport-reports');
+import JsReportScripts = require('jsreport-scripts');
+import JsReportTemplates = require('jsreport-templates');
 import JsReportXlsx = require('jsreport-xlsx');
 
 // just reexport types from core


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/jsreport/jsreport-core>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.