### PR TITLE
Add type definitions for zEdit UPF and xelib

### DIFF
--- a/types/xelib/index.d.ts
+++ b/types/xelib/index.d.ts
@@ -471,7 +471,13 @@ export interface XELib
      * Plugin loading is performed in a background thread, use GetLoaderStatus to track the loader and determine when it is done.
      * @see GetLoaderStatus
      */
-    LoadPlugins(loadOrder: string, smartLoad: boolean): void;
+    LoadPlugins(
+        loadOrder: string,
+        /**
+         * @default true
+         */
+        smartLoad?: boolean,
+    ): void;
     /**
      * Loads the plugin file filename at the next available load order position after currently loaded plugins files.
      * Plugin loading is performed in a background thread, use GetLoaderStatus to track the loader and determine when it is done.

--- a/types/xelib/index.d.ts
+++ b/types/xelib/index.d.ts
@@ -1,0 +1,1629 @@
+// Type definitions for non-npm package xelib 0.6
+// Project: https://github.com/z-edit/xelib
+// Definitions by: Alex Layton <https://github.com/awlayton>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.4
+
+/**
+ * xelib instance
+ */
+export const wrapper: XELib;
+
+// Distinguish handles from regular numbers
+export type Handle = number & { __xelib_handle__: never };
+export type Zeroable<H extends Handle> = H | 0;
+// Distinguish types of handles
+/**
+ * Handle to an Element
+ */
+export type ElementHandle = Handle & { __xelib_element__: never };
+/**
+ * Handle to a Container
+ */
+export type ContainerHandle = Handle & { __xelib_container__: never };
+/**
+ * Handle to a file
+ */
+export type FileHandle = ContainerHandle & { __xelib_file__: never };
+/**
+ * Handle to a Record
+ */
+export type RecordHandle = ElementHandle & { __xelib_record__: never };
+/**
+ * Handle to node tree
+ * @see GetNodes
+ */
+export type NodeTreeHandle = Handle & { __xelib_nodetree__: never };
+
+/**
+ * Sort modes that can be used with SetSortMode.
+ * @see SetSortMode
+ */
+export enum SortMode {
+    /**
+     * No sorting.
+     * Elements will be in native order corresponding to the order in which they were found in the plugin file they were loaded from.
+     */
+    None = 0,
+    /**
+     * Files are sorted by load order,
+     * groups are sorted by signature,
+     * and records are sorted by FormID
+     */
+    FormID = 1,
+    /**
+     * Files are sorted by filename,
+     * groups are sorted by display name,
+     * and record are sorted by their EditorID.
+     */
+    EditorID = 2,
+    /**
+     * Files are sorted by filename,
+     * groups are sorted by display name,
+     * and records are sorted by their FULL name.
+     */
+    Name = 3,
+}
+
+/**
+ * States returned by GetLoaderStatus.
+ * @see GetLoaderStatus
+ */
+export enum LoaderState {
+    /**
+     * Indicates the loader hasn't been run and isn't running.
+     */
+    IsInactive = 0,
+    /**
+     * Indicates the loader is currently active.
+     */
+    IsActive = 1,
+    /**
+     * Indicates the loader is done.
+     */
+    IsDone = 2,
+    /**
+     * Indicates the loader encountered an error.
+     */
+    IsError = 3,
+}
+
+/**
+ * Game modes for use with SetGameMode.
+ * @see SetGameMode
+ */
+export enum GameMode {
+    /**
+     * Fallout: New Vegas
+     */
+    gmFNV = 0,
+    /**
+     * Fallout 3
+     */
+    gmFO3 = 1,
+    /**
+     * The Elder Scrolls IV: Oblivion
+     */
+    gmTES4 = 2,
+    /**
+     * The Elder Scrolls V: Skyrim
+     */
+    gmTES5 = 3,
+    /**
+     * Skyrim: Special Edition
+     */
+    gmSSE = 4,
+    /**
+     * Fallout 4
+     */
+    gmFO4 = 5,
+}
+
+/**
+ * Object corresponding to a supported game mode.
+ */
+export interface Game {
+    /**
+     * The name of the game used for display purposes.
+     */
+    name: string;
+    /**
+     * The name of the game used to find the correct Hardcoded.dat file.
+     */
+    shortName: string;
+    /**
+     * The game mode for the game.
+     */
+    mode: GameMode;
+    /**
+     * The filename of the game executable.
+     */
+    exeName: string;
+}
+
+/**
+ * @see BuildArchive
+ */
+export enum ArchiveType {
+    /**
+     * Unused.
+     */
+    baNone = 0,
+    /**
+     * Used for Morrowind archives.
+     */
+    baTES3 = 1,
+    /**
+     * Used for Fallout 3, Oblivion, and Skyrim Classic archives.
+     */
+    baFO3 = 2,
+    /**
+     * Used for Skyrim: Special Edition archives.
+     */
+    baSSE = 3,
+    /**
+     * Used for Fallout 4 archives.
+     */
+    baFO4 = 4,
+    /**
+     * Used for Fallout 4 texture archives.
+     */
+    baFO4dds = 5,
+}
+
+/**
+ * @see XELib.ElementType
+ */
+export enum ElementType {
+    etFile = 0,
+    etMainRecord = 1,
+    etGroupRecord = 2,
+    etSubRecord = 3,
+    etSubRecordStruct = 4,
+    etSubRecordArray = 5,
+    etSubRecordUnion = 6,
+    etArray = 7,
+    etStruct = 8,
+    etValue = 9,
+    etFlag = 10,
+    etStringListTerminator = 11,
+    etUnion = 12,
+    etStructChapter = 13,
+}
+
+/**
+ * @see XELib.DefType
+ */
+export enum DefType {
+    dtSubRecord = 1,
+    dtSubRecordArray = 2,
+    dtSubRecordStruct = 3,
+    dtSubRecordUnion = 4,
+    dtString = 5,
+    dtLString = 6,
+    dtLenString = 7,
+    dtByteArray = 8,
+    dtInteger = 9,
+    dtIntegerFormater = 10,
+    dtIntegerFormaterUnion = 11,
+    dtFlag = 12,
+    dtFloat = 13,
+    dtArray = 14,
+    dtStruct = 15,
+    dtUnion = 16,
+    dtEmpty = 17,
+    dtStructChapter = 18,
+}
+
+/**
+ * Used by Smash.
+ * @see XELib.SmashType
+ */
+export enum SmashType {
+    stUnknown = 0,
+    stRecord = 1,
+    stString = 2,
+    stInteger = 3,
+    stFlag = 4,
+    stFloat = 5,
+    stStruct = 6,
+    stUnsortedArray = 7,
+    stUnsortedStructArray = 8,
+    stSortedArray = 9,
+    stSortedStructArray = 10,
+    stByteArray = 11,
+    stUnion = 12,
+}
+
+/**
+ * Used to determine what form to use when the user is editing values.
+ * @see XELib.ValueType
+ */
+export enum ValueType {
+    vtUnknown = 0,
+    vtBytes = 1,
+    vtNumber = 2,
+    vtString = 3,
+    vtText = 4,
+    vtReference = 5,
+    vtFlags = 6,
+    vtEnum = 7,
+    vtColor = 8,
+    vtArray = 9,
+    vtStruct = 10,
+}
+
+/**
+ * Corresponds to the conflict status of an individual element.
+ * @see XELib.ConflictThis
+ */
+export enum ConflictThis {
+    ctUnknown = 0,
+    ctIgnored = 1,
+    ctNotDefined = 2,
+    ctIdenticalToMaster = 3,
+    ctOnlyOne = 4,
+    ctHiddenByModGroup = 5,
+    ctMaster = 6,
+    ctConflictBenign = 7,
+    ctOverride = 8,
+    ctIdenticalToMasterWinsConflict = 9,
+    ctConflictWins = 10,
+    ctConflictLoses = 11,
+}
+
+/**
+ * Corresponds to the overall conflict status of an element.
+ * @see XELib.ConflictAll
+ */
+export enum ConflictAll {
+    caUnknown = 0,
+    caOnlyOne = 1,
+    caNoConflict = 2,
+    caConflictBenign = 3,
+    caOverride = 4,
+    caConflict = 5,
+    caConflictCritical = 6,
+}
+
+/**
+ * Options that can be passed to GetREFRs.
+ * @see GetREFRs
+ */
+export interface GetREFRsOptions {
+    /**
+     * Pass true to exclude deleted REFRs.
+     * @default false
+     */
+    excludeDeleted?: boolean;
+    /**
+     * Pass true to exclude disabled REFRs.
+     * @default false
+     */
+    excludeDisabled?: boolean;
+    /**
+     * Pass true to exclude REFRs which have an XESP element.
+     * @default false
+     */
+    excludeXESP?: boolean;
+}
+
+export interface Vector {
+    X?: number;
+    Y?: number;
+    Z?: number;
+}
+
+/**
+ * Identity utility type
+ *
+ * So I can "extend" the typeof an enum
+ * @internal
+ */
+export type I<T> = T;
+
+/**
+ * API for xelib wrapper
+ */
+export interface XELib
+    extends I<typeof LoaderState>,
+        I<typeof GameMode>,
+        I<typeof ArchiveType>,
+        I<typeof ElementType>,
+        I<typeof DefType>,
+        I<typeof SmashType>,
+        I<typeof ValueType>,
+        I<typeof ConflictThis>,
+        I<typeof ConflictAll> {
+    /**
+     * Meta functions
+     * @see {@link https://z-edit.github.io#/docs?t=Development%2FAPIs%2Fxelib%2FMeta}
+     */
+    /**
+     * @see SortMode
+     */
+    sortBy: typeof SortMode;
+    /**
+     * Initializes XEditLib.
+     * This should be called after the DLL loaded to prepare the library for future function calls.
+     *
+     * @param dllPath Path to XEditLib.dll
+     */
+    Initialize(dllPath: string): void;
+    /**
+     * Finalizes XEditLib.
+     * This should be called just before the DLL is unloaded to rename saved files, save logs, and free all memory used by the library.
+     */
+    Finalize(): void;
+    /**
+     * Gets the value of a global from the library. Supported globals include:
+     *
+     * - ProgramPath: The path to the folder containing XEditLib.dll.
+     * - Version: The version of XEditLib.dll.
+     * - GameName: The short game name associated with the current game mode.
+     * - AppName: The abbreviated game name associated with the current game mode.
+     * - LongGameName: The full game name associated with the current game mode.
+     * - DataPath: The game data path associated with the current game mode.
+     * - AppDataPath: The game application data path associated with the current game mode.
+     * - MyGamesPath: The my games folder path associated with the current game mode.
+     * - GameIniPath: The path to the INI file associated with the current game mode.
+     */
+    GetGlobal(key: string): string;
+    /**
+     * Returns a list of name value pairs for all globals.
+     * Entries are separated by \r\n, and name value pairs are separated by =.
+     */
+    GetGlobals(): string;
+    /**
+     * Sets the sort mode to be used by GetElements when the sort argument is set to true.
+     * @see GetElements
+     * @see SortMode
+     */
+    SetSortMode(mode: keyof typeof SortMode, reverse: boolean): void;
+    /**
+     * Releases the input handle if it is allocated.
+     */
+    Release(id: Handle): void;
+    /**
+     * Releases the input handle if it is allocated.
+     * For use with handles returned by GetNodes.
+     * @see GetNodes
+     */
+    ReleaseNodes(id: Handle): void;
+    /**
+     * Finds other handles to a particular interface.
+     */
+    GetDuplicateHandles(id: Handle): Handle[];
+
+    /**
+     * Message functions
+     * @see {@link https://z-edit.github.io#/docs?t=Development%2FAPIs%2Fxelib%2FMessages}
+     */
+    /**
+     * Gets any messages that have been added to XEditLib's internal log
+     * since the last time this function was called.
+     */
+    GetMessages(): string;
+    /**
+     * Clears all messages from the XEditLib's internal log.
+     */
+    ClearMessages(): void;
+    /**
+     * Returns a message corresponding to the last exception that occurred.
+     * Returns an empty string if no exception has occurred since the last time this function was called.
+     */
+    GetExceptionMessage(): string;
+
+    /**
+     * Setup functions
+     * @see {@link https://z-edit.github.io#/docs?t=Development%2FAPIs%2Fxelib%2FSetup}
+     */
+    /**
+     * @see LoaderState
+     */
+    loaderStates: typeof LoaderState;
+    /**
+     * @see GameMode
+     */
+    gameModes: typeof GameMode;
+    /**
+     * Array of game objects corresponding to each supported game mode.
+     */
+    games: readonly Game[];
+    /**
+     * Retrieves the path to the game corresponding to gameMode from the registry.
+     * Returns an empty string if the game path cannot be found.
+     * @see GameMode
+     */
+    GetGamePath(gameMode: GameMode): string;
+    /**
+     * Sets the game path to be used when loading plugin and resource files to gamePath.
+     */
+    SetGamePath(gamePath: string): void;
+    /**
+     * Retrieves the the language used for gameMode from the game INI file.
+     * Returns an empty string if the game INI file cannot be found.
+     * @see GameMode
+     */
+    GetGameLanguage(gameMode: GameMode): string;
+    /**
+     * Sets the language to be used when loading string files to language.
+     */
+    SetLanguage(language: string): void;
+    /**
+     * Sets the game mode to gameMode.
+     * @see GameMode
+     */
+    SetGameMode(gameMode: GameMode): void;
+    /**
+     * Returns the user's load order determined from loadorder.txt, plugins.txt, or plugin dates depending on the game and available files.
+     * The load order is returned as a list of filenames separated by \r\n.
+     */
+    GetLoadOrder(): string;
+    /**
+     * Returns the user's active plugins determined from plugins.txt.
+     * Active plugins are returned as a list of filenames separated by \r\n.
+     */
+    GetActivePlugins(): string;
+    /**
+     * Loads plugin files in loadOrder.
+     * If smartLoad is set to true, master files required by files in loadOrder will be automatically loaded as necessary.
+     * Plugin loading is performed in a background thread, use GetLoaderStatus to track the loader and determine when it is done.
+     * @see GetLoaderStatus
+     */
+    LoadPlugins(loadOrder: string, smartLoad: boolean): void;
+    /**
+     * Loads the plugin file filename at the next available load order position after currently loaded plugins files.
+     * Plugin loading is performed in a background thread, use GetLoaderStatus to track the loader and determine when it is done.
+     * @see GetLoaderStatus
+     */
+    LoadPlugin(filename: string): void;
+    /**
+     * Loads the header of plugin file filename and returns a handle to it.
+     * This plugin should be unloaded with UnloadPlugin once you're done with it.
+     * Note: Unlike LoadPlugin, this function does not use a background thread.
+     * @see UnloadPlugin
+     */
+    LoadPluginHeader(filename: string): FileHandle;
+    /**
+     * Builds referenced by information for the plugin file id.
+     * If id is 0 reference information will be built for all loaded plugins.
+     */
+    BuildReferences(id: Zeroable<FileHandle>, sync: boolean): void;
+    /**
+     * Unloads the plugin file id.
+     * Only plugins at the end of the active load order which have not have references built can be unloaded.
+     * Plugin headers loaded with LoadPluginHeader can also be unloaded.
+     */
+    UnloadPlugin(id: FileHandle): void;
+    /**
+     * Returns the status of the loader.
+     * @see LoaderState
+     */
+    GetLoaderStatus(): LoaderState;
+    /**
+     * Returns an array of all loaded filenames.
+     * Excludes hardcoded files if excludeHardcoded is true.
+     */
+    GetLoadedFileNames(excludeHardcoded: boolean): string[];
+
+    /**
+     * Resource functions
+     * @see {@link https://z-edit.github.io#/docs?t=Development%2FAPIs%2Fxelib%2FResources}
+     */
+    /**
+     * @see ArchiveType
+     */
+    archiveTypes: typeof ArchiveType;
+    /**
+     * Extracts container name to destination, replacing existing files if replace is true.
+     * Returns true if the container is extracted successfully.
+     */
+    ExtractContainer(name: string, destination: string, replace: boolean): boolean;
+    /**
+     * Extracts file source from container name to destination.
+     * Returns true if the file is extracted successfully.
+     */
+    ExtractFile(name: string, source: string, destination: string): boolean;
+    /**
+     * Returns an array of the file paths in container name in folder.
+     */
+    GetContainerFiles(name: string, folder: string): string[];
+    /**
+     * Returns the name of the container where the winning version of the file path is stored.
+     */
+    GetFileContainer(path: string): string;
+    /**
+     * Returns an array of the names of the currently loaded containers.
+     */
+    GetLoadedContainers(): string[];
+    /**
+     * Loads the container at filePath.
+     * Returns true if the container is loaded succesfully.
+     */
+    LoadContainer(filePath: string): boolean;
+    /**
+     * Creates a new archive name in folder containing files at the filePaths relative to folder.
+     * Uses archive type archiveType.
+     * Compresses the archive if compress is true and packs data if share is true.
+     * Pass a hexadecimal integer as a string to af or ff to set custom archive flags or file flags, respectively.
+     * @see ArchiveType
+     */
+    BuildArchive(
+        name: string,
+        folder: string,
+        filePaths: string,
+        archiveType: ArchiveType,
+        compress: boolean,
+        share: boolean,
+        af: string,
+        ff: string,
+    ): void;
+    /**
+     * Return the pixel image data for the texture resource resourceName.
+     */
+    GetTextureData(resourceName: string): ImageData;
+
+    /**
+     * Element functions
+     * @see {@link https://z-edit.github.io#/docs?t=Development%2FAPIs%2Fxelib%2FElements}
+     */
+    /**
+     * @see ElementType
+     */
+    elementTypes: typeof ElementType;
+    /**
+     * @see DefType
+     */
+    defTypes: typeof DefType;
+    /**
+     * @see SmashType
+     */
+    smashTypes: typeof SmashType;
+    /**
+     * @see ValueType
+     */
+    valueTypes: typeof ValueType;
+    /**
+     * Returns true if an element exists at the given path.
+     */
+    HasElement(id: Handle, path: string): boolean;
+    /**
+     * Resolves the element at path and returns a handle to it.
+     * Returns 0 if the element is not found.
+     */
+    GetElement(id: Handle, path: string): Zeroable<ElementHandle>;
+    /**
+     * Traverses path, creating any elements that are not found.
+     * Returns a handle to the element at the end of the path.
+     */
+    AddElement(id: Handle, path: string): ElementHandle;
+    /**
+     * Traverses path, creating any elements that are not found.
+     * Sets the value of the element at the end of the path to value, and returns a handle to it.
+     */
+    AddElementValue(id: Handle, path: string, value: string): ElementHandle;
+    /**
+     * Removes the element at path if it exists.
+     */
+    RemoveElement(id: Handle, path: string): void;
+    /**
+     * Removes the element id.
+     * If the element cannot be removed it gets its parent container and attempts to remove it.
+     * This repeats until the container can be removed or the code reaches a main record.
+     */
+    RemoveElementOrParent(id: ElementHandle): void;
+    /**
+     * Assigns id2 to id.
+     * This is equivalent to drag and drop.
+     */
+    SetElement(id: ElementHandle, id2: ElementHandle): void;
+    /**
+     * Returns an array of handles for all of the elements found in the container at path.
+     */
+    GetElements(id: ContainerHandle, path: string): ElementHandle[];
+    /**
+     * Returns an array of the names of all elements that can exist at path.
+     */
+    GetDefNames(id: Handle, path: string): string[];
+    /**
+     * Returns an array of the signatures that can be added to id.
+     */
+    GetAddList(id: Handle): string[];
+    /**
+     * Returns the record referenced by the element at path.
+     * Note: this returns the master of the record, not the winning override.
+     */
+    GetLinksTo(id: Handle, path: string): RecordHandle;
+    /**
+     * Sets the record referenced by the element at path to id2.
+     */
+    SetLinksTo(id: Handle, id2: RecordHandle, path: string): void;
+    /**
+     * Returns a handle to the container of id.
+     * Returns 0 on failure.
+     */
+    GetContainer(id: Handle): Zeroable<ContainerHandle>;
+    /**
+     * Returns a handle to the file id belongs to.
+     */
+    GetElementFile(id: ElementHandle): FileHandle;
+    /**
+     * Returns the number of element children id has.
+     */
+    ElementCount(id: Handle): number;
+    /**
+     * Returns true if id and id2 refer to the same element.
+     */
+    ElementEquals(id: ElementHandle, id2: ElementHandle): boolean;
+    /**
+     * Returns true if the value at path matches value.
+     * When the element at path contains a reference, value can be a Form ID, Editor ID, or FULL Name.
+     * FULL Names passed to this function must be surrounded by double quotes.
+     */
+    ElementMatches(id: Handle, path: string, value: string): boolean;
+    /**
+     * Returns true if the array at path contains an item which matches value at subpath.
+     */
+    HasArrayItem(id: Handle, path: string, subpath: string, value: string): boolean;
+    /**
+     * Returns the first item in the array at path which matches value at subpath.
+     * Returns 0 if no matching element is found.
+     */
+    GetArrayItem(id: Handle, path: string, subpath: string, value: string): Zeroable<ElementHandle>;
+    /**
+     * Adds an item to the array at path and sets value at subpath.
+     * @returns Handle to the added array item.
+     */
+    AddArrayItem(id: Handle, path: string, subpath: string, value: string): ElementHandle;
+    /**
+     * Removes the first item in the array at path which matches value at subpath.
+     */
+    RemoveArrayItem(id: Handle, path: string, subpath: string, value: string): void;
+    /**
+     * Moves the array item id to position index.
+     */
+    MoveArrayItem(id: ElementHandle, index: number): void;
+    /**
+     * Copies element id into id2.
+     * Records are copied as overrides if asNew is false.
+     * @returns Handle to the copied element.
+     */
+    CopyElement(id: ElementHandle, id2: ContainerHandle, asNew: boolean): ElementHandle;
+    /**
+     * @returns true if id is allowed to reference signature.
+     */
+    GetSignatureAllowed(id: Handle, signature: string): boolean;
+    /**
+     * @returns Array of all signatures id is allowed to reference.
+     */
+    GetAllowedSignatures(id: Handle): string[];
+    /**
+     * @returns true if id has been modified during the current session.
+     */
+    GetIsModified(id: Handle): boolean;
+    /**
+     * @returns true if id has can be edited.
+     */
+    GetIsEditable(id: Handle): boolean;
+    /**
+     * @returns true if id can be removed.
+     */
+    GetIsRemoveable(id: Handle): boolean;
+    /**
+     * @returns true if elements can be added to id.
+     */
+    GetCanAdd(id: Handle): boolean;
+    /**
+     * @returns the elementType of id.
+     */
+    ElementType(id: ElementHandle): ElementType;
+    /**
+     * @returns id's element type.
+     */
+    DefType(id: ElementHandle): DefType;
+    /**
+     * @returns id's definition type.
+     */
+    SmashType(id: ElementHandle): SmashType;
+    /**
+     * @returns id's value type.
+     */
+    ValueType(id: ElementHandle): ValueType;
+    /**
+     * @returns true if id is a sorted array.
+     */
+    IsSorted(id: ElementHandle): boolean;
+    /**
+     * @returns true if id contains flags.
+     */
+    IsFlags(id: ElementHandle): boolean;
+
+    /**
+     * Element value functions
+     * @see {@link https://z-edit.github.io#/docs?t=Development%2FAPIs%2Fxelib%2FElement_Values}
+     */
+    /**
+     * Note: This is not the same as XEdit's Name function - LongName is.
+     * @returns The name of id.
+     */
+    Name(id: Handle): string;
+    /**
+     * Identical to the Name function from XEdit scripting.
+     */
+    LongName(id: Handle): string;
+    /**
+     * @returns the name of id used for display purposes in ZEdit's user interface.
+     */
+    DisplayName(id: Handle): string;
+    /**
+     * All paths returned from this function can be used with GetElement.
+     * @returns The path to id.
+     * @see GetElement
+     */
+    Path(id: Handle): string;
+    /**
+     * All paths returned from this function can be used with GetElement.
+     * @returns Fully qualified path to id.
+     * @see GetElement
+     */
+    LongPath(id: Handle): string;
+    /**
+     * All paths returned from this function can be used with GetElement.
+     * @returns Path of id within its parent record.
+     * @see GetElement
+     */
+    LocalPath(id: Handle): string;
+    /**
+     * @returns The signature of id.
+     */
+    Signature(id: Handle): string;
+    /**
+     * @returns The sort key of id.
+     */
+    SortKey(id: Handle): string;
+    /**
+     * This is the same value displayed in the record view.
+     * @returns the editor value at path.
+     * @returns an empty string if path does not exist.
+     */
+    GetValue(id: Handle, path: string): string;
+    /**
+     * Sets the editor value at path to value.
+     * This is the same value displayed in the record view.
+     */
+    SetValue(id: Handle, path: string, value: string): void;
+    /**
+     * @returns The native integer value at path.
+     * @returns 0 if path does not exist.
+     */
+    GetIntValye(id: Handle, path: string): number;
+    /**
+     * Sets the native integer value at path to value.
+     */
+    SetIntValue(id: Handle, path: string, value: number): void;
+    /**
+     * @returns The native unsigned integer value at path.
+     * @returns 0 if path does not exist.
+     */
+    GetUIntValue(id: Handle, path: string): number;
+    /**
+     * Sets the native unsigned integer value at path to value.
+     */
+    SetUIntValue(id: Handle, path: string, value: number): void;
+    /**
+     * @returns The native float value at path.
+     * @returns 0.0 if path does not exist.
+     */
+    GetFloatValue(id: Handle, path: string): number;
+    /**
+     * Sets the native float value at path to value.
+     */
+    SetFloatValue(id: Handle, path: string, value: number): void;
+    /**
+     * Resolves the flags element at path, and sets flag name to state.
+     */
+    SetFlag(id: Handle, path: string, name: string, state: boolean): void;
+    /**
+     * Resolves the flags element at path, and gets the state of flag name.
+     */
+    GetFlag(id: Handle, path: string, name: string): boolean;
+    /**
+     * Resolves the flags element at path and returns an array of the names of the enabled flags on it.
+     */
+    GetEnabledFlags(id: Handle, path: string): string[];
+    /**
+     * Resolves the flags element at path and sets the enabled flags to flags.
+     * Note: This disables any active flags that are not in flags.
+     */
+    SetEnabledFlags(id: Handle, path: string, flags: readonly string[]): void;
+    /**
+     * Resolves the flags element at path and returns an array of the names of all of the flags it supports.
+     * Flag positions in the array indicate the binary bits they corresponds to.
+     */
+    GetAllFlags(id: Handle, path: string): string[];
+    /**
+     * Resolves the enumeration element at path and returns an array of the options it supports.
+     * Enumeration positions in the array indicate the binary bits they corresponds to.
+     */
+    GetEnumOptions(id: Handle, path: string): string[];
+
+    /**
+     * File functions
+     * @see {@link https://z-edit.github.io#/docs?t=Development%2FAPIs%2Fxelib%2FFiles}
+     */
+    /**
+     * Creates a new file filename.
+     * @returns Handle to the file
+     */
+    AddFile(filename: string): FileHandle;
+    /**
+     * Resolves the file with load order loadOrder and returns a handle to it.
+     * Returns 0 if a matching file is not found.
+     */
+    FileByLoadOrder(loadOrder: number): Zeroable<FileHandle>;
+    /**
+     * Resolves the file with name equal to filename and returns a handle to it.
+     * Returns 0 if a matching file is not found.
+     */
+    FileByName(filename: string): Zeroable<FileHandle>;
+    /**
+     * Resolves the file with author equal to author and returns a handle to it.
+     * Returns 0 if a matching file is not found.
+     */
+    FileByAuthor(author: string): Zeroable<FileHandle>;
+    /**
+     * Removes all records and groups in file id.
+     */
+    NukeFile(id: FileHandle): void;
+    /**
+     * Renames file id to newFileName.
+     */
+    RenameFile(id: FileHandle): void;
+    /**
+     * Saves file to filePath.
+     * Passing an empty string for filePath indicates the file should be saved in the game data folder to {filename}.esp.
+     */
+    SaveFile(id: FileHandle, filePath: string): void;
+    /**
+     * @returns Number of records in file id.
+     */
+    GetRecordCount(id: FileHandle): number;
+    /**
+     * @returns Number of override records in file id.
+     */
+    GetOverrideRecordCount(id: FileHandle): number;
+    /**
+     * @returns MD5 Hash of file id.
+     */
+    MD5Hash(id: FileHandle): string;
+    /**
+     * @returns CRC Hash of file id.
+     */
+    CRCHash(id: FileHandle): string;
+    /**
+     * @returns Load order of file id.
+     */
+    GetFileLoadOrder(id: FileHandle): number;
+    /**
+     * @returns Handle to the file header of file id.
+     */
+    GetFileHeader(id: FileHandle): Handle;
+
+    /**
+     * File value functions
+     * @see {@link https://z-edit.github.io#/docs?t=Development%2FAPIs%2Fxelib%2FFile_Values}
+     */
+    /**
+     * @returns Next Object ID of file id.
+     */
+    GetNextObjecID(id: FileHandle): number;
+    /**
+     * Sets the Next Object ID of file id to nextObjectID.
+     */
+    SetNextObjectID(id: FileHandle, nextObjectID: number): void;
+    /**
+     * This is equivalent to calling Name(id).
+     * @returns File name of file id.
+     */
+    GetFileName(id: FileHandle): string;
+    /**
+     * @returns Author of file id.
+     */
+    GetFileAuthor(id: FileHandle): string;
+    /**
+     * Sets the author of file id to author.
+     */
+    SetFileAuthor(id: FileHandle, author: string): void;
+    /**
+     * @returns Description of file id.
+     */
+    GetFileDescription(id: FileHandle): string;
+    /**
+     * Sets the description of file id to description.
+     */
+    SetFileDescription(id: FileHandle, description: string): void;
+    /**
+     * @returns State of the ESM flag on file id.
+     */
+    GetIsESM(id: FileHandle): boolean;
+    /**
+     * Sets the the state of the ESM flag on file id to state.
+     */
+    SetIsESM(id: FileHandle, state: boolean): void;
+
+    /**
+     * Record functions
+     * @see {@link https://z-edit.github.io#/docs?t=Development%2FAPIs%2Fxelib%2FRecords}
+     */
+    /**
+     * @see ConflictThis
+     */
+    conflictThis: typeof ConflictThis;
+    /**
+     * @see ConflictAll
+     */
+    conflictAll: typeof ConflictAll;
+    /**
+     * @returns Form ID of the record id.
+     */
+    GetFormID(id: RecordHandle, native?: boolean, local?: boolean): number;
+    /**
+     * @returns Form ID of the record id as a hexadecimal string.
+     */
+    GetHexFormID(id: RecordHandle, native?: boolean, local?: boolean): string;
+    /**
+     * Set the form ID of the record id.
+     * @returns Form ID of the record id as a hexadecimal string.
+     */
+    SetFormID(id: RecordHandle, newFormID: number, native?: boolean, fixReferences?: boolean): string;
+    /**
+     * Pass 0 as id and a load order formID to perform a lookup by load order form ID.
+     * Pass a file handle as id and a file formID to perform a lookup by native (file) form ID.
+     * @returns Handle to the record matching formID in id.
+     */
+    GetRecord(id: Zeroable<FileHandle>, formID: number): RecordHandle;
+    /**
+     * Pass 0 for id to search all loaded files.
+     * @returns Array of all records matching search found in id.
+     */
+    GetRecords(
+        id: Zeroable<FileHandle>,
+        search: string,
+        /**
+         * @default false
+         */
+        includeOverrides?: boolean,
+    ): RecordHandle[];
+    /**
+     * @returns Array of all REFR records referencing base records with signatures in search found within id.
+     * @see GetREFRsOptions
+     */
+    GetREFRs(id: Handle, search: string, opts?: GetREFRsOptions): RecordHandle[];
+    /**
+     * @returns Array of handles corresponding to the overrides of record id.
+     */
+    GetOverrides(id: RecordHandle): RecordHandle[];
+    /**
+     * @returns Handle for the master record of id.
+     * @returns New handle to record id if it is a master record.
+     */
+    GetMasterRecord(id: RecordHandle): RecordHandle;
+    /**
+     * @returns Handle for the winning override of record id in the masters of file id2.
+     */
+    GetPreviousOverride(id: RecordHandle, id2: FileHandle): RecordHandle;
+    /**
+     * @returns Handle for the winning override of record id.
+     */
+    GetWinningOverride(id: RecordHandle): RecordHandle;
+    /**
+     * @returns Handle for the file that record id is injected into.
+     */
+    GetInjectionTarget(id: RecordHandle): FileHandle;
+    /**
+     * @returns Next record after id which matches search.
+     * @returns 0 if no match is found.
+     */
+    FindNextRecord(id: Handle, search: string, byEdid: boolean, byName: boolean): Zeroable<RecordHandle>;
+    /**
+     * @returns Previous record after id which matches search.
+     * @returns 0 if no match is found.
+     */
+    FindPreviousRecord(id: Handle, search: string, byEdid: boolean, byName: boolean): Zeroable<RecordHandle>;
+    /**
+     * Excludes results which do not contain search in their LongName.
+     * @returns Up to limitTo records matching signature which can be referenced by the file containing id.
+     */
+    FindValidReferences(id: FileHandle, signature: string, search: string, limitTo: number): string[];
+    /**
+     * References must be built with xelib.BuildReferences to be returned.
+     * @returns Array of the records that reference record id.
+     */
+    GetReferencedBy(id: RecordHandle): RecordHandle[];
+    /**
+     * Exchanges all references to oldFormID with references to newFormID on record id.
+     */
+    ExchangeReferences(id: RecordHandle, oldFormID: number, newFormID: number): void;
+    /**
+     * @returns true if record id is a master record.
+     */
+    IsMaster(id: RecordHandle): boolean;
+    /**
+     * @returns true if record id is an injected record.
+     */
+    IsInjected(id: RecordHandle): boolean;
+    /**
+     * @returns true if record id is an override record.
+     */
+    IsOverride(id: RecordHandle): boolean;
+    /**
+     * @returns true if record id is a winning override record.
+     */
+    IsWinningOverride(id: RecordHandle): boolean;
+    /**
+     * The handle returned by this function must be freed with xelib.ReleaseNodes.
+     * NOTE: Can be slow for very large records like NAVI.
+     * @returns Handle pointing to a node tree for rec.
+     * @see ReleaseNodes
+     */
+    GetNodes(rec: RecordHandle): NodeTreeHandle;
+    /**
+     * Pass a handle for a node tree retrieved using GetNodes for nodes if you plan on calling this function for more than one element from the same record.
+     * NOTE: Can be slow for very large records like NAVI.
+     * @returns ConflictAll and ConflictThis values for element.
+     */
+    GetConflictData(
+        nodes: Zeroable<NodeTreeHandle>,
+        element: ElementHandle,
+        asString: true,
+    ): [keyof typeof ConflictAll, keyof typeof ConflictThis];
+    GetConflictData(
+        nodes: Zeroable<NodeTreeHandle>,
+        element: ElementHandle,
+        asString?: false,
+    ): [ConflictAll, ConflictThis];
+    /**
+     * You must pass a handle for a node tree retrieved using GetNodes to nodes.
+     * Note that this is different from xelib.GetElements in that it returns an array with null handles in it as placeholders for unassigned elements.
+     * @returns Handles for the element children of element.
+     * @see GetNodes
+     * @see GetElements
+     */
+    GetNodeElements(nodes: NodeTreeHandle, element: ElementHandle): Array<Zeroable<ElementHandle>>;
+
+    /**
+     * Record value functions
+     * @see {@link https://z-edit.github.io#/docs?t=Development%2FAPIs%2Fxelib%2FRecord_Values}
+     */
+    /**
+     * @returns Editor ID of record id.
+     * @returns Empty string if the record does not have an editor ID.
+     */
+    EditorID(id: RecordHandle): string;
+    /**
+     * @returns FULL name of record id.
+     * @returns Empty string if the record does not have an FULL name.
+     */
+    FullName(id: RecordHandle): string;
+    /**
+     * Translates record id by vector.
+     */
+    Translate(id: RecordHandle, vector: Vector): void;
+    /**
+     * Rotates record id by vector degrees.
+     */
+    Rotate(id: RecordHandle, vector: Vector): void;
+    /**
+     * Gets the state of record flag name on record id.
+     */
+    GetRecordFlag(id: RecordHandle, name: string): boolean;
+    /**
+     * Sets record flag name on record id to state.
+     */
+    SetRecordFlag(id: RecordHandle, name: string, state: boolean): void;
+    /**
+     * @returns true if the `Keywords` array on `record` has an element matching `value`.
+     */
+    HasKeyword(record: RecordHandle, value: string): boolean;
+    /**
+     * Finds the first item in the `Keywords` array on `record` matching `value`.
+     * @returns Handle to the element if found, else returns 0.
+     */
+    GetKeyword(record: RecordHandle, value: string): Zeroable<ElementHandle>;
+    /**
+     * Adds an item to the `Keywords` array on `record`.
+     * @returns Handle to the added Keyword element.
+     */
+    AddKeyword(record: RecordHandle, value: string): ElementHandle;
+    /**
+     * Removes the first item in the `Keywords` array on `record` matching `value`.
+     */
+    RemoveKeyword(record: RecordHandle, value: string): void;
+    /**
+     * @returns true if the `FormIDs` array on `record` has an element matching `value`.
+     */
+    HasFormID(record: RecordHandle, value: string): boolean;
+    /**
+     * Finds the first item in the `FormIDs` array on `record` matching `value`.
+     * @returns Handle to the element if found, else returns 0.
+     */
+    // tslint:disable-next-line adjacent-overload-signatures
+    GetFormID(record: RecordHandle, value: string): Zeroable<ElementHandle>;
+    /**
+     * Adds an item to the `FormIDs` array on `record`.
+     * @returns Handle to the added Form ID element.
+     */
+    AddFormID(record: RecordHandle, value: string): ElementHandle;
+    /**
+     * Removes the first item in the `FormIDs` array on `record` matching `value`.
+     */
+    RemoveFormID(record: RecordHandle, value: string): void;
+    /**
+     * @returns true if the `Music Tracks` array on `record` has an element matching `value`.
+     */
+    HasMusicTrack(record: RecordHandle, value: string): boolean;
+    /**
+     * Finds the first item in the `Music Tracks` array on `record` matching `value`.
+     * @returns Handle to the element if found, else returns 0.
+     */
+    GetMusicTrack(record: RecordHandle, value: string): Zeroable<ElementHandle>;
+    /**
+     * Adds an item to the `Music Tracks` array on `record`.
+     * @returns Handle to the added Music Track element.
+     */
+    AddMusicTrack(record: RecordHandle, value: string): ElementHandle;
+    /**
+     * Removes the first item in the `Music Tracks` array on `record` matching `value`.
+     */
+    RemoveMusicTrack(record: RecordHandle, value: string): void;
+    /**
+     * @returns true if the `Footstep Sets` array on `record` has an element matching `value`.
+     */
+    HasFootstep(record: RecordHandle, value: string): boolean;
+    /**
+     * Finds the first item in the `Footstep Sets` array on `record` matching `value`.
+     * @returns Handle to the element if found, else returns 0.
+     */
+    GetFootstep(record: RecordHandle, value: string): Zeroable<ElementHandle>;
+    /**
+     * Adds an item to the `Footstep Sets` array on `record`.
+     * @returns Handle to the added Footstep element.
+     */
+    AddFootstep(record: Handle, value: string): ElementHandle;
+    /**
+     * Removes the first item in the `Footstep Sets` array on `record` matching `value`.
+     */
+    RemoveFootstep(record: RecordHandle, value: string): void;
+    /**
+     * @returns true if the `Additional Races` array on `record` has an element matching `value`.
+     */
+    HasAdditionalRace(record: RecordHandle, value: string): boolean;
+    /**
+     * Finds the first item in the `Additional Races` array on `record` matching `value`.
+     * @returns Handle to the element if found, else returns 0.
+     */
+    GetAdditionalRace(record: RecordHandle, value: string): Zeroable<ElementHandle>;
+    /**
+     * Adds an value the `Additional Races` array on `record`.
+     * @returns Handle to the added Additional Race element.
+     */
+    AddAdditionalRace(record: RecordHandle, value: string): ElementHandle;
+    /**
+     * Removes the first item in the `Additional Races` array on `record` matching `value`.
+     */
+    RemoveAdditionalRace(record: RecordHandle, value: string): void;
+    /**
+     * @returns true if the `Perks` array on `record` has an element matching `value` at path `Perk`.
+     */
+    HasPerk(record: RecordHandle, value: string): boolean;
+    /**
+     * Finds the first item in the `Perks` array on `record` matching `value` at path `Perk`.
+     * @returns Handle to the element if found, else returns 0.
+     */
+    GetPerk(record: RecordHandle, value: string): Zeroable<ElementHandle>;
+    /**
+     * Adds an value the `Perks` array on `record`,
+     * setting `Perk` to `value` and `rank` if provided.
+     * @returns Handle to the added Perk element.
+     */
+    AddPerk(record: RecordHandle, value: string, rank?: string): ElementHandle;
+    /**
+     * Removes the first item in the `Perks` array on `record` matching `value` at `Perk`.
+     */
+    RemovePerk(record: RecordHandle, value: string): void;
+    /**
+     * @returns true if the `Effects` array on `record` has an element matching `value` at `EFID - Base Effect`.
+     */
+    HasEffect(record: RecordHandle, value: string): boolean;
+    /**
+     * Finds the first item in the `Effects` array on `record` matching `value` at `EFID - Base Effect`.
+     * @returns Handle to the element if found, else returns 0.
+     */
+    GetEffect(record: RecordHandle, value: string): Zeroable<ElementHandle>;
+    /**
+     * Adds an item to the `Effects` array on `record`,
+     * setting `EFID - Base Effect` to `value`,
+     * `EFIT\Magnitude` to `value2`,
+     * `EFIT\Area` to `value3`,
+     * and `EFIT\Duration` to `value4`.
+     * @returns Handle to the added Effect element.
+     */
+    AddEffect(record: RecordHandle, value: string, value2: string, value3: string, value4: string): ElementHandle;
+    /**
+     * Removes the first item in the `Effects` array on `record` matching `value` at `EFID - Base Effect`.
+     */
+    RemoveEffect(record: RecordHandle, value: string): void;
+    /**
+     * @returns true if the `Items` array on `record` has an element matching `value` at `CNTO\Item`.
+     */
+    HasItem(record: RecordHandle, value: string): boolean;
+    /**
+     * Finds the first item in the `Items` array on `record` matching `value` at `CNTO\Item`.
+     * @returns Handle to the element if found, else returns 0.
+     */
+    GetItem(record: RecordHandle, value: string): Zeroable<ElementHandle>;
+    /**
+     * Adds an item to the `Items` array on `record`,
+     * setting `CNTO\Item` to `value`, and `CNTO\Count` to `value2`.
+     * @returns Handle to the added Item element.
+     */
+    AddItem(record: RecordHandle, value: string, value2: string): ElementHandle;
+    /**
+     * Removes the first item in the `Items` array on `record` matching `value` at `CNTO\Item`.
+     */
+    RemoveItem(record: RecordHandle, value: string): void;
+    /**
+     * @returns true if the `Leveled List Entries` array on `record` has an element matching `value` at `LVLO\Reference`.
+     */
+    HasLeveledEntry(record: RecordHandle, value: string): boolean;
+    /**
+     * Finds the first item in the `Leveled List Entries` array on `record` matching `value` at `LVLO\Reference`.
+     * @returns Handle to the element if found, else returns 0.
+     */
+    GetLeveledEntry(record: RecordHandle, value: string): Zeroable<ElementHandle>;
+    /**
+     * Adds an item to the `Leveled List Entries` array on `record`,
+     * setting `LVLO\Reference` to `value`, `LVLO\Level` to `value2`, and `LVLO\Count` to `value3`.
+     * @returns Handle to the added LeveledEntry element.
+     */
+    AddLeveledEntry(record: RecordHandle, value: string, value2: string, value3: string): ElementHandle;
+    /**
+     * Removes the first item in the `Leveled List Entries` array on `record`
+     * matching `value` at `LVLO\Reference`.
+     */
+    RemoveLeveledEntry(record: RecordHandle, value: string): void;
+    /**
+     * @returns true if the `VMAD\Scripts` array on `record` has an element matching `value` at `scriptName`.
+     */
+    HasScript(record: RecordHandle, value: string): boolean;
+    /**
+     * Finds the first item in the `VMAD\Scripts` array on `record` matching `value` at `scriptName`.
+     * @returns Handle to the element if found, else returns 0.
+     */
+    GetScript(record: RecordHandle, value: string): Zeroable<ElementHandle>;
+    /**
+     * Adds an item to the `VMAD\Scripts` array on `record`,
+     * setting `scriptName` to `value`, and `Flags` to `value2`.
+     * @returns Handle to the added Script element.
+     */
+    AddScript(record: RecordHandle, value: string, value2: string): ElementHandle;
+    /**
+     * Removes the first item in the `VMAD\Scripts` array on `record` matching `value` at `scriptName`.
+     */
+    RemoveScript(record: RecordHandle, value: string): void;
+    /**
+     * @returns true if the `Properties` array on `scriptElement` has an element matching `value` at `propertyName`.
+     */
+    HasScriptProperty(scriptElement: ElementHandle, value: string): boolean;
+    /**
+     * Finds the first item in the `Properties` array on `scriptElement` matching `value` at `propertyName`.
+     * @returns Handle to the element if found, else returns 0.
+     */
+    GetScriptProperty(scriptElement: ElementHandle, value: string): Zeroable<ElementHandle>;
+    /**
+     * Adds an item to the `Properties` array on `scriptElement`,
+     * setting `propertyName` to `value`, and `CNTO\Count` to `value2`.
+     * @returns Handle to the added ScriptProperty element.
+     */
+    AddScriptProperty(scriptElement: ElementHandle, value: string, value2: string): ElementHandle;
+    /**
+     * Removes the first item in the `Properties` array on `scriptElement` matching `value` at `propertyName`.
+     */
+    RemoveScriptProperty(scriptElement: ElementHandle, value: string): void;
+    /**
+     * @returns true if the `Conditions` array on `record` has an element matching `value` at `CTDA\Function`.
+     */
+    HasCondition(record: RecordHandle, value: string): boolean;
+    /**
+     * Finds the first item in the `Conditions` array on `record` matching `value` at `CTDA\Function`.
+     * @returns Handle to the element if found, else returns 0.
+     */
+    GetCondition(record: RecordHandle, value: string): Zeroable<ElementHandle>;
+    /**
+     * Adds an item to the `Conditions` array on `record`,
+     * setting `CTDA\Function` to `value`,
+     * `CTDA\Type` to `value2`,
+     * `CTDA\Comparison Value` to `value3`,
+     * and `CTDA\Parameter #1` to `value4`.
+     * @returns Handle to the added Condition element.
+     */
+    AddCondition(record: RecordHandle, value: string, value2: string, value3: string, value4: string): ElementHandle;
+    /**
+     * Removes the first item in the `Conditions` array on `record` matching `value` at `CTDA\Function`.
+     */
+    RemoveCondition(record: RecordHandle, value: string): void;
+    /**
+     * @returns Value at `DATA\Value` on `record`.
+     */
+    GetGoldValue(record: RecordHandle): number;
+    /**
+     * Sets the value at `DATA\Value` on `record` to `value`.
+     */
+    SetGoldValue(record: RecordHandle, value: number): void;
+    /**
+     * @returns Value at `DATA\Weight` on `record`.
+     */
+    GetWeight(record: RecordHandle): number;
+    /**
+     * Sets the value at `DATA\Weight` on `record` to `value`.
+     */
+    SetWeight(record: RecordHandle, value: number): void;
+    /**
+     * @returns Value at `DATA\Damage` on `record`.
+     */
+    GetDamage(record: RecordHandle): number;
+    /**
+     * Sets the value at `DATA\Damage` on `record` to `value`.
+     */
+    SetDamage(record: RecordHandle, value: number): void;
+    /**
+     * @returns Value at `DNAM` on `record`.
+     */
+    GetArmorRating(record: RecordHandle): number;
+    /**
+     * Sets the value at `DNAM` on `record` to `value`.
+     */
+    SetArmorRating(record: RecordHandle, value: number): void;
+    /**
+     * @returns Value at `[BODT|BOD2]\Armor Type` on `record`.
+     */
+    GetArmorType(record: RecordHandle): string;
+    /**
+     * Sets the value at `[BODT|BOD2]\Armor Type` on `record` to `armorType`.
+     */
+    SetArmorType(record: RecordHandle, armorType: string): void;
+    /**
+     * @returns State of flag Female at `ACBS\Flags` on `record`.
+     */
+    GetIsFemale(record: RecordHandle): boolean;
+    /**
+     * Sets flag Female at `ACBS\Flags` on `record` to `state`.
+     */
+    SetIsFemale(record: RecordHandle, state: boolean): void;
+    /**
+     * @returns State of flag Essential at `ACBS\Flags` on `record`.
+     */
+    GetIsEssential(record: RecordHandle): boolean;
+    /**
+     * Sets flag Essential at `ACBS\Flags` on `record` to `state`.
+     */
+    SetIsEssential(record: RecordHandle, state: boolean): void;
+    /**
+     * @returns State of flag Unique at `ACBS\Flags` on `record`.
+     */
+    GetIsUnique(record: RecordHandle): boolean;
+    /**
+     * Sets flag Unique at `ACBS\Flags` on `record` to `state`.
+     */
+    SetIsUnique(record: RecordHandle, state: boolean): void;
+
+    /**
+     * Masters functions
+     * @see {@link https://z-edit.github.io#/docs?t=Development%2FAPIs%2Fxelib%2FMasters}
+     */
+    /**
+     * Removes unnecessary masters from file `id`.
+     */
+    CleanMasters(id: FileHandle): void;
+    /**
+     * Orders the masters in file `id` based on the order in which they are loaded.
+     */
+    SortMasters(id: FileHandle): void;
+    /**
+     * Adds master `filename` to file `id` if missing.
+     */
+    AddMaster(id: FileHandle, filename: string): void;
+    /**
+     * Adds masters to file `id2` which are required when copying element `id` to it.
+     * Set `asNew` to true when copying `id` as a new record.
+     */
+    AddRequiredMasters(
+        id: ElementHandle,
+        id2: FileHandle,
+        /**
+         * @default false
+         */
+        asNew?: boolean,
+    ): void;
+    /**
+     * @returns Array of handles for the master files of file `id`.
+     */
+    GetMasters(id: FileHandle): FileHandle[];
+    /**
+     * @returns Array of the master filenames of the file `id`.
+     */
+    GetMasterNames(id: FileHandle): string[];
+    /**
+     * Adds all files loaded before file `id` as masters to it.
+     */
+    AddAllMasters(id: FileHandle): void;
+    /**
+     * @returns Array of the filenames of files loaded before file `id` that aren't already masters for it.
+     */
+    GetAvailableMasters(id: FileHandle): string[];
+
+    /**
+     * Group functions
+     * @see {@link https://z-edit.github.io#/docs?t=Development%2FAPIs%2Fxelib%2FGroups}
+     */
+    /**
+     * @returns true if group `signature` is present in file `id`.
+     */
+    HasGroup(id: FileHandle, signature: string): boolean;
+    /**
+     * Adds the group `signature` to file `id` if missing and returns a handle to it.
+     */
+    AddGroup(id: FileHandle, signature: string): Handle;
+    /**
+     * @returns Handle to the child group of id.
+     * @returns 0 if id does not have a child group.
+     */
+    GetChildGroup(id: Handle): Zeroable<Handle>;
+
+    /**
+     * Serialization functions
+     * @see {@link https://z-edit.github.io#/docs?t=Development%2FAPIs%2Fxelib%2FSerialization}
+     */
+    /**
+     * @returns Element `id` as a JSON string.
+     */
+    ElementToJSON(id: ElementHandle): string;
+    /**
+     * @returns Element `id` as a JavaScript object.
+     */
+    ElementToObject(id: ElementHandle): object;
+    /**
+     * Creates elements by deserializing `json` in the context of `id` at `path`.
+     */
+    ElementFromJSON(id: Handle, path: string, json: string): void;
+    /**
+     * Creates elements from `obj` in the context of `id` at `path`.
+     */
+    ElementFromObject(id: Handle, path: string, obj: object): void;
+
+    /**
+     * Plugin Error functions
+     */
+    /**
+     * Starts a background thread which checks for errors in `id`.
+     */
+    CheckForErrors(id: FileHandle): void;
+    /**
+     * @returns true if the error thread started by `CheckForErrors` is done.
+     * @see CheckForErrors
+     */
+    GetErrorThreadDone(): boolean;
+    /**
+     * @returns Errors found by `CheckForErrors` as an array of error objects.
+     * @see CheckForErrors
+     */
+    GetErrors(): Array<{
+        group: number;
+        handle: Handle;
+        signature: string;
+        form_id: number;
+        path: string;
+        data: string;
+    }>;
+
+    /**
+     * Utils functions
+     * @see {@link https://z-edit.github.io#/docs?t=Development%2FAPIs%2Fxelib%2FUtils}
+     */
+    /**
+     * Converts `n` to a hexadecimal string and pads it with zeros until it has a length equal to `padding`.
+     * @param n unsigned integer
+     * @param padding integer
+     */
+    Hex(n: number, padding: number): string;
+    /**
+     * Passes `handle` to `callback`, executes it, and then releases `handle`.
+     * Uses a try-finally to ensure the handle gets released
+     * regardless of any exceptions that occur in `callback`.
+     */
+    WithHandle(handle: Handle, callback: (handle: Handle) => void): void;
+    /**
+     * Passes `handles` to `callback`, executes it, and then releases `handles`.
+     * Uses a try-finally to ensure the handles get released
+     * regardless of any exceptions that occur in `callback`.
+     */
+    WithHandles(handles: Handle[], callback: (handle: Handle[]) => void): void;
+    /**
+     * Creates an array in xelib at `xelib.HandleGroup`.
+     * All handles retrieved from `xelib` functions will be appended to this array.
+     * @see HandleGroup
+     */
+    CreateHandleGroup(): void;
+    /**
+     * @see CreateHandleGroup
+     */
+    HandleGroup?: Handle[];
+    /**
+     * Releases all handles in `xelib.HandleGroup`.
+     * After calling this, handles retrieved from xelib
+     * will no longer be appended to the `xelib.HandleGroup` array.
+     * @see HandleGroup
+     */
+    FreeHandleGroup(): void;
+    /**
+     * Executes `callback`.
+     * Any handles retrieved from `xelib` in `callback` will not be added to the active handle group.
+     */
+    OutsideHandleGroup(callback: () => void): void;
+    /**
+     * Executes `callback` in a handle group.
+     * Any handles retrieved from `xelib` in `callback` will be automatically released
+     * once it finishes executing.
+     */
+    WithHandleGroup(callback: () => void): void;
+    /**
+     * Extracts a signature from a string.
+     * E.g. extracts `ARMO`, from `ArmorIronCuirass "Iron Armor" [ARMO:00012E49]`.
+     */
+    ExtractSignature(str: string): string;
+    /**
+     * Gets all records matching `search` found in `id`
+     * and returns an object with properties corresponding to each record found.
+     * The object's properties have keys produced by calling `keyFn` on the record
+     * and values produced by calling `valueFn` on the record.
+     * If `valueFn` is falsy, the record's handle is used as the value.
+     */
+    BuildReferenceMap<V = RecordHandle>(
+        id: Handle,
+        /**
+         * @default ''
+         */
+        search?: string,
+        /**
+         * @default xelib.EditorID
+         * @see EditorID
+         */
+        keyFn?: (rec: RecordHandle) => string,
+        /**
+         * @default null
+         */
+        valueFn?: (rec: RecordHandle) => V,
+    ): { [k: string]: V };
+    /**
+     * @returns object constructed by mapping each value in the `paths` object
+     * to an element resolved relative to `id`.
+     */
+    ResolveElements<P extends { [k: string]: string }>(
+        id: Handle,
+        paths: P,
+    ): {
+        [K in keyof P]: Zeroable<ElementHandle>;
+    };
+    /**
+     * Raises an exception if any element fails to resolve.
+     * @returns object constructed by mapping each value in the `paths` object
+     * to an element resolved relative to `id`.
+     */
+    ResolveElementsEx<P extends { [k: string]: string }>(
+        id: Handle,
+        paths: P,
+    ): {
+        [K in keyof P]: ElementHandle;
+    };
+}

