### PR TITLE
Fix amap-js-api-scale reference to Position type

### DIFF
--- a/types/amap-js-api-scale/index.d.ts
+++ b/types/amap-js-api-scale/index.d.ts
@@ -42,7 +42,7 @@ declare namespace AMap {
         /**
          * 控件停靠位置
          */
-        position: Position;
+        position: Scale.Position;
         /**
          * 相对于地图容器左上角的偏移量
          */


### PR DESCRIPTION
It was supposed to be a local type, not the DOM one