### PR TITLE
[@types/fs-extra] Added readdir definition with withFileTypes option set to true

### DIFF
--- a/types/fs-extra/fs-extra-tests.ts
+++ b/types/fs-extra/fs-extra-tests.ts
@@ -255,3 +255,6 @@ const openDirTest = async (path: string, opts: fs.OpenDirOptions) => {
     await fs.opendir(path); // $ExpectType Dir
     await fs.opendir(path, opts); // $ExpectType Dir
 };
+
+// $ExpectType Promise<Dirent[]>
+fs.readdir(path, {withFileTypes: true});

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -207,6 +207,7 @@ export function readFile(file: string | Buffer | number): Promise<Buffer>;
 
 export function readdir(path: string | Buffer, callback: (err: NodeJS.ErrnoException, files: string[]) => void): void;
 export function readdir(path: string | Buffer): Promise<string[]>;
+export function readdir(path: string | Buffer, options: fs.BaseEncodingOptions & { withFileTypes: true }): Promise<fs.Dirent[]>;
 
 export function readlink(path: string | Buffer, callback: (err: NodeJS.ErrnoException, linkString: string) => any): void;
 export function readlink(path: string | Buffer): Promise<string>;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.


