### PR TITLE
[d3-format] Update types to v2.0

### DIFF
--- a/types/d3-format/v1/d3-format-tests.ts
+++ b/types/d3-format/v1/d3-format-tests.ts
@@ -1,0 +1,124 @@
+/**
+ * Typescript definition tests for d3/d3-format module
+ *
+ * Note: These tests are intended to test the definitions only
+ * in the sense of typing and call signature consistency. They
+ * are not intended as functional tests.
+ */
+
+import * as d3Format from 'd3-format';
+
+// ----------------------------------------------------------------------
+// Preparatory Steps
+// ----------------------------------------------------------------------
+
+class NumCoercible {
+    a: number;
+
+    constructor(a: number) {
+        this.a = a;
+    }
+
+    valueOf() {
+        return this.a;
+    }
+}
+
+const numeric: NumCoercible = new NumCoercible(10);
+
+let num: number;
+
+let formatFn: (n: number) => string;
+
+let specifier: d3Format.FormatSpecifier;
+
+let localeDef: d3Format.FormatLocaleDefinition;
+
+let localeObj: d3Format.FormatLocaleObject;
+
+// ----------------------------------------------------------------------
+// Test Format and FormatPrefix
+// ----------------------------------------------------------------------
+
+formatFn = d3Format.format('.0%');
+
+formatFn = d3Format.formatPrefix(',.0', 1e-6);
+
+d3Format.format('.0%')(10);
+d3Format.format('.0%')(numeric);
+
+d3Format.formatPrefix(',.0', 1e-6)(10);
+d3Format.formatPrefix(',.0', 1e-6)(numeric);
+
+// ----------------------------------------------------------------------
+// Test Format Specifier
+// ----------------------------------------------------------------------
+
+specifier = d3Format.formatSpecifier('.0%');
+specifier = new d3Format.FormatSpecifier({});
+
+const fill: string = specifier.fill;
+const align: '>' | '<' | '^' | '=' = specifier.align;
+const sign: '-' | '+' | '(' | ' ' = specifier.sign;
+const symbol: '$' | '#' | '' = specifier.symbol;
+const zero: boolean = specifier.zero;
+const width: number | undefined = specifier.width;
+const comma: boolean = specifier.comma;
+const precision: number | undefined = specifier.precision;
+const trim: boolean = specifier.trim;
+const type: 'e' | 'f' | 'g' | 'r' | 's' | '%' | 'p' | 'b' | 'o' | 'd' | 'x' | 'X' | 'c' | '' | 'n' = specifier.type;
+
+const formatString: string = specifier.toString();
+
+// ----------------------------------------------------------------------
+// Test Precision Suggestors
+// ----------------------------------------------------------------------
+
+num = d3Format.precisionFixed(0.0005);
+
+num = d3Format.precisionPrefix(0.0005, 1000);
+
+num = d3Format.precisionRound(0.0005, 3000);
+
+// ----------------------------------------------------------------------
+// Test Locale Definition
+// ----------------------------------------------------------------------
+
+localeDef = {
+    decimal: ',',
+    thousands: '.',
+    grouping: [3],
+    currency: ['EUR', '']
+};
+
+localeDef = {
+    decimal: "\u066b",
+    thousands: "\u066c",
+    grouping: [3],
+    currency: ["", ""],
+    numerals : ["\u0660", "\u0661", "\u0662", "\u0663", "\u0664", "\u0665", "\u0666", "\u0667", "\u0668", "\u0669"]
+};
+
+localeDef = {
+    decimal: "\u066b",
+    thousands: "\u066c",
+    grouping: [3],
+    currency: ["", ""],
+    percent : "\u202f%",
+    minus: "-",
+    nan: "NaN",
+};
+
+const decimal: string = localeDef.decimal;
+const thousands: string = localeDef.thousands;
+const grouping: number[] = localeDef.grouping;
+const currency: [string, string] = localeDef.currency;
+const numerals: string[] | undefined = localeDef.numerals;
+const percent: string | undefined = localeDef.percent;
+
+localeObj = d3Format.formatLocale(localeDef);
+
+localeObj = d3Format.formatDefaultLocale(localeDef);
+
+const formatFactory: (specifier: string) => ((n: number) => string) = localeObj.format;
+const formatPrefixFactory: (specifier: string, value: number) => ((n: number) => string) = localeObj.formatPrefix;

--- a/types/d3-format/v1/index.d.ts
+++ b/types/d3-format/v1/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-format module 2.0
+// Type definitions for D3JS d3-format module 1.4
 // Project: https://github.com/d3/d3-format/, https://d3js.org/d3-format
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>
 //                 Alex Ford <https://github.com/gustavderdrache>
@@ -7,7 +7,7 @@
 //                 Nathan Bierema <https://github.com/Methuselah96>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// Last module patch version validated against: 2.0.0
+// Last module patch version validated against: 1.4.5
 
 /**
  * Specification of locale to use when creating a new FormatLocaleObject
@@ -18,7 +18,7 @@ export interface FormatLocaleDefinition {
      */
     decimal: string;
     /**
-     * The group separator (e.g., ","). Note that the thousands property is a misnomer, as
+     * The group separator (e.g., ","). Note that the thousands property is a misnomer, as\
      * the grouping definition allows groups other than thousands.
      */
     thousands: string;
@@ -39,11 +39,11 @@ export interface FormatLocaleDefinition {
      */
     percent?: string;
     /**
-     * Optional; the minus sign (defaults to "−").
+     * Optional; the minus sign (defaults to hyphen-minus, "-").
      */
     minus?: string;
     /**
-     * Optional; the not-a-number value (defaults "NaN").
+     * Optional; the not-a-number value (defaults `"NaN"`).
      */
     nan?: string;
 }

--- a/types/d3-format/v1/tsconfig.json
+++ b/types/d3-format/v1/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "d3-format-tests.ts"
+    ]
+}

--- a/types/d3-format/v1/tsconfig.json
+++ b/types/d3-format/v1/tsconfig.json
@@ -12,6 +12,11 @@
         "typeRoots": [
             "../"
         ],
+        "paths": {
+            "d3-format": [
+                "d3-format/v1"
+            ]
+        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/d3-format/v1/tsconfig.json
+++ b/types/d3-format/v1/tsconfig.json
@@ -8,9 +8,9 @@
         "noImplicitThis": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
-        "baseUrl": "../",
+        "baseUrl": "../../",
         "typeRoots": [
-            "../"
+            "../../"
         ],
         "paths": {
             "d3-format": [

--- a/types/d3-format/v1/tslint.json
+++ b/types/d3-format/v1/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/d3/tsconfig.json
+++ b/types/d3/tsconfig.json
@@ -23,6 +23,9 @@
             "d3-contour": [
                 "d3-contour/v1"
             ],
+            "d3-format": [
+                "d3-format/v1"
+            ],
             "d3-hierarchy": [
                 "d3-hierarchy/v1"
             ],

--- a/types/d3/v4/tsconfig.json
+++ b/types/d3/v4/tsconfig.json
@@ -23,6 +23,9 @@
             "d3-chord": [
                 "d3-chord/v1"
             ],
+            "d3-format": [
+                "d3-format/v1"
+            ],
             "d3-hierarchy": [
                 "d3-hierarchy/v1"
             ],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-format/releases/tag/v2.0.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Related: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/38939
