### PR TITLE
[pino] Update LogDescriptor interface

### DIFF
--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -600,12 +600,10 @@ declare namespace P {
     type SerializerFn = (value: any) => any;
     type WriteFn = (o: object) => void;
 
-    interface LogDescriptor {
-        level: number;
-        time: number;
-        msg: string;
-        [key: string]: any;
-    }
+    /**
+     * Describes a log line.
+     */
+    type LogDescriptor = Record<string, any>; // TODO replace `any` with `unknown` when TypeScript version >= 3.0
 
     interface Bindings {
         level?: Level | string;

--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -604,7 +604,7 @@ declare namespace P {
         pid: number;
         hostname: string;
         level: number;
-        time: string;
+        time: number;
         msg: string;
         v: number;
         [key: string]: any;

--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -606,7 +606,6 @@ declare namespace P {
         level: number;
         time: number;
         msg: string;
-        v: number;
         [key: string]: any;
     }
 

--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -601,8 +601,6 @@ declare namespace P {
     type WriteFn = (o: object) => void;
 
     interface LogDescriptor {
-        pid: number;
-        hostname: string;
         level: number;
         time: number;
         msg: string;

--- a/types/pino/pino-tests.ts
+++ b/types/pino/pino-tests.ts
@@ -244,3 +244,10 @@ interface StrictShape {
 info<StrictShape>({
     activity: 'Required property',
 });
+
+const logLine: pino.LogDescriptor = {
+    level: 20,
+    msg: 'A log message',
+    time: new Date().getTime(),
+    aCustomProperty: true,
+};


### PR DESCRIPTION
### Commits
- [pino] Add LogDescriptor to tests
- [pino] Remove default base properties from LogDescriptor  
  The properties `hostname` and `pid` are not guaranteed to be present in all log lines. They can be disabled or overridden with the [`base`](https://getpino.io/#/docs/api?id=base-object) option. As such, they should not be present in the universal `LogDescriptor` interface.

- [pino] Remove v property from LogDescriptor  
  This was removed in Pino 6.0.0: https://github.com/pinojs/pino/releases/tag/v6.0.0

- [pino] Change time from string to number in LogDescriptor  
  The documentation's usage example shows that this value is a number: https://getpino.io/#/?id=usage

### Template
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: provided in the
commits, reproduced above
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.