### PR TITLE
fix(webidl2): Use tuples for Generic IDL Type arguments

### DIFF
--- a/types/webidl2/index.d.ts
+++ b/types/webidl2/index.d.ts
@@ -3,9 +3,9 @@
 // Definitions by: Kagama Sascha Rosylight <https://github.com/saschanaz>
 //                 ExE Boss <https://github.com/ExE-Boss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
 
 export as namespace WebIDL2;
+export {};
 
 export function parse(str: string, options?: ParseOptions): IDLRootType[];
 
@@ -107,25 +107,55 @@ export interface AbstractTypeDescription extends AbstractBase {
         | UnionTypeDescription;
 }
 
-export interface GenericTypeDescription extends AbstractTypeDescription {
+interface AbstractNonUnionTypeDescription extends AbstractTypeDescription {
     /** String indicating the generic type (e.g. "Promise", "sequence"). The empty string otherwise. */
-    generic: "FrozenArray" | "ObservableArray" | "Promise"| "record" | "sequence";
+    generic: IDLTypeDescription["generic"];
     /** Boolean indicating whether this is a union type or not. */
     union: false;
+}
+
+interface AbstractGenericTypeDescription extends AbstractNonUnionTypeDescription {
     /**
-     * In most cases, this will just be a string with the type name.
-     * If the type is a union, then this contains an array of the types it unites.
-     * If it is a generic type, it contains the IDL type description for the type in the sequence,
+     * Contains the IDL type description for the type in the sequence,
      * the eventual value of the promise, etc.
      */
     idlType: IDLTypeDescription[];
 }
 
-export interface SingleTypeDescription extends AbstractTypeDescription {
-    /** String indicating the generic type (e.g. "Promise", "sequence"). The empty string otherwise. */
+export type GenericTypeDescription =
+    | FrozenArrayTypeDescription
+    | ObservableArrayTypeDescription
+    | PromiseTypeDescription
+    | RecordTypeDescription
+    | SequenceTypeDescription;
+
+export interface FrozenArrayTypeDescription extends AbstractGenericTypeDescription {
+    generic: "FrozenArray";
+    idlType: [IDLTypeDescription];
+}
+
+export interface ObservableArrayTypeDescription extends AbstractGenericTypeDescription {
+    generic: "ObservableArray";
+    idlType: [IDLTypeDescription];
+}
+
+export interface PromiseTypeDescription extends AbstractGenericTypeDescription {
+    generic: "Promise";
+    idlType: [IDLTypeDescription];
+}
+
+export interface RecordTypeDescription extends AbstractGenericTypeDescription {
+    generic: "record";
+    idlType: [IDLTypeDescription, IDLTypeDescription];
+}
+
+export interface SequenceTypeDescription extends AbstractGenericTypeDescription {
+    generic: "sequence";
+    idlType: [IDLTypeDescription];
+}
+
+export interface SingleTypeDescription extends AbstractNonUnionTypeDescription {
     generic: "";
-    /** Boolean indicating whether this is a union type or not. */
-    union: false;
     /**
      * In most cases, this will just be a string with the type name.
      * If the type is a union, then this contains an array of the types it unites.

--- a/types/webidl2/webidl2-tests.ts
+++ b/types/webidl2/webidl2-tests.ts
@@ -215,6 +215,19 @@ function logIdlType(idlType: webidl2.IDLTypeDescription) {
         idlType; // $ExpectType GenericTypeDescription
         idlType.generic; // $ExpectType "FrozenArray" | "ObservableArray" | "Promise" | "record" | "sequence"
         console.log(idlType);
+        switch (idlType.generic) {
+            case "FrozenArray":
+            case "ObservableArray":
+            case "Promise":
+            case "sequence":
+                idlType.idlType; // $ExpectType [IDLTypeDescription]
+                idlType.idlType.length; // $ExpectType 1
+                break;
+
+            case "record":
+                idlType.idlType.length; // $ExpectType 2
+                break;
+        }
     } else {
         idlType; // $ExpectType SingleTypeDescription
         console.log(idlType);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/w3c/webidl2.js/blob/aa38fd7b922849552e5b8f199fcf9d39cc84b5fd/lib/productions/type.js#L19-L43>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
