### PR TITLE
[p5] Fix lerp static return type in Vector class

### DIFF
--- a/types/p5/src/math/p5.Vector.d.ts
+++ b/types/p5/src/math/p5.Vector.d.ts
@@ -160,9 +160,9 @@ declare module '../../index' {
          *   between 0.0 (old vector) and 1.0 (new vector). 0.9
          *   is very near the new vector. 0.5 is halfway in
          *   between.
-         *   @return the lerped value
+         *   @return the resulting new p5.Vector
          */
-        static lerp(v1: Vector, v2: Vector, amt: number): number;
+        static lerp(v1: Vector, v2: Vector, amt: number): Vector;
 
         /**
          *   Make a new 2D vector from an angle


### PR DESCRIPTION
As explained in [p5 documentation](https://p5js.org/reference/#/p5.Vector/lerp) `p5.Vector.lerp` is returning a `Vector`, the same way `mult`, `add` or `div` do. 

<hr />

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.) => **no tests in this repo**
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing) => **no tests in this repo**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
