### PR TITLE
[babel__standalone] Use wildcards for scope path mappings

### DIFF
--- a/types/babel__standalone/tsconfig.json
+++ b/types/babel__standalone/tsconfig.json
@@ -14,20 +14,8 @@
             "../"
         ],
         "paths": {
-            "@babel/standalone": [
-                "babel__standalone"
-            ],
-            "@babel/core": [
-                "babel__core"
-            ],
-            "@babel/generator": [
-                "babel__generator"
-            ],
-            "@babel/template": [
-                "babel__template"
-            ],
-            "@babel/traverse": [
-                "babel__traverse"
+            "@babel/*": [
+                "babel__*"
             ]
         },
         "types": [],


### PR DESCRIPTION
#47089