### PR TITLE
[ramda] Add missing overload for concat

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -29,6 +29,7 @@
 //                 Saul Mirone <https://github.com/Saul-Mirone>
 //                 Nicholai Nissen <https://github.com/Nicholaiii>
 //                 Mike Deverell <https://github.com/devrelm>
+//                 Jorge Santana <https://github.com/LORDBABUINO>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.7
 
@@ -360,11 +361,11 @@ export function composeWith<V0, T>(composer: (a: any) => any, fns: ComposeWithFn
 export function composeWith(composer: (a: any) => any): <V0, T>(fns: ComposeWithFns<V0, T>) => (x: V0) => T;
 
 /**
- * Returns a new list consisting of the elements of the first list followed by the elements
- * of the second.
+ * Returns the result of concatenating the given lists or strings.
  */
-export function concat<T>(placeholder: Placeholder): (list2: readonly T[], list1: readonly T[]) => T[];
+export function concat<T extends string | readonly any[]>(placeholder: Placeholder): (list2: T, list1: T) => T;
 export function concat<T>(placeholder: Placeholder, list2: readonly T[]): (list1: readonly T[]) => T[];
+export function concat(placeholder: Placeholder, list2: string): (list1: string) => string;
 export function concat<T>(list1: readonly T[], list2: readonly T[]): T[];
 export function concat<T>(list1: readonly T[]): (list2: readonly T[]) => T[];
 export function concat(list1: string, list2: string): string;

--- a/types/ramda/test/concat-tests.ts
+++ b/types/ramda/test/concat-tests.ts
@@ -10,4 +10,6 @@ import * as R from 'ramda';
 () => {
   R.concat(R.__, [4, 5, 6])([1, 2, 3]); // [1, 2, 3, 4, 5, 6]
   R.concat(R.__)([4, 5, 6], [1, 2, 3]); // [1, 2, 3, 4, 5, 6]
+  R.concat(R.__, 'DEF')('ABC'); // 'ABCDEF'
+  R.concat(R.__)('DEF', 'ABC'); // 'ABCDEF'
 };


### PR DESCRIPTION
Adds 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://ramdajs.com/docs/#concat
https://github.com/ramda/ramda/blob/v0.27.0/source/concat.js
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~