### PR TITLE
add types for @terraformer/arcgis

### DIFF
--- a/types/terraformer__arcgis/index.d.ts
+++ b/types/terraformer__arcgis/index.d.ts
@@ -7,5 +7,6 @@
 import * as GeoJSON from 'geojson';
 import * as ArcGIS from 'arcgis-rest-api';
 
-export function arcgisToGeoJSON<T extends ArcGIS.Geometry>(arcgis: T): GeoJSON.GeometryObject;
+// tslint:disable-next-line [no-unnecessary-generics]
+export function arcgisToGeoJSON(arcgis: ArcGIS.Geometry): GeoJSON.GeometryObject;
 export function geojsonToArcGIS(geojson: GeoJSON.GeometryObject): ArcGIS.Geometry;

--- a/types/terraformer__arcgis/index.d.ts
+++ b/types/terraformer__arcgis/index.d.ts
@@ -8,5 +8,5 @@ import * as GeoJSON from 'geojson';
 import * as ArcGIS from 'arcgis-rest-api';
 
 // tslint:disable-next-line [no-unnecessary-generics]
-export function arcgisToGeoJSON(arcgis: ArcGIS.Geometry): GeoJSON.GeometryObject;
-export function geojsonToArcGIS(geojson: GeoJSON.GeometryObject): ArcGIS.Geometry;
+export function arcgisToGeoJSON(arcgis: ArcGIS.Geometry, idAttribute?: string): GeoJSON.GeometryObject;
+export function geojsonToArcGIS(geojson: GeoJSON.GeometryObject, idAttribute?: string): ArcGIS.Geometry;

--- a/types/terraformer__arcgis/index.d.ts
+++ b/types/terraformer__arcgis/index.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for @terraformer/arcgis 2.0
+// Project: https://github.com/terraformer-js/terraformer
+// Definitions by: Jeff Jacobson <https://github.com/JeffJacobson>, Gavin Rehkemper <https://github.com/gavinr>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.7
+
+import * as GeoJSON from 'geojson';
+import * as ArcGIS from 'arcgis-rest-api';
+
+export function arcgisToGeoJSON<T extends ArcGIS.Geometry>(arcgis: T): GeoJSON.GeometryObject;
+export function geojsonToArcGIS(geojson: GeoJSON.GeometryObject): ArcGIS.Geometry;

--- a/types/terraformer__arcgis/index.d.ts
+++ b/types/terraformer__arcgis/index.d.ts
@@ -7,6 +7,5 @@
 import * as GeoJSON from 'geojson';
 import * as ArcGIS from 'arcgis-rest-api';
 
-// tslint:disable-next-line [no-unnecessary-generics]
 export function arcgisToGeoJSON(arcgis: ArcGIS.Geometry, idAttribute?: string): GeoJSON.GeometryObject;
 export function geojsonToArcGIS(geojson: GeoJSON.GeometryObject, idAttribute?: string): ArcGIS.Geometry;

--- a/types/terraformer__arcgis/terraformer__arcgis-tests.ts
+++ b/types/terraformer__arcgis/terraformer__arcgis-tests.ts
@@ -1,0 +1,20 @@
+import * as arcgisApi from 'arcgis-rest-api';
+import * as Terraformer from '@terraformer/arcgis';
+
+const arcgisPoint: arcgisApi.Point = {
+    x: -122.6764,
+    y: 45.5165,
+    spatialReference: {
+        wkid: 4326,
+    },
+};
+const geojsonPoint: GeoJSON.Point = {
+    type: 'Point',
+    coordinates: [45.5165, -122.6764],
+};
+
+// parse ArcGIS JSON, convert it to GeoJSON
+Terraformer.arcgisToGeoJSON(arcgisPoint);
+
+// take GeoJSON and convert it to ArcGIS JSON
+Terraformer.geojsonToArcGIS(geojsonPoint);

--- a/types/terraformer__arcgis/tsconfig.json
+++ b/types/terraformer__arcgis/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@terraformer/arcgis": ["terraformer__arcgis"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "terraformer__arcgis-tests.ts"
+    ]
+} 

--- a/types/terraformer__arcgis/tslint.json
+++ b/types/terraformer__arcgis/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

https://github.com/terraformer-js/terraformer/issues/46 cc @jgravois