### PR TITLE
add typings for nodemailer-html-to-text:3.1

### DIFF
--- a/types/nodemailer-html-to-text/index.d.ts
+++ b/types/nodemailer-html-to-text/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/andris9/nodemailer-html-to-text
 // Definitions by: Vinícius Fagundes <https://github.com/fagundes>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.3
 
 import Mail = require('nodemailer/lib/mailer');
 import HtmlToText = require('html-to-text');

--- a/types/nodemailer-html-to-text/index.d.ts
+++ b/types/nodemailer-html-to-text/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for nodemailer-html-to-text 3.1
+// Project: https://github.com/andris9/nodemailer-html-to-text
+// Definitions by: Vinícius Fagundes <https://github.com/fagundes>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import Mail = require('nodemailer/lib/mailer');
+import HtmlToText = require('html-to-text');
+
+/**
+ * Takes options for the html-to-text converter and returns a nodemailer plugin function
+ */
+export function htmlToText(options?: HtmlToText.HtmlToTextOptions): Mail.PluginFunction;

--- a/types/nodemailer-html-to-text/nodemailer-html-to-text-tests.ts
+++ b/types/nodemailer-html-to-text/nodemailer-html-to-text-tests.ts
@@ -1,0 +1,31 @@
+import * as formatters from 'html-to-text/lib/formatter';
+import * as nodemailer from 'nodemailer';
+import { htmlToText } from 'nodemailer-html-to-text';
+import { HtmlToTextOptions } from 'html-to-text';
+
+function plugin_without_options_test() {
+    const transporter = nodemailer.createTransport();
+
+    transporter.use('compile', htmlToText());
+}
+
+function plugin_with_options_test() {
+    const transporter = nodemailer.createTransport();
+
+    const options: HtmlToTextOptions = {
+        wordwrap: null,
+        tables: true,
+        hideLinkHrefIfSameAsText: true,
+        ignoreImage: true,
+        format: {
+            text: (el, options) => {
+                return formatters.text(el, options);
+            },
+            table: (el, walk, options) => {
+                return formatters.table(el, walk, options);
+            },
+        },
+    };
+
+    transporter.use('compile', htmlToText(options));
+}

--- a/types/nodemailer-html-to-text/tsconfig.json
+++ b/types/nodemailer-html-to-text/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "nodemailer-html-to-text-tests.ts"
+    ]
+}

--- a/types/nodemailer-html-to-text/tslint.json
+++ b/types/nodemailer-html-to-text/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.