### PR TITLE
Add connectionTimeoutMillis to ClientConfig type definition

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -28,6 +28,7 @@ export interface ClientConfig {
     keepAliveInitialDelayMillis?: number;
     idle_in_transaction_session_timeout?: number;
     application_name?: string;
+    connectionTimeoutMillis?: number;
 }
 
 export type ConnectionConfig = ClientConfig;
@@ -44,7 +45,6 @@ export interface PoolConfig extends ClientConfig {
     // properties from module 'node-pool'
     max?: number;
     min?: number;
-    connectionTimeoutMillis?: number;
     idleTimeoutMillis?: number;
     log?: (...messages: any[]) => void;
     Promise?: PromiseConstructorLike;

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -225,3 +225,7 @@ pool.end().then(() => console.log('pool has ended'));
 // client config object tested above
 let c = new Client(); // empty constructor allowed
 c = new Client('connectionString'); // connection string allowed
+c = new Client({
+    connectionString: 'connectionString',
+    connectionTimeoutMillis: 1000, // connection timeout optionally specified
+});


### PR DESCRIPTION
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://node-postgres.com/api/client
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The library defines `connectionTimeoutMillis` on just the `PoolConfig` interface. This change moves it into `ClientConfig`, which is extended by `PoolConfig`. 