--- a/types/xelib/index.d.ts
+++ b/types/xelib/index.d.ts
@@ -9,8 +9,17 @@
  */
 export const wrapper: XELib;
 
-// Distinguish handles from regular numbers
+/**
+ * Handles are distinguished from `number`.
+ *
+ * They are only meaninful to xelib and one should not pass arbitrary numbers.
+ */
 export type Handle = number & { __xelib_handle__: never };
+/**
+ * A type which can either be a `Handle` type or `0`.
+ *
+ * In most cases `0` means "all files", "not found", etc.
+ */
 export type Zeroable<H extends Handle> = H | 0;
 // Distinguish types of handles
 /**
@@ -593,26 +602,26 @@ export interface XELib
     /**
      * Returns true if an element exists at the given path.
      */
-    HasElement(id: Handle, path: string): boolean;
+    HasElement(id: Zeroable<Handle>, path: string): boolean;
     /**
      * Resolves the element at path and returns a handle to it.
      * Returns 0 if the element is not found.
      */
-    GetElement(id: Handle, path: string): Zeroable<ElementHandle>;
+    GetElement(id: Zeroable<Handle>, path: string): Zeroable<ElementHandle>;
     /**
      * Traverses path, creating any elements that are not found.
      * Returns a handle to the element at the end of the path.
      */
