### PR TITLE
[node] Update `worker_threads` module

### DIFF
--- a/types/node/test/worker_threads.ts
+++ b/types/node/test/worker_threads.ts
@@ -2,6 +2,7 @@ import * as workerThreads from "worker_threads";
 import assert = require("assert");
 import { createContext } from "vm";
 import { Readable } from "stream";
+import * as fs from "fs";
 
 {
     if (workerThreads.isMainThread) {
@@ -80,4 +81,26 @@ import { Readable } from "stream";
     const wwwww = new workerThreads.Worker(__filename, {
       trackUnmanagedFds: true
     });
+}
+
+{
+    const pooledBuffer = new ArrayBuffer(8);
+    const typedArray1 = new Uint8Array(pooledBuffer);
+    const typedArray2 = new Float64Array(pooledBuffer);
+
+    workerThreads.markAsUntransferable(pooledBuffer);
+
+    const { port1 } = new MessageChannel();
+    port1.postMessage(typedArray1, [ typedArray1.buffer ]);
+
+    console.log(typedArray1);
+    console.log(typedArray2);
+}
+
+{
+    (async () => {
+        const fileHandle = await fs.promises.open("thefile.txt", "r");
+        const worker = new workerThreads.Worker(__filename);
+        worker.postMessage("some message", [ fileHandle ]);
+    })();
 }

--- a/types/node/v12/worker_threads.d.ts
+++ b/types/node/v12/worker_threads.d.ts
@@ -5,6 +5,7 @@ declare module "worker_threads" {
 
     const isMainThread: boolean;
     const parentPort: null | MessagePort;
+    const resourceLimits: ResourceLimits;
     const SHARE_ENV: unique symbol;
     const threadId: number;
     const workerData: any;
@@ -62,6 +63,26 @@ declare module "worker_threads" {
         stdout?: boolean;
         stderr?: boolean;
         execArgv?: string[];
+        resourceLimits?: ResourceLimits;
+        /**
+         * Additional data to send in the first worker message.
+         */
+        transferList?: Array<ArrayBuffer | MessagePort>;
+    }
+
+    interface ResourceLimits {
+        /**
+         * The maximum size of a heap space for recently created objects.
+         */
+        maxYoungGenerationSizeMb?: number;
+        /**
+         * The maximum size of the main heap in MB.
+         */
+        maxOldGenerationSizeMb?: number;
+        /**
+         * The size of a pre-allocated memory range used for generated code.
+         */
+        codeRangeSizeMb?: number;
     }
 
     class Worker extends EventEmitter {

--- a/types/node/v12/worker_threads.d.ts
+++ b/types/node/v12/worker_threads.d.ts
@@ -15,9 +15,11 @@ declare module "worker_threads" {
         readonly port2: MessagePort;
     }
 
+    type TransferListItem = ArrayBuffer | MessagePort;
+
     class MessagePort extends EventEmitter {
         close(): void;
-        postMessage(value: any, transferList?: Array<ArrayBuffer | MessagePort>): void;
+        postMessage(value: any, transferList?: TransferListItem[]): void;
         ref(): void;
         unref(): void;
         start(): void;
@@ -67,7 +69,7 @@ declare module "worker_threads" {
         /**
          * Additional data to send in the first worker message.
          */
-        transferList?: Array<ArrayBuffer | MessagePort>;
+        transferList?: TransferListItem[];
     }
 
     interface ResourceLimits {
@@ -93,7 +95,7 @@ declare module "worker_threads" {
 
         constructor(filename: string, options?: WorkerOptions);
 
-        postMessage(value: any, transferList?: Array<ArrayBuffer | MessagePort>): void;
+        postMessage(value: any, transferList?: TransferListItem[]): void;
         ref(): void;
         unref(): void;
         /**

--- a/types/node/v13/worker_threads.d.ts
+++ b/types/node/v13/worker_threads.d.ts
@@ -6,6 +6,7 @@ declare module "worker_threads" {
 
     const isMainThread: boolean;
     const parentPort: null | MessagePort;
+    const resourceLimits: ResourceLimits;
     const SHARE_ENV: unique symbol;
     const threadId: number;
     const workerData: any;
@@ -80,6 +81,21 @@ declare module "worker_threads" {
     interface ResourceLimits {
         maxYoungGenerationSizeMb?: number;
         maxOldGenerationSizeMb?: number;
+        codeRangeSizeMb?: number;
+    }
+
+    interface ResourceLimits {
+        /**
+         * The maximum size of a heap space for recently created objects.
+         */
+        maxYoungGenerationSizeMb?: number;
+        /**
+         * The maximum size of the main heap in MB.
+         */
+        maxOldGenerationSizeMb?: number;
+        /**
+         * The size of a pre-allocated memory range used for generated code.
+         */
         codeRangeSizeMb?: number;
     }
 

--- a/types/node/v13/worker_threads.d.ts
+++ b/types/node/v13/worker_threads.d.ts
@@ -16,9 +16,11 @@ declare module "worker_threads" {
         readonly port2: MessagePort;
     }
 
+    type TransferListItem = ArrayBuffer | MessagePort;
+
     class MessagePort extends EventEmitter {
         close(): void;
-        postMessage(value: any, transferList?: Array<ArrayBuffer | MessagePort>): void;
+        postMessage(value: any, transferList?: TransferListItem[]): void;
         ref(): void;
         unref(): void;
         start(): void;
@@ -75,7 +77,7 @@ declare module "worker_threads" {
         /**
          * Additional data to send in the first worker message.
          */
-        transferList?: Array<ArrayBuffer | MessagePort>;
+        transferList?: TransferListItem[];
     }
 
     interface ResourceLimits {
@@ -113,7 +115,7 @@ declare module "worker_threads" {
          */
         constructor(filename: string | URL, options?: WorkerOptions);
 
-        postMessage(value: any, transferList?: Array<ArrayBuffer | MessagePort>): void;
+        postMessage(value: any, transferList?: TransferListItem[]): void;
         ref(): void;
         unref(): void;
         /**

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -86,7 +86,7 @@ declare module "worker_threads" {
         /**
          * Additional data to send in the first worker message.
          */
-        transferList?: Array<ArrayBuffer | MessagePort>;
+        transferList?: TransferListItem[];
         trackUnmanagedFds?: boolean;
     }
 

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -3,9 +3,11 @@ declare module "worker_threads" {
     import { EventEmitter } from "events";
     import { Readable, Writable } from "stream";
     import { URL } from "url";
+    import { FileHandle } from "fs/promises";
 
     const isMainThread: boolean;
     const parentPort: null | MessagePort;
+    const resourceLimits: ResourceLimits;
     const SHARE_ENV: unique symbol;
     const threadId: number;
     const workerData: any;
@@ -15,43 +17,53 @@ declare module "worker_threads" {
         readonly port2: MessagePort;
     }
 
+    type TransferListItem = ArrayBuffer | MessagePort | FileHandle;
+
     class MessagePort extends EventEmitter {
         close(): void;
-        postMessage(value: any, transferList?: Array<ArrayBuffer | MessagePort>): void;
+        postMessage(value: any, transferList?: TransferListItem[]): void;
         ref(): void;
         unref(): void;
         start(): void;
 
         addListener(event: "close", listener: () => void): this;
         addListener(event: "message", listener: (value: any) => void): this;
+        addListener(event: "messageerror", listener: (error: Error) => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
         emit(event: "close"): boolean;
         emit(event: "message", value: any): boolean;
+        emit(event: "messageerror", error: Error): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
 
         on(event: "close", listener: () => void): this;
         on(event: "message", listener: (value: any) => void): this;
+        on(event: "messageerror", listener: (error: Error) => void): this;
         on(event: string | symbol, listener: (...args: any[]) => void): this;
 
         once(event: "close", listener: () => void): this;
         once(event: "message", listener: (value: any) => void): this;
+        once(event: "messageerror", listener: (error: Error) => void): this;
         once(event: string | symbol, listener: (...args: any[]) => void): this;
 
         prependListener(event: "close", listener: () => void): this;
         prependListener(event: "message", listener: (value: any) => void): this;
+        prependListener(event: "messageerror", listener: (error: Error) => void): this;
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
         prependOnceListener(event: "close", listener: () => void): this;
         prependOnceListener(event: "message", listener: (value: any) => void): this;
+        prependOnceListener(event: "messageerror", listener: (error: Error) => void): this;
         prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
         removeListener(event: "close", listener: () => void): this;
         removeListener(event: "message", listener: (value: any) => void): this;
+        removeListener(event: "messageerror", listener: (error: Error) => void): this;
         removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
         off(event: "close", listener: () => void): this;
         off(event: "message", listener: (value: any) => void): this;
+        off(event: "messageerror", listener: (error: Error) => void): this;
         off(event: string | symbol, listener: (...args: any[]) => void): this;
     }
 
@@ -79,9 +91,23 @@ declare module "worker_threads" {
     }
 
     interface ResourceLimits {
+        /**
+         * The maximum size of a heap space for recently created objects.
+         */
         maxYoungGenerationSizeMb?: number;
+        /**
+         * The maximum size of the main heap in MB.
+         */
         maxOldGenerationSizeMb?: number;
+        /**
+         * The size of a pre-allocated memory range used for generated code.
+         */
         codeRangeSizeMb?: number;
+        /**
+         * The default maximum stack size for the thread. Small values may lead to unusable Worker instances.
+         * @default 4
+         */
+        stackSizeMb?: number;
     }
 
     class Worker extends EventEmitter {
@@ -98,7 +124,7 @@ declare module "worker_threads" {
          */
         constructor(filename: string | URL, options?: WorkerOptions);
 
-        postMessage(value: any, transferList?: Array<ArrayBuffer | MessagePort>): void;
+        postMessage(value: any, transferList?: TransferListItem[]): void;
         ref(): void;
         unref(): void;
         /**
@@ -120,51 +146,71 @@ declare module "worker_threads" {
         addListener(event: "error", listener: (err: Error) => void): this;
         addListener(event: "exit", listener: (exitCode: number) => void): this;
         addListener(event: "message", listener: (value: any) => void): this;
+        addListener(event: "messageerror", listener: (error: Error) => void): this;
         addListener(event: "online", listener: () => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
         emit(event: "error", err: Error): boolean;
         emit(event: "exit", exitCode: number): boolean;
         emit(event: "message", value: any): boolean;
+        emit(event: "messageerror", error: Error): boolean;
         emit(event: "online"): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
 
         on(event: "error", listener: (err: Error) => void): this;
         on(event: "exit", listener: (exitCode: number) => void): this;
         on(event: "message", listener: (value: any) => void): this;
+        on(event: "messageerror", listener: (error: Error) => void): this;
         on(event: "online", listener: () => void): this;
         on(event: string | symbol, listener: (...args: any[]) => void): this;
 
         once(event: "error", listener: (err: Error) => void): this;
         once(event: "exit", listener: (exitCode: number) => void): this;
         once(event: "message", listener: (value: any) => void): this;
+        once(event: "messageerror", listener: (error: Error) => void): this;
         once(event: "online", listener: () => void): this;
         once(event: string | symbol, listener: (...args: any[]) => void): this;
 
         prependListener(event: "error", listener: (err: Error) => void): this;
         prependListener(event: "exit", listener: (exitCode: number) => void): this;
         prependListener(event: "message", listener: (value: any) => void): this;
+        prependListener(event: "messageerror", listener: (error: Error) => void): this;
         prependListener(event: "online", listener: () => void): this;
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
         prependOnceListener(event: "error", listener: (err: Error) => void): this;
         prependOnceListener(event: "exit", listener: (exitCode: number) => void): this;
         prependOnceListener(event: "message", listener: (value: any) => void): this;
+        prependOnceListener(event: "messageerror", listener: (error: Error) => void): this;
         prependOnceListener(event: "online", listener: () => void): this;
         prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
         removeListener(event: "error", listener: (err: Error) => void): this;
         removeListener(event: "exit", listener: (exitCode: number) => void): this;
         removeListener(event: "message", listener: (value: any) => void): this;
+        removeListener(event: "messageerror", listener: (error: Error) => void): this;
         removeListener(event: "online", listener: () => void): this;
         removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
         off(event: "error", listener: (err: Error) => void): this;
         off(event: "exit", listener: (exitCode: number) => void): this;
         off(event: "message", listener: (value: any) => void): this;
+        off(event: "messageerror", listener: (error: Error) => void): this;
         off(event: "online", listener: () => void): this;
         off(event: string | symbol, listener: (...args: any[]) => void): this;
     }
+
+    /**
+     * Mark an object as not transferable.
+     * If `object` occurs in the transfer list of a `port.postMessage()` call, it will be ignored.
+     *
+     * In particular, this makes sense for objects that can be cloned, rather than transferred,
+     * and which are used by other objects on the sending side. For example, Node.js marks
+     * the `ArrayBuffer`s it uses for its Buffer pool with this.
+     *
+     * This operation cannot be undone.
+     */
+    function markAsUntransferable(object: object): void;
 
     /**
      * Transfer a `MessagePort` to a different `vm` Context. The original `port`


### PR DESCRIPTION
Docs: https://nodejs.org/docs/latest/api/worker_threads.html

https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V14.md#14.5.0

- Event 'messageerror' was added - https://github.com/nodejs/node/pull/33772
- `FileHandle` was added to the list of transferable types in `postMessage` - https://github.com/nodejs/node/pull/33772
- `worker.markAsUntransferable` was added  - https://github.com/nodejs/node/pull/33979

https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V13.md#13.2.0

- allow specifying resource limits - https://github.com/nodejs/node/pull/26628

https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#12.16.0

- allow specifying resource limits - https://github.com/nodejs/node/pull/26628