### PR TITLE
@types/osrm: Expose annotations and distances matrix

### DIFF
--- a/types/osrm/index.d.ts
+++ b/types/osrm/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for osrm 5.12
+// Type definitions for osrm 5.22.0
 // Project: https://github.com/Project-OSRM/osrm-backend
 // Definitions by: Denis Carriere <https://github.com/DenisCarriere>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/osrm/index.d.ts
+++ b/types/osrm/index.d.ts
@@ -50,6 +50,7 @@ declare namespace OSRM {
     type Radius = number;
     type Hint = string;
     type Duration = number;
+    type Distance = number;
     type Tile = [number, number, number];
     type StepManeuverTypes = 'turn' | 'new name' | 'depart' | 'arrive' | 'merge' |
                              'ramp' | 'on ramp' | 'off ramp' | 'fork' | 'end of road' |
@@ -466,6 +467,10 @@ declare namespace OSRM {
          * to use location with given index as destination. Default is to use all.
          */
         destinations?: number[];
+        /**
+         * specify which table results to return.
+         */
+        annotations?: Array<('duration' | 'distance')>;
     }
 
     /**
@@ -570,6 +575,7 @@ declare namespace OSRM {
 
     interface TableResults {
         durations: Duration[][];
+        distances?: Distance[][];
         sources: Waypoint[];
         destinations: Waypoint[];
     }

--- a/types/osrm/index.d.ts
+++ b/types/osrm/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for osrm 5.22.0
+// Type definitions for osrm 5.22
 // Project: https://github.com/Project-OSRM/osrm-backend
 // Definitions by: Denis Carriere <https://github.com/DenisCarriere>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/osrm/osrm-tests.ts
+++ b/types/osrm/osrm-tests.ts
@@ -35,6 +35,21 @@ osrm.table({coordinates}, (err, response) => {
   console.log(response.destinations); // array of Waypoint objects
 });
 
+// Table Distances
+osrm.table({coordinates, annotations: ['distance']}, (err, response) => {
+  console.log(response.distances); // array of arrays, matrix in row-major order
+  console.log(response.sources); // array of Waypoint objects
+  console.log(response.destinations); // array of Waypoint objects
+});
+
+// Table Durations and Distances
+osrm.table({coordinates, annotations: ['distance', 'duration']}, (err, response) => {
+  console.log(response.durations); // array of arrays, matrix in row-major order
+  console.log(response.distances); // array of arrays, matrix in row-major order
+  console.log(response.sources); // array of Waypoint objects
+  console.log(response.destinations); // array of Waypoint objects
+});
+
 // Tile
 osrm.tile([0, 0, 0], (err, response) => {
   if (err) throw err;


### PR DESCRIPTION
Annotations to specify what matrices are returned is available in OSRM but was not exposed via the types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://project-osrm.org/docs/v5.22.0/api/#table-service
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

I will also be making a PR to osrm-backend to update their documentation specifically for their [nodejs api docs](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/nodejs/api.md)