### PR TITLE
feat(parse-cache-control): new definition

### DIFF
--- a/types/parse-cache-control/index.d.ts
+++ b/types/parse-cache-control/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for parse-cache-control 1.0
+// Project: https://github.com/roryf/parse-cache-control
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Simple function to parse Cache-Control headers.
+ * Taken from {@link https://github.com/hapijs/wreck|Wreck}.
+ */
+declare function parseCacheControl(field: string): parseCacheControl.Header | null;
+
+declare namespace parseCacheControl {
+    interface Header {
+        'max-age'?: number;
+        'must-revalidate'?: boolean;
+        'no-cache'?: boolean;
+        'no-store'?: boolean;
+        private?: boolean;
+    }
+}
+
+export = parseCacheControl;

--- a/types/parse-cache-control/parse-cache-control-tests.ts
+++ b/types/parse-cache-control/parse-cache-control-tests.ts
@@ -1,0 +1,5 @@
+import parseCacheControl = require('parse-cache-control');
+
+const header = parseCacheControl('must-revalidate, max-age=3600');
+
+parseCacheControl('must-revalidate, max-age=3600'); // $ExpectType Header | null

--- a/types/parse-cache-control/tsconfig.json
+++ b/types/parse-cache-control/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "parse-cache-control-tests.ts"
+    ]
+}

--- a/types/parse-cache-control/tslint.json
+++ b/types/parse-cache-control/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Small module used e.g. in Google's Lighthouse

- definition
- tests

https://github.com/roryf/parse-cache-control

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.