### PR TITLE
[@types/react-redux] Fix type inference for connect() when using action creators that create thunks

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -127,8 +127,8 @@ export type InferableComponentEnhancer<TInjectedProps> =
     InferableComponentEnhancerWithProps<TInjectedProps, {}>;
 
 export type InferThunkActionCreatorType<TActionCreator extends (...args: any[]) => any> =
-    TActionCreator extends (...args: infer TParams) => (...args: any[]) => infer TReturn
-        ? (...args: TParams) => TReturn
+    TActionCreator extends (...args: infer TACParams) => (...args: Array<infer TParams>) => infer TReturn
+        ? (...args: TACParams) => (...args: TParams[]) => TReturn
         : TActionCreator;
 
 export type HandleThunkActionCreator<TActionCreator> =

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -127,8 +127,8 @@ export type InferableComponentEnhancer<TInjectedProps> =
     InferableComponentEnhancerWithProps<TInjectedProps, {}>;
 
 export type InferThunkActionCreatorType<TActionCreator extends (...args: any[]) => any> =
-    TActionCreator extends (...args: infer TACParams) => (...args: Array<infer TParams>) => infer TReturn
-        ? (...args: TACParams) => (...args: TParams[]) => TReturn
+    TActionCreator extends (...args: infer TACParams) => (...args: infer TParams) => infer TReturn
+        ? (...args: TACParams) => (...args: TParams) => TReturn
         : TActionCreator;
 
 export type HandleThunkActionCreator<TActionCreator> =

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -170,7 +170,7 @@ function MapDispatchWithThunkActionCreators() {
     }
     interface TestComponentProps extends OwnProps {
         simpleAction: typeof simpleAction;
-        thunkAction(param1: number, param2: string): Promise<string>;
+        thunkAction: typeof thunkAction;
     }
     class TestComponent extends React.Component<TestComponentProps> { }
 


### PR DESCRIPTION
#### When calling `connect` with `mapDispatchToProps`, the type inference for *actionCreators* that create thunks seems to be incorrect.  It should infer the thunk instead of the return value of the thunk.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [connect-mapDispatchToProps](https://react-redux.js.org/api/connect#object-shorthand-form) [redux-thunk-middleware](https://redux.js.org/api/applymiddleware)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - N/A
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

