### PR TITLE
[d3-brush] Update types to v2.1

### DIFF
--- a/types/d3-brush/d3-brush-tests.ts
+++ b/types/d3-brush/d3-brush-tests.ts
@@ -205,3 +205,4 @@ const target: d3Brush.BrushBehavior<BrushDatum> = e.target;
 const type: 'start' | 'brush' | 'end' | string = e.type;
 const brushSelection: d3Brush.BrushSelection | null = e.selection;
 const sourceEvent: any = e.sourceEvent;
+const mode: 'drag' | 'space' | 'handle' | 'center' = e.mode;

--- a/types/d3-brush/index.d.ts
+++ b/types/d3-brush/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-brush module 2.0
+// Type definitions for D3JS d3-brush module 2.1
 // Project: https://github.com/d3/d3-brush/, https://d3js.org/d3-brush
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>
 //                 Alex Ford <https://github.com/gustavderdrache>
@@ -7,7 +7,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-// Last module patch version validated against: 2.0.1
+// Last module patch version validated against: 2.1.0
 
 import { Selection, TransitionLike, ValueFn } from 'd3-selection';
 

--- a/types/d3-brush/index.d.ts
+++ b/types/d3-brush/index.d.ts
@@ -298,4 +298,8 @@ export interface D3BrushEvent<Datum> {
      * The underlying input event, such as mousemove or touchmove.
      */
     sourceEvent: any;
+    /**
+     * The mode of the brush.
+     */
+    mode: 'drag' | 'space' | 'handle' | 'center';
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-brush/releases/tag/v2.1.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Related: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/38939
