### PR TITLE
Update README with Minimum TypeScript Version instructions

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -343,9 +343,9 @@ Definitely Typed 包的发布者会为在 Definitely Typed 之外没有依赖的
 请不要更改准确的类型定义。
 对于一个 NPM 包，如果使用 `node -p 'require("foo")'` 去导入模块，那么 `export =` 是准确的。如果使用 `node -p 'require("foo").default'` 去导入模块，那么 `export default` 是准确的。
 
-#### 我想使用 TypeScript 3.1 或更高版本的功能。
+#### 我想使用 TypeScript 3.3 或更高版本的功能。
 
-那么你必须在你的定义头部的最后一行添加注释（在 `// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped` 之后）：`// TypeScript Version: 3.1`.
+那么你必须在你的定义头部的最后一行添加注释（在 `// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped` 之后）：`// Minimum TypeScript Version: 3.3`.
 但是，如果你的项目在维护类型时需要在兼容 3.1 版本及以上的同时还要兼容 3.0 及以下的版本，那么你需要使用一个只有在 TypeScript 3.1 及以上版本的新特性 `typesVersions`.
 你可以在 [官方 TypeScript 文档](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-1.html#version-selection-with-typesversions) 中找到此功能的详细说明。
 

--- a/README.es.md
+++ b/README.es.md
@@ -276,9 +276,9 @@ Si la import predeterminada trabaja en tu ambiente, considera hacer un cambio en
 No cambies la type definition si es preciso.
 Para un paquete NPM, `export =` es exacto si `node -p 'require("foo")'` es la export, y `export default` es exacto si `node -p 'require("foo").default'` es el export.
 
-#### Quiero usar las características de TypeScript 3.1 o superior.
+#### Quiero usar las características de TypeScript 3.3 o superior.
 
-Entonces deberás añadir un comentario a la última línea de la definición en el encabezado (despues de `// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped`): `// TypeScript Version: 3.1`.
+Entonces deberás añadir un comentario a la última línea de la definición en el encabezado (despues de `// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped`): `// Minimum TypeScript Version: 3.3`.
 
 #### Quiero añadir un DOM API que no está presente en TypeScript por defecto.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -316,9 +316,9 @@ NPM 의 패키지들은 수시간 안에 갱신될 겁니다. 만약 24 시간�
 자료형 정의(Type definition)가 맞는 경우에는 자료형 정의(Type definition)을 수정하지 마세요.
 NPM 패키지의 경우, `node -p 'require("foo")'` 가 원하는 값이라면 `export =` 이 맞고, `node -p 'require("foo").default'` 이 원하는 값이라면 `export default` 이 맞습니다.
 
-#### 자료형 선언(Type declaration)에서 타입스크립트(TypeScript) 3.1 이상의 기능을 사용하고 싶습니다.
+#### 자료형 선언(Type declaration)에서 타입스크립트(TypeScript) 3.3 이상의 기능을 사용하고 싶습니다.
 
-정의(Definition) 머릿주석(`// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped`) 뒤에 `// TypeScript Version: 3.1` 를 추가해주시면 됩니다.
+정의(Definition) 머릿주석(`// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped`) 뒤에 `// Minimum TypeScript Version: 3.3` 를 추가해주시면 됩니다.
 
 #### 타입스크립트(TypeScript)에 기본으로 포함되지 않은 DOM API 를 추가하고 싶어요.
 

--- a/README.md
+++ b/README.md
@@ -417,9 +417,9 @@ compiler options.
 Do not change the type definition if it is accurate.
 For an NPM package, `export =` is accurate if `node -p 'require("foo")'` works to import a module, and `export default` is accurate if `node -p 'require("foo").default'` works to import a module.
 
-#### I want to use features from TypeScript 3.2 or above.
+#### I want to use features from TypeScript 3.3 or above.
 
-Then you will have to add a comment to the last line of your definition header (after `// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped`): `// Minimum TypeScript Version: 3.2`.
+Then you will have to add a comment to the last line of your definition header (after `// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped`): `// Minimum TypeScript Version: 3.3`.
 
 However, if your project needs to maintain types that are compatible with, say, 3.7 and above *at the same time as* types that are compatible with 3.6 or below, you will need to use the `typesVersions` feature.
 You can find a detailed explanation of this feature in the [official TypeScript documentation](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-1.html#version-selection-with-typesversions).

--- a/README.pt.md
+++ b/README.pt.md
@@ -413,9 +413,9 @@ e [`--esModuleInterop`](https://www.typescriptlang.org/docs/handbook/release-not
 Não mude a definição de tipo se ela já está correta.
 Para um pacote NPM, `export =` é o certo, se `node -p 'require("foo")'` funciona para importar um módulo, e `export default` é o certo se `node -p 'require("foo").default'` funciona para importar um módulo.
 
-#### Eu quero usar features do TypeScript 3.1 ou superior.
+#### Eu quero usar features do TypeScript 3.3 ou superior.
 
-Então você vai precisar adicionar este comentário na última linha do seu cabeçalho de definição (depois de `// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped`): `// TypeScript Version: 3.1`.
+Então você vai precisar adicionar este comentário na última linha do seu cabeçalho de definição (depois de `// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped`): `// Minimum TypeScript Version: 3.3`.
 
 Entretanto, se o seu projeto precisa manter tipos que são compatíveis com o 3.1 e superior *ao mesmo tempo que* tipos que são compatíveis com o 3.0 ou inferior, você vai precisar usar a feature `typesVersions`, que está disponível no TypeScript 3.1 e superior.
 Você pode achar uma explicação detalhada dessa feature na [documentação oficial do TypeScript](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-1.html#version-selection-with-typesversions).

--- a/README.ru.md
+++ b/README.ru.md
@@ -323,9 +323,9 @@ f('one');
 Не меняйте определение типа, если оно точное.
 Для пакета NPM, `export =` является точным, если `node -p 'require("foo")'` является экспортом, а `export default` является точным, если `node -p 'require("foo").default'` является экспортом.
 
-#### Я хочу использовать функции из TypeScript 3.1 или выше.
+#### Я хочу использовать функции из TypeScript 3.3 или выше.
 
-В таком случае вам нужно будет добавить комментарий к последней строке заголовка вашего определения (после `// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped`): `// TypeScript Version: 3.1`.
+В таком случае вам нужно будет добавить комментарий к последней строке заголовка вашего определения (после `// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped`): `// Minimum TypeScript Version: 3.3`.
 
 #### Я хочу добавить DOM API, отсутствующий в TypeScript по умолчанию.
 


### PR DESCRIPTION
Note that I previously updated the English version's typesVersions instructions when I flipped the order; only Chinese and Portuguese have these sections, but they are stuck at 3.1, and tell how to set up the old pre-flip order.

This PR just fixes the numbers in the first sentence, so doesn't require me to write anything.