### PR TITLE
[single-trailing-newline] Add type definitions

### DIFF
--- a/types/single-trailing-newline/index.d.ts
+++ b/types/single-trailing-newline/index.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for single-trailing-newline 1.0
+// Project: https://github.com/johnotander/single-trailing-newline
+// Definitions by: Peter Juras <https://github.com/peterjuras>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Takes a string and returns it with a single trailing newline
+ */
+declare function singleTrailingNewline(str: string): string;
+
+export = singleTrailingNewline;

--- a/types/single-trailing-newline/single-trailing-newline-tests.ts
+++ b/types/single-trailing-newline/single-trailing-newline-tests.ts
@@ -1,0 +1,3 @@
+import singleTrailingNewline = require('single-trailing-newline');
+
+singleTrailingNewline(''); // $ExpectType string

--- a/types/single-trailing-newline/tsconfig.json
+++ b/types/single-trailing-newline/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "single-trailing-newline-tests.ts"
+    ]
+}

--- a/types/single-trailing-newline/tslint.json
+++ b/types/single-trailing-newline/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
