### PR TITLE
QUnit test methods allow an async function to be provided.

### DIFF
--- a/types/ember-qunit/ember-qunit-tests.ts
+++ b/types/ember-qunit/ember-qunit-tests.ts
@@ -5,6 +5,8 @@ import {
     start,
     test,
     skip,
+    only,
+    todo,
     moduleFor,
     moduleForModel,
     moduleForComponent,
@@ -113,9 +115,53 @@ test('It can calculate the result', function(assert) {
     assert.equal(subject.get('result'), 'bar');
 });
 
+// This test is intended to ensure the appropriate behavior for @typescript-eslint/no-misused-promises.
+// However, we don't actually use typescript-eslint in this project and tslint has no equivalent,
+// so we can't properly test it.
+test('it can be async', async function(assert) {
+    assert.expect(1);
+
+    await this.render();
+
+    assert.ok(true, 'rendered');
+});
+
 skip('disabled test');
 
 skip('disabled test', function(assert) { });
+
+// This test is intended to ensure the appropriate behavior for @typescript-eslint/no-misused-promises.
+// However, we don't actually use typescript-eslint in this project and tslint has no equivalent,
+// so we can't properly test it.
+skip('it can skip async', async function(assert) {
+    assert.expect(1);
+
+    await this.render();
+
+    assert.ok(true, 'rendered');
+});
+
+// This test is intended to ensure the appropriate behavior for @typescript-eslint/no-misused-promises.
+// However, we don't actually use typescript-eslint in this project and tslint has no equivalent,
+// so we can't properly test it.
+only('it can only run async', async function(assert) {
+    assert.expect(1);
+
+    await this.render();
+
+    assert.ok(true, 'rendered');
+});
+
+// This test is intended to ensure the appropriate behavior for @typescript-eslint/no-misused-promises.
+// However, we don't actually use typescript-eslint in this project and tslint has no equivalent,
+// so we can't properly test it.
+todo('it can have an async todo', async function(assert) {
+    assert.expect(1);
+
+    await this.render();
+
+    assert.ok(true, 'rendered');
+});
 
 // https://github.com/emberjs/rfcs/blob/master/text/0232-simplify-qunit-testing-api.md#qunit-nested-modules-api
 QUnit.module('some description', function(hooks) {

--- a/types/ember-qunit/index.d.ts
+++ b/types/ember-qunit/index.d.ts
@@ -173,7 +173,7 @@ declare module 'qunit' {
      * @param name Title of unit being tested
      * @param callback Function to close over assertions
      */
-    export function test(name: string, callback: (this: TestContext, assert: Assert) => void): void;
+    export function test(name: string, callback: (this: TestContext, assert: Assert) => void | Promise<void>): void;
 
     /**
      * Adds a test to exclusively run, preventing all other tests from running.
@@ -191,7 +191,7 @@ declare module 'qunit' {
      * @param name Title of unit being tested
      * @param callback Function to close over assertions
      */
-    export function only(name: string, callback: (this: TestContext, assert: Assert) => void): void;
+    export function only(name: string, callback: (this: TestContext, assert: Assert) => void | Promise<void>): void;
 
     /**
      * Use this method to test a unit of code which is still under development (in a “todo” state).
@@ -203,7 +203,7 @@ declare module 'qunit' {
      * @param name Title of unit being tested
      * @param callback Function to close over assertions
      */
-    export function todo(name: string, callback: (this: TestContext, assert: Assert) => void): void;
+    export function todo(name: string, callback: (this: TestContext, assert: Assert) => void | Promise<void>): void;
 
     /**
      * Adds a test like object to be skipped.
@@ -218,7 +218,7 @@ declare module 'qunit' {
      * @param name Title of unit being tested
      * @param callback Function to close over assertions
      */
-    export function skip(name: string, callback?: (this: TestContext, assert: Assert) => void): void;
+    export function skip(name: string, callback?: (this: TestContext, assert: Assert) => void | Promise<void>): void;
 
     export default QUnit;
 }


### PR DESCRIPTION
The lack of explicit support is generally not problematic except when
used in conjunction with @typescript-eslint/no-misused-promises which
complains when a Promise is provided to a function that doesn't allow
for it.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.qunitjs.com/QUnit/test/
> QUnit.test() can automatically handle the asynchronous resolution of a Promise on your behalf if you return a thenable Promise as the result of your callback function.
- ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~
