### PR TITLE
Fix invalid indexFields in mongoose-delete

### DIFF
--- a/types/mongoose-delete/index.d.ts
+++ b/types/mongoose-delete/index.d.ts
@@ -84,7 +84,7 @@ interface Options {
     overrideMethods: boolean | 'all' | mongoose_delete.overridableMethods[];
     deletedAt: boolean;
     deletedBy: boolean;
-    indexFields: boolean | 'all' | keyof mongoose_delete.SoftDeleteInterface;
+    indexFields: boolean | 'all' | Array<keyof mongoose_delete.SoftDeleteInterface>;
     validateBeforeDelete: boolean;
 
     /**

--- a/types/mongoose-delete/index.d.ts
+++ b/types/mongoose-delete/index.d.ts
@@ -84,7 +84,7 @@ interface Options {
     overrideMethods: boolean | 'all' | mongoose_delete.overridableMethods[];
     deletedAt: boolean;
     deletedBy: boolean;
-    indexFields: boolean | 'all' | keyof mongoose_delete.SoftDeleteInterface;
+    indexFields: boolean | 'all' | (keyof mongoose_delete.SoftDeleteInterface)[];
     validateBeforeDelete: boolean;
 
     /**

--- a/types/mongoose-delete/mongoose-delete-tests.ts
+++ b/types/mongoose-delete/mongoose-delete-tests.ts
@@ -29,6 +29,9 @@ PetSchema.plugin(mongoose_delete, {
   overrideMethods: 'all',
   deletedByType: String,
 });
+PetSchema.plugin(mongoose_delete, { overrideMethods: 'all', deletedBy: true, indexFields: ['deleted'] });
+PetSchema.plugin(mongoose_delete, { overrideMethods: 'all', deletedBy: true, indexFields: 'all' });
+PetSchema.plugin(mongoose_delete, { overrideMethods: 'all', deletedBy: true, indexFields: 'invalid' }); // $ExpectError
 
 const idUser = mongoose.Types.ObjectId('53da93b16b4a6670076b16bf');
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test mongoose-delete`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/dsanel/mongoose-delete/blob/79d7f611bd47238ecd02feb3b87b96c84c060673/index.js#L64-L68
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

This fixes a simple error with the indexFields that is parsed using:

```js
function parseIndexFields (options) {
    var indexFields = {
        deleted: false,
        deletedAt: false,
        deletedBy: false
    };

    if (!options.indexFields) {
        return indexFields;
    }

    if ((typeof options.indexFields === 'string' || options.indexFields instanceof String) && options.indexFields === 'all') {
        indexFields.deleted = indexFields.deletedAt = indexFields.deletedBy = true;
    }

    if (typeof(options.indexFields) === "boolean" && options.indexFields === true) {
        indexFields.deleted = indexFields.deletedAt = indexFields.deletedBy = true;
    }

    if (Array.isArray(options.indexFields)) {
        indexFields.deleted = options.indexFields.indexOf('deleted') > -1;
        indexFields.deletedAt = options.indexFields.indexOf('deletedAt') > -1;
        indexFields.deletedBy = options.indexFields.indexOf('deletedBy') > -1;
    }

    return indexFields;
}
```