### PR TITLE
[koa-pino-logger] Add logger to Middleware interface

### DIFF
--- a/types/koa-pino-logger/index.d.ts
+++ b/types/koa-pino-logger/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for koa-pino-logger 2.1
+// Type definitions for koa-pino-logger 3.0
 // Project: https://github.com/pinojs/koa-pino-logger, https://github.com/davidmarkclements/koa-pino-logger
 // Definitions by: Cameron Yan <https://github.com/khell>
+//                 Jeremy Hull <https://github.com/sourrust>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 

--- a/types/koa-pino-logger/index.d.ts
+++ b/types/koa-pino-logger/index.d.ts
@@ -4,15 +4,17 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
-/// <reference types="node"/>
-
-import { Middleware } from 'koa';
+import { Middleware as BaseMiddleware } from 'koa';
 import { DestinationStream, LoggerOptions, Logger, Level } from 'pino';
 import { Options } from 'pino-http';
 import * as stream from 'stream';
 import * as http from 'http';
 
 export = logger;
+
+interface Middleware extends BaseMiddleware {
+    logger: Logger;
+}
 
 declare function logger(
     opts?: Options,

--- a/types/koa-pino-logger/index.d.ts
+++ b/types/koa-pino-logger/index.d.ts
@@ -5,10 +5,8 @@
 // TypeScript Version: 2.7
 
 import { Middleware as BaseMiddleware } from 'koa';
-import { DestinationStream, LoggerOptions, Logger, Level } from 'pino';
+import { DestinationStream, Logger } from 'pino';
 import { Options } from 'pino-http';
-import * as stream from 'stream';
-import * as http from 'http';
 
 export = logger;
 

--- a/types/koa-pino-logger/koa-pino-logger-tests.ts
+++ b/types/koa-pino-logger/koa-pino-logger-tests.ts
@@ -3,6 +3,8 @@ import logger = require('koa-pino-logger');
 import { Writable } from 'stream';
 
 const app = new koa();
+const pino = logger();
+
 app.use(logger());
 app.use(logger(new Writable()));
 app.use(logger({stream: new Writable()}));
@@ -11,4 +13,8 @@ app.use(logger({genReqId: () => 'foo'}));
 app.use((ctx) => {
   ctx.log.info('something else');
   ctx.body = 'hello world';
+});
+
+app.listen(3000, () => {
+  pino.logger.info('Server running on http://localhost:3000');
 });


### PR DESCRIPTION
Although this change is to a new major version of `koa-pino-logger`, the only change is to the Middleware interface that adds a logger property, not breaking anything from the previous version. The update also removes unused imports in the definition.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pinojs/koa-pino-logger/blob/428db80/logger.js#L17
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
