### PR TITLE
Added missing property `firstArg` to the Sinon library

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -23,8 +23,8 @@ interface Document {} // tslint:disable-line no-empty-interface
 declare namespace Sinon {
     type MatchArguments<T> = {
         [K in keyof T]: SinonMatcher
-        | (T[K] extends object ? MatchArguments<T[K]> : never)
-        | T[K];
+            | (T[K] extends object ? MatchArguments<T[K]> : never)
+            | T[K];
     };
 
     interface SinonSpyCallApi<TArgs extends any[] = any[], TReturnValue = any> {
@@ -172,9 +172,9 @@ declare namespace Sinon {
 
     interface SinonSpy<TArgs extends any[] = any[], TReturnValue = any>
         extends Pick<
-        SinonSpyCallApi<TArgs, TReturnValue>,
-        Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, 'args'>
-        > {
+                SinonSpyCallApi<TArgs, TReturnValue>,
+                Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, 'args'>
+            > {
         // Properties
         /**
          * The number of recorded calls.
@@ -909,10 +909,10 @@ declare namespace Sinon {
          */
         addFilter(
             filter: (
-                method: string, 
-                url: string, 
-                async: boolean, 
-                username: string, 
+                method: string,
+                url: string,
+                async: boolean,
+                username: string,
                 password: string
             ) => boolean
         ): void;
@@ -982,7 +982,7 @@ declare namespace Sinon {
          * Responds to all requests to given URL, e.g. /posts/1.
          */
         respondWith(
-            url: string, 
+            url: string,
             fn: (xhr: SinonFakeXMLHttpRequest) => void
         ): void;
         /**
@@ -1000,8 +1000,8 @@ declare namespace Sinon {
          * method is an HTTP verb.
          */
         respondWith(
-            method: string, 
-            url: string, 
+            method: string,
+            url: string,
             fn: (xhr: SinonFakeXMLHttpRequest) => void
         ): void;
         /**
@@ -1019,7 +1019,7 @@ declare namespace Sinon {
          * If the response is a Function, it will be passed any capture groups from the regular expression along with the XMLHttpRequest object:
          */
         respondWith(
-            url: RegExp, 
+            url: RegExp,
             fn: (xhr: SinonFakeXMLHttpRequest) => void
         ): void;
         /**
@@ -1034,8 +1034,8 @@ declare namespace Sinon {
          * Responds to all method requests to URLs matching the regular expression.
          */
         respondWith(
-            method: string, 
-            url: RegExp, 
+            method: string,
+            url: RegExp,
             fn: (xhr: SinonFakeXMLHttpRequest) => void
         ): void;
         /**
@@ -1191,7 +1191,7 @@ declare namespace Sinon {
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledWithMatch(spy.secondCall, arg1, arg2, ...);.
          */
         calledWithMatch<TArgs extends any[]>(
-            spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>, 
+            spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
             ...args: TArgs
         ): void;
         /**
@@ -1637,8 +1637,8 @@ declare namespace Sinon {
          * This method only works on non-accessor properties, for replacing accessors, use sandbox.replaceGetter() and sandbox.replaceSetter().
          */
         replace<T, TKey extends keyof T>(
-            obj: T, 
-            prop: TKey, 
+            obj: T,
+            prop: TKey,
             replacement: T[TKey]
         ): T[TKey];
         /**
@@ -1649,10 +1649,10 @@ declare namespace Sinon {
          * @param replacement
          */
         replaceGetter<T, TKey extends keyof T>(
-            obj: T, 
-            prop: TKey, 
+            obj: T,
+            prop: TKey,
             replacement: () => T[TKey]
-            ): () => T[TKey];
+        ): () => T[TKey];
         /**
          * Replaces setter for property on object with replacement argument. Attempts to replace an already replaced setter cause an exception.
          * replacement must be a Function, and can be instances of spies, stubs and fakes.

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -23,8 +23,8 @@ interface Document {} // tslint:disable-line no-empty-interface
 declare namespace Sinon {
     type MatchArguments<T> = {
         [K in keyof T]: SinonMatcher
-        | (T[K] extends object ? MatchArguments<T[K]> : never)
-        | T[K];
+            | (T[K] extends object ? MatchArguments<T[K]> : never)
+            | T[K];
     };
 
     interface SinonSpyCallApi<TArgs extends any[] = any[], TReturnValue = any> {
@@ -172,9 +172,9 @@ declare namespace Sinon {
 
     interface SinonSpy<TArgs extends any[] = any[], TReturnValue = any>
         extends Pick<
-        SinonSpyCallApi<TArgs, TReturnValue>,
-        Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, 'args'>
-        > {
+            SinonSpyCallApi<TArgs, TReturnValue>,
+            Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, 'args'>
+            > {
         // Properties
         /**
          * The number of recorded calls.
@@ -909,10 +909,10 @@ declare namespace Sinon {
          */
         addFilter(
             filter: (
-                method: string, 
-                url: string, 
-                async: boolean, 
-                username: string, 
+                method: string,
+                url: string,
+                async: boolean,
+                username: string,
                 password: string
             ) => boolean
         ): void;
@@ -982,7 +982,7 @@ declare namespace Sinon {
          * Responds to all requests to given URL, e.g. /posts/1.
          */
         respondWith(
-            url: string, 
+            url: string,
             fn: (xhr: SinonFakeXMLHttpRequest) => void
         ): void;
         /**
@@ -1000,8 +1000,8 @@ declare namespace Sinon {
          * method is an HTTP verb.
          */
         respondWith(
-            method: string, 
-            url: string, 
+            method: string,
+            url: string,
             fn: (xhr: SinonFakeXMLHttpRequest) => void
         ): void;
         /**
@@ -1019,7 +1019,7 @@ declare namespace Sinon {
          * If the response is a Function, it will be passed any capture groups from the regular expression along with the XMLHttpRequest object:
          */
         respondWith(
-            url: RegExp, 
+            url: RegExp,
             fn: (xhr: SinonFakeXMLHttpRequest) => void
         ): void;
         /**
@@ -1034,8 +1034,8 @@ declare namespace Sinon {
          * Responds to all method requests to URLs matching the regular expression.
          */
         respondWith(
-            method: string, 
-            url: RegExp, 
+            method: string,
+            url: RegExp,
             fn: (xhr: SinonFakeXMLHttpRequest) => void
         ): void;
         /**
@@ -1191,7 +1191,7 @@ declare namespace Sinon {
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledWithMatch(spy.secondCall, arg1, arg2, ...);.
          */
         calledWithMatch<TArgs extends any[]>(
-            spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>, 
+            spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
             ...args: TArgs
         ): void;
         /**
@@ -1637,8 +1637,8 @@ declare namespace Sinon {
          * This method only works on non-accessor properties, for replacing accessors, use sandbox.replaceGetter() and sandbox.replaceSetter().
          */
         replace<T, TKey extends keyof T>(
-            obj: T, 
-            prop: TKey, 
+            obj: T,
+            prop: TKey,
             replacement: T[TKey]
         ): T[TKey];
         /**
@@ -1649,10 +1649,10 @@ declare namespace Sinon {
          * @param replacement
          */
         replaceGetter<T, TKey extends keyof T>(
-            obj: T, 
-            prop: TKey, 
+            obj: T,
+            prop: TKey,
             replacement: () => T[TKey]
-            ): () => T[TKey];
+        ): () => T[TKey];
         /**
          * Replaces setter for property on object with replacement argument. Attempts to replace an already replaced setter cause an exception.
          * replacement must be a Function, and can be instances of spies, stubs and fakes.

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -22,9 +22,7 @@ interface Document {} // tslint:disable-line no-empty-interface
 
 declare namespace Sinon {
     type MatchArguments<T> = {
-        [K in keyof T]: SinonMatcher
-            | (T[K] extends object ? MatchArguments<T[K]> : never)
-            | T[K];
+        [K in keyof T]: SinonMatcher | (T[K] extends object ? MatchArguments<T[K]> : never) | T[K];
     };
 
     interface SinonSpyCallApi<TArgs extends any[] = any[], TReturnValue = any> {
@@ -86,7 +84,7 @@ declare namespace Sinon {
          * Uses deep comparison for objects and arrays. Use spy.returned(sinon.match.same(obj)) for strict comparison (see matchers).
          * @param value
          */
-        returned(value: TReturnValue|SinonMatcher): boolean;
+        returned(value: TReturnValue | SinonMatcher): boolean;
         /**
          * Returns true if spy threw an exception at least once.
          */
@@ -146,6 +144,12 @@ declare namespace Sinon {
          * When the last argument in a call is a Function, then callback will reference that. Otherwise it will be undefined.
          */
         callback: Function | undefined;
+
+        /**
+         * This property is a convenience for the last argument of the call.
+         */
+        firstArg: any;
+
         /**
          * This property is a convenience for the last argument of the call.
          */
@@ -166,9 +170,9 @@ declare namespace Sinon {
 
     interface SinonSpy<TArgs extends any[] = any[], TReturnValue = any>
         extends Pick<
-                SinonSpyCallApi<TArgs, TReturnValue>,
-                Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, 'args'>
-            > {
+            SinonSpyCallApi<TArgs, TReturnValue>,
+            Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, 'args'>
+        > {
         // Properties
         /**
          * The number of recorded calls.
@@ -372,20 +376,17 @@ declare namespace Sinon {
          * The original method can be restored by calling object.method.restore().
          * The returned spy is the function object which replaced the original method. spy === object.method.
          */
-        <T, K extends keyof T>(obj: T, method: K): T[K] extends (
-            ...args: infer TArgs
-        ) => infer TReturnValue
+        <T, K extends keyof T>(obj: T, method: K): T[K] extends (...args: infer TArgs) => infer TReturnValue
             ? SinonSpy<TArgs, TReturnValue>
             : SinonSpy;
 
-        <T, K extends keyof T>(obj: T, method: K, types: Array<('get'|'set')>): PropertyDescriptor & {
+        <T, K extends keyof T>(obj: T, method: K, types: Array<'get' | 'set'>): PropertyDescriptor & {
             get: SinonSpy<[], T[K]>;
             set: SinonSpy<[T[K]], void>;
         };
     }
 
-    interface SinonStub<TArgs extends any[] = any[], TReturnValue = any>
-        extends SinonSpy<TArgs, TReturnValue> {
+    interface SinonStub<TArgs extends any[] = any[], TReturnValue = any> extends SinonSpy<TArgs, TReturnValue> {
         /**
          * Resets the stub’s behaviour to the default behaviour
          * You can reset behaviour of all stubs using sinon.resetBehavior()
@@ -430,7 +431,9 @@ declare namespace Sinon {
          * The Promise library can be overwritten using the usingPromise method.
          * Since sinon@2.0.0
          */
-        resolves(value?: TReturnValue extends PromiseLike<infer TResolveValue> ? TResolveValue : any): SinonStub<TArgs, TReturnValue>;
+        resolves(
+            value?: TReturnValue extends PromiseLike<infer TResolveValue> ? TResolveValue : any,
+        ): SinonStub<TArgs, TReturnValue>;
         /**
          * Causes the stub to return a Promise which resolves to the argument at the provided index.
          * stub.resolvesArg(0); causes the stub to return a Promise which resolves to the first argument.
@@ -506,11 +509,7 @@ declare namespace Sinon {
          * @param context
          * @param args
          */
-        callsArgOnWith(
-            index: number,
-            context: any,
-            ...args: any[]
-        ): SinonStub<TArgs, TReturnValue>;
+        callsArgOnWith(index: number, context: any, ...args: any[]): SinonStub<TArgs, TReturnValue>;
         /**
          * Same as their corresponding non-Async counterparts, but with callback being deferred at called after all instructions in the current call stack are processed.
          * In Node environment the callback is deferred with process.nextTick.
@@ -537,11 +536,7 @@ declare namespace Sinon {
          * In Node environment the callback is deferred with process.nextTick.
          * In a browser the callback is deferred with setTimeout(callback, 0).
          */
-        callsArgOnWithAsync(
-            index: number,
-            context: any,
-            ...args: any[]
-        ): SinonStub<TArgs, TReturnValue>;
+        callsArgOnWithAsync(index: number, context: any, ...args: any[]): SinonStub<TArgs, TReturnValue>;
         /**
          * Makes the stub call the provided @param func when invoked.
          * @param func
@@ -606,11 +601,7 @@ declare namespace Sinon {
         /**
          * Like above but with an additional parameter to pass the this context.
          */
-        yieldsToOn(
-            property: string,
-            context: any,
-            ...args: any[]
-        ): SinonStub<TArgs, TReturnValue>;
+        yieldsToOn(property: string, context: any, ...args: any[]): SinonStub<TArgs, TReturnValue>;
         /**
          * Same as their corresponding non-Async counterparts, but with callback being deferred at called after all instructions in the current call stack are processed.
          * In Node environment the callback is deferred with process.nextTick.
@@ -642,11 +633,7 @@ declare namespace Sinon {
          * @param context
          * @param args
          */
-        yieldsToOnAsync(
-            property: string,
-            context: any,
-            ...args: any[]
-        ): SinonStub<TArgs, TReturnValue>;
+        yieldsToOnAsync(property: string, context: any, ...args: any[]): SinonStub<TArgs, TReturnValue>;
         /**
          * Stubs the method only for the provided arguments.
          * This is useful to be more expressive in your assertions, where you can access the spy with the same call.
@@ -678,9 +665,7 @@ declare namespace Sinon {
          * An exception is thrown if the property is not already a function.
          * The original function can be restored by calling object.method.restore(); (or stub.restore();).
          */
-        <T, K extends keyof T>(obj: T, method: K): T[K] extends (
-            ...args: infer TArgs
-        ) => infer TReturnValue
+        <T, K extends keyof T>(obj: T, method: K): T[K] extends (...args: infer TArgs) => infer TReturnValue
             ? SinonStub<TArgs, TReturnValue>
             : SinonStub;
     }
@@ -902,13 +887,7 @@ declare namespace Sinon {
          * @param filter
          */
         addFilter(
-            filter: (
-                method: string,
-                url: string,
-                async: boolean,
-                username: string,
-                password: string
-            ) => boolean
+            filter: (method: string, url: string, async: boolean, username: string, password: string) => boolean,
         ): void;
         /**
          * By assigning a function to the onCreate property of the returned object from useFakeXMLHttpRequest()
@@ -975,10 +954,7 @@ declare namespace Sinon {
         /**
          * Responds to all requests to given URL, e.g. /posts/1.
          */
-        respondWith(
-            url: string,
-            fn: (xhr: SinonFakeXMLHttpRequest) => void
-        ): void;
+        respondWith(url: string, fn: (xhr: SinonFakeXMLHttpRequest) => void): void;
         /**
          * Responds to all method requests to the given URL with the given response.
          * method is an HTTP verb.
@@ -993,11 +969,7 @@ declare namespace Sinon {
          * Responds to all method requests to the given URL with the given response.
          * method is an HTTP verb.
          */
-        respondWith(
-            method: string,
-            url: string,
-            fn: (xhr: SinonFakeXMLHttpRequest) => void
-        ): void;
+        respondWith(method: string, url: string, fn: (xhr: SinonFakeXMLHttpRequest) => void): void;
         /**
          * URL may be a regular expression, e.g. /\\/post\\//\\d+
          * If the response is a Function, it will be passed any capture groups from the regular expression along with the XMLHttpRequest object:
@@ -1012,10 +984,7 @@ declare namespace Sinon {
          * URL may be a regular expression, e.g. /\\/post\\//\\d+
          * If the response is a Function, it will be passed any capture groups from the regular expression along with the XMLHttpRequest object:
          */
-        respondWith(
-            url: RegExp,
-            fn: (xhr: SinonFakeXMLHttpRequest) => void
-        ): void;
+        respondWith(url: RegExp, fn: (xhr: SinonFakeXMLHttpRequest) => void): void;
         /**
          * Responds to all method requests to URLs matching the regular expression.
          */
@@ -1027,11 +996,7 @@ declare namespace Sinon {
         /**
          * Responds to all method requests to URLs matching the regular expression.
          */
-        respondWith(
-            method: string,
-            url: RegExp,
-            fn: (xhr: SinonFakeXMLHttpRequest) => void
-        ): void;
+        respondWith(method: string, url: RegExp, fn: (xhr: SinonFakeXMLHttpRequest) => void): void;
         /**
          * Causes all queued asynchronous requests to receive a response.
          * If none of the responses added through respondWith match, the default response is [404, {}, ""].
@@ -1143,7 +1108,10 @@ declare namespace Sinon {
          * @param spyOrSpyCall
          * @param args
          */
-        calledWith<TArgs extends any[]>(spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>, ...args: MatchArguments<TArgs>): void;
+        calledWith<TArgs extends any[]>(
+            spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
+            ...args: MatchArguments<TArgs>
+        ): void;
         /**
          * Passes if spy was always called with the provided arguments.
          * @param spy
@@ -1184,10 +1152,7 @@ declare namespace Sinon {
          * This behaves the same way as sinon.assert.calledWith(spy, sinon.match(arg1), sinon.match(arg2), ...).
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledWithMatch(spy.secondCall, arg1, arg2, ...);.
          */
-        calledWithMatch<TArgs extends any[]>(
-            spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
-            ...args: TArgs
-        ): void;
+        calledWithMatch<TArgs extends any[]>(spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>, ...args: TArgs): void;
         /**
          * Passes if spy was always called with matching arguments.
          * This behaves the same way as sinon.assert.alwaysCalledWith(spy, sinon.match(arg1), sinon.match(arg2), ...).
@@ -1485,15 +1450,15 @@ declare namespace Sinon {
      * @template TType Object type being stubbed.
      */
     type SinonStubbedInstance<TType> = {
-        [P in keyof TType]: SinonStubbedMember<TType[P]>
+        [P in keyof TType]: SinonStubbedMember<TType[P]>;
     };
 
     /**
      * Replaces a type with a Sinon stub if it's a function.
      */
-    type SinonStubbedMember<T> = T extends (
-        ...args: infer TArgs
-    ) => infer TReturnValue ? SinonStub<TArgs, TReturnValue> : T;
+    type SinonStubbedMember<T> = T extends (...args: infer TArgs) => infer TReturnValue
+        ? SinonStub<TArgs, TReturnValue>
+        : T;
 
     interface SinonFake {
         /**
@@ -1577,9 +1542,7 @@ declare namespace Sinon {
          * You would have to call either clock.next(), clock.tick(), clock.runAll() or clock.runToLast() (see example below). Please refer to the lolex documentation for more information.
          * @param config
          */
-        useFakeTimers(
-            config?: number | Date | Partial<SinonFakeTimersConfig>
-        ): SinonFakeTimers;
+        useFakeTimers(config?: number | Date | Partial<SinonFakeTimersConfig>): SinonFakeTimers;
         /**
          * Causes Sinon to replace the native XMLHttpRequest object in browsers that support it with a custom implementation which does not send actual requests.
          * In browsers that support ActiveXObject, this constructor is replaced, and fake objects are returned for XMLHTTP progIds.
@@ -1630,11 +1593,7 @@ declare namespace Sinon {
          * replacement can be any value, including spies, stubs and fakes.
          * This method only works on non-accessor properties, for replacing accessors, use sandbox.replaceGetter() and sandbox.replaceSetter().
          */
-        replace<T, TKey extends keyof T>(
-            obj: T,
-            prop: TKey,
-            replacement: T[TKey]
-        ): T[TKey];
+        replace<T, TKey extends keyof T>(obj: T, prop: TKey, replacement: T[TKey]): T[TKey];
         /**
          * Replaces getter for property on object with replacement argument. Attempts to replace an already replaced getter cause an exception.
          * replacement must be a Function, and can be instances of spies, stubs and fakes.
@@ -1642,11 +1601,7 @@ declare namespace Sinon {
          * @param prop
          * @param replacement
          */
-        replaceGetter<T, TKey extends keyof T>(
-            obj: T,
-            prop: TKey,
-            replacement: () => T[TKey]
-        ): () => T[TKey];
+        replaceGetter<T, TKey extends keyof T>(obj: T, prop: TKey, replacement: () => T[TKey]): () => T[TKey];
         /**
          * Replaces setter for property on object with replacement argument. Attempts to replace an already replaced setter cause an exception.
          * replacement must be a Function, and can be instances of spies, stubs and fakes.
@@ -1657,7 +1612,7 @@ declare namespace Sinon {
         replaceSetter<T, TKey extends keyof T>(
             obj: T,
             prop: TKey,
-            replacement: (val: T[TKey]) => void
+            replacement: (val: T[TKey]) => void,
         ): (val: T[TKey]) => void;
 
         /**
@@ -1671,8 +1626,11 @@ declare namespace Sinon {
          */
         createStubInstance<TType>(
             constructor: StubbableType<TType>,
-            overrides?: { [K in keyof TType]?:
-                SinonStubbedMember<TType[K]> | (TType[K] extends (...args: any[]) => infer R ? R : TType[K]) }
+            overrides?: {
+                [K in keyof TType]?:
+                    | SinonStubbedMember<TType[K]>
+                    | (TType[K] extends (...args: any[]) => infer R ? R : TType[K]);
+            },
         ): SinonStubbedInstance<TType>;
     }
 

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -22,7 +22,9 @@ interface Document {} // tslint:disable-line no-empty-interface
 
 declare namespace Sinon {
     type MatchArguments<T> = {
-        [K in keyof T]: SinonMatcher | (T[K] extends object ? MatchArguments<T[K]> : never) | T[K];
+        [K in keyof T]: SinonMatcher
+        | (T[K] extends object ? MatchArguments<T[K]> : never)
+        | T[K];
     };
 
     interface SinonSpyCallApi<TArgs extends any[] = any[], TReturnValue = any> {
@@ -84,7 +86,7 @@ declare namespace Sinon {
          * Uses deep comparison for objects and arrays. Use spy.returned(sinon.match.same(obj)) for strict comparison (see matchers).
          * @param value
          */
-        returned(value: TReturnValue | SinonMatcher): boolean;
+        returned(value: TReturnValue|SinonMatcher): boolean;
         /**
          * Returns true if spy threw an exception at least once.
          */
@@ -146,7 +148,7 @@ declare namespace Sinon {
         callback: Function | undefined;
 
         /**
-         * This property is a convenience for the last argument of the call.
+         * This property is a convenience for the first argument of the call.
          */
         firstArg: any;
 
@@ -170,8 +172,8 @@ declare namespace Sinon {
 
     interface SinonSpy<TArgs extends any[] = any[], TReturnValue = any>
         extends Pick<
-            SinonSpyCallApi<TArgs, TReturnValue>,
-            Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, 'args'>
+        SinonSpyCallApi<TArgs, TReturnValue>,
+        Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, 'args'>
         > {
         // Properties
         /**
@@ -376,17 +378,20 @@ declare namespace Sinon {
          * The original method can be restored by calling object.method.restore().
          * The returned spy is the function object which replaced the original method. spy === object.method.
          */
-        <T, K extends keyof T>(obj: T, method: K): T[K] extends (...args: infer TArgs) => infer TReturnValue
+        <T, K extends keyof T>(obj: T, method: K): T[K] extends (
+            ...args: infer TArgs
+        ) => infer TReturnValue
             ? SinonSpy<TArgs, TReturnValue>
             : SinonSpy;
 
-        <T, K extends keyof T>(obj: T, method: K, types: Array<'get' | 'set'>): PropertyDescriptor & {
+        <T, K extends keyof T>(obj: T, method: K, types: Array<('get'|'set')>): PropertyDescriptor & {
             get: SinonSpy<[], T[K]>;
             set: SinonSpy<[T[K]], void>;
         };
     }
 
-    interface SinonStub<TArgs extends any[] = any[], TReturnValue = any> extends SinonSpy<TArgs, TReturnValue> {
+    interface SinonStub<TArgs extends any[] = any[], TReturnValue = any>
+        extends SinonSpy<TArgs, TReturnValue> {
         /**
          * Resets the stub’s behaviour to the default behaviour
          * You can reset behaviour of all stubs using sinon.resetBehavior()
@@ -431,9 +436,7 @@ declare namespace Sinon {
          * The Promise library can be overwritten using the usingPromise method.
          * Since sinon@2.0.0
          */
-        resolves(
-            value?: TReturnValue extends PromiseLike<infer TResolveValue> ? TResolveValue : any,
-        ): SinonStub<TArgs, TReturnValue>;
+        resolves(value?: TReturnValue extends PromiseLike<infer TResolveValue> ? TResolveValue : any): SinonStub<TArgs, TReturnValue>;
         /**
          * Causes the stub to return a Promise which resolves to the argument at the provided index.
          * stub.resolvesArg(0); causes the stub to return a Promise which resolves to the first argument.
@@ -509,7 +512,11 @@ declare namespace Sinon {
          * @param context
          * @param args
          */
-        callsArgOnWith(index: number, context: any, ...args: any[]): SinonStub<TArgs, TReturnValue>;
+        callsArgOnWith(
+            index: number,
+            context: any,
+            ...args: any[]
+        ): SinonStub<TArgs, TReturnValue>;
         /**
          * Same as their corresponding non-Async counterparts, but with callback being deferred at called after all instructions in the current call stack are processed.
          * In Node environment the callback is deferred with process.nextTick.
@@ -536,7 +543,11 @@ declare namespace Sinon {
          * In Node environment the callback is deferred with process.nextTick.
          * In a browser the callback is deferred with setTimeout(callback, 0).
          */
-        callsArgOnWithAsync(index: number, context: any, ...args: any[]): SinonStub<TArgs, TReturnValue>;
+        callsArgOnWithAsync(
+            index: number,
+            context: any,
+            ...args: any[]
+        ): SinonStub<TArgs, TReturnValue>;
         /**
          * Makes the stub call the provided @param func when invoked.
          * @param func
@@ -601,7 +612,11 @@ declare namespace Sinon {
         /**
          * Like above but with an additional parameter to pass the this context.
          */
-        yieldsToOn(property: string, context: any, ...args: any[]): SinonStub<TArgs, TReturnValue>;
+        yieldsToOn(
+            property: string,
+            context: any,
+            ...args: any[]
+        ): SinonStub<TArgs, TReturnValue>;
         /**
          * Same as their corresponding non-Async counterparts, but with callback being deferred at called after all instructions in the current call stack are processed.
          * In Node environment the callback is deferred with process.nextTick.
@@ -633,7 +648,11 @@ declare namespace Sinon {
          * @param context
          * @param args
          */
-        yieldsToOnAsync(property: string, context: any, ...args: any[]): SinonStub<TArgs, TReturnValue>;
+        yieldsToOnAsync(
+            property: string,
+            context: any,
+            ...args: any[]
+        ): SinonStub<TArgs, TReturnValue>;
         /**
          * Stubs the method only for the provided arguments.
          * This is useful to be more expressive in your assertions, where you can access the spy with the same call.
@@ -665,7 +684,9 @@ declare namespace Sinon {
          * An exception is thrown if the property is not already a function.
          * The original function can be restored by calling object.method.restore(); (or stub.restore();).
          */
-        <T, K extends keyof T>(obj: T, method: K): T[K] extends (...args: infer TArgs) => infer TReturnValue
+        <T, K extends keyof T>(obj: T, method: K): T[K] extends (
+            ...args: infer TArgs
+        ) => infer TReturnValue
             ? SinonStub<TArgs, TReturnValue>
             : SinonStub;
     }
@@ -887,7 +908,13 @@ declare namespace Sinon {
          * @param filter
          */
         addFilter(
-            filter: (method: string, url: string, async: boolean, username: string, password: string) => boolean,
+            filter: (
+                method: string, 
+                url: string, 
+                async: boolean, 
+                username: string, 
+                password: string
+            ) => boolean
         ): void;
         /**
          * By assigning a function to the onCreate property of the returned object from useFakeXMLHttpRequest()
@@ -954,7 +981,10 @@ declare namespace Sinon {
         /**
          * Responds to all requests to given URL, e.g. /posts/1.
          */
-        respondWith(url: string, fn: (xhr: SinonFakeXMLHttpRequest) => void): void;
+        respondWith(
+            url: string, 
+            fn: (xhr: SinonFakeXMLHttpRequest) => void
+        ): void;
         /**
          * Responds to all method requests to the given URL with the given response.
          * method is an HTTP verb.
@@ -969,7 +999,11 @@ declare namespace Sinon {
          * Responds to all method requests to the given URL with the given response.
          * method is an HTTP verb.
          */
-        respondWith(method: string, url: string, fn: (xhr: SinonFakeXMLHttpRequest) => void): void;
+        respondWith(
+            method: string, 
+            url: string, 
+            fn: (xhr: SinonFakeXMLHttpRequest) => void
+        ): void;
         /**
          * URL may be a regular expression, e.g. /\\/post\\//\\d+
          * If the response is a Function, it will be passed any capture groups from the regular expression along with the XMLHttpRequest object:
@@ -984,7 +1018,10 @@ declare namespace Sinon {
          * URL may be a regular expression, e.g. /\\/post\\//\\d+
          * If the response is a Function, it will be passed any capture groups from the regular expression along with the XMLHttpRequest object:
          */
-        respondWith(url: RegExp, fn: (xhr: SinonFakeXMLHttpRequest) => void): void;
+        respondWith(
+            url: RegExp, 
+            fn: (xhr: SinonFakeXMLHttpRequest) => void
+        ): void;
         /**
          * Responds to all method requests to URLs matching the regular expression.
          */
@@ -996,7 +1033,11 @@ declare namespace Sinon {
         /**
          * Responds to all method requests to URLs matching the regular expression.
          */
-        respondWith(method: string, url: RegExp, fn: (xhr: SinonFakeXMLHttpRequest) => void): void;
+        respondWith(
+            method: string, 
+            url: RegExp, 
+            fn: (xhr: SinonFakeXMLHttpRequest) => void
+        ): void;
         /**
          * Causes all queued asynchronous requests to receive a response.
          * If none of the responses added through respondWith match, the default response is [404, {}, ""].
@@ -1108,10 +1149,7 @@ declare namespace Sinon {
          * @param spyOrSpyCall
          * @param args
          */
-        calledWith<TArgs extends any[]>(
-            spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
-            ...args: MatchArguments<TArgs>
-        ): void;
+        calledWith<TArgs extends any[]>(spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>, ...args: MatchArguments<TArgs>): void;
         /**
          * Passes if spy was always called with the provided arguments.
          * @param spy
@@ -1152,7 +1190,10 @@ declare namespace Sinon {
          * This behaves the same way as sinon.assert.calledWith(spy, sinon.match(arg1), sinon.match(arg2), ...).
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledWithMatch(spy.secondCall, arg1, arg2, ...);.
          */
-        calledWithMatch<TArgs extends any[]>(spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>, ...args: TArgs): void;
+        calledWithMatch<TArgs extends any[]>(
+            spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>, 
+            ...args: TArgs
+        ): void;
         /**
          * Passes if spy was always called with matching arguments.
          * This behaves the same way as sinon.assert.alwaysCalledWith(spy, sinon.match(arg1), sinon.match(arg2), ...).
@@ -1450,15 +1491,15 @@ declare namespace Sinon {
      * @template TType Object type being stubbed.
      */
     type SinonStubbedInstance<TType> = {
-        [P in keyof TType]: SinonStubbedMember<TType[P]>;
+        [P in keyof TType]: SinonStubbedMember<TType[P]>
     };
 
     /**
      * Replaces a type with a Sinon stub if it's a function.
      */
-    type SinonStubbedMember<T> = T extends (...args: infer TArgs) => infer TReturnValue
-        ? SinonStub<TArgs, TReturnValue>
-        : T;
+    type SinonStubbedMember<T> = T extends (
+        ...args: infer TArgs
+    ) => infer TReturnValue ? SinonStub<TArgs, TReturnValue> : T;
 
     interface SinonFake {
         /**
@@ -1542,7 +1583,9 @@ declare namespace Sinon {
          * You would have to call either clock.next(), clock.tick(), clock.runAll() or clock.runToLast() (see example below). Please refer to the lolex documentation for more information.
          * @param config
          */
-        useFakeTimers(config?: number | Date | Partial<SinonFakeTimersConfig>): SinonFakeTimers;
+        useFakeTimers(
+            config?: number | Date | Partial<SinonFakeTimersConfig>
+        ): SinonFakeTimers;
         /**
          * Causes Sinon to replace the native XMLHttpRequest object in browsers that support it with a custom implementation which does not send actual requests.
          * In browsers that support ActiveXObject, this constructor is replaced, and fake objects are returned for XMLHTTP progIds.
@@ -1593,7 +1636,11 @@ declare namespace Sinon {
          * replacement can be any value, including spies, stubs and fakes.
          * This method only works on non-accessor properties, for replacing accessors, use sandbox.replaceGetter() and sandbox.replaceSetter().
          */
-        replace<T, TKey extends keyof T>(obj: T, prop: TKey, replacement: T[TKey]): T[TKey];
+        replace<T, TKey extends keyof T>(
+            obj: T, 
+            prop: TKey, 
+            replacement: T[TKey]
+        ): T[TKey];
         /**
          * Replaces getter for property on object with replacement argument. Attempts to replace an already replaced getter cause an exception.
          * replacement must be a Function, and can be instances of spies, stubs and fakes.
@@ -1601,7 +1648,11 @@ declare namespace Sinon {
          * @param prop
          * @param replacement
          */
-        replaceGetter<T, TKey extends keyof T>(obj: T, prop: TKey, replacement: () => T[TKey]): () => T[TKey];
+        replaceGetter<T, TKey extends keyof T>(
+            obj: T, 
+            prop: TKey, 
+            replacement: () => T[TKey]
+            ): () => T[TKey];
         /**
          * Replaces setter for property on object with replacement argument. Attempts to replace an already replaced setter cause an exception.
          * replacement must be a Function, and can be instances of spies, stubs and fakes.
@@ -1612,7 +1663,7 @@ declare namespace Sinon {
         replaceSetter<T, TKey extends keyof T>(
             obj: T,
             prop: TKey,
-            replacement: (val: T[TKey]) => void,
+            replacement: (val: T[TKey]) => void
         ): (val: T[TKey]) => void;
 
         /**
@@ -1626,11 +1677,8 @@ declare namespace Sinon {
          */
         createStubInstance<TType>(
             constructor: StubbableType<TType>,
-            overrides?: {
-                [K in keyof TType]?:
-                    | SinonStubbedMember<TType[K]>
-                    | (TType[K] extends (...args: any[]) => infer R ? R : TType[K]);
-            },
+            overrides?: { [K in keyof TType]?:
+                SinonStubbedMember<TType[K]> | (TType[K] extends (...args: any[]) => infer R ? R : TType[K]) }
         ): SinonStubbedInstance<TType>;
     }
 

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -443,10 +443,6 @@ function testSpy() {
     arr = spy.exceptions;
     arr = spy.returnValues;
 
-    let arg: sinon.SinonSpyCall;
-    arg = spy.firstCall;
-    arg = spy.lastCall;
-
     const fnSpy = sinon.spy(fn); // $ExpectType SinonSpy<[string, number], boolean> || SinonSpy<[arg: string, arg2: number], boolean>
     fn = fnSpy; // Should be assignable to original function
     fnSpy('a', 1); // $ExpectType boolean
@@ -505,6 +501,10 @@ function testSpy() {
     call = spy.lastCall;
     call = spy.getCall(1);
     call = spy.getCalls()[0];
+
+    let arg: any;
+    arg = call.firstArg;
+    arg = call.lastArg;
 
     call.calledBefore(call);
     call.calledAfter(call);

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -1,4 +1,4 @@
-import sinon = require('sinon');
+import sinon = require("sinon");
 
 function testSandbox() {
     const obj = {};
@@ -7,17 +7,17 @@ function testSandbox() {
         injectInto: obj,
         properties: ['spy', 'stub'],
         useFakeTimers: true,
-        useFakeServer: true,
+        useFakeServer: true
     });
     sinon.createSandbox({
-        injectInto: null,
+        injectInto: null
     });
     sinon.createSandbox({
         useFakeTimers: {
             now: 1000,
-            shouldAdvanceTime: false,
+            shouldAdvanceTime: false
         },
-        useFakeServer: sinon.fakeServer.create(),
+        useFakeServer: sinon.fakeServer.create()
     });
     sinon.createSandbox(sinon.defaultConfig);
     sinon.sandbox.create();
@@ -35,7 +35,7 @@ function testSandbox() {
     sb.useFakeTimers(1000);
     sb.useFakeTimers(new Date());
     sb.useFakeTimers({
-        now: 1000,
+        now: 1000
     });
 
     const xhr = sb.useFakeXMLHttpRequest();
@@ -55,32 +55,24 @@ function testSandbox() {
 
     const replaceMe = {
         prop: 5,
-        method() {
-            return 6;
-        },
-        get getter() {
-            return 7;
-        },
-        get setter() {
-            return true;
-        },
-        set setter(val) {},
+        method() { return 6; },
+        get getter() { return 7; },
+        get setter() { return true; },
+        set setter(val) { }
     };
 
     sb.replace(replaceMe, 'prop', 10);
     sb.replace(replaceMe, 'method', sb.spy());
     sb.replaceGetter(replaceMe, 'getter', () => 14);
-    sb.replaceSetter(replaceMe, 'setter', v => {});
+    sb.replaceSetter(replaceMe, 'setter', (v) => { });
 
     const cls = class {
-        foo(arg1: string, arg2: number): number {
-            return 1;
-        }
+        foo(arg1: string, arg2: number): number { return 1; }
         bar: number;
     };
     const PrivateFoo = class {
-        private constructor() {}
-        foo() {}
+        private constructor() { }
+        foo() { }
         bar: number;
         static create() {
             return new PrivateFoo();
@@ -98,7 +90,7 @@ function testSandbox() {
     const privateFooBar: number = privateFooStubbedInstance.bar;
     sb.createStubInstance(cls, {
         foo: sinon.stub<[string, number], number>().returns(1),
-        bar: 1,
+        bar: 1
     });
     sb.createStubInstance(cls, {
         foo: 1, // used as return value
@@ -113,12 +105,12 @@ function testFakeServer() {
         autoRespond: true,
         autoRespondAfter: 3,
         fakeHTTPMethods: true,
-        respondImmediately: false,
+        respondImmediately: false
     });
 
     sinon.fakeServer.create({
         autoRespond: true,
-        autoRespondAfter: 3,
+        autoRespondAfter: 3
     });
 }
 
@@ -134,7 +126,7 @@ function testXHR() {
 
     sinon.FakeXMLHttpRequest.useFilters = true;
     sinon.FakeXMLHttpRequest.addFilter((method, url, async, user, pass) => true);
-    sinon.FakeXMLHttpRequest.onCreate = xhr => {};
+    sinon.FakeXMLHttpRequest.onCreate = (xhr) => { };
     sinon.FakeXMLHttpRequest.restore();
 }
 
@@ -145,7 +137,7 @@ function testClock() {
     let now: sinon.SinonTimerId = 0;
     now = clock.now;
 
-    const fn = () => {};
+    const fn = () => { };
     const fnWithArgs = (a: number, b: string) => {};
 
     clock.setTimeout(fn, 0);
@@ -213,14 +205,14 @@ function testExpectation() {
 
 function testMatch() {
     const obj = {};
-    const fn = () => {};
+    const fn = () => { };
 
     sinon.match(5).test(5);
     sinon.match('str').test('foo');
     sinon.match(/foo/).test('foo');
     sinon.match({ a: 5, b: 6 }).test({});
-    sinon.match(v => true).test('foo');
-    sinon.match(v => true, 'some message').test('foo');
+    sinon.match((v) => true).test('foo');
+    sinon.match((v) => true, 'some message').test('foo');
     sinon.match.any.test('foo');
     sinon.match.defined.test('foo');
     sinon.match.truthy.test('foo');
@@ -230,12 +222,7 @@ function testMatch() {
     sinon.match.string.test('foo');
     sinon.match.object.test('foo');
     sinon.match.func.test(fn);
-    sinon.match.map.test(
-        new Map([
-            ['a', 1],
-            ['b', 2],
-        ]),
-    );
+    sinon.match.map.test(new Map([['a', 1], ['b', 2]]));
     sinon.match.set.test(new Set([1, 2, 3]));
     sinon.match.array.test([1, 2, 3]);
     sinon.match.regexp.test('foo');
@@ -257,19 +244,12 @@ function testMatch() {
     sinon.match.array.startsWith([{ a: 'b' }]).test([]);
     sinon.match.array.deepEquals([{ a: 'b' }]).test([]);
     sinon.match.array.contains([{ a: 'b' }]).test([]);
-    sinon.match.map
-        .deepEquals(
-            new Map([
-                ['a', true],
-                ['b', false],
-            ]),
-        )
-        .test(new Map());
+    sinon.match.map.deepEquals(new Map([['a', true], ['b', false]])).test(new Map());
     sinon.match.map.contains(new Map([['a', true]])).test(new Map());
 }
 
 function testFake() {
-    const fn = () => {};
+    const fn = () => { };
     let fake = sinon.fake();
 
     fake = sinon.fake(() => true);
@@ -376,14 +356,10 @@ function testAssert() {
 
 function testTypedSpy() {
     const cls = class {
-        get accessorTest() {
-            return 5;
-        }
-        set accessorTest(v: number) {}
-        get getterTest() {
-            return 5;
-        }
-        set setterTest(v: number) {}
+        get accessorTest() { return 5; }
+        set accessorTest(v: number) { }
+        get getterTest() { return 5; }
+        set setterTest(v: number) { }
         foo(a: number, b: string): number {
             return 3;
         }
@@ -430,14 +406,10 @@ function testTypedSpy() {
 function testSpy() {
     let fn = (arg: string, arg2: number): boolean => true;
     const obj = class {
-        foo() {}
-        foobar(p1?: string) {
-            return p1;
-        }
-        set bar(val: number) {}
-        get bar() {
-            return 0;
-        }
+        foo() { }
+        foobar(p1?: string) { return p1; }
+        set bar(val: number) { }
+        get bar() { return 0; }
     };
     const instance = new obj();
 
@@ -471,7 +443,7 @@ function testSpy() {
     arr = spy.exceptions;
     arr = spy.returnValues;
 
-    let arg: any;
+    let arg: sinon.SinonSpyCall;
     arg = spy.firstCall;
     arg = spy.lastCall;
 
@@ -544,21 +516,11 @@ function testSpy() {
 
 function testStub() {
     const obj = class {
-        foo(arg: string): number {
-            return 1;
-        }
-        promiseFunc() {
-            return Promise.resolve('foo');
-        }
-        promiseLikeFunc() {
-            return Promise.resolve('foo') as PromiseLike<string>;
-        }
-        unresolvableReturnFunc(): any {
-            return Promise.resolve();
-        }
-        fooDeep(arg: { s: string }): void {
-            return undefined;
-        }
+        foo(arg: string): number { return 1; }
+        promiseFunc() { return Promise.resolve('foo'); }
+        promiseLikeFunc() { return Promise.resolve('foo') as PromiseLike<string>; }
+        unresolvableReturnFunc(): any { return Promise.resolve(); }
+        fooDeep(arg: { s: string }): void { return undefined; }
     };
     const instance = new obj();
 
@@ -570,7 +532,8 @@ function testStub() {
     promiseStub.resolves('test');
     promiseStub.resolves(123); // $ExpectError
 
-    const promiseUnresolvableReturn = sinon.stub(instance, 'unresolvableReturnFunc');
+    const promiseUnresolvableReturn =
+        sinon.stub(instance, 'unresolvableReturnFunc');
     promiseUnresolvableReturn.resolves(['anything', 123, true]);
 
     const promiseLikeStub = sinon.stub(instance, 'promiseLikeFunc');
@@ -608,10 +571,10 @@ function testStub() {
     stub.callsArgOnAsync(1, instance);
     stub.callsArgWithAsync(1, 'a', 2);
     stub.callsArgOnWithAsync(1, instance, 'a', 2);
-    stub.callsFake((s1, s2, s3) => {});
-    stub.callsFake(() => {});
+    stub.callsFake((s1, s2, s3) => { });
+    stub.callsFake(() => { });
     stub.get(() => true);
-    stub.set(v => {});
+    stub.set((v) => { });
     stub.onCall(1).returns(true);
     stub.onFirstCall().resolves('foo');
     stub.onSecondCall().resolves('foo');
@@ -664,7 +627,7 @@ function testTypedStub() {
     stub2 = sinon.stub(foo, 'bar');
     const result: boolean = stub(42, 'qux');
     const fooStub: sinon.SinonStubbedInstance<Foo> = {
-        bar: sinon.stub(),
+        bar: sinon.stub()
     };
 }
 

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -1,4 +1,4 @@
-import sinon = require("sinon");
+import sinon = require('sinon');
 
 function testSandbox() {
     const obj = {};
@@ -7,17 +7,17 @@ function testSandbox() {
         injectInto: obj,
         properties: ['spy', 'stub'],
         useFakeTimers: true,
-        useFakeServer: true
+        useFakeServer: true,
     });
     sinon.createSandbox({
-        injectInto: null
+        injectInto: null,
     });
     sinon.createSandbox({
         useFakeTimers: {
             now: 1000,
-            shouldAdvanceTime: false
+            shouldAdvanceTime: false,
         },
-        useFakeServer: sinon.fakeServer.create()
+        useFakeServer: sinon.fakeServer.create(),
     });
     sinon.createSandbox(sinon.defaultConfig);
     sinon.sandbox.create();
@@ -35,7 +35,7 @@ function testSandbox() {
     sb.useFakeTimers(1000);
     sb.useFakeTimers(new Date());
     sb.useFakeTimers({
-        now: 1000
+        now: 1000,
     });
 
     const xhr = sb.useFakeXMLHttpRequest();
@@ -55,24 +55,32 @@ function testSandbox() {
 
     const replaceMe = {
         prop: 5,
-        method() { return 6; },
-        get getter() { return 7; },
-        get setter() { return true; },
-        set setter(val) { }
+        method() {
+            return 6;
+        },
+        get getter() {
+            return 7;
+        },
+        get setter() {
+            return true;
+        },
+        set setter(val) {},
     };
 
     sb.replace(replaceMe, 'prop', 10);
     sb.replace(replaceMe, 'method', sb.spy());
     sb.replaceGetter(replaceMe, 'getter', () => 14);
-    sb.replaceSetter(replaceMe, 'setter', (v) => { });
+    sb.replaceSetter(replaceMe, 'setter', v => {});
 
     const cls = class {
-        foo(arg1: string, arg2: number): number { return 1; }
+        foo(arg1: string, arg2: number): number {
+            return 1;
+        }
         bar: number;
     };
     const PrivateFoo = class {
-        private constructor() { }
-        foo() { }
+        private constructor() {}
+        foo() {}
         bar: number;
         static create() {
             return new PrivateFoo();
@@ -90,7 +98,7 @@ function testSandbox() {
     const privateFooBar: number = privateFooStubbedInstance.bar;
     sb.createStubInstance(cls, {
         foo: sinon.stub<[string, number], number>().returns(1),
-        bar: 1
+        bar: 1,
     });
     sb.createStubInstance(cls, {
         foo: 1, // used as return value
@@ -105,12 +113,12 @@ function testFakeServer() {
         autoRespond: true,
         autoRespondAfter: 3,
         fakeHTTPMethods: true,
-        respondImmediately: false
+        respondImmediately: false,
     });
 
     sinon.fakeServer.create({
         autoRespond: true,
-        autoRespondAfter: 3
+        autoRespondAfter: 3,
     });
 }
 
@@ -126,7 +134,7 @@ function testXHR() {
 
     sinon.FakeXMLHttpRequest.useFilters = true;
     sinon.FakeXMLHttpRequest.addFilter((method, url, async, user, pass) => true);
-    sinon.FakeXMLHttpRequest.onCreate = (xhr) => { };
+    sinon.FakeXMLHttpRequest.onCreate = xhr => {};
     sinon.FakeXMLHttpRequest.restore();
 }
 
@@ -137,7 +145,7 @@ function testClock() {
     let now: sinon.SinonTimerId = 0;
     now = clock.now;
 
-    const fn = () => { };
+    const fn = () => {};
     const fnWithArgs = (a: number, b: string) => {};
 
     clock.setTimeout(fn, 0);
@@ -205,14 +213,14 @@ function testExpectation() {
 
 function testMatch() {
     const obj = {};
-    const fn = () => { };
+    const fn = () => {};
 
     sinon.match(5).test(5);
     sinon.match('str').test('foo');
     sinon.match(/foo/).test('foo');
     sinon.match({ a: 5, b: 6 }).test({});
-    sinon.match((v) => true).test('foo');
-    sinon.match((v) => true, 'some message').test('foo');
+    sinon.match(v => true).test('foo');
+    sinon.match(v => true, 'some message').test('foo');
     sinon.match.any.test('foo');
     sinon.match.defined.test('foo');
     sinon.match.truthy.test('foo');
@@ -222,7 +230,12 @@ function testMatch() {
     sinon.match.string.test('foo');
     sinon.match.object.test('foo');
     sinon.match.func.test(fn);
-    sinon.match.map.test(new Map([['a', 1], ['b', 2]]));
+    sinon.match.map.test(
+        new Map([
+            ['a', 1],
+            ['b', 2],
+        ]),
+    );
     sinon.match.set.test(new Set([1, 2, 3]));
     sinon.match.array.test([1, 2, 3]);
     sinon.match.regexp.test('foo');
@@ -244,12 +257,19 @@ function testMatch() {
     sinon.match.array.startsWith([{ a: 'b' }]).test([]);
     sinon.match.array.deepEquals([{ a: 'b' }]).test([]);
     sinon.match.array.contains([{ a: 'b' }]).test([]);
-    sinon.match.map.deepEquals(new Map([['a', true], ['b', false]])).test(new Map());
+    sinon.match.map
+        .deepEquals(
+            new Map([
+                ['a', true],
+                ['b', false],
+            ]),
+        )
+        .test(new Map());
     sinon.match.map.contains(new Map([['a', true]])).test(new Map());
 }
 
 function testFake() {
-    const fn = () => { };
+    const fn = () => {};
     let fake = sinon.fake();
 
     fake = sinon.fake(() => true);
@@ -356,10 +376,14 @@ function testAssert() {
 
 function testTypedSpy() {
     const cls = class {
-        get accessorTest() { return 5; }
-        set accessorTest(v: number) { }
-        get getterTest() { return 5; }
-        set setterTest(v: number) { }
+        get accessorTest() {
+            return 5;
+        }
+        set accessorTest(v: number) {}
+        get getterTest() {
+            return 5;
+        }
+        set setterTest(v: number) {}
         foo(a: number, b: string): number {
             return 3;
         }
@@ -406,10 +430,14 @@ function testTypedSpy() {
 function testSpy() {
     let fn = (arg: string, arg2: number): boolean => true;
     const obj = class {
-        foo() { }
-        foobar(p1?: string) { return p1; }
-        set bar(val: number) { }
-        get bar() { return 0; }
+        foo() {}
+        foobar(p1?: string) {
+            return p1;
+        }
+        set bar(val: number) {}
+        get bar() {
+            return 0;
+        }
     };
     const instance = new obj();
 
@@ -442,6 +470,10 @@ function testSpy() {
     arr = spy.args;
     arr = spy.exceptions;
     arr = spy.returnValues;
+
+    let arg: any;
+    arg = spy.firstCall;
+    arg = spy.lastCall;
 
     const fnSpy = sinon.spy(fn); // $ExpectType SinonSpy<[string, number], boolean> || SinonSpy<[arg: string, arg2: number], boolean>
     fn = fnSpy; // Should be assignable to original function
@@ -512,11 +544,21 @@ function testSpy() {
 
 function testStub() {
     const obj = class {
-        foo(arg: string): number { return 1; }
-        promiseFunc() { return Promise.resolve('foo'); }
-        promiseLikeFunc() { return Promise.resolve('foo') as PromiseLike<string>; }
-        unresolvableReturnFunc(): any { return Promise.resolve(); }
-        fooDeep(arg: { s: string }): void { return undefined; }
+        foo(arg: string): number {
+            return 1;
+        }
+        promiseFunc() {
+            return Promise.resolve('foo');
+        }
+        promiseLikeFunc() {
+            return Promise.resolve('foo') as PromiseLike<string>;
+        }
+        unresolvableReturnFunc(): any {
+            return Promise.resolve();
+        }
+        fooDeep(arg: { s: string }): void {
+            return undefined;
+        }
     };
     const instance = new obj();
 
@@ -528,8 +570,7 @@ function testStub() {
     promiseStub.resolves('test');
     promiseStub.resolves(123); // $ExpectError
 
-    const promiseUnresolvableReturn =
-        sinon.stub(instance, 'unresolvableReturnFunc');
+    const promiseUnresolvableReturn = sinon.stub(instance, 'unresolvableReturnFunc');
     promiseUnresolvableReturn.resolves(['anything', 123, true]);
 
     const promiseLikeStub = sinon.stub(instance, 'promiseLikeFunc');
@@ -567,10 +608,10 @@ function testStub() {
     stub.callsArgOnAsync(1, instance);
     stub.callsArgWithAsync(1, 'a', 2);
     stub.callsArgOnWithAsync(1, instance, 'a', 2);
-    stub.callsFake((s1, s2, s3) => { });
-    stub.callsFake(() => { });
+    stub.callsFake((s1, s2, s3) => {});
+    stub.callsFake(() => {});
     stub.get(() => true);
-    stub.set((v) => { });
+    stub.set(v => {});
     stub.onCall(1).returns(true);
     stub.onFirstCall().resolves('foo');
     stub.onSecondCall().resolves('foo');
@@ -623,7 +664,7 @@ function testTypedStub() {
     stub2 = sinon.stub(foo, 'bar');
     const result: boolean = stub(42, 'qux');
     const fooStub: sinon.SinonStubbedInstance<Foo> = {
-        bar: sinon.stub()
+        bar: sinon.stub(),
     };
 }
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://sinonjs.org/releases/v9.0.3/spy-call/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.