### PR TITLE
[chromecast-caf-receiver] PlayerManger.getStats()

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -558,6 +558,11 @@ export class PlayerManager {
      */
     getQueueManager(): QueueManager;
 
+    /**
+     * Returns stats about playback. Stats are aggregated over the entire playback session where appropriate.
+     */
+    getStats(): Stats;
+
     getTextTracksManager(): TextTracksManager;
 
     /**
@@ -1260,4 +1265,16 @@ export class AudioTracksManager {
     getTracksByLanguage(language: string): messages.Track[];
     setActiveById(id: number): void;
     setActiveByLanguage(language: string): void;
+}
+
+/** Represents playback statistics */
+export class Stats {
+    bufferingTime: number;
+    decodedFrames: number;
+    droppedFrames: number;
+    estimatedBandwidth: number;
+    height: number;
+    playTime: number;
+    streamBandwidth: number;
+    width: number;
 }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.PlayerManager#getStats>>
<<https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.Stats>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
