### PR TITLE
Sync frida-gum typings with Frida 12.11.16

### DIFF
--- a/types/frida-gum/frida-gum-tests.ts
+++ b/types/frida-gum/frida-gum-tests.ts
@@ -3,6 +3,11 @@ Frida.version; // $ExpectType string
 // $ExpectType NativePointer
 const p = ptr(1234);
 
+// $ExpectType number
+p.toInt32();
+// $ExpectType number
+p.toUInt32();
+
 // $ExpectType NativePointer
 p.sign();
 // $ExpectType NativePointer
@@ -72,6 +77,29 @@ Interceptor.attach(puts, {
     }
 });
 
+Interceptor.flush();
+
+const cm = new CModule(`
+#include <gum/gumstalker.h>
+
+void
+process (const GumEvent * event,
+         GumCpuContext * cpu_context,
+         gpointer user_data)
+{
+}
+`);
+
+Stalker.follow(Process.getCurrentThreadId(), {
+    events: {
+        compile: true,
+        call: true,
+        ret: true
+    },
+    onEvent: cm.process,
+    data: ptr(42)
+});
+
 const obj = new ObjC.Object(ptr("0x42"));
 
 // $ExpectType Object
@@ -134,5 +162,3 @@ Java.perform(() => {
         });
     });
 });
-
-Interceptor.flush();

--- a/types/frida-gum/index.d.ts
+++ b/types/frida-gum/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package frida-gum 16.1
+// Type definitions for non-npm package frida-gum 16.2
 // Project: https://github.com/frida/frida
 // Definitions by: Ole André Vadla Ravnås <https://github.com/oleavr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -1465,6 +1465,11 @@ declare class NativePointer {
     toInt32(): number;
 
     /**
+     * Converts to an unsigned 32-bit integer.
+     */
+    toUInt32(): number;
+
+    /**
      * Converts to a “0x”-prefixed hexadecimal string, unless a `radix`
      * is specified.
      */
@@ -2668,6 +2673,19 @@ interface StalkerOptions {
     onCallSummary?: (summary: StalkerCallSummary) => void;
 
     /**
+     * C callback that processes events as they occur, allowing synchronous
+     * processing of events in native code – typically implemented using
+     * CModule.
+     *
+     * This is useful when wanting to implement custom filtering and/or queuing
+     * logic to improve performance, or sacrifice performance in exchange for
+     * reliable event delivery.
+     *
+     * Note that this precludes usage of `onReceive()` and `onCallSummary()`.
+     */
+    onEvent?: StalkerNativeEventCallback;
+
+    /**
      * Callback that transforms each basic block compiled whenever Stalker
      * wants to recompile a basic block of the code that's about to be executed
      * by the stalked thread.
@@ -2675,7 +2693,7 @@ interface StalkerOptions {
     transform?: StalkerTransformCallback;
 
     /**
-     * User data to be passed to `StalkerNativeTransformCallback`.
+     * User data to be passed to `StalkerNativeEventCallback` and `StalkerNativeTransformCallback`.
      */
     data?: NativePointerValue;
 }
@@ -2741,6 +2759,11 @@ type StalkerBlockEventBare = [          NativePointer | string, NativePointer | 
 
 type StalkerCompileEventFull = [ "compile", NativePointer | string, NativePointer | string ];
 type StalkerCompileEventBare = [            NativePointer | string, NativePointer | string ];
+
+/**
+ * Signature: `void process (const GumEvent * event, GumCpuContext * cpu_context, gpointer user_data)`
+ */
+type StalkerNativeEventCallback = NativePointer;
 
 type StalkerTransformCallback =
     | StalkerX86TransformCallback

--- a/types/frida-gum/index.d.ts
+++ b/types/frida-gum/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for non-npm package frida-gum 16.2
 // Project: https://github.com/frida/frida
 // Definitions by: Ole André Vadla Ravnås <https://github.com/oleavr>
+//                 Francesco Tamagni <https://github.com/mrmacete>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.5
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://frida.re/news/2020/07/24/frida-12-11-released/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.