### PR TITLE
feat(enamdict): new definition

### DIFF
--- a/types/enamdict/enamdict-tests.ts
+++ b/types/enamdict/enamdict-tests.ts
@@ -1,0 +1,33 @@
+import enamdict = require('enamdict');
+import { Entry } from 'enamdict';
+
+const entries: Entry[] = [
+    {
+        romaji: 'Utagawa',
+        kana: 'うたがわ',
+        kanji: ['哥川', '唄川', '宇多川', '宇田川', '歌川', '詩川', '雅楽川'],
+        type: 'surname',
+    },
+    {
+        romaji: ['katsugawa', 'katsukawa'],
+        kana: ['かつがわ', 'かつかわ'],
+        kanji: '曷川',
+        type: 'surname',
+    },
+];
+
+enamdict.init(() => {
+    const entries = enamdict.find('utagawa'); // $ExpectType Entries
+    entries.romaji(); // $ExpectType string | string[]
+    entries.kana(); // $ExpectType string | string[]
+    entries.kanji(); // $ExpectType string | string[]
+    entries.type(); // $ExpectType NameType
+    enamdict.findKanji('曷川'); // $ExpectType Entries
+    // $$ExpectType Entry[]
+    entries.entries().forEach(entry => {
+        entry.kana; // $ExpectType string | string[]
+        entry.kanji; // $ExpectType string | string[]
+        entry.romaji; // $ExpectType string | string[]
+        entry.type; // $ExpectType NameType
+    });
+});

--- a/types/enamdict/index.d.ts
+++ b/types/enamdict/index.d.ts
@@ -1,0 +1,89 @@
+// Type definitions for enamdict 0.1
+// Project: https://github.com/jeresig/node-enamdict#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * A module for efficiently querying name records from `ENAMDICT` (A Japanese-English mapping of proper names).
+ * Specifically this module is designed for the use case of finding a good English/Kana/Kanji mapping for given names and surnames.
+ * Finding these mappings can be especially challenging and ENAMDICT appears to have the best available mapping.
+ * At this time all other entries in ENAMDICT are ignored (such as place names, full names, company names, etc.).
+ */
+
+/**
+ * Asynchronously loads the previously-generated reduced ENAMDICT.
+ * Must be called before attempting to call `.find()` or `.findKanji()`.
+ */
+export function init(callback: () => void): void;
+
+/**
+ * Finds matching entries by Romaji name (English name).
+ * This is the default search mechanism, the search index is optimized for this particular method
+ */
+export function find(romajiName: string): Entries;
+
+/**
+ * Finds matching entries by Kanji name (Japanese name).
+ * The search index is NOT optimized for this particular method and may be slow
+ */
+export function findKanji(kanjiName: string): Entries;
+
+/**
+ * The result object returned from the `.find()` and `.findKanji()` methods.
+ * Holds a collection of entries that are then used in aggregate
+ */
+export interface Entries {
+    /**
+     * Returns an array of objects representing matching entries.
+     */
+    entries(): Entry[];
+    /**
+     * Returns the most popular type of the name, aggregated from all matching entries.
+     * For example if 5 entries were found, three of which were "surname", 1 of which was "given", and 1 of which was "unknown" then this method would return "surname".
+     * Returns the same possible values as the type property itself.
+     */
+    type(): NameType;
+
+    /**
+     * If a query was done with `.find()` then this will return a string representing the Kana reading of the name.
+     *
+     * If a query was done with `.findKanji()` then this will return an array of all the possible Kana readings of the Kanji.
+     */
+    kana(): string | string[];
+    /**
+     * If a query was done with .find() then this will return a string representing the Romaji reading of the name.
+     *
+     * If a query was done with `.findKanji()` then this will return an array of all the possible Romaji readings of the Kanji.
+     */
+    romaji(): string | string[];
+    /**
+     * If a query was done with `.find()` then this will return an array of all the possible Kanji versions of the name.
+     *
+     * If a query was done with `.findKanji()` then this will return a string representing the Kanji version of the name.
+     */
+    kanji(): string | string[];
+}
+
+export interface Entry {
+    /**
+     * A string holding an English (Romaji) representation of a name.
+     */
+    romaji: string | string[];
+    /**
+     *  A string holding a Kana representation of a name.
+     */
+    kana: string | string[];
+    /**
+     * A string holding a Kanji representation of a name.
+     */
+    kanji: string | string[];
+    /**
+     * A string that represents the type of the name.
+     */
+    type: NameType;
+}
+
+/**
+ * the type of the name.
+ */
+export type NameType = 'unknown' | 'surname' | 'given';

--- a/types/enamdict/tsconfig.json
+++ b/types/enamdict/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "enamdict-tests.ts"
+    ]
+}

--- a/types/enamdict/tslint.json
+++ b/types/enamdict/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- definition file
- tests

Please note that only public, documented API is being exported in .d.ts.

https://github.com/jeresig/node-enamdict

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.