-    AddElement(id: Handle, path: string): ElementHandle;
+    AddElement(id: Zeroable<Handle>, path: string): ElementHandle;
     /**
      * Traverses path, creating any elements that are not found.
      * Sets the value of the element at the end of the path to value, and returns a handle to it.
      */
-    AddElementValue(id: Handle, path: string, value: string): ElementHandle;
+    AddElementValue(id: Zeroable<Handle>, path: string, value: string): ElementHandle;
     /**
      * Removes the element at path if it exists.
      */
-    RemoveElement(id: Handle, path: string): void;
+    RemoveElement(id: Zeroable<Handle>, path: string): void;
     /**
      * Removes the element id.
      * If the element cannot be removed it gets its parent container and attempts to remove it.
@@ -627,11 +636,11 @@ export interface XELib
     /**
      * Returns an array of handles for all of the elements found in the container at path.
      */
-    GetElements(id: ContainerHandle, path: string): ElementHandle[];
+    GetElements(id: Zeroable<ContainerHandle>, path: string): ElementHandle[];
     /**
      * Returns an array of the names of all elements that can exist at path.
      */
-    GetDefNames(id: Handle, path: string): string[];
+    GetDefNames(id: Zeroable<Handle>, path: string): string[];
     /**
      * Returns an array of the signatures that can be added to id.
      */
