### PR TITLE
[i18n] Add class for I18n (support i18n version 0.12.0)

### DIFF
--- a/types/i18n/i18n-tests.ts
+++ b/types/i18n/i18n-tests.ts
@@ -8,9 +8,10 @@
 import express = require("express");
 import i18n = require("i18n");
 import { I18n } from "i18n";
+import { Request } from "express-serve-static-core";
 
 const app = express();
-declare const req: express.Request;
+declare const req: Express.Request & Request;
 
 /**
  * Configuration
@@ -79,6 +80,11 @@ i18n.configure({
         console.log('error', msg);
     },
 
+    // Function to provide missing translations.
+    missingKeyFn: (locale, value) => {
+        return `Translation for "${value}" is missing for locale "${locale}"!`;
+    },
+
     // object or [obj1, obj2] to bind the i18n api and current locale to - defaults to null
     register: global,
 
@@ -92,7 +98,23 @@ i18n.configure({
     // Downcase locale when passed on queryParam; e.g. lang=en-US becomes
     // en-us.  When set to false, the queryParam value will be used as passed;
     // e.g. lang=en-US remains en-US.
-    preserveLegacyCase: true
+    preserveLegacyCase: true,
+
+    // Static translation catalog. Setting this option overrides `locales`
+    // tslint:disable:object-literal-key-quotes
+    staticCatalog: {
+        'en-US': {
+            'no': 'No',
+            'ok': 'Ok',
+            'yes': 'Yes'
+        },
+        'nl-NL': {
+            'no': 'Nee',
+            'ok': 'Oké',
+            'yes': 'Ja'
+        }
+    }
+    // tslint:enable:object-literal-key-quotes
 });
 
 /**
@@ -164,7 +186,7 @@ i18n.__n({ singular: "%s cat", plural: "%s cats", locale: "fr", count: 3 }); // 
  * __mf()
  * https://github.com/mashpie/i18n-node#i18n__mf
  */
