### PR TITLE
Remove Reflect.enumerate

### DIFF
--- a/types/core-js/core-js-tests.ts
+++ b/types/core-js/core-js-tests.ts
@@ -313,7 +313,6 @@ b = Reflect.defineProperty(a, sym, pd);
 b = Reflect.deleteProperty(a, s);
 b = Reflect.deleteProperty(a, i);
 b = Reflect.deleteProperty(a, sym);
-iterableIteratorOfAny = Reflect.enumerate(a);
 a = Reflect.get(a, s, a);
 a = Reflect.get(a, i, a);
 a = Reflect.get(a, sym, a);

--- a/types/core-js/index.d.ts
+++ b/types/core-js/index.d.ts
@@ -462,7 +462,6 @@ declare namespace core {
         function construct(target: Function, argumentsList: ArrayLike<any>): any;
         function defineProperty(target: any, propertyKey: PropertyKey, attributes: PropertyDescriptor): boolean;
         function deleteProperty(target: any, propertyKey: PropertyKey): boolean;
-        function enumerate(target: any): IterableIterator<any>;
         function get(target: any, propertyKey: PropertyKey, receiver?: any): any;
         function getOwnPropertyDescriptor(target: any, propertyKey: PropertyKey): PropertyDescriptor;
         function getPrototypeOf(target: any): any;

--- a/types/core-js/index.d.ts
+++ b/types/core-js/index.d.ts
@@ -1362,10 +1362,6 @@ declare module "core-js/fn/reflect/delete-property" {
     const deleteProperty: typeof core.Reflect.deleteProperty;
     export = deleteProperty;
 }
-declare module "core-js/fn/reflect/enumerate" {
-    const enumerate: typeof core.Reflect.enumerate;
-    export = enumerate;
-}
 declare module "core-js/fn/reflect/get" {
     const get: typeof core.Reflect.get;
     export = get;
@@ -2136,10 +2132,6 @@ declare module "core-js/library/fn/reflect/define-property" {
 declare module "core-js/library/fn/reflect/delete-property" {
     const deleteProperty: typeof core.Reflect.deleteProperty;
     export = deleteProperty;
-}
-declare module "core-js/library/fn/reflect/enumerate" {
-    const enumerate: typeof core.Reflect.enumerate;
-    export = enumerate;
 }
 declare module "core-js/library/fn/reflect/get" {
     const get: typeof core.Reflect.get;


### PR DESCRIPTION
It will be removed in Typescript 4.1's es2015 lib because implementers decided against it. See microsoft/Typescript#38967

Showed up in the nightly tests we run on typescript@next:
https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/results?buildId=63075&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a&t=4d2ea636-6e6e-5831-8b5a-8ce5e9ce8bbc&l=17659

I don't know enough about core-js to know whether Reflect.enumerate should be removed entirely. But it seems like a polyfill library shouldn't polyfill something that isn't there in modern browsers, so I removed it in this first draft.