### PR TITLE
[iobroker] Use Node.js native errors in methods that return them

### DIFF
--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -1665,8 +1665,8 @@ declare global {
                 options?: unknown,
             ): ReadDirPromise;
 
-            mkDir(adapterName: string | null, path: string, callback: ErrorCallback): void;
-            mkDir(adapterName: string | null, path: string, options: unknown, callback: ErrorCallback): void;
+            mkDir(adapterName: string | null, path: string, callback: ErrnoCallback): void;
+            mkDir(adapterName: string | null, path: string, options: unknown, callback: ErrnoCallback): void;
             mkDirAsync(adapterName: string | null, path: string, options?: unknown): Promise<void>;
 
             readFile(adapterName: string | null, path: string, callback: ReadFileCallback): void;
@@ -1677,14 +1677,14 @@ declare global {
                 options?: unknown,
             ): ReadFilePromise;
 
-            writeFile(adapterName: string | null, path: string, data: Buffer | string, callback: ErrorCallback): void;
+            writeFile(adapterName: string | null, path: string, data: Buffer | string, callback: ErrnoCallback): void;
             // options see https://github.com/ioBroker/ioBroker.js-controller/blob/master/lib/objects/objectsInMemServer.js#L599
             writeFile(
                 adapterName: string | null,
                 path: string,
                 data: Buffer | string,
                 options: unknown,
-                callback: ErrorCallback,
+                callback: ErrnoCallback,
             ): void;
             writeFileAsync(
                 adapterName: string | null,
@@ -1698,8 +1698,8 @@ declare global {
              * @param adapterName - adapter name. If adapter name is null, default will be the name of the current adapter.
              * @param path - path to directory without adapter name. E.g. If you want to delete "/vis.0/main/views.json", here must be "/main/views.json" and _adapter must be equal to "vis.0".
              */
-            delFile(adapterName: string | null, path: string, callback: ErrorCallback): void;
-            delFile(adapterName: string | null, path: string, options: unknown, callback: ErrorCallback): void;
+            delFile(adapterName: string | null, path: string, callback: ErrnoCallback): void;
+            delFile(adapterName: string | null, path: string, options: unknown, callback: ErrnoCallback): void;
             /**
              * Deletes a given file
              * @param adapterName - adapter name. If adapter name is null, default will be the name of the current adapter.
@@ -1712,8 +1712,8 @@ declare global {
              * @param adapterName - adapter name. If adapter name is null, default will be the name of the current adapter.
              * @param path - path to directory without adapter name. E.g. If you want to delete "/vis.0/main/views.json", here must be "/main/views.json" and _adapter must be equal to "vis.0".
              */
-            unlink(adapterName: string | null, path: string, callback: ErrorCallback): void;
-            unlink(adapterName: string | null, path: string, options: unknown, callback: ErrorCallback): void;
+            unlink(adapterName: string | null, path: string, callback: ErrnoCallback): void;
+            unlink(adapterName: string | null, path: string, options: unknown, callback: ErrnoCallback): void;
             /**
              * Deletes a given file
              * @param adapterName - adapter name. If adapter name is null, default will be the name of the current adapter.
@@ -1721,13 +1721,13 @@ declare global {
              */
             unlinkAsync(adapterName: string | null, path: string, options?: unknown): Promise<void>;
 
-            rename(adapterName: string | null, oldName: string, newName: string, callback: ErrorCallback): void;
+            rename(adapterName: string | null, oldName: string, newName: string, callback: ErrnoCallback): void;
             rename(
                 adapterName: string | null,
                 oldName: string,
                 newName: string,
                 options: unknown,
-                callback: ErrorCallback,
+                callback: ErrnoCallback,
             ): void;
             renameAsync(adapterName: string | null, oldName: string, newName: string, options?: unknown): Promise<void>;
 
@@ -1818,6 +1818,8 @@ declare global {
 
         type EmptyCallback = () => void;
         type ErrorCallback = (err?: Error | null) => void;
+        /** Special variant of ErrorCallback for methods where Node.js returns an ErrnoException */
+        type ErrnoCallback = (err?: NodeJS.ErrnoException | null) => void;
         // TODO: Redefine callbacks as subclass of GenericCallback
         type GenericCallback<T> = (err?: Error | null, result?: T) => void;
 
@@ -1914,10 +1916,10 @@ declare global {
             /** Date of creation */
             createdAt?: number;
         }
-        type ReadDirCallback = (err?: Error | null, entries?: ReadDirResult[]) => void;
+        type ReadDirCallback = (err?: NodeJS.ErrnoException | null, entries?: ReadDirResult[]) => void;
         type ReadDirPromise = Promise<NonNullCallbackReturnTypeOf<ReadDirCallback>>;
 
-        type ReadFileCallback = (err?: Error | null, file?: Buffer | string, mimeType?: string) => void;
+        type ReadFileCallback = (err?: NodeJS.ErrnoException | null, file?: Buffer | string, mimeType?: string) => void;
         type ReadFilePromise = Promise<{ file: string | Buffer; mimeType: string }>;
 
         /** Contains the return values of chownFile */
@@ -1937,7 +1939,7 @@ declare global {
             /** Date of creation */
             createdAt: number;
         }
-        type ChownFileCallback = (err?: Error | null, entries?: ChownFileResult[], id?: string) => void;
+        type ChownFileCallback = (err?: NodeJS.ErrnoException | null, entries?: ChownFileResult[], id?: string) => void;
 
         /** Contains the return values of rm */
         interface RmResult {
@@ -1948,9 +1950,9 @@ declare global {
             /** Whether the deleted object was a directory or a file */
             isDir: boolean;
         }
-        type RmCallback = (err?: Error | null, entries?: RmResult[]) => void;
+        type RmCallback = (err?: NodeJS.ErrnoException | null, entries?: RmResult[]) => void;
 
-        type ChownObjectCallback = (err?: Error | null, list?: ioBroker.Object[]) => void;
+        type ChownObjectCallback = (err?: NodeJS.ErrnoException | null, list?: ioBroker.Object[]) => void;
 
         type GetConfigKeysCallback = (err?: Error | null, list?: string[]) => void;
 

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -531,8 +531,14 @@ adapter.clearTimeout(adapter.setInterval(() => {}, 10));
 
 // Error callbacks were changed to Error objects
 adapter.delFile(null, "foo", (err) => {
-    if (err) err.message;
+    if (err) {
+        // And the fs-specific ones now contain the code
+        err.code;
+        err.message;
+        err.syscall;
+    }
 });
+
 // Repro from ioBroker.i2c
 {
     interface PCF8574Config {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **nothing specific, but several of JS-Controller's methods just pass errors through. In these cases, Node.js uses ErrnoExceptions, which have additional properties**
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~
