### PR TITLE
[webpack] add module federation plugin

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -29,17 +29,17 @@
 
 import { Hash as CryptoHash } from 'crypto';
 import {
-  Tapable,
-  HookMap,
-  SyncBailHook,
-  SyncHook,
-  SyncLoopHook,
-  SyncWaterfallHook,
-  AsyncParallelBailHook,
-  AsyncParallelHook,
-  AsyncSeriesBailHook,
-  AsyncSeriesHook,
-  AsyncSeriesWaterfallHook,
+    Tapable,
+    HookMap,
+    SyncBailHook,
+    SyncHook,
+    SyncLoopHook,
+    SyncWaterfallHook,
+    AsyncParallelBailHook,
+    AsyncParallelHook,
+    AsyncSeriesBailHook,
+    AsyncSeriesHook,
+    AsyncSeriesWaterfallHook,
 } from 'tapable';
 import * as UglifyJS from 'uglify-js';
 import * as anymatch from 'anymatch';
@@ -49,18 +49,14 @@ import { ConcatSource } from 'webpack-sources';
 export = webpack;
 
 declare function webpack(
-    options:
-        | webpack.Configuration
-        | webpack.ConfigurationFactory,
+    options: webpack.Configuration | webpack.ConfigurationFactory,
     handler: webpack.Compiler.Handler,
 ): webpack.Compiler.Watching | webpack.Compiler;
 declare function webpack(options?: webpack.Configuration): webpack.Compiler;
 
 declare function webpack(
-    options:
-        | webpack.Configuration[]
-        | webpack.MultiConfigurationFactory,
-    handler: webpack.MultiCompiler.Handler
+    options: webpack.Configuration[] | webpack.MultiConfigurationFactory,
+    handler: webpack.MultiCompiler.Handler,
 ): webpack.MultiWatching | webpack.MultiCompiler;
 declare function webpack(options: webpack.Configuration[]): webpack.MultiCompiler;
 
