### PR TITLE
[airbnb-prop-types] Include "dom" library in tsconfig.json

### DIFF
--- a/types/airbnb-prop-types/tsconfig.json
+++ b/types/airbnb-prop-types/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": ["es6"],
+        "lib": ["es6","dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,


### PR DESCRIPTION
Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: Description in this PR

For my library I need the definition to work with its own tsconfig.json but it's not the case for airbnb-prop-types.

index.d.ts can't be "compiled" by itself because tsconfig.json doesn't include "dom" library when the definition uses HtmlElement.
To fix that I've added "dom" library in the tsconfig.json

- [X] `npm test airbnb-prop-types` works
- [X] `npm run lint airbnb-prop-types` works