### PR TITLE
Adding definition for SharedRuntime API in office-js and adding office.actions.associate in office-js-preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ For example:
 }
 ```
 
-When you add a `package.json` to dependents of `foo`, you will also need to open a PR to add `foo` [to dependenciesWhitelist.txt in types-publisher](https://github.com/Microsoft/types-publisher/blob/master/dependenciesWhitelist.txt).
+When you add a `package.json` to dependents of `foo`, you will also need to open a PR to add `foo` [to allowedPackageJsonDependencies.txt in DefinitelyTyped-tools](https://github.com/microsoft/DefinitelyTyped-tools/blob/master/packages/definitions-parser/allowedPackageJsonDependencies.txt).
 
 If a package was never on Definitely Typed, it does not need to be added to `notNeededPackages.json`.
 

--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -331,7 +331,7 @@ declare namespace Office {
      */
     function useShortNamespace(useShortNamespace: boolean): void;
     /**
-     * Represents the actions.
+     * Provides a method for associating action names with functions that carry out an action.
      */
     const actions: Actions;
     /**
@@ -526,11 +526,11 @@ declare namespace Office {
         value: T;
     }
     /**
-     * Used to associate an action.
+     * Used to associate an action name to a function.
      */
     interface Actions {
         /**
-         * Function to associate a action name with the action function.
+         * Function to associate a name with the action function.
          */
         associate: (actionName: string, action: (arg?: any) => void) => void;
     }

--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -331,6 +331,10 @@ declare namespace Office {
      */
     function useShortNamespace(useShortNamespace: boolean): void;
     /**
+     * Represents the actions.
+     */
+    const actions: Actions;
+    /**
      * Represents the add-in.
      */
     const addin: Addin;
@@ -520,6 +524,15 @@ declare namespace Office {
         * To determine what is returned by the value property for an "Async" method, refer to the "Callback value" section of the method's topic.
         */
         value: T;
+    }
+    /**
+     * Used to associate an action.
+     */
+    interface Actions {
+        /**
+         * Function to associate a action name with the action function.
+         */
+        associate: (actionName: string, action: (arg?: any) => void) => void;
     }
     /**
      * Message used in the `onVisibilityModeChanged` invocation.

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -330,7 +330,37 @@ declare namespace Office {
      * @param useShortNamespace True to use the shortcut alias; otherwise false to disable it. The default is true.
      */
     function useShortNamespace(useShortNamespace: boolean): void;
+    /**
+     * Represents the add-in.
+     */
+    const addin: Addin;
     // Enumerations
+    /**
+     * Provides options to determine the startup behavior of the add-in upon next start-up.
+     */
+    enum StartupBehavior {
+        /**
+         * The add-in does not load until opened by the user.
+         */
+        none = 'None',
+        /**
+         * Load the add-in but do not show UI.
+         */
+        load = 'Load',
+    }
+    /**
+     * Visibility mode of the add-in.
+     */
+    enum VisibilityMode {
+        /**
+         * UI is Hidden
+         */
+        hidden = 'Hidden',
+        /**
+         * Displayed as taskpane
+         */
+        taskpane = 'Taskpane',
+    }
     /**
      * Specifies the result of an asynchronous call.
      * 
@@ -481,7 +511,51 @@ declare namespace Office {
         */
         value: T;
     }
-	
+	/**
+     * Message used in the `onVisibilityModeChanged` invocation.
+     */
+    interface VisibilityModeChangedMessage {
+        /**
+         * Visibility changed state.
+         */
+        visibilityMode: Office.VisibilityMode;
+    }
+    /**
+     * Function type to turn off the event.
+     */
+    type RemoveEventListener = () => Promise<void>;
+    /**
+     * Represents add-in level functionality for operating or configuring various aspects of the add-in.
+     */
+    interface Addin {
+        /**
+         * Sets the startup behavior for the add-in for when the document is opened next time.
+         * @param behavior - Specifies startup behavior of the add-in.
+         */
+        setStartupBehavior(behavior: Office.StartupBehavior): Promise<void>;
+        /**
+         * Gets the current startup behavior for the add-in.
+         */
+        getStartupBehavior(): Promise<Office.StartupBehavior>;
+        /**
+         * Shows the task pane associated with the add-in.
+         * @returns A promise that is resolved when the UI is shown.
+         */
+        showAsTaskpane(): Promise<void>;
+        /**
+         * Hides the task pane.
+         * @returns A promise that is resolved when the UI is hidden.
+         */
+        hide(): Promise<void>;
+        /**
+         * Adds a listener for the `onVisbilityModeChanged` event.
+         * @param listener - The listener function that is called when the event is emitted. This function takes in a message for the receiving component.
+         * @returns A promise that resolves when the listener is added.
+         */
+        onVisibilityModeChanged(
+            listener: (message: VisibilityModeChangedMessage) => void,
+        ): Promise<RemoveEventListener>;
+    }
     /**
      * An interface that contains all the functionality provided to manage the state of the Office ribbon.
 	 *


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins
- [ x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
