### PR TITLE
[qunit] Explicitly support Promise callbacks

### DIFF
--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -426,7 +426,7 @@ declare global {
          *
          * @callback callback Callback to execute.
          */
-        begin(callback: (details: QUnit.BeginDetails) => void): void;
+        begin(callback: (details: QUnit.BeginDetails) => void | Promise<void>): void;
 
         /**
          * Configuration for QUnit
@@ -441,7 +441,7 @@ declare global {
          *
          * @param callback Callback to execute
          */
-        done(callback: (details: QUnit.DoneDetails) => void): void;
+        done(callback: (details: QUnit.DoneDetails) => void | Promise<void>): void;
 
         /**
          * Advanced and extensible data dumping for JavaScript.
@@ -532,14 +532,14 @@ declare global {
          *
          * @param callback Callback to execute
          */
-        moduleDone(callback: (details: QUnit.ModuleDoneDetails) => void): void;
+        moduleDone(callback: (details: QUnit.ModuleDoneDetails) => void | Promise<void>): void;
 
         /**
          * Register a callback to fire whenever a module begins.
          *
          * @param callback Callback to execute
          */
-        moduleStart(callback: (details: QUnit.ModuleStartDetails) => void): void;
+        moduleStart(callback: (details: QUnit.ModuleStartDetails) => void | Promise<void>): void;
 
         /**
          * Adds a test to exclusively run, preventing all other tests from running.
@@ -648,14 +648,14 @@ declare global {
             passed: number;
             total: number;
             runtime: number;
-        }) => void): void;
+        }) => void | Promise<void>): void;
 
         /**
          * Register a callback to fire whenever a test begins.
          *
          * @param callback Callback to execute
          */
-        testStart(callback: (details: QUnit.TestStartDetails) => void): void;
+        testStart(callback: (details: QUnit.TestStartDetails) => void | Promise<void>): void;
 
         /**
          * Adds a test which expects at least one failing assertion during its run.

--- a/types/qunit/test/global-test.ts
+++ b/types/qunit/test/global-test.ts
@@ -270,6 +270,37 @@ QUnit.testStart(function( details: QUnit.TestStartDetails ) {
   console.log( "Now running: ", details.name, ' from module ', details.module );
 });
 
+async function timeout() {
+  return new Promise(resolve => setTimeout(resolve, 1));
+}
+
+// These async tests are intended to ensure the appropriate behavior for @typescript-eslint/no-misused-promises.
+// However, we don't actually use typescript-eslint in this project and tslint has no equivalent,
+// so we can't properly test it.
+QUnit.begin(async function() {
+  await timeout();
+});
+
+QUnit.done(async function() {
+  await timeout();
+});
+
+QUnit.moduleDone(async function() {
+  await timeout();
+});
+
+QUnit.moduleStart(async function() {
+  await timeout();
+});
+
+QUnit.testDone(async function() {
+  await timeout();
+});
+
+QUnit.testStart(async function() {
+  await timeout();
+});
+
 let Robot: any = () => {};
 
 QUnit.module( "robot", {


### PR DESCRIPTION
The lack of explicit support is generally not problematic except when
used in conjunction with @typescript-eslint/no-misused-promises which
complains when a Promise is provided to a function that doesn't allow
for it.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://api.qunitjs.com/callbacks/QUnit.begin/
https://api.qunitjs.com/callbacks/QUnit.done/
https://api.qunitjs.com/callbacks/QUnit.moduleDone/
https://api.qunitjs.com/callbacks/QUnit.moduleStart/
https://api.qunitjs.com/callbacks/QUnit.testDone/
https://api.qunitjs.com/callbacks/QUnit.testStart/
