### PR TITLE
feat(xast): add type definitions for xast

### DIFF
--- a/types/xast/index.d.ts
+++ b/types/xast/index.d.ts
@@ -78,7 +78,7 @@ export interface Comment extends Literal {
 /**
  * XML doctype.
  */
-export interface DocType extends UnistNode {
+export interface Doctype extends UnistNode {
     type: 'doctype';
     name: string;
     /**

--- a/types/xast/index.d.ts
+++ b/types/xast/index.d.ts
@@ -58,7 +58,7 @@ export interface Element extends Parent {
  * Information associated with an element.
  */
 export interface Attributes {
-    [name: string]: string;
+    [name: string]: string | null | undefined;
 }
 
 /**

--- a/types/xast/index.d.ts
+++ b/types/xast/index.d.ts
@@ -16,7 +16,7 @@ export { UnistNode as Node };
  * Its content is limited to only other xast content.
  */
 export interface Parent extends UnistParent {
-    children: Array<Element | Text | Comment | DocType | Instruction | Cdata>;
+    children: Array<Element | Text | Comment | Doctype | Instruction | Cdata>;
 }
 
 /**

--- a/types/xast/index.d.ts
+++ b/types/xast/index.d.ts
@@ -1,0 +1,107 @@
+// Type definitions for non-npm package xast 1.0
+// Project: https://github.com/syntax-tree/xast
+// Definitions by: stefanprobst <https://github.com/stefanprobst>
+//                 Titus Wormer <https://github.com/wooorm>
+//                 Christian Murphy <https://github.com/ChristianMurphy>
+//                 Junyoung Choi <https://github.com/rokt33r>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+import { Parent as UnistParent, Literal as UnistLiteral, Node as UnistNode } from 'unist';
+
+export { UnistNode as Node };
+
+/**
+ * Node in xast containing other nodes.
+ * Its content is limited to only other xast content.
+ */
+export interface Parent extends UnistParent {
+    children: Array<Element | Text | Comment | DocType | Instruction | Cdata>;
+}
+
+/**
+ * Node in xast containing a value.
+ */
+export interface Literal extends UnistLiteral {
+    value: string;
+}
+
+/**
+ * Document fragment or a whole document.
+ * Should be used as the root of a tree and must not be used as a child.
+ *
+ * XML specifies that documents should have exactly one element child,
+ * therefore a root should have exactly one element child when representing a
+ * whole document.
+ */
+export interface Root extends Parent {
+    type: 'root';
+}
+
+/**
+ * An XML element.
+ */
+export interface Element extends Parent {
+    type: 'element';
+    /**
+     * The element's qualified name.
+     */
+    name: string;
+    /**
+     * Information associated with the element.
+     */
+    attributes?: Attributes;
+    children: Array<Element | Text | Comment | Instruction | Cdata>;
+}
+
+/**
+ * Information associated with an element.
+ */
+export interface Attributes {
+    [name: string]: string;
+}
+
+/**
+ * XML character data.
+ */
+export interface Text extends Literal {
+    type: 'text';
+}
+
+/**
+ * XML comment.
+ */
+export interface Comment extends Literal {
+    type: 'comment';
+}
+
+/**
+ * XML doctype.
+ */
+export interface DocType extends UnistNode {
+    type: 'doctype';
+    name: string;
+    /**
+     * The document’s public identifier.
+     */
+    public?: string;
+    /**
+     * The document’s system identifier.
+     */
+    system?: string;
+}
+
+/**
+ * XML processing instruction.
+ */
+export interface Instruction extends Literal {
+    type: 'instruction';
+    name: string;
+}
+
+/**
+ * XML CDATA section.
+ */
+export interface Cdata extends Literal {
+    type: 'cdata';
+}

--- a/types/xast/tsconfig.json
+++ b/types/xast/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "xast-tests.ts"]
+}

--- a/types/xast/tslint.json
+++ b/types/xast/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
+}

--- a/types/xast/xast-tests.ts
+++ b/types/xast/xast-tests.ts
@@ -86,7 +86,9 @@ const root: Root = {
 };
 
 const attributes: Attributes = {
-    attributeName: 'attributeValue',
+    attributeName1: 'attributeValue',
+    attributeName2: null,
+    attributeName3: undefined,
 };
 
 function getElement(): Element {

--- a/types/xast/xast-tests.ts
+++ b/types/xast/xast-tests.ts
@@ -1,0 +1,99 @@
+import { Data, Point, Position } from 'unist';
+import { Parent, Attributes, Literal, Root, Element, DocType, Comment, Text, Instruction, Cdata } from 'xast';
+
+const data: Data = {
+    string: 'string',
+    number: 1,
+    object: {
+        key: 'value',
+    },
+    array: [],
+    boolean: true,
+    null: null,
+};
+
+const point: Point = {
+    line: 1,
+    column: 1,
+    offset: 0,
+};
+
+const position: Position = {
+    start: point,
+    end: point,
+    indent: [1],
+};
+
+const literal: Literal = {
+    type: 'text',
+    data,
+    point,
+    value: 'value',
+};
+
+const comment: Comment = {
+    type: 'comment',
+    data,
+    point,
+    value: 'value',
+};
+
+const text: Text = {
+    type: 'text',
+    data,
+    point,
+    value: 'value',
+};
+
+const docType: DocType = {
+    type: 'doctype',
+    data,
+    point,
+    name: 'name',
+    public: 'public',
+    system: 'system',
+};
+
+const cdata: Cdata = {
+    type: 'cdata',
+    data,
+    point,
+    value: 'value',
+};
+
+const instruction: Instruction = {
+    type: 'instruction',
+    data,
+    point,
+    name: 'name',
+    value: 'value',
+};
+
+const element: Element = getElement();
+
+const parent: Parent = {
+    type: 'parent',
+    data,
+    position,
+    children: [getElement(), docType, comment, text, instruction, cdata],
+};
+
+const root: Root = {
+    type: 'root',
+    data,
+    position,
+    children: [getElement(), docType, comment, text, instruction, cdata],
+};
+
+const attributes: Attributes = {
+    attributeName: 'attributeValue',
+};
+
+function getElement(): Element {
+    return {
+        type: 'element',
+        name: 'name',
+        attributes,
+        children: [element, comment, text, cdata, instruction],
+    };
+}

--- a/types/xast/xast-tests.ts
+++ b/types/xast/xast-tests.ts
@@ -1,5 +1,5 @@
 import { Data, Point, Position } from 'unist';
-import { Parent, Attributes, Literal, Root, Element, DocType, Comment, Text, Instruction, Cdata } from 'xast';
+import { Parent, Attributes, Literal, Root, Element, Doctype, Comment, Text, Instruction, Cdata } from 'xast';
 
 const data: Data = {
     string: 'string',
@@ -45,7 +45,7 @@ const text: Text = {
     value: 'value',
 };
 
-const docType: DocType = {
+const docType: Doctype = {
     type: 'doctype',
     data,
     point,


### PR DESCRIPTION
this adds type definitions for [xast](https://github.com/syntax-tree/xast).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

