### PR TITLE
[react-select] Add missing properties to component props interfaces for Control and Menu

### DIFF
--- a/types/react-select/src/components/Control.d.ts
+++ b/types/react-select/src/components/Control.d.ts
@@ -8,6 +8,8 @@ interface State {
   isDisabled: boolean;
   /** Whether the select is focused. */
   isFocused: boolean;
+  /** Whether the select is expanded. */
+  menuIsOpen: boolean;
 }
 
 export type ControlProps<OptionType extends OptionTypeBase> = CommonProps<OptionType> &

--- a/types/react-select/src/components/Menu.d.ts
+++ b/types/react-select/src/components/Menu.d.ts
@@ -53,6 +53,8 @@ export type MenuProps<OptionType extends OptionTypeBase> = CommonProps<OptionTyp
   getPortalPlacement: (state: MenuState) => void,
   /** Props to be passed to the menu wrapper. */
   innerProps: object,
+  /** Reference to the internal element, consumed by the MenuPlacer component */
+  innerRef: InnerRef,
   /** Set the maximum height of the menu. */
   maxMenuHeight: number,
   /** Set whether the menu should be at the top, at the bottom. The auto options sets it to bottom. */

--- a/types/react-select/src/types.d.ts
+++ b/types/react-select/src/types.d.ts
@@ -33,6 +33,7 @@ export interface PropsWithStyles {
     See the `styles` object for the properties available.
   */
   getStyles: (name: string, props: any) => {};
+  theme: Theme;
 }
 
 export type ClassNameList = string[];


### PR DESCRIPTION
While implementing a full custom component set replacement for react-select@3, I found issues with the DT definitions for Control and Menu props interfaces.  See the URLs listed in the template answers below for the JS lines in the library which do did not have corresponding fields in the type definitions.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - https://github.com/JedWatson/react-select/blob/5bee3f40e74c165117a6765588ae906f07ad76f9/packages/react-select/src/types.js#L48
    - https://github.com/JedWatson/react-select/blob/5bee3f40e74c165117a6765588ae906f07ad76f9/packages/react-select/src/components/Menu.js#L228
    - https://github.com/JedWatson/react-select/blob/5bee3f40e74c165117a6765588ae906f07ad76f9/packages/react-select/src/components/Control.js#L14
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
