### PR TITLE
Fix adone for ts 4.1

### DIFF
--- a/types/adone/glosses/collections/default_map.d.ts
+++ b/types/adone/glosses/collections/default_map.d.ts
@@ -4,6 +4,8 @@ declare namespace adone.collection {
      * Each get of non-existent key goes through the factory
      */
     class DefaultMap<K = string, V = any> extends Map<K, V> {
-        constructor(factory?: ((key: K) => V) | { [key: string]: V }, iterable?: Iterable<[K, V]>);
+        constructor(factory: ((key: K) => V) | { [key: string]: V } | undefined, iterable: Iterable<[K, V]>);
+        constructor(factory: ((key: K) => V) | { [key: string]: V });
+        constructor();
     }
 }


### PR DESCRIPTION
Work around a TS 4.1 bug by splitting DefaultMap's constructor with optional
parameters into 3 constructors without optional parameters.

Edit: Here is the bug https://github.com/microsoft/TypeScript/issues/40587