### PR TITLE
[bwip-js] Add toCanvas() function declaration

### DIFF
--- a/types/bwip-js/bwip-js-tests.ts
+++ b/types/bwip-js/bwip-js-tests.ts
@@ -50,3 +50,13 @@ bwipjs(canvas, {
         cvs; // $ExpectType HTMLCanvasElement
     }
 });
+
+// Browser canvas implementation using .toCanvas()
+// See: https://github.com/metafloor/bwip-js#browser-usage
+const canvasElement = document.createElement('div') as HTMLElement;
+canvasElement.setAttribute("id", "canvas2");
+const toCanvas = bwipjs.toCanvas('canvas2', {
+    bcid: 'code128',
+    text: 'testing'
+});
+toCanvas; // $ExpectType HTMLCanvasElement

--- a/types/bwip-js/bwip-js-tests.ts
+++ b/types/bwip-js/bwip-js-tests.ts
@@ -53,7 +53,7 @@ bwipjs(canvas, {
 
 // Browser canvas implementation using .toCanvas()
 // See: https://github.com/metafloor/bwip-js#browser-usage
-const canvasElement = document.createElement('div') as HTMLElement;
+const canvasElement = document.createElement('canvas') as HTMLCanvasElement;
 canvasElement.setAttribute("id", "canvas2");
 const toCanvas = bwipjs.toCanvas('canvas2', {
     bcid: 'code128',

--- a/types/bwip-js/index.d.ts
+++ b/types/bwip-js/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for bwip-js 1.7.3
+// Type definitions for bwip-js  2.0.10
 // Project: https://github.com/metafloor/bwip-js
 // Definitions by: TANAKA Koichi <https://github.com/MugeSo>
 //                 Guillaume VanderEst <https://github.com/gvanderest>
+//                 Ryan Jentzsch <http://github.com/RyanNerd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -11,6 +12,7 @@ import { IncomingMessage as Request, ServerResponse as Response } from 'http';
 declare namespace BwipJs {
     export function loadFont(fontName:string, sizeMulti: number, fontFile: string): void;
     export function toBuffer(opts: ToBufferOptions, callback:(err: string|Error, png: Buffer) => void): void;
+    export function toCanvas(canvas: string | HTMLCanvasElement, opts: ToBufferOptions): HTMLCanvasElement;
     interface ToBufferOptions {
         bcid: string;
         text: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/metafloor/bwip-js/wiki/Methods-Reference#bwipjstocanvas
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

This adds the `toCanvas()` function declaration for the browser implmentation of bwip-js and test.
See: https://github.com/metafloor/bwip-js#browser-usage
Previous contributors: @MugeSo and @gvanderest  