### PR TITLE
NodeJS: add perf_hooks.performance.eventLoopUtilization implemented in version 14.10.0

### DIFF
--- a/types/node/test/perf_hooks.ts
+++ b/types/node/test/perf_hooks.ts
@@ -1,4 +1,4 @@
-import { performance, monitorEventLoopDelay, PerformanceObserverCallback, PerformanceObserver, PerformanceEntry, EntryType, constants } from 'perf_hooks';
+import { performance, monitorEventLoopDelay, PerformanceObserverCallback, PerformanceObserver, PerformanceEntry, EntryType, constants, EventLoopUtilization } from 'perf_hooks';
 
 performance.mark('start');
 (
@@ -47,3 +47,7 @@ const max: number = monitor.max;
 const mean: number = monitor.mean;
 const stddev: number = monitor.stddev;
 const exceeds: number = monitor.exceeds;
+
+const eventLoopUtilization1: EventLoopUtilization = performance.eventLoopUtilization();
+const eventLoopUtilization2: EventLoopUtilization = performance.eventLoopUtilization(eventLoopUtilization1);
+const eventLoopUtilization3: EventLoopUtilization = performance.eventLoopUtilization(eventLoopUtilization2, eventLoopUtilization1);

--- a/types/node/ts3.1/perf_hooks.d.ts
+++ b/types/node/ts3.1/perf_hooks.d.ts
@@ -214,9 +214,7 @@ declare module 'perf_hooks' {
          * @param util1 The result of a previous call to eventLoopUtilization()
          * @param util2 The result of a previous call to eventLoopUtilization() prior to util1
          */
-        eventLoopUtilization(): EventLoopUtilization;
-        eventLoopUtilization(util1: EventLoopUtilization): EventLoopUtilization;
-        eventLoopUtilization(util1: EventLoopUtilization, util2: EventLoopUtilization): EventLoopUtilization;
+        eventLoopUtilization(util1?: EventLoopUtilization, util2?: EventLoopUtilization): EventLoopUtilization;
     }
 
     interface PerformanceObserverEntryList {

--- a/types/node/ts3.1/perf_hooks.d.ts
+++ b/types/node/ts3.1/perf_hooks.d.ts
@@ -108,6 +108,12 @@ declare module 'perf_hooks' {
         readonly v8Start: number;
     }
 
+    interface EventLoopUtilization {
+        idle: number;
+        active: number;
+        utilization: number;
+    }
+
     interface Performance {
         /**
          * If name is not provided, removes all PerformanceFunction objects from the Performance Timeline.
@@ -199,6 +205,18 @@ declare module 'perf_hooks' {
          * @param fn
          */
         timerify<T extends (...optionalParams: any[]) => any>(fn: T): T;
+
+        /**
+         * eventLoopUtilization is similar to CPU utilization except that it is calculated using high precision wall-clock time.
+         * It represents the percentage of time the event loop has spent outside the event loop's event provider (e.g. epoll_wait).
+         * No other CPU idle time is taken into consideration.
+         *
+         * @param util1 The result of a previous call to eventLoopUtilization()
+         * @param util2 The result of a previous call to eventLoopUtilization() prior to util1
+         */
+        eventLoopUtilization(): EventLoopUtilization;
+        eventLoopUtilization(util1: EventLoopUtilization): EventLoopUtilization;
+        eventLoopUtilization(util1: EventLoopUtilization, util2: EventLoopUtilization): EventLoopUtilization;
     }
 
     interface PerformanceObserverEntryList {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/perf_hooks.html#perf_hooks_performance_eventlooputilization_util1_util2
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
