### PR TITLE
Add types for outliers

### DIFF
--- a/types/outliers/index.d.ts
+++ b/types/outliers/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for outliers 0.0
+// Project: https://github.com/MatthewMueller/outliers
+// Definitions by: Glenn Reyes <https://github.com/glennreyes>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function outliers(input: number[]): number[];
+declare function outliers(path?: string): () => unknown[];
+
+export = outliers;

--- a/types/outliers/index.d.ts
+++ b/types/outliers/index.d.ts
@@ -4,6 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare function outliers(input: number[]): number[];
-declare function outliers(path?: string): () => unknown[];
+declare function outliers<T>(path?: string): (element: T, index: number, array: T[]) => boolean;
 
 export = outliers;

--- a/types/outliers/outliers-tests.ts
+++ b/types/outliers/outliers-tests.ts
@@ -1,0 +1,5 @@
+import outliers = require('outliers');
+
+outliers([1, 2, 3]);
+[1, 2, 3].filter(outliers());
+[{ n: 1 }, { n: 2 }, { n: 3 }].filter(outliers('n'));

--- a/types/outliers/tsconfig.json
+++ b/types/outliers/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "outliers-tests.ts"
+    ]
+}

--- a/types/outliers/tslint.json
+++ b/types/outliers/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.