### PR TITLE
[@types/pino] Add optional generic to log function

### DIFF
--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -733,6 +733,7 @@ declare namespace P {
          * Log at `'fatal'` level the given msg. If the first argument is an object, all its properties will be included in the JSON line.
          * If more args follows `msg`, these will be used to format `msg` using `util.format`.
          *
+         * @typeparam T: the interface of the object being serialized. Default is object.
          * @param obj: object to be serialized
          * @param msg: the log message to write
          * @param ...args: format string values when `msg` is a format string
@@ -742,6 +743,7 @@ declare namespace P {
          * Log at `'error'` level the given msg. If the first argument is an object, all its properties will be included in the JSON line.
          * If more args follows `msg`, these will be used to format `msg` using `util.format`.
          *
+         * @typeparam T: the interface of the object being serialized. Default is object.
          * @param obj: object to be serialized
          * @param msg: the log message to write
          * @param ...args: format string values when `msg` is a format string
@@ -751,6 +753,7 @@ declare namespace P {
          * Log at `'warn'` level the given msg. If the first argument is an object, all its properties will be included in the JSON line.
          * If more args follows `msg`, these will be used to format `msg` using `util.format`.
          *
+         * @typeparam T: the interface of the object being serialized. Default is object.
          * @param obj: object to be serialized
          * @param msg: the log message to write
          * @param ...args: format string values when `msg` is a format string
@@ -760,6 +763,7 @@ declare namespace P {
          * Log at `'info'` level the given msg. If the first argument is an object, all its properties will be included in the JSON line.
          * If more args follows `msg`, these will be used to format `msg` using `util.format`.
          *
+         * @typeparam T: the interface of the object being serialized. Default is object.
          * @param obj: object to be serialized
          * @param msg: the log message to write
          * @param ...args: format string values when `msg` is a format string
@@ -769,6 +773,7 @@ declare namespace P {
          * Log at `'debug'` level the given msg. If the first argument is an object, all its properties will be included in the JSON line.
          * If more args follows `msg`, these will be used to format `msg` using `util.format`.
          *
+         * @typeparam T: the interface of the object being serialized. Default is object.
          * @param obj: object to be serialized
          * @param msg: the log message to write
          * @param ...args: format string values when `msg` is a format string
@@ -778,6 +783,7 @@ declare namespace P {
          * Log at `'trace'` level the given msg. If the first argument is an object, all its properties will be included in the JSON line.
          * If more args follows `msg`, these will be used to format `msg` using `util.format`.
          *
+         * @typeparam T: the interface of the object being serialized. Default is object.
          * @param obj: object to be serialized
          * @param msg: the log message to write
          * @param ...args: format string values when `msg` is a format string
@@ -812,8 +818,9 @@ declare namespace P {
     ) => void;
 
     interface LogFn {
-        (msg: string, ...args: any[]): void;
+        /* tslint:disable:no-unnecessary-generics */
         <T extends object>(obj: T, msg?: string, ...args: any[]): void;
+        (msg: string, ...args: any[]): void;
     }
 
     interface redactOptions {

--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -813,7 +813,6 @@ declare namespace P {
 
     interface LogFn {
         (msg: string, ...args: any[]): void;
-        (obj: object, msg?: string, ...args: any[]): void;
         <T extends object>(obj: T, msg?: string, ...args: any[]): void;
     }
 

--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -814,6 +814,7 @@ declare namespace P {
     interface LogFn {
         (msg: string, ...args: any[]): void;
         (obj: object, msg?: string, ...args: any[]): void;
+        <T extends object>(obj: T, msg?: string, ...args: any[]): void;
     }
 
     interface redactOptions {

--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -733,7 +733,7 @@ declare namespace P {
          * Log at `'fatal'` level the given msg. If the first argument is an object, all its properties will be included in the JSON line.
          * If more args follows `msg`, these will be used to format `msg` using `util.format`.
          *
-         * @typeparam T: the interface of the object being serialized. Default is object.
+         * @typeParam T: the interface of the object being serialized. Default is object.
          * @param obj: object to be serialized
          * @param msg: the log message to write
          * @param ...args: format string values when `msg` is a format string
@@ -743,7 +743,7 @@ declare namespace P {
          * Log at `'error'` level the given msg. If the first argument is an object, all its properties will be included in the JSON line.
          * If more args follows `msg`, these will be used to format `msg` using `util.format`.
          *
-         * @typeparam T: the interface of the object being serialized. Default is object.
+         * @typeParam T: the interface of the object being serialized. Default is object.
          * @param obj: object to be serialized
          * @param msg: the log message to write
          * @param ...args: format string values when `msg` is a format string
@@ -753,7 +753,7 @@ declare namespace P {
          * Log at `'warn'` level the given msg. If the first argument is an object, all its properties will be included in the JSON line.
          * If more args follows `msg`, these will be used to format `msg` using `util.format`.
          *
-         * @typeparam T: the interface of the object being serialized. Default is object.
+         * @typeParam T: the interface of the object being serialized. Default is object.
          * @param obj: object to be serialized
          * @param msg: the log message to write
          * @param ...args: format string values when `msg` is a format string
@@ -763,7 +763,7 @@ declare namespace P {
          * Log at `'info'` level the given msg. If the first argument is an object, all its properties will be included in the JSON line.
          * If more args follows `msg`, these will be used to format `msg` using `util.format`.
          *
-         * @typeparam T: the interface of the object being serialized. Default is object.
+         * @typeParam T: the interface of the object being serialized. Default is object.
          * @param obj: object to be serialized
          * @param msg: the log message to write
          * @param ...args: format string values when `msg` is a format string
@@ -773,7 +773,7 @@ declare namespace P {
          * Log at `'debug'` level the given msg. If the first argument is an object, all its properties will be included in the JSON line.
          * If more args follows `msg`, these will be used to format `msg` using `util.format`.
          *
-         * @typeparam T: the interface of the object being serialized. Default is object.
+         * @typeParam T: the interface of the object being serialized. Default is object.
          * @param obj: object to be serialized
          * @param msg: the log message to write
          * @param ...args: format string values when `msg` is a format string
@@ -783,7 +783,7 @@ declare namespace P {
          * Log at `'trace'` level the given msg. If the first argument is an object, all its properties will be included in the JSON line.
          * If more args follows `msg`, these will be used to format `msg` using `util.format`.
          *
-         * @typeparam T: the interface of the object being serialized. Default is object.
+         * @typeParam T: the interface of the object being serialized. Default is object.
          * @param obj: object to be serialized
          * @param msg: the log message to write
          * @param ...args: format string values when `msg` is a format string

--- a/types/pino/pino-tests.ts
+++ b/types/pino/pino-tests.ts
@@ -236,3 +236,14 @@ pino(destinationViaStream);
 pino({ name: 'my-logger' }, destinationViaStream);
 pino(destinationViaOptionsObject);
 pino({ name: 'my-logger' }, destinationViaOptionsObject);
+
+interface StrictShape {
+    activity: string;
+    err?: unknown;
+}
+
+info<StrictShape>({
+    activity: 'Required property',
+    // @ts-expect-error
+    reason: 'Not allowed',
+});

--- a/types/pino/pino-tests.ts
+++ b/types/pino/pino-tests.ts
@@ -32,7 +32,9 @@ pino({
 });
 
 pino({
-    mixin() { return { customName: 'unknown', customId: 111 }; },
+    mixin() {
+        return { customName: 'unknown', customId: 111 };
+    },
 });
 
 pino({
@@ -49,18 +51,15 @@ pino({
 
 pino({
     browser: {
-        write(o) {
-        }
-    }
+        write(o) {},
+    },
 });
 
 pino({
     browser: {
         write: {
-            info(o) {
-            },
-            error(o) {
-            }
+            info(o) {},
+            error(o) {},
         },
         serialize: true,
         asObject: true,
@@ -72,9 +71,9 @@ pino({
                 logEvent.level;
                 logEvent.ts;
                 logEvent.messages;
-            }
-        }
-    }
+            },
+        },
+    },
 });
 
 pino({ base: null });
@@ -95,7 +94,7 @@ child.bindings();
 const customSerializers = {
     test() {
         return 'this is my serializer';
-    }
+    },
 };
 pino().child({ serializers: customSerializers }).info({ test: 'should not show up' });
 const child2 = log.child({ father: true });
@@ -142,24 +141,24 @@ const handler = pino.final(logExtreme, (err: Error, finalLogger: pino.BaseLogger
 handler(new Error('error'));
 
 const redacted = pino({
-    redact: ['path']
+    redact: ['path'],
 });
 
 redacted.info({
     msg: 'logged with redacted properties',
-    path: 'Not shown'
+    path: 'Not shown',
 });
 
 const anotherRedacted = pino({
     redact: {
         paths: ['anotherPath'],
-        censor: 'Not the log you\re looking for'
-    }
+        censor: 'Not the log you\re looking for',
+    },
 });
 
 anotherRedacted.info({
     msg: 'another logged with redacted properties',
-    anotherPath: 'Not shown'
+    anotherPath: 'Not shown',
 });
 
 const pretty = pino({
@@ -175,8 +174,8 @@ const pretty = pino({
         timestampKey: 'timestamp',
         translateTime: 'UTC:h:MM:ss TT Z',
         search: 'foo == `bar`',
-        suppressFlushSyncWarning: true
-    }
+        suppressFlushSyncWarning: true,
+    },
 });
 
 const withTimeFn = pino({
@@ -191,19 +190,19 @@ const withHooks = pino({
     hooks: {
         logMethod(args, method) {
             return method.apply(this, args);
-        }
-    }
+        },
+    },
 });
 
 // Properties/types imported from pino-std-serializers
 const wrappedErrSerializer = pino.stdSerializers.wrapErrorSerializer((err: pino.SerializedError) => {
-  return {...err, newProp: 'foo'};
+    return { ...err, newProp: 'foo' };
 });
 const wrappedReqSerializer = pino.stdSerializers.wrapRequestSerializer((req: pino.SerializedRequest) => {
-  return {...req, newProp: 'foo'};
+    return { ...req, newProp: 'foo' };
 });
 const wrappedResSerializer = pino.stdSerializers.wrapResponseSerializer((res: pino.SerializedResponse) => {
-  return {...res, newProp: 'foo'};
+    return { ...res, newProp: 'foo' };
 });
 
 const socket = new Socket();
@@ -236,3 +235,12 @@ pino(destinationViaStream);
 pino({ name: 'my-logger' }, destinationViaStream);
 pino(destinationViaOptionsObject);
 pino({ name: 'my-logger' }, destinationViaOptionsObject);
+
+interface StrictShape {
+    activity: string;
+    err?: unknown;
+}
+
+info<StrictShape>({
+    activity: 'Required property',
+});

--- a/types/pino/pino-tests.ts
+++ b/types/pino/pino-tests.ts
@@ -236,14 +236,3 @@ pino(destinationViaStream);
 pino({ name: 'my-logger' }, destinationViaStream);
 pino(destinationViaOptionsObject);
 pino({ name: 'my-logger' }, destinationViaOptionsObject);
-
-interface StrictShape {
-    activity: string;
-    err?: unknown;
-}
-
-info<StrictShape>({
-    activity: 'Required property',
-    // @ts-expect-error
-    reason: 'Not allowed',
-});


### PR DESCRIPTION
Just means of providing a convenience in terms of enforcing specific type consumer is logging.
