### PR TITLE
[@wordpress/components] Add explicit react dependency

### DIFF
--- a/types/wordpress__components/package.json
+++ b/types/wordpress__components/package.json
@@ -2,6 +2,7 @@
     "private": true,
     "dependencies": {
         "@wordpress/element": "^2.14.0",
+        "csstype": "^3.0.2",
         "re-resizable": "^4.7.1"
     }
 }


### PR DESCRIPTION
Previously this dependency was transient through @wordpress/element
but due to @wordpress/element's reliance on JSDoc to generate types,
it is unable to re-export React's types. More details here:

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/47381#discussion_r487071633

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/47381#discussion_r487071633
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
