### PR TITLE
[@types/react-native] Make Pressable children optional

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -505,7 +505,7 @@ export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'sty
      * Either children or a render prop that receives a boolean reflecting whether
      * the component is currently pressed.
      */
-    children: React.ReactNode | ((state: PressableStateCallbackType) => React.ReactNode);
+    children?: React.ReactNode | ((state: PressableStateCallbackType) => React.ReactNode);
 
     /**
      * Duration (in milliseconds) from `onPressIn` before `onLongPress` is called.


### PR DESCRIPTION
Link to doc: https://reactnative.dev/docs/pressable#children
PR for issue #47333
@alloy, @huhuanming, @iRoachie