### PR TITLE
[@types/yup] Reverting previous changes that cause `any` type

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -82,10 +82,8 @@ export interface Schema<T, C = object> {
 // `defined`, and `required` would all have no effect.
 
 export interface MixedSchemaConstructor {
-    // tslint:disable-next-line:no-unnecessary-generics
-    <T = {} | null | undefined, C = object>(): MixedSchema<T, C>;
-    // tslint:disable-next-line:no-unnecessary-generics
-    new <T = {} | null | undefined, C = object>(options?: { type?: string; [key: string]: any }): MixedSchema<T, C>;
+    (): MixedSchema;
+    new (options?: { type?: string; [key: string]: any }): MixedSchema;
 }
 
 export interface MixedSchema<T extends any = {} | null | undefined, C = object> extends Schema<T, C> {
@@ -117,10 +115,8 @@ export interface MixedSchema<T extends any = {} | null | undefined, C = object> 
 }
 
 export interface StringSchemaConstructor {
-    // tslint:disable-next-line:no-unnecessary-generics
-    <T extends string | null | undefined = string | undefined, C = object>(): StringSchema<T, C>;
-    // tslint:disable-next-line:no-unnecessary-generics
-    new <T extends string | null | undefined = string | undefined, C = object>(): StringSchema<T, C>;
+    (): StringSchema;
+    new (): StringSchema;
 }
 
 export interface StringSchema<T extends string | null | undefined = string | undefined, C = object>
@@ -171,10 +167,8 @@ export interface StringSchema<T extends string | null | undefined = string | und
 }
 
 export interface NumberSchemaConstructor {
-    // tslint:disable-next-line:no-unnecessary-generics
-    <T extends number | null | undefined = number | undefined, C = object>(): NumberSchema<T, C>;
-    // tslint:disable-next-line:no-unnecessary-generics
-    new <T extends number | null | undefined = number | undefined, C = object>(): NumberSchema<T, C>;
+    (): NumberSchema;
+    new (): NumberSchema;
 }
 
 export interface NumberSchema<T extends number | null | undefined = number | undefined, C = object>
@@ -214,10 +208,8 @@ export interface NumberSchema<T extends number | null | undefined = number | und
 }
 
 export interface BooleanSchemaConstructor {
-    // tslint:disable-next-line:no-unnecessary-generics
-    <T extends boolean | null | undefined = boolean | undefined, C = object>(): BooleanSchema<T, C>;
-    // tslint:disable-next-line:no-unnecessary-generics
-    new <T extends boolean | null | undefined = boolean | undefined, C = object>(): BooleanSchema<T, C>;
+    (): BooleanSchema;
+    new (): BooleanSchema;
 }
 
 export interface BooleanSchema<T extends boolean | null | undefined = boolean | undefined, C = object>
