### PR TITLE
[ioBroker] Remove the constraint for Object.native

### DIFF
--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -63,15 +63,6 @@ declare global {
 
         type Languages = 'en' | 'de' | 'ru' | 'pt' | 'nl' | 'fr' | 'it' | 'es' | 'pl' | 'zh-cn';
 
-        // Objects are JSON-serializable
-        type ObjectField =
-            | string
-            | number
-            | boolean
-            | null
-            | ObjectField[]
-            | {[property: string]: ObjectField};
-
         interface ObjectCommon {
             /** name of this object */
             name: string;
@@ -171,7 +162,7 @@ declare global {
             members?: string[];
         }
         interface OtherCommon extends ObjectCommon {
-            [propName: string]: ObjectField | undefined;
+            [propName: string]: any;
 
             // Only states can have common.custom
             custom?: undefined;
@@ -180,8 +171,9 @@ declare global {
         interface BaseObject {
             /** The ID of this object */
             _id: string;
-            // Be strict with what we allow here. Read objects overwrite this with any.
-            native: Record<string, ObjectField>;
+            // Ideally we would limit this to JSON-serializable objects, but TypeScript doesn't allow this
+            // without bugging users to change their code --> https://github.com/microsoft/TypeScript/issues/15300
+            native: any;
             /** An array of `native` properties which cannot be accessed from outside the defining adapter */
             protectedNative?: string[];
             /** Like protectedNative, but the properties are also encrypted and decrypted automatically */

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -274,17 +274,18 @@ adapter.setObject(
     },
 );
 
-adapter.setObject('id', {
-    type: 'device',
-    common: {
-        name: 'foo',
-    },
-    native: {
-        // Date is not allowed here
-        // $ExpectError
-        date: new Date(),
-    },
-});
+// TODO: Cannot enforce this without making it impossible to use interfaces to describe the shape of `native`
+// adapter.setObject('id', {
+//     type: 'device',
+//     common: {
+//         name: 'foo',
+//     },
+//     native: {
+//         // Date is not allowed here
+//         // $ExpectError
+//         date: new Date(),
+//     },
+// });
 
 adapter.getObjectView('system', 'admin', { startkey: 'foo', endkey: 'bar' }, (err, docs) => {
     docs && docs.rows[0] && docs.rows[0].id.toLowerCase();
@@ -532,3 +533,30 @@ adapter.clearTimeout(adapter.setInterval(() => {}, 10));
 adapter.delFile(null, "foo", (err) => {
     if (err) err.message;
 });
+// Repro from ioBroker.i2c
+{
+    interface PCF8574Config {
+        pollingInterval: number;
+        interrupt?: string;
+        pins: PinConfig[];
+    }
+
+    interface PinConfig {
+        dir: 'in' | 'out';
+        inv?: boolean;
+    }
+
+    const config: PCF8574Config = undefined as any;
+
+    adapter.extendObject(`some state`, {
+        type: 'state',
+        common: {
+            name: `some name`,
+            read: true,
+            write: false,
+            type: 'boolean',
+            role: 'indicator',
+        },
+        native: config,
+    });
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **I previously changed this to be stricter, but until https://github.com/microsoft/TypeScript/issues/15300 is solved, it is impossible to just allow any JSON-like structure for `native`
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~
