### PR TITLE
Add type definitions for json-bigint

### DIFF
--- a/types/json-bigint/index.d.ts
+++ b/types/json-bigint/index.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for json-bigint 1.0
+// Project: https://github.com/sidorares/json-bigint#readme
+// Definitions by: yamachu <https://github.com/yamachu>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare const stringify: typeof JSON.stringify;
+declare const parse: typeof JSON.parse;
+
+declare function JSONBig(options?: Options): { parse: typeof parse; stringify: typeof stringify };
+
+interface Options {
+    /**
+     * @default false
+     */
+    strict?: boolean;
+    /**
+     * @default false
+     */
+    storeAsString?: boolean;
+    /**
+     * @default false
+     */
+    alwaysParseAsBig?: boolean;
+    /**
+     * @default false
+     */
+    useNativeBigInt?: boolean;
+    /**
+     * @default 'error'
+     */
+    protoAction?: 'error' | 'ignore' | 'preserve';
+    /**
+     * @default 'error'
+     */
+    constructorAction?: 'error' | 'ignore' | 'preserve';
+}
+
+type JSONBigExport = typeof JSONBig & { parse: typeof parse; stringify: typeof stringify };
+
+declare const _: JSONBigExport;
+export = _;

--- a/types/json-bigint/json-bigint-tests.ts
+++ b/types/json-bigint/json-bigint-tests.ts
@@ -1,0 +1,19 @@
+import JSONBig = require('json-bigint');
+
+const jsonString = `{ "a": "b"}`;
+const jsonObject = { a: 'b' };
+
+// $ExpectType any
+JSONBig({
+    useNativeBigInt: true,
+    alwaysParseAsBig: false,
+    constructorAction: 'error',
+    protoAction: 'preserve',
+    storeAsString: undefined,
+    strict: true,
+}).parse(jsonString);
+
+JSONBig.parse(jsonString); // $ExpectType any
+
+JSONBig().stringify(jsonObject); // $ExpectType string
+JSONBig.stringify(jsonObject); // $ExpectType string

--- a/types/json-bigint/tsconfig.json
+++ b/types/json-bigint/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "json-bigint-tests.ts"
+    ]
+}

--- a/types/json-bigint/tslint.json
+++ b/types/json-bigint/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

