### PR TITLE
Add declarations for 'convert-excel-to-json'

### DIFF
--- a/types/convert-excel-to-json/convert-excel-to-json-tests.ts
+++ b/types/convert-excel-to-json/convert-excel-to-json-tests.ts
@@ -1,5 +1,3 @@
-/// <reference types="node" />
-
 import excelToJson = require("convert-excel-to-json");
 import { readFileSync } from "fs";
 

--- a/types/convert-excel-to-json/convert-excel-to-json-tests.ts
+++ b/types/convert-excel-to-json/convert-excel-to-json-tests.ts
@@ -1,0 +1,73 @@
+/// <reference types="node" />
+
+import excelToJson = require("convert-excel-to-json");
+import { readFileSync } from "fs";
+
+const sourceFile = "test-data.xlsx";
+const sourceBuffer = readFileSync(sourceFile);
+
+// $ExpectError
+excelToJson({
+    header: {
+        rows: 1
+    }
+});
+
+// $ExpectType any
+excelToJson({
+    sourceFile
+}).sheet1[2];
+
+// $ExpectType any[]
+excelToJson(`{"sourceFile": "${sourceFile}"}`).sheet1;
+
+// $ExpectType any
+excelToJson({
+    source: sourceBuffer
+}).sheet1[0];
+
+// $ExpectType any[]
+excelToJson({
+    sourceFile,
+    range: "A2:B3",
+    sheets: ["sheet1", {
+        name: "sheet2",
+        header: {
+            rows: 1
+        },
+        columnToKey: {
+            A: "id",
+            B: "firstName",
+            D: "email"
+        }
+    }]
+}).sheet2;
+
+// $ExpectType { [key: string]: any[]; }
+excelToJson({
+    sourceFile,
+    sheets: [{
+        name: "sheet2",
+    }],
+    header: {
+        rows: 1
+    },
+    columnToKey: {
+        A: "{{A1}}",
+        B: "{{B1}}",
+        D: "{{D1}}"
+    }
+});
+
+// $ExpectType any[]
+excelToJson({
+    sourceFile,
+    sheets: [{
+        name: "sheet3",
+    }],
+    header: {
+        rows: 0
+    },
+    includeEmptyLines: false,
+    sheetStubs: true
+}).sheet3;

--- a/types/convert-excel-to-json/index.d.ts
+++ b/types/convert-excel-to-json/index.d.ts
@@ -1,0 +1,24 @@
+// Type definitions for convert-excel-to-json 1.7
+// Project: https://github.com/DiegoZoracKy/convert-excel-to-json
+// Definitions by: UNIDY2002 <https://github.com/UNIDY2002>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+interface SheetConfig {
+    header?: { rows: number };
+    range?: string;
+    columnToKey?: { [key: string]: string };
+    includeEmptyLines?: boolean;
+    sheetStubs?: boolean;
+}
+
+declare function excelToJson(
+    config: ({ sourceFile: string } | { source: string | Buffer })                 // Either sourceFile or source should have a value
+        & { sheets?: ReadonlyArray<(string | (SheetConfig & { name: string }))> }  // Nested SheetConfig should be allowed
+        & SheetConfig                                                              // ... or just a simple config for all
+        | string,                                                                  // Input can also be a json-string (for cli)
+    sourceFile?: string,                                                           // For cli
+): { [key: string]: any[] };        // Using any to provide more flexibility for downstream usages
+
+export = excelToJson;

--- a/types/convert-excel-to-json/tsconfig.json
+++ b/types/convert-excel-to-json/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "convert-excel-to-json-tests.ts"
+    ]
+}

--- a/types/convert-excel-to-json/tslint.json
+++ b/types/convert-excel-to-json/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.