### PR TITLE
NeDB: projection is not T

### DIFF
--- a/types/nedb/index.d.ts
+++ b/types/nedb/index.d.ts
@@ -96,8 +96,8 @@ declare class Nedb<G = any> extends EventEmitter {
      * @param query MongoDB-style query
      * @param projection MongoDB-style projection
      */
-    find<T extends G>(query: any, projection: T, callback: (err: Error | null, documents: T[]) => void): void;
-    find<T extends G>(query: any, projection?: T): Nedb.Cursor<T>;
+    find<T extends G>(query: any, projection: any, callback: (err: Error | null, documents: T[]) => void): void;
+    find<T extends G>(query: any, projection?: any): Nedb.Cursor<T>;
 
     /**
      * Find all documents matching the query
@@ -111,7 +111,7 @@ declare class Nedb<G = any> extends EventEmitter {
      * @param query MongoDB-style query
      * @param projection MongoDB-style projection
      */
-    findOne<T extends G>(query: any, projection: T, callback: (err: Error | null, document: T) => void): void;
+    findOne<T extends G>(query: any, projection: any, callback: (err: Error | null, document: T) => void): void;
 
     /**
      * Find one document matching the query


### PR DESCRIPTION
`projection` is a MongoDB-style projection.
Ideally, it would have a type as detailed as the projection from `mongodb`.
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b049e84b384fecb579295a0883a943437d4643b8/types/mongodb/index.d.ts#L1976

Possible values include `{_id: 0}` and `{'foo.bar': 1}`. This does not mean that `T` will be an object that has either of those properties nor that their are numbers. `1` means to include the property in the return value and `0` means to leave the property out.

NeDB hasn't been maintained in five years and we're deprecating it. I don't have time to work on this PR.