### PR TITLE
node: socket is optional on http.OutgoingMessage

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -160,8 +160,8 @@ declare module "http" {
         /**
          * @deprecate Use `socket` instead.
          */
-        connection: Socket;
-        socket: Socket;
+        connection: Socket | null;
+        socket: Socket | null;
 
         constructor();
 
@@ -205,8 +205,6 @@ declare module "http" {
 
     // https://github.com/nodejs/node/blob/master/lib/_http_client.js#L77
     class ClientRequest extends OutgoingMessage {
-        connection: Socket;
-        socket: Socket;
         aborted: number;
 
         constructor(url: string | URL | ClientRequestArgs, cb?: (res: IncomingMessage) => void);

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -115,7 +115,11 @@ import * as net from 'net';
     req.abort();
 
     // connection
-    req.connection.on('pause', () => { });
+    req.connection?.on('pause', () => { });
+
+    if (req.socket) {
+        req.socket.on("connect", () => {});
+    }
 
     // event
     req.on('data', () => { });


### PR DESCRIPTION
The field socket is optional on http.OutgoingMessage.

For `ClientRequests` a socket may be assigned later if there are no free sockets availble in `http.agent`.

For `ServerResponse` socket is set to null after end() has been called.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/nodejs/node/blob/efd5c83255d77b741cbdd485cdf5926c0447f233/lib/_http_outgoing.js#L119
https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_response_socket
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

