### PR TITLE
braintree-web: paypal tokenize promise return type

### DIFF
--- a/types/braintree-web/modules/core.d.ts
+++ b/types/braintree-web/modules/core.d.ts
@@ -3,7 +3,7 @@
  */
 export const VERSION: string;
 
-export type callback<T=any> = (err?: BraintreeError, data?: T) => void;
+export type callback<T = any> = (err?: BraintreeError, data?: T) => void;
 
 /**
  * Enum for {@link BraintreeError} types.

--- a/types/braintree-web/modules/core.d.ts
+++ b/types/braintree-web/modules/core.d.ts
@@ -3,7 +3,7 @@
  */
 export const VERSION: string;
 
-export type callback = (err?: BraintreeError, data?: any) => void;
+export type callback<T=any> = (err?: BraintreeError, data?: T) => void;
 
 /**
  * Enum for {@link BraintreeError} types.

--- a/types/braintree-web/modules/paypal.d.ts
+++ b/types/braintree-web/modules/paypal.d.ts
@@ -63,7 +63,7 @@ export interface PayPal {
      * });
      */
     create(options: { client: Client }): Promise<PayPal>;
-    create(options: { client: Client }, callback: callback): void;
+    create(options: { client: Client }, callback: callback<PayPal>): void;
 
     VERSION: string;
 

--- a/types/braintree-web/modules/paypal.d.ts
+++ b/types/braintree-web/modules/paypal.d.ts
@@ -150,7 +150,7 @@ export interface PayPal {
         shippingAddressOverride?: PayPalShippingAddress;
         shippingAddressEditable?: boolean;
         billingAgreementDescription?: string;
-    }): Promise<PayPalTokenizeReturn>;
+    }): Promise<PayPalTokenizePayload>;
     tokenize(
         options: {
             flow: string;
@@ -166,7 +166,7 @@ export interface PayPal {
             shippingAddressEditable?: boolean;
             billingAgreementDescription?: string;
         },
-        callback: callback,
+        callback: callback<PayPalTokenizePayload>,
     ): PayPalTokenizeReturn;
 
     /**

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -386,7 +386,7 @@ braintree.client.create(
             {
                 client: clientInstance,
             },
-            (createErr, paypalInstance) => {
+            (createErr, paypalInstance: braintree.PayPal) => {
                 if (createErr) {
                     if (createErr.code === 'PAYPAL_BROWSER_NOT_SUPPORTED') {
                         console.error('This browser is not supported.');
@@ -435,6 +435,59 @@ braintree.client.create(
                             }
                         },
                     );
+                });
+            },
+        );
+
+        braintree.paypal.create(
+            {
+                client: clientInstance,
+            },
+            (createErr, paypalInstance) => {
+                if (createErr) {
+                    if (createErr.code === 'PAYPAL_BROWSER_NOT_SUPPORTED') {
+                        console.error('This browser is not supported.');
+                    } else {
+                        console.error('Error!', createErr);
+                    }
+                }
+
+                const button = new HTMLButtonElement();
+
+                button.addEventListener('click', async () => {
+                    // Disable the button so that we don't attempt to open multiple popups.
+                    button.setAttribute('disabled', 'disabled');
+
+                    // Because PayPal tokenization opens a popup, this must be called
+                    // as a result of a user action, such as a button click.
+                    try {
+                        const payload = await paypalInstance.tokenize({
+                            flow: 'vault', // Required
+                            // Any other tokenization options
+                        });
+                        payload.nonce;
+                        // Submit payload.nonce to your server
+                    } catch (tokenizeErr /*braintree.BraintreeError*/) {
+                        // Handle tokenization errors or premature flow closure
+                        switch (tokenizeErr.code) {
+                            case 'PAYPAL_POPUP_CLOSED':
+                                console.error('Customer closed PayPal popup.');
+                                break;
+                            case 'PAYPAL_ACCOUNT_TOKENIZATION_FAILED':
+                                console.error('PayPal tokenization failed. See details:', tokenizeErr.details);
+                                break;
+                            case 'PAYPAL_FLOW_FAILED':
+                                console.error(
+                                    'Unable to initialize PayPal flow. Are your options correct?',
+                                    tokenizeErr.details,
+                                );
+                                break;
+                            default:
+                                console.error('Error!', tokenizeErr);
+                        }
+                    } finally {
+                        button.removeAttribute('disabled');
+                    }
                 });
             },
         );


### PR DESCRIPTION
The promise returning version of `Paypal.tokenize()` returns a different type than the callback version.

Additionally, modified `callback` type to be support the Generic specification of expected type for instance.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
 - callback return signature https://github.com/braintree/braintree-web/blob/master/src/paypal/external/paypal.js#L297
 - promise return https://github.com/braintree/braintree-web/blob/master/src/paypal/external/paypal.js#L304

- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
