### PR TITLE
fix redundant jsdoc in bull/v2

### DIFF
--- a/types/bull/v2/index.d.ts
+++ b/types/bull/v2/index.d.ts
@@ -38,13 +38,13 @@ declare module "bull" {
 
             /**
              * Removes a Job from the queue from all the lists where it may be included.
-             * @returns {Promise} A promise that resolves when the job is removed.
+             * @returns A promise that resolves when the job is removed.
              */
             remove(): Promise<void>;
 
             /**
              * Rerun a Job that has failed.
-             * @returns {Promise} A promise that resolves when the job is scheduled for retry.
+             * @returns A promise that resolves when the job is scheduled for retry.
              */
             retry(): Promise<void>;
 


### PR DESCRIPTION
jsdoc types aren't allowed on DT, but previously the lint rule was crashing before it could report results
