### PR TITLE
jquery-mockjax: Fix type for $.mockjaxSettings.logging

### DIFF
--- a/types/jquery-mockjax/index.d.ts
+++ b/types/jquery-mockjax/index.d.ts
@@ -33,7 +33,7 @@ interface MockJaxSettings {
     data?: any;
     type?: string;
     headers?: MockJaxSettingsHeaders;
-    logging?: boolean;
+    logging?: boolean | number;
     status?: number;
     statusText?: string;
     responseTime?: number;

--- a/types/jquery-mockjax/jquery-mockjax-tests.ts
+++ b/types/jquery-mockjax/jquery-mockjax-tests.ts
@@ -201,7 +201,7 @@ class Tests {
 
             let settings: MockJaxSettings = {
                 url: '/custom-logging-function',
-                logging: true,
+                logging: 2,
                 logger: {
                     error: logFunction,
                     warn: logFunction,
@@ -231,7 +231,7 @@ class Tests {
 
             let settings: MockJaxSettings = {
                 url: '/custom-logging-function',
-                logging: true,
+                logging: 2,
                 logger: {
                     customName: logFunction
                 },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jakerella/jquery-mockjax#logging and https://github.com/jakerella/jquery-mockjax/blob/master/src/jquery.mockjax.js#L835
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The type for `$.mockjaxSettings.logging` should allow either a boolean or a number, per the links above. This was the case in version 2.3.0 and is still the case with the latest version. I am not (currently) bringing the types up to date with the latest minor version, so I have left that alone.