### PR TITLE
[@types/xrm] Fix typings for multiselectoptionset on getAttributeType.

### DIFF
--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -2082,7 +2082,7 @@ declare namespace Xrm {
          * @see {@link XrmEnum.AttributeType}
          */
         type AttributeType = "boolean" | "datetime" | "decimal" | "double" | "integer" |
-            "lookup" | "memo" | "money" | "multioptionset" | "optionset" | "string";
+            "lookup" | "memo" | "money" | "multiselectoptionset" | "optionset" | "string";
 
         /**
          * Attribute formats for {@link Attributes.Attribute.getFormat Attributes.Attribute.getFormat()}.

--- a/types/xrm/xrm-tests.ts
+++ b/types/xrm/xrm-tests.ts
@@ -124,6 +124,8 @@ attribute.setSubmitMode(submitModeString); // Works if the string is a const
 attribute.setRequiredLevel(requirementLevel);
 attribute.setRequiredLevel(requirementLevelString); // Works if the string is a const
 
+const isMulitselect = attribute.getAttributeType() === 'multiselectoptionset';
+
 /// Demonstrate v8 AutoComplete
 
 let autoCompleteControl = Xrm.Page.getControl<Xrm.Page.AutoLookupControl>("name");

--- a/types/xrm/xrm-tests.ts
+++ b/types/xrm/xrm-tests.ts
@@ -124,7 +124,7 @@ attribute.setSubmitMode(submitModeString); // Works if the string is a const
 attribute.setRequiredLevel(requirementLevel);
 attribute.setRequiredLevel(requirementLevelString); // Works if the string is a const
 
-const isMulitselect = attribute.getAttributeType() === 'multiselectoptionset';
+const isMulitselect = attribute.getAttributeType() === "multiselectoptionset";
 
 /// Demonstrate v8 AutoComplete
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). 

The linter throw an error unrelated to this change: "The 'no-redundant-jsdoc-2' rule threw an error." "Error: Unexpected tag kind: JSDocSeeTag". The package has quite a few @see tags. Not sure if they should be removed or the rule should be disabled but this change doesn't add a see tag. 

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.microsoft.com/en-us/powerapps/developer/model-driven-apps/clientapi/reference/attributes/getattributetype
- [N/A] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
