### PR TITLE
ffluent-ffmpeg: Added cwd to FfmpegCommandOptions

### DIFF
--- a/types/fluent-ffmpeg/fluent-ffmpeg-tests.ts
+++ b/types/fluent-ffmpeg/fluent-ffmpeg-tests.ts
@@ -3,6 +3,10 @@ import { createWriteStream } from 'fs';
 
 const stream = createWriteStream('outputfile.divx');
 
+// Set the CWD
+ffmpeg('file.avi', { cwd: '/path/to' })
+    .output('ouptutfile.mp4');
+
 ffmpeg('/path/to/file.avi')
     .output('outputfile.mp4')
     .output(stream);

--- a/types/fluent-ffmpeg/index.d.ts
+++ b/types/fluent-ffmpeg/index.d.ts
@@ -29,6 +29,7 @@ declare namespace Ffmpeg {
         stdoutLines?: number;
         timeout?: number;
         source?: string | stream.Readable;
+        cwd?: string;
     }
 
     interface FilterSpecification {


### PR DESCRIPTION
# Overview
`fluent-ffmpeg` added support for the `cwd` parameter in the the options object that can be passed to `ffmpeg()`, represented by the `FfmpegCommandOptions` type back in 2015 (see [url](https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/pull/443)). This change just adds that parameter to bring the type closer to the actual supported parameter set.

# Template

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/pull/443
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

