### PR TITLE
[@types/node] Add valid encoding to Hash.update in crypto module

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -120,7 +120,7 @@ declare module "crypto" {
     function createHash(algorithm: string, options?: HashOptions): Hash;
     function createHmac(algorithm: string, key: BinaryLike | KeyObject, options?: stream.TransformOptions): Hmac;
 
-    type Utf8AsciiLatin1Encoding = "utf8" | "ascii" | "latin1";
+    type Utf8AsciiLatin1Encoding = "utf8" | "utf16le" | "ascii" | "latin1";
     type HexBase64Latin1Encoding = "latin1" | "hex" | "base64";
     type Utf8AsciiBinaryEncoding = "utf8" | "ascii" | "binary";
     type HexBase64BinaryEncoding = "binary" | "base64" | "hex";

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -31,6 +31,11 @@ import { promisify } from 'util';
 }
 
 {
+    const hashResult: string = crypto.createHash('md5')
+        .update('world', 'utf16le').digest();
+}
+
+{
     // crypto_hmac_string_test
     const hmacResult: string = crypto.createHmac('md5', 'hello').update('world').digest('hex');
 }


### PR DESCRIPTION
This is a change to the accepted encoding for crypto APIs such as `Hash.update`, `Cipher.update`, etc.

The documentation for all Node APIs concerning encoding is [here](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings). It defines several encoding including `"utf16le"` which is added in this pull request.

This is corroborated by the Node source code, which uses this validation function: https://github.com/nodejs/node/blob/master/src/api/encoding.cc#L18.

This means Node recognizes this encoding and testing the API does work. However, I can't pinpoint to the library code that declares valid encodings for hash updates. It does look like these input encoding type definitions should be refactored to a shared place. I made this a very targeted change to make it easier to merge, but I'm happy to help refactor if you have ideas on a better way to do this.