### PR TITLE
[sarif] Upgrading to version to 2.1.0-rtm.5

### DIFF
--- a/types/sarif/index.d.ts
+++ b/types/sarif/index.d.ts
@@ -1,11 +1,11 @@
 // Type definitions for non-npm package Sarif 2.1
 // Project: https://github.com/Microsoft/sarif-sdk
-// Definitions by: Rusty Scrivens <https://github.com/rscrivens>
+// Definitions by: Jeff King <https://github.com/jeffersonking>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
 /**
- * Static Analysis Results Format (SARIF) Version 2.1.0-rtm.4 JSON Schema: a standard format for the output of static
+ * Static Analysis Results Format (SARIF) Version 2.1.0-rtm.5 JSON Schema: a standard format for the output of static
  * analysis tools.
  */
 export interface Log {
@@ -2026,9 +2026,9 @@ export interface Suppression {
     location?: Location;
 
     /**
-     * A string that indicates the state of the suppression.
+     * A string that indicates the review status of the suppression.
      */
-    state?: Suppression.state;
+    status?: Suppression.status;
 
     /**
      * Key/value pairs that provide additional information about the suppression.
@@ -2041,7 +2041,7 @@ export namespace Suppression {
         "inSource" |
         "external";
 
-    type state =
+    type status =
         "accepted" |
         "underReview" |
         "rejected";


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/oasis-tcs/sarif-spec/blob/master/Schemata/sarif-schema-2.1.0.json
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

I am a new/inheriting owner. The pre-existing tests were essentially absent. These types are generated (by tool) from a JSON schema. Generating meaningful tests by hand may be cost prohibitive. Asking for a pass on the 3rd checkbox.