### PR TITLE
Fix empty jsdoc in algoliasearch

### DIFF
--- a/types/algoliasearch/index.d.ts
+++ b/types/algoliasearch/index.d.ts
@@ -1374,22 +1374,16 @@ declare namespace algoliasearch {
     objectID?: string;
   }
 
-  /**
-   */
   interface MultiObjectTask {
     objectIDs: string[];
     taskID: number;
   }
 
-  /**
-   */
   interface UpdateIndexTask {
     updatedAt: string;
     taskID: number;
   }
 
-  /**
-   */
   interface BatchTask {
     objectIDs: string[];
     taskID: Record<string, number>;


### PR DESCRIPTION
The lint rule was crashing before, so was not reporting the error.