### PR TITLE
[printer] New typings for module "printer"

### DIFF
--- a/types/printer/index.d.ts
+++ b/types/printer/index.d.ts
@@ -7,8 +7,6 @@
 
 export as namespace Printer;
 
-/*~ If this module has methods, declare them as functions like so.
- */
 export function getPrinters(): PrinterDetails[];
 export function getPrinter(printerName: string): PrinterDetails;
 export function getPrinterDriverOptions(printerName: string): PrinterDriverOptions;

--- a/types/printer/index.d.ts
+++ b/types/printer/index.d.ts
@@ -5,8 +5,6 @@
 
 /// <reference types="node" />
 
-export as namespace Printer;
-
 export function getPrinters(): PrinterDetails[];
 export function getPrinter(printerName: string): PrinterDetails;
 export function getPrinterDriverOptions(printerName: string): PrinterDriverOptions;

--- a/types/printer/index.d.ts
+++ b/types/printer/index.d.ts
@@ -1,0 +1,67 @@
+// Type definitions for printer 0.4
+// Project: http://github.com/tojocky/node-printer
+// Definitions by: Christos Panagiotakopoulos <https://github.com/chrispanag>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+export as namespace Printer;
+
+/*~ If this module has methods, declare them as functions like so.
+ */
+export function getPrinters(): PrinterDetails[];
+export function getPrinter(printerName: string): PrinterDetails;
+export function getPrinterDriverOptions(printerName: string): PrinterDriverOptions;
+export function getSelectedPaperSize(printerName: string): string;
+export function getDefaultPrinterName(): string | undefined;
+export function printDirect(options: PrintDirectOptions): void;
+export function printFile(options: PrintFileOptions): void;
+export function getSupportedPrintFormats(): string[];
+export function getJob(printerName: string, jobId: number): JobDetails;
+export function setJob(printerName: string, jobId: number, command: 'CANCEL' | string): void;
+export function getSupportedJobCommands(): string[];
+
+export interface PrintDirectOptions {
+    data: string | Buffer;
+    printer?: string;
+    type?: 'RAW' | 'TEXT' | 'PDF' | 'JPEG' | 'POSTSCRIPT' | 'COMMAND' | 'AUTO';
+    options?: { [key: string]: string };
+    success?: PrintOnSuccessFunction;
+    error?: PrintOnErrorFunction;
+}
+
+export interface PrintFileOptions {
+    filename: string;
+    printer?: string;
+    success?: PrintOnSuccessFunction;
+    error?: PrintOnErrorFunction;
+}
+
+export type PrintOnSuccessFunction = (jobId: string) => any;
+export type PrintOnErrorFunction = (err: Error) => any;
+
+export interface PrinterDetails {
+    name: string;
+    isDefault: boolean;
+    options: { [key: string]: string; };
+}
+
+export interface PrinterDriverOptions {
+    [key: string]: { [key: string]: boolean; };
+}
+
+export interface JobDetails {
+    id: number;
+    name: string;
+    printerName: string;
+    user: string;
+    format: string;
+    priority: number;
+    size: number;
+    status: JobStatus[];
+    completedTime: Date;
+    creationTime: Date;
+    processingTime: Date;
+}
+
+export type JobStatus = 'PAUSED' | 'PRINTING' | 'PRINTED' | 'CANCELLED' | 'PENDING' | 'ABORTED';

--- a/types/printer/printer-tests.ts
+++ b/types/printer/printer-tests.ts
@@ -1,0 +1,17 @@
+import printer = require("printer");
+
+printer.getDefaultPrinterName(); // $ExpectType string | undefined
+printer.getJob("test", 5); // $ExpectType JobDetails
+printer.getPrinter("printerName"); // $ExpectType PrinterDetails
+printer.getPrinterDriverOptions("printerName"); // $ExpectType PrinterDriverOptions
+printer.getPrinters(); // $ExpectType PrinterDetails[]
+printer.getSelectedPaperSize("printerName"); // $ExpectType string
+printer.getSupportedJobCommands(); // $ExpectType string[]
+printer.getSupportedPrintFormats(); // $ExpectType string[]
+printer.printDirect({
+    data: 'test'
+});
+printer.printFile({
+    filename: 'test'
+});
+printer.setJob("printerName", 5, "CANCEL"); // $ExpectType void

--- a/types/printer/tsconfig.json
+++ b/types/printer/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "printer-tests.ts"
+    ]
+}

--- a/types/printer/tslint.json
+++ b/types/printer/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.