### PR TITLE
Prettier Plugin generics

### DIFF
--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -5,15 +5,25 @@
 //                 Florian Keller <https://github.com/ffflorian>,
 //                 Sosuke Suzuki <https://github.com/sosukesuzuki>,
 //                 Christopher Quadflieg <https://github.com/Shinigami92>
+//                 Kevin Deisz <https://github.com/kddeisz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
+
+// This utility is here to handle the case where you have an explicit union
+// between string literals and the generic string type. It would normally
+// resolve out to just the string type, but this generic LiteralUnion maintains
+// the intellisense of the original union.
+//
+// It comes from this issue: microsoft/TypeScript#29729:
+//   https://github.com/microsoft/TypeScript/issues/29729#issuecomment-700527227
+export type LiteralUnion<T extends U, U = string> = T | (Pick<U, never> & { _?: never });
 
 export type AST = any;
 export type Doc = doc.builders.Doc;
 
 // https://github.com/prettier/prettier/blob/master/src/common/fast-path.js
 export interface FastPath<T = any> {
-    stack: any[];
+    stack: T[];
     getName(): null | PropertyKey;
     getValue(): T;
     getNode(count?: number): null | T;
@@ -93,7 +103,7 @@ export interface RequiredOptions extends doc.printer.Options {
     /**
      * Specify which parser to use.
      */
-    parser: BuiltInParserName | CustomParser;
+    parser: LiteralUnion<BuiltInParserName> | CustomParser;
     /**
      * Specify the input filepath. This will be used to do parser inference.
      */
@@ -154,36 +164,36 @@ export interface RequiredOptions extends doc.printer.Options {
     embeddedLanguageFormatting: 'auto' | 'off';
 }
 
-export interface ParserOptions extends RequiredOptions {
-    locStart: (node: any) => number;
-    locEnd: (node: any) => number;
+export interface ParserOptions<T = any> extends RequiredOptions {
+    locStart: (node: T) => number;
+    locEnd: (node: T) => number;
     originalText: string;
 }
 
-export interface Plugin {
+export interface Plugin<T = any> {
     languages?: SupportLanguage[];
-    parsers?: { [parserName: string]: Parser };
-    printers?: { [astFormat: string]: Printer };
+    parsers?: { [parserName: string]: Parser<T> };
+    printers?: { [astFormat: string]: Printer<T> };
     options?: SupportOptions;
     defaultOptions?: Partial<RequiredOptions>;
 }
 
-export interface Parser {
-    parse: (text: string, parsers: { [parserName: string]: Parser }, options: ParserOptions) => AST;
+export interface Parser<T = any> {
+    parse: (text: string, parsers: { [parserName: string]: Parser }, options: ParserOptions<T>) => T;
     astFormat: string;
     hasPragma?: (text: string) => boolean;
-    locStart: (node: any) => number;
-    locEnd: (node: any) => number;
-    preprocess?: (text: string, options: ParserOptions) => string;
+    locStart: (node: T) => number;
+    locEnd: (node: T) => number;
+    preprocess?: (text: string, options: ParserOptions<T>) => string;
 }
 
-export interface Printer {
-    print(path: FastPath, options: ParserOptions, print: (path: FastPath) => Doc): Doc;
+export interface Printer<T = any> {
+    print(path: FastPath<T>, options: ParserOptions<T>, print: (path: FastPath<T>) => Doc): Doc;
     embed?: (
-        path: FastPath,
-        print: (path: FastPath) => Doc,
+        path: FastPath<T>,
+        print: (path: FastPath<T>) => Doc,
         textToDoc: (text: string, options: Options) => Doc,
-        options: ParserOptions,
+        options: ParserOptions<T>,
     ) => Doc | null;
     insertPragma?: (text: string) => string;
     /**
@@ -192,24 +202,24 @@ export interface Printer {
      * @returns anything if you want to replace the node with it
      */
     massageAstNode?: (node: any, newNode: any, parent: any) => any;
-    hasPrettierIgnore?: (path: FastPath) => boolean;
-    canAttachComment?: (node: any) => boolean;
-    willPrintOwnComments?: (path: FastPath) => boolean;
-    printComments?: (path: FastPath, print: (path: FastPath) => Doc, options: ParserOptions, needsSemi: boolean) => Doc;
+    hasPrettierIgnore?: (path: FastPath<T>) => boolean;
+    canAttachComment?: (node: T) => boolean;
+    willPrintOwnComments?: (path: FastPath<T>) => boolean;
+    printComments?: (path: FastPath<T>, print: (path: FastPath<T>) => Doc, options: ParserOptions<T>, needsSemi: boolean) => Doc;
     handleComments?: {
-        ownLine?: (commentNode: any, text: string, options: ParserOptions, ast: any, isLastComment: boolean) => boolean;
+        ownLine?: (commentNode: any, text: string, options: ParserOptions<T>, ast: T, isLastComment: boolean) => boolean;
         endOfLine?: (
             commentNode: any,
             text: string,
-            options: ParserOptions,
-            ast: any,
+            options: ParserOptions<T>,
+            ast: T,
             isLastComment: boolean,
         ) => boolean;
         remaining?: (
             commentNode: any,
             text: string,
-            options: ParserOptions,
-            ast: any,
+            options: ParserOptions<T>,
+            ast: T,
             isLastComment: boolean,
         ) => boolean;
     };

--- a/types/prettier/prettier-tests.ts
+++ b/types/prettier/prettier-tests.ts
@@ -74,13 +74,13 @@ prettierStandalone.formatWithCursor(' 1', { cursorOffset: 2, parser: 'babel' });
 prettierStandalone.format(' 1', { parser: 'babel' });
 prettierStandalone.check(' console.log(b)');
 
-typescriptParser.parsers.typescript.parse; // $ExpectType (text: string, parsers: { [parserName: string]: Parser; }, options: ParserOptions) => any
-graphqlParser.parsers.graphql.parse; // $ExpectType (text: string, parsers: { [parserName: string]: Parser; }, options: ParserOptions) => any
-babelParser.parsers.babel.parse; // $ExpectType (text: string, parsers: { [parserName: string]: Parser; }, options: ParserOptions) => any
-htmlParser.parsers.html.parse; // $ExpectType (text: string, parsers: { [parserName: string]: Parser; }, options: ParserOptions) => any
-markdownParser.parsers.markdown.parse; // $ExpectType (text: string, parsers: { [parserName: string]: Parser; }, options: ParserOptions) => any
-postcssParser.parsers.css.parse; // $ExpectType (text: string, parsers: { [parserName: string]: Parser; }, options: ParserOptions) => any
-yamlParser.parsers.yaml.parse; // $ExpectType (text: string, parsers: { [parserName: string]: Parser; }, options: ParserOptions) => any
+typescriptParser.parsers.typescript.parse; // $ExpectType (text: string, parsers: { [parserName: string]: Parser<any>; }, options: ParserOptions<any>) => any
+graphqlParser.parsers.graphql.parse; // $ExpectType (text: string, parsers: { [parserName: string]: Parser<any>; }, options: ParserOptions<any>) => any
+babelParser.parsers.babel.parse; // $ExpectType (text: string, parsers: { [parserName: string]: Parser<any>; }, options: ParserOptions<any>) => any
+htmlParser.parsers.html.parse; // $ExpectType (text: string, parsers: { [parserName: string]: Parser<any>; }, options: ParserOptions<any>) => any
+markdownParser.parsers.markdown.parse; // $ExpectType (text: string, parsers: { [parserName: string]: Parser<any>; }, options: ParserOptions<any>) => any
+postcssParser.parsers.css.parse; // $ExpectType (text: string, parsers: { [parserName: string]: Parser<any>; }, options: ParserOptions<any>) => any
+yamlParser.parsers.yaml.parse; // $ExpectType (text: string, parsers: { [parserName: string]: Parser<any>; }, options: ParserOptions<any>) => any
 
 prettier.format('hello world', {
     plugins: [typescriptParser, graphqlParser, babelParser, htmlParser, markdownParser, postcssParser, yamlParser],
@@ -96,3 +96,42 @@ doc.builders.dedent;
 doc.printer.printDocToString;
 doc.utils.isEmpty;
 doc.debug.printDocToDebug;
+
+interface PluginAST {
+    kind: "line";
+    value: string;
+}
+
+const plugin: prettier.Plugin<PluginAST> = {
+    parsers: {
+        lines: {
+            parse(text, parsers, options) {
+                return { kind: "line", value: "This is a line" };
+            },
+            astFormat: "lines",
+            locStart: (node) => {
+                node; // $ExpectType PluginAST
+                return 0;
+            },
+            locEnd: (node) => {
+                node; // $ExpectType PluginAST
+                return 0;
+            }
+        }
+    },
+    printers: {
+        lines: {
+            print(path, options, print) {
+                path; // $ExpectType FastPath<PluginAST>
+                print; // $ExpectType (path: FastPath<PluginAST>) => Doc
+
+                const node = path.getValue();
+                node; // $ExpectType PluginAST
+
+                return node.value;
+            }
+        }
+    }
+};
+
+prettier.format("a line!", { parser: "lines", plugins: [plugin] });


### PR DESCRIPTION
At the moment most of the APIs used by prettier plugins reference explicit `any`s. We can leverage some generics here to get a little more explicit about the AST nodes that get passed around.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Not sure if any of these necessarily apply, this just makes the types easier to work with.
