### PR TITLE
[es6template] Add es6template types

### DIFF
--- a/types/es6template/es6template-tests.ts
+++ b/types/es6template/es6template-tests.ts
@@ -1,0 +1,14 @@
+import es6template = require('es6template');
+
+// This rule is disabled because the library uses ES6-looking template strings, but with normal strings.
+/* tslint:disable:no-invalid-template-strings */
+
+const test1 = es6template('foo ${bar} baz ${quux}', {bar: 'BAR', quux: 'QUUX'});
+const test2 = es6template.render('Hello ${place} and ${user.name}!', {
+    place: 'world',
+    user: {
+        name: 'Charlike'
+    }
+});
+const fn = es6template.compile('Hello ${place} and ${user.name}!');
+const test3 = fn({place: 'world', user: {name: 'Charlike'}});

--- a/types/es6template/index.d.ts
+++ b/types/es6template/index.d.ts
@@ -10,8 +10,6 @@ interface Default {
     // calling the `compile` function.
     // tslint:disable-next-line:no-unnecessary-generics
     compile: <Locals>(str: string) => ((locals: Locals) => string);
-}
-interface Default {
     (str: string, locals: Record<string, unknown>): string;
 }
 declare const _default: Default;

--- a/types/es6template/index.d.ts
+++ b/types/es6template/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for es6template 1.0
+// Project: https://github.com/zalmoxisus/es6-template
+// Definitions by: Nathan Bierema <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/*~ If this module is a UMD module that exposes a global variable 'myLib' when
+ *~ loaded outside a module loader environment, declare that global here.
+ *~ Otherwise, delete this declaration.
+ */
+export as namespace myLib;
+
+/*~ If this module has methods, declare them as functions like so.
+ */
+export function myMethod(a: string): string;
+export function myOtherMethod(a: number): number;
+
+/*~ You can declare types that are available via importing the module */
+export interface someType {
+    name: string;
+    length: number;
+    extras?: string[];
+}
+
+/*~ You can declare properties of the module using const, let, or var */
+export const myField: number;
+
+/*~ If there are types, properties, or methods inside dotted names
+ *~ of the module, declare them inside a 'namespace'.
+ */
+export namespace subProp {
+    /*~ For example, given this definition, someone could write:
+     *~   import { subProp } from 'yourModule';
+     *~   subProp.foo();
+     *~ or
+     *~   import * as yourMod from 'yourModule';
+     *~   yourMod.subProp.foo();
+     */
+    function foo(): void;
+}

--- a/types/es6template/index.d.ts
+++ b/types/es6template/index.d.ts
@@ -1,39 +1,21 @@
 // Type definitions for es6template 1.0
 // Project: https://github.com/zalmoxisus/es6-template
-// Definitions by: Nathan Bierema <https://github.com/me>
+// Definitions by: Nathan Bierema <https://github.com/Methuselah96>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/*~ If this module is a UMD module that exposes a global variable 'myLib' when
- *~ loaded outside a module loader environment, declare that global here.
- *~ Otherwise, delete this declaration.
- */
-export as namespace myLib;
+declare function render(str: string, locals: Record<string, unknown>): string;
 
-/*~ If this module has methods, declare them as functions like so.
- */
-export function myMethod(a: string): string;
-export function myOtherMethod(a: number): number;
+// This rule is disabled because the caller of `compile()` knows what the type of the `locals` parameter should be when
+// calling the `compile` function.
+// tslint:disable-next-line:no-unnecessary-generics
+declare function compile<Locals>(str: string): ((locals: Locals) => string);
 
-/*~ You can declare types that are available via importing the module */
-export interface someType {
-    name: string;
-    length: number;
-    extras?: string[];
+interface Default {
+    render: typeof render;
+    compile: typeof compile;
 }
-
-/*~ You can declare properties of the module using const, let, or var */
-export const myField: number;
-
-/*~ If there are types, properties, or methods inside dotted names
- *~ of the module, declare them inside a 'namespace'.
- */
-export namespace subProp {
-    /*~ For example, given this definition, someone could write:
-     *~   import { subProp } from 'yourModule';
-     *~   subProp.foo();
-     *~ or
-     *~   import * as yourMod from 'yourModule';
-     *~   yourMod.subProp.foo();
-     */
-    function foo(): void;
+interface Default {
+    (str: string, locals: Record<string, unknown>): string;
 }
+declare const _default: Default;
+export = _default;

--- a/types/es6template/index.d.ts
+++ b/types/es6template/index.d.ts
@@ -3,16 +3,13 @@
 // Definitions by: Nathan Bierema <https://github.com/Methuselah96>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function render(str: string, locals: Record<string, unknown>): string;
-
-// This rule is disabled because the caller of `compile()` knows what the type of the `locals` parameter should be when
-// calling the `compile` function.
-// tslint:disable-next-line:no-unnecessary-generics
-declare function compile<Locals>(str: string): ((locals: Locals) => string);
-
 interface Default {
-    render: typeof render;
-    compile: typeof compile;
+    render: (str: string, locals: Record<string, unknown>) => string;
+
+    // This rule is disabled because the caller of `compile()` knows what the type of the `locals` parameter should be when
+    // calling the `compile` function.
+    // tslint:disable-next-line:no-unnecessary-generics
+    compile: <Locals>(str: string) => ((locals: Locals) => string);
 }
 interface Default {
     (str: string, locals: Record<string, unknown>): string;

--- a/types/es6template/tsconfig.json
+++ b/types/es6template/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "es6template-tests.ts"
+    ]
+}

--- a/types/es6template/tslint.json
+++ b/types/es6template/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
