### PR TITLE
Exempt bulma-tagsinput from default export rule

### DIFF
--- a/types/creativebulma__bulma-tagsinput/tslint.json
+++ b/types/creativebulma__bulma-tagsinput/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}


### PR DESCRIPTION
Reading the code, it appears to create a default export. We just can't understand webpack-generated code in most cases.