### PR TITLE
Fixing all callbacks defined as required

### DIFF
--- a/types/activedirectory2/index.d.ts
+++ b/types/activedirectory2/index.d.ts
@@ -106,110 +106,110 @@ declare class ActiveDirectory {
     authenticate(
         username: string,
         password: string,
-        callback: (err: string, authenticated: boolean) => void
+        callback?: (err: string, authenticated: boolean) => void
     ): void;
     isUserMemberOf(
         username: string,
         groupName: string,
-        callback: (err: object, res: boolean) => void
+        callback?: (err: object, res: boolean) => void
     ): void;
     isUserMemberOf(
         opts: ReqProps,
         username: string,
         groupName: string,
-        callback: (err: object, res: boolean) => void
+        callback?: (err: object, res: boolean) => void
     ): void;
-    find(callback: (err: object, results: FindResult) => void): void;
+    find(callback?: (err: object, results: FindResult) => void): void;
     find(
         opts: string | ReqProps,
-        callback: (err: object, results: FindResult) => void
+        callback?: (err: object, results: FindResult) => void
     ): void;
-    findDeletedObjects(callback: (err: object, results: object[]) => void): void;
+    findDeletedObjects(callback?: (err: object, results: object[]) => void): void;
     findDeletedObjects(
         opts: string | ReqProps,
-        callback: (err: object, results: object[]) => void
+        callback?: (err: object, results: object[]) => void
     ): void;
     findUser(
         username: string,
-        callback: (err: object, user: object) => void
+        callback?: (err: object, user: object) => void
     ): void;
     findUser(
         opts: string | ReqProps,
         username: string,
-        callback: (err: object, user: object) => void
+        callback?: (err: object, user: object) => void
     ): void;
-    findUsers(callback: (err: object, users: object[]) => void): void;
+    findUsers(callback?: (err: object, users: object[]) => void): void;
     findUsers(
         opts: string | ReqProps,
-        callback: (err: object, users: object[]) => void
+        callback?: (err: object, users: object[]) => void
     ): void;
     findGroup(
         groupName: string,
-        callback: (err: object, group: object) => void
+        callback?: (err: object, group: object) => void
     ): void;
     findGroup(
         opts: string | ReqProps,
         groupName: string,
-        callback: (err: object, group: object) => void
+        callback?: (err: object, group: object) => void
     ): void;
     findGroups(
         groupName: string,
-        callback: (err: object, groups: object[]) => void
+        callback?: (err: object, groups: object[]) => void
     ): void;
     findGroups(
         opts: string | ReqProps,
         groupName: string,
-        callback: (err: object, groups: object[]) => void
+        callback?: (err: object, groups: object[]) => void
     ): void;
     groupExists(
         groupName: string,
-        callback: (err: object, res: boolean) => void
+        callback?: (err: object, res: boolean) => void
     ): void;
     groupExists(
         opts: string | ReqProps,
         groupName: string,
-        callback: (err: object, res: boolean) => void
+        callback?: (err: object, res: boolean) => void
     ): void;
     userExists(
         username: string,
-        callback: (err: object, res: boolean) => void
+        callback?: (err: object, res: boolean) => void
     ): void;
     userExists(
         opts: string | ReqProps,
         username: string,
-        callback: (err: object, res: boolean) => void
+        callback?: (err: object, res: boolean) => void
     ): void;
     getGroupMembershipForGroup(
         groupName: string,
-        callback: (err: object, groups: object[]) => void
+        callback?: (err: object, groups: object[]) => void
     ): void;
     getGroupMembershipForGroup(
         opts: string | ReqProps,
         groupName: string,
-        callback: (err: object, groups: object[]) => void
+        callback?: (err: object, groups: object[]) => void
     ): void;
     getGroupMembershipForUser(
         username: string,
-        callback: (err: object, groups: object[]) => void
+        callback?: (err: object, groups: object[]) => void
     ): void;
     getGroupMembershipForUser(
         opts: string | ReqProps,
         username: string,
-        callback: (err: object, groups: object[]) => void
+        callback?: (err: object, groups: object[]) => void
     ): void;
     getUsersForGroup(
         groupName: string,
-        callback: (err: object, users: object[]) => void
+        callback?: (err: object, users: object[]) => void
     ): void;
     getUsersForGroup(
         opts: string | ReqProps,
         groupName: string,
-        callback: (err: object, users: object[]) => void
+        callback?: (err: object, users: object[]) => void
     ): void;
     getRootDSE(
         url: string,
         attributes: string[],
-        callback: (err: object, result: object) => void
+        callback?: (err: object, result: object) => void
     ): void;
 }
 


### PR DESCRIPTION
As defined in documentation, a Promise wrapper is available for all methods by an alternate require statement:
`const AD = require('activedirectory2').promiseWrapper;`

Making all callbacks optional to use async/await syntax without IDE warnings.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jsumners/node-activedirectory#documentation
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.