### PR TITLE
update(fs-extra): missing aliases

### DIFF
--- a/types/fs-extra/fs-extra-tests.ts
+++ b/types/fs-extra/fs-extra-tests.ts
@@ -1,5 +1,4 @@
 import * as fs from "fs-extra";
-import * as Path from "path";
 
 const len = 2;
 const src = "";
@@ -186,7 +185,10 @@ fs.emptyDir(path).then(() => {
     // stub
 });
 fs.emptyDir(path, errorCallback);
+fs.emptydir(path, errorCallback);
+fs.emptydir(path).then(() => {});
 fs.emptyDirSync(path);
+fs.emptydirSync(path);
 fs.pathExists(path).then((_exist: boolean) => {
     // stub
 });

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -109,7 +109,10 @@ export function ensureSymlinkSync(src: string, dest: string, type?: SymlinkType)
 
 export function emptyDir(path: string): Promise<void>;
 export function emptyDir(path: string, callback: (err: Error) => void): void;
+export const emptydir: typeof emptyDir;
+
 export function emptyDirSync(path: string): void;
+export const emptydirSync: typeof emptyDirSync;
 
 export function pathExists(path: string): Promise<boolean>;
 export function pathExists(path: string, callback: (err: Error, exists: boolean) => void): void;


### PR DESCRIPTION
- added missing aliases:
https://github.com/jprichardson/node-fs-extra/blob/3c3865cad8cae7f3046edf434c2ac76abaec7759/lib/empty/index.js#L43-L48
~~- dropped older v4 version to free resources and cut down tests timed
https://www.npmjs.com/package/fs-extra/v/4.0.3~~~
[edited] removed v4 removal as it is requried for other package compatibiltiy

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).