### PR TITLE
Added types for amazon-dax-client

### DIFF
--- a/types/amazon-dax-client/amazon-dax-client-tests.ts
+++ b/types/amazon-dax-client/amazon-dax-client-tests.ts
@@ -1,0 +1,11 @@
+import AmazonDaxClient = require('amazon-dax-client');
+
+const dax = new AmazonDaxClient({
+    endpoints: ['endpoint'],
+    region: 'region',
+    apiVersion: '2012-08-10',
+    httpOptions: {
+        timeout: 50
+    },
+    maxRetries: 3
+});

--- a/types/amazon-dax-client/index.d.ts
+++ b/types/amazon-dax-client/index.d.ts
@@ -1,0 +1,36 @@
+// Type definitions for amazon-dax-client 1.2
+// Project: https://aws.amazon.com/dynamodb/dax/
+// Definitions by: Courtney Pitcher <https://github.com/DefinitelyTyped>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node"/>
+import * as AWS from 'aws-sdk';
+
+declare class AmazonDaxClient {
+    constructor(options: AmazonDaxClientOptions);
+    createCluster(params?: object, callback?: (err: any, data: object) => void): AWS.Request<object, any>;
+}
+
+interface AmazonDaxClientOptions {
+    params?: Map<string, any>;
+    endpoint?: string;
+    endpoints?: ReadonlyArray<string>;
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    region?: string;
+    maxRetries?: number;
+    maxRedirects?: number;
+    apiVersion?: string | Date;
+    httpOptions?: AmazonDaxClientHttpOptions;
+}
+
+interface AmazonDaxClientHttpOptions {
+    proxy?: string;
+    agent?: any;
+    connectTimeout?: number;
+    timeout?: number;
+    xhrAsync?: boolean;
+    xhrWithCredentials?: boolean;
+}
+
+export = AmazonDaxClient;

--- a/types/amazon-dax-client/package.json
+++ b/types/amazon-dax-client/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "aws-sdk": "^2.755.0"
+    },
+    "private": true
+}

--- a/types/amazon-dax-client/tsconfig.json
+++ b/types/amazon-dax-client/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "amazon-dax-client-tests.ts"
+    ]
+}

--- a/types/amazon-dax-client/tslint.json
+++ b/types/amazon-dax-client/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
