### PR TITLE
[@types/underscore] Fix for augmented list collection type extraction

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -96,7 +96,7 @@ declare module _ {
         (value: T): boolean;
     }
 
-    interface CollectionIterator<T extends TypeOfCollection<V, any>, TResult, V = Collection<T>> {
+    interface CollectionIterator<T extends TypeOfList<V> | TypeOfDictionary<V, any>, TResult, V = Collection<T>> {
         (element: T, key: CollectionKey<V>, collection: V): TResult;
     }
 
@@ -122,7 +122,7 @@ declare module _ {
 
     type PropertyTypeOrAny<T, K> = K extends keyof T ? T[K] : any;
 
-    interface MemoCollectionIterator<T extends TypeOfCollection<V>, TResult, V = Collection<T>> {
+    interface MemoCollectionIterator<T extends TypeOfList<V> | TypeOfDictionary<V, any>, TResult, V = Collection<T>> {
         (prev: TResult, curr: T, key: CollectionKey<V>, collection: V): TResult;
     }
 
@@ -140,7 +140,7 @@ declare module _ {
         : V extends Dictionary<infer T> ? T
         : TDefault;
 
-    type TypeOfCollection<V, TObjectDefault = never> = TypeOfList<V> | TypeOfDictionary<V, TObjectDefault>;
+    type TypeOfCollection<V, TObjectDefault = never> = V extends List<any> ? TypeOfList<V> : TypeOfDictionary<V, TObjectDefault>;
 
     type ListItemOrSelf<T> = T extends List<infer TItem> ? TItem : T;
 

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -22,7 +22,7 @@ interface AugmentedList extends _.List<StringRecord> {
 type AugmentedListLiteral = {
     [index: number]: StringRecord;
     length: number;
-    otherProperty: string;
+    notAListProperty: string;
 };
 
 interface ExplicitDictionary extends _.Dictionary<StringRecord> {
@@ -36,7 +36,7 @@ type ExplicitDictionaryLiteral = {
     a: StringRecord;
     b: StringRecord;
     c: StringRecord;
-}
+};
 
 declare const shallowProperty: 'a';
 declare const deepProperty: ['a', 'length'];

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -18,7 +18,21 @@ interface AugmentedList extends _.List<StringRecord> {
     notAListProperty: boolean;
 }
 
+// tslint:disable-next-line:interface-over-type-literal
+type AugmentedListLiteral = {
+    [index: number]: StringRecord;
+    length: number;
+    otherProperty: string;
+};
+
 interface ExplicitDictionary extends _.Dictionary<StringRecord> {
+    a: StringRecord;
+    b: StringRecord;
+    c: StringRecord;
+}
+
+// tslint:disable-next-line:interface-over-type-literal
+type ExplicitDictionaryLiteral = {
     a: StringRecord;
     b: StringRecord;
     c: StringRecord;
@@ -801,6 +815,28 @@ declare const extractChainTypes: ChainTypeExtractor;
 
 // Types
 
+// TypeOfCollection
+declare const listItem: _.TypeOfCollection<_.List<StringRecord>>;
+listItem; // $ExpectType StringRecord
+
+declare const arrayItem: _.TypeOfCollection<StringRecord[]>;
+arrayItem; // $ExpectType StringRecord
+
+declare const augmentedListItem: _.TypeOfCollection<AugmentedList>;
+augmentedListItem; // $ExpectType StringRecord
+
+declare const augmentedListLiteralItem: _.TypeOfCollection<AugmentedListLiteral>;
+augmentedListLiteralItem; // $ExpectType StringRecord
+
+declare const dictionaryItem: _.TypeOfCollection<_.Dictionary<StringRecord>>;
+dictionaryItem; // $ExpectType StringRecord
+
+declare const explicitDictionaryItem: _.TypeOfCollection<ExplicitDictionary>;
+explicitDictionaryItem; // $ExpectType StringRecord
+
+declare const explicitDictionaryLiteralItem: _.TypeOfCollection<ExplicitDictionaryLiteral>;
+explicitDictionaryLiteralItem; // $ExpectType StringRecord
+
 // Iteratee
 {
     // functions
@@ -831,7 +867,7 @@ declare const extractChainTypes: ChainTypeExtractor;
     const collectionFunctionIteratee: _.Iteratee<_.Dictionary<StringRecord> | StringRecord[], string> = (element, key, collection) => {
         element; // $ExpectType StringRecord
         key; // $ExpectType string | number
-        collection; // $ExpectType Dictionary<StringRecord> | StringRecord[]
+        collection; // $ExpectType StringRecord[] | Dictionary<StringRecord>
         return element.a;
     };
     collectionFunctionIteratee(recordDictionary['a'], 'a', recordDictionary); // $ExpectType string


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This fixes an issue where TypeOfCollection is extracting both the list and dictionary types from augmented list types. In cases where Underscore functions take a collection, Underscore prefers list implementations and falls back to dictionary implementations; this keeps TypeOfCollection consistent with that behavior while still allowing TypeOfDictionary to treat lists as objects for Object functions that don't handle lists differently from other objects (e.g. `pick` and `omit`).

I ran into this when updating the codebase of the company that I work for to TS4.0 - after upgrading, the type `JQuery<HTMLElement>` started being interpreted as both a list and a dictionary. I attempted to replicate this behavior in tests by using interfaces (going so far as to try generics and an interface with the same name as a namespace) but was unable to do so. However, the use of type literals still allowed for a comparable repro to help prevent regressions in the future.