### PR TITLE
added types for chai-snapshot-matcher

### DIFF
--- a/types/chai-snapshot-matcher/chai-snapshot-matcher-tests.ts
+++ b/types/chai-snapshot-matcher/chai-snapshot-matcher-tests.ts
@@ -1,0 +1,6 @@
+import chai = require('chai');
+
+const { expect } = chai;
+const context: Mocha.Context = <any> {};
+
+expect('foo').to.matchSnapshot(context);

--- a/types/chai-snapshot-matcher/chai-snapshot-matcher-tests.ts
+++ b/types/chai-snapshot-matcher/chai-snapshot-matcher-tests.ts
@@ -4,3 +4,16 @@ const { expect } = chai;
 const context: Mocha.Context = <any> {};
 
 expect('foo').to.matchSnapshot(context);
+expect('foo').to.matchSnapshot(context, 'hint');
+
+expect('foo').to.matchSpecificSnapshot(context);
+expect('foo').to.matchSpecificSnapshot(context, { hint: "(hint)" });
+expect('foo').to.matchSpecificSnapshot(context, { name: "snapshot with a specific name" });
+expect('foo').to.matchSpecificSnapshot(context, { folder: "Examples" });
+expect('foo').to.matchSpecificSnapshot(context, { snapshotPath: "/Users/my.user/Downloads/MySnapshots/" });
+expect('foo').to.matchSpecificSnapshot(context, {
+    hint: "(hint)",
+    name: "snapshot with a specific name",
+    folder: "Examples",
+    snapshotPath: "/Users/my.user/Downloads/MySnapshots/"
+});

--- a/types/chai-snapshot-matcher/index.d.ts
+++ b/types/chai-snapshot-matcher/index.d.ts
@@ -11,7 +11,13 @@ import { Context } from 'mocha';
 declare global {
   namespace Chai {
     interface Assertion {
-      matchSnapshot(that: Context): void;
+      matchSnapshot(that: Context, hint?: string): void;
+      matchSpecificSnapshot(that: Context, options?: {
+          hint?: string;
+          name?: string;
+          folder?: string;
+          snapshotPath?: string;
+      }): void;
     }
   }
 }

--- a/types/chai-snapshot-matcher/index.d.ts
+++ b/types/chai-snapshot-matcher/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for chai-snapshot-matcher 1.0
+// Project: https://github.com/tlameiras/chai-snapshot#readme
+// Definitions by: tpluscode <https://github.com/tpluscode>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+/// <reference types="chai" />
+
+import { Context } from 'mocha';
+
+declare global {
+  namespace Chai {
+    interface Assertion {
+      matchSnapshot(that: Context): void;
+    }
+  }
+}
+
+export {};

--- a/types/chai-snapshot-matcher/tsconfig.json
+++ b/types/chai-snapshot-matcher/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "chai-snapshot-matcher-tests.ts"
+    ]
+}

--- a/types/chai-snapshot-matcher/tslint.json
+++ b/types/chai-snapshot-matcher/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.