### PR TITLE
deflate-js type bindings for v0.2.3

### DIFF
--- a/types/deflate-js/index.d.ts
+++ b/types/deflate-js/index.d.ts
@@ -21,5 +21,3 @@ export function deflate(data: Uint8Array, compression?: number): Uint8Array;
  * @return Uint8Array the deflated bytes
  */
 export function inflate(data: Uint8Array): Uint8Array;
-
-export as namespace deflatejs;

--- a/types/deflate-js/index.d.ts
+++ b/types/deflate-js/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for deflate-js 0.2
+// Project: https://github.com/beatgammit/deflate-js
+// Definitions by: Seb Renauld <https://github.com/srenauld>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Takes a byte sequence and deflates it
+ *
+ * @param data Uint8Array the raw, inflated payload
+ * @param compression number the compression level (defined in RFC 1951, higher is better)
+ *
+ * @return Uint8Array the deflated bytes
+ */
+export function deflate(data: Uint8Array, compression?: number): Uint8Array;
+
+/**
+ * Takes a byte sequence and inflates it
+ *
+ * @param data Uint8Array the deflated payload
+ *
+ * @return Uint8Array the deflated bytes
+ */
+export function inflate(data: Uint8Array): Uint8Array;
+
+export as namespace deflatejs;

--- a/types/deflate-js/test/deflate-js-tests.cjs.ts
+++ b/types/deflate-js/test/deflate-js-tests.cjs.ts
@@ -1,0 +1,5 @@
+import deflatejs = require("deflate-js");
+
+deflatejs.deflate(new Uint8Array([1, 2, 3, 4]), 3); // $ExpectType Uint8Array
+deflatejs.deflate(new Uint8Array([1, 2, 3, 4])); // $ExpectType Uint8Array
+deflatejs.inflate(new Uint8Array([1, 2, 3, 4])); // $ExpectType Uint8Array

--- a/types/deflate-js/test/deflate-js-tests.global.ts
+++ b/types/deflate-js/test/deflate-js-tests.global.ts
@@ -1,0 +1,3 @@
+deflatejs.deflate(new Uint8Array([1, 2, 3, 4]), 3); // $ExpectType Uint8Array
+deflatejs.deflate(new Uint8Array([1, 2, 3, 4])); // $ExpectType Uint8Array
+deflatejs.inflate(new Uint8Array([1, 2, 3, 4])); // $ExpectType Uint8Array

--- a/types/deflate-js/test/deflate-js-tests.global.ts
+++ b/types/deflate-js/test/deflate-js-tests.global.ts
@@ -1,3 +1,0 @@
-deflatejs.deflate(new Uint8Array([1, 2, 3, 4]), 3); // $ExpectType Uint8Array
-deflatejs.deflate(new Uint8Array([1, 2, 3, 4])); // $ExpectType Uint8Array
-deflatejs.inflate(new Uint8Array([1, 2, 3, 4])); // $ExpectType Uint8Array

--- a/types/deflate-js/tsconfig.json
+++ b/types/deflate-js/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "test/deflate-js-tests.cjs.ts",
+        "test/deflate-js-tests.global.ts"
+    ]
+}

--- a/types/deflate-js/tsconfig.json
+++ b/types/deflate-js/tsconfig.json
@@ -18,7 +18,6 @@
     },
     "files": [
         "index.d.ts",
-        "test/deflate-js-tests.cjs.ts",
-        "test/deflate-js-tests.global.ts"
+        "test/deflate-js-tests.cjs.ts"
     ]
 }

--- a/types/deflate-js/tslint.json
+++ b/types/deflate-js/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Additional, potentially useful info:

**NPM URL**: https://www.npmjs.com/package/deflate-js

The package itself is very straightforward, providing two simple methods; in structure, it was very similar to the `base64-js` example, and fits a similar purpose (encoding/decoding). 

Don't hesitate to let me know if there is anything that can be done to improve this!