### PR TITLE
[@types/jsx-pdf] add missing SVG props

### DIFF
--- a/types/jsx-pdf/index.d.ts
+++ b/types/jsx-pdf/index.d.ts
@@ -42,7 +42,12 @@ declare global {
             column: Ele<{ width: number | string }>;
 
             image: EleNoChidlren<Omit<PDFMake.ContentImage, 'image'> & { src: string }>;
-            svg: EleNoChidlren<{ content: string }>;
+            svg: EleNoChidlren<{
+                content: string;
+                width?: number;
+                height?: number;
+                fit?: [number, number];
+            }>;
         }
     }
 }

--- a/types/jsx-pdf/index.d.ts
+++ b/types/jsx-pdf/index.d.ts
@@ -7,6 +7,8 @@ import * as PDFMake from 'pdfmake/interfaces';
 
 export function renderPdf(jsx: JSX.Element): PDFMake.TDocumentDefinitions;
 
+export const Fragment: JSX.IntrinsicElements['stack'];
+
 declare global {
     namespace JSX {
         // tslint:disable-next-line:no-empty-interface
@@ -42,6 +44,7 @@ declare global {
             column: Ele<{ width: number | string }>;
 
             image: EleNoChidlren<Omit<PDFMake.ContentImage, 'image'> & { src: string }>;
+            qr: EleNoChidlren<Omit<PDFMake.ContentQr, 'qr'> & { content: string }>;
             svg: EleNoChidlren<{
                 content: string;
                 width?: number;

--- a/types/jsx-pdf/jsx-pdf-tests.tsx
+++ b/types/jsx-pdf/jsx-pdf-tests.tsx
@@ -231,11 +231,23 @@ const doc12 = (
     </document>
 );
 
+const doc13 = (
+    <document>
+        <content>
+            <qr content="hi" />
+            <qr content="hi" foreground="#f9c7bf" />
+        </content>
+    </document>
+);
+
 // @ts-expect-error image can't have children
 const invalid1 = <image>children</image>;
 
 // @ts-expect-error svg can't have children
 const invalid1 = <svg>children</svg>;
+
+// @ts-expect-error qr can't have children
+const invalid2 = <qr content="hi">children</qr>;
 
 // @ts-expect-error header doesn't accept props
 const invalid1 = <header color="green">children</header>;

--- a/types/jsx-pdf/jsx-pdf-tests.tsx
+++ b/types/jsx-pdf/jsx-pdf-tests.tsx
@@ -116,6 +116,8 @@ const doc5 = (
           </svg>
         `}
             />
+            <svg content="..." width={10} height={10} />
+            <svg content="..." fit={[150, 150]} />
         </content>
     </document>
 );


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/schibsted/jsx-pdf#images and https://pdfmake.github.io/docs/0.1/document-definition-object/svgs/
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~
