### PR TITLE
fix(emoji-mart): add support for JSX.Element in fallback prop

### DIFF
--- a/types/emoji-mart/dist-es/utils/shared-props.d.ts
+++ b/types/emoji-mart/dist-es/utils/shared-props.d.ts
@@ -5,12 +5,13 @@ import { EmojiData, EmojiSkin, CustomEmoji } from './emoji-index/nimble-emoji-in
 export type BackgroundImageFn = (set: EmojiSet, sheetSize: EmojiSheetSize) => string;
 export type EmojiSet = 'apple' | 'google' | 'twitter' | 'emojione' | 'messenger' | 'facebook';
 export type EmojiSheetSize = 16 | 20 | 32 | 64;
+type Element = React.Component | JSX.Element;
 
 export interface EmojiProps {
     onOver?(emoji: EmojiData, e: React.MouseEvent<HTMLElement>): void;
     onLeave?(emoji: EmojiData, e: React.MouseEvent<HTMLElement>): void;
     onClick?(emoji: EmojiData, e: React.MouseEvent<HTMLElement>): void;
-    fallback?(emoji: EmojiData, props: EmojiProps): React.Component;
+    fallback?(emoji: EmojiData, props: EmojiProps): Element;
     /** defaults to returning a png from unpkg.com-hosted emoji-datasource-${set} */
     backgroundImageFn?: BackgroundImageFn;
     native?: boolean;

--- a/types/emoji-mart/dist-es/utils/shared-props.d.ts
+++ b/types/emoji-mart/dist-es/utils/shared-props.d.ts
@@ -5,13 +5,12 @@ import { EmojiData, EmojiSkin, CustomEmoji } from './emoji-index/nimble-emoji-in
 export type BackgroundImageFn = (set: EmojiSet, sheetSize: EmojiSheetSize) => string;
 export type EmojiSet = 'apple' | 'google' | 'twitter' | 'emojione' | 'messenger' | 'facebook';
 export type EmojiSheetSize = 16 | 20 | 32 | 64;
-type Element = React.Component | JSX.Element;
 
 export interface EmojiProps {
     onOver?(emoji: EmojiData, e: React.MouseEvent<HTMLElement>): void;
     onLeave?(emoji: EmojiData, e: React.MouseEvent<HTMLElement>): void;
     onClick?(emoji: EmojiData, e: React.MouseEvent<HTMLElement>): void;
-    fallback?(emoji: EmojiData, props: EmojiProps): Element;
+    fallback?(emoji: EmojiData, props: EmojiProps): React.Component | JSX.Element;
     /** defaults to returning a png from unpkg.com-hosted emoji-datasource-${set} */
     backgroundImageFn?: BackgroundImageFn;
     native?: boolean;
@@ -70,7 +69,7 @@ export interface PickerProps {
     i18n?: PartialI18n;
     style?: React.CSSProperties;
     title?: string;
-    theme?: "auto" | "light" | "dark";
+    theme?: 'auto' | 'light' | 'dark';
     emoji?: string;
     color?: string;
     set?: EmojiSet;


### PR DESCRIPTION
### What I am doing:

Now that React is largely hook-based, the use of `React.Component` is less and less. This would allow a user to do something like this:

```
const getFallback = (_emoji: EmojiData, props: EmojiProps) => {
  const emoji = props?.emoji as BaseEmoji;
  return <span>{emoji?.native}</span>;
};

...

<Emoji emoji=":relaxed:" size={64} fallback={getFallback} />
```

Without getting this typecheck error on the `Emoji` component:

```
Type '(_emoji: EmojiData, props: EmojiProps) => JSX.Element' is not assignable to type '(emoji: EmojiData, props: EmojiProps) => Component<{}, {}, any>'.
  Type 'Element' is missing the following properties from type 'Component<{}, {}, any>': context, setState, forceUpdate, render, and 2 more.ts(2322)
shared-props.d.ts(13, 5): The expected type comes from property 'fallback' which is declared here on type 'IntrinsicAttributes & EmojiProps & { children?: ReactNode; }'
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://codesandbox.io/s/boring-noether-ot37b?file=/src/App.tsx