### PR TITLE
[babel__core] Use wildcards for scope path mappings

### DIFF
--- a/types/babel__core/tsconfig.json
+++ b/types/babel__core/tsconfig.json
@@ -16,17 +16,8 @@
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,
         "paths": {
-            "@babel/core": [
-                "babel__core"
-            ],
-            "@babel/generator": [
-                "babel__generator"
-            ],
-            "@babel/template": [
-                "babel__template"
-            ],
-            "@babel/traverse": [
-                "babel__traverse"
+            "@babel/*": [
+                "babel__*"
             ]
         }
     },


### PR DESCRIPTION
#47089