### PR TITLE
Added new typing for graygelf

### DIFF
--- a/types/graygelf/graygelf-tests.ts
+++ b/types/graygelf/graygelf-tests.ts
@@ -1,0 +1,292 @@
+/// <reference types="node" />
+import graygelf =  require('graygelf');
+import { join } from 'path';
+import * as fs from 'fs';
+
+let log = graygelf('graylog.server.local');
+log = graygelf({
+    host: 'graylog.server.local',
+    port: 12201,
+    mock: false
+});
+
+log.on('message', (msg) => {
+    // output messages to console
+    console.log(msg.full_message);
+});
+
+log.on('error', (msg) => {
+    // output messages to console
+    console.log(msg);
+});
+
+// setup global custom fields to be passed with every message
+log.fields.facility = 'redicomps';
+log.fields.other = 'redicomps';
+
+// printf style "hello world"
+log.info('hello %s', 'world');
+
+// concat by space style "hello world"
+log.info('hello', 'world');
+
+// include a full message and custom fields using .a(ttach)
+log.info.a('short', 'full', { foo: 'bar' });
+log.info.a('short', 'full', { foo: 'bar' });
+
+// if an Error is passed as the only argument...
+let er = new Error('oh no!');
+log.info(er);
+// ... it expands to:
+log.info.a(er.message, er.stack);
+
+// writable streams can be created
+const infostream = log.stream('info');
+
+// raw gelf: version, host, and timestamp will be supplied if missing
+log.raw({
+    // version: '1.1',
+    // host: 'wavded',
+    short_message: 'oh no!',
+    full_message: 'howdy',
+    // timestamp: 1412087767.704356,
+    level: 6,
+    _foo: 'bar'
+});
+
+// the following tests were taken from the tests in graygelf project
+// test graygelf
+log = graygelf(); // defaults
+log.graylogHost;
+log.graylogPort;
+log.compressType;
+log.chunkSize;
+log.alwaysCompress;
+log._udp;
+
+const loghost = graygelf('a.server.yo');
+loghost.graylogHost;
+
+const logopts = graygelf({
+    host: 'word',
+    port: 23232,
+    compressType: 'gzip',
+    chunkSize: 10,
+    alwaysCompress: true,
+});
+logopts.graylogHost;
+logopts.graylogPort;
+logopts.compressType;
+logopts.chunkSize;
+logopts.alwaysCompress;
+
+const logmock = graygelf({ mock: true });
+logmock.write('blah blah');
+
+// test log.on("message")
+
+log = graygelf();
+log.once('message', (data) => {
+    data.level;
+    data.timestamp;
+    data.version;
+    data.host;
+    data.short_message;
+    data.full_message;
+});
+log.emerg('oh', 'no');
+
+// test log.on("error")
+
+log = graygelf();
+log.once('error', (er) => {
+    er; // 'will emit errors emitted by udp client')
+});
+if (log._udp) log._udp.emit('error', 'oh no');
+
+// test log.fields
+
+log = graygelf();
+log.fields.facility = 'test';
+
+let gelf = log.info('test');
+gelf._facility;
+
+gelf = log.info.a('test', 'full', { facility: 'testa', row: 32 });
+gelf._row;
+gelf._facility;
+
+// test log[level]
+
+log = graygelf();
+gelf = log.info('hello', 'world');
+gelf.short_message;
+gelf.level;
+
+gelf = log.error('hello %s', 'world');
+gelf.short_message;
+gelf.level;
+
+er = new Error('oh no');
+gelf = log.crit(er);
+gelf.short_message;
+gelf.level;
+gelf.full_message;
+
+log.once('message', () => {
+    gelf.short_message;
+    gelf.full_message;
+});
+const ee = new (require('events').EventEmitter)();
+ee.on('error', log.crit);
+ee.emit('error', new Error('oh no'));
+
+// test log[level].a
+
+log = graygelf();
+gelf = log.info.a('hello world', 'a long message', { custom: 'field' });
+gelf.short_message;
+gelf.full_message;
+gelf._custom;
+
+// test log.stream
+
+log = graygelf();
+
+try {
+    log.stream('wfasdfas');
+} catch (e) {
+    // throws cause is invalid, a valid message is one of the levels
+}
+
+const rstream = fs.createReadStream(join(__dirname, 'stream.txt'));
+const data = [
+    'A line',
+    'A second line',
+];
+
+log.on('message', (gelf) => {
+    gelf.level;
+    gelf.short_message;
+});
+
+rstream.pipe(log.stream('info'));
+
+// test log.raw
+
+log = graygelf();
+gelf = log.raw({
+    level: 0,
+    short_message: 'a short message',
+    _custom: 'field',
+});
+
+gelf._custom;
+gelf.version;
+gelf.host;
+gelf.timestamp;
+
+gelf = log.raw({
+    version: '1.0',
+    host: 'ahost',
+    timestamp: 100,
+});
+gelf.version;
+gelf.host;
+gelf.timestamp;
+
+// test log._send (plain json)
+
+log = graygelf();
+
+// overwrite for testing
+log.write = (chunk) => {
+    Buffer.isBuffer(chunk);
+    chunk[0] === 0x7b;
+};
+
+gelf = log._prepGelf(0, 'my message');
+log._send(gelf);
+
+// test log._send (deflate)
+
+log = graygelf();
+
+// overwrite for testing
+log.write = (chunk) => {
+    Buffer.isBuffer(chunk);
+    chunk[0] === 0x78;
+};
+
+// Force the message to be too big to fit as simple JSON
+// but not so large as to force splitting across multiple chunks
+let full_message = Array(8192 / 16).fill(' 123456789abcdef').join('');
+gelf = log._prepGelf(0, 'my message', full_message);
+log._send(gelf);
+
+// test log._send (gzip)
+
+log = graygelf();
+log.compressType = 'gzip';
+// overwrite for testing
+log.write = (chunk) => {
+    Buffer.isBuffer(chunk);
+    chunk[0] === 0x1f;
+};
+
+// Force the message to be too big to fit as simple JSON
+// but not so large as to force splitting across multiple chunks
+full_message = Array(8192 / 16).fill(' 123456789abcdef').join('');
+gelf = log._prepGelf(0, 'my message', full_message);
+log._send(gelf);
+
+// test log._send (chunked)
+
+log = graygelf();
+log.chunkSize = 100;
+
+const expectedChunks = 2;
+const index = 0;
+
+// overwrite for testing
+log.write = (chunk) => {
+    Buffer.isBuffer(chunk);
+    chunk[0] === 0x1e;
+    chunk[10] === index;
+    chunk[11] === expectedChunks;
+    (index + 1) === expectedChunks;
+};
+
+gelf = log._prepGelf(0, 'my message', 'full message', { extra: 'field' });
+log._send(gelf);
+
+// test log._send (gzip, alwaysCompress: false)
+
+log = graygelf();
+log.chunkSize = 500;
+log.compressType = 'gzip';
+
+// overwrite for testing
+log.write = (chunk) => {
+    Buffer.isBuffer(chunk);
+    chunk[0] === 0x7b;
+};
+
+gelf = log._prepGelf(0, 'my message', 'full message', { extra: 'field' });
+log._send(gelf);
+
+// test log._send (gzip, alwaysCompress: true)
+
+log = graygelf();
+log.chunkSize = 500;
+log.compressType = 'gzip';
+log.alwaysCompress = true;
+
+// overwrite for testing
+log.write = (chunk) => {
+    Buffer.isBuffer(chunk);
+    chunk[0] === 0x1f;
+};
+
+gelf = log._prepGelf(0, 'my message', 'full message', { extra: 'field' });
+log._send(gelf);

