### PR TITLE
feat(react-relay): Added loadQuery function

### DIFF
--- a/types/react-relay/lib/hooks.d.ts
+++ b/types/react-relay/lib/hooks.d.ts
@@ -7,6 +7,8 @@ export { EntryPointContainer } from './relay-experimental/EntryPointContainer';
 export { LazyLoadEntryPointContainer } from './relay-experimental/LazyLoadEntryPointContainer';
 export { RelayEnvironmentProvider } from './relay-experimental/RelayEnvironmentProvider';
 
+export { loadQuery } from './relay-experimental/loadQuery';
+
 export { preloadQuery } from './relay-experimental/preloadQuery';
 export { prepareEntryPoint } from './relay-experimental/prepareEntryPoint';
 

--- a/types/react-relay/lib/relay-experimental/EntryPointTypes.d.ts
+++ b/types/react-relay/lib/relay-experimental/EntryPointTypes.d.ts
@@ -44,13 +44,17 @@ export type PreloadedQueryInner_DEPRECATED<
     TQuery extends OperationType,
     TEnvironmentProviderOptions = EnvironmentProviderOptions
 > = Readonly<{
+    kind: 'PreloadedQuery_DEPRECATED',
     environment: IEnvironment;
-    environmentProviderOptions: TEnvironmentProviderOptions | null | undefined;
-    fetchKey: string | number | null | undefined;
+    environmentProviderOptions?: TEnvironmentProviderOptions | null;
+    fetchKey?: string | number | null;
     fetchPolicy: PreloadFetchPolicy;
+    networkCacheConfig?: CacheConfig | null,
+    id?: string | null
     name: string;
-    source: Observable<GraphQLResponse> | null | undefined;
+    source?: Observable<GraphQLResponse> | null;
     variables: TQuery['variables'];
+    status: PreloadQueryStatus
 }>;
 
 export type PreloadedQueryInner<
@@ -61,13 +65,19 @@ export type PreloadedQueryInner<
     environment: IEnvironment;
     environmentProviderOptions?: TEnvironmentProviderOptions | null;
     fetchPolicy: PreloadFetchPolicy;
-    name: string;
     id?: string | null;
     isDisposed: boolean;
+    name: string;
     networkCacheConfig?: CacheConfig | null;
     source?: Observable<GraphQLResponse> | null;
     kind: 'PreloadedQuery';
     variables: TQuery['variables']
