### PR TITLE
update(update-notifier): v5 non breaking changes

### DIFF
--- a/types/update-notifier/index.d.ts
+++ b/types/update-notifier/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for update-notifier 4.1
+// Type definitions for update-notifier 5.0
 // Project: https://github.com/yeoman/update-notifier
 // Definitions by: vvakame <https://github.com/vvakame>
 //                 Noah Chen <https://github.com/nchen63>
@@ -6,8 +6,6 @@
 //                 Michael Grinich <https://github.com/grinich>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.2
-
 import boxen = require('boxen');
 import ConfigStore = require('configstore');
 
@@ -23,14 +21,20 @@ declare namespace UpdateNotifier {
         readonly config: ConfigStore;
         readonly update?: UpdateInfo;
         check(): void;
-        /** Check update information */
+        /**
+         * Check update information
+         * @async
+         */
         fetchInfo(): UpdateInfo | Promise<UpdateInfo>;
         /** Convenience method to display a notification message */
         notify(customMessage?: NotifyOptions): void;
     }
 
     interface Settings {
-        /** Which dist-tag to use to find the latest version */
+        /**
+         * Which dist-tag to use to find the latest version
+         * @default 'latest'
+         */
         distTag?: string;
         pkg?: Package;
         /**


### PR DESCRIPTION
- version bump
- minor changes to document usage properly (async/latest)
- drop custom TS version header, as 3.2 is now the latest supported
  version anyway

https://github.com/yeoman/update-notifier/compare/v4.1.1...v5.0.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.