### PR TITLE
feat(romans): new definition

### DIFF
--- a/types/romans/index.d.ts
+++ b/types/romans/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for romans 1.0
+// Project: https://github.com/qbunt/romanize#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * A no dependency, simple lib for converting from decimal notation to roman numerals and back again
+ */
+export as namespace romans;
+
+/**
+ * property containing all roman numeral characters
+ * [ 'M', 'CM', 'D', 'CD', 'C', 'XC', 'L', 'XL', 'X', 'IX', 'V', 'IV', 'I' ]
+ */
+export const allChars: string[];
+
+/**
+ *  property containing [ 1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1 ]
+ */
+export const allNumerals: number[];
+
+/**
+ * takes in a floating point number, returns a roman numeral string
+ * @param decimal
+ */
+export function romanize(decimal: number): string;
+
+/**
+ * takes in a roman numeral string, returns a number
+ * @param romanStr
+ */
+export function deromanize(romanStr: string): number;

--- a/types/romans/test/romans-tests.cjs.ts
+++ b/types/romans/test/romans-tests.cjs.ts
@@ -1,0 +1,6 @@
+import romans = require('romans');
+
+romans.romanize(454); // $ExpectType string
+romans.deromanize('CDLIV'); // $ExpectType number
+romans.allNumerals; // $ExpectType number[]
+romans.allChars; // $ExpectType string[]

--- a/types/romans/test/romans-tests.global.ts
+++ b/types/romans/test/romans-tests.global.ts
@@ -1,0 +1,4 @@
+romans.romanize(454); // $ExpectType string
+romans.deromanize('CDLIV'); // $ExpectType number
+romans.allNumerals; // $ExpectType number[]
+romans.allChars; // $ExpectType string[]

--- a/types/romans/tsconfig.json
+++ b/types/romans/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "test/romans-tests.cjs.ts",
+        "test/romans-tests.global.ts"
+    ]
+}

--- a/types/romans/tslint.json
+++ b/types/romans/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Simple module converting decimals to Lating script (and back)

- definition file
- tests

https://github.com/qbunt/romans#readme

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.