@@ -640,11 +649,11 @@ export interface XELib
      * Returns the record referenced by the element at path.
      * Note: this returns the master of the record, not the winning override.
      */
-    GetLinksTo(id: Handle, path: string): RecordHandle;
+    GetLinksTo(id: Zeroable<Handle>, path: string): RecordHandle;
     /**
      * Sets the record referenced by the element at path to id2.
      */
-    SetLinksTo(id: Handle, id2: RecordHandle, path: string): void;
+    SetLinksTo(id: Handle, id2: Zeroable<RecordHandle>, path: string): void;
     /**
      * Returns a handle to the container of id.
      * Returns 0 on failure.
@@ -667,25 +676,25 @@ export interface XELib
      * When the element at path contains a reference, value can be a Form ID, Editor ID, or FULL Name.
      * FULL Names passed to this function must be surrounded by double quotes.
      */
-    ElementMatches(id: Handle, path: string, value: string): boolean;
+    ElementMatches(id: Zeroable<Handle>, path: string, value: string): boolean;
     /**
      * Returns true if the array at path contains an item which matches value at subpath.
      */
-    HasArrayItem(id: Handle, path: string, subpath: string, value: string): boolean;
+    HasArrayItem(id: Zeroable<Handle>, path: string, subpath: string, value: string): boolean;
     /**
      * Returns the first item in the array at path which matches value at subpath.
      * Returns 0 if no matching element is found.
      */