@@ -70,7 +66,7 @@ declare namespace webpack {
 
     interface Configuration {
         /** Enable production optimizations or development hints. */
-        mode?: "development" | "production" | "none";
+        mode?: 'development' | 'production' | 'none';
         /** Name of the configuration. Used when loading multiple configurations. */
         name?: string;
         /**
@@ -109,7 +105,18 @@ declare namespace webpack {
          * - "atom" Alias for electron-main.
          * - "electron" Alias for electron-main.
          */
-        target?: 'web' | 'webworker' | 'node' | 'async-node' | 'node-webkit' | 'atom' | 'electron' | 'electron-renderer' | 'electron-preload' | 'electron-main' | ((compiler?: any) => void);
+        target?:
+            | 'web'
+            | 'webworker'
+            | 'node'
+            | 'async-node'
+            | 'node-webkit'
+            | 'atom'
+            | 'electron'
+            | 'electron-renderer'
+            | 'electron-preload'
+            | 'electron-main'
+            | ((compiler?: any) => void);
         /** Report the first error as a hard error instead of tolerating it. */
         bail?: boolean;
         /** Capture timing information for each module. */
@@ -143,7 +150,7 @@ declare namespace webpack {
 
     interface CliConfigOptions {
         config?: string;
-        mode?: Configuration["mode"];
+        mode?: Configuration['mode'];
         env?: string;
         'config-register'?: string;
         configRegister?: string;
@@ -151,21 +158,21 @@ declare namespace webpack {
         configName?: string;
     }
 
-    type ConfigurationFactory = ((
+    type ConfigurationFactory = (
         env: string | Record<string, boolean | number | string> | undefined,
         args: CliConfigOptions,
-    ) => Configuration | Promise<Configuration>);
+    ) => Configuration | Promise<Configuration>;
 
-    type MultiConfigurationFactory = ((
+    type MultiConfigurationFactory = (
         env: string | Record<string, boolean | number | string> | undefined,
         args: CliConfigOptions,
-    ) => Configuration[] | Promise<Configuration[]>);
+    ) => Configuration[] | Promise<Configuration[]>;
 
     interface Entry {
         [name: string]: string | string[];
     }
 
-    type EntryFunc = () => (string | string[] | Entry | Promise<string | string[] | Entry>);
+    type EntryFunc = () => string | string[] | Entry | Promise<string | string[] | Entry>;
 
     interface DevtoolModuleFilenameTemplateInfo {
         identifier: string;
@@ -214,7 +221,7 @@ declare namespace webpack {
         /** The filename of the Hot Update Main File. It is inside the output.path directory. */
         hotUpdateMainFilename?: string;
         /** If set, export the bundle as library. output.library is the name. */
-        library?: string | string[] | {[key: string]: string};
+        library?: string | string[] | { [key: string]: string };
         /**
          * Which format to export the library:
          * - "var" - Export by setting a variable: var Library = xxx (default)
@@ -261,7 +268,18 @@ declare namespace webpack {
         futureEmitAssets?: boolean;
     }
 
-    type LibraryTarget = 'var' | 'assign' | 'this' | 'window' | 'global' | 'commonjs' | 'commonjs2' | 'amd' | 'umd' | 'jsonp' | 'system';
+    type LibraryTarget =
+        | 'var'
+        | 'assign'
+        | 'this'
+        | 'window'
+        | 'global'
+        | 'commonjs'
+        | 'commonjs2'
+        | 'amd'
+        | 'umd'
+        | 'jsonp'
+        | 'system';
 
     type AuxiliaryCommentObject = { [P in LibraryTarget]: string };
 
@@ -354,7 +372,7 @@ declare namespace webpack {
          *
          * @see aliasFields
          */
-        alias?: { [key: string]: string; };
+        alias?: { [key: string]: string };
 
         /**
          * Whether to use a cache for resolving, or the specific object
@@ -370,7 +388,7 @@ declare namespace webpack {
          *
          * Defaults to `() => true`.
          */
-        cachePredicate?(data: { path: string, request: string }): boolean;
+        cachePredicate?(data: { path: string; request: string }): boolean;
 
         /**
          * A list of additional resolve plugins which should be applied.
@@ -423,7 +441,7 @@ declare namespace webpack {
         /**
          * Callback with an Error
          */
-        (error: {}): void; /* tslint:disable-line */
+        (error: {}): void /* tslint:disable-line */;
         /**
          * Externalize the dependency
          */
@@ -459,31 +477,31 @@ declare namespace webpack {
         | ((path: string) => boolean)
         | RuleSetConditions
         | {
-            /**
-             * Logical AND
-             */
-            and?: RuleSetCondition[];
-            /**
-             * Exclude all modules matching any of these conditions
-             */
-            exclude?: RuleSetCondition;
-            /**
-             * Exclude all modules matching not any of these conditions
-             */
-            include?: RuleSetCondition;
-            /**
-             * Logical NOT
-             */
-            not?: RuleSetCondition[];
-            /**
-             * Logical OR
-             */
-            or?: RuleSetCondition[];
-            /**
-             * Exclude all modules matching any of these conditions
-             */
-            test?: RuleSetCondition;
-        };
+              /**
+               * Logical AND
+               */
+              and?: RuleSetCondition[];
+              /**
+               * Exclude all modules matching any of these conditions
+               */
+              exclude?: RuleSetCondition;
+              /**
+               * Exclude all modules matching not any of these conditions
+               */
+              include?: RuleSetCondition;
+              /**
+               * Logical NOT
+               */
+              not?: RuleSetCondition[];
+              /**
+               * Logical OR
+               */
+              or?: RuleSetCondition[];
+              /**
+               * Exclude all modules matching any of these conditions
+               */
+              test?: RuleSetCondition;
+          };
 
     // A hack around circular type referencing
     interface RuleSetConditions extends Array<RuleSetCondition> {}
@@ -492,7 +510,7 @@ declare namespace webpack {
         /**
          * Enforce this rule as pre or post step
          */
-        enforce?: "pre" | "post";
+        enforce?: 'pre' | 'post';
         /**
          * Shortcut for resource.exclude
          */
@@ -540,7 +558,7 @@ declare namespace webpack {
         /**
          * Module type to use for the module
          */
-        type?: "javascript/auto" | "javascript/dynamic" | "javascript/esm" | "json" | "webassembly/experimental";
+        type?: 'javascript/auto' | 'javascript/dynamic' | 'javascript/esm' | 'json' | 'webassembly/experimental';
         /**
          * Match the resource path of the module
          */
@@ -567,10 +585,7 @@ declare namespace webpack {
         use?: RuleSetUse;
     }
 
-    type RuleSetUse =
-        | RuleSetUseItem
-        | RuleSetUseItem[]
-        | ((data: any) => RuleSetUseItem | RuleSetUseItem[]);
+    type RuleSetUse = RuleSetUseItem | RuleSetUseItem[] | ((data: any) => RuleSetUseItem | RuleSetUseItem[]);
 
     interface RuleSetLoader {
         /**
@@ -591,14 +606,9 @@ declare namespace webpack {
         query?: RuleSetQuery;
     }
 
-    type RuleSetUseItem =
-        | string
-        | RuleSetLoader
-        | ((data: any) => string | RuleSetLoader);
+    type RuleSetUseItem = string | RuleSetLoader | ((data: any) => string | RuleSetLoader);
 
-    type RuleSetQuery =
-        | string
-        | { [k: string]: any };
+    type RuleSetQuery = string | { [k: string]: any };
 
     /**
      * @deprecated Use RuleSetCondition instead
@@ -612,13 +622,54 @@ declare namespace webpack {
 
     namespace Options {
         // tslint:disable-next-line:max-line-length
-        type Devtool = 'eval' | 'inline-source-map' | 'cheap-eval-source-map' | 'cheap-source-map' | 'cheap-module-eval-source-map' | 'cheap-module-source-map' | 'eval-source-map'
-            | 'source-map' | 'nosources-source-map' | 'hidden-source-map' | 'nosources-source-map' | 'inline-cheap-source-map' | 'inline-cheap-module-source-map' | '@eval'
-            | '@inline-source-map' | '@cheap-eval-source-map' | '@cheap-source-map' | '@cheap-module-eval-source-map' | '@cheap-module-source-map' | '@eval-source-map'
-            | '@source-map' | '@nosources-source-map' | '@hidden-source-map' | '@nosources-source-map' | '#eval' | '#inline-source-map' | '#cheap-eval-source-map'
-            | '#cheap-source-map' | '#cheap-module-eval-source-map' | '#cheap-module-source-map' | '#eval-source-map' | '#source-map' | '#nosources-source-map'
-            | '#hidden-source-map' | '#nosources-source-map' | '#@eval' | '#@inline-source-map' | '#@cheap-eval-source-map' | '#@cheap-source-map' | '#@cheap-module-eval-source-map'
-            | '#@cheap-module-source-map' | '#@eval-source-map' | '#@source-map' | '#@nosources-source-map' | '#@hidden-source-map' | '#@nosources-source-map' | boolean;
+        type Devtool =
+            | 'eval'
+            | 'inline-source-map'
+            | 'cheap-eval-source-map'
+            | 'cheap-source-map'
+            | 'cheap-module-eval-source-map'
+            | 'cheap-module-source-map'
+            | 'eval-source-map'
+            | 'source-map'
+            | 'nosources-source-map'
+            | 'hidden-source-map'
+            | 'nosources-source-map'
+            | 'inline-cheap-source-map'
+            | 'inline-cheap-module-source-map'
+            | '@eval'
+            | '@inline-source-map'
+            | '@cheap-eval-source-map'
+            | '@cheap-source-map'
+            | '@cheap-module-eval-source-map'
+            | '@cheap-module-source-map'
+            | '@eval-source-map'
+            | '@source-map'
+            | '@nosources-source-map'
+            | '@hidden-source-map'
+            | '@nosources-source-map'
+            | '#eval'
+            | '#inline-source-map'
+            | '#cheap-eval-source-map'
+            | '#cheap-source-map'
+            | '#cheap-module-eval-source-map'
+            | '#cheap-module-source-map'
+            | '#eval-source-map'
+            | '#source-map'
+            | '#nosources-source-map'
+            | '#hidden-source-map'
+            | '#nosources-source-map'
+            | '#@eval'
+            | '#@inline-source-map'
+            | '#@cheap-eval-source-map'
+            | '#@cheap-source-map'
+            | '#@cheap-module-eval-source-map'
+            | '#@cheap-module-source-map'
+            | '#@eval-source-map'
+            | '#@source-map'
+            | '#@nosources-source-map'
+            | '#@hidden-source-map'
+            | '#@nosources-source-map'
+            | boolean;
 
         interface Performance {
             /** This property allows webpack to control what files are used to calculate performance hints. */
@@ -646,7 +697,7 @@ declare namespace webpack {
             /** Assign modules to a cache group */
             test?: ((...args: any[]) => boolean) | string | RegExp;
             /** Select chunks for determining cache group content (defaults to \"initial\", \"initial\" and \"all\" requires adding these chunks to the HTML) */
-            chunks?: "initial" | "async" | "all" | ((chunk: compilation.Chunk) => boolean);
+            chunks?: 'initial' | 'async' | 'all' | ((chunk: compilation.Chunk) => boolean);
             /** Ignore minimum size, minimum chunks and maximum requests and always create chunks for this cache group */
             enforce?: boolean;
             /** Priority of this cache group */
@@ -668,7 +719,7 @@ declare namespace webpack {
         }
         interface SplitChunksOptions {
             /** Select chunks for determining shared modules (defaults to \"async\", \"initial\" and \"all\" requires adding these chunks to the HTML) */
-            chunks?: "initial" | "async" | "all" | ((chunk: compilation.Chunk) => boolean);
+            chunks?: 'initial' | 'async' | 'all' | ((chunk: compilation.Chunk) => boolean);
             /** Minimal size for the created chunk */
             minSize?: number;
             /** Maximum size for the created chunk */
@@ -682,7 +733,12 @@ declare namespace webpack {
             /** Give chunks created a name (chunks with equal name are merged) */
             name?: boolean | string | ((...args: any[]) => any);
             /** Assign modules to a cache group (modules from different cache groups are tried to keep in separate chunks) */
-            cacheGroups?: false | string | ((...args: any[]) => any) | RegExp | { [key: string]: CacheGroupsOptions | false };
+            cacheGroups?:
+                | false
+                | string
+                | ((...args: any[]) => any)
+                | RegExp
+                | { [key: string]: CacheGroupsOptions | false };
             /** Override the default name separator (~) when generating names automatically (name: true)  */
             automaticNameDelimiter?: string;
         }
@@ -723,7 +779,7 @@ declare namespace webpack {
             /** Finds modules which are shared between chunk and splits them into separate chunks to reduce duplication or separate vendor modules from application modules. */
             splitChunks?: SplitChunksOptions | false;
             /** Create a separate chunk for the webpack runtime code and chunk hash maps. This chunk should be inlined into the HTML */
-            runtimeChunk?: boolean | "single" | "multiple" | RuntimeChunkOptions;
+            runtimeChunk?: boolean | 'single' | 'multiple' | RuntimeChunkOptions;
             /** Avoid emitting assets when errors occur. */
             noEmitOnErrors?: boolean;
             /** Instead of numeric ids, give modules readable names for better debugging. */
@@ -731,9 +787,9 @@ declare namespace webpack {
             /** Instead of numeric ids, give chunks readable names for better debugging. */
             namedChunks?: boolean;
             /** Tells webpack which algorithm to use when choosing module ids. Default false. */
-            moduleIds?: boolean | "natural" | "named" | "hashed" | "size" | "total-size";
+            moduleIds?: boolean | 'natural' | 'named' | 'hashed' | 'size' | 'total-size';
             /** Tells webpack which algorithm to use when choosing chunk ids. Default false. */
-            chunkIds?: boolean | "natural" | "named" | "size" | "total-size";
+            chunkIds?: boolean | 'natural' | 'named' | 'size' | 'total-size';
             /** Defines the process.env.NODE_ENV constant to a compile-time-constant value. This allows to remove development only code from code. */
             nodeEnv?: string | false;
             /** Use the minimizer (optimization.minimizer, by default uglify-js) to minimize output assets. */
@@ -787,11 +843,9 @@ declare namespace webpack {
     }
 
     namespace compilation {
-        class Asset {
-        }
+        class Asset {}
 
-        class DependenciesBlock {
-        }
+        class DependenciesBlock {}
 
         class Module extends DependenciesBlock {
             constructor(type: string, context?: string);
@@ -820,9 +874,12 @@ declare namespace webpack {
             used: null | boolean;
             usedExports: false | true | string[] | null;
             optimizationBailout: string | any[];
-            _rewriteChunkInReasons: {
-                oldChunk: Chunk, newChunks: Chunk[]
-            } | undefined;
+            _rewriteChunkInReasons:
+                | {
+                      oldChunk: Chunk;
+                      newChunks: Chunk[];
+                  }
+                | undefined;
             useSourceMap: boolean;
             _source: any;
 
@@ -856,8 +913,7 @@ declare namespace webpack {
             unbuild(): void;
         }
 
-        class Record {
-        }
+        class Record {}
 
         class Chunk {
             constructor(name?: string);
@@ -915,21 +971,18 @@ declare namespace webpack {
                 size: number,
                 options: {
                     chunkOverhead?: number;
-                    entryChunkMultiplicator?: number
+                    entryChunkMultiplicator?: number;
                 },
             ): number;
             modulesSize(): number;
-            size(options?: {
-                chunkOverhead?: number;
-                entryChunkMultiplicator?: number
-            }): number;
+            size(options?: { chunkOverhead?: number; entryChunkMultiplicator?: number }): number;
             integratedSize(otherChunk: Chunk, options: any): number | false;
-            sortModules(
-                sortByFn: (module1: Module, module2: Module) => -1 | 0 | 1
-            ): void;
+            sortModules(sortByFn: (module1: Module, module2: Module) => -1 | 0 | 1): void;
             sortItems(): void;
             getAllAsyncChunks(): Set<Chunk>;
-            getChunkMaps(realHash: boolean): {
+            getChunkMaps(
+                realHash: boolean,
+            ): {
                 hash: any;
                 contentHash: any;
                 name: any;
@@ -938,14 +991,11 @@ declare namespace webpack {
             getChildIdsByOrdersMap(includeDirectChildren?: boolean): any;
             // tslint:disable-next-line:ban-types
             getChunkModuleMaps(filterFn: Function): { id: any; hash: any };
-            hasModuleInGraph(
-                filterFn: (module: Module) => boolean,
-                filterChunkFn: (chunk: Chunk) => boolean
-            ): boolean;
+            hasModuleInGraph(filterFn: (module: Module) => boolean, filterChunkFn: (chunk: Chunk) => boolean): boolean;
             toString(): string;
         }
 
-        type GroupOptions = string | { name?: string; };
+        type GroupOptions = string | { name?: string };
 
         class ChunkGroup {
             chunks: Chunk[];
@@ -962,8 +1012,7 @@ declare namespace webpack {
             setParents(newParents: Iterable<ChunkGroup>): void;
         }
 
-        class ChunkHash {
-        }
+        class ChunkHash {}
 
         interface SourcePosition {
             line: number;
@@ -1172,20 +1221,25 @@ declare namespace webpack {
         }
 
         class MainTemplate extends Tapable {
-          hooks: {
-            jsonpScript?: SyncWaterfallHook<string, Chunk, string>;
-            require: SyncWaterfallHook<string, Chunk, string>;
-            requireExtensions: SyncWaterfallHook<string, Chunk, string>;
-            requireEnsure: SyncWaterfallHook<string, Chunk, string>;
-            localVars: SyncWaterfallHook<string, Chunk, string>;
-            afterStartup: SyncWaterfallHook<string, Chunk, string>;
-            hash: SyncHook<CryptoHash>;
-            hashForChunk: SyncHook<CryptoHash, Chunk>;
-          };
-          outputOptions: Output;
-          requireFn: string;
-          renderRequireFunctionForModule(hash: string, chunk: Chunk, varModuleId?: number | string): string;
-          renderAddModule(hash: string, chunk: Chunk, varModuleId: number | string | undefined, varModule: string): string;
+            hooks: {
+                jsonpScript?: SyncWaterfallHook<string, Chunk, string>;
+                require: SyncWaterfallHook<string, Chunk, string>;
+                requireExtensions: SyncWaterfallHook<string, Chunk, string>;
+                requireEnsure: SyncWaterfallHook<string, Chunk, string>;
+                localVars: SyncWaterfallHook<string, Chunk, string>;
+                afterStartup: SyncWaterfallHook<string, Chunk, string>;
+                hash: SyncHook<CryptoHash>;
+                hashForChunk: SyncHook<CryptoHash, Chunk>;
+            };
+            outputOptions: Output;
+            requireFn: string;
+            renderRequireFunctionForModule(hash: string, chunk: Chunk, varModuleId?: number | string): string;
+            renderAddModule(
+                hash: string,
+                chunk: Chunk,
+                varModuleId: number | string | undefined,
+                varModule: string,
+            ): string;
         }
         class ChunkTemplate extends Tapable {}
         class HotUpdateChunkTemplate extends Tapable {}
@@ -1260,20 +1314,28 @@ declare namespace webpack {
             hash?: string;
             getStats(): Stats;
             addChunkInGroup(groupOptions: GroupOptions): ChunkGroup;
-            addChunkInGroup(groupOptions: GroupOptions, module: Module, loc: DependencyLocation, request: string): ChunkGroup;
+            addChunkInGroup(
+                groupOptions: GroupOptions,
+                module: Module,
+                loc: DependencyLocation,
+                request: string,
+            ): ChunkGroup;
             addModule(module: CompilationModule, cacheGroup: any): any;
             // tslint:disable-next-line:ban-types
             addEntry(context: any, entry: any, name: any, callback: Function): void;
 
-            getPath(filename: string, data: {
-                hash?: any,
-                chunk?: any,
-                filename?: string,
-                basename?: string,
-                query?: any,
-                contentHashType?: string,
-                contentHash?: string,
-            }): string;
+            getPath(
+                filename: string,
+                data: {
+                    hash?: any;
+                    chunk?: any;
+                    filename?: string;
+                    basename?: string;
+                    query?: any;
+                    contentHashType?: string;
+                    contentHash?: string;
+                },
+            ): string;
 
             /**
              * @deprecated Compilation.applyPlugins is deprecated. Use new API on `.hooks` instead
@@ -1386,7 +1448,7 @@ declare namespace webpack {
         sortWith(sortFn: (a: T, b: T) => number): void;
         sort(): void;
         getFromCache(fn: (set: SortableSet<T>) => T[]): T[];
-        getFromUnorderedCache(fn: (set: SortableSet<T>) => string|number|T[]): any;
+        getFromUnorderedCache(fn: (set: SortableSet<T>) => string | number | T[]): any;
     }
 
     class Compiler extends Tapable implements ICompiler {
@@ -1458,8 +1520,8 @@ declare namespace webpack {
         endTime?: number;
 
         static filterWarnings(
-          warnings: string[],
-          warningsFilter?: Array<string | RegExp | ((warning: string) => boolean)>
+            warnings: string[],
+            warningsFilter?: Array<string | RegExp | ((warning: string) => boolean)>,
         ): string[];
         /**
          * Returns the default json options from the stats preset.
@@ -1485,14 +1547,7 @@ declare namespace webpack {
     }
 
     namespace Stats {
-        type Preset
-            = boolean
-            | 'errors-only'
-            | 'errors-warnings'
-            | 'minimal'
-            | 'none'
-            | 'normal'
-            | 'verbose';
+        type Preset = boolean | 'errors-only' | 'errors-warnings' | 'minimal' | 'none' | 'normal' | 'verbose';
 
         interface ToJsonOptionsObject {
             /** fallback value for stats options when an option is not defined (has precedence over local webpack defaults) */
@@ -1574,17 +1629,20 @@ declare namespace webpack {
         interface ChunkGroup {
             assets: string[];
             chunks: Array<number | string>;
-            children: Record<string, {
-                assets: string[];
-                chunks: Array<number | string>;
-                name: string;
-            }>;
+            children: Record<
+                string,
+                {
+                    assets: string[];
+                    chunks: Array<number | string>;
+                    name: string;
+                }
+            >;
             childAssets: Record<string, string[]>;
             isOverSizeLimit?: boolean;
         }
 
-        type ReasonType
-            = 'amd define'
+        type ReasonType =
+            | 'amd define'
             | 'amd require array'
             | 'amd require context'
             | 'amd require'
@@ -1728,7 +1786,13 @@ declare namespace webpack {
             warnings: string[];
         }
 
-        type StatsExcludeFilter = string | string[] | RegExp | RegExp[] | ((assetName: string) => boolean) | Array<(assetName: string) => boolean>;
+        type StatsExcludeFilter =
+            | string
+            | string[]
+            | RegExp
+            | RegExp[]
+            | ((assetName: string) => boolean)
+            | Array<(assetName: string) => boolean>;
 
         interface ToStringOptionsObject extends ToJsonOptionsObject {
             /** `webpack --colors` equivalent */
@@ -1764,10 +1828,10 @@ declare namespace webpack {
     }
 
     class DefinePlugin extends Plugin {
-        constructor(definitions: {[key: string]: DefinePlugin.CodeValueObject});
+        constructor(definitions: { [key: string]: DefinePlugin.CodeValueObject });
         static runtimeValue(
             fn: ({ module }: { module: compilation.Module }) => DefinePlugin.CodeValuePrimitive,
-            fileDependencies?: true | string[]
+            fileDependencies?: true | string[],
         ): DefinePlugin.RuntimeValue;
     }
 
@@ -1775,12 +1839,12 @@ declare namespace webpack {
         class RuntimeValue {
             constructor(
                 fn: ({ module }: { module: compilation.Module }) => CodeValuePrimitive,
-                fileDependencies?: string[]
+                fileDependencies?: string[],
             );
             exec(parser: compilation.normalModuleFactory.Parser): CodeValuePrimitive;
         }
         type CodeValuePrimitive = string | number | boolean | RegExp | RuntimeValue | null | undefined;
-        type CodeValueObject = CodeValuePrimitive | {[key: string]: CodeValueObject};
+        type CodeValueObject = CodeValuePrimitive | { [key: string]: CodeValueObject };
     }
 
     class DllPlugin extends Plugin {
@@ -1831,7 +1895,7 @@ declare namespace webpack {
             /**
              * An object containing `content` and `name`.
              */
-            manifest: { content: string, name: string } | string;
+            manifest: { content: string; name: string } | string;
 
             /**
              * The name where the DLL is exposed.
@@ -1866,11 +1930,13 @@ declare namespace webpack {
         interface Options {
             append?: false | string;
             columns?: boolean;
-            lineToLine?: boolean | {
-                exclude?: Condition | Condition[];
-                include?: Condition | Condition[];
-                test?: Condition | Condition[];
-            };
+            lineToLine?:
+                | boolean
+                | {
+                      exclude?: Condition | Condition[];
+                      include?: Condition | Condition[];
+                      test?: Condition | Condition[];
+                  };
             module?: boolean;
             moduleFilenameTemplate?: string;
             sourceRoot?: string;
@@ -1886,11 +1952,7 @@ declare namespace webpack {
     }
 
     class HashedModuleIdsPlugin extends Plugin {
-        constructor(options?: {
-            hashFunction?: string,
-            hashDigest?: string,
-            hashDigestLength?: number
-        });
+        constructor(options?: { hashFunction?: string; hashDigest?: string; hashDigestLength?: number });
     }
 
     class HotModuleReplacementPlugin extends Plugin {
@@ -1996,11 +2058,13 @@ declare namespace webpack {
             fallbackModuleFilenameTemplate?: string;
             filename?: null | false | string;
             include?: Condition | Condition[];
-            lineToLine?: boolean | {
-                exclude?: Condition | Condition[];
-                include?: Condition | Condition[];
-                test?: Condition | Condition[];
-            };
+            lineToLine?:
+                | boolean
+                | {
+                      exclude?: Condition | Condition[];
+                      include?: Condition | Condition[];
+                      test?: Condition | Condition[];
+                  };
             module?: boolean;
             moduleFilenameTemplate?: string;
             noSources?: boolean;
@@ -2020,7 +2084,7 @@ declare namespace webpack {
 
     namespace optimize {
         /** @deprecated use config.optimization.concatenateModules */
-        class ModuleConcatenationPlugin extends Plugin { }
+        class ModuleConcatenationPlugin extends Plugin {}
         class AggressiveMergingPlugin extends Plugin {
             constructor(options?: AggressiveMergingPlugin.Options);
         }
@@ -2103,19 +2167,34 @@ declare namespace webpack {
                 exclude?: Condition | Condition[];
                 include?: Condition | Condition[];
                 /** Parallelization can speedup your build significantly and is therefore highly recommended. */
-                parallel?: boolean | { cache: boolean, workers: boolean | number };
+                parallel?: boolean | { cache: boolean; workers: boolean | number };
                 sourceMap?: boolean;
                 test?: Condition | Condition[];
             }
         }
     }
 
-    namespace dependencies {
+    class ModuleFederationPlugin extends Plugin {
+        constructor(options?: ModuleFederationPlugin.Options);
     }
+
+    namespace ModuleFederationPlugin {
+        interface Options {
+            filename?: string;
+            name?: string;
+            shareScope?: string;
+        }
+    }
+
+    namespace dependencies {}
 
     namespace loader {
         interface Loader extends Function {
-            (this: LoaderContext, source: string | Buffer, sourceMap?: RawSourceMap): string | Buffer | void | undefined;
+            (this: LoaderContext, source: string | Buffer, sourceMap?: RawSourceMap):
+                | string
+                | Buffer
+                | void
+                | undefined;
 
             /**
              * The order of chained loaders are always called from right to left.
@@ -2135,7 +2214,11 @@ declare namespace webpack {
             raw?: boolean;
         }
 
-        type loaderCallback = (err: Error | undefined | null, content?: string | Buffer, sourceMap?: RawSourceMap) => void;
+        type loaderCallback = (
+            err: Error | undefined | null,
+            content?: string | Buffer,
+            sourceMap?: RawSourceMap,
+        ) => void;
 
         interface LoaderContext {
             /**
@@ -2255,7 +2338,10 @@ declare namespace webpack {
              * instance of NormalModule). Use this function if you need to know the source code
              * of another module to generate the result.
              */
-            loadModule(request: string, callback: (err: Error | null, source: string, sourceMap: RawSourceMap, module: Module) => void): any;
+            loadModule(
+                request: string,
+                callback: (err: Error | null, source: string, sourceMap: RawSourceMap, module: Module) => void,
+            ): any;
 
             /**
              * Resolve a request like a require expression.
@@ -2322,7 +2408,15 @@ declare namespace webpack {
              * Target of compilation. Passed from configuration options.
              * Example values: "web", "node"
              */
-            target: 'web' | 'webworker' | 'async-node' | 'node' | 'electron-main' | 'electron-renderer' | 'node-webkit' | string;
+            target:
+                | 'web'
+                | 'webworker'
+                | 'async-node'
+                | 'node'
+                | 'electron-main'
+                | 'electron-renderer'
+                | 'node-webkit'
+                | string;
 
             /**
              * This boolean is set to true when this is compiled by webpack.
@@ -2387,9 +2481,11 @@ declare namespace webpack {
 
         function asString(str: string | string[]): string;
 
-        function getModulesArrayBounds(modules: ReadonlyArray<{
-            id: string | number;
-        }>): [number, number] | false;
+        function getModulesArrayBounds(
+            modules: ReadonlyArray<{
+                id: string | number;
+            }>,
+        ): [number, number] | false;
 
         function renderChunkModules(
             chunk: compilation.Chunk,


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://webpack.js.org/concepts/module-federation/#modulefederationplugin-high-level>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


I attempted to run linting and testing but it bailed with the following error:
```
../uglify-js/index.d.ts(9,30): error TS7016: Could not find a declaration file for module 'source-map'. '/home/zac/_dev/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
```

My addition is on 2177, the other changes are from running prettier.

Addresses #45037