### PR TITLE
[node] Update some apis

### DIFF
--- a/types/node/assert.d.ts
+++ b/types/node/assert.d.ts
@@ -1,4 +1,5 @@
 declare module "assert" {
+    /** An alias of `assert.ok()`. */
     function assert(value: any, message?: string | Error): asserts value;
     namespace assert {
         class AssertionError implements Error {
@@ -11,9 +12,35 @@ declare module "assert" {
             code: 'ERR_ASSERTION';
 
             constructor(options?: {
-                message?: string; actual?: any; expected?: any;
-                operator?: string; stackStartFn?: Function
+                /** If provided, the error message is set to this value. */
+                message?: string;
+                /** The `actual` property on the error instance. */
+                actual?: any;
+                /** The `expected` property on the error instance. */
+                expected?: any;
+                /** The `operator` property on the error instance. */
+                operator?: string;
+                /** If provided, the generated stack trace omits frames before this function. */
+                stackStartFn?: Function
             });
+        }
+
+        class CallTracker {
+            calls(exact?: number): () => void;
+            calls<Func extends (...args: any[]) => any>(fn?: Func, exact?: number): Func;
+            report(): CallTrackerReportInformation[];
+            verify(): void;
+        }
+        export interface CallTrackerReportInformation {
+            message: string;
+            /** The actual number of times the function was called. */
+            actual: number;
+            /** The number of times the function was expected to be called. */
+            expected: number;
+            /** The name of the function that is wrapped. */
+            operator: string;
+            /** A stack trace of the function. */
+            stack: object;
         }
 
         type AssertPredicate = RegExp | (new() => object) | ((thrown: any) => boolean) | object | Error;

--- a/types/node/test/assert.ts
+++ b/types/node/test/assert.ts
@@ -1,5 +1,39 @@
 import * as assert from 'assert';
 
+{
+    const { message } = new assert.AssertionError({
+        actual: 1,
+        expected: 2,
+        operator: 'strictEqual'
+    });
+
+    try {
+        assert.strictEqual(1, 2);
+    } catch (err) {
+        assert(err instanceof assert.AssertionError);
+        assert.strictEqual(err.message, message);
+        assert.strictEqual(err.name, 'AssertionError');
+        assert.strictEqual(err.actual, 1);
+        assert.strictEqual(err.expected, 2);
+        assert.strictEqual(err.code, 'ERR_ASSERTION');
+        assert.strictEqual(err.operator, 'strictEqual');
+        assert.strictEqual(err.generatedMessage, true);
+    }
+}
+
+{
+    const tracker = new assert.CallTracker();
+    const callsFunc = tracker.calls((a: number) => a, 2);
+    const res = callsFunc(42);
+    const report = tracker.report();
+
+    try {
+        tracker.verify();
+    } catch (err) {
+        assert(err instanceof assert.AssertionError);
+    }
+}
+
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 
 assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, "DEEP WENT DERP");

--- a/types/node/test/async_hooks.ts
+++ b/types/node/test/async_hooks.ts
@@ -47,6 +47,10 @@ import { AsyncResource, createHook, triggerAsyncId, executionAsyncId, executionA
       triggerAsyncId: 0,
       requireManualDestroy: true
     });
+
+    let res = AsyncResource.bind((x: number) => x)(42);
+    const asyncResource = new AsyncResource('');
+    res = asyncResource.bind((x: number) => x)(42);
 }
 
 {

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -603,6 +603,10 @@ import { promisify } from 'util';
 }
 
 {
+    const fips: 0 | 1 = crypto.getFips();
+}
+
+{
     crypto.createPrivateKey(Buffer.from('asdf'));
     crypto.createPrivateKey({
         key: 'asd',

--- a/types/node/test/perf_hooks.ts
+++ b/types/node/test/perf_hooks.ts
@@ -6,7 +6,6 @@ performance.mark('start');
 )();
 performance.mark('end');
 
-const perfEntry: PerformanceEntry = performance.getEntriesByName('discover')[0];
 const timeOrigin: number = performance.timeOrigin;
 
 const performanceObserverCallback: PerformanceObserverCallback = (list, obs) => {
@@ -24,7 +23,6 @@ const performanceObserverCallback: PerformanceObserverCallback = (list, obs) => 
     }
 
     obs.disconnect();
-    performance.clearFunctions();
 };
 const obs = new PerformanceObserver(performanceObserverCallback);
 obs.observe({

--- a/types/node/ts3.1/async_hooks.d.ts
+++ b/types/node/ts3.1/async_hooks.d.ts
@@ -116,6 +116,19 @@ declare module "async_hooks" {
         constructor(type: string, triggerAsyncId?: number|AsyncResourceOptions);
 
         /**
+         * Binds the given function to the current execution context.
+         * @param fn The function to bind to the current execution context.
+         * @param type An optional name to associate with the underlying `AsyncResource`.
+         */
+        static bind<Func extends (...args: any[]) => any>(fn: Func, type?: string): Func & { asyncResource: AsyncResource };
+
+        /**
+         * Binds the given function to execute to this `AsyncResource`'s scope.
+         * @param fn The function to bind to the current `AsyncResource`.
+         */
+        bind<Func extends (...args: any[]) => any>(fn: Func): Func & { asyncResource: AsyncResource };
+
+        /**
          * Call the provided function with the provided arguments in the
          * execution context of the async resource. This will establish the
          * context, trigger the AsyncHooks before callbacks, call the function,

--- a/types/node/ts3.1/crypto.d.ts
+++ b/types/node/ts3.1/crypto.d.ts
@@ -408,6 +408,7 @@ declare module "crypto" {
     function privateEncrypt(private_key: RsaPrivateKey | KeyLike, buffer: NodeJS.ArrayBufferView): Buffer;
     function getCiphers(): string[];
     function getCurves(): string[];
+    function getFips(): 1 | 0;
     function getHashes(): string[];
     class ECDH {
         private constructor();

--- a/types/node/ts3.1/globals.d.ts
+++ b/types/node/ts3.1/globals.d.ts
@@ -576,7 +576,8 @@ declare namespace NodeJS {
         id: string;
         filename: string;
         loaded: boolean;
-        parent: Module | null;
+        /** @deprecated since 14.6.0 Please use `require.main` and `module.children` instead. */
+        parent: Module | null | undefined;
         children: Module[];
         /**
          * @since 11.14.0

--- a/types/node/ts3.1/perf_hooks.d.ts
+++ b/types/node/ts3.1/perf_hooks.d.ts
@@ -48,59 +48,29 @@ declare module 'perf_hooks' {
         readonly bootstrapComplete: number;
 
         /**
-         * The high resolution millisecond timestamp at which cluster processing ended.
+         * The high resolution millisecond timestamp at which the Node.js process completed bootstrapping.
+         * If bootstrapping has not yet finished, the property has the value of -1.
          */
-        readonly clusterSetupEnd: number;
+        readonly environment: number;
 
         /**
-         * The high resolution millisecond timestamp at which cluster processing started.
+         * The high resolution millisecond timestamp at which the Node.js environment was initialized.
          */
-        readonly clusterSetupStart: number;
+        readonly idleTime: number;
 
         /**
-         * The high resolution millisecond timestamp at which the Node.js event loop exited.
+         * The high resolution millisecond timestamp of the amount of time the event loop has been idle
+         *  within the event loop's event provider (e.g. `epoll_wait`). This does not take CPU usage
+         * into consideration. If the event loop has not yet started (e.g., in the first tick of the main script),
+         *  the property has the value of 0.
          */
         readonly loopExit: number;
 
         /**
          * The high resolution millisecond timestamp at which the Node.js event loop started.
+         * If the event loop has not yet started (e.g., in the first tick of the main script), the property has the value of -1.
          */
         readonly loopStart: number;
-
-        /**
-         * The high resolution millisecond timestamp at which main module load ended.
-         */
-        readonly moduleLoadEnd: number;
-
-        /**
-         * The high resolution millisecond timestamp at which main module load started.
-         */
-        readonly moduleLoadStart: number;
-
-        /**
-         * The high resolution millisecond timestamp at which the Node.js process was initialized.
-         */
-        readonly nodeStart: number;
-
-        /**
-         * The high resolution millisecond timestamp at which preload module load ended.
-         */
-        readonly preloadModuleLoadEnd: number;
-
-        /**
-         * The high resolution millisecond timestamp at which preload module load started.
-         */
-        readonly preloadModuleLoadStart: number;
-
-        /**
-         * The high resolution millisecond timestamp at which third_party_main processing ended.
-         */
-        readonly thirdPartyMainEnd: number;
-
-        /**
-         * The high resolution millisecond timestamp at which third_party_main processing started.
-         */
-        readonly thirdPartyMainStart: number;
 
         /**
          * The high resolution millisecond timestamp at which the V8 platform was initialized.
@@ -110,47 +80,11 @@ declare module 'perf_hooks' {
 
     interface Performance {
         /**
-         * If name is not provided, removes all PerformanceFunction objects from the Performance Timeline.
-         * If name is provided, removes entries with name.
-         * @param name
-         */
-        clearFunctions(name?: string): void;
-
-        /**
          * If name is not provided, removes all PerformanceMark objects from the Performance Timeline.
          * If name is provided, removes only the named mark.
          * @param name
          */
         clearMarks(name?: string): void;
-
-        /**
-         * If name is not provided, removes all PerformanceMeasure objects from the Performance Timeline.
-         * If name is provided, removes only objects whose performanceEntry.name matches name.
-         */
-        clearMeasures(name?: string): void;
-
-        /**
-         * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime.
-         * @return list of all PerformanceEntry objects
-         */
-        getEntries(): PerformanceEntry[];
-
-        /**
-         * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime
-         * whose performanceEntry.name is equal to name, and optionally, whose performanceEntry.entryType is equal to type.
-         * @param name
-         * @param type
-         * @return list of all PerformanceEntry objects
-         */
-        getEntriesByName(name: string, type?: EntryType): PerformanceEntry[];
-
-        /**
-         * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime
-         * whose performanceEntry.entryType is equal to type.
-         * @param type
-         * @return list of all PerformanceEntry objects
-         */
-        getEntriesByType(type: EntryType): PerformanceEntry[];
 
         /**
          * Creates a new PerformanceMark entry in the Performance Timeline.

--- a/types/node/ts3.1/process.d.ts
+++ b/types/node/ts3.1/process.d.ts
@@ -245,6 +245,8 @@ declare module "process" {
                 title: string;
                 arch: string;
                 platform: Platform;
+                /** @deprecated since v14.0.0 - use `require.main` instead. */
+                mainModule?: Module;
                 memoryUsage(): MemoryUsage;
                 cpuUsage(previousValue?: CpuUsage): CpuUsage;
                 nextTick(callback: Function, ...args: any[]): void;
@@ -259,6 +261,12 @@ declare module "process" {
                     tls_ocsp: boolean;
                     tls: boolean;
                 };
+                /**
+                 * @deprecated since v14.0.0 - Calling process.umask() with no argument causes
+                 * the process-wide umask to be written twice. This introduces a race condition between threads,
+                 * and is a potential security vulnerability. There is no safe, cross-platform alternative API.
+                 */
+                umask(): number;
                 /**
                  * Can only be set if not in worker thread.
                  */

--- a/types/node/v10/ts3.1/node-tests.ts
+++ b/types/node/v10/ts3.1/node-tests.ts
@@ -4308,7 +4308,6 @@ import * as constants from 'constants';
     )();
     perf_hooks.performance.mark('end');
 
-    const { duration } = perf_hooks.performance.getEntriesByName('discover')[0];
     const timeOrigin = perf_hooks.performance.timeOrigin;
 
     const performanceObserverCallback: perf_hooks.PerformanceObserverCallback = (list, obs) => {
@@ -4319,7 +4318,6 @@ import * as constants from 'constants';
             startTime,
         } = list.getEntries()[0];
         obs.disconnect();
-        perf_hooks.performance.clearFunctions();
     };
     const obs = new perf_hooks.PerformanceObserver(performanceObserverCallback);
     obs.observe({

--- a/types/node/v10/ts3.1/perf_hooks.d.ts
+++ b/types/node/v10/ts3.1/perf_hooks.d.ts
@@ -35,63 +35,27 @@ declare module "perf_hooks" {
     interface PerformanceNodeTiming extends PerformanceEntry {
         /**
          * The high resolution millisecond timestamp at which the Node.js process completed bootstrap.
+         * If bootstrapping has not yet finished, the property has the value of -1.
          */
         readonly bootstrapComplete: number;
 
         /**
-         * The high resolution millisecond timestamp at which cluster processing ended.
-         */
-        readonly clusterSetupEnd: number;
-
-        /**
-         * The high resolution millisecond timestamp at which cluster processing started.
-         */
-        readonly clusterSetupStart: number;
-
-        /**
          * The high resolution millisecond timestamp at which the Node.js event loop exited.
+         * If the event loop has not yet exited, the property has the value of -1.
+         * It can only have a value of not -1 in a handler of the 'exit' event.
          */
         readonly loopExit: number;
 
         /**
          * The high resolution millisecond timestamp at which the Node.js event loop started.
+         * If the event loop has not yet started (e.g., in the first tick of the main script), the property has the value of -1.
          */
         readonly loopStart: number;
-
-        /**
-         * The high resolution millisecond timestamp at which main module load ended.
-         */
-        readonly moduleLoadEnd: number;
-
-        /**
-         * The high resolution millisecond timestamp at which main module load started.
-         */
-        readonly moduleLoadStart: number;
 
         /**
          * The high resolution millisecond timestamp at which the Node.js process was initialized.
          */
         readonly nodeStart: number;
-
-        /**
-         * The high resolution millisecond timestamp at which preload module load ended.
-         */
-        readonly preloadModuleLoadEnd: number;
-
-        /**
-         * The high resolution millisecond timestamp at which preload module load started.
-         */
-        readonly preloadModuleLoadStart: number;
-
-        /**
-         * The high resolution millisecond timestamp at which third_party_main processing ended.
-         */
-        readonly thirdPartyMainEnd: number;
-
-        /**
-         * The high resolution millisecond timestamp at which third_party_main processing started.
-         */
-        readonly thirdPartyMainStart: number;
 
         /**
          * The high resolution millisecond timestamp at which the V8 platform was initialized.
@@ -101,47 +65,11 @@ declare module "perf_hooks" {
 
     interface Performance {
         /**
-         * If name is not provided, removes all PerformanceFunction objects from the Performance Timeline.
-         * If name is provided, removes entries with name.
-         * @param name
-         */
-        clearFunctions(name?: string): void;
-
-        /**
          * If name is not provided, removes all PerformanceMark objects from the Performance Timeline.
          * If name is provided, removes only the named mark.
          * @param name
          */
         clearMarks(name?: string): void;
-
-        /**
-         * If name is not provided, removes all PerformanceMeasure objects from the Performance Timeline.
-         * If name is provided, removes only objects whose performanceEntry.name matches name.
-         */
-        clearMeasures(name?: string): void;
-
-        /**
-         * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime.
-         * @return list of all PerformanceEntry objects
-         */
-        getEntries(): PerformanceEntry[];
-
-        /**
-         * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime
-         * whose performanceEntry.name is equal to name, and optionally, whose performanceEntry.entryType is equal to type.
-         * @param name
-         * @param type
-         * @return list of all PerformanceEntry objects
-         */
-        getEntriesByName(name: string, type?: string): PerformanceEntry[];
-
-        /**
-         * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime
-         * whose performanceEntry.entryType is equal to type.
-         * @param type
-         * @return list of all PerformanceEntry objects
-         */
-        getEntriesByType(type: string): PerformanceEntry[];
 
         /**
          * Creates a new PerformanceMark entry in the Performance Timeline.

--- a/types/node/v11/test/perf_hooks.ts
+++ b/types/node/v11/test/perf_hooks.ts
@@ -6,7 +6,6 @@ performance.mark('start');
 )();
 performance.mark('end');
 
-const { duration } = performance.getEntriesByName('discover')[0];
 const timeOrigin = performance.timeOrigin;
 
 const performanceObserverCallback: PerformanceObserverCallback = (list, obs) => {
@@ -17,7 +16,6 @@ const performanceObserverCallback: PerformanceObserverCallback = (list, obs) => 
         startTime,
     } = list.getEntries()[0];
     obs.disconnect();
-    performance.clearFunctions();
 };
 const obs = new PerformanceObserver(performanceObserverCallback);
 obs.observe({

--- a/types/node/v11/ts3.1/perf_hooks.d.ts
+++ b/types/node/v11/ts3.1/perf_hooks.d.ts
@@ -35,63 +35,27 @@ declare module "perf_hooks" {
     interface PerformanceNodeTiming extends PerformanceEntry {
         /**
          * The high resolution millisecond timestamp at which the Node.js process completed bootstrap.
+         * If bootstrapping has not yet finished, the property has the value of -1.
          */
         readonly bootstrapComplete: number;
 
         /**
-         * The high resolution millisecond timestamp at which cluster processing ended.
-         */
-        readonly clusterSetupEnd: number;
-
-        /**
-         * The high resolution millisecond timestamp at which cluster processing started.
-         */
-        readonly clusterSetupStart: number;
-
-        /**
          * The high resolution millisecond timestamp at which the Node.js event loop exited.
+         * If the event loop has not yet exited, the property has the value of -1.
+         * It can only have a value of not -1 in a handler of the 'exit' event.
          */
         readonly loopExit: number;
 
         /**
          * The high resolution millisecond timestamp at which the Node.js event loop started.
+         * If the event loop has not yet started (e.g., in the first tick of the main script), the property has the value of -1.
          */
         readonly loopStart: number;
-
-        /**
-         * The high resolution millisecond timestamp at which main module load ended.
-         */
-        readonly moduleLoadEnd: number;
-
-        /**
-         * The high resolution millisecond timestamp at which main module load started.
-         */
-        readonly moduleLoadStart: number;
 
         /**
          * The high resolution millisecond timestamp at which the Node.js process was initialized.
          */
         readonly nodeStart: number;
-
-        /**
-         * The high resolution millisecond timestamp at which preload module load ended.
-         */
-        readonly preloadModuleLoadEnd: number;
-
-        /**
-         * The high resolution millisecond timestamp at which preload module load started.
-         */
-        readonly preloadModuleLoadStart: number;
-
-        /**
-         * The high resolution millisecond timestamp at which third_party_main processing ended.
-         */
-        readonly thirdPartyMainEnd: number;
-
-        /**
-         * The high resolution millisecond timestamp at which third_party_main processing started.
-         */
-        readonly thirdPartyMainStart: number;
 
         /**
          * The high resolution millisecond timestamp at which the V8 platform was initialized.
@@ -101,47 +65,11 @@ declare module "perf_hooks" {
 
     interface Performance {
         /**
-         * If name is not provided, removes all PerformanceFunction objects from the Performance Timeline.
-         * If name is provided, removes entries with name.
-         * @param name
-         */
-        clearFunctions(name?: string): void;
-
-        /**
          * If name is not provided, removes all PerformanceMark objects from the Performance Timeline.
          * If name is provided, removes only the named mark.
          * @param name
          */
         clearMarks(name?: string): void;
-
-        /**
-         * If name is not provided, removes all PerformanceMeasure objects from the Performance Timeline.
-         * If name is provided, removes only objects whose performanceEntry.name matches name.
-         */
-        clearMeasures(name?: string): void;
-
-        /**
-         * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime.
-         * @return list of all PerformanceEntry objects
-         */
-        getEntries(): PerformanceEntry[];
-
-        /**
-         * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime
-         * whose performanceEntry.name is equal to name, and optionally, whose performanceEntry.entryType is equal to type.
-         * @param name
-         * @param type
-         * @return list of all PerformanceEntry objects
-         */
-        getEntriesByName(name: string, type?: string): PerformanceEntry[];
-
-        /**
-         * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime
-         * whose performanceEntry.entryType is equal to type.
-         * @param type
-         * @return list of all PerformanceEntry objects
-         */
-        getEntriesByType(type: string): PerformanceEntry[];
 
         /**
          * Creates a new PerformanceMark entry in the Performance Timeline.

--- a/types/node/v12/test/perf_hooks.ts
+++ b/types/node/v12/test/perf_hooks.ts
@@ -6,7 +6,6 @@ performance.mark('start');
 )();
 performance.mark('end');
 
-const { duration } = performance.getEntriesByName('discover')[0];
 const timeOrigin = performance.timeOrigin;
 
 const performanceObserverCallback: PerformanceObserverCallback = (list, obs) => {
@@ -17,7 +16,6 @@ const performanceObserverCallback: PerformanceObserverCallback = (list, obs) => 
         startTime,
     } = list.getEntries()[0];
     obs.disconnect();
-    performance.clearFunctions();
 };
 const obs = new PerformanceObserver(performanceObserverCallback);
 obs.observe({

--- a/types/node/v12/ts3.1/perf_hooks.d.ts
+++ b/types/node/v12/ts3.1/perf_hooks.d.ts
@@ -35,63 +35,33 @@ declare module "perf_hooks" {
     interface PerformanceNodeTiming extends PerformanceEntry {
         /**
          * The high resolution millisecond timestamp at which the Node.js process completed bootstrap.
+         * If bootstrapping has not yet finished, the property has the value of -1.
          */
         readonly bootstrapComplete: number;
 
         /**
-         * The high resolution millisecond timestamp at which cluster processing ended.
+         * The high resolution millisecond timestamp at which the Node.js process completed bootstrapping.
+         * If bootstrapping has not yet finished, the property has the value of -1.
          */
-        readonly clusterSetupEnd: number;
-
-        /**
-         * The high resolution millisecond timestamp at which cluster processing started.
-         */
-        readonly clusterSetupStart: number;
+        readonly environment: number;
 
         /**
          * The high resolution millisecond timestamp at which the Node.js event loop exited.
+         * If the event loop has not yet exited, the property has the value of -1.
+         * It can only have a value of not -1 in a handler of the 'exit' event.
          */
         readonly loopExit: number;
 
         /**
          * The high resolution millisecond timestamp at which the Node.js event loop started.
+         * If the event loop has not yet started (e.g., in the first tick of the main script), the property has the value of -1.
          */
         readonly loopStart: number;
-
-        /**
-         * The high resolution millisecond timestamp at which main module load ended.
-         */
-        readonly moduleLoadEnd: number;
-
-        /**
-         * The high resolution millisecond timestamp at which main module load started.
-         */
-        readonly moduleLoadStart: number;
 
         /**
          * The high resolution millisecond timestamp at which the Node.js process was initialized.
          */
         readonly nodeStart: number;
-
-        /**
-         * The high resolution millisecond timestamp at which preload module load ended.
-         */
-        readonly preloadModuleLoadEnd: number;
-
-        /**
-         * The high resolution millisecond timestamp at which preload module load started.
-         */
-        readonly preloadModuleLoadStart: number;
-
-        /**
-         * The high resolution millisecond timestamp at which third_party_main processing ended.
-         */
-        readonly thirdPartyMainEnd: number;
-
-        /**
-         * The high resolution millisecond timestamp at which third_party_main processing started.
-         */
-        readonly thirdPartyMainStart: number;
 
         /**
          * The high resolution millisecond timestamp at which the V8 platform was initialized.
@@ -101,47 +71,11 @@ declare module "perf_hooks" {
 
     interface Performance {
         /**
-         * If name is not provided, removes all PerformanceFunction objects from the Performance Timeline.
-         * If name is provided, removes entries with name.
-         * @param name
-         */
-        clearFunctions(name?: string): void;
-
-        /**
          * If name is not provided, removes all PerformanceMark objects from the Performance Timeline.
          * If name is provided, removes only the named mark.
          * @param name
          */
         clearMarks(name?: string): void;
-
-        /**
-         * If name is not provided, removes all PerformanceMeasure objects from the Performance Timeline.
-         * If name is provided, removes only objects whose performanceEntry.name matches name.
-         */
-        clearMeasures(name?: string): void;
-
-        /**
-         * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime.
-         * @return list of all PerformanceEntry objects
-         */
-        getEntries(): PerformanceEntry[];
-
-        /**
-         * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime
-         * whose performanceEntry.name is equal to name, and optionally, whose performanceEntry.entryType is equal to type.
-         * @param name
-         * @param type
-         * @return list of all PerformanceEntry objects
-         */
-        getEntriesByName(name: string, type?: string): PerformanceEntry[];
-
-        /**
-         * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime
-         * whose performanceEntry.entryType is equal to type.
-         * @param type
-         * @return list of all PerformanceEntry objects
-         */
-        getEntriesByType(type: string): PerformanceEntry[];
 
         /**
          * Creates a new PerformanceMark entry in the Performance Timeline.

--- a/types/node/v13/ts3.1/perf_hooks.d.ts
+++ b/types/node/v13/ts3.1/perf_hooks.d.ts
@@ -44,63 +44,33 @@ declare module 'perf_hooks' {
     interface PerformanceNodeTiming extends PerformanceEntry {
         /**
          * The high resolution millisecond timestamp at which the Node.js process completed bootstrap.
+         * If bootstrapping has not yet finished, the property has the value of -1.
          */
         readonly bootstrapComplete: number;
 
         /**
-         * The high resolution millisecond timestamp at which cluster processing ended.
+         * The high resolution millisecond timestamp at which the Node.js process completed bootstrapping.
+         * If bootstrapping has not yet finished, the property has the value of -1.
          */
-        readonly clusterSetupEnd: number;
-
-        /**
-         * The high resolution millisecond timestamp at which cluster processing started.
-         */
-        readonly clusterSetupStart: number;
+        readonly environment: number;
 
         /**
          * The high resolution millisecond timestamp at which the Node.js event loop exited.
+         * If the event loop has not yet exited, the property has the value of -1.
+         * It can only have a value of not -1 in a handler of the 'exit' event.
          */
         readonly loopExit: number;
 
         /**
          * The high resolution millisecond timestamp at which the Node.js event loop started.
+         * If the event loop has not yet started (e.g., in the first tick of the main script), the property has the value of -1.
          */
         readonly loopStart: number;
-
-        /**
-         * The high resolution millisecond timestamp at which main module load ended.
-         */
-        readonly moduleLoadEnd: number;
-
-        /**
-         * The high resolution millisecond timestamp at which main module load started.
-         */
-        readonly moduleLoadStart: number;
 
         /**
          * The high resolution millisecond timestamp at which the Node.js process was initialized.
          */
         readonly nodeStart: number;
-
-        /**
-         * The high resolution millisecond timestamp at which preload module load ended.
-         */
-        readonly preloadModuleLoadEnd: number;
-
-        /**
-         * The high resolution millisecond timestamp at which preload module load started.
-         */
-        readonly preloadModuleLoadStart: number;
-
-        /**
-         * The high resolution millisecond timestamp at which third_party_main processing ended.
-         */
-        readonly thirdPartyMainEnd: number;
-
-        /**
-         * The high resolution millisecond timestamp at which third_party_main processing started.
-         */
-        readonly thirdPartyMainStart: number;
 
         /**
          * The high resolution millisecond timestamp at which the V8 platform was initialized.
@@ -110,47 +80,11 @@ declare module 'perf_hooks' {
 
     interface Performance {
         /**
-         * If name is not provided, removes all PerformanceFunction objects from the Performance Timeline.
-         * If name is provided, removes entries with name.
-         * @param name
-         */
-        clearFunctions(name?: string): void;
-
-        /**
          * If name is not provided, removes all PerformanceMark objects from the Performance Timeline.
          * If name is provided, removes only the named mark.
          * @param name
          */
         clearMarks(name?: string): void;
-
-        /**
-         * If name is not provided, removes all PerformanceMeasure objects from the Performance Timeline.
-         * If name is provided, removes only objects whose performanceEntry.name matches name.
-         */
-        clearMeasures(name?: string): void;
-
-        /**
-         * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime.
-         * @return list of all PerformanceEntry objects
-         */
-        getEntries(): PerformanceEntry[];
-
-        /**
-         * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime
-         * whose performanceEntry.name is equal to name, and optionally, whose performanceEntry.entryType is equal to type.
-         * @param name
-         * @param type
-         * @return list of all PerformanceEntry objects
-         */
-        getEntriesByName(name: string, type?: EntryType): PerformanceEntry[];
-
-        /**
-         * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime
-         * whose performanceEntry.entryType is equal to type.
-         * @param type
-         * @return list of all PerformanceEntry objects
-         */
-        getEntriesByType(type: EntryType): PerformanceEntry[];
 
         /**
          * Creates a new PerformanceMark entry in the Performance Timeline.

--- a/types/node/v13/ts3.1/test/perf_hooks.ts
+++ b/types/node/v13/ts3.1/test/perf_hooks.ts
@@ -6,7 +6,6 @@ performance.mark('start');
 )();
 performance.mark('end');
 
-const perfEntry: PerformanceEntry = performance.getEntriesByName('discover')[0];
 const timeOrigin: number = performance.timeOrigin;
 
 const performanceObserverCallback: PerformanceObserverCallback = (list, obs) => {
@@ -24,7 +23,6 @@ const performanceObserverCallback: PerformanceObserverCallback = (list, obs) => 
     }
 
     obs.disconnect();
-    performance.clearFunctions();
 };
 const obs = new PerformanceObserver(performanceObserverCallback);
 obs.observe({


### PR DESCRIPTION
- [x] Add `assert.CallTracker` - [was added in 14.2.0](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V14.md#track-function-calls-with-assertcalltracker-experimental)
- [x] Add `crypto.getFips` to latest version - I missed it in #47298
- [x] Add `AsyncResource.bind` - [was added in 14.8.0](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V14.md#2020-08-11-version-1480-current-codebytere)
- [x] Deprecate `module.parent` - [14.6.0](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V14.md#2020-07-21-version-1460-current-mylesborins)
- [x] Add `PerformanceNodeTiming.idleTime` - [were added in 14.10.0](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V14.md#2020-09-08-version-14100-current-richardlau)
- [x] Remove old properties from `PerformanceNodeTiming` and `Performance` - [were removed from 10.0.0 docs](https://github.com/nodejs/node/pull/21247) and [from code](https://github.com/nodejs/node/pull/19563) [later](https://github.com/nodejs/node/pull/29528)
- [x] Add `process.mainModule` and `process.umask()` - they [were deprecated in 14.0.0](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V14.md#2020-04-21-version-1400-current-bethgriggs) but still available.