### PR TITLE
[@types/ssh2-sftp-client] Replaced outdated ssh2Stream.TransferOptions interface references

### DIFF
--- a/types/ssh2-sftp-client/index.d.ts
+++ b/types/ssh2-sftp-client/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ssh2-sftp-client 5.2
+// Type definitions for ssh2-sftp-client 5.3
 // Project: https://github.com/theophilusx/ssh2-sftp-client
 // Definitions by: igrayson <https://github.com/igrayson>
 //                 Ascari Andrea <https://github.com/ascariandrea>
@@ -9,10 +9,10 @@
 //                 Lorenzo Adinolfi <https://github.com/loru88>
 //                 Sam Galizia <https://github.com/sgalizia>
 //                 Tom Xu <https://github.com/hengkx>
+//                 Joseph Burger <https://github.com/candyapplecorn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as ssh2 from 'ssh2';
-import * as ssh2Stream from 'ssh2-streams';
 
 export = sftp;
 
@@ -30,18 +30,18 @@ declare class sftp {
     get(
         path: string,
         dst?: string | NodeJS.WritableStream,
-        options?: ssh2Stream.TransferOptions,
+        options?: sftp.GetTransferOptions,
     ): Promise<string | NodeJS.WritableStream | Buffer>;
 
-    fastGet(remoteFilePath: string, localPath: string, options?: ssh2Stream.TransferOptions): Promise<string>;
+    fastGet(remoteFilePath: string, localPath: string, options?: sftp.FastGetTransferOptions): Promise<string>;
 
     put(
         input: string | Buffer | NodeJS.ReadableStream,
         remoteFilePath: string,
-        options?: ssh2Stream.TransferOptions,
+        options?: sftp.TransferOptions,
     ): Promise<string>;
 
-    fastPut(localPath: string, remoteFilePath: string, options?: ssh2Stream.TransferOptions): Promise<string>;
+    fastPut(localPath: string, remoteFilePath: string, options?: sftp.FastPutTransferOptions): Promise<string>;
 
     cwd(): Promise<string>;
 
@@ -58,7 +58,7 @@ declare class sftp {
     append(
         input: Buffer | NodeJS.ReadableStream,
         remotePath: string,
-        options?: ssh2Stream.TransferOptions,
+        options?: sftp.TransferOptions,
     ): Promise<string>;
 
     uploadDir(srcDir: string, destDir: string): Promise<string>;
@@ -80,6 +80,28 @@ declare namespace sftp {
         retry_factor?: number;
         retry_minTimeout?: number;
     }
+
+    interface ModeOption {
+        mode?: number;
+    }
+
+    interface TransferOptions extends ModeOption {
+        flags?: 'w' | 'a';
+        encoding?: null | string;
+        autoClose?: true | boolean;
+    }
+
+    interface GetTransferOptions extends TransferOptions {
+        handle?: null | string;
+    }
+
+    interface FastGetTransferOptions {
+        concurrency?: number;
+        chunkSize?: number;
+        step?: (totalTransferred: number, chunk: number, total: number) => void;
+    }
+
+    interface FastPutTransferOptions extends FastGetTransferOptions, ModeOption {}
 
     interface FileInfo {
         type: string;

--- a/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
+++ b/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
@@ -35,8 +35,10 @@ client.fastGet('/remote/path', 'local/path').then(() => null);
 client.put('/local/path', '/remote/path').then(() => null);
 client.put(new Buffer('content'), '/remote/path').then(() => null);
 client.put(fs.createReadStream('Hello World'), '/remote/path').then(() => null);
+client.put('/local/path', '/remote/path', { flags: 'w', encoding: 'utf-8', autoClose: true }).then(() => null);
 
 client.fastPut('/remote/path', 'local/path').then(() => null);
+client.fastPut('/remote/path', 'local/path', { concurrency: 4, chunkSize: 256, mode: 0o066 }).then(() => null);
 
 client.cwd().then(() => null);
 


### PR DESCRIPTION
* Replaced ssh2Stream.TransferOptions interface references with updated custom interfaces pulled from the ssh2 library's docs.
* Updated tests. 
* Removed unused dependency.
* Updated version header from 5.2 -> 5.3

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/ssh2-sftp-client#sec-5-2-9
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
