### PR TITLE
[React-Select] Changing Option type definition back to mutable arrays

### DIFF
--- a/types/react-select/src/types.d.ts
+++ b/types/react-select/src/types.d.ts
@@ -5,14 +5,14 @@ export interface OptionTypeBase {
   [key: string]: any;
 }
 
-export type OptionsType<OptionType extends OptionTypeBase> = ReadonlyArray<OptionType>;
+export type OptionsType<OptionType extends OptionTypeBase> = OptionType[];
 
 export interface GroupType<OptionType extends OptionTypeBase> {
   options: OptionsType<OptionType>;
   [key: string]: any;
 }
 
-export type GroupedOptionsType<OptionType extends OptionTypeBase> = ReadonlyArray<GroupType<OptionType>>;
+export type GroupedOptionsType<OptionType extends OptionTypeBase> = Array<GroupType<OptionType>>;
 
 export type ValueType<OptionType extends OptionTypeBase> = OptionType | OptionsType<OptionType> | null | undefined;
 

--- a/types/react-select/test/data.ts
+++ b/types/react-select/test/data.ts
@@ -7,7 +7,7 @@ export interface ColourOption {
     disabled?: boolean;
 }
 
-export const colourOptions: ReadonlyArray<ColourOption> = [
+export const colourOptions: ColourOption[] = [
   { value: 'ocean', label: 'Ocean', color: '#00B8D9' },
   { value: 'blue', label: 'Blue', color: '#0052CC', disabled: true },
   { value: 'purple', label: 'Purple', color: '#5243AA' },


### PR DESCRIPTION
Please consult my explanation for this change here: https://github.com/Blackglade/DefinitelyTyped/issues/1

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Blackglade/DefinitelyTyped/issues/1
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.