### PR TITLE
update axios version used by moxios types

### DIFF
--- a/types/moxios/package.json
+++ b/types/moxios/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "axios": "^0.19.0"
+        "axios": "^0.20.0"
     }
 }


### PR DESCRIPTION
Increases the axios version to account for `purge` being added to the `Method` [](https://github.com/axios/axios/blob/b7e954eba3911874575ed241ec2ec38ff8af21bb/index.d.ts#L24-L34). Without this change `moxios.install(axios.create)` will fails with incompatible types for method.