### PR TITLE
[d3-scale] Remove undefined as a possible return type for scaleOrdinal

### DIFF
--- a/types/d3-scale/d3-scale-tests.ts
+++ b/types/d3-scale/d3-scale-tests.ts
@@ -916,9 +916,9 @@ if (typeof unknownValue === 'string') {
 
 // (...) value mapping from domain to output -----------------------------------
 
-outputString = ordinalScaleStringString('neutral');
+const ordinalOutputString: string = ordinalScaleStringString('neutral');
 
-outputNumber = ordinalScaleStringNumber('negative');
+const ordinalOutputNumber: number = ordinalScaleStringNumber('negative');
 
 // copy(...) -----------------------------------------------------------------
 

--- a/types/d3-scale/index.d.ts
+++ b/types/d3-scale/index.d.ts
@@ -1954,7 +1954,7 @@ export interface ScaleOrdinal<Domain extends { toString(): string }, Range> {
      *
      * @param x A value from the domain.
      */
-    (x: Domain): Range | undefined;
+    (x: Domain): Range;
 
     /**
      * Returns the scale's current domain.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-scale#ordinal_unknown
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Related: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/48299
