### PR TITLE
[react-native-svg-charts] Add startAngle, endAngle to PieChartProps

### DIFF
--- a/types/react-native-svg-charts/index.d.ts
+++ b/types/react-native-svg-charts/index.d.ts
@@ -84,6 +84,8 @@ export interface PieChartProps<T extends PieChartData> extends ChartProps<T> {
     outerRadius?: number | string;
     labelRadius?: number | string;
     padAngle?: number;
+    startAngle?: number;
+    endAngle?: number;
     sort?: SortFunction<T>;
     valueAccessor?: AccessorFunction<T, number>;
 }


### PR DESCRIPTION
Added `startAngle: number`, `endAngle: number` as according to `react-native-svg-charts`'s docs here -> https://github.com/JesperLekland/react-native-svg-charts#props-5
