### PR TITLE
feat(@koozaki/romaji-conv): new definition

### DIFF
--- a/types/koozaki__romaji-conv/index.d.ts
+++ b/types/koozaki__romaji-conv/index.d.ts
@@ -1,0 +1,66 @@
+// Type definitions for @koozaki/romaji-conv 2.0
+// Project: https://romaji-conv.koozaki.com/
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace romajiConv;
+
+/**
+ * RomajiConv のインスタンスを返す
+ *
+ * @param someString 変換対象の文字列
+ * @return のインスタンス
+ */
+declare function romajiConv(someString: string): romajiConv.RomajiConv;
+
+declare namespace romajiConv {
+    interface RomajiConv {
+        /**
+         * 変換前の文字列を返す
+         *
+         * @return 変換前の文字列
+         */
+        string(): string;
+
+        /**
+         * 文字列の変換
+         *
+         * @param someString ローマ字 or ひらがな or カタカナ
+         * @param mapObject マッピングオブジェクト
+         * @return ひらがな or カタカナ
+         */
+        convert(someString: string, mapObject: object): string;
+
+        /**
+         * 変換後のひらがなを返す
+         *
+         * @return 変換後のひらがな
+         */
+        toHiragana(): string;
+
+        /**
+         * 変換後のカタカナを返す
+         *
+         * @return 変換後のカタカナ
+         */
+        toKatakana(): string;
+    }
+
+    /**
+     * 変換後のひらがなを返す
+     *
+     * @param someString 変換対象の文字列
+     * @return 変換後のひらがな
+     */
+    function toHiragana(someString: string): string;
+
+    /**
+     * 変換後のカタカナを返す
+     *
+     * @param someString 変換対象の文字列
+     * @return 変換後のカタカナ
+     */
+    function toKatakana(someString: string): string;
+}
+
+export = romajiConv;

--- a/types/koozaki__romaji-conv/test/koozaki__romaji-conv.browser.ts
+++ b/types/koozaki__romaji-conv/test/koozaki__romaji-conv.browser.ts
@@ -1,0 +1,5 @@
+const romaji = romajiConv('アノイヌチャウチャウトチャウンチャウ');
+romaji.toHiragana(); // $ExpectType string
+romaji.toKatakana(); // $ExpectType string
+romajiConv.toKatakana('ほげほげ'); // $ExpectType string
+romajiConv.toHiragana('ホゲホゲ'); // $ExpectType string

--- a/types/koozaki__romaji-conv/test/koozaki__romaji-conv.node.ts
+++ b/types/koozaki__romaji-conv/test/koozaki__romaji-conv.node.ts
@@ -1,0 +1,8 @@
+import romajiConv = require('@koozaki/romaji-conv');
+import { toHiragana, toKatakana } from '@koozaki/romaji-conv';
+
+const romaji = romajiConv('アノイヌチャウチャウトチャウンチャウ');
+romaji.toHiragana(); // $ExpectType string
+romaji.toKatakana(); // $ExpectType string
+toKatakana('ほげほげ'); // $ExpectType string
+toHiragana('ホゲホゲ'); // $ExpectType string

--- a/types/koozaki__romaji-conv/tsconfig.json
+++ b/types/koozaki__romaji-conv/tsconfig.json
@@ -1,0 +1,29 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@koozaki/romaji-conv": [
+                "koozaki__romaji-conv"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "test/koozaki__romaji-conv.browser.ts",
+        "test/koozaki__romaji-conv.node.ts"
+    ]
+}

--- a/types/koozaki__romaji-conv/tslint.json
+++ b/types/koozaki__romaji-conv/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- definition file
- tests

https://github.com/koozaki/romaji-conv/blob/master/README.md

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.