### PR TITLE
Fixed meteor:universe-i18n runWithLocale.

### DIFF
--- a/types/meteor-universe-i18n/index.d.ts
+++ b/types/meteor-universe-i18n/index.d.ts
@@ -55,7 +55,7 @@ declare module 'meteor/universe:i18n' {
         // executes function in the locale context,
         // it means that every default locale used inside a called function will be set to a passed locale
         // keep in mind that locale must be loaded first (if it is not bundled)
-        function runWithLocale(locale: string, func: (...keys: any[]) => void): void;
+        function runWithLocale<T>(locale: string, func: () => T): T;
 
         // language getters
         let _locales: Readonly<{ [locale: string]: Readonly<i18nLocaleEntry> }>;

--- a/types/meteor-universe-i18n/meteor-universe-i18n-tests.ts
+++ b/types/meteor-universe-i18n/meteor-universe-i18n-tests.ts
@@ -107,3 +107,6 @@ i18n.normalize('en');
 i18n.onChangeLocale((newLocale: string) => {
     console.log(newLocale);
 });
+
+// $ExpectType number
+i18n.runWithLocale('de-CH', () => 1);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/vazco/meteor-universe-i18n/blob/77899915ddbbaec96d8d7358b92c7d1a39acfb6e/lib/i18n.js#L51-L58
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

I couldn't run the tests nor linter because of the `Cannot find module 'csstype'` error.