### PR TITLE
dogapi: add send_all to metric

### DIFF
--- a/types/dogapi/dogapi-tests.ts
+++ b/types/dogapi/dogapi-tests.ts
@@ -17,3 +17,51 @@ dogapi.event.create(
     { date_happened: Math.floor(Date.now() / 1000) },
     (err: Error | null, res: dogapi.EventCreateResponse) => {},
 );
+
+// metric.send_all
+// one metric
+// single point without date
+dogapi.metric.send_all(
+    [{
+        metric: 'metricName',
+        points: 500,
+    }],
+    (err: Error | null, res: string) => {}
+);
+
+// multiple metric
+dogapi.metric.send_all(
+    [
+        {
+            metric: 'metricOne',
+            points: 500,
+        },
+        {
+            metric: 'metricTwo',
+            points: 200,
+        }
+    ],
+    (err: Error | null, res: string) => {}
+);
+
+// multi point without date
+// tags
+dogapi.metric.send_all(
+    [{
+        metric: 'metricName',
+        points: [500, 600],
+        tags: ['tag1', 'tag2'],
+    }],
+    (err: Error | null, res: string) => {}
+);
+
+// multi point with date
+// metric_type
+dogapi.metric.send_all(
+    [{
+        metric: 'metricName',
+        points: [['123', 500], ['124', 600]],
+        metric_type: 'type',
+    }],
+    (err: Error | null, res: string) => {}
+);

--- a/types/dogapi/index.d.ts
+++ b/types/dogapi/index.d.ts
@@ -33,6 +33,16 @@ interface metric {
             host?: string,
             tags?: ReadonlyArray<string>,
         }, callback: (err: Error | null, res: "ok") => void): void;
+    send_all(
+        metrics: Array<{
+            metric: string;
+            points: number | number[] | Array<[string, number]>;
+            tags?: string[];
+            type?: string;
+            metric_type?: string;
+        }>,
+        callback: (err: Error | null, res: 'ok') => void
+    ): void;
 }
 
 export const metric: metric;


### PR DESCRIPTION
## explanation
The dogapi types provided here are only a subset of what the dogapi module actually exports. This is still the case; this PR simply expands that coverage by one exported function - `metric.send_all`.


## template
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://brettlangdon.github.io/node-dogapi/#metric-send_all
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.