### PR TITLE
`unsplash-js`: improve types with stricter types

### DIFF
--- a/types/unsplash-js/index.d.ts
+++ b/types/unsplash-js/index.d.ts
@@ -7,14 +7,18 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-type PhotoOrderBy = 'latest' | 'oldest'
-type Orientation = 'portrait' | 'landscape' | 'squareish'
-type ContentSafety = 'high' | 'low'
-type CollectionIds = ReadonlyArray<number> | ReadonlyArray<string>
-type Scopes = 'public' | 'read_user' | 'write_user' | 'read_photos' | 'write_photos' | 'write_likes' | 'write_followers' | 'read_collections' | 'write_collections'
+export type PhotoOrderBy = 'latest' | 'oldest';
+export type Orientation = 'portrait' | 'landscape' | 'squareish';
+export type ContentSafety = 'high' | 'low';
+export type CollectionIds = ReadonlyArray<number> | ReadonlyArray<string>;
+export type Scopes = 'public' | 'read_user' | 'write_user' | 'read_photos' | 'write_photos' | 'write_likes' | 'write_followers' | 'read_collections' | 'write_collections';
 
 // Supported ISO-639-1 languages
-type Languages = 'af' | 'am' | 'ar' | 'az' | 'be' | 'bg' | 'bn' | 'bs' | 'ca' | 'ceb' | 'co' | 'cs' | 'cy' | 'da' | 'de' | 'el' | 'en' | 'eo' | 'es' | 'et' | 'eu' | 'fa' | 'fi' | 'fr' | 'fy' | 'ga' | 'gd' | 'gl' | 'gu' | 'ha' | 'haw' | 'hi' | 'hmn' | 'hr' | 'ht' | 'hu' | 'hy' | 'id' | 'ig' | 'is' | 'it' | 'iw' | 'ja' | 'jw' | 'ka' | 'kk' | 'km' | 'kn' | 'ko' | 'ku' | 'ky' | 'la' | 'lb' | 'lo' | 'lt' | 'lv' | 'mg' | 'mi' | 'mk' | 'ml' | 'mn' | 'mr' | 'ms' | 'mt' | 'my' | 'ne' | 'nl' | 'no' | 'ny' | 'or' | 'pa' | 'pl' | 'ps' | 'pt' | 'ro' | 'ru' | 'rw' | 'sd' | 'si' | 'sk' | 'sl' | 'sm' | 'sn' | 'so' | 'sq' | 'sr' | 'st' | 'su' | 'sv' | 'sw' | 'ta' | 'te' | 'tg' | 'th' | 'tk' | 'tl' | 'tr' | 'tt' | 'ug' | 'uk' | 'ur' | 'uz' | 'vi' | 'xh' | 'yi' | 'yo' | 'zh' | 'zh-TW' | 'zu'
+export type Languages = 'af' | 'am' | 'ar' | 'az' | 'be' | 'bg' | 'bn' | 'bs' | 'ca' | 'ceb' | 'co' | 'cs' | 'cy' | 'da' | 'de' | 'el' | 'en' | 'eo' | 'es' | 'et' | 'eu' | 'fa' | 'fi' | 'fr' | 'fy'
+    | 'ga' | 'gd' | 'gl' | 'gu' | 'ha' | 'haw' | 'hi' | 'hmn' | 'hr' | 'ht' | 'hu' | 'hy' | 'id' | 'ig' | 'is' | 'it' | 'iw' | 'ja' | 'jw' | 'ka' | 'kk' | 'km' | 'kn' | 'ko' | 'ku' | 'ky' | 'la'
+    | 'lb' | 'lo' | 'lt' | 'lv' | 'mg' | 'mi' | 'mk' | 'ml' | 'mn' | 'mr' | 'ms' | 'mt' | 'my' | 'ne' | 'nl' | 'no' | 'ny' | 'or' | 'pa' | 'pl' | 'ps' | 'pt' | 'ro' | 'ru' | 'rw' | 'sd' | 'si'
+    | 'sk' | 'sl' | 'sm' | 'sn' | 'so' | 'sq' | 'sr' | 'st' | 'su' | 'sv' | 'sw' | 'ta' | 'te' | 'tg' | 'th' | 'tk' | 'tl' | 'tr' | 'tt' | 'ug' | 'uk' | 'ur' | 'uz' | 'vi' | 'xh' | 'yi' | 'yo'
+    | 'zh' | 'zh-TW' | 'zu';
 
 export default class Unsplash {
     auth: UnsplashApi.Auth;

--- a/types/unsplash-js/index.d.ts
+++ b/types/unsplash-js/index.d.ts
@@ -10,7 +10,7 @@
 export type PhotoOrderBy = 'latest' | 'oldest';
 export type Orientation = 'portrait' | 'landscape' | 'squareish';
 export type ContentSafety = 'high' | 'low';
-export type CollectionIds = ReadonlyArray<number> | ReadonlyArray<string>;
+export type CollectionIds = ReadonlyArray<number | string>;
 export type Scopes = 'public' | 'read_user' | 'write_user' | 'read_photos' | 'write_photos' | 'write_likes' | 'write_followers' | 'read_collections' | 'write_collections';
 
 // Supported ISO-639-1 languages

--- a/types/unsplash-js/index.d.ts
+++ b/types/unsplash-js/index.d.ts
@@ -7,6 +7,15 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
+type PhotoOrderBy = 'latest' | 'oldest'
+type Orientation = 'portrait' | 'landscape' | 'squareish'
+type ContentSafety = 'high' | 'low'
+type CollectionIds = ReadonlyArray<number> | ReadonlyArray<string>
+type Scopes = 'public' | 'read_user' | 'write_user' | 'read_photos' | 'write_photos' | 'write_likes' | 'write_followers' | 'read_collections' | 'write_collections'
+
+// Supported ISO-639-1 languages
+type Languages = 'af' | 'am' | 'ar' | 'az' | 'be' | 'bg' | 'bn' | 'bs' | 'ca' | 'ceb' | 'co' | 'cs' | 'cy' | 'da' | 'de' | 'el' | 'en' | 'eo' | 'es' | 'et' | 'eu' | 'fa' | 'fi' | 'fr' | 'fy' | 'ga' | 'gd' | 'gl' | 'gu' | 'ha' | 'haw' | 'hi' | 'hmn' | 'hr' | 'ht' | 'hu' | 'hy' | 'id' | 'ig' | 'is' | 'it' | 'iw' | 'ja' | 'jw' | 'ka' | 'kk' | 'km' | 'kn' | 'ko' | 'ku' | 'ky' | 'la' | 'lb' | 'lo' | 'lt' | 'lv' | 'mg' | 'mi' | 'mk' | 'ml' | 'mn' | 'mr' | 'ms' | 'mt' | 'my' | 'ne' | 'nl' | 'no' | 'ny' | 'or' | 'pa' | 'pl' | 'ps' | 'pt' | 'ro' | 'ru' | 'rw' | 'sd' | 'si' | 'sk' | 'sl' | 'sm' | 'sn' | 'so' | 'sq' | 'sr' | 'st' | 'su' | 'sv' | 'sw' | 'ta' | 'te' | 'tg' | 'th' | 'tk' | 'tl' | 'tr' | 'tt' | 'ug' | 'uk' | 'ur' | 'uz' | 'vi' | 'xh' | 'yi' | 'yo' | 'zh' | 'zh-TW' | 'zu'
+
 export default class Unsplash {
     auth: UnsplashApi.Auth;
     collections: UnsplashApi.Collections;
@@ -41,7 +50,7 @@ export function toJson(response: any): any;
 
 export namespace UnsplashApi {
     interface Photo {
-        listPhotos(page?: number, perPage?: number, orderBy?: string): Promise<Response>;
+        listPhotos(page?: number, perPage?: number, orderBy?: PhotoOrderBy): Promise<Response>;
 
         getPhoto(id: string): Promise<Response>;
 
@@ -51,8 +60,9 @@ export namespace UnsplashApi {
             query?: string;
             username?: string;
             featured?: boolean;
-            orientation?: string;
-            collections?: ReadonlyArray<string>;
+            orientation?: Orientation;
+            c?: string;
+            collections?: CollectionIds;
             count?: number;
         }): Promise<Response>;
 
@@ -68,11 +78,13 @@ export namespace UnsplashApi {
     }
 
     interface Collections {
-        listCollections(page?: number, perPage?: number, orderBy?: string): Promise<Response>;
+        listCollections(page?: number, perPage?: number): Promise<Response>;
 
         getCollection(id: number): Promise<Response>;
 
-        getCollectionPhotos(id: number, page?: number, perPage?: number, orderBy?: string): Promise<Response>;
+        getCollectionPhotos(id: number, page?: number, perPage?: number, orderBy?: PhotoOrderBy, options?: {
+            orientation?: Orientation
+        }): Promise<Response>;
 
         createCollection(title: string, description?: string, isPrivate?: boolean): Promise<Response>;
 
@@ -93,12 +105,12 @@ export namespace UnsplashApi {
             page?: number,
             perPage?: number,
             filters?: {
-                orientation?: string;
-                contentFilter?: string;
-                color?: string;
-                orderBy?: string;
-                lang?: string;
-                collections?: ReadonlyArray<string>
+                orientation?: Orientation;
+                contentFilter?: ContentSafety;
+                color?: 'black_and_white' | 'black' | 'white' | 'yellow' | 'orange' | 'red' | 'purple' | 'magenta' | 'green' | 'teal' | 'blue';
+                orderBy?: 'latest' | 'relevant';
+                lang?: Languages;
+                collections?: CollectionIds
             }
         ): Promise<Response>;
 
@@ -129,17 +141,22 @@ export namespace UnsplashApi {
     interface Users {
         profile(username: string): Promise<Response>;
 
-        photos(username: string, page?: number, perPage?: number, orderBy?: string, stats?: boolean): Promise<Response>;
+        photos(username: string, page?: number, perPage?: number, orderBy?: PhotoOrderBy, options?: {
+            stats?: boolean,
+            orientation?: Orientation
+        }): Promise<Response>;
 
-        likes(username: string, page?: number, perPage?: number, orderBy?: string): Promise<Response>;
+        likes(username: string, page?: number, perPage?: number, orderBy?: PhotoOrderBy, options?: {
+            orientation: Orientation,
+        }): Promise<Response>;
 
         collections(username: string, page?: number, perPage?: number, orderBy?: string): Promise<Response>;
 
-        statistics(username: string, resolution?: string, quantity?: number): Promise<Response>;
+        statistics(username: string, resolution?: 'days', quantity?: number): Promise<Response>;
     }
 
     interface Auth {
-        getAuthenticationUrl(scopes?: ReadonlyArray<string>): string;
+        getAuthenticationUrl(scopes?: Scopes[]): string;
 
         userAuthentication(code: string): Promise<Response>;
 

--- a/types/unsplash-js/unsplash-js-tests.ts
+++ b/types/unsplash-js/unsplash-js-tests.ts
@@ -11,6 +11,10 @@ const authenticationUrl = unsplash.auth.getAuthenticationUrl([
     'write_user',
     'read_photos',
     'write_photos',
+    'write_likes',
+    'write_followers',
+    'read_collections',
+    'write_collections'
 ]);
 
 unsplash.auth
@@ -37,9 +41,12 @@ unsplash.users.profile('naoufal');
 
 unsplash.users.statistics('naoufal', 'days', 30);
 
-unsplash.users.photos('naoufal', 1, 10, 'popular', false);
+unsplash.users.photos('naoufal', 1, 10, 'latest', {
+    orientation: 'landscape',
+    stats: true
+});
 
-unsplash.users.likes('naoufal', 2, 15, 'popular');
+unsplash.users.likes('naoufal', 2, 15, 'latest', { orientation: 'landscape' });
 
 unsplash.users.collections('naoufal', 2, 15, 'updated');
 
@@ -63,11 +70,11 @@ unsplash.photos
         unsplash.photos.trackDownload(json);
     });
 
-unsplash.collections.listCollections(1, 10, 'popular');
+unsplash.collections.listCollections(1, 10);
 
 unsplash.collections.getCollection(123456);
 
-unsplash.collections.getCollectionPhotos(123456, 1, 10, 'popular');
+unsplash.collections.getCollectionPhotos(123456, 1, 10, 'latest', { orientation: 'landscape' });
 
 unsplash.collections.createCollection('Birds', "Wild birds from 'round the world", true);
 
@@ -82,12 +89,12 @@ unsplash.collections.removePhotoFromCollection(88, 'abc1234');
 unsplash.collections.listRelatedCollections(88);
 
 unsplash.search.photos('dogs', 1, 0, {
-    orientation: 'foo',
-    contentFilter: 'foo',
-    color: 'foo',
-    orderBy: 'foo',
-    lang: 'foo',
-    collections: ['foo'],
+    orientation: 'landscape',
+    contentFilter: 'low',
+    color: 'black',
+    orderBy: 'latest',
+    lang: 'en',
+    collections: [1, 2],
 });
 
 unsplash.search.users('steve', 1);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Changelog](https://github.com/unsplash/unsplash-js/blob/master/CHANGELOG.md#620) and [API docs](https://unsplash.com/documentation)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.