### PR TITLE
[@types/react-table] Add getToggleAllPageRowsSelectedProps to useRowSelect types

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -709,6 +709,7 @@ export type UseRowSelectOptions<D extends object> = Partial<{
 export interface UseRowSelectHooks<D extends object> {
     getToggleRowSelectedProps: Array<PropGetter<D, TableToggleRowsSelectedProps>>;
     getToggleAllRowsSelectedProps: Array<PropGetter<D, TableToggleAllRowsSelectedProps>>;
+    getToggleAllPageRowsSelectedProps: Array<PropGetter<D, TableToggleAllRowsSelectedProps>>;
 }
 
 export interface UseRowSelectState<D extends object> {
@@ -719,6 +720,9 @@ export interface UseRowSelectInstanceProps<D extends object> {
     toggleRowSelected: (rowId: IdType<D>, set?: boolean) => void;
     toggleAllRowsSelected: (value?: boolean) => void;
     getToggleAllRowsSelectedProps: (
+        props?: Partial<TableToggleAllRowsSelectedProps>,
+    ) => TableToggleAllRowsSelectedProps;
+    getToggleAllPageRowsSelectedProps: (
         props?: Partial<TableToggleAllRowsSelectedProps>,
     ) => TableToggleAllRowsSelectedProps;
     isAllRowsSelected: boolean;


### PR DESCRIPTION
Adds `getToggleAllPageRowsSelectedProps` option to `useExpanded` interfaces. Reference: https://github.com/tannerlinsley/react-table/blob/205c7a9ffca144ab9260022cd0227145f47381a7/src/plugin-hooks/useRowSelect.js#L312

It has the same signature as the currently defined `getToggleAllRowsSelectedProps`.