+}>;
+
+export type PreloadQueryStatus = Readonly<{
+    cacheConfig?: CacheConfig | null,
+    source: 'cache' | 'network',
+    fetchTime?: number | null,
 }>;
 
 /**

--- a/types/react-relay/lib/relay-experimental/EntryPointTypes.d.ts
+++ b/types/react-relay/lib/relay-experimental/EntryPointTypes.d.ts
@@ -158,3 +158,17 @@ export type EntryPoint<TEntryPointParams, TEntryPointComponent> = InternalEntryP
 export interface IEnvironmentProvider<TOptions> {
     getEnvironment(options: TOptions | null): IEnvironment;
 }
+
+export type PreloadedQueryInner<TQuery extends OperationType, TEnvironmentProviderOptions extends EnvironmentProviderOptions = {}> = Readonly<{
+    dispose: () => void;
+    environment: IEnvironment;
+    environmentProviderOptions?: TEnvironmentProviderOptions | null;
+    fetchPolicy: PreloadFetchPolicy;
+    id?: string | null;
+    isDisposed: boolean;
+    name: string;
+    networkCacheConfig?: CacheConfig | null;
+    source?: Observable<GraphQLResponse> | null;
+    kind: 'PreloadedQuery';
+    variables: TQuery['variables']
+}>;

--- a/types/react-relay/lib/relay-experimental/EntryPointTypes.d.ts
+++ b/types/react-relay/lib/relay-experimental/EntryPointTypes.d.ts
@@ -33,18 +33,42 @@ export interface EnvironmentProviderOptions {
     [key: string]: unknown;
 }
 
-export interface PreloadedQuery<
+export type PreloadedQuery<
     TQuery extends OperationType,
     TEnvironmentProviderOptions = EnvironmentProviderOptions
-> {
-    readonly environment: IEnvironment;
-    readonly environmentProviderOptions: TEnvironmentProviderOptions | null | undefined;
-    readonly fetchKey: string | number | null | undefined;
-    readonly fetchPolicy: PreloadFetchPolicy;
-    readonly name: string;
-    readonly source: Observable<GraphQLResponse> | null | undefined;
-    readonly variables: TQuery['variables'];
-}
+> =
+    | PreloadedQueryInner_DEPRECATED<TQuery, TEnvironmentProviderOptions>
+    | PreloadedQueryInner<TQuery, TEnvironmentProviderOptions>;
+
+export type PreloadedQueryInner_DEPRECATED<
+    TQuery extends OperationType,
+    TEnvironmentProviderOptions = EnvironmentProviderOptions
+> = Readonly<{
+    environment: IEnvironment;
+    environmentProviderOptions: TEnvironmentProviderOptions | null | undefined;
+    fetchKey: string | number | null | undefined;
+    fetchPolicy: PreloadFetchPolicy;
+    name: string;
+    source: Observable<GraphQLResponse> | null | undefined;
+    variables: TQuery['variables'];
+}>;
+
+export type PreloadedQueryInner<
+    TQuery extends OperationType,
+    TEnvironmentProviderOptions = EnvironmentProviderOptions
+> = Readonly<{
+    dispose: () => void;
+    environment: IEnvironment;
+    environmentProviderOptions?: TEnvironmentProviderOptions | null;
+    fetchPolicy: PreloadFetchPolicy;
+    name: string;
+    id?: string | null;
+    isDisposed: boolean;
+    networkCacheConfig?: CacheConfig | null;
+    source?: Observable<GraphQLResponse> | null;
+    kind: 'PreloadedQuery';
+    variables: TQuery['variables']
+}>;
 
 /**
  * The Interface of the EntryPoints .entrypoint files
@@ -158,17 +182,3 @@ export type EntryPoint<TEntryPointParams, TEntryPointComponent> = InternalEntryP
 export interface IEnvironmentProvider<TOptions> {
     getEnvironment(options: TOptions | null): IEnvironment;
 }
-
-export type PreloadedQueryInner<TQuery extends OperationType, TEnvironmentProviderOptions extends EnvironmentProviderOptions = {}> = Readonly<{
-    dispose: () => void;
-    environment: IEnvironment;
-    environmentProviderOptions?: TEnvironmentProviderOptions | null;
-    fetchPolicy: PreloadFetchPolicy;
-    id?: string | null;
-    isDisposed: boolean;
-    name: string;
-    networkCacheConfig?: CacheConfig | null;
-    source?: Observable<GraphQLResponse> | null;
-    kind: 'PreloadedQuery';
-    variables: TQuery['variables']
-}>;

--- a/types/react-relay/lib/relay-experimental/loadQuery.d.ts
+++ b/types/react-relay/lib/relay-experimental/loadQuery.d.ts
@@ -1,0 +1,10 @@
+import { GraphQLTaggedNode, IEnvironment, OperationType } from 'relay-runtime';
+import { PreloadedQueryInner, LoadQueryOptions, PreloadableConcreteRequest, EnvironmentProviderOptions } from './EntryPointTypes';
+
+export function loadQuery<TQuery extends OperationType, TEnvironmentProviderOptions extends EnvironmentProviderOptions = {}>(
+    environment: IEnvironment,
+    preloadableRequest: GraphQLTaggedNode | PreloadableConcreteRequest<TQuery>,
+    variables: TQuery['variables'],
+    options?: LoadQueryOptions,
+    environmentProviderOptions?: TEnvironmentProviderOptions
+): PreloadedQueryInner<TQuery, TEnvironmentProviderOptions>;

--- a/types/react-relay/test/relay-experimental-tests.tsx
+++ b/types/react-relay/test/relay-experimental-tests.tsx
@@ -959,7 +959,7 @@ function LoadQuery() {
 
     const variables: AppQueryVariables  = {
         id: "1"
-    }
+    };
 
     const dataWithoutExtraOptions = loadQuery<AppQuery>(environment, query, variables);
 

--- a/types/react-relay/test/relay-experimental-tests.tsx
+++ b/types/react-relay/test/relay-experimental-tests.tsx
@@ -25,6 +25,7 @@ import {
     useMutation,
     useSubscription,
     useQueryLoader,
+    loadQuery
 } from 'react-relay/hooks';
 
 const source = new RecordSource();
@@ -925,5 +926,53 @@ function QueryLoader() {
         } else {
             return null;
         }
+    }
+}
+
+/**
+ * Tests for loadQuery
+ * see https://github.com/facebook/relay/blob/master/packages/relay-experimental/loadQuery.js
+ */
+function LoadQuery() {
+    interface AppQueryVariables {
+        id: string;
+    }
+
+    interface AppQueryResponse {
+        readonly user: {
+            readonly name: string;
+        };
+    }
+
+    interface AppQuery {
+        readonly response: AppQueryResponse;
+        readonly variables: AppQueryVariables;
+    }
+
+    const query = graphql`
+        query AppQuery($id: ID!) {
+            user(id: $id) {
+                name
+            }
+        }
+    `;
+
+    const variables: AppQueryVariables  = {
+        id: "1"
+    }
+
+    const dataWithoutExtraOptions = loadQuery<AppQuery>(environment, query, variables);
+
+    const dataWithOptions = loadQuery<AppQuery>(environment, query, variables, {
+        fetchPolicy: 'store-or-network',
+        networkCacheConfig: {
+            force: true
+        }
+    });
+
+    function ShouldPassIntoUsePreloadQuery() {
+        const data = usePreloadedQuery<AppQuery>(query, dataWithOptions);
+
+        return <>{data.user.name}</>;
     }
 }

