### PR TITLE
Add types for Screen Wake Lock API

### DIFF
--- a/types/dom-screen-wake-lock/dom-screen-wake-lock-tests.ts
+++ b/types/dom-screen-wake-lock/dom-screen-wake-lock-tests.ts
@@ -1,0 +1,17 @@
+function tryKeepScreenAlive(minutes: number) {
+    navigator.wakeLock.request('screen').then(lock => {
+        setTimeout(() => lock.release(), minutes * 60 * 1000);
+    });
+}
+
+tryKeepScreenAlive(10);
+
+const lockingCheckbox = async () => {
+    const checkbox = document.createElement('input');
+    checkbox.setAttribute('type', 'checkbox');
+    document.body.appendChild(checkbox);
+
+    const sentinel = await navigator.wakeLock.request('screen');
+    checkbox.checked = !sentinel.released;
+    sentinel.onrelease = () => (checkbox.checked = !sentinel.released);
+};

--- a/types/dom-screen-wake-lock/index.d.ts
+++ b/types/dom-screen-wake-lock/index.d.ts
@@ -1,0 +1,58 @@
+// Type definitions for non-npm package w3c Screen Wake Lock API 1.0
+// Project: https://w3c.github.io/screen-wake-lock/
+// Definitions by: Chris Milson <https://github.com/chrismilson>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type WakeLockType = 'screen';
+
+/**
+ * A WakeLockSentinel provides a handle to a platform wake lock, and it holds on
+ * to it until it is either manually released or until the underlying platform
+ * wake lock is released. Its existence keeps a platform wake lock for a given
+ * wake lock type active, and releasing all WakeLockSentinel instances of a
+ * given wake lock type will cause the underlying platform wake lock to be
+ * released.
+ */
+interface WakeLockSentinel extends EventTarget {
+    /** Whether the WakeLockSentinel's handle has been released. */
+    readonly released: boolean;
+    /** The WakeLockSentinel's wake lock type. */
+    readonly type: WakeLockType;
+    /** Releases the WakeLockSentinel's lock on the screen. */
+    release(): Promise<undefined>;
+    /**
+     * Called when the WakeLockSentinel's handle is released. Note that the
+     * WakeLockSentinel's handle being released does not necessarily mean that
+     * the underlying wake lock has been released.
+     */
+    onrelease: EventListener;
+}
+
+/**
+ * Allows a document to acquire a screen wake lock.
+ */
+interface WakeLock {
+    /**
+     * The request method will attempt to obtain a wake lock, and will return
+     * a promise that will resolve with a sentinel to the obtained lock if
+     * successful.
+     *
+     * If unsuccessful, the promise will reject with a "NotAllowedError"
+     * DOMException. There are multiple different situations that may cause the
+     * request to be unsucessful, including:
+     *
+     * 1. The _document_ is not allowed to use the wake lock feature.
+     * 2. The _user-agent_ denied the specific type of wake lock.
+     * 3. The _document_'s browsing context is `null`.
+     * 4. The _document_ is not fully active.
+     * 5. The _document_ is hidden.
+     * 6. The request was aborted.
+     *
+     * @param type The type of wake lock to be requested.
+     */
+    request(type: WakeLockType): Promise<WakeLockSentinel>;
+}
+
+interface Navigator {
+    readonly wakeLock: WakeLock;
+}

--- a/types/dom-screen-wake-lock/tsconfig.json
+++ b/types/dom-screen-wake-lock/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "dom-screen-wake-lock-tests.ts"
+    ]
+}

--- a/types/dom-screen-wake-lock/tslint.json
+++ b/types/dom-screen-wake-lock/tslint.json
@@ -1,3 +1,3 @@
 {
-	"extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json"
 }

--- a/types/dom-screen-wake-lock/tslint.json
+++ b/types/dom-screen-wake-lock/tslint.json
@@ -1,0 +1,3 @@
+{
+	"extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Here is the documentation for the experimental [Screen Wake Lock API](https://w3c.github.io/screen-wake-lock/).

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
