### PR TITLE
[d3-fetch] Update types to v2.0

### DIFF
--- a/types/d3-fetch/index.d.ts
+++ b/types/d3-fetch/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for d3-fetch 1.2
+// Type definitions for d3-fetch 2.0
 // Project: https://d3js.org/d3-fetch/
 // Definitions by: Hugues Stefanski <https://github.com/ledragon>
 //                 denisname <https://github.com/denisname>
@@ -6,7 +6,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-// Last module patch version validated against: 1.2.0
+// Last module patch version validated against: 2.0.0
 
 import { DSVParsedArray, DSVRowArray, DSVRowString } from "d3-dsv";
 

--- a/types/d3-fetch/v1/d3-fetch-tests.ts
+++ b/types/d3-fetch/v1/d3-fetch-tests.ts
@@ -1,0 +1,158 @@
+import * as d3Fetch from 'd3-fetch';
+import { DSVParsedArray, DSVRaw, DSVRowString } from 'd3-dsv';
+
+// ----------------------------------------------------------------------------
+// Preparatory Steps
+// ----------------------------------------------------------------------------
+
+type Headers = "Year" | "Make" | "Model" | "Length";
+
+interface Car {
+    year: Date;
+    make: string;
+    model: string;
+    length: number;
+}
+
+let anyPromise: Promise<any>;
+let arrayPromise: Promise<ArrayBuffer>;
+let blobPromise: Promise<Blob>;
+let docPromise: Promise<Document>;
+let imagePromise: Promise<HTMLImageElement>;
+let carPromise: Promise<Car | undefined>;
+let stringPromise: Promise<string>;
+let xmlDocPromise: Promise<XMLDocument>;
+
+const url = 'example.org';
+const init: RequestInit = {};
+const map = new Map<string, number>();
+
+const imageProperties = {
+    width: 300,
+    height: 500,
+    crossOrigin: "anonymous",
+};
+
+// ----------------------------------------------------------------------------
+// Non DSV file format
+// ----------------------------------------------------------------------------
+
+blobPromise = d3Fetch.blob(url);
+blobPromise = d3Fetch.blob(url, init);
+
+arrayPromise = d3Fetch.buffer(url);
+arrayPromise = d3Fetch.buffer(url, init);
+
+imagePromise = d3Fetch.image(url);
+imagePromise = d3Fetch.image(url, imageProperties);
+// $ExpectError
+imagePromise = d3Fetch.image(url, {width: "500px"}); // fails, string not assignable to number | undefined
+
+anyPromise = d3Fetch.json(url);
+anyPromise = d3Fetch.json(url, init);
+
+carPromise = d3Fetch.json<Car>(url);
+carPromise = d3Fetch.json<Car>(url, init);
+
+stringPromise = d3Fetch.text(url);
+stringPromise = d3Fetch.text(url, init);
+
+docPromise = d3Fetch.html(url);
+docPromise = d3Fetch.html(url, init);
+
+docPromise = d3Fetch.svg(url);
+docPromise = d3Fetch.svg(url, init);
+
+xmlDocPromise = d3Fetch.xml(url);
+xmlDocPromise = d3Fetch.xml(url, init);
+
+// ----------------------------------------------------------------------------
+// DSV file format
+// ----------------------------------------------------------------------------
+
+let rawPromise: Promise<DSVParsedArray<DSVRowString>>;
+let rawPromiseHeader: Promise<DSVParsedArray<DSVRowString<Headers>>>;
+let parsedPromise: Promise<DSVParsedArray<Car>>;
+
+declare const parseRowString: (rawRow: DSVRowString, index: number, columns: string[]) => Car | undefined | null;
+
+const parseRow = (d: DSVRowString<Headers>, index: number, columns: Headers[]): Car | undefined | null => {
+    const item: string | undefined = d[columns[0]];
+    const car = d.Make === 'Ford' ? null :
+        {
+            year: new Date(+d.Make!, 0, 1),
+            make: d.Make!,
+            model: d.Model!,
+            length: +d.Length!,
+        };
+    return index % 2 === 0 ? undefined : car;
+};
+
+const parseRowSimple = (d: DSVRaw<Car>) => {
+    return {
+        year: new Date(+d.make!, 0, 1),
+        make: d.make!,
+        model: d.model!,
+        length: +d.length!,
+    };
+};
+
+// CSV
+
+rawPromise = d3Fetch.csv(url);
+rawPromise = d3Fetch.csv(url, init);
+
+rawPromiseHeader = d3Fetch.csv<Headers>(url);
+rawPromiseHeader = d3Fetch.csv<Headers>(url, init);
+
+parsedPromise = d3Fetch.csv<Car>(url, parseRowString);
+parsedPromise = d3Fetch.csv<Car>(url, init, parseRowString);
+
+parsedPromise = d3Fetch.csv<Car, Headers>(url, parseRow);
+parsedPromise = d3Fetch.csv<Car, Headers>(url, init, parseRow);
+
+parsedPromise = d3Fetch.csv(url, parseRow);
+parsedPromise = d3Fetch.csv(url, init, parseRow);
+parsedPromise = d3Fetch.csv(url, parseRowSimple);
+
+anyPromise = d3Fetch.csv(url, (d: DSVRaw<Car>) => map.set(d.model!, +d.year!));
+
+// DSV
+
+rawPromise = d3Fetch.dsv("|", url);
+rawPromise = d3Fetch.dsv("|", url, init);
+
+rawPromiseHeader = d3Fetch.dsv<Headers>("|", url);
+rawPromiseHeader = d3Fetch.dsv<Headers>("|", url, init);
+
+parsedPromise = d3Fetch.dsv<Car>("|", url, parseRowString);
+parsedPromise = d3Fetch.dsv<Car>("|", url, init, parseRowString);
+
+parsedPromise = d3Fetch.dsv<Car, Headers>("|", url, parseRow);
+parsedPromise = d3Fetch.dsv<Car, Headers>("|", url, init, parseRow);
+
+parsedPromise = d3Fetch.dsv("|", url, parseRow);
+parsedPromise = d3Fetch.dsv("|", url, init, parseRow);
+parsedPromise = d3Fetch.dsv("|", url, parseRowSimple);
+
+anyPromise = d3Fetch.dsv("|", url, (d: DSVRaw<Car>) => map.set(d.model!, +d.year!));
+
+// TSV
+
+rawPromise = d3Fetch.tsv(url);
+rawPromise = d3Fetch.tsv(url, init);
+
+rawPromiseHeader = d3Fetch.tsv<Headers>(url);
+rawPromiseHeader = d3Fetch.tsv<Headers>(url, init);
+
+parsedPromise = d3Fetch.tsv<Car>(url, parseRowString);
+parsedPromise = d3Fetch.tsv<Car>(url, init, parseRowString);
+
+parsedPromise = d3Fetch.tsv<Car, Headers>(url, parseRow);
+parsedPromise = d3Fetch.tsv<Car, Headers>(url, init, parseRow);
+
+parsedPromise = d3Fetch.tsv(url, parseRow);
+parsedPromise = d3Fetch.tsv(url, init, parseRow);
+parsedPromise = d3Fetch.tsv(url, parseRowSimple);
+
+anyPromise = d3Fetch.csv(url, (d: DSVRaw<Car>) => map.set(d.model!, +d.year!));

