### PR TITLE
fix(echarts): type declaration for overloading of echartsInstance.on

### DIFF
--- a/types/echarts/index.d.ts
+++ b/types/echarts/index.d.ts
@@ -273,6 +273,111 @@ declare namespace echarts {
         on(eventName: string, handler: Function, context?: object): void;
 
         /**
+         * Binds event-handling function.
+         *     There are two kinds of events in ECharts, one of which is mouse
+         *     events, which will be triggered when the mouse clicks certain
+         *     element in the chart, the other kind will be triggered after
+         *     `dispatchAction` is called. Every action has a corresponding
+         *     event.
+         *     If event is triggered externally by `dispatchAction`, and there
+         *     is batch attribute in action to trigger batch action, then the
+         *     corresponding response event parameters be in batch.
+         *
+         * @param {string} eventName Event names are all in lower-cases,
+         *     for example, `'click'`, `'mousemove'`, `'legendselected'`
+         * @param {string | Object} query Condition for filtering, optional.
+         *     `query` enables only call handlers on graphic elements of
+         *     specified components. Can be `string` or `Object`.
+         *     If `string`, the formatter can be 'mainType' or 'mainType.subType'.
+         *     For example:
+         *  ```ts
+         *  chart.on('click', 'series', function () {...});
+         *  chart.on('click', 'series.line', function () {...});
+         *  chart.on('click', 'dataZoom', function () {...});
+         *  chart.on('click', 'xAxis.category', function () {...});
+         *  ```
+         *     If `Object`, one or more properties below can be included,
+         *     and any of them is optional.
+         *  ```ts
+         *  {
+         *      <mainType>Index: number // component index
+         *      <mainType>Name: string // component name
+         *      <mainType>Id: string // component id
+         *      dataIndex: number // data item index
+         *      name: string // data item name
+         *      dataType: string // data item type, e.g.,
+         *                       // 'node' and 'edge' in graph.
+         *      element: string // element name in custom series
+         *  }
+         *  ```
+         *     For example:
+         *  ```ts
+         *  chart.setOption({
+         *      // ...
+         *      series: [{
+         *          name: 'uuu'
+         *          // ...
+         *      }]
+         *  });
+         *  chart.on('mouseover', {seriesName: 'uuu'}, function () {
+         *      // When the graphic elements in the series with name 'uuu' mouse
+         *      // overed, this method is called.
+         *  });
+         *  ```
+         *     For example:
+         *  ```ts
+         *  chart.setOption({
+         *      // ...
+         *      series: [{
+         *          type: 'graph',
+         *          nodes: [{name: 'a', value: 10}, {name: 'b', value: 20}],
+         *          edges: [{source: 0, target: 1}]
+         *      }]
+         *  });
+         *  chart.on('click', {dataType: 'node'}, function () {
+         *      // When the nodes of the graph clicked, this method is called.
+         *  });
+         *  chart.on('click', {dataType: 'edge'}, function () {
+         *      // When the edges of the graph clicked, this method is called.
+         *  });
+         *  ```
+         *     For example
+         *  ```ts
+         *  chart.setOption({
+         *      // ...
+         *      series: {
+         *          // ...
+         *          type: 'custom',
+         *          renderItem: function (params, api) {
+         *              return {
+         *                  type: 'group',
+         *                  children: [{
+         *                      type: 'circle',
+         *                      name: 'my_el',
+         *                      // ...
+         *                  }, {
+         *                      // ...
+         *                  }]
+         *              }
+         *          },
+         *          data: [[12, 33]]
+         *      }
+         *  })
+         *  chart.on('click', {targetName: 'my_el'}, function () {
+         *      // When the element with name 'my_el' clicked, this method is called.
+         *  });
+         *  ```
+         * @param {Function} handler Event-handling function, whose format
+         *     is as following:
+            ```js
+            (event: object)
+            ```
+         * @param {object} [context] context of callback function, what
+         *     `this` refers to.
+         */
+        on(eventName: string, query: string | Object, handler: Function, context?: object): void;
+
+        /**
          * Unbind event-handler function.
          *
          * @param {string} eventName Event names are all in lower-cases,


### PR DESCRIPTION
The js api echartsInstance.on accepts 'query', but the declaration is missing in index.d.ts.
A type declaration is added for this overloading, and comments are copied from official api document.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://echarts.apache.org/en/api.html#echartsInstance.on>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.