### PR TITLE
Add missing restApiOptions for jsforce connection

### DIFF
--- a/types/jsforce/connection.d.ts
+++ b/types/jsforce/connection.d.ts
@@ -21,6 +21,8 @@ export type Callback<T> = (err: Error | null, result: T) => void;
 // and search for options
 export interface RestApiOptions {
     headers?: { [x: string]: string }
+    allowRecursive?: boolean;
+    allOrNone?: boolean;
 }
 
 // These are pulled out because according to http://jsforce.github.io/jsforce/doc/connection.js.html#line49

--- a/types/jsforce/jsforce-tests.ts
+++ b/types/jsforce/jsforce-tests.ts
@@ -42,7 +42,9 @@ async function testSObject(connection: sf.Connection) {
 
     // currently untyped, but some future change may make this stricter
     const restApiOptions = {
-        headers: { Bearer: 'I have no idea what this wants' }
+        headers: { Bearer: 'I have no idea what this wants' },
+        allowRecursive: true,
+        allOrNone: true
     };
 
     { // Test SObject.record


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: jsforce/jsforce/issues/1068
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


