### PR TITLE
Position -> Dom.Position in video.js

### DIFF
--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -2320,7 +2320,7 @@ declare namespace videojs {
          *
          * @return The position of the element that was passed in.
          */
-        findPosition(el: Element): Position;
+        findPosition(el: Element): Dom.Position;
 
         /**
          * Get the value of an element's attribute


### PR DESCRIPTION
TS 4.1 doesn't have a built-in type named Position anymore, which exposed this bug.
