### PR TITLE
[yargs] Add types for deprecate, deprecated, and deprecatedOptions

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -247,6 +247,11 @@ declare namespace yargs {
         demandCommand(min: number, max?: number, minMsg?: string, maxMsg?: string): Argv<T>;
 
         /**
+         * Shows a [deprecated] notice in front of the option
+         */
+        deprecateOption(option: string, msg?: string): Argv<T>;
+
+        /**
          * Describe a `key` for the generated usage information.
          *
          * Optionally `.describe()` can take an object that maps keys to descriptions.
@@ -645,6 +650,10 @@ declare namespace yargs {
          *  Use 'demandOption' instead
          */
         demand?: boolean | string;
+        /** boolean or string, mark the argument as deprecated, see `deprecateOption()` */
+        deprecate?: boolean | string;
+        /** boolean or string, mark the argument as deprecated, see `deprecateOption()` */
+        deprecated?: boolean | string;
         /** boolean or string, demand the option be given, with optional error message, see `demandOption()` */
         demandOption?: boolean | string;
         /** string, the option description for help content, see `describe()` */

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -805,6 +805,8 @@ function Argv$commandObject() {
         defaultDescription: "description",
         demand: true,
         demandOption: true,
+        deprecate: true,
+        deprecated: "deprecated",
         desc: "desc",
         describe: "describe",
         description: "description",
@@ -839,6 +841,14 @@ function Argv$demandOption() {
         .demandOption(['a', 'b'])
         .demandOption(['a', 'b'], 'a and b are required')
         .demandOption(['a', 'b'], true)
+        .argv;
+}
+
+function Argv$deprecateOption() {
+    const ya = yargs
+        .option('old', {})
+        .deprecateOption('old', 'use --new')
+        .option('new', {})
         .argv;
 }
 


### PR DESCRIPTION
-  [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/yargs/yargs/pull/1559 (PR it was added in)
  - https://github.com/yargs/yargs/pull/1762 (PR adding docs)

Note this was added in `yargs@15.2.0` -- I don't know if there is a version update that should be made here
