### PR TITLE
Fix bugs discovered by TS 4.1

### DIFF
--- a/types/better-scroll/index.d.ts
+++ b/types/better-scroll/index.d.ts
@@ -256,7 +256,7 @@ declare class BScroll {
             'scroll' |
             'scrollEnd' |
             'touchEnd',
-        fn: (pos: Position) => any
+        fn: (pos: BScroll.Position) => any
     ): void;
 
     off(

--- a/types/react-cytoscapejs/index.d.ts
+++ b/types/react-cytoscapejs/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/plotly/react-cytoscapejs
 // Definitions by:  Emmanuel COunasse <https://github.com/manuc66/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
 
 import cytoscape = require('cytoscape');
 import { Component, CSSProperties } from 'react';
@@ -16,7 +15,7 @@ interface CytoscapeComponentProps {
     stylesheet?: cytoscape.Stylesheet | cytoscape.Stylesheet[] | string;
     className?: string;
     zoom?: number;
-    pan?: Position;
+    pan?: cytoscape.Position;
     minZoom?: number;
     maxZoom?: number;
     zoomingEnabled?: boolean;

--- a/types/react-shadow-dom-retarget-events/react-shadow-dom-retarget-events-tests.tsx
+++ b/types/react-shadow-dom-retarget-events/react-shadow-dom-retarget-events-tests.tsx
@@ -19,4 +19,5 @@ class MyCustomElement extends HTMLElement {
     }
 }
 
+const name = "name";
 customElements.define(name, MyCustomElement);


### PR DESCRIPTION
1. TS 4.1 no longer has a built-in type named 'Position' (it's called GeolocationPosition now).
2. TS 4.1 intentionally sets the global `name: void` to make it less usable.

This flushed out a few bugs.