### PR TITLE
office-js, office-js-preview, changing a type

### DIFF
--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -1475,6 +1475,10 @@ declare namespace Office {
          */
          column?: number
     }
+	/**
+	 * Used to strong type the `handler` property of RemoveHandlerOptions.
+	 */
+	 type BindingEventHandler = (eventArgs?: Office.BindingDataChangedEventArgs | Office.BindingSelectionChangedEventArgs) => any;
     /**
      * Provides options to determine which event handler or handlers are removed.
      */
@@ -1482,7 +1486,7 @@ declare namespace Office {
         /**
          * The handler to be removed. If not specified all handlers for the specified event type are removed.
          */
-        handler?: string
+        handler?: BindingEventHandler
         /**
          * A user-defined item of any type that is returned, unchanged, in the asyncContext property of the AsyncResult object that is passed to a callback.
          */

--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -1476,7 +1476,7 @@ declare namespace Office {
          column?: number
     }
 	/**
-	 * Used to strong type the `handler` property of RemoveHandlerOptions.
+	 * Used to strongly type the `handler` property of RemoveHandlerOptions.
 	 */
 	 type BindingEventHandler = (eventArgs?: Office.BindingDataChangedEventArgs | Office.BindingSelectionChangedEventArgs) => any;
     /**

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -1411,7 +1411,7 @@ declare namespace Office {
         /**
          * The handler to be removed. If not specified all handlers for the specified event type are removed.
          */
-        handler?: string
+        handler?: any
         /**
          * A user-defined item of any type that is returned, unchanged, in the asyncContext property of the AsyncResult object that is passed to a callback.
          */

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -1405,7 +1405,7 @@ declare namespace Office {
          column?: number
     }
 	/**
-	 * Used to strong type the `handler` property of RemoveHandlerOptions.
+	 * Used to strongly type the `handler` property of RemoveHandlerOptions.
 	 */
 	 type BindingEventHandler = (eventArgs?: Office.BindingDataChangedEventArgs | Office.BindingSelectionChangedEventArgs) => any;
     /**

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -1405,7 +1405,7 @@ declare namespace Office {
          column?: number
     }
 	/**
-	 * Used to strong type the handler property of RemoveHandlerOptions.
+	 * Used to strong type the `handler` property of RemoveHandlerOptions.
 	 */
 	 type BindingEventHandler = (eventArgs?: Office.BindingDataChangedEventArgs | Office.BindingSelectionChangedEventArgs) => any;
     /**

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -1404,6 +1404,10 @@ declare namespace Office {
          */
          column?: number
     }
+	/**
+	 * Used to strong type the handler property of RemoveHandlerOptions.
+	 */
+	 type BindingEventHandler = (name: string) => number;
     /**
      * Provides options to determine which event handler or handlers are removed.
      */

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -1407,7 +1407,7 @@ declare namespace Office {
 	/**
 	 * Used to strong type the handler property of RemoveHandlerOptions.
 	 */
-	 type BindingEventHandler = (name: string) => number;
+	 type BindingEventHandler = (eventArgs?: Office.BindingDataChangedEventArgs | Office.BindingSelectionChangedEventArgs) => any;
     /**
      * Provides options to determine which event handler or handlers are removed.
      */
@@ -1415,7 +1415,7 @@ declare namespace Office {
         /**
          * The handler to be removed. If not specified all handlers for the specified event type are removed.
          */
-        handler?: any
+        handler?: BindingEventHandler
         /**
          * A user-defined item of any type that is returned, unchanged, in the asyncContext property of the AsyncResult object that is passed to a callback.
          */


### PR DESCRIPTION
Please fill in this template.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/OfficeDev/office-js-docs-pr/issues/2182
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Fixes https://github.com/OfficeDev/office-js-docs-pr/issues/2182