### PR TITLE
[ramda] R.when does not always apply given function

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -2080,8 +2080,8 @@ export function view<T, U>(lens: Lens, obj: T): U;
  * will return the result of calling the whenTrueFn function with the same argument. If the predicate is not satisfied,
  * the argument is returned as is.
  */
-export function when<T, U>(pred: (a: T) => boolean, whenTrueFn: (a: T) => U, obj: T): U;
-export function when<T, U>(pred: (a: T) => boolean, whenTrueFn: (a: T) => U): (obj: T) => U;
+export function when<T, U>(pred: (a: T) => boolean, whenTrueFn: (a: T) => U, obj: T): T | U;
+export function when<T, U>(pred: (a: T) => boolean, whenTrueFn: (a: T) => U): (obj: T) => T | U;
 
 /**
  * Takes a spec object and a test object and returns true if the test satisfies the spec.

--- a/types/ramda/test/when-tests.ts
+++ b/types/ramda/test/when-tests.ts
@@ -11,4 +11,12 @@ import * as R from 'ramda';
   );
   const a: string = truncate('12345'); // => '12345'
   const b: string = truncate('0123456789ABC'); // => '0123456789…'
+
+  const addOneIfNotNil = R.when(
+      R.complement(R.isNil),
+      R.add(1)
+  );
+
+  const nil: undefined = addOneIfNotNil(undefined);
+  const two: number = addOneIfNotNil(1);
 };


### PR DESCRIPTION
Changed the type definition from 

```ts
export function when<T, U>(pred: (a: T) => boolean, whenTrueFn: (a: T) => U, obj: T): U;
export function when<T, U>(pred: (a: T) => boolean, whenTrueFn: (a: T) => U): (obj: T) => U;
```

to 

```ts
export function when<T, U>(pred: (a: T) => boolean, whenTrueFn: (a: T) => U, obj: T): T | U;
export function when<T, U>(pred: (a: T) => boolean, whenTrueFn: (a: T) => U): (obj: T) => T | U;
```
because, depending on the predicate result, the function may return the target value unchanged.

This PR makes the following code work :

```ts
 const addOneIfNotNil = R.when(
      R.complement(R.isNil),
      R.add(1)
  );

  const nil: undefined = addOneIfNotNil(undefined);
  const two: number = addOneIfNotNil(1);
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)  => Already failing on master
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).   => Already failing on master

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://ramdajs.com/docs/#when
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
