### PR TITLE
[@types/pdfmake] add unbreakable prop to stack

### DIFF
--- a/types/pdfmake/interfaces.d.ts
+++ b/types/pdfmake/interfaces.d.ts
@@ -198,6 +198,8 @@ export interface ContentColumns extends ContentBase {
 }
 
 export interface ContentStack extends ContentBase {
+    /** if true, ensures that the contents of the stack are always on the same page */
+    unbreakable?: boolean;
     stack: Content[];
 }
 

--- a/types/pdfmake/test/pdfmake-examples-tests.ts
+++ b/types/pdfmake/test/pdfmake-examples-tests.ts
@@ -1452,6 +1452,22 @@ const svgs: TDocumentDefinitions = {
     ],
 };
 
+const stack: TDocumentDefinitions = {
+    content: [
+        {
+            stack: [
+                {
+                    text: 'first paragraph',
+                },
+                {
+                    text: 'beginning of another paragraph',
+                    unbreakable: true,
+                },
+            ],
+        },
+    ],
+};
+
 const tables: TDocumentDefinitions = {
     content: [
         { text: 'Tables', style: 'header' },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Not documented for some reason but see here: https://github.com/bpampuch/pdfmake/blob/380b4d19/tests/unit/LayoutBuilder.spec.js#L1442
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
