### PR TITLE
[yup] allow date validator to be used with string properties

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -249,12 +249,12 @@ export interface BooleanSchema<T extends boolean | null | undefined = boolean | 
 
 export interface DateSchemaConstructor {
     // tslint:disable-next-line:no-unnecessary-generics
-    <T extends Date | null | undefined = Date | undefined, C = object>(): DateSchema<T, C>;
+    <T extends Date | string | null | undefined = Date | undefined, C = object>(): DateSchema<T, C>;
     // tslint:disable-next-line:no-unnecessary-generics
-    new <T extends Date | null | undefined = Date | undefined, C = object>(): DateSchema<T, C>;
+    new <T extends Date | string | null | undefined = Date | undefined, C = object>(): DateSchema<T, C>;
 }
 
-export interface DateSchema<T extends Date | null | undefined = Date | undefined, C = object> extends Schema<T, C> {
+export interface DateSchema<T extends Date | string | null | undefined = Date | undefined, C = object> extends Schema<T, C> {
     min(limit: Date | string | Ref, message?: DateLocale['min']): DateSchema<T, C>;
     max(limit: Date | string | Ref, message?: DateLocale['max']): DateSchema<T, C>;
     nullable(isNullable?: true): DateSchema<T | null, C>;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -433,6 +433,7 @@ boolSchema.defined();
 const dateSchema = yup.date(); // $ExpectType DateSchema<Date | undefined, object>
 dateSchema.type;
 dateSchema.isValid(new Date()); // => true
+dateSchema.isValid('2017-11-12'); // => true
 dateSchema.min(new Date());
 dateSchema.min('2017-11-12');
 dateSchema.min(new Date(), 'message');
@@ -926,6 +927,8 @@ person.mustBeAString = undefined;
 person.friends = new Set([1, 2, 3]);
 // $ExpectError
 person.friends = ["Amy", "Beth"];
+// $ExpectError
+person.birthDate = '2017-11-12';
 
 const castPerson = personSchema.cast({});
 castPerson.firstName = '';
@@ -945,6 +948,50 @@ castPerson.isAlive = undefined;
 castPerson.children = ['1', '2', '3'];
 castPerson.children = null;
 castPerson.children = undefined;
+
+// date validations on a string field
+const stringDateSchema = yup.object({
+    stringyDateRequired: yup
+        .date<string>()
+        .required(),
+    stringyDateOptional: yup
+        .date<string>()
+        .nullable()
+        .notRequired(),
+    flexibleDate: yup.date<Date | string>().required(),
+    realDate: yup.date().required()
+}).defined();
+
+type StringDate = yup.InferType<typeof stringDateSchema>;
+const stringDate: StringDate = {
+    stringyDateRequired: "2020-01-01",
+    stringyDateOptional: null,
+    flexibleDate: "2020-01-01",
+    realDate: new Date(),
+};
+
+stringDate.stringyDateRequired = "2020-01-01";
+// $ExpectError
+stringDate.stringyDateRequired = new Date();
+// $ExpectError
+stringDate.stringyDateRequired = null;
+
+stringDate.stringyDateOptional = "2020-01-01";
+stringDate.stringyDateOptional = undefined;
+stringDate.stringyDateOptional = null;
+// $ExpectError
+stringDate.stringyDateOptional = new Date();
+
+stringDate.flexibleDate = new Date();
+stringDate.flexibleDate = "2020-01-01";
+// $ExpectError
+stringDate.flexibleDate = null;
+// $ExpectError
+stringDate.flexibleDate = undefined;
+
+stringDate.realDate = new Date();
+// $ExpectError
+stringDate.realDate = "2020-01-01";
 
 const loginSchema = yup.object({
     password: yup.string(),


### PR DESCRIPTION
The yup date validator is designed to work with string properties, so I've updated its type parameters to accept "string". Like so: `yup.date<string>()`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquense/yup/blob/master/src/date.js#L20-L27
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
