### PR TITLE
Add ts3.6 references to node v10

### DIFF
--- a/types/node/v10/index.d.ts
+++ b/types/node/v10/index.d.ts
@@ -42,3 +42,4 @@
 // Typically type modificatons should be made in base.d.ts instead of here
 
 /// <reference path="base.d.ts" />
+/// <reference path="ts3.6/base.d.ts" />

--- a/types/node/v10/node-tests.ts
+++ b/types/node/v10/node-tests.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import util = require('util');
 
 assert(true, "it's working");
 
@@ -56,4 +57,10 @@ assert['fail'](true, true, 'works like a charm');
     const a = { b: 2 } as any;
     assert.deepStrictEqual(a, { b: 2 });
     a; // $ExpectType { b: number; }
+}
+
+{
+    const o = {
+        [util.inspect.custom](): string { return "hi"; }
+    };
 }


### PR DESCRIPTION
This may need to be added to other node versions as well.

Fixes #47239