### PR TITLE
[ioBroker] allow language dictionaries in Object.common.name

### DIFF
--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -64,8 +64,8 @@ declare global {
         type Languages = 'en' | 'de' | 'ru' | 'pt' | 'nl' | 'fr' | 'it' | 'es' | 'pl' | 'zh-cn';
 
         interface ObjectCommon {
-            /** name of this object */
-            name: string;
+            /** The name of this object as a simple string or an object with translations */
+            name: string | { [lang in Languages]?: string; };
 
             // Icon and role aren't defined in SCHEMA.md,
             // but they are being used by some adapters

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -53,7 +53,10 @@ function objectChangeHandler(id: string, object: ioBroker.Object | null | undefi
     // Test properties of all objects
     if (object) {
         object._id.toLowerCase();
-        object.common.name.toLowerCase();
+        const name = object.common.name;
+        if (typeof name !== "string") {
+            name.de; // $ExpectType string | undefined
+        }
         object.common.role && object.common.role.toLowerCase();
         object.common.icon && object.common.icon.toLowerCase();
         object.native.toString();
@@ -286,6 +289,16 @@ adapter.setObject(
 //         date: new Date(),
 //     },
 // });
+
+// Check that name as object is okay:
+adapter.extendForeignObject("id", {
+    common: {
+        name: {
+            en: "foobar",
+            fr: "le foo de bar",
+        }
+    }
+});
 
 adapter.getObjectView('system', 'admin', { startkey: 'foo', endkey: 'bar' }, (err, docs) => {
     docs && docs.rows[0] && docs.rows[0].id.toLowerCase();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **apparently, this has been like this for a while but there's no documentation.**
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~