-    GetArrayItem(id: Handle, path: string, subpath: string, value: string): Zeroable<ElementHandle>;
+    GetArrayItem(id: Zeroable<Handle>, path: string, subpath: string, value: string): Zeroable<ElementHandle>;
     /**
      * Adds an item to the array at path and sets value at subpath.
      * @returns Handle to the added array item.
      */
-    AddArrayItem(id: Handle, path: string, subpath: string, value: string): ElementHandle;
+    AddArrayItem(id: Zeroable<Handle>, path: string, subpath: string, value: string): ElementHandle;
     /**
      * Removes the first item in the array at path which matches value at subpath.
      */
-    RemoveArrayItem(id: Handle, path: string, subpath: string, value: string): void;
+    RemoveArrayItem(id: Zeroable<Handle>, path: string, subpath: string, value: string): void;
     /**
      * Moves the array item id to position index.
      */
@@ -793,66 +802,66 @@ export interface XELib
      * @returns the editor value at path.
      * @returns an empty string if path does not exist.
      */
-    GetValue(id: Handle, path: string): string;
+    GetValue(id: Zeroable<Handle>, path: string): string;
     /**
      * Sets the editor value at path to value.
      * This is the same value displayed in the record view.
      */
-    SetValue(id: Handle, path: string, value: string): void;
+    SetValue(id: Zeroable<Handle>, path: string, value: string): void;
     /**
      * @returns The native integer value at path.
      * @returns 0 if path does not exist.
      */
