### PR TITLE
[@types/react] Add imagesrcset and imagesizes to LinkHTMLAttributes interface

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2136,8 +2136,8 @@ declare namespace React {
         sizes?: string;
         type?: string;
         charSet?: string;
-        imagesrcset?: string;
-        imagesizes?: string;
+        imageSrcset?: string;
+        imageSizes?: string;
     }
 
     interface MapHTMLAttributes<T> extends HTMLAttributes<T> {

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2136,6 +2136,8 @@ declare namespace React {
         sizes?: string;
         type?: string;
         charSet?: string;
+        imagesrcset?: string;
+        imagesizes?: string;
     }
 
     interface MapHTMLAttributes<T> extends HTMLAttributes<T> {


### PR DESCRIPTION
A `<link rel="preload" as="image">` can take `imagesrcset` and `imagesizes` attributes to preload the correct version of a responsive image

See https://web.dev/preload-responsive-images/#imagesrcset-and-imagesizes

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://web.dev/preload-responsive-images/#imagesrcset-and-imagesizes
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
