### PR TITLE
[qunit] Explicitly allow Promises for QUnit NestedHooks

### DIFF
--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -354,22 +354,22 @@ declare global {
          * Runs after the last test. If additional tests are defined after the
          * module's queue has emptied, it will not run this hook again.
          */
-        after: (fn: (assert: Assert) => void) => void;
+        after: (fn: (assert: Assert) => void | Promise<void>) => void;
 
         /**
          * Runs after each test.
          */
-        afterEach: (fn: (assert: Assert) => void) => void;
+        afterEach: (fn: (assert: Assert) => void | Promise<void>) => void;
 
         /**
          * Runs before the first test.
          */
-        before: (fn: (assert: Assert) => void) => void;
+        before: (fn: (assert: Assert) => void | Promise<void>) => void;
 
         /**
          * Runs before each test.
          */
-        beforeEach: (fn: (assert: Assert) => void) => void;
+        beforeEach: (fn: (assert: Assert) => void | Promise<void>) => void;
 
     }
 
@@ -560,7 +560,7 @@ declare global {
          * @param {string} name Title of unit being tested
          * @param callback Function to close over assertions
          */
-        only(name: string, callback: (assert: Assert) => void | Promise<any>): void;
+        only(name: string, callback: (assert: Assert) => void | Promise<void>): void;
 
         /**
          * DEPRECATED: Report the result of a custom assertion.
@@ -591,7 +591,7 @@ declare global {
          *
          * @param {string} Title of unit being tested
          */
-        skip(name: string, callback?: (assert: Assert) => void | Promise<any>): void;
+        skip(name: string, callback?: (assert: Assert) => void | Promise<void>): void;
 
         /**
          * Returns a single line string representing the stacktrace (call stack).
@@ -637,7 +637,7 @@ declare global {
          * @param {string} Title of unit being tested
          * @param callback Function to close over assertions
          */
-        test(name: string, callback: (assert: Assert) => void | Promise<any>): void;
+        test(name: string, callback: (assert: Assert) => void | Promise<void>): void;
 
         /**
          * Register a callback to fire whenever a test ends.
@@ -673,7 +673,7 @@ declare global {
          * @param {string} Title of unit being tested
          * @param callback Function to close over assertions
          */
-        todo(name: string, callback?: (assert: Assert) => void): void;
+        todo(name: string, callback?: (assert: Assert) => void | Promise<void>): void;
 
         /**
          * Compares two values. Returns true if they are equivalent.

--- a/types/qunit/test/global-test.ts
+++ b/types/qunit/test/global-test.ts
@@ -270,37 +270,6 @@ QUnit.testStart(function( details: QUnit.TestStartDetails ) {
   console.log( "Now running: ", details.name, ' from module ', details.module );
 });
 
-async function timeout() {
-  return new Promise(resolve => setTimeout(resolve, 1));
-}
-
-// These async tests are intended to ensure the appropriate behavior for @typescript-eslint/no-misused-promises.
-// However, we don't actually use typescript-eslint in this project and tslint has no equivalent,
-// so we can't properly test it.
-QUnit.begin(async function() {
-  await timeout();
-});
-
-QUnit.done(async function() {
-  await timeout();
-});
-
-QUnit.moduleDone(async function() {
-  await timeout();
-});
-
-QUnit.moduleStart(async function() {
-  await timeout();
-});
-
-QUnit.testDone(async function() {
-  await timeout();
-});
-
-QUnit.testStart(async function() {
-  await timeout();
-});
-
 let Robot: any = () => {};
 
 QUnit.module( "robot", {
@@ -373,9 +342,9 @@ QUnit.test( "a test", function( assert ) {
 // declare var Promise: any;
 QUnit.test( "a Promise-returning test", function( assert ) {
   assert.expect( 0 );
-  var thenable = new Promise(function( resolve: any, reject: any ) {
+  var thenable = new Promise<void>(function( resolve: any, reject: any ) {
     setTimeout(function() {
-      resolve( "result" );
+      resolve();
     }, 500 );
   });
   return thenable;
@@ -695,4 +664,95 @@ QUnit.test('steps', assert => {
   assert.step('two');
   assert.step('three');
   assert.verifySteps(['one', 'two', 'three'], 'Counting to three correctly');
+});
+
+async function timeout() {
+  return new Promise(resolve => setTimeout(resolve, 1));
+}
+
+// These async tests are intended to ensure the appropriate behavior for @typescript-eslint/no-misused-promises.
+// However, we don't actually use typescript-eslint in this project and tslint has no equivalent,
+// so we can't properly test it.
+QUnit.begin(async function() {
+  await timeout();
+});
+
+QUnit.done(async function() {
+  await timeout();
+});
+
+QUnit.moduleDone(async function() {
+  await timeout();
+});
+
+QUnit.moduleStart(async function() {
+  await timeout();
+});
+
+QUnit.testDone(async function() {
+  await timeout();
+});
+
+QUnit.testStart(async function() {
+  await timeout();
+});
+
+QUnit.test( "async test", async function( assert ) {
+  await timeout();
+  assert.ok(true);
+});
+
+QUnit.only( "async only", async function( assert ) {
+  await timeout();
+  assert.ok(true);
+});
+
+
+QUnit.skip( "async skip", async function( assert ) {
+  await timeout();
+  assert.ok(true);
+});
+
+QUnit.module( "async", {
+  async after( assert ) {
+    await timeout();
+    assert.ok( true, "async after called" );
+  },
+
+  async before( assert ) {
+    await timeout();
+    assert.ok( true, "async before called" );
+  },
+
+  async beforeEach( assert ) {
+    await timeout();
+    assert.ok( true, "async beforeEach called" );
+  },
+
+  async afterEach( assert ) {
+    await timeout();
+    assert.ok( true, "async afterEach called" );
+  }
+});
+
+QUnit.module( "async nested hooks", function( hooks ) {
+  hooks.after( async function( assert ) {
+    await timeout();
+    assert.ok( true, "async after called" );
+  } );
+
+  hooks.before( async function( assert ) {
+    await timeout();
+    assert.ok( true, "async before called" );
+  } );
+
+  hooks.beforeEach( async function( assert ) {
+    await timeout();
+    assert.ok( true, "async beforeEach called" );
+  } );
+
+  hooks.afterEach( async function( assert ) {
+    await timeout();
+    assert.ok( true, "async afterEach called" );
+  } );
 });


### PR DESCRIPTION
The lack of explicit support is generally not problematic except when
used in conjunction with @typescript-eslint/no-misused-promises which
complains when a Promise is provided to a function that doesn't allow
for it.

This has already been done elsewhere, but I missed this spot.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~
