### PR TITLE
[react-native] Fix return type of `createObjectURL`

### DIFF
--- a/types/react-native/globals.d.ts
+++ b/types/react-native/globals.d.ts
@@ -259,7 +259,7 @@ declare type XMLHttpRequestResponseType = '' | 'arraybuffer' | 'blob' | 'documen
  * built into React Native (as of 0.63) does not implement all the properties.
  */
 declare class URL {
-    static createObjectURL(blob: Blob): URL;
+    static createObjectURL(blob: Blob): string;
     static revokeObjectURL(url: string): void;
 
     constructor(url: string, base?: string);


### PR DESCRIPTION
The signature for `URL.createObjectURL` is incorrect. It returns a `string`, not a `URL`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/blob/3a6327a5d9ebfd0de56c37009ab7de1d0e6bdf85/Libraries/Blob/URL.js#L118
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
