### PR TITLE
[node] Remove deprecation from `assert.strict.*`

### DIFF
--- a/types/node/assert.d.ts
+++ b/types/node/assert.d.ts
@@ -77,7 +77,12 @@ declare module "assert" {
         function match(value: string, regExp: RegExp, message?: string | Error): void;
         function doesNotMatch(value: string, regExp: RegExp, message?: string | Error): void;
 
-        const strict: typeof assert;
+        const strict: typeof assert & {
+            deepEqual: typeof deepStrictEqual;
+            notDeepEqual: typeof notDeepStrictEqual;
+            equal: typeof strictEqual;
+            notEqual: typeof notStrictEqual;
+        };
     }
 
     export = assert;

--- a/types/node/v10/assert.d.ts
+++ b/types/node/v10/assert.d.ts
@@ -45,7 +45,12 @@ declare module "assert" {
         function doesNotReject(block: Function | Promise<any>, message?: string | Error): Promise<void>;
         function doesNotReject(block: Function | Promise<any>, error: RegExp | Function, message?: string | Error): Promise<void>;
 
-        const strict: typeof assert;
+        const strict: typeof assert & {
+            deepEqual: typeof deepStrictEqual;
+            notDeepEqual: typeof notDeepStrictEqual;
+            equal: typeof strictEqual;
+            notEqual: typeof notStrictEqual;
+        };
     }
 
     export = assert;

--- a/types/node/v11/assert.d.ts
+++ b/types/node/v11/assert.d.ts
@@ -45,7 +45,12 @@ declare module "assert" {
         function doesNotReject(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
         function doesNotReject(block: (() => Promise<any>) | Promise<any>, error: RegExp | Function, message?: string | Error): Promise<void>;
 
-        const strict: typeof assert;
+        const strict: typeof assert & {
+            deepEqual: typeof deepStrictEqual;
+            notDeepEqual: typeof notDeepStrictEqual;
+            equal: typeof strictEqual;
+            notEqual: typeof notStrictEqual;
+        };
     }
 
     export = assert;

--- a/types/node/v12/assert.d.ts
+++ b/types/node/v12/assert.d.ts
@@ -45,7 +45,12 @@ declare module "assert" {
         function doesNotReject(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
         function doesNotReject(block: (() => Promise<any>) | Promise<any>, error: RegExp | Function, message?: string | Error): Promise<void>;
 
-        const strict: typeof assert;
+        const strict: typeof assert & {
+            deepEqual: typeof deepStrictEqual;
+            notDeepEqual: typeof notDeepStrictEqual;
+            equal: typeof strictEqual;
+            notEqual: typeof notStrictEqual;
+        };
     }
 
     export = assert;

--- a/types/node/v13/assert.d.ts
+++ b/types/node/v13/assert.d.ts
@@ -50,7 +50,12 @@ declare module "assert" {
         function match(value: string, regExp: RegExp, message?: string | Error): void;
         function doesNotMatch(value: string, regExp: RegExp, message?: string | Error): void;
 
-        const strict: typeof assert;
+        const strict: typeof assert & {
+            deepEqual: typeof deepStrictEqual;
+            notDeepEqual: typeof notDeepStrictEqual;
+            equal: typeof strictEqual;
+            notEqual: typeof notStrictEqual;
+        };
     }
 
     export = assert;


### PR DESCRIPTION
Fixed https://github.com/DefinitelyTyped/DefinitelyTyped/issues/48253

Docs: https://nodejs.org/docs/latest/api/assert.html#assert_strict_assertion_mode

> In strict assertion mode, non-strict methods behave like their corresponding strict methods. For example, `assert.deepEqual()` will behave like `assert.deepStrictEqual()`.