### PR TITLE
[google-apps-script] Added topicId to CourseWork

### DIFF
--- a/types/google-apps-script/apis/classroom_v1.d.ts
+++ b/types/google-apps-script/apis/classroom_v1.d.ts
@@ -877,6 +877,7 @@ declare namespace GoogleAppsScript {
         state?: string;
         submissionModificationMode?: string;
         title?: string;
+        topicId?: string;
         updateTime?: string;
         workType?: string;
       }


### PR DESCRIPTION
Added missing property `topicId` to interface `CourseWork` in the Google Classroom API.

[CourseWork object from the Google Classroom API v1 Documentation](https://developers.google.com/classroom/reference/rest/v1/courses.courseWork)