### PR TITLE
update(ratelimiter): version 3.4 update and other changes

### DIFF
--- a/types/ratelimiter/index.d.ts
+++ b/types/ratelimiter/index.d.ts
@@ -1,58 +1,73 @@
-// Type definitions for ratelimiter 2.1.1
+// Type definitions for ratelimiter 3.4
 // Project: https://github.com/tj/node-ratelimiter
 // Definitions by: Aya Morisawa <https://github.com/AyaMorisawa>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 import { RedisClient } from 'redis';
 
-interface LimiterOption {
-    /**
-     * The identifier to limit against (typically a user id)
-     */
-    id: string;
-
-    /**
-     * Redis connection instance
-     */
-    db: RedisClient;
-
-    /**
-     * Max requests within duration
-     */
-    max?: number;
-
-    /**
-     * Duration of limit in milliseconds
-     */
-    duration?: number;
-}
-
-interface LimiterInfo {
-    /**
-     * max value
-     */
-    total: number;
-
-    /**
-     * Number of calls left in current duration without decreasing current get
-     */
-    remaining: number;
-
-    /**
-     * Time in milliseconds until the end of current duration
-     */
-    reset: number;
-}
-
 declare class Limiter {
-    constructor(opts: LimiterOption);
+    constructor(opts: Limiter.LimiterOption);
 
+    /**
+     * Inspect implementation
+     */
     inspect(): string;
 
-    get(fn: (err: any, info: LimiterInfo) => void): void;
+    /**
+     * Get values and header / status code and invoke `fn(err, info)`.
+     */
+    get(fn: (err: any, info: Limiter.LimiterInfo) => void): void;
 }
 
-declare namespace Limiter { }
+declare namespace Limiter {
+    interface LimiterOption {
+        /**
+         * The identifier to limit against (typically a user id)
+         */
+        id: string;
+
+        /**
+         * Redis connection instance
+         */
+        db: RedisClient;
+
+        /**
+         * Max requests within duration
+         * @default 2500
+         */
+        max?: number;
+
+        /**
+         * Duration of limit in milliseconds
+         * @default 3600000
+         */
+        duration?: number;
+    }
+
+    /**
+     * Result Object
+     */
+    interface LimiterInfo {
+        /**
+         * `max` value
+         */
+        total: number;
+
+        /**
+         * number of calls left in current `duration` without decreasing current `get`
+         */
+        remaining: number;
+
+        /**
+         * time since epoch in seconds at which the rate limiting period will end (or already ended)
+         */
+        reset: number;
+
+        /**
+         * time since epoch in milliseconds at which the rate limiting period will end (or already ended)
+         */
+        resetMs: number;
+    }
+}
 
 export = Limiter;

--- a/types/ratelimiter/ratelimiter-tests.ts
+++ b/types/ratelimiter/ratelimiter-tests.ts
@@ -3,12 +3,19 @@ import Limiter = require('ratelimiter');
 
 declare let id: string;
 declare let db: redis.RedisClient;
-let limit = new Limiter({ id: id, db: db });
 
-const str: string = limit.inspect();
+const limit = new Limiter({ id, db, duration: 3_600, max: 1_000 });
 
-limit.get((err, limit): void => {
-    const total: number = limit.total;
-    const remaining: number = limit.remaining;
-    const reset: number = limit.reset;
+limit.inspect(); // $ExpectType string
+
+limit.get((error, limit): void => {
+    if (error) {
+        console.error(error);
+        return;
+    }
+
+    limit.total; // $ExpectType number
+    limit.remaining; // $ExpectType number
+    limit.reset; // $ExpectType number
+    limit.resetMs; // $ExpectType number
 });

--- a/types/ratelimiter/tslint.json
+++ b/types/ratelimiter/tslint.json
@@ -1,9 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "dt-header": false,
-        "no-consecutive-blank-lines": false,
-        "object-literal-shorthand": false,
-        "prefer-const": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
This introduces minor updates from 3.4, while at the same time exporting
types from the module:
- new creation options
- new properties in results
- version bump
- export types properly
- tests amended
- mantainer added

https://github.com/tj/node-ratelimiter/compare/v2.1.1...v3.3.1#diff-168726dbe96b3ce427e7fedce31bb0bc

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.