### PR TITLE
Fix typo in definition of papaparse

### DIFF
--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -32,7 +32,7 @@ export function unparse(data: object[] | any[][] | UnparseObject, config?: Unpar
  * Read-Only Properties
  */
 // An array of characters that are not allowed as delimiters.
-export const BAD_DELIMETERS: string[];
+export const BAD_DELIMITERS: string[];
 
 // The true delimiter. Invisible. ASCII code 30. Should be doing the job we strangely rely upon commas and tabs for.
 export type RECORD_SEP_TYPE = '';

--- a/types/papaparse/papaparse-tests.ts
+++ b/types/papaparse/papaparse-tests.ts
@@ -139,6 +139,7 @@ Papa.unparse(
  */
 Papa.SCRIPT_PATH;
 Papa.LocalChunkSize;
+Papa.BAD_DELIMITERS;
 
 /**
  * Parser


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.papaparse.com/docs#readonly or https://github.com/mholt/PapaParse/blob/master/papaparse.js#L67
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

