### PR TITLE
Dedupe bad chai-datetime merge

### DIFF
--- a/types/chai-datetime/chai-datetime-tests.ts
+++ b/types/chai-datetime/chai-datetime-tests.ts
@@ -13,13 +13,6 @@ function test_equalTime(){
     assert.equalTime(date, date);
 }
 
-function test_closeToTime(){
-    const date: Date = new Date(2014, 1, 1);
-    const closeTime: Date = new Date(2014, 1, 1, 0, 0, 30);
-    expect(date).to.be.closeToTime(closeTime, 40);
-    expect(date).not.to.be.closeToTime(closeTime, 20);
-}
-
 function test_beforeTime(){
     const date: Date = new Date(2014, 1, 1);
     expect(date).to.be.beforeTime(date);
@@ -34,7 +27,14 @@ function test_afterTime(){
     assert.afterTime(date, date);
 }
 
-function test_closeToTime(){
+function test_closeToTime1(){
+    const date: Date = new Date(2014, 1, 1);
+    const closeTime: Date = new Date(2014, 1, 1, 0, 0, 30);
+    expect(date).to.be.closeToTime(closeTime, 40);
+    expect(date).not.to.be.closeToTime(closeTime, 20);
+}
+
+function test_closeToTime2(){
     const date: Date = new Date(2014, 1, 1, 6, 0);
     const closeDate: Date = new Date(2014, 1, 1, 6, 1);
     expect(date).to.be.closeToTime(closeDate, 120);

--- a/types/chai-datetime/index.d.ts
+++ b/types/chai-datetime/index.d.ts
@@ -21,7 +21,6 @@ declare global {
             afterTime(date: Date): Assertion;
             beforeTime(date: Date): Assertion;
             equalTime(date: Date): Assertion;
-            closeToTime(date: Date, delta: number): Assertion;
             withinTime(dateFrom: Date, dateTo: Date): Assertion;
         }
 


### PR DESCRIPTION
Two PRs arrived for the same thing: add closeToTime to chai-datetime.

The two PRs are #46803 and #46697

This PR keeps both tests but fixes the duplicate declarations.