--- a/types/d3-fetch/v1/index.d.ts
+++ b/types/d3-fetch/v1/index.d.ts
@@ -1,0 +1,283 @@
+// Type definitions for d3-fetch 1.2
+// Project: https://d3js.org/d3-fetch/
+// Definitions by: Hugues Stefanski <https://github.com/ledragon>
+//                 denisname <https://github.com/denisname>
+//                 Nathan Bierema <https://github.com/Methuselah96>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+// Last module patch version validated against: 1.2.0
+
+import { DSVParsedArray, DSVRowArray, DSVRowString } from "d3-dsv";
+
+/**
+ * Fetches the binary file at the specified input URL and returns it as a Promise of a Blob.
+ * If init is specified, it is passed along to the underlying call to fetch.
+ *
+ * @param url A valid URL string.
+ * @param init An optional request initialization object.
+ */
+export function blob(url: string, init?: RequestInit): Promise<Blob>;
+
+/**
+ * Fetches the binary file at the specified input URL and returns it as a Promise of an ArrayBuffer.
+ * If init is specified, it is passed along to the underlying call to fetch.
+ *
+ * @param url A valid URL string.
+ * @param init An optional request initialization object.
+ */
+export function buffer(url: string, init?: RequestInit): Promise<ArrayBuffer>;
+
+/**
+ * Fetches the CSV file at the specified input URL and returns
+ * a promise of an array of objects representing the parsed rows. The values of the properties of the parsed row
+ * objects are represented as strings.
+ *
+ * If init is specified, it is passed along to the underlying call to fetch.
+ *
+ * The generic parameter describes the column names as a union of string literal types.
+ *
+ * @param url A valid URL string.
+ * @param init An optional request initialization object.
+ */
+export function csv<Columns extends string>(
+    url: string,
+    init?: RequestInit
+): Promise<DSVRowArray<Columns>>;
+/**
+ * Fetches the CSV file at the specified input URL and returns
+ * a promise of an array of objects representing the parsed rows.
+ *
+ * The specified row conversion function is used to map and filter row objects to a more-specific representation;
+ * see dsv.csvParse for details.
+ *
+ * The first generic parameter describes the type of the object representation of a parsed row.
+ * The second generic parameter describes the column names as a union of string literal types.
+ *
+ * @param url A valid URL string.
+ * @param row A row conversion function which is invoked for each row, being passed an object representing the current row (d),
+ * the index (i) starting at zero for the first non-header row, and the array of column names. If the returned value is null or undefined,
+ * the row is skipped and will be omitted from the array returned by dsv.csvParse; otherwise, the returned value defines the corresponding row object.
+ * In effect, row is similar to applying a map and filter operator to the returned rows.
+ */
+export function csv<ParsedRow extends object, Columns extends string = string>(
+    url: string,
+    row: (rawRow: DSVRowString<Columns>, index: number, columns: Columns[]) => ParsedRow | undefined | null
+): Promise<DSVParsedArray<ParsedRow>>;
+/**
+ * Fetches the CSV file at the specified input URL and returns
+ * a promise of an array of objects representing the parsed rows.
+ *
+ * The init object is passed along to the underlying call to fetch.
+ *
+ * The specified row conversion function is used to map and filter row objects to a more-specific representation;
+ * see dsv.csvParse for details.
+ *
+ * The first generic parameter describes the type of the object representation of a parsed row.
+ * The second generic parameter describes the column names as a union of string literal types.
+ *
+ * @param url A valid URL string.
+ * @param init An request initialization object.
+ * @param row A row conversion function which is invoked for each row, being passed an object representing the current row (d),
+ * the index (i) starting at zero for the first non-header row, and the array of column names. If the returned value is null or undefined,
+ * the row is skipped and will be omitted from the array returned by dsv.csvParse; otherwise, the returned value defines the corresponding row object.
+ * In effect, row is similar to applying a map and filter operator to the returned rows.
+ */
+export function csv<ParsedRow extends object, Columns extends string = string>(
+    url: string,
+    init: RequestInit,
+    row: (rawRow: DSVRowString<Columns>, index: number, columns: Columns[]) => ParsedRow | undefined | null
+): Promise<DSVParsedArray<ParsedRow>>;
+
+/**
+ * Fetches the DSV file with the specified delimiter character at the specified input URL and returns
+ * a promise of an array of objects representing the parsed rows. The values of the properties of the parsed row
+ * objects are represented as strings.
+ *
+ * If init is specified, it is passed along to the underlying call to fetch.
+ *
+ * The generic parameter describes the column names as a union of string literal types.
+ *
+ * @param delimiter The delimiter character used in the DSV file to be fetched.
+ * @param url A valid URL string.
+ * @param init An optional request initialization object.
+ */
+export function dsv<Columns extends string>(
+    delimiter: string,
+    url: string,
+    init?: RequestInit
+): Promise<DSVRowArray<Columns>>;
+/**
+ * Fetches the DSV file with the specified delimiter character at the specified input URL and returns
+ * a promise of an array of objects representing the parsed rows.
+ *
+ * The specified row conversion function is used to map and filter row objects to a more-specific representation;
+ * see dsv.parse for details.
+ *
+ * The first generic parameter describes the type of the object representation of a parsed row.
+ * The second generic parameter describes the column names as a union of string literal types.
+ *
+ * @param delimiter The delimiter character used in the DSV file to be fetched.
+ * @param url A valid URL string.
+ * @param row A row conversion function which is invoked for each row, being passed an object representing the current row (d),
+ * the index (i) starting at zero for the first non-header row, and the array of column names. If the returned value is null or undefined,
+ * the row is skipped and will be omitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
+ * In effect, row is similar to applying a map and filter operator to the returned rows.
+ */
+export function dsv<ParsedRow extends object, Columns extends string = string>(
+    delimiter: string,
+    url: string,
+    row: (rawRow: DSVRowString<Columns>, index: number, columns: Columns[]) => ParsedRow | undefined | null
+): Promise<DSVParsedArray<ParsedRow>>;
+/**
+ * Fetches the DSV file with the specified delimiter character at the specified input URL and returns
+ * a promise of an array of objects representing the parsed rows.
+ *
+ * The init object is passed along to the underlying call to fetch.
+ *
+ * The specified row conversion function is used to map and filter row objects to a more-specific representation;
+ * see dsv.parse for details.
+ *
+ * The first generic parameter describes the type of the object representation of a parsed row.
+ * The second generic parameter describes the column names as a union of string literal types.
+ *
+ * @param delimiter The delimiter character used in the DSV file to be fetched.
+ * @param url A valid URL string.
+ * @param init An request initialization object.
+ * @param row A row conversion function which is invoked for each row, being passed an object representing the current row (d),
+ * the index (i) starting at zero for the first non-header row, and the array of column names. If the returned value is null or undefined,
+ * the row is skipped and will be omitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
+ * In effect, row is similar to applying a map and filter operator to the returned rows.
+ */
+export function dsv<ParsedRow extends object, Columns extends string = string>(
+    delimiter: string,
+    url: string,
+    init: RequestInit,
+    row: (rawRow: DSVRowString<Columns>, index: number, columns: Columns[]) => ParsedRow | undefined | null
+): Promise<DSVParsedArray<ParsedRow>>;
+
+/**
+ * Fetches the file at the specified input URL as text, parses it as HTML and returns a Promise of an HTML DOM Document.
+ *
+ * If init is specified, it is passed along to the underlying call to fetch.
+ *
+ * @param url A valid URL string.
+ * @param init An optional request initialization object.
+ */
+export function html(url: string, init?: RequestInit): Promise<Document>;
+
+/**
+ * Fetches the image at the specified input URL and returns a promise of an HTML image element.
+ *
+ * If init is specified, sets any additional properties on the image before loading.
+ *
+ * @param url A valid URL string.
+ * @param init An optional object of image properties to set.
+ */
+export function image(url: string, init?: Partial<HTMLImageElement>): Promise<HTMLImageElement>;
+
+/**
+ * Fetches the json file at the specified input URL and returns it as a Promise of a parsed JSON object.
+ *
+ * If init is specified, it is passed along to the underlying call to fetch.
+ *
+ * If the server returns a status code of [204 No Content](https://developer.mozilla.org/docs/Web/HTTP/Status/204)
+ * or [205 Reset Content](https://developer.mozilla.org/docs/Web/HTTP/Status/205), the promise resolves to `undefined`.
+ *
+ * The generic parameter describes the type of the object parsed from the returned JSON.
+ *
+ * @param url A valid URL string.
+ * @param init An optional request initialization object.
+ */
+export function json<ParsedJSONObject extends any>(url: string, init?: RequestInit): Promise<ParsedJSONObject | undefined>;
+
+/**
+ * Fetches the file at the specified input URL as text, parses it as SVG and returns a Promise of an SVG Document.
+ *
+ * If init is specified, it is passed along to the underlying call to fetch.
+ *
+ * @param url A valid URL string.
+ * @param init An optional request initialization object.
+ */
+export function svg(url: string, init?: RequestInit): Promise<Document>;
+
+/**
+ * Fetches the text file at the specified input URL and returns it as a Promise of a string.
+ *
+ * If init is specified, it is passed along to the underlying call to fetch.
+ *
+ * @param url A valid URL string.
+ * @param init An optional request initialization object.
+ */
+export function text(url: string, init?: RequestInit): Promise<string>;
+
+/**
+ * Fetches the TSV file at the specified input URL and returns
+ * a promise of an array of objects representing the parsed rows.
+ *
+ * If init is specified, it is passed along to the underlying call to fetch.
+ *
+ * The generic parameter describes the column names as a union of string literal types.
+ *
+ * @param url A valid URL string.
+ * @param init An optional request initialization object.
+ */
+export function tsv<Columns extends string>(
+    url: string,
+    init?: RequestInit
+): Promise<DSVRowArray<Columns>>;
+/**
+ * Fetches the TSV file at the specified input URL and returns
+ * a promise of an array of objects representing the parsed rows. The values of the properties of the parsed row
+ * objects are represented as strings.
+ *
+ * The specified row conversion function is used to map and filter row objects to a more-specific representation;
+ * see dsv.tsvParse for details.
+ *
+ * The first generic parameter describes the type of the object representation of a parsed row.
+ * The second generic parameter describes the column names as a union of string literal types.
+ *
+ * @param url A valid URL string.
+ * @param row A row conversion function which is invoked for each row, being passed an object representing the current row (d),
+ * the index (i) starting at zero for the first non-header row, and the array of column names. If the returned value is null or undefined,
+ * the row is skipped and will be omitted from the array returned by dsv.tsvParse; otherwise, the returned value defines the corresponding row object.
+ * In effect, row is similar to applying a map and filter operator to the returned rows.
+ */
+export function tsv<ParsedRow extends object, Columns extends string = string>(
+    url: string,
+    row: (rawRow: DSVRowString<Columns>, index: number, columns: Columns[]) => ParsedRow | undefined | null
+): Promise<DSVParsedArray<ParsedRow>>;
+/**
+ * Fetches the TSV file at the specified input URL and returns
+ * a promise of an array of objects representing the parsed rows.
+ *
+ * The init object is passed along to the underlying call to fetch.
+ *
+ * The specified row conversion function is used to map and filter row objects to a more-specific representation;
+ * see dsv.tsvParse for details.
+ *
+ * The first generic parameter describes the type of the object representation of a parsed row.
+ * The second generic parameter describes the column names as a union of string literal types.
+ *
+ * @param url A valid URL string.
+ * @param init An request initialization object.
+ * @param row A row conversion function which is invoked for each row, being passed an object representing the current row (d),
+ * the index (i) starting at zero for the first non-header row, and the array of column names. If the returned value is null or undefined,
+ * the row is skipped and will be omitted from the array returned by dsv.tsvParse; otherwise, the returned value defines the corresponding row object.
+ * In effect, row is similar to applying a map and filter operator to the returned rows.
+ */
+export function tsv<ParsedRow extends object, Columns extends string = string>(
+    url: string,
+    init: RequestInit,
+    row: (rawRow: DSVRowString<Columns>, index: number, columns: Columns[]) => ParsedRow | undefined | null
+): Promise<DSVParsedArray<ParsedRow>>;
+
+/**
+ * Fetches the file at the specified input URL as text, parses it as XML and returns a Promise of an XML Document.
+ *
+ * If init is specified, it is passed along to the underlying call to fetch.
+ *
+ * @param url A valid URL string.
+ * @param init An optional request initialization object.
+ */
+export function xml(url: string, init?: RequestInit): Promise<XMLDocument>;

--- a/types/d3-fetch/v1/tsconfig.json
+++ b/types/d3-fetch/v1/tsconfig.json
@@ -9,10 +9,18 @@
         "noImplicitThis": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
-        "baseUrl": "../",
+        "baseUrl": "../../",
         "typeRoots": [
-            "../"
+            "../../"
         ],
+        "paths": {
+            "d3-dsv": [
+                "d3-dsv/v1"
+            ],
+            "d3-fetch": [
+                "d3-fetch/v1"
+            ]
+        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/d3-fetch/v1/tslint.json
+++ b/types/d3-fetch/v1/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-unnecessary-generics": false
+    }
+}

--- a/types/d3/tsconfig.json
+++ b/types/d3/tsconfig.json
@@ -44,6 +44,9 @@
             "d3-ease": [
                 "d3-ease/v1"
             ],
+            "d3-fetch": [
+                "d3-fetch/v1"
+            ],
             "d3-force": [
                 "d3-force/v1"
             ],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-fetch/releases/tag/v2.0.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Related: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/38939
