### PR TITLE
`Mousetrap`: convert to UMD

### DIFF
--- a/types/mousetrap/index.d.ts
+++ b/types/mousetrap/index.d.ts
@@ -4,35 +4,38 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-interface ExtendedKeyboardEvent extends KeyboardEvent {
-    returnValue: boolean; // IE returnValue
+declare namespace Mousetrap {
+    interface ExtendedKeyboardEvent extends KeyboardEvent {
+        returnValue: boolean; // IE returnValue
+    }
+
+    interface MousetrapStatic {
+        (el: Element): MousetrapInstance;
+        new (el?: Element): MousetrapInstance;
+        addKeycodes(keycodes: { [key: number]: string }): void;
+        stopCallback: (e: ExtendedKeyboardEvent, element: Element, combo: string) => boolean;
+        bind(keys: string|string[], callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): MousetrapInstance;
+        unbind(keys: string|string[], action?: string): MousetrapInstance;
+        trigger(keys: string, action?: string): MousetrapInstance;
+        reset(): MousetrapInstance;
+
+        /** https://craig.is/killing/mice#extensions.global */
+        bindGlobal(keyArray: string|string[], callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): void;
+    }
+
+    interface MousetrapInstance {
+        stopCallback: (e: ExtendedKeyboardEvent, element: Element, combo: string) => boolean;
+        bind(keys: string|string[], callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): this;
+        unbind(keys: string|string[], action?: string): this;
+        trigger(keys: string, action?: string): this;
+        handleKey(character: string, modifiers: string[], e: ExtendedKeyboardEvent): void;
+        reset(): this;
+    }
 }
 
-interface MousetrapStatic {
-    (el: Element): MousetrapInstance;
-    new (el?: Element): MousetrapInstance;
-    addKeycodes(keycodes: { [key: number]: string }): void;
-    stopCallback: (e: ExtendedKeyboardEvent, element: Element, combo: string) => boolean;
-    bind(keys: string|string[], callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): MousetrapInstance;
-    unbind(keys: string|string[], action?: string): MousetrapInstance;
-    trigger(keys: string, action?: string): MousetrapInstance;
-    reset(): MousetrapInstance;
 
-    /** https://craig.is/killing/mice#extensions.global */
-    bindGlobal(keyArray: string|string[], callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): void;
-}
+declare var Mousetrap: Mousetrap.MousetrapStatic;
 
-interface MousetrapInstance {
-    stopCallback: (e: ExtendedKeyboardEvent, element: Element, combo: string) => boolean;
-    bind(keys: string|string[], callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): this;
-    unbind(keys: string|string[], action?: string): this;
-    trigger(keys: string, action?: string): this;
-    handleKey(character: string, modifiers: string[], e: ExtendedKeyboardEvent): void;
-    reset(): this;
-}
+export = Mousetrap;
 
-declare var Mousetrap: MousetrapStatic;
-
-declare module "mousetrap" {
-    export = Mousetrap;
-}
+export as namespace Mousetrap;

--- a/types/mousetrap/test/global-bind.ts
+++ b/types/mousetrap/test/global-bind.ts
@@ -23,9 +23,12 @@ Mousetrap.bindGlobal('up up down down left right left right b a enter', function
     console.log('konami code');
 });
 
-// Test that union types are accepted.
-const unionTypeKeys: string | string[] = ['a', 'b', 'c'];
-Mousetrap.bindGlobal(unionTypeKeys, function() { console.log('Union type test') });
+// Wrapped in block to avoid naming conflicts with another global `unionTypeKeys`
+{
+    // Test that union types are accepted.
+    const unionTypeKeys: string | string[] = ['a', 'b', 'c'];
+    Mousetrap.bindGlobal(unionTypeKeys, function() { console.log('Union type test') });
+}
 
 
 Mousetrap.bindGlobal(['ctrl+s', 'meta+s'], (e, combo) => {

--- a/types/mousetrap/test/index-module.ts
+++ b/types/mousetrap/test/index-module.ts
@@ -1,0 +1,10 @@
+// Test that Mousetrap can be loaded as an external module.
+// Assume that if the externally-loaded module can be assigned to a variable with the type of global Mousetrap,
+// then everything is working correctly.
+
+import importedMousetrap = require('mousetrap');
+// $ExpectType MousetrapStatic
+var mousetrapModuleReference = importedMousetrap;
+
+// Can import event
+type Event = importedMousetrap.ExtendedKeyboardEvent;

--- a/types/mousetrap/test/index.ts
+++ b/types/mousetrap/test/index.ts
@@ -64,10 +64,3 @@ const unionTypeKeys: string | string[] = ['a', 'b', 'c'];
 Mousetrap(element).bind(unionTypeKeys, function() { console.log('Union type test') });
 
 Mousetrap(element).handleKey = (character: string, modifiers: string[], e: KeyboardEvent) => { console.log('Override handleKey test') };
-
-// Test that Mousetrap can be loaded as an external module.
-// Assume that if the externally-loaded module can be assigned to a variable with the type of global Mousetrap,
-// then everything is working correctly.
-
-import importedMousetrap = require('mousetrap');
-var mousetrapModuleReference: typeof Mousetrap = importedMousetrap;

--- a/types/mousetrap/tsconfig.json
+++ b/types/mousetrap/tsconfig.json
@@ -20,6 +20,7 @@
     "files": [
         "index.d.ts",
         "test/index.ts",
+        "test/index-module.ts",
         "test/global-bind.ts"
     ]
 }

--- a/types/redux-shortcuts/index.d.ts
+++ b/types/redux-shortcuts/index.d.ts
@@ -8,7 +8,7 @@ import { ActionCreator, Action, Dispatch } from "redux";
 import Mousetrap = require('mousetrap');
 
 export { Mousetrap };
-export const mousetrap: MousetrapInstance;
+export const mousetrap: Mousetrap.MousetrapInstance;
 
 export function bindShortcut(
     keys: KeyBindings,


### PR DESCRIPTION
- UMD modules should use `export as namespace` https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html#optional-global-usage
- Previously the event type was not available via the import—only as a global.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