-app.get('/de', (_req: Express.Request, res: Express.Response) => {
+app.get('/de', (_req: Express.Request, res: i18n.Response) => {
     // assume res is set to german
     res.setLocale('de');
 
@@ -201,7 +223,7 @@ i18n.setLocale('de');
 i18n.setLocale(req, 'de');
 req.setLocale('de');
 
-app.get('/ar', (_req: Express.Request, res: Express.Response) => {
+app.get('/ar', (_req: Express.Request, res: i18n.Response) => {
     i18n.setLocale(req, 'ar');
     i18n.setLocale(res, 'ar');
     i18n.setLocale(res.locals, 'ar');

--- a/types/i18n/i18n-tests.ts
+++ b/types/i18n/i18n-tests.ts
@@ -224,6 +224,9 @@ req.getLocale(); // --> de
  */
 i18n.getLocales(); // --> ['en', 'de', 'en-GB']
 
+i18n.addLocale('de'); // adds locale
+i18n.removeLocale('de'); // removes locale
+
 /**
  * getCatalog()
  * https://github.com/mashpie/i18n-node#getcatalog

--- a/types/i18n/i18n-tests.ts
+++ b/types/i18n/i18n-tests.ts
@@ -7,6 +7,7 @@
 
 import express = require("express");
 import i18n = require("i18n");
+import { I18n } from "i18n";
 
 const app = express();
 declare const req: express.Request;
@@ -235,3 +236,10 @@ i18n.getCatalog(req, 'de'); // returns just 'de'
 
 req.getCatalog(); // returns all locales
 req.getCatalog('de'); // returns just 'de'
+
+const i18nInstance = new I18n(); // creates new instance of i18n
+
+i18nInstance.configure({
+    locales: ['en', 'de'],
+    directory: __dirname + '/locales'
+});

--- a/types/i18n/index.d.ts
+++ b/types/i18n/index.d.ts
@@ -1,9 +1,9 @@
-// Type definitions for i18n-node 0.8
+// Type definitions for i18n-node 0.12
 // Project: http://github.com/mashpie/i18n-node
 // Definitions by: Maxime LUCE <https://github.com/SomaticIT>
 //                 FindQ <https://github.com/FindQ>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 4.1
 
 declare namespace i18n {
     interface Response extends i18nAPI {

--- a/types/i18n/index.d.ts
+++ b/types/i18n/index.d.ts
@@ -293,6 +293,10 @@ declare namespace i18n {
      */
     function getLocales(): string[];
 
+    function addLocale(locale: string): void;
+
+    function removeLocale(locale: string): void;
+
     //#endregion
 
     //#region Catalog
@@ -363,6 +367,10 @@ declare namespace i18n {
         getLocale(request?: Express.Request): string;
 
         getLocales(): string[];
+
+        addLocale(locale: string): void;
+
+        removeLocale(locale: string): void;
 
         getCatalog(): GlobalCatalog;
 

--- a/types/i18n/index.d.ts
+++ b/types/i18n/index.d.ts
@@ -328,6 +328,52 @@ declare namespace i18n {
      * Get current i18n-node version
      */
     const version: string;
+
+    class I18n {
+        configure(options: ConfigurationOptions): void;
+
+        init(request: Express.Request, response: Express.Response, next?: () => void): void;
+
+        __(phraseOrOptions: string | TranslateOptions, ...replace: string[]): string;
+
+        __(phraseOrOptions: string | TranslateOptions, replacements: Replacements): string;
+
+        __n(phrase: string, count: number): string;
+
+        __n(options: PluralOptions, count?: number): string;
+
+        __n(singular: string, plural: string, count: number | string): string;
+
+        __mf(phraseOrOptions: string | TranslateOptions, ...replace: any[]): string;
+
+        __mf(phraseOrOptions: string | TranslateOptions, replacements: Replacements): string;
+
+        __l(phrase: string): string[];
+
+        __h(phrase: string): HashedList[];
+
+        setLocale(locale: string): void;
+
+        // tslint:disable-next-line:unified-signatures
+        setLocale(requestOrResponse: Express.Request | Express.Response, locale: string, inheritance?: boolean): void;
+
+        // tslint:disable-next-line:unified-signatures
+        setLocale(objects: any | any[], locale: string, inheritance?: boolean): void;
+
+        getLocale(request?: Express.Request): string;
+
+        getLocales(): string[];
+
+        getCatalog(): GlobalCatalog;
+
+        getCatalog(locale: string): LocaleCatalog;
+
+        getCatalog(request: Express.Request, locale?: string): LocaleCatalog;
+
+        overrideLocaleFromQuery(request?: Express.Request): void;
+
+        version: string;
+    }
 }
 
 interface i18nAPI {

--- a/types/i18n/index.d.ts
+++ b/types/i18n/index.d.ts
@@ -6,6 +6,10 @@
 // TypeScript Version: 2.3
 
 declare namespace i18n {
+    interface Response extends i18nAPI {
+        locals: Partial<i18nAPI>;
+    }
+
     interface ConfigurationOptions {
         /**
          * Setup some locales - other locales default to en silently
@@ -112,6 +116,12 @@ declare namespace i18n {
         logErrorFn?: (msg: string) => void;
 
         /**
+         * Function to provide missing translations.
+         * @since 0.10.0
+         */
+        missingKeyFn?: (locale: string, value: string) => string;
+
+        /**
          * object or [obj1, obj2] to bind the i18n api and current locale to
          * @default null
          */
@@ -132,6 +142,14 @@ declare namespace i18n {
          * @default true
          */
         preserveLegacyCase?: boolean;
+
+        /**
+         * Static translation catalog. Setting this option overrides `locales`.
+         *
+         * **NOTE**: Enabling `staticCatalog` disables all other fs realated options such as `updateFiles`, `autoReload` and `syncFiles`.
+         * @since 0.10.0
+         */
+        staticCatalog?: GlobalCatalog;
     }
     interface TranslateOptions {
         phrase: string;
@@ -503,14 +521,11 @@ declare module "i18n" {
 }
 
 declare namespace Express {
+    // tslint:disable-next-line:no-empty-interface
     interface Request extends i18nAPI {
-        languages: string[];
-        regions: string[];
-        language: string;
-        region: string;
     }
 
+    // tslint:disable-next-line:no-empty-interface
     interface Response extends i18nAPI {
-        locals: Partial<i18nAPI>;
     }
 }


### PR DESCRIPTION
Add support for 18n v 0.12.0

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mashpie/i18n-node/releases/tag/0.12.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.