### PR TITLE
[prompts] Add missing instructions option

### DIFF
--- a/types/prompts/index.d.ts
+++ b/types/prompts/index.d.ts
@@ -87,6 +87,7 @@ declare namespace prompts {
         max?: number;
         float?: boolean;
         round?: number;
+        instructions?: string | boolean;
         increment?: number;
         separator?: string;
         active?: string;

--- a/types/prompts/prompts-tests.ts
+++ b/types/prompts/prompts-tests.ts
@@ -1,16 +1,16 @@
-import prompts = require("prompts");
+import prompts = require('prompts');
 
 type HasProperty<T, K> = K extends keyof T ? true : false;
 
 (async () => {
     const response = await prompts({
-        type: "number",
-        name: "value",
-        message: "Input value to double:",
-        validate: (value: any) => (value < 0 ? `Cant be less than zero` : true)
+        type: 'number',
+        name: 'value',
+        message: 'Input value to double:',
+        validate: (value: any) => (value < 0 ? `Cant be less than zero` : true),
     });
-    const HasPropValue: HasProperty<typeof response, "value"> = true;
-    const DoesntHavePropAsdf: HasProperty<typeof response, "asdf"> = false;
+    const HasPropValue: HasProperty<typeof response, 'value'> = true;
+    const DoesntHavePropAsdf: HasProperty<typeof response, 'asdf'> = false;
 })();
 
 (async () => {
@@ -18,17 +18,17 @@ type HasProperty<T, K> = K extends keyof T ? true : false;
         {
             type: 'text',
             name: 'language',
-            message: "What langauge is the next greatest thing since sliced bread?",
+            message: 'What langauge is the next greatest thing since sliced bread?',
         },
         {
             type: (prev, values) => {
-                const HasPromptName: HasProperty<typeof values, "language"> = true;
-                const DoesntHavePromptTypes: HasProperty<typeof values, "text"> = false;
+                const HasPromptName: HasProperty<typeof values, 'language'> = true;
+                const DoesntHavePromptTypes: HasProperty<typeof values, 'text'> = false;
 
                 return prev === 'javascript' ? 'confirm' : null;
             },
             name: 'confirmation',
-            message: "Have you tried TypeScript?"
+            message: 'Have you tried TypeScript?',
         },
         {
             type: 'select',
@@ -36,20 +36,35 @@ type HasProperty<T, K> = K extends keyof T ? true : false;
             choices: [
                 {
                     title: 'A',
-                    value: 'A'
+                    value: 'A',
                 },
                 {
                     title: 'B',
-                    value: {foo: 'bar'}
+                    value: { foo: 'bar' },
                 },
                 {
                     title: 'C',
                     value: 'C',
                     disabled: false,
                     selected: false,
-                    description: 'a description'
+                    description: 'a description',
                 },
-            ]
-        }
+            ],
+        },
+        {
+            type: 'multiselect',
+            name: 'choices',
+            instructions: false,
+            choices: [
+                {
+                    value: 'A',
+                    title: 'A',
+                },
+                {
+                    value: 'B',
+                    title: 'B',
+                },
+            ],
+        },
     ]);
 })();


### PR DESCRIPTION
The [`instructions` option](https://github.com/terkelg/prompts#options-7) for multiselect prompts is missing.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