-    GetIntValye(id: Handle, path: string): number;
+    GetIntValye(id: Zeroable<Handle>, path: string): number;
     /**
      * Sets the native integer value at path to value.
      */
-    SetIntValue(id: Handle, path: string, value: number): void;
+    SetIntValue(id: Zeroable<Handle>, path: string, value: number): void;
     /**
      * @returns The native unsigned integer value at path.
      * @returns 0 if path does not exist.
      */
-    GetUIntValue(id: Handle, path: string): number;
+    GetUIntValue(id: Zeroable<Handle>, path: string): number;
     /**
      * Sets the native unsigned integer value at path to value.
      */
-    SetUIntValue(id: Handle, path: string, value: number): void;
+    SetUIntValue(id: Zeroable<Handle>, path: string, value: number): void;
     /**
      * @returns The native float value at path.
      * @returns 0.0 if path does not exist.
      */
-    GetFloatValue(id: Handle, path: string): number;
+    GetFloatValue(id: Zeroable<Handle>, path: string): number;
     /**
      * Sets the native float value at path to value.
      */
-    SetFloatValue(id: Handle, path: string, value: number): void;
+    SetFloatValue(id: Zeroable<Handle>, path: string, value: number): void;
     /**
      * Resolves the flags element at path, and sets flag name to state.
      */
-    SetFlag(id: Handle, path: string, name: string, state: boolean): void;
+    SetFlag(id: Zeroable<Handle>, path: string, name: string, state: boolean): void;
     /**
      * Resolves the flags element at path, and gets the state of flag name.
      */
-    GetFlag(id: Handle, path: string, name: string): boolean;
+    GetFlag(id: Zeroable<Handle>, path: string, name: string): boolean;
     /**
      * Resolves the flags element at path and returns an array of the names of the enabled flags on it.
      */
-    GetEnabledFlags(id: Handle, path: string): string[];
+    GetEnabledFlags(id: Zeroable<Handle>, path: string): string[];
     /**
      * Resolves the flags element at path and sets the enabled flags to flags.
      * Note: This disables any active flags that are not in flags.
      */
-    SetEnabledFlags(id: Handle, path: string, flags: readonly string[]): void;
+    SetEnabledFlags(id: Zeroable<Handle>, path: string, flags: readonly string[]): void;
     /**
      * Resolves the flags element at path and returns an array of the names of all of the flags it supports.
      * Flag positions in the array indicate the binary bits they corresponds to.
      */
-    GetAllFlags(id: Handle, path: string): string[];
+    GetAllFlags(id: Zeroable<Handle>, path: string): string[];
     /**
      * Resolves the enumeration element at path and returns an array of the options it supports.
      * Enumeration positions in the array indicate the binary bits they corresponds to.
      */
-    GetEnumOptions(id: Handle, path: string): string[];
+    GetEnumOptions(id: Zeroable<Handle>, path: string): string[];
 
     /**
      * File functions
@@ -1502,11 +1511,11 @@ export interface XELib
     /**
      * Creates elements by deserializing `json` in the context of `id` at `path`.
      */
-    ElementFromJSON(id: Handle, path: string, json: string): void;
+    ElementFromJSON(id: Zeroable<Handle>, path: string, json: string): void;
     /**
      * Creates elements from `obj` in the context of `id` at `path`.
      */
