### PR TITLE
[forest-express-sequelize] separate smart field|action|segment option from collection option

### DIFF
--- a/types/forest-express-mongoose/forest-express-mongoose-tests.ts
+++ b/types/forest-express-mongoose/forest-express-mongoose-tests.ts
@@ -5,6 +5,7 @@ import {
     PUBLIC_ROUTES, RecordCreator,
     RecordGetter, RecordRemover, RecordsCounter, RecordSerializer,
     RecordsGetter, RecordsRemover, RecordUpdater, StatSerialized, StatSerializer,
+    SmartActionOptions, SmartFieldOptions, SmartSegmentOptions,
     collection, CollectionOptions,
 } from 'forest-express-mongoose';
 import { RequestHandler } from 'express';
@@ -81,18 +82,19 @@ statSerialized = statSerializer.perform();
 
 collection('simpleCollection', { });
 
+const fields: SmartFieldOptions[] = [{
+    field: 'simple-field',
+    type: 'boolean',
+}];
+const actions: SmartActionOptions[] = [{
+    name: 'simple-action',
+}];
+const segments: SmartSegmentOptions[] = [{
+    name: 'simple-segment',
+    where: () => ({ }),
+}];
 const simpleCollectionOptions: CollectionOptions = {
-    fields: [{
-        field: 'simple-field',
-        type: 'boolean',
-    }],
-    actions: [{
-        name: 'simple-action',
-    }],
-    segments: [{
-        name: 'simple-segment',
-        where: () => ({ }),
-    }],
+    fields, actions, segments,
 };
 collection('simpleCollection', simpleCollectionOptions);
 

--- a/types/forest-express-mongoose/index.d.ts
+++ b/types/forest-express-mongoose/index.d.ts
@@ -138,39 +138,45 @@ export interface SegmentAggregationCreator {
     (record: any): object;
 }
 
