### PR TITLE
[bson] EJSON.stringify replacer argument may be null or undefined

### DIFF
--- a/types/bson/bson-tests.ts
+++ b/types/bson/bson-tests.ts
@@ -32,9 +32,17 @@ const { EJSON, Int32, ObjectId } = BSON;
 console.log(EJSON.stringify(doc, { relaxed: false }));
 console.log(EJSON.stringify(doc, ['int32'], { relaxed: false }));
 console.log(EJSON.stringify(doc, ['int32'], 2, { relaxed: false }));
+console.log(EJSON.stringify(doc, null, { relaxed: false }));
+console.log(EJSON.stringify(doc, null, 2, { relaxed: false }));
+console.log(EJSON.stringify(doc, undefined, { relaxed: false }));
+console.log(EJSON.stringify(doc, undefined, 2, { relaxed: false }));
 console.log(EJSON.stringify(doc));
 console.log(EJSON.stringify(doc, ['int32']));
 console.log(EJSON.stringify(doc, ['int32'], 2));
+console.log(EJSON.stringify(doc, null));
+console.log(EJSON.stringify(doc, null, 2));
+console.log(EJSON.stringify(doc, undefined));
+console.log(EJSON.stringify(doc, undefined, 2));
 
 let doc2 = { int32: new Int32(10), _id: new ObjectId() };
 const text = '{ "int32": { "$numberInt": "10" } }';

--- a/types/bson/index.d.ts
+++ b/types/bson/index.d.ts
@@ -58,7 +58,7 @@ export interface CalculateObjectSizeOptions {
 
 /**
  * Serialize a Javascript object.
- * 
+ *
  * @param object The Javascript object to serialize.
  * @param options Serialize options.
  * @return The Buffer object containing the serialized object.
@@ -67,7 +67,7 @@ export function serialize(object: any, options?: SerializeOptions): Buffer;
 
 /**
  * Serialize a Javascript object using a predefined Buffer and index into the buffer, useful when pre-allocating the space for serialization.
- * 
+ *
  * @param object The Javascript object to serialize.
  * @param buffer The Buffer you pre-allocated to store the serialized BSON object.
  * @param options Serialize options.
@@ -77,7 +77,7 @@ export function serializeWithBufferAndIndex(object: any, buffer: Buffer, options
 
 /**
  * Deserialize data as BSON.
- * 
+ *
  * @param buffer The buffer containing the serialized set of BSON documents.
  * @param options Deserialize options.
  * @returns The deserialized Javascript Object.
@@ -95,7 +95,7 @@ export function calculateObjectSize(object: any, options?: CalculateObjectSizeOp
 
 /**
  * Deserialize stream data as BSON documents.
- * 
+ *
  * @param data The buffer containing the serialized set of BSON documents.
  * @param startIndex The start index in the data Buffer where the deserialization is to start.
  * @param numberOfDocuments Number of documents to deserialize
@@ -112,7 +112,7 @@ export function deserializeStream(
     docStartIndex: number,
     options?: DeserializeOptions
 ): number;
-  
+
 /** A class representation of the BSON Binary type. */
 export class Binary {
 
@@ -408,7 +408,7 @@ export class ObjectId {
 }
 
 /**
- * ObjectID (with capital "D") is deprecated. Use ObjectId (lowercase "d") instead. 
+ * ObjectID (with capital "D") is deprecated. Use ObjectId (lowercase "d") instead.
  * @deprecated
  */
 export { ObjectId as ObjectID };
@@ -535,7 +535,7 @@ export namespace EJSON {
      * console.log(EJSON.stringify(doc));
      */
     export function stringify(
-        value: {}, 
+        value: {},
         options?: {relaxed?: boolean;}
     ): string;
 
@@ -564,8 +564,8 @@ export namespace EJSON {
      */
 
     export function stringify(
-        value: {}, 
-        replacer: ((key: string, value: any) => any) | Array<string|number>, 
+        value: {},
+        replacer: ((key: string, value: any) => any) | Array<string|number> | null | undefined,
         options?: {relaxed?: boolean;}
     ): string;
     /**
@@ -592,9 +592,9 @@ export namespace EJSON {
      * console.log(EJSON.stringify(doc));
      */
     export function stringify(
-        value: {}, 
-        replacer: ((key: string, value: any) => any) | Array<string | number>, 
-        indents?: string | number, 
+        value: {},
+        replacer: ((key: string, value: any) => any) | Array<string | number> | null | undefined,
+        indents?: string | number,
         options?: {relaxed?: boolean;}
-        ): string;  
+        ): string;
 }


### PR DESCRIPTION
As per the docstring above, the replacer can be null or not provided (undefined).
