### PR TITLE
[node] crypto fixes, additions

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -282,15 +282,26 @@ declare module "crypto" {
 
     function createSign(algorithm: string, options?: stream.WritableOptions): Signer;
 
+    type DSAEncoding = 'der' | 'ieee-p1363';
+
     interface SigningOptions {
         /**
          * @See crypto.constants.RSA_PKCS1_PADDING
          */
         padding?: number;
         saltLength?: number;
+        dsaEncoding?: DSAEncoding;
     }
 
     interface SignPrivateKeyInput extends PrivateKeyInput, SigningOptions {
+    }
+    interface SignKeyObjectInput extends SigningOptions {
+        key: KeyObject;
+    }
+    interface VerifyPublicKeyInput extends PublicKeyInput, SigningOptions {
+    }
+    interface VerifyKeyObjectInput extends SigningOptions {
+        key: KeyObject;
     }
 
     type KeyLike = string | Buffer | KeyObject;
@@ -300,8 +311,8 @@ declare module "crypto" {
 
         update(data: BinaryLike): Signer;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Signer;
-        sign(private_key: SignPrivateKeyInput | KeyLike): Buffer;
-        sign(private_key: SignPrivateKeyInput | KeyLike, output_format: HexBase64Latin1Encoding): string;
+        sign(private_key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput): Buffer;
+        sign(private_key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput, output_format: HexBase64Latin1Encoding): string;
     }
 
     function createVerify(algorithm: string, options?: stream.WritableOptions): Verify;
@@ -310,8 +321,8 @@ declare module "crypto" {
 
         update(data: BinaryLike): Verify;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Verify;
-        verify(object: object | KeyLike, signature: NodeJS.ArrayBufferView): boolean;
-        verify(object: object | KeyLike, signature: string, signature_format?: HexBase64Latin1Encoding): boolean;
+        verify(object: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput, signature: NodeJS.ArrayBufferView): boolean;
+        verify(object: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput, signature: string, signature_format?: HexBase64Latin1Encoding): boolean;
         // https://nodejs.org/api/crypto.html#crypto_verifier_verify_object_signature_signature_format
         // The signature field accepts a TypedArray type, but it is only available starting ES2017
     }
@@ -672,10 +683,7 @@ declare module "crypto" {
      * If `key` is not a [`KeyObject`][], this function behaves as if `key` had been
      * passed to [`crypto.createPrivateKey()`][].
      */
-    function sign(algorithm: string | null | undefined, data: NodeJS.ArrayBufferView, key: KeyLike | SignPrivateKeyInput): Buffer;
-
-    interface VerifyKeyWithOptions extends KeyObject, SigningOptions {
-    }
+    function sign(algorithm: string | null | undefined, data: NodeJS.ArrayBufferView, key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput): Buffer;
 
     /**
      * Calculates and returns the signature for `data` using the given private key and
@@ -685,7 +693,7 @@ declare module "crypto" {
      * If `key` is not a [`KeyObject`][], this function behaves as if `key` had been
      * passed to [`crypto.createPublicKey()`][].
      */
-    function verify(algorithm: string | null | undefined, data: NodeJS.ArrayBufferView, key: KeyLike | VerifyKeyWithOptions, signature: NodeJS.ArrayBufferView): boolean;
+    function verify(algorithm: string | null | undefined, data: NodeJS.ArrayBufferView, key: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput, signature: NodeJS.ArrayBufferView): boolean;
 
     /**
      * Computes the Diffie-Hellman secret based on a privateKey and a publicKey.

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -211,14 +211,14 @@ declare module "crypto" {
         final(output_encoding: BufferEncoding): string;
         setAutoPadding(auto_padding?: boolean): this;
         // getAuthTag(): Buffer;
-        // setAAD(buffer: Buffer): this; // docs only say buffer
+        // setAAD(buffer: NodeJS.ArrayBufferView): this;
     }
     interface CipherCCM extends Cipher {
-        setAAD(buffer: Buffer, options: { plaintextLength: number }): this;
+        setAAD(buffer: NodeJS.ArrayBufferView, options: { plaintextLength: number }): this;
         getAuthTag(): Buffer;
     }
     interface CipherGCM extends Cipher {
-        setAAD(buffer: Buffer, options?: { plaintextLength: number }): this;
+        setAAD(buffer: NodeJS.ArrayBufferView, options?: { plaintextLength: number }): this;
         getAuthTag(): Buffer;
     }
     /** @deprecated since v10.0.0 use `createDecipheriv()` */

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -790,3 +790,51 @@ import { promisify } from 'util';
     crypto.randomInt(10, callback);
     crypto.randomInt(1, 10, callback);
 }
+
+{
+    const key = crypto.createPrivateKey('pkey');
+    crypto.sign('sha256', Buffer.from('asd'), {
+        key: Buffer.from('keylike'),
+        dsaEncoding: 'der'
+    });
+    crypto.createSign('sha256')
+        .update(Buffer.from('asd'))
+        .sign({
+            key: Buffer.from('keylike'),
+            dsaEncoding: 'der'
+        });
+    crypto.sign('sha256', Buffer.from('asd'), {
+        key,
+        dsaEncoding: 'der'
+    });
+    crypto.createSign('sha256')
+        .update(Buffer.from('asd'))
+        .sign({
+            key,
+            dsaEncoding: 'der'
+        });
+}
+
+{
+    const key = crypto.createPublicKey('pkey');
+    crypto.verify('sha256', Buffer.from('asd'), {
+        key: Buffer.from('keylike'),
+        dsaEncoding: 'der'
+    }, Buffer.from('sig'));
+    crypto.createVerify('sha256')
+        .update(Buffer.from('asd'))
+        .verify({
+            key: Buffer.from('keylike'),
+            dsaEncoding: 'der'
+        }, Buffer.from('sig'));
+    crypto.verify('sha256', Buffer.from('asd'), {
+        key,
+        dsaEncoding: 'der'
+    }, Buffer.from('sig'));
+    crypto.createVerify('sha256')
+        .update(Buffer.from('asd'))
+        .verify({
+            key,
+            dsaEncoding: 'der'
+        }, Buffer.from('sig'));
+}

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -838,3 +838,9 @@ import { promisify } from 'util';
             dsaEncoding: 'der'
         }, Buffer.from('sig'));
 }
