### PR TITLE
fix(copyfiles): correct `exclude` option and version bump

### DIFF
--- a/types/copyfiles/copyfiles-tests.ts
+++ b/types/copyfiles/copyfiles-tests.ts
@@ -6,3 +6,11 @@ copyfiles(['file'], { up: true, follow: true }, error => {});
 copyfiles(['file'], { up: 1 }, error => {});
 copyfiles(['file'], { all: true }, error => {});
 copyfiles(['file'], 10, error => {});
+copyfiles(
+    ['input/*.txt', 'output'],
+    {
+        // exclude is mapped into glob's `ignore`
+        exclude: ['**/*.js.txt', '**/*.ps.txt'],
+    },
+    err => {},
+);

--- a/types/copyfiles/index.d.ts
+++ b/types/copyfiles/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for copyfiles 2.2
+// Type definitions for copyfiles 2.4
 // Project: https://github.com/calvinmetcalf/copyfiles#readme
 // Definitions by: Florian Keller <https://github.com/ffflorian>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
@@ -11,7 +11,7 @@ declare namespace copyfiles {
         /** throw error if nothing is copied */
         error?: boolean;
         /** pattern or glob to exclude */
-        exclude?: string;
+        exclude?: string | ReadonlyArray<string>;
         /** flatten the output */
         flat?: boolean;
         /**


### PR DESCRIPTION
- `exclude` option is being mapped into `ignore`, which allows
  array of patterns:
  https://github.com/calvinmetcalf/copyfiles/blob/master/test/test.fromNode.js#L75
  https://github.com/isaacs/node-glob#options
- test amended
- minor version (non-breaking) bump:

https://github.com/calvinmetcalf/copyfiles/compare/v2.2.0...v2.4.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)