### PR TITLE
fix(archiver): data event argument type should be a Buffer

### DIFF
--- a/types/archiver/archiver-tests.ts
+++ b/types/archiver/archiver-tests.ts
@@ -1,5 +1,6 @@
 import Archiver = require('archiver');
 import * as fs from 'fs';
+import { Readable, Writable } from 'stream';
 
 const options: Archiver.ArchiverOptions = {
     statConcurrency: 1,
@@ -22,6 +23,9 @@ const options: Archiver.ArchiverOptions = {
 Archiver('zip', options);
 
 const archiver = Archiver.create('zip');
+
+const archiverAsReadable: Readable = archiver;
+const archiverAsWritable: Writable = archiver;
 
 const writeStream = fs.createWriteStream('./archiver.d.ts');
 const readStream = fs.createReadStream('./archiver.d.ts');
@@ -78,3 +82,5 @@ const fakeError = new Archiver.ArchiverError('code', 'foo');
 
 archiver.on('error', fakeHandler);
 archiver.on('warning', fakeHandler);
+
+archiver.on('data', (chunk: Buffer) => console.log(chunk));

--- a/types/archiver/index.d.ts
+++ b/types/archiver/index.d.ts
@@ -90,7 +90,7 @@ declare namespace archiver {
         symlink(filepath: string, target: string): this;
 
         on(event: 'error' | 'warning', listener: (error: ArchiverError) => void): this;
-        on(event: 'data', listener: (data: EntryData) => void): this;
+        on(event: 'data', listener: (data: Buffer) => void): this;
         on(event: 'progress', listener: (progress: ProgressData) => void): this;
         on(event: 'close' | 'drain' | 'finish', listener: () => void): this;
         on(event: 'pipe' | 'unpipe', listener: (src: stream.Readable) => void): this;


### PR DESCRIPTION
`Archiver` instances are Readable streams in binary mode, thus the `data` event argument must be a `Buffer`.

https://github.com/archiverjs/node-archiver/blob/e34d0a39dd636509687277a2ba8dae3be49dd954/lib/core.js#L69

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/archiverjs/node-archiver/blob/e34d0a39dd636509687277a2ba8dae3be49dd954/lib/core.js#L69
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
