### PR TITLE
Update types for jsonwebtoken for null secrets

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -133,10 +133,14 @@ export type GetPublicKeyOrSecret = (
     callback: SigningKeyCallback
 ) => void;
 
+/**
+ * 'null' secret is only valid when algorithm is 'none'
+ */
 export type Secret =
     | string
     | Buffer
-    | { key: string | Buffer; passphrase: string };
+    | { key: string | Buffer; passphrase: string }
+    | null;
 
 /**
  * Synchronously sign the given payload into a JSON Web Token string
@@ -177,7 +181,7 @@ export function sign(
  * [options] - Options for the verification
  * returns - The decoded token.
  */
-export function verify(token: string, secretOrPublicKey: Secret | null, options?: VerifyOptions): object | string;
+export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): object | string;
 
 /**
  * Asynchronously verify given token using a secret or a public key to get a decoded token
@@ -190,12 +194,12 @@ export function verify(token: string, secretOrPublicKey: Secret | null, options?
  */
 export function verify(
     token: string,
-    secretOrPublicKey: Secret | GetPublicKeyOrSecret | null,
+    secretOrPublicKey: Secret | GetPublicKeyOrSecret,
     callback?: VerifyCallback,
 ): void;
 export function verify(
     token: string,
-    secretOrPublicKey: Secret | GetPublicKeyOrSecret | null,
+    secretOrPublicKey: Secret | GetPublicKeyOrSecret,
     options?: VerifyOptions,
     callback?: VerifyCallback,
 ): void;

--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -66,6 +66,8 @@ export interface SignOptions {
     encoding?: string;
 }
 
+export type SignOptionsForNoneAlgorithm = SignOptions & { algorithm: 'none' };
+
 export interface VerifyOptions {
     algorithms?: Algorithm[];
     audience?: string | RegExp | Array<string | RegExp>;
@@ -89,6 +91,8 @@ export interface VerifyOptions {
      */
     maxAge?: string;
 }
+
+export type VerifyOptionsForNoneAlgorithm = VerifyOptions & { algorithms: ['none'] };
 
 export interface DecodeOptions {
     complete?: boolean;
@@ -139,8 +143,7 @@ export type GetPublicKeyOrSecret = (
 export type Secret =
     | string
     | Buffer
-    | { key: string | Buffer; passphrase: string }
-    | null;
+    | { key: string | Buffer; passphrase: string };
 
 /**
  * Synchronously sign the given payload into a JSON Web Token string
@@ -153,6 +156,11 @@ export function sign(
     payload: string | Buffer | object,
     secretOrPrivateKey: Secret,
     options?: SignOptions,
+): string;
+export function sign(
+    payload: string | Buffer | object,
+    secretOrPrivateKey: null,
+    options?: SignOptionsForNoneAlgorithm,
 ): string;
 
 /**
@@ -182,6 +190,7 @@ export function sign(
  * returns - The decoded token.
  */
 export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): object | string;
+export function verify(token: string, secretOrPublicKey: null, options?: VerifyOptionsForNoneAlgorithm): object | string;
 
 /**
  * Asynchronously verify given token using a secret or a public key to get a decoded token

--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -137,9 +137,6 @@ export type GetPublicKeyOrSecret = (
     callback: SigningKeyCallback
 ) => void;
 
-/**
- * 'null' secret is only valid when algorithm is 'none'
- */
 export type Secret =
     | string
     | Buffer

--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -177,7 +177,7 @@ export function sign(
  * [options] - Options for the verification
  * returns - The decoded token.
  */
-export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): object | string;
+export function verify(token: string, secretOrPublicKey: Secret | null, options?: VerifyOptions): object | string;
 
 /**
  * Asynchronously verify given token using a secret or a public key to get a decoded token
@@ -190,12 +190,12 @@ export function verify(token: string, secretOrPublicKey: Secret, options?: Verif
  */
 export function verify(
     token: string,
-    secretOrPublicKey: Secret | GetPublicKeyOrSecret,
+    secretOrPublicKey: Secret | GetPublicKeyOrSecret | null,
     callback?: VerifyCallback,
 ): void;
 export function verify(
     token: string,
-    secretOrPublicKey: Secret | GetPublicKeyOrSecret,
+    secretOrPublicKey: Secret | GetPublicKeyOrSecret | null,
     options?: VerifyOptions,
     callback?: VerifyCallback,
 ): void;

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -142,6 +142,10 @@ jwt.verify(token, cert, { ignoreExpiration: true }, (err, decoded) => {
     // if ignoreExpration == false and token is expired, err == expired token
 });
 
+// verify a non-signed token
+const unsigned = jwt.sign({ aud: 'foo', sub: 'bar' }, null, { algorithm: 'none' });
+jwt.verify(unsigned, null, { algorithms: ['none' ]});
+
 /**
  * jwt.decode
  * https://github.com/auth0/node-jsonwebtoken#jwtdecodetoken


### PR DESCRIPTION
The `verify()` and `sign()` methods accepts a `null` secret when the JWT being verified has `alg: 'none'` (meaning it is unsigned).  The only way to verify an unsigned token is to pass `null` as the secret, as passing an invalid secret results in an error.

The library allows this but the types don't, so I have to do `null as any` to trick the type system. 

The underlying ability was added in this commit:
https://github.com/auth0/node-jsonwebtoken/commit/0f193887d362f919cb17b1f1f9ece0c67b97684d

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
