### PR TITLE
[node] Update `zlib` module

### DIFF
--- a/types/node/v10/zlib.d.ts
+++ b/types/node/v10/zlib.d.ts
@@ -10,6 +10,28 @@ declare module "zlib" {
         memLevel?: number; // compression only
         strategy?: number; // compression only
         dictionary?: Buffer | NodeJS.TypedArray | DataView | ArrayBuffer; // deflate/inflate only, empty dictionary by default
+        info?: boolean;
+    }
+
+    interface BrotliOptions {
+        /**
+         * @default constants.BROTLI_OPERATION_PROCESS
+         */
+        flush?: number;
+        /**
+         * @default constants.BROTLI_OPERATION_FINISH
+         */
+        finishFlush?: number;
+        /**
+         * @default 16*1024
+         */
+        chunkSize?: number;
+        params?: {
+            /**
+             * Each key is a `constants.BROTLI_*` constant.
+             */
+            [key: number]: boolean | number;
+        };
     }
 
     interface Zlib {
@@ -29,6 +51,8 @@ declare module "zlib" {
         reset(): void;
     }
 
+    interface BrotliCompress extends stream.Transform, Zlib { }
+    interface BrotliDecompress extends stream.Transform, Zlib { }
     interface Gzip extends stream.Transform, Zlib { }
     interface Gunzip extends stream.Transform, Zlib { }
     interface Deflate extends stream.Transform, Zlib, ZlibReset, ZlibParams { }
@@ -37,6 +61,8 @@ declare module "zlib" {
     interface InflateRaw extends stream.Transform, Zlib, ZlibReset { }
     interface Unzip extends stream.Transform, Zlib { }
 
+    function createBrotliCompress(options?: BrotliOptions): BrotliCompress;
+    function createBrotliDecompress(options?: BrotliOptions): BrotliDecompress;
     function createGzip(options?: ZlibOptions): Gzip;
     function createGunzip(options?: ZlibOptions): Gunzip;
     function createDeflate(options?: ZlibOptions): Deflate;
@@ -46,6 +72,15 @@ declare module "zlib" {
     function createUnzip(options?: ZlibOptions): Unzip;
 
     type InputType = string | Buffer | DataView | ArrayBuffer | NodeJS.TypedArray;
+
+    type CompressCallback = (error: Error | null, result: Buffer) => void;
+
+    function brotliCompress(buf: InputType, options: BrotliOptions, callback: CompressCallback): void;
+    function brotliCompress(buf: InputType, callback: CompressCallback): void;
+    function brotliCompressSync(buf: InputType, options?: BrotliOptions): Buffer;
+    function brotliDecompress(buf: InputType, options: BrotliOptions, callback: CompressCallback): void;
+    function brotliDecompress(buf: InputType, callback: CompressCallback): void;
+    function brotliDecompressSync(buf: InputType, options?: BrotliOptions): Buffer;
     function deflate(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
     function deflate(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
     function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
@@ -105,6 +140,74 @@ declare module "zlib" {
         const Z_RLE: number;
         const Z_FIXED: number;
         const Z_DEFAULT_STRATEGY: number;
+
+        const BROTLI_DECODE: number;
+        const BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES: number;
+        const BROTLI_DECODER_ERROR_ALLOC_CONTEXT_MAP: number;
+        const BROTLI_DECODER_ERROR_ALLOC_CONTEXT_MODES: number;
+        const BROTLI_DECODER_ERROR_ALLOC_RING_BUFFER_1: number;
+        const BROTLI_DECODER_ERROR_ALLOC_RING_BUFFER_2: number;
+        const BROTLI_DECODER_ERROR_ALLOC_TREE_GROUPS: number;
+        const BROTLI_DECODER_ERROR_DICTIONARY_NOT_SET: number;
+        const BROTLI_DECODER_ERROR_FORMAT_BLOCK_LENGTH_1: number;
+        const BROTLI_DECODER_ERROR_FORMAT_BLOCK_LENGTH_2: number;
+        const BROTLI_DECODER_ERROR_FORMAT_CL_SPACE: number;
+        const BROTLI_DECODER_ERROR_FORMAT_CONTEXT_MAP_REPEAT: number;
+        const BROTLI_DECODER_ERROR_FORMAT_DICTIONARY: number;
+        const BROTLI_DECODER_ERROR_FORMAT_DISTANCE: number;
+        const BROTLI_DECODER_ERROR_FORMAT_EXUBERANT_META_NIBBLE: number;
+        const BROTLI_DECODER_ERROR_FORMAT_EXUBERANT_NIBBLE: number;
+        const BROTLI_DECODER_ERROR_FORMAT_HUFFMAN_SPACE: number;
+        const BROTLI_DECODER_ERROR_FORMAT_PADDING_1: number;
+        const BROTLI_DECODER_ERROR_FORMAT_PADDING_2: number;
+        const BROTLI_DECODER_ERROR_FORMAT_RESERVED: number;
+        const BROTLI_DECODER_ERROR_FORMAT_SIMPLE_HUFFMAN_ALPHABET: number;
+        const BROTLI_DECODER_ERROR_FORMAT_SIMPLE_HUFFMAN_SAME: number;
+        const BROTLI_DECODER_ERROR_FORMAT_TRANSFORM: number;
+        const BROTLI_DECODER_ERROR_FORMAT_WINDOW_BITS: number;
+        const BROTLI_DECODER_ERROR_INVALID_ARGUMENTS: number;
+        const BROTLI_DECODER_ERROR_UNREACHABLE: number;
+        const BROTLI_DECODER_NEEDS_MORE_INPUT: number;
+        const BROTLI_DECODER_NEEDS_MORE_OUTPUT: number;
+        const BROTLI_DECODER_NO_ERROR: number;
+        const BROTLI_DECODER_PARAM_DISABLE_RING_BUFFER_REALLOCATION: number;
+        const BROTLI_DECODER_PARAM_LARGE_WINDOW: number;
+        const BROTLI_DECODER_RESULT_ERROR: number;
+        const BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT: number;
+        const BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT: number;
+        const BROTLI_DECODER_RESULT_SUCCESS: number;
+        const BROTLI_DECODER_SUCCESS: number;
+
+        const BROTLI_DEFAULT_MODE: number;
+        const BROTLI_DEFAULT_QUALITY: number;
+        const BROTLI_DEFAULT_WINDOW: number;
+        const BROTLI_ENCODE: number;
+        const BROTLI_LARGE_MAX_WINDOW_BITS: number;
+        const BROTLI_MAX_INPUT_BLOCK_BITS: number;
+        const BROTLI_MAX_QUALITY: number;
+        const BROTLI_MAX_WINDOW_BITS: number;
+        const BROTLI_MIN_INPUT_BLOCK_BITS: number;
+        const BROTLI_MIN_QUALITY: number;
+        const BROTLI_MIN_WINDOW_BITS: number;
+
+        const BROTLI_MODE_FONT: number;
+        const BROTLI_MODE_GENERIC: number;
+        const BROTLI_MODE_TEXT: number;
+
+        const BROTLI_OPERATION_EMIT_METADATA: number;
+        const BROTLI_OPERATION_FINISH: number;
+        const BROTLI_OPERATION_FLUSH: number;
+        const BROTLI_OPERATION_PROCESS: number;
+
+        const BROTLI_PARAM_DISABLE_LITERAL_CONTEXT_MODELING: number;
+        const BROTLI_PARAM_LARGE_WINDOW: number;
+        const BROTLI_PARAM_LGBLOCK: number;
+        const BROTLI_PARAM_LGWIN: number;
+        const BROTLI_PARAM_MODE: number;
+        const BROTLI_PARAM_NDIRECT: number;
+        const BROTLI_PARAM_NPOSTFIX: number;
+        const BROTLI_PARAM_QUALITY: number;
+        const BROTLI_PARAM_SIZE_HINT: number;
     }
 
     // Constants

--- a/types/node/v11/zlib.d.ts
+++ b/types/node/v11/zlib.d.ts
@@ -19,6 +19,7 @@ declare module "zlib" {
         memLevel?: number; // compression only
         strategy?: number; // compression only
         dictionary?: Buffer | NodeJS.TypedArray | DataView | ArrayBuffer; // deflate/inflate only, empty dictionary by default
+        info?: boolean;
     }
 
     interface BrotliOptions {

--- a/types/node/v12/zlib.d.ts
+++ b/types/node/v12/zlib.d.ts
@@ -19,6 +19,7 @@ declare module "zlib" {
         memLevel?: number; // compression only
         strategy?: number; // compression only
         dictionary?: NodeJS.ArrayBufferView | ArrayBuffer; // deflate/inflate only, empty dictionary by default
+        info?: boolean;
     }
 
     interface BrotliOptions {

--- a/types/node/v13/zlib.d.ts
+++ b/types/node/v13/zlib.d.ts
@@ -19,6 +19,7 @@ declare module "zlib" {
         memLevel?: number; // compression only
         strategy?: number; // compression only
         dictionary?: NodeJS.ArrayBufferView | ArrayBuffer; // deflate/inflate only, empty dictionary by default
+        info?: boolean;
     }
 
     interface BrotliOptions {

--- a/types/node/zlib.d.ts
+++ b/types/node/zlib.d.ts
@@ -19,6 +19,8 @@ declare module "zlib" {
         memLevel?: number; // compression only
         strategy?: number; // compression only
         dictionary?: NodeJS.ArrayBufferView | ArrayBuffer; // deflate/inflate only, empty dictionary by default
+        info?: boolean;
+        maxOutputLength?: number;
     }
 
     interface BrotliOptions {
@@ -40,6 +42,7 @@ declare module "zlib" {
              */
             [key: number]: boolean | number;
         };
+        maxOutputLength?: number;
     }
 
     interface Zlib {


### PR DESCRIPTION
Docs: https://nodejs.org/docs/latest/api/zlib.html

- [ ] The `maxOutputLength` option was added to `BrotliOptions` in v14.5.0 - https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V14.md#14.5.0
- [ ] Brotli support was added in v10.16.0 - https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#10.16.0