### PR TITLE
[absinthe__socket-apollo-link] Use wildcards for scope path mappings

### DIFF
--- a/types/absinthe__socket-apollo-link/tsconfig.json
+++ b/types/absinthe__socket-apollo-link/tsconfig.json
@@ -12,8 +12,7 @@
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,
         "paths": {
-            "@absinthe/socket": ["absinthe__socket"],
-            "@absinthe/socket-apollo-link": ["absinthe__socket-apollo-link"]
+            "@absinthe/*": ["absinthe__*"]
         }
     },
     "files": ["index.d.ts", "absinthe__socket-apollo-link-tests.ts"]


### PR DESCRIPTION
#47089