### PR TITLE
[next-auth] Allow session to be null or undefined

### DIFF
--- a/types/next-auth/client.d.ts
+++ b/types/next-auth/client.d.ts
@@ -25,7 +25,7 @@ interface SessionProvider extends GenericObject {
 }
 
 interface ContextProviderProps {
-    session: Session;
+    session: Session | null | undefined;
     options?: SetOptionsParams;
 }
 
@@ -43,7 +43,7 @@ interface NextContext {
     ctx?: { req: IncomingMessage };
 }
 
-declare function useSession(): [Session, boolean];
+declare function useSession(): [Session | null | undefined, boolean];
 declare function providers(): Promise<GetProvidersResponse | null>;
 declare const getProviders: typeof providers;
 declare function session(

--- a/types/next-auth/next-auth-tests.ts
+++ b/types/next-auth/next-auth-tests.ts
@@ -190,7 +190,7 @@ const session = {
     expires: '1234',
 };
 
-// $ExpectType [Session, boolean]
+// $ExpectType [Session | null | undefined, boolean]
 client.useSession();
 
 // $ExpectType Promise<Session | null>
@@ -227,6 +227,28 @@ client.Provider({
         baseUrl: 'https://foo.com',
         basePath: '/',
         clientMaxAge: 1234,
+    },
+});
+
+// $ExpectType ReactElement<any, any> | null
+client.Provider({
+    session,
+});
+
+// $ExpectType ReactElement<any, any> | null
+client.Provider({
+    session: undefined,
+    options: {},
+});
+
+// $ExpectType ReactElement<any, any> | null
+client.Provider({
+    session: null,
+    options: {
+        baseUrl: 'https://foo.com',
+        basePath: '/',
+        clientMaxAge: 1234,
+        keepAlive: 4321,
     },
 });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - The first time `useSession` is called [as described in the docs](https://next-auth.js.org/getting-started/client#usesession), the context will be `undefined`, and `useState` within `_useSessionHook` will be called with `undefined`, which is then returned from `_useSessionHook` (see https://github.com/nextauthjs/next-auth/blob/v3.1.0/src/client/index.js#L142-L222)
  - As for `Provider`, [see the docs](https://next-auth.js.org/getting-started/client#provider) for the common usage
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Additional Information:

While the session data is being fetched, `useSession` will return `undefined`. If a session doesn't exist, `useSession` will return `null`.

The result of `useSession` is commonly passed to the `Provider` component (e.g. see the examples at https://next-auth.js.org/getting-started/client#provider), and it seems to allow the `undefined` and `null` values for the `session` prop, so allow them in the type information, too.