### PR TITLE
[@mapbox/mapbox-sdk] Rename getMatching to getMatch

### DIFF
--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -1027,7 +1027,7 @@ declare module '@mapbox/mapbox-sdk/services/map-matching' {
     export default function MapMatching(config: SdkConfig | MapiClient): MapMatchingService;
 
     interface MapMatchingService {
-        getMatching(request: MapMatchingRequest): MapiRequest;
+        getMatch(request: MapMatchingRequest): MapiRequest;
     }
 
     interface MapMatchingRequest {

--- a/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
+++ b/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
@@ -2,6 +2,7 @@ import MapiClient, { SdkConfig } from '@mapbox/mapbox-sdk/lib/classes/mapi-clien
 import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
 import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
 import Directions, { DirectionsService, DirectionsResponse } from '@mapbox/mapbox-sdk/services/directions';
+import MapMatching, { MapMatchingResponse, MapMatchingService } from '@mapbox/mapbox-sdk/services/map-matching';
 import Styles, { StylesService } from '@mapbox/mapbox-sdk/services/styles';
 import StaticMap, { StaticMapService } from '@mapbox/mapbox-sdk/services/static';
 import { LineString } from 'geojson';
@@ -28,6 +29,25 @@ const mapiRequest: MapiRequest = directionsService.getDirections({
 mapiRequest.send().then((response: MapiResponse) => {
     const body = response.body as DirectionsResponse;
     const route = body.routes;
+});
+
+const mapMatchingService: MapMatchingService = MapMatching(client);
+
+const mapMatchingRequest: MapiRequest = mapMatchingService.getMatch({
+    profile: 'walking',
+    points: [
+        {
+            coordinates: [1, 3],
+        },
+        {
+            coordinates: [2, 4],
+        },
+    ],
+});
+
+mapMatchingRequest.send().then((response: MapiResponse) => {
+    const body = response.body as MapMatchingResponse;
+    const matchings = body.matchings;
 });
 
 const stylesService: StylesService = Styles(config);


### PR DESCRIPTION
The method name has changed since 0.3 but this was not reflected in the types package. See https://github.com/mapbox/mapbox-sdk-js/blob/8ba742e04878b726d8f3967241961de836e2a0b5/CHANGELOG.md#030

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.