### PR TITLE
feat(webpack-entry-manifest-plugin): new definition

### DIFF
--- a/types/webpack-entry-manifest-plugin/index.d.ts
+++ b/types/webpack-entry-manifest-plugin/index.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for webpack-entry-manifest-plugin 2.0
+// Project: https://github.com/nuintun/webpack-entry-manifest-plugin#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Plugin } from 'webpack';
+
+/**
+ * Webpack plugin for generating an asset manifest with grouped entry chunks
+ */
+declare class WebpackEntryManifestPlugin extends Plugin {
+    name: 'WebpackEntryManifestPlugin';
+    constructor(options?: WebpackEntryManifestPlugin.Options);
+}
+
+declare namespace WebpackEntryManifestPlugin {
+    interface Options {
+        /**
+         * Assets manifest filename
+         * @default 'manifest.json'
+         */
+        filename?: string;
+
+        /**
+         * Assets path map function
+         * @default path => path
+         */
+        map?: (path: string, chunk: string) => string;
+
+        /**
+         * Assets path filter function
+         * @default () => true
+         */
+        filter?: (path: string, chunk: string) => boolean;
+
+        /**
+         * Assets manifest serialize function
+         * @default manifest => JSON.stringify(manifest)
+         */
+        serialize?: (manifest: any) => string;
+    }
+}
+
+export = WebpackEntryManifestPlugin;

--- a/types/webpack-entry-manifest-plugin/tsconfig.json
+++ b/types/webpack-entry-manifest-plugin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "webpack-entry-manifest-plugin-tests.ts"
+    ]
+}

--- a/types/webpack-entry-manifest-plugin/tslint.json
+++ b/types/webpack-entry-manifest-plugin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/webpack-entry-manifest-plugin/webpack-entry-manifest-plugin-tests.ts
+++ b/types/webpack-entry-manifest-plugin/webpack-entry-manifest-plugin-tests.ts
@@ -1,0 +1,13 @@
+import webpack = require('webpack');
+import WebpackEntryManifestPlugin = require('webpack-entry-manifest-plugin');
+
+const config: webpack.Configuration = {
+    plugins: [
+        new WebpackEntryManifestPlugin({
+            filename: 'manifest.json',
+            map: (path, chunk) => path,
+            filter: (path, chunk) => true,
+            serialize: manifest => JSON.stringify(manifest),
+        }),
+    ],
+};


### PR DESCRIPTION
- definition file
- tests

https://github.com/nuintun/webpack-entry-manifest-plugin

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.