@@ -248,10 +240,8 @@ export interface BooleanSchema<T extends boolean | null | undefined = boolean | 
 }
 
 export interface DateSchemaConstructor {
-    // tslint:disable-next-line:no-unnecessary-generics
-    <T extends Date | null | undefined = Date | undefined, C = object>(): DateSchema<T, C>;
-    // tslint:disable-next-line:no-unnecessary-generics
-    new <T extends Date | null | undefined = Date | undefined, C = object>(): DateSchema<T, C>;
+    (): DateSchema;
+    new (): DateSchema;
 }
 
 export interface DateSchema<T extends Date | null | undefined = Date | undefined, C = object> extends Schema<T, C> {
@@ -284,7 +274,6 @@ export interface DateSchema<T extends Date | null | undefined = Date | undefined
 
 export interface ArraySchemaConstructor {
     <T, C = object>(schema?: Schema<T, C>): NotRequiredArraySchema<T, C>;
-    // tslint:disable-next-line:no-unnecessary-generics
     new <C = object>(): NotRequiredArraySchema<{}, C>;
 }
 
@@ -369,7 +358,6 @@ export type Shape<T extends object | null | undefined, U extends object> =
 
 export interface ObjectSchemaConstructor {
     <T extends object, C = object>(fields?: ObjectSchemaDefinition<T, C>): ObjectSchema<T | undefined, C>;
-    // tslint:disable-next-line:no-unnecessary-generics
     new <C = object>(): ObjectSchema<{}, C>;
 }
 

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -14,6 +14,7 @@
 //                 Elías García <https://github.com/elias-garcia>
 //                 Ian Sanders <https://github.com/iansan5653>
 //                 Jay Fong <https://github.com/fjc0k>
+//                 Aerophite <https://github.com/Aerophite>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 
@@ -82,8 +83,8 @@ export interface Schema<T, C = object> {
 // `defined`, and `required` would all have no effect.
 
 export interface MixedSchemaConstructor {
-    (): MixedSchema;
-    new (options?: { type?: string; [key: string]: any }): MixedSchema;
+    <T = {} | null | undefined>(): MixedSchema<T>; <T = {} | null | undefined, C = object>(): MixedSchema<T, C>;
+    new <T = {} | null | undefined>(options?: { type?: string;[key: string]: any; }): MixedSchema<T>;
 }
 
 export interface MixedSchema<T extends any = {} | null | undefined, C = object> extends Schema<T, C> {
@@ -274,6 +275,7 @@ export interface DateSchema<T extends Date | null | undefined = Date | undefined
 
 export interface ArraySchemaConstructor {
     <T, C = object>(schema?: Schema<T, C>): NotRequiredArraySchema<T, C>;
+    // tslint:disable-next-line:no-unnecessary-generics
     new <C = object>(): NotRequiredArraySchema<{}, C>;
 }
 
@@ -358,6 +360,7 @@ export type Shape<T extends object | null | undefined, U extends object> =
 
 export interface ObjectSchemaConstructor {
     <T extends object, C = object>(fields?: ObjectSchemaDefinition<T, C>): ObjectSchema<T | undefined, C>;
+    // tslint:disable-next-line:no-unnecessary-generics
     new <C = object>(): ObjectSchema<{}, C>;
 }
 

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -84,9 +84,9 @@ export interface Schema<T, C = object> {
 
 export interface MixedSchemaConstructor {
     // tslint:disable-next-line:no-unnecessary-generics
-    <T = {} | null | undefined>(): MixedSchema<T>; <T = {} | null | undefined, C = object>(): MixedSchema<T, C>;
+    <T = {} | null | undefined, C = object>(): MixedSchema<T, C>;
     // tslint:disable-next-line:no-unnecessary-generics
-    new <T = {} | null | undefined>(options?: { type?: string;[key: string]: any; }): MixedSchema<T>;
+    new <T = {} | null | undefined, C = object>(options?: { type?: string;[key: string]: any; }): MixedSchema<T, C>;
 }
 
 export interface MixedSchema<T extends any = {} | null | undefined, C = object> extends Schema<T, C> {

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -83,7 +83,9 @@ export interface Schema<T, C = object> {
 // `defined`, and `required` would all have no effect.
 
 export interface MixedSchemaConstructor {
+    // tslint:disable-next-line:no-unnecessary-generics
     <T = {} | null | undefined>(): MixedSchema<T>; <T = {} | null | undefined, C = object>(): MixedSchema<T, C>;
+    // tslint:disable-next-line:no-unnecessary-generics
     new <T = {} | null | undefined>(options?: { type?: string;[key: string]: any; }): MixedSchema<T>;
 }
 

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -86,7 +86,7 @@ export interface MixedSchemaConstructor {
     // tslint:disable-next-line:no-unnecessary-generics
     <T = {} | null | undefined, C = object>(): MixedSchema<T, C>;
     // tslint:disable-next-line:no-unnecessary-generics
-    new <T = {} | null | undefined, C = object>(options?: { type?: string;[key: string]: any; }): MixedSchema<T, C>;
+    new <T = {} | null | undefined, C = object>(options?: { type?: string; [key: string]: any }): MixedSchema<T, C>;
 }
 
 export interface MixedSchema<T extends any = {} | null | undefined, C = object> extends Schema<T, C> {


### PR DESCRIPTION
Updating some of the Yup types back to declarations prior to PR #47367. This change is required for the types to not be considered `all`. Note that this revert does **not** change any functionality that was added as part of PR #47367.

### Example of the problem
![image](https://user-images.githubusercontent.com/6826088/93392369-48b58700-f836-11ea-8307-ed4ec3fc4705.png)

Evaluates to
![image](https://user-images.githubusercontent.com/6826088/93392428-6256ce80-f836-11ea-995a-53aa58e207a7.png)

But should evaluate to
![image](https://user-images.githubusercontent.com/6826088/93392479-77cbf880-f836-11ea-9a88-77f0dd207151.png)


### PR template
[ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquense/yup

---

Note that I didn't modify any tests because there are tests that should have caught this already using the `$ExpectType` that resolve correctly. I am unsure why this is.
