### PR TITLE
[html-to-rtf] Adding types for html-to-rtf

### DIFF
--- a/types/html-to-rtf/html-to-rtf-tests.ts
+++ b/types/html-to-rtf/html-to-rtf-tests.ts
@@ -1,0 +1,29 @@
+import * as htmlToRtf from 'html-to-rtf';
+
+const html = `
+<h1>Title <span style="color:rgb(255,0,0);">with</span> tag h1<h1>
+<div>
+  <p style="color:#333; margin:5px;" class="test" align="center">
+      text of paragraph <b>text with bold <i>text with italic and bold</i></b><i>text with italic</i>
+  </p>
+  <p style="color:rgb(255,0,0);" align="right">red paragraph => right with tag</p>
+  <p style="color:rgb(0,0,255); text-align:center;">blue paragraph => center with style</p>
+  <table>
+    <tbody>
+      <tr>
+        <td><mark>column 1</mark></td>
+        <td>column 2</td>
+        <td><mark>column 3</mark></td>
+        <td>column 4</td>
+      </tr>
+      <tr>
+        <td>content 1</td>
+        <td>content 2<br></td>
+        <td>content 3<br></td>
+        <td>content 4<br></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+htmlToRtf.saveRtfInFile('<Path>/<FileName>.rtf', htmlToRtf.convertHtmlToRtf(html));

--- a/types/html-to-rtf/index.d.ts
+++ b/types/html-to-rtf/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for html-to-rtf 1.3
+// Project: https://github.com/oziresrds/html-to-rtf
+// Definitions by: Alex Brick <https://github.com/bricka>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function convertHtmlToRtf(html: string): string;
+export function saveRtfInFile(path: string, value: string): void;

--- a/types/html-to-rtf/tsconfig.json
+++ b/types/html-to-rtf/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "html-to-rtf-tests.ts"
+    ]
+}

--- a/types/html-to-rtf/tslint.json
+++ b/types/html-to-rtf/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.