### PR TITLE
`jest`: force `toEqual` type to match input

### DIFF
--- a/types/jest/ts3.1/index.d.ts
+++ b/types/jest/ts3.1/index.d.ts
@@ -818,12 +818,9 @@ declare namespace jest {
         /**
          * Used when you want to check that two objects have the same value.
          * This matcher recursively checks the equality of all fields, rather than checking for object identity.
-         *
-         * Optionally, you can provide a type for the expected value via a generic.
-         * This is particularly useful for ensuring expected objects have the right structure.
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        toEqual<E = any>(expected: E): R;
+        toEqual(expected: T extends Promise<infer P> ? P : T): R;
         /**
          * Ensures that a mock function is called.
          */

--- a/types/jest/ts3.1/jest-tests.ts
+++ b/types/jest/ts3.1/jest-tests.ts
@@ -823,6 +823,8 @@ describe('', () => {
         expect('').resolves.resolves;
         // $ExpectType void
         expect('').toEqual('');
+        // $ExpectError
+        expect('').toEqual(1);
         // $ExpectType Promise<void>
         expect(Promise.resolve('')).resolves.toEqual('');
 
@@ -1034,8 +1036,10 @@ describe('', () => {
 
         /* Promise matchers */
 
-        expect(Promise.reject('jest')).rejects.toEqual('jest').then(() => {});
-        expect(Promise.reject('jest')).rejects.not.toEqual('other').then(() => {});
+        // tslint:disable-next-line: no-unnecessary-type-assertion
+        expect(Promise.reject('jest') as Promise<string>).rejects.toEqual('jest').then(() => {});
+        // tslint:disable-next-line: no-unnecessary-type-assertion
+        expect(Promise.reject('jest') as Promise<string>).rejects.not.toEqual('other').then(() => {});
 
         expect(Promise.resolve('jest')).resolves.toEqual('jest').then(() => {});
         expect(Promise.resolve('jest')).resolves.not.toEqual('other').then(() => {});


### PR DESCRIPTION
I think this implements https://github.com/DefinitelyTyped/DefinitelyTyped/issues/27840.

IIUC, the value passed to `toEqual` should _always_ have the same type as the input (the value passed to `expect`). I can not think of a single use case where you would want the types to be different (excepts `Promise`s, which I have handled in this PR).

I suppose we should also make this change to `toStrictEqual` and `toBe`. Any others I'm missing?

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.