### PR TITLE
[properties-reader] Add missing optinal parameters types

### DIFF
--- a/types/properties-reader/index.d.ts
+++ b/types/properties-reader/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for properties-reader 0.0
+// Type definitions for properties-reader 2.1.1
 // Project: https://github.com/steveukx/properties
 // Definitions by: Zlatko Andonovski <https://github.com/Goldsmith42>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -22,8 +22,24 @@ declare namespace PropertiesReader {
         getByRoot(root: any): { [key: string]: Value; };
         bindToExpress(app: object, basePath?: string, makePaths?: boolean): Reader;
     }
+
+    interface AppenderOptions {
+        allowDuplicateSections: boolean;
+    }
+    interface WriterOptions {
+        saveSections: boolean;
+    }
+
+    interface FullOptions {
+        appender?: AppenderOptions;
+        writer?: WriterOptions;
+    }
 }
 
-declare function PropertiesReader(path: string): PropertiesReader.Reader;
+declare function PropertiesReader(
+    path: string,
+    encoding?: string,
+    options?: PropertiesReader.AppenderOptions | PropertiesReader.WriterOptions | PropertiesReader.FullOptions,
+): PropertiesReader.Reader;
 
 export = PropertiesReader;

--- a/types/properties-reader/index.d.ts
+++ b/types/properties-reader/index.d.ts
@@ -4,11 +4,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace PropertiesReader {
-    type Value = string|number|boolean;
+    type Value = string | number | boolean;
 
     interface Reader {
-        get(propertyName: string): Value|null;
-        getRaw(propertyName: string): string|null;
+        get(propertyName: string): Value | null;
+        getRaw(propertyName: string): string | null;
         path(): {};
         append(path: string): Reader;
         read(properties: string): Reader;
@@ -16,10 +16,10 @@ declare namespace PropertiesReader {
         length: number;
         each(iterator: (key: string, value: Value) => void): Reader;
         each<T>(iterator: (this: T, key: string, value: Value) => void, scope: T): Reader;
-        getAllProperties(): { [key: string]: Value; };
+        getAllProperties(): { [key: string]: Value };
         clone(): Reader;
         save(destFile: string, onComplete?: (err: any, data: string) => void): Promise<string>;
-        getByRoot(root: any): { [key: string]: Value; };
+        getByRoot(root: any): { [key: string]: Value };
         bindToExpress(app: object, basePath?: string, makePaths?: boolean): Reader;
     }
 

--- a/types/properties-reader/index.d.ts
+++ b/types/properties-reader/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for properties-reader 2.1.1
+// Type definitions for properties-reader 2.1
 // Project: https://github.com/steveukx/properties
 // Definitions by: Zlatko Andonovski <https://github.com/Goldsmith42>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/properties-reader/properties-reader-tests.ts
+++ b/types/properties-reader/properties-reader-tests.ts
@@ -6,7 +6,7 @@ let properties = PropertiesReader('/path/to/properties.file');
 // Fully qualified name
 let property = properties.get('some.property.name');
 // Yeah, so we have no way of doing this properly.
-property = (<any>properties.path()).some.property.name;
+property = (<any> properties.path()).some.property.name;
 
 properties = properties.append('/another.file').append('/yet/another.file');
 properties = properties.read('some.property = Value \n another.property = Another Value');
@@ -22,7 +22,7 @@ const raw: string | null = properties.getRaw('path.to.prop');
 
 properties = properties.each((key, value) => {});
 properties = properties.each(
-    function (key, value) {
+    function(key, value) {
         this.x = 5;
     },
     { x: 3 },

--- a/types/properties-reader/properties-reader-tests.ts
+++ b/types/properties-reader/properties-reader-tests.ts
@@ -6,7 +6,7 @@ let properties = PropertiesReader('/path/to/properties.file');
 // Fully qualified name
 let property = properties.get('some.property.name');
 // Yeah, so we have no way of doing this properly.
-property = (<any> properties.path()).some.property.name;
+property = (<any>properties.path()).some.property.name;
 
 properties = properties.append('/another.file').append('/yet/another.file');
 properties = properties.read('some.property = Value \n another.property = Another Value');
@@ -18,17 +18,25 @@ properties.get('main.some.thing') === 'foo';
 properties.get('blah.some.thing') === 'bar';
 
 const propertiesCount: number = properties.length;
-const raw: string|null = properties.getRaw('path.to.prop');
+const raw: string | null = properties.getRaw('path.to.prop');
 
 properties = properties.each((key, value) => {});
-properties = properties.each(function(key, value) {
-    this.x = 5;
-}, { x: 3 });
-const value = properties.getAllProperties()["myKey"];
+properties = properties.each(
+    function (key, value) {
+        this.x = 5;
+    },
+    { x: 3 },
+);
+const value = properties.getAllProperties()['myKey'];
 
 // Short options as from readme
 const shortOptions = PropertiesReader('/path/to/properties.file', 'utf-8', { allowDuplicateSections: true });
 // It actually allows longer variants as well
-const writerProps = PropertiesReader('/path/to/properties.file', undefined, { writer: {saveSections: true}});
-const appenderProps = PropertiesReader('/path/to/properties.file', 'utf-8', { appender: {allowDuplicateSections: false}});
-const allOptions = PropertiesReader('/path/to/properties.file', 'utf-8', { appender: {allowDuplicateSections: false}, writer: {saveSections: true}});
+const writerProps = PropertiesReader('/path/to/properties.file', undefined, { writer: { saveSections: true } });
+const appenderProps = PropertiesReader('/path/to/properties.file', 'utf-8', {
+    appender: { allowDuplicateSections: false },
+});
+const allOptions = PropertiesReader('/path/to/properties.file', 'utf-8', {
+    appender: { allowDuplicateSections: false },
+    writer: { saveSections: true },
+});

--- a/types/properties-reader/properties-reader-tests.ts
+++ b/types/properties-reader/properties-reader-tests.ts
@@ -25,3 +25,10 @@ properties = properties.each(function(key, value) {
     this.x = 5;
 }, { x: 3 });
 const value = properties.getAllProperties()["myKey"];
+
+// Short options as from readme
+const shortOptions = PropertiesReader('/path/to/properties.file', 'utf-8', { allowDuplicateSections: true });
+// It actually allows longer variants as well
+const writerProps = PropertiesReader('/path/to/properties.file', undefined, { writer: {saveSections: true}});
+const appenderProps = PropertiesReader('/path/to/properties.file', 'utf-8', { appender: {allowDuplicateSections: false}});
+const allOptions = PropertiesReader('/path/to/properties.file', 'utf-8', { appender: {allowDuplicateSections: false}, writer: {saveSections: true}});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - long options seen here: https://github.com/steveukx/properties/blob/master/README.md#saving-changes
  - short options seen here: https://github.com/steveukx/properties/blob/master/README.md#duplicate-section-headings
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. (already contains)