--- a/types/graygelf/index.d.ts
+++ b/types/graygelf/index.d.ts
@@ -1,0 +1,233 @@
+// Type definitions for graygelf 2.0
+// Project: https://github.com/wavded/graygelf
+// Definitions by: David Lima <https://github.com/DavidProf>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.6
+
+import { ThroughStream } from 'through';
+import { Socket } from 'dgram';
+
+type setup = string | {
+    /**
+     * graylog host
+     *
+     * @default "localhost"
+     */
+    host?: string;
+    /**
+     * graylog port
+     *
+     * @default 12201
+     */
+    port?: number;
+    /**
+     * size of chunked messages in bytes
+     *
+     * @default 1240
+     */
+    chunkSize?: number;
+    /**
+     * compression 'gzip' or 'deflate'
+     *
+     * @default "deflate"
+     */
+    compressType?: 'gzip' | 'deflate';
+    /**
+     * whether to always compress or go by chunkSize
+     *
+     * @default false
+     */
+    alwaysCompress?: boolean;
+    /**
+     * don't send messages to GrayLog2
+     *
+     * @default false
+     */
+    mock?: boolean;
+};
+
+interface GelfMessage {
+    /**
+     * app version
+     */
+    version?: string | number;
+    /**
+     * app host
+     */
+    host?: string | number;
+    /**
+     * log short message
+     */
+    short_message?: string | number;
+    /**
+     * log full message
+     */
+    full_message?: string | number;
+    /**
+     * log timestamp
+     */
+    timestamp?: string | number;
+    /**
+     * GELF level
+     *
+     *  emerg: 0; panic: 0;
+     *  alert: 1;
+     *  crit: 2;
+     *  error: 3; err: 3;
+     *  warn: 4; warning: 4;
+     *  notice: 5;
+     *  info: 6;
+     *  debug: 7.
+     */
+    level?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7';
+    /**
+     * any other personal property
+     */
+    [key: string]: string | number | undefined;
+}
+
+interface EventListener {
+    /**
+     * Set a listener to message event
+     *
+     * @param event listen message event
+     * @param cb callback function that receives message
+     */
+    (event: 'message', cb: (message: GelfMessage) => void): void;
+    /**
+     * Set a listener to error event
+     *
+     * @param event listen error event
+     * @param cb callback function that receives error messsage
+     */
+    (event: 'error', cbErr: (err: string) => void): void;
+}
+
+type Instance = {
+    /**
+     * Send GELF message
+     *
+     * May some custom fields return started by '_', like graygelfMessage._facility
+     * @returns {GelfMessage}
+     */
+    [
+    key in 'emerg' | 'panic' | 'alert' | 'crit' | 'error' | 'err' | 'warn' | 'warning' | 'notice' | 'info' | 'debug'
+    ]: (short_message: string | Error, ...args: string[]) => GelfMessage
+} & {
+        /**
+         * Send GELF message and can accept custom fields
+         *
+         * @returns {GelfMessage} May some custom fields return started by '_', like graygelfMessage._facility
+         */
+        [
+        key in 'emerg' | 'panic' | 'alert' | 'crit' | 'error' | 'err' | 'warn' | 'warning' | 'notice' | 'info' | 'debug'
+        ]: {
+            a: (short_message: string | Error, full_message?: string, customFields?: GelfMessage) => GelfMessage
+        }
+    } & {
+        /**
+         * Send a complete custom GELF message.
+         *
+         * Version, host, and timestamp will be supplied if missing.
+         * @returns May some custom fields return started by '_', like graygelfMessage._facility
+         */
+        raw: (fields: GelfMessage) => GelfMessage,
+        /**
+         * I don't really know
+         */
+        stream: (name: string) => ThroughStream,
+        /**
+         * send udp message
+         */
+        write: (msg: string | Uint8Array) => void,
+        /**
+         * Build a Gelf Message
+         */
+        _prepGelf: (level: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7, short: string, long?: string, fields?: { [key: string]: string }) => GelfMessage,
+        /**
+         * send a gelf message
+         */
+        _send: (gelfMessage: GelfMessage) => void,
+        on: EventListener;
+        once: EventListener;
+        /**
+         * Setup global custom fields to be passed with every message
+         */
+        fields: {
+            /**
+             * Suggested property - facility can be the app name.
+             */
+            facility?: string;
+            /**
+             * any other
+             */
+            [key: string]: string | undefined;
+        },
+        /**
+         * Chunk size for wide network
+         */
+        CHUNK_WAN: 1240,
+        /**
+         * Chunk size for local network
+         */
+        CHUNK_LAN: 8154,
+        /**
+         * GELF log levels
+         */
+        LOG_LEVELS: {
+            emerg: 0,
+            panic: 0,
+            alert: 1,
+            crit: 2,
+            error: 3,
+            err: 3,
+            warn: 4,
+            warning: 4,
+            notice: 5,
+            info: 6,
+            debug: 7,
+        },
+        /**
+         * Endpoint setted
+         *
+         * @default "localhost"
+         */
+        graylogHost: string,
+        /**
+         * Port setted
+         *
+         * @default "12201"
+         */
+        graylogPort: string,
+        /**
+         * Compress type
+         *
+         * @default "deflate"
+         */
+        compressType: 'deflate' | 'gzip',
+        /**
+         * Chunk size
+         *
+         * @default 1240
+         */
+        chunkSize: number,
+        /**
+         * Should always compress
+         *
+         * @default false
+         */
+        alwaysCompress: boolean,
+        /**
+         * udp socket (not setted if mock is true)
+         */
+        _udp?: Socket,
+    };
+
+/**
+ * Create a graygelf instance
+ *
+ * @param setup
+ */
+declare function graygelf(setup?: setup): Instance;
+
+export = graygelf;

--- a/types/graygelf/tsconfig.json
+++ b/types/graygelf/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "graygelf-tests.ts"
+    ]
+}

--- a/types/graygelf/tslint.json
+++ b/types/graygelf/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
* Add types for heft-jest package

Please fill in this template.

- [X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