+
+{
+    const cipher = crypto.createCipheriv('aes-256-gcm', Buffer.from('key'), Buffer.from('iv'), { authTagLength: 16 });
+    cipher.setAAD(Buffer.from('iv'));
+    cipher.setAAD(new Uint8Array());
+}

--- a/types/node/v12/crypto.d.ts
+++ b/types/node/v12/crypto.d.ts
@@ -281,15 +281,26 @@ declare module "crypto" {
 
     function createSign(algorithm: string, options?: stream.WritableOptions): Signer;
 
+    type DSAEncoding = 'der' | 'ieee-p1363';
+
     interface SigningOptions {
         /**
          * @See crypto.constants.RSA_PKCS1_PADDING
          */
         padding?: number;
         saltLength?: number;
+        dsaEncoding?: DSAEncoding;
     }
 
     interface SignPrivateKeyInput extends PrivateKeyInput, SigningOptions {
+    }
+    interface SignKeyObjectInput extends SigningOptions {
+        key: KeyObject;
+    }
+    interface VerifyPublicKeyInput extends PublicKeyInput, SigningOptions {
+    }
+    interface VerifyKeyObjectInput extends SigningOptions {
+        key: KeyObject;
     }
 
     type KeyLike = string | Buffer | KeyObject;
@@ -299,8 +310,8 @@ declare module "crypto" {
 
         update(data: BinaryLike): Signer;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Signer;
-        sign(private_key: SignPrivateKeyInput | KeyLike): Buffer;
-        sign(private_key: SignPrivateKeyInput | KeyLike, output_format: HexBase64Latin1Encoding): string;
+        sign(private_key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput): Buffer;
+        sign(private_key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput, output_format: HexBase64Latin1Encoding): string;
     }
 
     function createVerify(algorithm: string, options?: stream.WritableOptions): Verify;
@@ -309,8 +320,8 @@ declare module "crypto" {
 
         update(data: BinaryLike): Verify;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Verify;
-        verify(object: Object | KeyLike, signature: NodeJS.ArrayBufferView): boolean;
-        verify(object: Object | KeyLike, signature: string, signature_format?: HexBase64Latin1Encoding): boolean;
+        verify(object: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput, signature: NodeJS.ArrayBufferView): boolean;
+        verify(object: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput, signature: string, signature_format?: HexBase64Latin1Encoding): boolean;
         // https://nodejs.org/api/crypto.html#crypto_verifier_verify_object_signature_signature_format
         // The signature field accepts a TypedArray type, but it is only available starting ES2017
     }
@@ -598,10 +609,7 @@ declare module "crypto" {
      * If `key` is not a [`KeyObject`][], this function behaves as if `key` had been
      * passed to [`crypto.createPrivateKey()`][].
      */
-    function sign(algorithm: string | null | undefined, data: NodeJS.ArrayBufferView, key: KeyLike | SignPrivateKeyInput): Buffer;
-
-    interface VerifyKeyWithOptions extends KeyObject, SigningOptions {
-    }
+    function sign(algorithm: string | null | undefined, data: NodeJS.ArrayBufferView, key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput): Buffer;
 
     /**
      * Calculates and returns the signature for `data` using the given private key and
@@ -611,5 +619,5 @@ declare module "crypto" {
      * If `key` is not a [`KeyObject`][], this function behaves as if `key` had been
      * passed to [`crypto.createPublicKey()`][].
      */
-    function verify(algorithm: string | null | undefined, data: NodeJS.ArrayBufferView, key: KeyLike | VerifyKeyWithOptions, signature: NodeJS.ArrayBufferView): Buffer;
+    function verify(algorithm: string | null | undefined, data: NodeJS.ArrayBufferView, key: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput, signature: NodeJS.ArrayBufferView): Buffer;
 }

--- a/types/node/v12/crypto.d.ts
+++ b/types/node/v12/crypto.d.ts
@@ -210,14 +210,14 @@ declare module "crypto" {
         final(output_encoding: string): string;
         setAutoPadding(auto_padding?: boolean): this;
         // getAuthTag(): Buffer;
-        // setAAD(buffer: Buffer): this; // docs only say buffer
+        // setAAD(buffer: NodeJS.ArrayBufferView): this;
     }
     interface CipherCCM extends Cipher {
-        setAAD(buffer: Buffer, options: { plaintextLength: number }): this;
+        setAAD(buffer: NodeJS.ArrayBufferView, options: { plaintextLength: number }): this;
         getAuthTag(): Buffer;
     }
     interface CipherGCM extends Cipher {
-        setAAD(buffer: Buffer, options?: { plaintextLength: number }): this;
+        setAAD(buffer: NodeJS.ArrayBufferView, options?: { plaintextLength: number }): this;
         getAuthTag(): Buffer;
     }
     /** @deprecated since v10.0.0 use createDecipheriv() */

--- a/types/node/v12/test/crypto.ts
+++ b/types/node/v12/test/crypto.ts
@@ -689,3 +689,51 @@ import { promisify } from 'util';
     const bufP: Buffer = crypto.privateEncrypt(key, Buffer.from([]));
     const decp: Buffer = crypto.privateDecrypt(key, bufP);
 }
