### PR TITLE
[CBuffer] new definitions for CBuffer

### DIFF
--- a/types/CBuffer/CBuffer-tests.ts
+++ b/types/CBuffer/CBuffer-tests.ts
@@ -1,0 +1,15 @@
+import CBuffer = require('CBuffer');
+
+const cbuffer_limit = new CBuffer<object>(4);
+cbuffer_limit.data; // $ExpectType ReadonlyArray<object>
+cbuffer_limit.start; // $ExpectType number
+cbuffer_limit.end; // $ExpectType number
+cbuffer_limit.push({}); // $ExpectType number
+
+const cbuffer_typed = new CBuffer<string>('foo', 'bar');
+cbuffer_limit.length; // $ExpectType number
+cbuffer_limit.size; // $ExpectType number
+cbuffer_limit.overflow; // $ExpectType ((overwrittenEntry: object) => void) | null
+cbuffer_typed.pop(); // $ExpectType string | undefined
+
+const cbuffer_error = new CBuffer<any>(); // $ExpectError

--- a/types/CBuffer/CBuffer-tests.ts
+++ b/types/CBuffer/CBuffer-tests.ts
@@ -1,6 +1,6 @@
 import CBuffer = require('CBuffer');
 
-const cbuffer_limit = new CBuffer<object>(4);
+const cbuffer_limit = new CBuffer<object>(2);
 cbuffer_limit.data; // $ExpectType ReadonlyArray<object>
 cbuffer_limit.start; // $ExpectType number
 cbuffer_limit.end; // $ExpectType number

--- a/types/CBuffer/index.d.ts
+++ b/types/CBuffer/index.d.ts
@@ -1,0 +1,121 @@
+// Type definitions for CBuffer 2.1
+// Project: https://github.com/trevnorris/cbuffer
+// Definitions by: russaa <https://github.com/mmig>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/*~ Note that ES6 modules cannot directly export class objects.
+ *~ This file should be imported using the CommonJS-style:
+ *~   import CBuffer = require('CBuffer');
+ *~
+ *~ Alternatively, if --allowSyntheticDefaultImports or
+ *~ --esModuleInterop is turned on, this file can also be
+ *~ imported as a default import:
+ *~   import CBuffer from 'CBuffer';
+ *~
+ *~ Refer to the documentation to understand common
+ *~ workarounds for this limitation of ES6 modules.
+ */
+
+/*~ This module is a UMD module that exposes a global variable 'CBuffer' when
+ *~ loaded outside a module loader environment.
+ */
+export as namespace CBuffer;
+
+/*~ This declaration specifies that the class constructor function
+ *~ is the exported object from the file
+ */
+export = CBuffer;
+
+declare class CBuffer<T> {
+    constructor(entry: T, ...entries: T[]);
+    constructor(size: number);
+
+    /* fields */
+    /** Gets or sets the length of the buffer */
+    length: number;
+    /** Gets or sets the capacity of the buffer */
+    size: number;
+
+    /* hooks */
+    /** overflow hook: is called when a data entry in the buffer is about to be overwritten */
+    overflow: null | ((overwrittenEntry: T) => void);
+
+    /* internal data representation */
+    /** internal data representation of the buffer */
+    readonly data: ReadonlyArray<T>;
+    /** start index for the data */
+    readonly start: number;
+    /** end index for the data */
+    readonly end: number;
+
+    /* mutator methods */
+    /** pop last item */
+    pop(): T | undefined;
+    /** push item to the end */
+    push(...items: T[]): number;
+    /** reverse order of the buffer */
+    reverse(): this;
+    /** rotate buffer to the left by cntr, or by 1 */
+    rotateLeft(cntr?: number): this;
+    /** rotate buffer to the right by cntr, or by 1 */
+    rotateRight(cntr?: number): this;
+    /** remove and return first item */
+    shift(): T;
+    /** sort items */
+    sort(sortFunction?: (v1: T, v2: T) => number): this;
+    /** add item to beginning of buffer */
+    unshift(...items: T[]): number;
+
+    /* accessor methods */
+    /** return index of first matched element */
+    indexOf(searchElement: T, fromIndex?: number): number;
+    /** return last index of the first match */
+    lastIndexOf(searchElement: T, fromIndex?: number): number;
+    /**
+     * return the index an item would be inserted to if this
+     * is a sorted circular buffer
+     */
+    sortedIndex(value: T, comparitor?: (v1: T, v2: T) => number, thisArg?: any): number;
+
+    /* iteration methods */
+    /** check every item in the array against a test */
+    every(callbackfn: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;
+    /** loop through each item in buffer */
+    // TODO: figure out how to emulate Array use better
+    forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void;
+    /** construct new CBuffer of same length, apply map function, and return new CBuffer */
+    map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): CBuffer<U>;
+    /** check items agains test until one returns true */
+    some(callbackfn: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;
+    /** calculate the average value of a circular buffer */
+    avg(): number;
+    /** loop through each item in buffer and calculate sum */
+    sum(): number;
+    /** loop through each item in buffer and calculate median */
+    median(): number;
+
+    /* utility methods */
+    /**
+     * reset pointers to buffer with zero items
+     * note: this will not remove values in cbuffer, so if for security values
+     *       need to be overwritten, run `.fill(null).empty()`
+     */
+    empty(): this;
+    /** fill all places with passed value or function */
+    fill(value: T | (() => T)): this; // NOTE orig. API Array.fill:  fill(value: T, start?: number, end?: number): this;
+    /** return first item in buffer */
+    first(): T | undefined;
+    /** return last item in buffer */
+    last(): T | undefined;
+    /** return specific index in buffer */
+    get(index: number): T | undefined;
+    isFull(): boolean;
+    /** set value at specified index */
+    set(idx: number, arg: T): T;
+    /** return clean array of values */
+    toArray(): T[];
+    /** return a string based on the array */
+    join(separator?: string): string;
+    /** slice the buffer to an array */
+    slice(start?: number, end?: number): T[];
+}

--- a/types/CBuffer/tsconfig.json
+++ b/types/CBuffer/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "CBuffer-tests.ts"
+    ]
+}

--- a/types/CBuffer/tslint.json
+++ b/types/CBuffer/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
