### PR TITLE
update(dompurify): v2.1 updates

### DIFF
--- a/types/dompurify/index.d.ts
+++ b/types/dompurify/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for DOM Purify 2.0
+// Type definitions for DOM Purify 2.1
 // Project: https://github.com/cure53/DOMPurify
 // Definitions by: Dave Taylor https://github.com/davetayls
 //                 Samira Bazuzi <https://github.com/bazuzi>
@@ -6,7 +6,6 @@
 //                 Exigerr <https://github.com/Exigerr>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
 /// <reference types="trusted-types"/>
 
 export as namespace DOMPurify;
@@ -59,7 +58,6 @@ declare namespace DOMPurify {
         RETURN_DOM_FRAGMENT?: boolean;
         RETURN_DOM_IMPORT?: boolean;
         RETURN_TRUSTED_TYPE?: boolean;
-        SAFE_FOR_JQUERY?: boolean;
         SANITIZE_DOM?: boolean;
         WHOLE_DOCUMENT?: boolean;
         ALLOWED_URI_REGEXP?: RegExp;

--- a/types/dompurify/test/dompurify-tests.ts
+++ b/types/dompurify/test/dompurify-tests.ts
@@ -58,9 +58,6 @@ trustedHtml = dompurify.sanitize(dirty, { RETURN_TRUSTED_TYPE: true });
 // return entire document including <html> tags (default is false)
 str = dompurify.sanitize(dirty, { WHOLE_DOCUMENT: true });
 
-// make output safe for usage in jQuery's $()/html() method (default is false)
-str = dompurify.sanitize(dirty, { SAFE_FOR_JQUERY: true });
-
 // disable DOM Clobbering protection on output (default is true, handle with care!)
 str = dompurify.sanitize(dirty, { SANITIZE_DOM: false });
 


### PR DESCRIPTION
- remove `SAFE_FOR_JQUERY`
- version bump
- TS 3.1 support is now deprecated (3.2 is default)

https://github.com/cure53/DOMPurify/releases/tag/2.1.0
https://github.com/DefinitelyTyped/DefinitelyTyped/commit/f87f81730a873caec8d737e16971b5a08db06a5c

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)