-export interface CollectionOptions {
+export interface SmartFieldOptions {
+    field: string;
+    description?: string;
+    type: string | string[];
+    isReadOnly?: boolean;
+    reference?: string;
+    enums?: string[];
+    defaultValue?: any;
+    get?: SmartFieldValueGetter;
+    set?: SmartFieldValueSetter;
+    search?: SmartFieldSearcher;
+}
+
+export interface SmartActionOptions {
+    name: string;
+    type?: string;
     fields?: Array<{
-        field: string,
-        description?: string,
-        type: string | string[],
-        isReadOnly?: boolean,
-        reference?: string,
-        enums?: string[],
-        defaultValue?: any,
-        get?: SmartFieldValueGetter,
-        set?: SmartFieldValueSetter,
-        search?: SmartFieldSearcher,
+        field: string;
+        type: string | string[];
+        reference?: string;
+        enums?: string[];
+        description?: string;
+        isRequired?: boolean;
     }>;
-    actions?: Array<{
-        name: string;
-        type?: string,
-        fields?: Array<{
-            field: string,
-            type: string | string[],
-            reference?: string,
-            enums?: string[],
-            description?: string,
-            isRequired?: boolean,
-        }>
-        download?: boolean,
-        endpoint?: string,
-        httpMethod?: string,
-        values?: SmartActionValuesInjector,
-    }>;
-    segments?: Array<{
-        name: string,
-        where: SegmentAggregationCreator;
-    }>;
+    download?: boolean;
+    endpoint?: string;
+    httpMethod?: string;
+    values?: SmartActionValuesInjector;
+}
+
+export interface SmartSegmentOptions {
+    name: string;
+    where: SegmentAggregationCreator;
+}
+
+export interface CollectionOptions {
+    fields?: SmartFieldOptions[];
+    actions?: SmartActionOptions[];
+    segments?: SmartSegmentOptions[];
 }
 
 export function collection(name: string, options: CollectionOptions): void;

--- a/types/forest-express-sequelize/forest-express-sequelize-tests.ts
+++ b/types/forest-express-sequelize/forest-express-sequelize-tests.ts
@@ -5,6 +5,7 @@ import {
     PUBLIC_ROUTES, RecordCreator,
     RecordGetter, RecordRemover, RecordsCounter, RecordSerializer,
     RecordsGetter, RecordsRemover, RecordUpdater, StatSerialized, StatSerializer,
+    SmartActionOption, SmartFieldOption, SmartSegmentOption,
     collection, CollectionOptions
 } from 'forest-express-sequelize';
 import { RequestHandler } from 'express';
@@ -81,18 +82,19 @@ statSerialized = statSerializer.perform();
 
 collection('simpleCollection', { });
 
+const fields: SmartFieldOption[] = [{
+    field: 'simple-field',
+    type: 'boolean',
+}];
+const actions: SmartActionOption[] = [{
+    name: 'simple-action',
+}];
+const segments: SmartSegmentOption[] = [{
+    name: 'simple-segment',
+    where: () => ({ }),
+}];
 const simpleCollectionOptions: CollectionOptions = {
-    fields: [{
-        field: 'simple-field',
-        type: 'boolean',
-    }],
-    actions: [{
-        name: 'simple-action',
-    }],
-    segments: [{
-        name: 'simple-segment',
-        where: () => ({ }),
-    }],
+    fields, actions, segments,
 };
 collection('simpleCollection', simpleCollectionOptions);
 

--- a/types/forest-express-sequelize/forest-express-sequelize-tests.ts
+++ b/types/forest-express-sequelize/forest-express-sequelize-tests.ts
@@ -5,7 +5,7 @@ import {
     PUBLIC_ROUTES, RecordCreator,
     RecordGetter, RecordRemover, RecordsCounter, RecordSerializer,
     RecordsGetter, RecordsRemover, RecordUpdater, StatSerialized, StatSerializer,
-    SmartActionOption, SmartFieldOption, SmartSegmentOption,
+    SmartActionOptions, SmartFieldOptions, SmartSegmentOptions,
     collection, CollectionOptions
 } from 'forest-express-sequelize';
 import { RequestHandler } from 'express';
@@ -82,14 +82,14 @@ statSerialized = statSerializer.perform();
 
 collection('simpleCollection', { });
 
-const fields: SmartFieldOption[] = [{
+const fields: SmartFieldOptions[] = [{
     field: 'simple-field',
     type: 'boolean',
 }];
-const actions: SmartActionOption[] = [{
+const actions: SmartActionOptions[] = [{
     name: 'simple-action',
 }];
-const segments: SmartSegmentOption[] = [{
+const segments: SmartSegmentOptions[] = [{
     name: 'simple-segment',
     where: () => ({ }),
 }];

--- a/types/forest-express-sequelize/index.d.ts
+++ b/types/forest-express-sequelize/index.d.ts
@@ -138,39 +138,45 @@ export interface SegmentAggregationCreator {
     (record: any): object;
 }
 
-export interface CollectionOptions {
+export interface SmartFieldOption {
+    field: string;
+    description?: string;
+    type: string | string[];
+    isReadOnly?: boolean;
+    reference?: string;
+    enums?: string[];
+    defaultValue?: any;
+    get?: SmartFieldValueGetter;
+    set?: SmartFieldValueSetter;
+    search?: SmartFieldSearcher;
+}
+
+export interface SmartActionOption {
+    name: string;
+    type?: string;
     fields?: Array<{
-        field: string,
-        description?: string,
-        type: string | string[],
-        isReadOnly?: boolean,
-        reference?: string,
-        enums?: string[],
-        defaultValue?: any,
-        get?: SmartFieldValueGetter,
-        set?: SmartFieldValueSetter,
-        search?: SmartFieldSearcher,
+        field: string;
+        type: string | string[];
+        reference?: string;
+        enums?: string[];
+        description?: string;
+        isRequired?: boolean;
     }>;
-    actions?: Array<{
-        name: string;
-        type?: string,
-        fields?: Array<{
-            field: string,
-            type: string | string[],
-            reference?: string,
-            enums?: string[],
-            description?: string,
-            isRequired?: boolean,
-        }>
-        download?: boolean,
-        endpoint?: string,
-        httpMethod?: string,
-        values?: SmartActionValuesInjector,
-    }>;
-    segments?: Array<{
-        name: string,
-        where: SegmentAggregationCreator;
-    }>;
+    download?: boolean;
+    endpoint?: string;
+    httpMethod?: string;
+    values?: SmartActionValuesInjector;
+}
+
+export interface SmartSegmentOption {
+    name: string;
+    where: SegmentAggregationCreator;
+}
+
+export interface CollectionOptions {
+    fields?: SmartFieldOption[];
+    actions?: SmartActionOption[];
+    segments?: SmartSegmentOption[];
 }
 
 export function collection(name: string, options: CollectionOptions): void;

--- a/types/forest-express-sequelize/index.d.ts
+++ b/types/forest-express-sequelize/index.d.ts
@@ -138,7 +138,7 @@ export interface SegmentAggregationCreator {
     (record: any): object;
 }
 
-export interface SmartFieldOption {
+export interface SmartFieldOptions {
     field: string;
     description?: string;
     type: string | string[];
@@ -151,7 +151,7 @@ export interface SmartFieldOption {
     search?: SmartFieldSearcher;
 }
 
-export interface SmartActionOption {
+export interface SmartActionOptions {
     name: string;
     type?: string;
     fields?: Array<{
@@ -168,15 +168,15 @@ export interface SmartActionOption {
     values?: SmartActionValuesInjector;
 }
 
-export interface SmartSegmentOption {
+export interface SmartSegmentOptions {
     name: string;
     where: SegmentAggregationCreator;
 }
 
 export interface CollectionOptions {
-    fields?: SmartFieldOption[];
-    actions?: SmartActionOption[];
-    segments?: SmartSegmentOption[];
+    fields?: SmartFieldOptions[];
+    actions?: SmartActionOptions[];
+    segments?: SmartSegmentOptions[];
 }
 
 export function collection(name: string, options: CollectionOptions): void;


### PR DESCRIPTION
just wanted to create separate definitions for each collection options.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.