### PR TITLE
nova-editor: Make completion and issue assistants async

### DIFF
--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -33,11 +33,11 @@ interface ColorAssistant {
 }
 
 interface CompletionAssistant {
-    provideCompletionItems(editor: TextEditor, context: CompletionContext): void | CompletionItem[];
+    provideCompletionItems(editor: TextEditor, context: CompletionContext): CompletionItem[] | Promise<CompletionItem[]>;
 }
 
 interface IssueAssistant {
-    provideIssues(editor: TextEditor): Issue[];
+    provideIssues(editor: TextEditor): Issue[] | Promise<Issue[]>;
 }
 
 /// https://novadocs.panic.com/api-reference/charset/

--- a/types/nova-editor-node/nova-editor-node-tests.ts
+++ b/types/nova-editor-node/nova-editor-node-tests.ts
@@ -37,13 +37,23 @@ nova.commands.register(
 
 nova.commands.invoke('apexskier.bar', 'foo');
 
-new CompletionItem('label', CompletionItemKind.Argument);
-
 // after 3.4: $ExpectType unknown
 nova.config.get('test');
 
 // $ExpectType string[] | null
 nova.config.get('test', 'array');
+
+/// https://novadocs.panic.com/api-reference/assistants-registry/
+
+nova.assistants.registerCompletionAssistant("foo", {
+    async provideCompletionItems(editor, context) {
+        // $ExpectType TextEditor
+        editor;
+        // $ExpectType CompletionContext
+        context;
+        return [completionItem];
+    }
+});
 
 /// https://novadocs.panic.com/api-reference/charset/
 


### PR DESCRIPTION
From an email with Nova support, and now reflected in the docs:

> 1.) Completion providers aren’t synchronous: They support returning a Promise. I will update the documentation to reflect this.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.nova.app/api-reference/assistants-registry/#registercompletionassistant-selector-object
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~
