### PR TITLE
Retry deprecating xumm-api

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -5989,6 +5989,12 @@
             "asOfVersion": "3.0.0"
         },
         {
+            "libraryName": "xumm-sdk",
+            "typingsPackageName": "xumm-api",
+            "sourceRepoURL": "https://github.com/XRPL-Labs/XUMM-SDK",
+            "asOfVersion": "0.1.4"
+        },
+        {
             "libraryName": "yaml",
             "typingsPackageName": "yaml",
             "sourceRepoURL": "https://github.com/eemeli/yaml",


### PR DESCRIPTION
Due to a bug in the DT publisher when deprecating a package to a different name (xumm-sdk in this case), I had to remove xumm-api without deprecating it.

This PR puts back the notNeededPackages entry, which I hope will deprecate the package. It might not succeed since the deletion has already happened though.