+
+{
+    const key = crypto.createPrivateKey('pkey');
+    crypto.sign('sha256', Buffer.from('asd'), {
+        key: Buffer.from('keylike'),
+        dsaEncoding: 'der'
+    });
+    crypto.createSign('sha256')
+        .update(Buffer.from('asd'))
+        .sign({
+            key: Buffer.from('keylike'),
+            dsaEncoding: 'der'
+        });
+    crypto.sign('sha256', Buffer.from('asd'), {
+        key,
+        dsaEncoding: 'der'
+    });
+    crypto.createSign('sha256')
+        .update(Buffer.from('asd'))
+        .sign({
+            key,
+            dsaEncoding: 'der'
+        });
+}
+
+{
+    const key = crypto.createPublicKey('pkey');
+    crypto.verify('sha256', Buffer.from('asd'), {
+        key: Buffer.from('keylike'),
+        dsaEncoding: 'der'
+    }, Buffer.from('sig'));
+    crypto.createVerify('sha256')
+        .update(Buffer.from('asd'))
+        .verify({
+            key: Buffer.from('keylike'),
+            dsaEncoding: 'der'
+        }, Buffer.from('sig'));
+    crypto.verify('sha256', Buffer.from('asd'), {
+        key,
+        dsaEncoding: 'der'
+    }, Buffer.from('sig'));
+    crypto.createVerify('sha256')
+        .update(Buffer.from('asd'))
+        .verify({
+            key,
+            dsaEncoding: 'der'
+        }, Buffer.from('sig'));
+}

--- a/types/node/v12/test/crypto.ts
+++ b/types/node/v12/test/crypto.ts
@@ -737,3 +737,9 @@ import { promisify } from 'util';
             dsaEncoding: 'der'
         }, Buffer.from('sig'));
 }
+
+{
+    const cipher = crypto.createCipheriv('aes-256-gcm', Buffer.from('key'), Buffer.from('iv'), { authTagLength: 16 });
+    cipher.setAAD(Buffer.from('iv'));
+    cipher.setAAD(new Uint8Array());
+}


### PR DESCRIPTION
- adds `NodeJS.ArrayBufferView` as a valid `setAAD` argument as per the docs ([12](https://nodejs.org/docs/latest-v12.x/api/crypto.html#crypto_cipher_setaad_buffer_options), [14](https://nodejs.org/docs/latest-v14.x/api/crypto.html#crypto_cipher_setaad_buffer_options))
- adds `dsaEncoding` option to Sign.sign, Verify.verify, crypto.sign and crypto.verify (added in [v12.16.0](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#2020-02-11-version-12160-erbium-lts-targos))
- allows KeyObject instance as the `key` property of the `object` argument on verify operations as per the actual handling - [code](https://github.com/nodejs/node/blob/9d12c14b19bc30baa4cf556a0b8281e76637f7db/lib/internal/crypto/keys.js#L273)
- allows KeyObject instance as the `key` property of the `private_key` / `key` argument on sign operations as per the actual handling - [code](https://github.com/nodejs/node/blob/9d12c14b19bc30baa4cf556a0b8281e76637f7db/lib/internal/crypto/keys.js#L273)
- adds tests for all of the above

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).