### PR TITLE
[@wordpress/components] Update Autocomplete to include all props and render props

### DIFF
--- a/types/wordpress__components/autocomplete/index.d.ts
+++ b/types/wordpress__components/autocomplete/index.d.ts
@@ -115,7 +115,6 @@ declare namespace Autocomplete {
         onChange?(value: Value): void;
         onReplace?(value: Value): void;
         record?: Value;
-        instanceId?: string;
         isSelected?: boolean;
     }
 }

--- a/types/wordpress__components/autocomplete/index.d.ts
+++ b/types/wordpress__components/autocomplete/index.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType, ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { Value } from '@wordpress/rich-text';
 
 declare namespace Autocomplete {
@@ -106,6 +106,7 @@ declare namespace Autocomplete {
         activeId: string;
         isExpanded: boolean;
         listBoxId: string;
+        onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
     }
 
     interface Props<T> {
@@ -114,6 +115,8 @@ declare namespace Autocomplete {
         onChange?(value: Value): void;
         onReplace?(value: Value): void;
         record?: Value;
+        instanceId?: string;
+        isSelected?: boolean;
     }
 }
 

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -33,7 +33,6 @@ let record: Value = {
     onReplace={(value) => (record = value)}
     onChange={(value) => (record = value)}
     record={record}
-    instanceId="test-instance-id"
     isSelected={false}
     completers={[
         {

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -1,5 +1,6 @@
 import * as C from '@wordpress/components';
 import { Component } from '@wordpress/element';
+import { Value } from '@wordpress/rich-text';
 import { MouseEvent as ReactMouseEvent } from 'react';
 
 //
@@ -23,7 +24,17 @@ interface MyCompleteOption {
     name: string;
     id: number;
 }
+let record: Value = {
+    formats: [],
+    replacements: [],
+    text: '',
+};
 <C.Autocomplete<MyCompleteOption>
+    onReplace={(value) => (record = value)}
+    onChange={(value) => (record = value)}
+    record={record}
+    instanceId="test-instance-id"
+    isSelected={false}
     completers={[
         {
             name: 'fruit',
@@ -51,7 +62,7 @@ interface MyCompleteOption {
         },
     ]}
 >
-    {({ isExpanded, listBoxId, activeId }) => (
+    {({ isExpanded, listBoxId, activeId, onKeyDown }) => (
         <div
             contentEditable
             suppressContentEditableWarning
@@ -59,6 +70,7 @@ interface MyCompleteOption {
             aria-expanded={isExpanded}
             aria-owns={listBoxId}
             aria-activedescendant={activeId}
+            onKeyDown={onKeyDown}
         ></div>
     )}
 </C.Autocomplete>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/blob/HEAD/packages/components/src/autocomplete/index.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (I think this is already done)
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.