### PR TITLE
[webpack-env] make __WebpackModuleApi.Module compatible with NodeJS.Module

### DIFF
--- a/types/webpack-env/index.d.ts
+++ b/types/webpack-env/index.d.ts
@@ -68,7 +68,7 @@ declare namespace __WebpackModuleApi {
         id: string;
         filename: string;
         loaded: boolean;
-        parent: NodeModule | null;
+        parent: NodeModule | null | undefined;
         children: NodeModule[];
         hot?: Hot;
     }

--- a/types/webpack-env/webpack-env-tests.ts
+++ b/types/webpack-env/webpack-env-tests.ts
@@ -1,4 +1,4 @@
-
+import 'node';
 
 interface SomeModule {
     someMethod(): void;

--- a/types/webpack-env/webpack-env-tests.ts
+++ b/types/webpack-env/webpack-env-tests.ts
@@ -1,4 +1,4 @@
-import 'node';
+/// <reference types="node"/>
 
 interface SomeModule {
     someMethod(): void;


### PR DESCRIPTION
A [recent update](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/47485) to `node` types made `__WebpackModuleApi.Module` incompatible with `NodeJS.Module`. Importing the node types in the test reveals this issue and ensures compatibility.

- Fixes #47602
- Closes #47607

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/47485
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
