### PR TITLE
[sonic-boom] Switch to default export

### DIFF
--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -20,7 +20,7 @@
 import stream = require('stream');
 import http = require('http');
 import { EventEmitter } from 'events';
-import SonicBoom = require('sonic-boom');
+import SonicBoom from 'sonic-boom';
 import * as pinoStdSerializers from 'pino-std-serializers';
 
 export = P;
@@ -47,32 +47,32 @@ declare namespace P {
     const LOG_VERSION: number;
     const levels: LevelMapping;
     const symbols: {
-        setLevelSym: symbol,
-        getLevelSym: symbol,
-        levelValSym: symbol,
-        useLevelLabelsSym: symbol,
-        mixinSym: symbol,
-        lsCacheSym: symbol,
-        chindingsSym: symbol,
-        parsedChindingsSym: symbol,
-        asJsonSym: symbol,
-        writeSym: symbol,
-        serializersSym: symbol,
-        redactFmtSym: symbol,
-        timeSym: symbol,
-        timeSliceIndexSym: symbol,
-        streamSym: symbol,
-        stringifySym: symbol,
-        stringifiersSym: symbol,
-        endSym: symbol,
-        formatOptsSym: symbol,
-        messageKeySym: symbol,
-        nestedKeySym: symbol,
-        wildcardFirstSym: symbol,
-        needsMetadataGsym: symbol,
-        useOnlyCustomLevelsSym: symbol,
-        formattersSym: symbol,
-        hooksSym: symbol,
+        setLevelSym: symbol;
+        getLevelSym: symbol;
+        levelValSym: symbol;
+        useLevelLabelsSym: symbol;
+        mixinSym: symbol;
+        lsCacheSym: symbol;
+        chindingsSym: symbol;
+        parsedChindingsSym: symbol;
+        asJsonSym: symbol;
+        writeSym: symbol;
+        serializersSym: symbol;
+        redactFmtSym: symbol;
+        timeSym: symbol;
+        timeSliceIndexSym: symbol;
+        streamSym: symbol;
+        stringifySym: symbol;
+        stringifiersSym: symbol;
+        endSym: symbol;
+        formatOptsSym: symbol;
+        messageKeySym: symbol;
+        nestedKeySym: symbol;
+        wildcardFirstSym: symbol;
+        needsMetadataGsym: symbol;
+        useOnlyCustomLevelsSym: symbol;
+        formattersSym: symbol;
+        hooksSym: symbol;
     };
     /**
      * Exposes the Pino package version. Also available on the logger instance.
@@ -191,7 +191,9 @@ declare namespace P {
      *                writing performance it is strongly recommended to use `pino.destination` to create the destination stream.
      * @returns A Sonic-Boom  stream to be used as destination for the pino function
      */
-    function destination(dest?: string | number | DestinationObjectOptions | DestinationStream | NodeJS.WritableStream): SonicBoom;
+    function destination(
+        dest?: string | number | DestinationObjectOptions | DestinationStream | NodeJS.WritableStream,
+    ): SonicBoom;
 
     /**
      * Create an extreme mode destination. This yields an additional 60% performance boost.
@@ -502,26 +504,26 @@ declare namespace P {
          * For example, they can be used to change the level key name or to enrich the default metadata.
          */
         formatters?: {
-          /**
-           * Changes the shape of the log level.
-           * The default shape is { level: number }.
-           * The function takes two arguments, the label of the level (e.g. 'info') and the numeric value (e.g. 30).
-           */
-          level?: (level: string, number: number) => object;
-          /**
-           * Changes the shape of the bindings.
-           * The default shape is { pid, hostname }.
-           * The function takes a single argument, the bindings object.
-           * It will be called every time a child logger is created.
-           */
-          bindings?: (bindings: Bindings) => object;
-          /**
-           * Changes the shape of the log object.
-           * This function will be called every time one of the log methods (such as .info) is called.
-           * All arguments passed to the log method, except the message, will be pass to this function.
-           * By default it does not change the shape of the log object.
-           */
-          log?: (object: object) => object;
+            /**
+             * Changes the shape of the log level.
+             * The default shape is { level: number }.
+             * The function takes two arguments, the label of the level (e.g. 'info') and the numeric value (e.g. 30).
+             */
+            level?: (level: string, number: number) => object;
+            /**
+             * Changes the shape of the bindings.
+             * The default shape is { pid, hostname }.
+             * The function takes a single argument, the bindings object.
+             * It will be called every time a child logger is created.
+             */
+            bindings?: (bindings: Bindings) => object;
+            /**
+             * Changes the shape of the log object.
+             * This function will be called every time one of the log methods (such as .info) is called.
+             * All arguments passed to the log method, except the message, will be pass to this function.
+             * By default it does not change the shape of the log object.
+             */
+            log?: (object: object) => object;
         };
 
         /**

--- a/types/sonic-boom/index.d.ts
+++ b/types/sonic-boom/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for sonic-boom 0.7
+// Type definitions for sonic-boom 1.2
 // Project: https://github.com/mcollina/sonic-boom
 // Definitions by: Alex Ferrando <https://github.com/alferpal>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -7,7 +7,7 @@
 
 import { EventEmitter } from 'events';
 
-export = SonicBoom;
+export default SonicBoom;
 
 declare class SonicBoom extends EventEmitter {
     /**
@@ -15,7 +15,7 @@ declare class SonicBoom extends EventEmitter {
      * relative protocol is enabled. Default: process.stdout
      * @returns a new sonic-boom instance
      */
-    constructor(fileDescriptor: string | number, minLength?: number, sync?: boolean)
+    constructor(fileDescriptor: string | number, minLength?: number, sync?: boolean);
 
     /**
      * Writes the string to the file. It will return false to signal the producer to slow down.

--- a/types/sonic-boom/sonic-boom-tests.ts
+++ b/types/sonic-boom/sonic-boom-tests.ts
@@ -1,4 +1,4 @@
-import SonicBoom = require('sonic-boom');
+import SonicBoom from 'sonic-boom';
 const sonic = new SonicBoom(1);
 
 sonic.write('hello sonic\n');

--- a/types/sonic-boom/tslint.json
+++ b/types/sonic-boom/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+  "extends": "dtslint/dt.json",
+  "rules": {
+    "npm-naming": false
+  }
+}


### PR DESCRIPTION
`sonic-boom` bundles its own TypeScript types as of v1.2.0, but they were switched over to default exports in the process. This fixes up compatibility with `@types/pino` and `@types/sonic-boom` until they can be fully dropped in favour of bundled types.

---

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/pinojs/pino/pull/913
  - https://github.com/mcollina/sonic-boom/commit/5a985baa9a59e07bcc12f2121845c8d5db715523
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
