### PR TITLE
update(favicons): version 6.*

### DIFF
--- a/types/favicons/favicons-tests.ts
+++ b/types/favicons/favicons-tests.ts
@@ -1,39 +1,75 @@
-import * as favicons from "favicons";
+import favicons = require('favicons');
+import { FaviconCallback } from 'favicons';
 
-let config: Partial<favicons.Configuration> = {
-    path: "/foo/bar"
-};
-
-config = {
+const source = 'test/logo.png';
+const options: Partial<favicons.FaviconOptions> = {
+    path: '/foo/bar',
+    appName: null,
+    appShortName: null,
+    appDescription: null,
+    developerName: null,
+    developerURL: null,
+    dir: 'auto',
+    lang: 'en-US',
+    background: '#fff',
+    theme_color: '#fff',
+    appleStatusBarStyle: 'black-translucent',
+    display: 'standalone',
+    orientation: 'any',
+    scope: '/',
+    start_url: '/?homescreen=1',
+    version: '1.0',
+    logging: false,
+    pixel_art: false,
+    loadManifestWithCredentials: false,
     icons: {
         android: true,
-        favicons: {
-            ovelayShadow: false
-        }
-    }
+        appleIcon: true,
+        appleStartup: true,
+        coast: true,
+        favicons: true,
+        firefox: true,
+        windows: true,
+        yandex: true,
+    },
 };
 
-let html = "";
-favicons("path/to/file.png", config, (err, res) => {
-    html = res.html.join("");
+const callback: FaviconCallback = (error, response) => {
+    if (error) {
+        error.message; // $ExpectType string
+        return;
+    }
+    response.images; // $ExpectType FaviconImage[]
+    response.files; // $ExpectType FaviconFile[]
+    response.html; // $ExpectType string[]
+};
+
+let html = '';
+favicons(source, options, (err, res) => {
+    html = res.html.join('');
 
     for (const { name, contents } of [...res.files, ...res.images]) {
         html = name + contents.toString();
     }
 });
 
-favicons("file.png", (err: any, res: any) => {
-    html = res.html.join("");
+favicons(source, (err: any, res: any) => {
+    html = res.html.join('');
 
     for (const { name, contents } of [...res.files, ...res.images]) {
         html = name + contents.toString();
     }
 });
 
-favicons("file.png").then((res) => {
-    html = res.html.join("");
+favicons(source).then(res => {
+    html = res.html.join('');
 
     for (const { name, contents } of [...res.files, ...res.images]) {
         html = name + contents.toString();
     }
 });
+
+(async () => {
+    // $ExpectType FaviconResponse
+    await favicons(source);
+})();

--- a/types/favicons/index.d.ts
+++ b/types/favicons/index.d.ts
@@ -1,11 +1,10 @@
-// Type definitions for favicons 5.5
+// Type definitions for favicons 6.2
 // Project: https://github.com/itgalaxy/favicons
 // Definitions by: Mohsen Azimi <https://github.com/mohsen1>
 //                 Nikk Radetskiy <https://github.com/metsawyr>
 //                 Artur Androsovych <https://github.com/arturovt>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
-
 /// <reference types="node" />
 
 import { Duplex } from 'stream';
@@ -19,12 +18,15 @@ declare namespace favicons {
         ovelayShadow?: boolean;
     }
 
-    interface Configuration {
+    interface FaviconOptions {
         /** Path for overriding default icons path @default '/' */
         path: string;
         /** Your application's name @default null */
         appName: string | null;
-        /** Your application's short_name. If not set, `appName` will be used @default null */
+        /**
+         * Your application's short_name.
+         * @default appName
+         */
         appShortName: string | null;
         /** Your application's description @default null */
         appDescription: string | null;
@@ -93,18 +95,30 @@ declare namespace favicons {
         }>;
     }
 
-    interface FavIconResponse {
-        images: Array<{ name: string; contents: Buffer }>;
-        files: Array<{ name: string; contents: Buffer }>;
-        html: string[];
+    interface FaviconResponse {
+        images: FaviconImage[];
+        files: FaviconFile[];
+        html: FaviconHtmlElement[];
     }
 
-    type Callback = (error: Error | null, response: FavIconResponse) => void;
+    interface FaviconImage {
+        name: string;
+        contents: Buffer;
+    }
+
+    interface FaviconFile {
+        name: string;
+        contents: string;
+    }
+
+    type FaviconHtmlElement = string;
+
+    type FaviconCallback = (error: Error | null, response: FaviconResponse) => void;
 
     /** You can programmatically access Favicons configuration (icon filenames, HTML, manifest files, etc) with this export */
-    const config: Configuration;
+    const config: FaviconOptions;
 
-    function stream(configuration?: Configuration): Duplex;
+    function stream(configuration?: FaviconOptions): Duplex;
 }
 /**
  * Generate favicons
@@ -114,16 +128,13 @@ declare namespace favicons {
  */
 declare function favicons(
     source: string | Buffer | string[],
-    configuration?: Partial<favicons.Configuration>,
-): Promise<favicons.FavIconResponse>;
+    options?: Partial<favicons.FaviconOptions>,
+): Promise<favicons.FaviconResponse>;
+declare function favicons(source: string | Buffer | string[], next?: favicons.FaviconCallback): void;
 declare function favicons(
     source: string | Buffer | string[],
-    callback?: favicons.Callback
-): void;
-declare function favicons(
-    source: string | Buffer | string[],
-    configuration?: Partial<favicons.Configuration>,
-    callback?: favicons.Callback
+    options?: Partial<favicons.FaviconOptions>,
+    next?: favicons.FaviconCallback,
 ): void;
 
 export = favicons;


### PR DESCRIPTION
- align names of the types with inline types from the package
- correct types for favicon file
- align parameter names with types from the package
- tests amended
- mantainer added
- version bump

https://github.com/itgalaxy/favicons/compare/v5.5.0...v6.2.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)