-    ElementFromObject(id: Handle, path: string, obj: object): void;
+    ElementFromObject(id: Zeroable<Handle>, path: string, obj: object): void;
 
     /**
      * Plugin Error functions

--- a/types/xelib/tsconfig.json
+++ b/types/xelib/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "xelib-tests.ts"
+    ]
+}

--- a/types/xelib/tslint.json
+++ b/types/xelib/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/xelib/xelib-tests.ts
+++ b/types/xelib/xelib-tests.ts
@@ -1,0 +1,27 @@
+import { wrapper as xelib, Handle, ElementHandle, RecordHandle, ConflictAll, ConflictThis } from 'xelib';
+
+xelib.GetGlobal('foo');
+
+xelib.SetSortMode('None', false);
+
+xelib.BuildReferences(0, false);
+
+// Fake handles for test
+const handle = 1 as Handle;
+const elHandle = 1 as ElementHandle;
+
+// Check that numbers for Handles error
+xelib.Name(1); // $ExpectError
+
+const [ca, ct]: [keyof typeof ConflictAll, keyof typeof ConflictThis] = xelib.GetConflictData(0, elHandle, true);
+xelib.GetConflictData(0, elHandle); // $ExpectType [ConflictAll, ConflictThis]
+
+// $ExpectType { [k: string]: RecordHandle; }
+xelib.BuildReferenceMap(handle, '');
+// $ExpectType { [k: string]: number; }
+xelib.BuildReferenceMap(handle, '', undefined, (_: RecordHandle) => 1);
+
+// $ExpectType { a: Zeroable<ElementHandle>; b: Zeroable<ElementHandle>; }
+xelib.ResolveElements(handle, { a: 'foo', b: 'bar' });
+// $ExpectType { a: ElementHandle; b: ElementHandle; }
+xelib.ResolveElementsEx(handle, { a: 'foo', b: 'bar' });

--- a/types/zedit__upf/index.d.ts
+++ b/types/zedit__upf/index.d.ts
@@ -1,0 +1,588 @@
+// Type definitions for non-npm package zedit__upf 2.0
+// Project: https://github.com/zedit/zedit-unified-patching-framework
+// Definitions by: Alex Layton <https://github.com/awlayton>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.8
+
+import type { XELib, GameMode, RecordHandle, FileHandle } from 'xelib';
+
+import type { FSJetpack } from 'fs-jetpack/types';
+import type { FileFilter } from 'electron';
+
+/**
+ * UPF modules have these variables exposed globally:
+ *
+ * registerPatcher, fh, info, patcherPath, patcherUrl, xelib
+ * @see {@link https://z-edit.github.io#/docs?t=Modules%2FPatcher_Modules}
+ */
+declare global {
+    /**
+     * @deprecated The Patcher used in this call contains deprecated option types
+     * @see LegacyPatcher
+     */
+    // tslint:disable-next-line no-unnecessary-generics
+    function registerPatcher<L = {}, S = {}>(patcher: LegacyPatcher<S, L>): void;
+    /**
+     * Function for registering a patcher with UPF
+     *
+     * Generics are needed for inference within Patcher interface to work
+     */
+    // tslint:disable-next-line no-unnecessary-generics unified-signatures
+    function registerPatcher<L = {}, S = {}>(patcher: Patcher<S, L>): void;
+
+    /**
+     * @see FileHelpers
+     */
+    const fh: FileHelpers;
+
+    /**
+     * Object containing information about your module.
+     * Basically just your module.json.
+     */
+    const info: ModuleInfo;
+
+    /**
+     * Absolute path for the folder where your patcher module is installed on the user's machine.
+     * Should be prepended to paths when loading/saving files.
+     */
+    const patcherPath: string;
+
+    /**
+     * `file://` URL for the folder where your patcher module is installed on the user's machine.
+     * Should be prepended to any HTML template/resource URLs.
+     */
+    const patcherUrl: string;
+
+    /**
+     * xelib wrapper instance exposed to zEdit modules
+     *
+     * @see XELib
+     */
+    const xelib: XELibModule;
+
+    /**
+     * The zEdit angular application.
+     *
+     * @see {@link https://docs.angularjs.org/api/ng/type/angular.Module}
+     * @see {@link https://docs.angularjs.org/guide/di}
+     */
+    const ngapp: object;
+}
+
+/**
+ * Modify XELib interface before exposing to module.
+ *
+ * Some xelib functions should not be used by zEdit modules.
+ */
+export interface XELibModule extends XELib {
+    /**
+     * This function should never be called from zEdit modules.
+     * @internal
+     * @see XELib.Initialize
+     */
+    Initialize: never;
+    /**
+     * This function should never be called from zEdit modules.
+     * @internal
+     * @see XELib.Finalize
+     */
+    Finalize: never;
+    /**
+     * This function should never be called from zEdit modules.
+     * @internal
+     * @see XELib.SetSortMode
+     */
+    SetSortMode: never;
+
+    /**
+     * This function should never be called from zEdit modules.
+     * @internal
+     * @see XELib.ClearMessages
+     */
+    ClearMessages: never;
+    /**
+     * This function should never be called from zEdit modules.
+     * @internal
+     * @see XELib.GetExceptionMessage
+     */
+    GetExceptionMessage: never;
+
+    /**
+     * This function should never be called from zEdit modules.
+     * @internal
+     * @see XELib.SetGamePath
+     */
+    SetGamePath: never;
+    /**
+     * This function should never be called from zEdit modules.
+     * @internal
+     * @see XELib.SetLanguage
+     */
+    SetLanguage: never;
+    /**
+     * This function should never be called from zEdit modules.
+     * @internal
+     * @see XELib.SetGameMode
+     */
+    SetGameMode: never;
+    /**
+     * This function should never be called from zEdit modules.
+     * @internal
+     * @see XELib.GetLoadOrder
+     */
+    GetLoadOrder: never;
+    /**
+     * This function should never be called from zEdit modules.
+     * @internal
+     * @see XELib.GetActivePlugins
+     */
+    GetActivePlugins: never;
+    /**
+     * This function should never be called from zEdit modules.
+     * @internal
+     * @see XELib.LoadPlugins
+     */
+    LoadPlugins: never;
+}
+
+export type ExectuteCTX<S, L> = [FileHandle, Helpers, S, L];
+
+export type ProcessBlock<S, L> = (
+    | {
+          /**
+           * Loaded records which pass filter will be copied to the patch plugin,
+           * and then passed to the patch function.
+           */
+          load: {
+              /**
+               * Record signature to load.
+               * You can view record signatures by top level group names
+               * on the tree view and in record headers.
+               */
+              signature: string;
+              /**
+               * Pass true to include override records.
+               *
+               * @default false
+               */
+              overrides?: boolean;
+              /**
+               * Filter function. Called for each loaded record.
+               * Return false to skip patching a record.
+               */
+              filter?: (record: RecordHandle) => boolean;
+          };
+      }
+    | {
+          /**
+           * A function which can be used instead of load.
+           * The records function allows you to return a custom array of records to patch.
+           */
+          records: (filesToPatch: FileHandle[], helpers: Helpers, settings: S, locals: L) => RecordHandle[];
+      }
+) & {
+    /**
+     * Called for each record copied to the patch plugin.
+     * This is the step where you set values on the record.
+     */
+    patch?: (record: RecordHandle, helpers: Helpers, settings: S, locals: L) => void;
+};
+
+/**
+ * @typeParam S Type for the Patcher's settings
+ * @typeParam L Type for the Patcher's local variables
+ *
+ * @see {@link https://z-edit.github.io#/docs?t=Development%2FAPIs%2FUPF_Patcher_API}
+ * @see registerPatcher
+ */
+export interface Patcher<S extends {}, L extends {}> {
+    /**
+     * Your patcher module information.
+     * You should use the `info` variable as the value here.
+     */
+    info: ModuleInfo;
+    /**
+     * Array of the game modes your patcher works with
+     */
+    gameModes: GameMode[];
+    settings: {
+        /**
+         * The label is what gets displayed as the settings tab's label
+         */
+        label: string;
+        /**
+         * If you set hide to true the settings tab will not be displayed
+         *
+         * @default false
+         */
+        hide?: boolean;
+        /**
+         * URL to the HTML template to use for the settings tab.
+         * You'll want to use the `patcherUrl` global in this URL.
+         *
+         * @example `${patcherUrl}/partials/settings.html`
+         */
+        templateUrl: string;
+        /**
+         * controller function for your patcher's settings tab.
+         * This is where you put any extra data binding/functions
+         * that you need to access through angular on the settings tab.
+         *
+         * @todo what is $scope?
+         */
+        controller?: ($scope: unknown) => void;
+        /**
+         * Default settings for your patcher.
+         */
+        defaultSettings: {
+            /**
+             * Use the patchFileName setting if you want to use a unique patch file
+             * for your patcher instead of the default zPatch.esp plugin file.
+             * (using zPatch.esp is recommended)
+             *
+             * @default zPatch.esp
+             */
+            patchFileName?: string;
+        } & S;
+    };
+    /**
+     * Optional array of required filenames.
+     * Can omit if empty.
+     *
+     * @default []
+     */
+    requiredFiles?: (() => string[]) | string[];
+    /**
+     * You can program strict exclusions here.
+     * These exclusions cannot be overridden by the user.
+     * This function can be removed if you don't want to hard-exclude any files.
+     */
+    getFilesToPatch?: (filenames: string[]) => string[];
+    /**
+     * This function gets called when your patcher is executed.
+     *
+     * @param patchFile Handle to patch file
+     * @param settings @see defaultSettings
+     * @param locals Store values to refer to them later in the patching process.
+     */
+    execute: ((...args: ExectuteCTX<S, L>) => Executor<S, L>) | Executor<S, L>;
+}
+
+/**
+ * Type for Patcher containing deprecated option types.
+ *
+ * @see Patcher
+ */
+export type LegacyPatcher<S, L> = Patcher<S, L> &
+    (
+        | {
+              /**
+               * @deprecated Use function version
+               * @see Patcher.requiredFiles
+               */
+              requiredFiles: string[];
+          }
+        | {
+              /**
+               * @deprecated Use function version
+               * @see Patcher.execute
+               */
+              execute: Executor<S, L>;
+          }
+    );
+
+/**
+ * @see Patcher.execute
+ */
+export interface Executor<S, L> {
+    /**
+     * Perform anything that needs to be done once at the beginning of the
+     * patcher's execution here.
+     * This can be used to cache records which don't need to be patched,
+     * but need to be referred to later on.  Store values
+     */
+    initialize?: (...args: ExectuteCTX<S, L>) => void;
+    /**
+     * Array of process blocks.
+     *
+     * The blocks are run sequentially
+     */
+    process: Array<ProcessBlock<S, L>>;
+    /**
+     * Called after processing.
+     * Can be used to perform any cleanup/final steps
+     * once your patcher has finished executing.
+     *
+     * Note that UPF automatically removes ITPO records and unused masters,
+     * so you don't need to do that here.
+     */
+    finalize?: (...args: ExectuteCTX<S, L>) => void;
+}
+
+/**
+ * @see {@link https://z-edit.github.io#/docs?t=Modules}
+ */
+export interface ModuleInfo {
+    /**
+     * The module's unique identifier.
+     */
+    id: string;
+    /**
+     * The module's display name.
+     * This is the name displayed in the Manage Extensions Modal.
+     */
+    name: string;
+    /**
+     * The author(s) of the module.
+     */
+    author: string;
+    /**
+     * Version string for the module.
+     */
+    version: string;
+    /**
+     * `MM/DD/YYYY` date string corresponding to when the module was initially released.
+     */
+    released: string;
+    /**
+     * `MM/DD/YYYY` date string corresponding to when the module was last updated.
+     */
+    updated: string;
+    /**
+     * Short description of the module.
+     */
+    description: string;
+    /**
+     * array of the module id strings which your module requires to function properly.
+     *
+     * @default []
+     */
+    requires?: string[];
+    /**
+     * string specifying the module loader your module should be loaded with.
+     *
+     * @default default
+     */
+    moduleLoader?: string;
+    /**
+     * boolean specifying whether or not the module can be hot loaded.
+     * Hot loading is when a module is loaded after zEdit has started.
+     * Modules cannot be hot loaded if they use `ngapp`.
+     *
+     * @default false
+     */
+    canHotLoad?: boolean;
+}
+
+/**
+ * Helpers which you can use at any point in your patcher's execution.
+ *
+ * @see {@link https://z-edit.github.io#/docs?t=Development%2FAPIs%2FUPF_Patcher_API}
+ */
+export interface Helpers {
+    /**
+     * Load records from the files your patcher is targeting.
+     */
+    loadRecords(
+        search: string,
+        /**
+         * @default false
+         */
+        includeOverride?: boolean,
+    ): RecordHandle[];
+    /**
+     * Call this function to print a message to the progress modal's log.
+     */
+    logMessage(message: string): void;
+    /**
+     * Uses record consistency caching to make certain the input record
+     * stays at the same Form ID when the patch gets regenerated.
+     * This function should be used on all records created by UPF patchers,
+     * excluding overrides.
+     * The id should be a unique string value for the record.
+     * It is recommended to use a unique prefix for id to avoid collisions
+     * with other patchers.
+     * The record's editor ID will be set to id if the record
+     * has an Editor ID field.
+     */
+    cacheRecord(record: RecordHandle, id: string): RecordHandle;
+}
+
+/**
+ * object/array representable in JSON
+ * @internal
+ */
+export type JSONAble = number | boolean | string | null | JSONAble[] | { [k: string]: JSONAble };
+
+/**
+ * This API provides functions for interfacing with the user's file system through
+ * `fs-jetpack`, `extract-zip`, and `shell`.
+ *
+ * Unless otherwise specified, all paths passed to functions can be a path relative to the application root folder or an absolute path.
+ * @see {@link https://z-edit.github.io#/docs?t=Development%2FAPIs%2FFile_Helpers}
+ */
+export interface FileHelpers {
+    /**
+     * `fs-jetpack` instance with current working directroy set to the application root directory.
+     */
+    jetpack: FSJetpack;
+
+    /**
+     * Path to the application resource directory.
+     * In a development environment this is just `.\app`,
+     * but in production it is `.\resources\app.asar\app`.
+     */
+    appPath: string;
+
+    /**
+     * Path to the application user data directory.
+     * In a development environment this is located at `%appdata%\zEdit (Development)`,
+     * and in production this is `%appdata%\zEdit`.
+     */
+    userPath: string;
+
+    /**
+     * `fs-jetpack` instance with current working directory set to `appPath`.
+     */
+    appDir: FSJetpack;
+
+    /**
+     * `fs-jetpack` instance with current working directory set to `userPath`.
+     */
+    userDir: FSJetpack;
+
+    /**
+     * If a file exists at `filePath`, it's read into memory and deserialized into a JavaScript object or array, which is then returned.
+     * If a file does not exist at the specified path the `defaultValue` is returned.
+     */
+    loadJsonFile<T>(filePath: string, defaultValue: T): JSONAble | T;
+
+    /**
+     * If a file exists at `filePath`, its contents are read into memory as a UTF8 string and returned.
+     * If a file does not exist at the specified path the `defaultValue` is returned.
+     */
+    loadTextFile<T>(filePath: string, defaultValue: T): string | T;
+
+    /**
+     * Serializes the object passed through `value` to the file at `filePath`.
+     * Creates the file if missing, else overwrites it.
+     */
+    saveJsonFile(
+        filePath: string,
+        value: JSONAble,
+        /**
+         * @default false
+         */
+        minify?: boolean,
+    ): void;
+
+    /**
+     * Writes the text value to the file at `filePath`.
+     * Creates the file if missing, else overwrites it.
+     */
+    saveTextFile(
+        filePath: string,
+        value: string,
+        /**
+         * @default utf8
+         */
+        encoding?: string,
+    ): void;
+
+    /**
+     * Opens the file at `filePath` with the default program configured to open it.
+     */
+    openFile(filePath: string): void;
+
+    /**
+     * Opens `url` in the user's web browser.
+     * The URI protocol must be included in the URL. (e.g. `https://...`)
+     */
+    openUrl(url: string): void;
+
+    /**
+     * Converts the input `path` to a `file://` URL.
+     */
+    pathToFileUrl(path: string): string;
+
+    /**
+     * Converts the input the `file://`` URL to a path.
+     */
+    fileUrlToPath(fileUrl: string): string;
+
+    /**
+     * Extracts the ZIP archive at `filePath` to `destDir`.
+     */
+    extractArchive(
+        filePath: string,
+        destDir: string,
+        /**
+         * @default false
+         */
+        empty?: boolean,
+    ): void;
+
+    getFileBase(filePath: string): string | undefined;
+
+    /**
+     * Extracts and returns the file extension from `filePath`.
+     * Returns undefined if the path does not end with a file extension.
+     */
+    getFileExt(filePath: string): string | undefined;
+
+    /**
+     * Extracts and returns the filename from `filePath`.
+     */
+    getFileName(filePath: string): string | undefined;
+
+    /**
+     * Extracts and returns the parent directory path from `filePath`.
+     */
+    getDirectory(filePath: string): string | undefined;
+
+    /**
+     * @returns Date modified for the file at `filePath`.
+     */
+    getDateModified(filePath: string): Date;
+
+    /**
+     * @returns array of paths for all directories in the folder at `path`.
+     */
+    getDirectories(path: string): string[];
+
+    /**
+     * @returns path to the directory selected by the user.
+     * @returns undefined if the user didn't select a directory.
+     */
+    selectDirectory(title: string, defaultPath?: string): string | undefined;
+
+    /**
+     * @returns path to the file selected by the user.
+     * @returns undefined if the user didn't select a file.
+     *
+     * @see {@link https://github.com/electron/electron/blob/master/docs/api/dialog.md#dialogshowopendialogbrowserwindow-options-callback}
+     */
+    selectFile(
+        title: string,
+        defaultPath: string,
+        /**
+         * @default []
+         */
+        filters?: FileFilter[],
+    ): string | undefined;
+
+    /**
+     * @returns path to the file saved by the user.
+     * @returns undefined if the user didn't choose to save a file.
+     *
+     * @see {@link https://github.com/electron/electron/blob/master/docs/api/dialog.md#dialogshowsavedialogbrowserwindow-options-callback}
+     */
+    saveFile(
+        title: string,
+        defaultPath: string,
+        /**
+         * @default []
+         */
+        filters?: FileFilter[],
+    ): string | undefined;
+}

