### PR TITLE
[office-js, office-js-preview] Move some styles from 1.12 into preview

### DIFF
--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -41119,7 +41119,8 @@ declare namespace Excel {
          *
          * The style applied to the Slicer.
          *
-         * [Api set: ExcelApi 1.12]
+         * [Api set: ExcelApi BETA (PREVIEW ONLY)]
+         * @beta
          */
         readonly slicerStyle: Excel.SlicerStyle;
         /**

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -31260,13 +31260,6 @@ declare namespace Excel {
         context: RequestContext;
         /**
          *
-         * The style applied to the PivotTable.
-         *
-         * [Api set: ExcelApi 1.12]
-         */
-        readonly pivotStyle: Excel.PivotTableStyle;
-        /**
-         *
          * Specifies if formatting will be automatically formatted when it’s refreshed or when fields are moved.
          *
          * [Api set: ExcelApi 1.9]
@@ -38442,13 +38435,6 @@ declare namespace Excel {
          * [Api set: ExcelApi 1.10]
          */
         readonly slicerItems: Excel.SlicerItemCollection;
-        /**
-         *
-         * The style applied to the Slicer.
-         *
-         * [Api set: ExcelApi 1.12]
-         */
-        readonly slicerStyle: Excel.SlicerStyle;
         /**
          *
          * Represents the worksheet containing the slicer.


### PR DESCRIPTION
I had missed a couple references during the manual move of this API set from 1.12 to preview.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
