### PR TITLE
feat(romaji-name): new definition

### DIFF
--- a/types/romaji-name/index.d.ts
+++ b/types/romaji-name/index.d.ts
@@ -1,0 +1,169 @@
+// Type definitions for romaji-name 0.1
+// Project: https://github.com/jeresig/node-romaji-name#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterbjazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Location of the default settings file
+ * @default __dirname + "/settings.json"
+ */
+export let settingsFile: string;
+
+/**
+ * Loads the dependent modules(namely, loads the `enamdict` name database).
+ * If, for some reason, you don't need to do any surname/given name correction, or correction of stress marks,
+ * then you can skip this step (this would likely be a very abnormal usage of this library).
+ */
+export function init(callback: () => void): void;
+
+/**
+ * Parses a single string name and returns an object representing that name.
+ * Optionally you can specify some settings to modify how the name is parsed.
+ */
+export function parseName(name: string, options?: ParseOptions): ParseResults;
+
+/**
+ * Same as the normal `parseName` method but accepts an object that's in the same form as the object returned from parseName.
+ * This is useful as you can take existing romaji-name-generated name objects and
+ * re-parse them again (to easily upgrade them when new changes are made to the romaji-name module).
+ */
+export function parseName(results: ParseResults): ParseResults;
+
+export interface ParseResults {
+    /**
+     * The original string that was passed in to parseName.
+     */
+    original: string;
+
+    /**
+     * An object holding the settings that were passed in to the parseName method.
+     */
+    settings?: ParseOptions;
+
+    /**
+     * A guess at the locale of the name. Only two values exist: "ja" and "".
+     * Note that just because "ja" was returned it does not guarantee that the person is actually Japanese,
+     * just that the name looks to be Japanese-like (for example: Some Chinese names also return "ja").
+     */
+    locale: Locale;
+
+    /**
+     * A string of the Romaji form of the given name. (Will only exist if a Romaji form was originally provided.)
+     */
+    given?: string;
+
+    /**
+     * A string of the Kana form of the given name.
+     * (Will only exist if a Romaji form was originally provided and if the locale is "ja".)
+     */
+    given_kana?: string;
+
+    /**
+     * A string of the Kanji form of the given name. (Will only exist if a Kanji form was originally provided.)
+     */
+    given_kanji?: string;
+
+    /**
+     * A string of the Romaji form of the middlename.
+     */
+    middle?: string;
+
+    /**
+     * A string of the Romaji form of the surname.
+     * (Will only exist if a Romaji form was originally provided.)
+     */
+    surname?: string;
+
+    /**
+     * A string of the Kana form of the surname.
+     * (Will only exist if a Romaji form was originally provided and if the locale is "ja".)
+     */
+    surname_kana?: string;
+
+    /**
+     * A string of the Kanji form of the surname. (Will only exist if a Kanji form was originally provided.)
+     */
+    surname_kanji?: string;
+
+    /**
+     * A number representing the generation of the name. For example "John Smith II" would have a generation of 2.
+     */
+    generation?: number;
+
+    /**
+     * The full name, in properly-stressed romaji, including the generation. For example: "Nakamura Gakuryō II".
+     */
+    name: string;
+
+    /**
+     * The full name, in ascii text, including the generation.
+     * This is a proper ascii representation of the name (with long vowels converted from "ō" into "oo", for example).
+     * Example: "Nakamura Gakuryoo II".
+     */
+    ascii?: string;
+
+    /**
+     * The full name, in plain text, including the generation.
+     * This is the same as the name property but with all stress formatting stripped from it.
+     * This could be useful to use in the generation of a URL slug, or some such. It should never be displayed to an end-user as it will almost always be incorrect.
+     * Example: "Nakamura Gakuryo II".
+     */
+    plain: string;
+
+    /**
+     * The full name, in kana, without the generation. For example: "なかむらがくりょう".
+     */
+    kana?: string;
+
+    /**
+     * The full name, in kanji, including the generation. For example: "戯画堂芦幸 2世".
+     */
+    kanji?: string;
+
+    /**
+     * If the name is a representation of an unknown individual (e.g. it's the string "Unknown", "Not known", or many of the other variations)
+     * then this property will exist and be true.
+     */
+    unknown?: true;
+
+    /**
+     * If the name includes a prefix like "Attributed to" then this will be true.
+     */
+    attributed?: boolean;
+
+    /**
+     *  If the name includes some sort of "After" or "In the style of" or similar prefix then this will be true.
+     */
+    after?: boolean;
+
+    /**
+     * If the name includes a prefix like "School of", "Pupil of", or similar then this will be true.
+     */
+    school?: boolean;
+}
+
+/**
+ * Optional settings that change how the name parsing functions
+ */
+export interface ParseOptions {
+    /**
+     * Names that don't have a "ja" locale should be flipped ("Smith John" becomes "John Smith").
+     */
+    flipNonJa?: boolean;
+
+    /**
+     * Removes anything that's wrapped in parentheses.
+     * Normally this is left intact and any extra information is parsed from it.
+     */
+    stripParens?: boolean;
+
+    /**
+     * Assumes that the first name is always the given name.
+     */
+    givenFirst?: boolean;
+}
+
+/**
+ * A guess at the locale of the name.
+ */
+export type Locale = 'ja' | '';

--- a/types/romaji-name/romaji-name-tests.ts
+++ b/types/romaji-name/romaji-name-tests.ts
@@ -1,0 +1,51 @@
+import { ParseResults } from 'romaji-name';
+import romajiName = require('romaji-name');
+
+romajiName.settingsFile; // $ExpectType string
+romajiName.settingsFile = './settings.json';
+const results: ParseResults[] = [
+    {
+        original: 'Kenichi Nakamura',
+        locale: 'ja',
+        given: "Ken'ichi",
+        given_kana: 'けんいち',
+        surname: 'Nakamura',
+        surname_kana: 'なかむら',
+        name: "Nakamura Ken'ichi",
+        ascii: "Nakamura Ken'ichi",
+        plain: "Nakamura Ken'ichi",
+        kana: 'なかむらけんいち',
+    },
+
+    {
+        original: 'Gakuryo Nakamura',
+        locale: 'ja',
+        given: 'Gakuryō',
+        given_kana: 'がくりょう',
+        surname: 'Nakamura',
+        surname_kana: 'なかむら',
+        name: 'Nakamura Gakuryō',
+        ascii: 'Nakamura Gakuryoo',
+        plain: 'Nakamura Gakuryo',
+        kana: 'なかむらがくりょう',
+    },
+    {
+        original: 'Charles Bartlett',
+        locale: '',
+        given: 'Charles',
+        surname: 'Bartlett',
+        name: 'Charles Bartlett',
+        ascii: 'Charles Bartlett',
+        plain: 'Charles Bartlett',
+    },
+];
+// $ExpectType void
+romajiName.init(() => {
+    romajiName.parseName('Kenichi Nakamura'); // $ExpectType ParseResults
+    romajiName.parseName('Kenichi Nakamura', {
+        flipNonJa: true,
+        givenFirst: true,
+        stripParens: true,
+    });
+    romajiName.parseName(results[0]);
+});

--- a/types/romaji-name/tsconfig.json
+++ b/types/romaji-name/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "romaji-name-tests.ts"
+    ]
+}

--- a/types/romaji-name/tslint.json
+++ b/types/romaji-name/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
John's Resig module:
- definition file
- tests

Note that undocumented exported api is not part of dt definition

https://github.com/jeresig/node-romaji-name#readme

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.