### PR TITLE
[mapbox-gl] Add missing 'idle' event

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -1764,6 +1764,7 @@ declare namespace mapboxgl {
         error: ErrorEvent;
 
         load: MapboxEvent;
+        idle: MapboxEvent;
         remove: MapboxEvent;
         render: MapboxEvent;
         resize: MapboxEvent;

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -897,13 +897,10 @@ expectType<mapboxgl.Map>(
         expectType<undefined>(ev.originalEvent);
     }),
 );
-expectType<mapboxgl.Map>(
-    map.on('idle', ev => {
-        expectType<mapboxgl.MapboxEvent>(ev);
-        expectType<mapboxgl.Map>(ev.target);
-        expectType<undefined>(ev.originalEvent);
-    }),
-);
+// $ExpectType Map
+map.on('idle', ev => {
+    ev; // $ExpectType MapboxEvent<undefined> & EventData
+});
 expectType<mapboxgl.Map>(
     map.on('remove', ev => {
         expectType<mapboxgl.MapboxEvent>(ev);

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -898,6 +898,13 @@ expectType<mapboxgl.Map>(
     }),
 );
 expectType<mapboxgl.Map>(
+    map.on('idle', ev => {
+        expectType<mapboxgl.MapboxEvent>(ev);
+        expectType<mapboxgl.Map>(ev.target);
+        expectType<undefined>(ev.originalEvent);
+    }),
+);
+expectType<mapboxgl.Map>(
     map.on('remove', ev => {
         expectType<mapboxgl.MapboxEvent>(ev);
         expectType<mapboxgl.Map>(ev.target);


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.mapbox.com/mapbox-gl-js/api/map/#map.event:idle
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
