### PR TITLE
"newrelic" package: Correct typing of setLambdaHandler()

### DIFF
--- a/types/newrelic/index.d.ts
+++ b/types/newrelic/index.d.ts
@@ -7,6 +7,7 @@
 //                 Kenneth Aasan <https://github.com/kennethaasan>
 //                 Jon Flaishans <https://github.com/funkswing>
 //                 Dylan Smith <https://github.com/dylansmith>
+//                 BlueJeans by Verizon <https://github.com/bluejeans>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // https://docs.newrelic.com/docs/agents/nodejs-agent/api-guides/nodejs-agent-api
@@ -356,12 +357,12 @@ export function getLinkingMetadata(omitSupportability?: boolean): LinkingMetadat
 export function getTraceMetadata(): TraceMetadata;
 
 /**
- * Wraps an AWS Lambda function with NewRelic instrumentation and returns the value of the handler
+ * Wraps an AWS Lambda function with NewRelic instrumentation and returns the wrapped function.
  *
- * The handler is a callback function whose value is returned from setLambdaHandler
- * Returns the value returned by handler
+ * The handler should be an AWS Lambda handler function.
+ * Returns a function with identical signature to the provided handler function.
  */
-export function setLambdaHandler<T>(handler: (...args: any[]) => T): T;
+export function setLambdaHandler<T extends (...args: any[]) => any>(handler: T): T;
 
 export interface Instrument {
     (opts: { moduleName: string; onRequire: () => void; onError?: (err: Error) => void }): void;

--- a/types/newrelic/newrelic-tests.ts
+++ b/types/newrelic/newrelic-tests.ts
@@ -122,4 +122,6 @@ newrelic.getLinkingMetadata();
 newrelic.getLinkingMetadata(true);
 newrelic.getTraceMetadata();
 
-newrelic.setLambdaHandler(() => void 0); // $ExpectType undefined
+newrelic.setLambdaHandler(() => void 0); // $ExpectType () => undefined
+newrelic.setLambdaHandler((event: unknown, context: unknown) => ({ statusCode: 200, body: "Hello!" })); // $ExpectType (event: unknown, context: unknown) => { statusCode: number; body: string; }
+newrelic.setLambdaHandler({some: "object"}); // $ExpectError


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: _discussed in detail below_
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. _Fixing an error, not a new version_
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. _Change is not substantial_

**Additional comments**:
New Relic does not provide specific API documentation for this function (something which I am bringing up with them). https://newrelic.github.io/node-newrelic/docs/api.js.html is usually cited as the documentation, but this simply calls an opaque internal function, making the type unclear.

Better evidence that this function returns another function, rather than a value, can be found in New Relic's "Enable Lambda Monitoring" guide, found at https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda. This page is huge, but there is a section showing the following code:

```
const newrelic = require('newrelic');
require('@newrelic/aws-sdk');

<Other module loads go under the two require statements above>

module.exports.handler = newrelic.setLambdaHandler((event, context, callback) => {
  // This is your handler function code
  console.log('Lambda executed');
  callback();
});
```

Since module.exports.handler is always a function for AWS Lambda, it's pretty clear the return type is a function.

On top of all this, I have tested this at runtime, and the return type is definitely a function!