### PR TITLE
feat(styled-components): merge host component props

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -69,12 +69,24 @@ export type StyledComponentProps<
 > =
     // Distribute O if O is a union type
     O extends object
-    ? WithOptionalTheme<
-          Omit<ReactDefaultizedProps<C, React.ComponentPropsWithRef<C>> & O, A> &
-              Partial<Pick<React.ComponentPropsWithRef<C> & O, A>>,
-          T
-      > &
-          WithChildrenIfReactComponentClass<C>
+    ?
+        C extends React.ComponentType<any>
+        ?
+            WithOptionalTheme<
+                Omit<ReactDefaultizedProps<C, React.ComponentPropsWithRef<C>> & O, A> &
+                    Partial<Pick<React.ComponentPropsWithRef<C> & O, A>>,
+                T
+            > &
+                WithChildrenIfReactComponentClass<C>
+        :
+            // Merge prop types if host component.
+            // See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46850
+            WithOptionalTheme<
+                LooseOmit<Merge<ReactDefaultizedProps<C, React.ComponentPropsWithRef<C>>, O>, A> &
+                    Partial<LoosePick<Merge<React.ComponentPropsWithRef<C>, O>, A>>,
+                T
+            > &
+                WithChildrenIfReactComponentClass<C>
     : never;
 
 // Because of React typing quirks, when getting props from a React.ComponentClass,
@@ -322,6 +334,11 @@ export type ThemedCssFunction<T extends object> = BaseThemedCssFunction<
 
 // Helper type operators
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+type Merge<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
+type LooseOmit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+type LoosePick<T, K extends keyof any> = {
+    [P in Extract<K, keyof T>]: T[P];
+};
 type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, "theme"> & {
     theme?: T;
 };

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1162,7 +1162,7 @@ function unionTest() {
     };
 
     const StyledReadable = styled(Readable)`
-        font-size: ${props => props.kind === 'book' ? 16 : 14}
+        font-size: ${props => props.kind === 'book' ? 16 : 14};
     `;
 
     // undesired, fix was reverted because of https://github.com/Microsoft/TypeScript/issues/30663
@@ -1184,4 +1184,35 @@ function unionTest2() {
     <C bar="foobar" />;
     <C />; // $ExpectError
     <C foo={123} bar="foobar" />; // $ExpectError
+}
+
+// Allow merging of props on host components.
+// See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46850
+function unionTest3() {
+    // Can occur when working with styled-system
+    // and any html props
+    interface Props {
+        color: number | string | Array<string | number | null> | { [x: string]: string | number; [x: number]: string | number; } | null;
+    }
+
+    const C1 = styled.p<Props>``;
+
+    <C1 color="test" />;
+    <C1 color={2} />;
+    <C1 color={["test", null, 2]} />;
+    <C1 color={null} />;
+    <C1 color={{ foo: "bar" }} />;
+    <C1 color={{ 1: "foo" }} />;
+
+    const C2 = ({ color }: { color: string }) => {
+        return <React.Fragment>{color.endsWith('green')}</React.Fragment>;
+    };
+
+    const S = styled(C2)<{ color: number }>``;
+
+    <C2 color="green" />;
+    <C2 color={123} />; // $ExpectError
+
+    // This would cause a runtime error.
+    <S color={123} />; // $ExpectError
 }

--- a/types/styled-components/ts3.6/test/index.tsx
+++ b/types/styled-components/ts3.6/test/index.tsx
@@ -1147,7 +1147,7 @@ function unionTest() {
     };
 
     const StyledReadable = styled(Readable)`
-        font-size: ${props => props.kind === 'book' ? 16 : 14}
+        font-size: ${props => props.kind === 'book' ? 16 : 14};
     `;
 
     // undesired, fix was reverted because of https://github.com/Microsoft/TypeScript/issues/30663
@@ -1169,4 +1169,35 @@ function unionTest2() {
     <C bar="foobar" />;
     <C />; // $ExpectError
     <C foo={123} bar="foobar" />; // $ExpectError
+}
+
+// Allow merging of props on host components.
+// See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46850
+function unionTest3() {
+    // Can occur when working with styled-system
+    // and any html props
+    interface Props {
+        color: number | string | Array<string | number | null> | { [x: string]: string | number; [x: number]: string | number; } | null;
+    }
+
+    const C1 = styled.p<Props>``;
+
+    <C1 color="test" />;
+    <C1 color={2} />;
+    <C1 color={["test", null, 2]} />;
+    <C1 color={null} />;
+    <C1 color={{ foo: "bar" }} />;
+    <C1 color={{ 1: "foo" }} />;
+
+    const C2 = ({ color }: { color: string }) => {
+        return <React.Fragment>{color.endsWith('green')}</React.Fragment>;
+    };
+
+    const S = styled(C2)<{ color: number }>``;
+
+    <C2 color="green" />;
+    <C2 color={123} />; // $ExpectError
+
+    // This would cause a runtime error.
+    <S color={123} />; // $ExpectError
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

---

This supersedes #46850.

Closes #37413.
Closes #42795.

When using libraries like `styled-system` with `styled-components` default HTML props (like `color`) commonly get their type overwritten.

As an example `color` on JSX intrinsic elements are typed as `color?: string`. But with `styled-system` we extend the type to `string | number | symbol | null` along with an array of those types or a keyed object of those types ([see `TextColorProps` from `styled-system`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/styled-system/index.d.ts#L306)).

Currently before this change, `color` would come back typed as:

```
string | (string & (string | number | symbol | null)[]) | (string & {
    [x: string]: string | number | symbol | undefined;
    [x: number]: string | number | symbol | undefined;
}) | undefined
```

After this change `color` comes back typed as:

```
string | number | symbol | (string | number | symbol | null)[] | {
[x: string]: string | number | symbol | undefined;
[x: number]: string | number | symbol | undefined;
} | null | undefined
```

Without this change the following fails:

```tsx
function unionTest3() {
    // Can occur when working with styled-system
    // and the `color` prop.
    interface Props {
        color: number | string | Array<string | number | null> | { [x: string]: string | number; [x: number]: string | number; } | null;
    }

    const C = styled.p<Props>``;

    <C color={2} />;  // Fails
    <C color={["test", null, 2]} />; // Fails
    <C color={null} />; // Fails
    <C color={{ foo: "bar" }} />; // Fails
    <C color={{ 1: "foo" }} />; // Fails
}
```

This PR removes the intersecting of prop types and merges the types.

As requested by @eps1lon, [this change has been restricted to "host" components only](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46850#pullrequestreview-469109450).