### PR TITLE
Update sns.d.ts: Correct a typo in SigningCertUrl when SNS is sending SigningCertURL. 

### DIFF
--- a/types/aws-lambda/trigger/sns.d.ts
+++ b/types/aws-lambda/trigger/sns.d.ts
@@ -16,12 +16,12 @@ export interface SNSMessage {
     SignatureVersion: string;
     Timestamp: string;
     Signature: string;
-    SigningCertUrl: string;
+    SigningCertURL: string;
     MessageId: string;
     Message: string;
     MessageAttributes: SNSMessageAttributes;
     Type: string;
-    UnsubscribeUrl: string;
+    UnsubscribeURL: string;
     TopicArn: string;
     Subject: string;
 }


### PR DESCRIPTION
In actual SNSMessage I'm receiving SigningCertURL instead of SigningCertUrl, and the same to UnsuscribeURL.

Please fill in this template.

- [X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ X] Test the change in your own code. (Compile and run.)
- [ X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X ] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.amazonaws.cn/en_us/sns/latest/dg/sns-message-and-json-formats.html