### PR TITLE
[qunit] add typed-ember team as owners

### DIFF
--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -3,6 +3,9 @@
 // Definitions by: James Bracy <https://github.com/waratuman>
 //                 Mike North <https://github.com/mike-north>
 //                 Stefan Sechelmann <https://github.com/sechel>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare global {


### PR DESCRIPTION
This PR does not change any type definitions. It is similar to #43429 in that it ensures that all active members of the "typed-ember" team are listed as authors for the `qunit` type definitions in DefinitelyTyped so that any of us can help manage them. The active members of typed-ember (@chriskrycho, @dfreeman, @jamescdavis, @mike-north) have committed to being jointly responsible for maintaining type definitions for Ember-related packages. As the default testing framework for Ember, I am including `qunit` as an Ember-related package.