### PR TITLE
[jsonexport] Add new definition for jsonexport

### DIFF
--- a/types/jsonexport/index.d.ts
+++ b/types/jsonexport/index.d.ts
@@ -1,0 +1,47 @@
+// Type definitions for jsonexport 3.0
+// Project: https://github.com/kaue/jsonexport
+// Definitions by: Guillaume Ongenae <https://github.com/g-ongenae>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+import { Transform } from 'stream';
+
+declare namespace jsonexport {
+    interface UserOptions {
+        headers?: string[];
+        rename?: string[];
+        headerPathString?: string;
+        rowDelimiter?: string;
+        textDelimiter?: string;
+        arrayPathString?: string;
+        undefinedString?: string;
+        endOfLine?: string;
+        mainPathItem?: string;
+        booleanTrueString?: string;
+        booleanFalseString?: string;
+        includeHeaders?: boolean;
+        fillGaps?: boolean;
+        verticalOutput?: boolean;
+        forceTextDelimiter?: boolean;
+    }
+}
+
+/**
+ * Main declare function that converts json to csv
+ *
+ * @param json - object or array to convert
+ * @param options - csv options
+ * @param callback(err, csv) - Callback declare function
+ *      if error, returning error in call back.
+ *      if csv is created successfully, returning csv output to callback.
+ */
+declare function jsonexport(userOptions?: jsonexport.UserOptions): Transform;
+declare function jsonexport(json: object | object[], userOptions?: jsonexport.UserOptions): Promise<string>;
+declare function jsonexport(json: object | object[], cb: (err: Error, csv: string) => void): void;
+declare function jsonexport(
+    json: object | object[],
+    userOptions: jsonexport.UserOptions,
+    cb: (err: Error, csv: string) => void,
+): void;
+
+export = jsonexport;

--- a/types/jsonexport/jsonexport-tests.ts
+++ b/types/jsonexport/jsonexport-tests.ts
@@ -1,0 +1,19 @@
+import jsonexport from 'jsonexport';
+import { Transform } from 'stream';
+
+// No user options
+const a: Transform = jsonexport();
+const b: Promise<string> = jsonexport({ key: 'value' });
+// $ExpectType void
+jsonexport({ key: 'value' }, (err: Error, csv: string) => undefined);
+
+// With user options
+
+const userOptions: jsonexport.UserOptions = {
+    textDelimiter: ';',
+};
+
+const c: Transform = jsonexport(userOptions);
+const d: Promise<string> = jsonexport({ key: 'value' }, userOptions);
+// $ExpectType void
+jsonexport({ key: 'value' }, userOptions, (err: Error, csv: string) => undefined);

--- a/types/jsonexport/jsonexport-tests.ts
+++ b/types/jsonexport/jsonexport-tests.ts
@@ -1,4 +1,4 @@
-import jsonexport from 'jsonexport';
+import jsonexport = require('jsonexport');
 import { Transform } from 'stream';
 
 // No user options
@@ -8,7 +8,6 @@ const b: Promise<string> = jsonexport({ key: 'value' });
 jsonexport({ key: 'value' }, (err: Error, csv: string) => undefined);
 
 // With user options
-
 const userOptions: jsonexport.UserOptions = {
     textDelimiter: ';',
 };

--- a/types/jsonexport/tsconfig.json
+++ b/types/jsonexport/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "jsonexport-tests.ts"]
+}

--- a/types/jsonexport/tsconfig.json
+++ b/types/jsonexport/tsconfig.json
@@ -10,7 +10,6 @@
         "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
-        "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": ["index.d.ts", "jsonexport-tests.ts"]

--- a/types/jsonexport/tslint.json
+++ b/types/jsonexport/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.



