### PR TITLE
[gestalt-datepicker] Add type definitions

### DIFF
--- a/types/gestalt-datepicker/gestalt-datepicker-tests.tsx
+++ b/types/gestalt-datepicker/gestalt-datepicker-tests.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { DatePicker } from 'gestalt-datepicker';
+
+const handleChange = (value: Date) => value;
+
+<DatePicker id="example-basic" label="Select a date" onChange={({ value }) => handleChange(value)} />;
+<DatePicker
+    disabled
+    id="example-preselected value"
+    minDate={new Date(1984, 6, 6)}
+    maxDate={new Date(2020, 6, 10)}
+    label="Alberto's birth date"
+    onChange={({ value }) => handleChange(value)}
+    value={new Date(1985, 6, 4)}
+/>;

--- a/types/gestalt-datepicker/gestalt-datepicker-tests.tsx
+++ b/types/gestalt-datepicker/gestalt-datepicker-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DatePicker } from 'gestalt-datepicker';
+import DatePicker from 'gestalt-datepicker';
 
 const handleChange = (value: Date) => value;
 

--- a/types/gestalt-datepicker/index.d.ts
+++ b/types/gestalt-datepicker/index.d.ts
@@ -35,4 +35,4 @@ export interface DatePickerProps {
     value?: Date;
 }
 
-export class DatePicker extends React.Component<DatePickerProps, any> {}
+export default class DatePicker extends React.Component<DatePickerProps, any> {}

--- a/types/gestalt-datepicker/index.d.ts
+++ b/types/gestalt-datepicker/index.d.ts
@@ -1,0 +1,38 @@
+// Type definitions for gestalt-datepicker 13.4
+// Project: https://gestalt.netlify.app/
+// Definitions by: cgu <https://github.com/czgu>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.4
+
+import * as React from 'react';
+import { Locale } from 'date-fns';
+
+/*
+DatePicker Props Interface
+https://gestalt.netlify.app/DatePicker
+*/
+
+export interface DatePickerProps {
+    id: string;
+    onChange: (args: { event: React.SyntheticEvent<HTMLInputElement>; value: Date }) => void;
+    disabled?: boolean;
+    errorMessage?: string;
+    excludeDates?: ReadonlyArray<Date>;
+    helperText?: string;
+    idealDirection?: 'up' | 'right' | 'down' | 'left';
+    includeDates?: ReadonlyArray<Date>;
+    label?: string;
+    localeData?: Locale;
+    maxDate?: Date;
+    minDate?: Date;
+    nextRef?: React.Ref<any>;
+
+    placeholder?: string;
+    rangeEndDate?: Date;
+    rangeSelector?: 'start' | 'end';
+    rangeStartDate?: Date;
+    ref?: React.Ref<any>;
+    value?: Date;
+}
+
+export class DatePicker extends React.Component<DatePickerProps, any> {}

--- a/types/gestalt-datepicker/index.d.ts
+++ b/types/gestalt-datepicker/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for gestalt-datepicker 13.4
-// Project: https://gestalt.netlify.app/
+// Project: https://github.com/pinterest/gestalt/tree/master/packages/gestalt-datepicker, https://gestalt.netlify.app/DatePicker
 // Definitions by: cgu <https://github.com/czgu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.4
@@ -10,6 +10,7 @@ import { Locale } from 'date-fns';
 /*
 DatePicker Props Interface
 https://gestalt.netlify.app/DatePicker
+https://github.com/pinterest/gestalt/blob/master/packages/gestalt-datepicker/src/DatePicker.js
 */
 
 export interface DatePickerProps {

--- a/types/gestalt-datepicker/package.json
+++ b/types/gestalt-datepicker/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "date-fns": "^2.0.1"
+    }
+}

--- a/types/gestalt-datepicker/tsconfig.json
+++ b/types/gestalt-datepicker/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "jsx": "react",
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "gestalt-datepicker-tests.tsx"
+    ]
+}

--- a/types/gestalt-datepicker/tslint.json
+++ b/types/gestalt-datepicker/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
 