### PR TITLE
[prosemirror-model] allow null,undefined as DOMOutputSpecArray values

### DIFF
--- a/types/prosemirror-model/index.d.ts
+++ b/types/prosemirror-model/index.d.ts
@@ -1390,7 +1390,7 @@ export class Schema<N extends string = any, M extends string = any> {
 }
 export interface DOMOutputSpecArray {
   0: string;
-  1?: DOMOutputSpec | 0 | { [attr: string]: string };
+  1?: DOMOutputSpec | 0 | { [attr: string]: string | null | undefined };
   2?: DOMOutputSpec | 0;
   3?: DOMOutputSpec | 0;
   4?: DOMOutputSpec | 0;

--- a/types/prosemirror-model/prosemirror-model-tests.ts
+++ b/types/prosemirror-model/prosemirror-model-tests.ts
@@ -7,6 +7,8 @@ let domOutputSpec: model.DOMOutputSpec;
 domOutputSpec = ['div'];
 domOutputSpec = ['div', { class: 'foo' }];
 domOutputSpec = ['div', { class: 'foo' }, 0];
+domOutputSpec = ['div', { class: null }];
+domOutputSpec = ['div', { class: undefined }];
 domOutputSpec = ['div', 0];
 domOutputSpec = ['div', ['div', 0]];
 domOutputSpec = ['div', ['div', { class: 'foo' }]];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ProseMirror/prosemirror-model/blob/5195332bfae7957729ce3052dcafa1f3675f3c73/src/to_dom.js#L131
- `N/A` If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- `N/A` If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

`prosemirror-model#to_dom.js#L131` checks for a truthy value before encoding the attribute, so `null` and `undefined` are perfectly valid, and make the interface a bit easier work with.