### PR TITLE
[@types/react] Resolve https://github.com/microsoft/TypeScript/issues/40511

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -475,12 +475,12 @@ declare namespace React {
         // TODO (TypeScript 3.0): unknown
         context: any;
 
-        constructor(props: Readonly<P>);
+        constructor(props: Readonly<P> | P);
         /**
          * @deprecated
          * @see https://reactjs.org/docs/legacy-context.html
          */
-        constructor(props: P, context?: any);
+        constructor(props: P, context: any);
 
         // We MUST keep setState() as a unified signature because it allows proper checking of the method return type.
         // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257


### PR DESCRIPTION
Resolve https://github.com/microsoft/TypeScript/issues/40511

PROBLEM:

The final overload here marks the second argument ("context") as
optional. This optional Legacy Context argument is deprecated, so
the overload is correctly marked as deprecated.
However, because the deprecated argument is itself optional, even
perfectly acceptable `super(props)` calls in plain JS are flagged
as deprecated.

SOLUTION:

Modify the first overload so that it accepts props simply of P.
The "context" argument of the second overload should no longer
be marked as optional.

After testing in VS Code, this resolves the incorrect behavior,
while preserving the deprecation warning from JSDocs when
providing a second parameter.

```js
constructor(props: Readonly<P> | P);
/**
* @deprecated
* @see https://reactjs.org/docs/legacy-context.html
*/
constructor(props: P, context: any);
```

- [ ✔️ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ✔️ ] Test the change in your own code. (Compile and run.)
- [ ❌ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [ ✔️ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ✔️ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ✔️ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ✔️ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/TypeScript/issues/40511
