### PR TITLE
fix(webidl2): Use union for DeclarationMemberType

### DIFF
--- a/types/webidl2/index.d.ts
+++ b/types/webidl2/index.d.ts
@@ -327,8 +327,8 @@ export interface ConstantMemberType extends AbstractBase {
     parent: CallbackInterfaceType | InterfaceMixinType | InterfaceType;
 }
 
-export interface DeclarationMemberType extends AbstractBase {
-    type: "iterable" | "maplike" | "setlike";
+interface AbstractDeclarationMemberType extends AbstractBase {
+    type: DeclarationMemberType["type"];
     /** An array with one or more IDL Types representing the declared type arguments. */
     idlType: IDLTypeDescription[];
     /** Whether the iterable is declared as async. */
@@ -338,6 +338,34 @@ export interface DeclarationMemberType extends AbstractBase {
     /** An array of arguments for the iterable declaration. */
     arguments: Argument[];
     parent: InterfaceMixinType | InterfaceType;
+}
+
+export type DeclarationMemberType =
+    | IterableDeclarationMemberType
+    | MaplikeDeclarationMemberType
+    | SetlikeDeclarationMemberType;
+
+export interface IterableDeclarationMemberType extends AbstractDeclarationMemberType {
+    type: "iterable";
+    idlType: [IDLTypeDescription] | [IDLTypeDescription, IDLTypeDescription];
+    async: boolean;
+    readonly: false;
+}
+
+interface AbstractCollectionLikeMemberType extends AbstractDeclarationMemberType {
+    async: false;
+    readonly: boolean;
+    arguments: [];
+}
+
+export interface MaplikeDeclarationMemberType extends AbstractCollectionLikeMemberType {
+    type: "maplike";
+    idlType: [IDLTypeDescription, IDLTypeDescription];
+}
+
+export interface SetlikeDeclarationMemberType extends AbstractCollectionLikeMemberType {
+    type: "setlike";
+    idlType: [IDLTypeDescription];
 }
 
 export interface Argument extends AbstractBase {

--- a/types/webidl2/webidl2-tests.ts
+++ b/types/webidl2/webidl2-tests.ts
@@ -11,14 +11,14 @@ for (const rootType of parsed) {
     }
 
     switch (rootType.type) {
-        case "interface":
-            rootType; // $ExpectType InterfaceType
-            console.log(rootType.inheritance);
+        case "interface mixin":
+            rootType; // $ExpectType InterfaceMixinType
             logMembers(rootType.members);
             console.log(rootType.partial);
             break;
-        case "interface mixin":
-            rootType; // $ExpectType InterfaceMixinType
+        case "interface":
+            rootType; // $ExpectType InterfaceType
+            console.log(rootType.inheritance);
             logMembers(rootType.members);
             console.log(rootType.partial);
             break;
@@ -101,15 +101,33 @@ function logMembers(members: webidl2.IDLInterfaceMemberType[]) {
                 console.log(member.nullable);
                 break;
             case "iterable":
-            case "maplike":
-            case "setlike":
-                member; // $ExpectType DeclarationMemberType
+                member; // $ExpectType IterableDeclarationMemberType
                 member.parent; // $ExpectType InterfaceMixinType | InterfaceType
                 member.async; // $ExpectType boolean
-                member.readonly; // $ExpectType boolean
-                console.log(member.readonly);
+                member.readonly; // $ExpectType false
+                member.idlType; // $ExpectType [IDLTypeDescription] | [IDLTypeDescription, IDLTypeDescription]
                 member.idlType.forEach(logIdlType);
                 member.arguments; // $ExpectType Argument[]
+                logArguments(member.arguments);
+                break;
+            case "maplike":
+                member; // $ExpectType MaplikeDeclarationMemberType
+                member.parent; // $ExpectType InterfaceMixinType | InterfaceType
+                member.async; // $ExpectType false
+                member.readonly; // $ExpectType boolean
+                member.idlType; // $ExpectType [IDLTypeDescription, IDLTypeDescription]
+                member.idlType.forEach(logIdlType);
+                member.arguments; // $ExpectType []
+                logArguments(member.arguments);
+                break;
+            case "setlike":
+                member; // $ExpectType SetlikeDeclarationMemberType
+                member.parent; // $ExpectType InterfaceMixinType | InterfaceType
+                member.async; // $ExpectType false
+                member.readonly; // $ExpectType boolean
+                member.idlType; // $ExpectType [IDLTypeDescription]
+                member.idlType.forEach(logIdlType);
+                member.arguments; // $ExpectType []
                 logArguments(member.arguments);
                 break;
             default:


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/w3c/webidl2.js/blob/aa38fd7b922849552e5b8f199fcf9d39cc84b5fd/lib/productions/iterable.js#L8-L60>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