--- a/types/react-relay/test/relay-experimental-tests.tsx
+++ b/types/react-relay/test/relay-experimental-tests.tsx
@@ -969,7 +969,7 @@ function LoadQuery() {
     });
 
     function ShouldPassIntoUsePreloadQuery({preloadedQuery}: {preloadedQuery: PreloadedQuery<AppQuery>}) {
-        const data = usePreloadedQuery<AppQuery>(query, preloadedQuery);
+        const data = usePreloadedQuery(query, preloadedQuery); // $ExpectType AppQueryResponse
 
         return <>{data.user.name}</>;
     }

--- a/types/react-relay/test/relay-experimental-tests.tsx
+++ b/types/react-relay/test/relay-experimental-tests.tsx
@@ -961,18 +961,23 @@ function LoadQuery() {
         id: "1"
     };
 
-    const dataWithoutExtraOptions = loadQuery<AppQuery>(environment, query, variables);
-
-    const dataWithOptions = loadQuery<AppQuery>(environment, query, variables, {
+    const preloadedQuery = loadQuery<AppQuery>(environment, query, variables, {
         fetchPolicy: 'store-or-network',
         networkCacheConfig: {
             force: true
         }
     });
 
-    function ShouldPassIntoUsePreloadQuery() {
-        const data = usePreloadedQuery<AppQuery>(query, dataWithOptions);
+    function ShouldPassIntoUsePreloadQuery({preloadedQuery}: {preloadedQuery: PreloadedQuery<AppQuery>}) {
+        const data = usePreloadedQuery<AppQuery>(query, preloadedQuery);
 
         return <>{data.user.name}</>;
+    }
+
+    // To depict some sort of running app
+    function App() {
+        return (
+            <ShouldPassIntoUsePreloadQuery preloadedQuery={preloadedQuery} />
+        );
     }
 }


### PR DESCRIPTION
Added new `loadQuery` method to the types.

- Interface: https://github.com/facebook/relay/blob/a12e05c6393041ebb6b38ace2cd482b5b47028d4/packages/relay-experimental/EntryPointTypes.flow.js#L82-L97
- `loadQuery` function: https://github.com/facebook/relay/blob/master/packages/relay-experimental/loadQuery.js#L55-L61