### PR TITLE
[aws-lambda] Add Amazon MSK event

### DIFF
--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -78,5 +78,6 @@ export * from "./trigger/s3-batch";
 export * from "./trigger/ses";
 export * from "./trigger/sns";
 export * from "./trigger/sqs";
+export * from './trigger/msk';
 
 export as namespace AWSLambda;

--- a/types/aws-lambda/test/msk-tests.ts
+++ b/types/aws-lambda/test/msk-tests.ts
@@ -1,0 +1,19 @@
+import { MSKHandler, MSKEvent, MSKRecord } from 'aws-lambda';
+
+const handler: MSKHandler = (_event, context, callback) => {
+    const event: MSKEvent = _event;
+    str = event.eventSource;
+    str = event.eventSourceArn;
+
+    const record: MSKRecord = event.records[str][num];
+    str = record.topic;
+    num = record.partition;
+    num = record.offset;
+    num = record.timestamp;
+    str = record.timestampType;
+    str = record.key;
+    str = record.value;
+
+    callback();
+    callback(new Error());
+};

--- a/types/aws-lambda/trigger/msk.d.ts
+++ b/types/aws-lambda/trigger/msk.d.ts
@@ -1,0 +1,21 @@
+import { Handler } from '../handler';
+
+export type MSKHandler = Handler<MSKEvent, void>;
+
+export interface MSKRecord {
+    topic: string;
+    partition: number;
+    offset: number;
+    timestamp: number;
+    timestampType: 'CREATE_TIME' | 'LOG_APPEND_TIME';
+    key: string;
+    value: string;
+}
+
+export interface MSKEvent {
+    eventSource: 'aws:kafka';
+    eventSourceArn: string;
+    records: {
+        [topic: string]: MSKRecord[];
+    };
+}

--- a/types/aws-lambda/tsconfig.json
+++ b/types/aws-lambda/tsconfig.json
@@ -35,6 +35,7 @@
         "test/s3-tests.ts",
         "test/ses-tests.ts",
         "test/sns-tests.ts",
-        "test/sqs-tests.ts"
+        "test/sqs-tests.ts",
+        "test/msk-tests.ts"
     ]
 }


### PR DESCRIPTION
This PR adds [recently released Amazon MSK event](https://aws.amazon.com/blogs/compute/using-amazon-msk-as-an-event-source-for-aws-lambda/) for AWS Lambda.

Closes #48264

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/lambda/latest/dg/with-msk.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