--- a/types/zedit__upf/index.d.ts
+++ b/types/zedit__upf/index.d.ts
@@ -145,6 +145,9 @@ export interface XELibModule extends XELib {
     LoadPlugins: never;
 }
 
+/**
+ * [patchFile, helpers, settings, locals]
+ */
 export type ExectuteCTX<S, L> = [FileHandle, Helpers, S, L];
 
 export type ProcessBlock<S, L> = (

--- a/types/zedit__upf/package.json
+++ b/types/zedit__upf/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "dependencies": {
+        "electron": "^10.1.2",
+        "fs-jetpack": "^3.1.0"
+    }
+}

--- a/types/zedit__upf/tsconfig.json
+++ b/types/zedit__upf/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "zedit__upf-tests.ts"
+    ],
+    "paths": {
+        "@zedit/upf": ["zedit__upf"]
+    }
+}

--- a/types/zedit__upf/tslint.json
+++ b/types/zedit__upf/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/zedit__upf/zedit__upf-tests.ts
+++ b/types/zedit__upf/zedit__upf-tests.ts
@@ -1,0 +1,243 @@
+/// <reference types="zedit__upf" />
+
+import { SortMode, GameMode } from 'xelib';
+
+// Check for UPF gloabls
+registerPatcher;
+fh; // $ExpectType FileHelpers
+info; // $ExpectType ModuleInfo
+patcherPath; // $ExpectType string
+patcherUrl; // $ExpectType string
+xelib; // $ExpectType XELibModule
+
+// Check for xelib functions disallowed in modules
+xelib.Initialize(''); // $ExpectError
+xelib.Finalize(); // $ExpectError
+xelib.SetSortMode(SortMode.None); // $ExpectError
+xelib.ClearMessages(); // $ExpectError
+xelib.GetExceptionMessage(); // $ExpectError
+xelib.SetGamePath(''); // $ExpectError
+xelib.SetLanguage(''); // $ExpectError
+xelib.SetGameMode(GameMode.gmSSE); // $ExpectError
+xelib.GetLoadOrder(); // $ExpectError
+xelib.GetActivePlugins(); // $ExpectError
+xelib.LoadPlugins(); // $ExpectError
+
+// Use all optional parameters
+registerPatcher({
+    info,
+    gameModes: [GameMode.gmSSE],
+    settings: {
+        label: 'test',
+        hide: true,
+        templateUrl: patcherUrl,
+        controller($scope) {
+            $scope;
+        },
+        defaultSettings: {
+            patchFileName: 'zTest.esp',
+        },
+    },
+    requiredFiles() {
+        return ['foo.esp', 'bar.esp'];
+    },
+    getFilesToPatch(filenames) {
+        return filenames.filter(f => f !== 'baz.esp');
+    },
+    execute(patchFile, helpers) {
+        // Check types
+        patchFile; // $ExpectType FileHandle
+        helpers; // $ExpectType Helpers
+
+        return {
+            initialize(patchFile, helpers) {
+                // Check types
+                patchFile; // $ExpectType FileHandle
+                helpers; // $ExpectType Helpers
+            },
+            process: [
+                {
+                    load: {
+                        signature: 'ARMA',
+                        overrides: true,
+                        filter(record) {
+                            record; // $ExpectType RecordHandle
+                            return true;
+                        },
+                    },
+                    records(filesToPatch, helpers) {
+                        filesToPatch; // $ExpectType FileHandle[]
+                        helpers; // $ExpectType Helpers
+
+                        return [];
+                    },
+                    patch(record, helpers) {
+                        record; // $ExpectType RecordHandle
+                        helpers; // $ExpectType Helpers
+                    },
+                },
+            ],
+            finalize(patchFile, helpers) {
+                // Check types
+                patchFile; // $ExpectType FileHandle
+                helpers; // $ExpectType Helpers
+            },
+        };
+    },
+});
+
+// Check type inference for S
+registerPatcher({
+    info,
+    gameModes: [GameMode.gmSSE],
+    settings: {
+        label: 'test',
+        templateUrl: patcherUrl,
+        defaultSettings: {
+            a: 1,
+        },
+    },
+    execute(patchFile, helpers, settings, locals) {
+        // Check types
+        patchFile; // $ExpectType FileHandle
+        helpers; // $ExpectType Helpers
+        settings; // $ExpectType { a: number; }
+        locals; // $ExpectType {}
+
+        return {
+            initialize(patchFile, helpers, settings, locals) {
+                // Check types
+                patchFile; // $ExpectType FileHandle
+                helpers; // $ExpectType Helpers
+                settings; // $ExpectType { a: number; }
+                locals; // $ExpectType {}
+            },
+            process: [
+                {
+                    records(filesToPatch, helpers, settings, locals) {
+                        filesToPatch; // $ExpectType FileHandle[]
+                        helpers; // $ExpectType Helpers
+                        settings; // $ExpectType { a: number; }
+                        locals; // $ExpectType {}
+
+                        return [];
+                    },
+                    patch(record, helpers, settings, locals) {
+                        record; // $ExpectType RecordHandle
+                        helpers; // $ExpectType Helpers
+                        settings; // $ExpectType { a: number; }
+                        locals; // $ExpectType {}
+                    },
+                },
+            ],
+            finalize(patchFile, helpers, settings, locals) {
+                // Check types
+                patchFile; // $ExpectType FileHandle
+                helpers; // $ExpectType Helpers
+                settings; // $ExpectType { a: number; }
+                locals; // $ExpectType {}
+            },
+        };
+    },
+});
+
+// Check type inference for L
+registerPatcher<{ a: number; b: string }>({
+    info,
+    gameModes: [GameMode.gmSSE],
+    settings: {
+        label: 'test',
+        templateUrl: patcherUrl,
+        defaultSettings: {},
+    },
+    execute(patchFile, helpers, settings, locals) {
+        // Check types
+        patchFile; // $ExpectType FileHandle
+        helpers; // $ExpectType Helpers
+        settings; // $ExpectType {}
+        locals; // $ExpectType { a: number; b: string; }
+
+        return {
+            initialize(patchFile, helpers, settings, locals) {
+                // Check types
+                patchFile; // $ExpectType FileHandle
+                helpers; // $ExpectType Helpers
+                settings; // $ExpectType {}
+                locals; // $ExpectType { a: number; b: string; }
+
+                locals.a = 2;
+                locals.b = 'foo';
+            },
+            process: [
+                {
+                    records(filesToPatch, helpers, settings, locals) {
+                        filesToPatch; // $ExpectType FileHandle[]
+                        helpers; // $ExpectType Helpers
+                        settings; // $ExpectType {}
+                        locals; // $ExpectType { a: number; b: string; }
+
+                        return [];
+                    },
+                    patch(record, helpers, settings, locals) {
+                        record; // $ExpectType RecordHandle
+                        helpers; // $ExpectType Helpers
+                        settings; // $ExpectType {}
+                        locals; // $ExpectType { a: number; b: string; }
+                    },
+                },
+            ],
+            finalize(patchFile, helpers, settings, locals) {
+                // Check types
+                patchFile; // $ExpectType FileHandle
+                helpers; // $ExpectType Helpers
+                settings; // $ExpectType {}
+                locals; // $ExpectType { a: number; b: string; }
+            },
+        };
+    },
+});
+
+// Check deprecated type for requiredFiles
+registerPatcher({
+    info,
+    gameModes: [GameMode.gmSSE],
+    settings: {
+        label: 'test',
+        templateUrl: patcherUrl,
+        defaultSettings: {},
+    },
+    requiredFiles: ['foo.esp'],
+    execute() {
+        return {
+            process: [
+                {
+                    load: {
+                        signature: 'ARMA',
+                    },
+                    patch() {},
+                },
+            ],
+        };
+    },
+});
+
+// Check deprecated type for execute
+registerPatcher({
+    info,
+    gameModes: [GameMode.gmSSE],
+    settings: {
+        label: 'test',
+        templateUrl: patcherUrl,
+        defaultSettings: {},
+    },
+    execute: {
+        process: [
+            {
+                load: {
+                    signature: 'ARMA',
+                },
+                patch() {},
+            },
+        ],
+    },
+});

--- a/types/zedit__upf/zedit__upf-tests.ts
+++ b/types/zedit__upf/zedit__upf-tests.ts
@@ -1,5 +1,3 @@
-/// <reference types="zedit__upf" />
-
 import { SortMode, GameMode } from 'xelib';
 
 // Check for UPF gloabls


### PR DESCRIPTION
This adds type definitions for [zEdit's UPF](https://github.com/z-edit/zedit-unified-patching-framework) modules and [xelib](https://github.com/z-edit/xelib) (xelib is a dependency of UPF).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.