### PR TITLE
Add definitions for 'fold-to-ascii'

### DIFF
--- a/types/fold-to-ascii/fold-to-ascii-tests.ts
+++ b/types/fold-to-ascii/fold-to-ascii-tests.ts
@@ -1,0 +1,5 @@
+import * as ASCIIFolder from 'fold-to-ascii';
+
+ASCIIFolder.foldReplacing('Lörem 🤧 ëripuît'); // $ExpectType string
+ASCIIFolder.foldReplacing('Lörem 🤧 ëripuît', 'X'); // $ExpectType string
+ASCIIFolder.foldMaintaining('Lörem 🤧 ëripuît'); // $ExpectType string

--- a/types/fold-to-ascii/index.d.ts
+++ b/types/fold-to-ascii/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for fold-to-ascii 5.0
+// Project: https://github.com/mplatt/fold-to-ascii
+// Definitions by: Morgan Zolob <https://github.com/mogzol>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Replace all known non-ASCII characters with appropriate replacements,
+ * replace the unknown ones with a fallback
+ *
+ * @param str Input string containing ASCII and/or non-ASCII characters
+ * @param replacement Fallback for unknown characters in the input string
+ *                    (defaults to empty string)
+ */
+export function foldReplacing(str?: string, replacement?: string): string;
+
+/**
+ * Replace all known non-ASCII characters with appropriate replacements,
+ * maintain the unknown ones
+ *
+ * @param str Input string containing ASCII and/or non-ASCII characters
+ */
+export function foldMaintaining(str?: string): string;

--- a/types/fold-to-ascii/tsconfig.json
+++ b/types/fold-to-ascii/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "fold-to-ascii-tests.ts"
+    ]
+}

--- a/types/fold-to-ascii/tslint.json
+++ b/types/fold-to-ascii/tslint.json
@@ -1,0 +1,4 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": { "npm-naming": [true, { "mode": "code", "errors": [["NeedsExportEquals", false]] }] }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
