### PR TITLE
node: updated child_process.signalCode to NodeJS.Signals type

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -23,7 +23,7 @@ declare module "child_process" {
         readonly pid: number;
         readonly connected: boolean;
         readonly exitCode: number | null;
-        readonly signalCode: number | null;
+        readonly signalCode: NodeJS.Signals | null;
         readonly spawnargs: string[];
         readonly spawnfile: string;
         kill(signal?: NodeJS.Signals | number): boolean;

--- a/types/node/test/child_process.ts
+++ b/types/node/test/child_process.ts
@@ -94,6 +94,7 @@ async function testPromisify() {
     let _string: string;
     let _stringArray: string[];
     let _maybeNumber: number | null;
+    let _maybeSignal: NodeJS.Signals | null;
 
     _boolean = cp.send(1);
     _boolean = cp.send('one');
@@ -311,7 +312,7 @@ async function testPromisify() {
     _boolean = cp.kill("SIGTERM");
 
     _maybeNumber = cp.exitCode;
-    _maybeNumber = cp.signalCode;
+    _maybeSignal = cp.signalCode;
 
     _string = cp.spawnfile;
 


### PR DESCRIPTION
Example code, showing that [node.js documentation](https://github.com/nodejs/node/pull/35223) is wrong:
```ts
const child_process = require('child_process');
const cp = child_process.spawn('sleep', ['10']);
cp.kill();
setTimeout(() => console.log(cp.signalCode, typeof cp.signalCode), 100);
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/nodejs/node/pull/35223>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

