### PR TITLE
[@wordpress/components] Update ColorPalette and ColorPicker props

### DIFF
--- a/types/wordpress__components/color-palette/index.d.ts
+++ b/types/wordpress__components/color-palette/index.d.ts
@@ -19,6 +19,7 @@ declare namespace ColorPalette {
         colors: readonly Color[];
         /**
          * Should custom color selection be disabled?
+         * @defaultValue false
          */
         disableCustomColors?: boolean;
         /**
@@ -30,6 +31,11 @@ declare namespace ColorPalette {
          * `undefined` if the color selection is the same as the current `value`.
          */
         onChange(color?: Color): void;
+        /**
+         * Whether the palette should have a clearing button or not.
+         * @defaultValue `true`
+         */
+        clearable?: boolean;
     }
 }
 declare const ColorPalette: ComponentType<ColorPalette.Props>;

--- a/types/wordpress__components/color-picker/index.d.ts
+++ b/types/wordpress__components/color-picker/index.d.ts
@@ -1,19 +1,42 @@
 import { ComponentType } from 'react';
+import * as tinycolor from 'tinycolor2';
 
 declare namespace ColorPicker {
+    interface OnChangeCompleteValue {
+        color: tinycolor.Instance;
+        hex: string;
+        hsl: string;
+        hsv: string;
+        rgb: string;
+        oldHue: string;
+        source: 'rgb' | undefined;
+        draftHex: string;
+        draftHsl: string;
+        draftRgb: string;
+    }
+
     interface Props {
         /**
          * Machine-readable color value.
+         * @defaultValue "0071a1"
          */
-        color: string;
+        color?: string;
         /**
          * Function to be called when color value changes.
          */
-        onChangeComplete(value: { hex: string; hsl: string; hsv: string; rgb: string }): void;
+        onChangeComplete(value: OnChangeCompleteValue): void;
         /**
          * Should alpha be disabled?
          */
         disableAlpha?: boolean;
+        /**
+         * A reference to the hue of the previous color, otherwise
+         * dragging the saturation to zero will reset the current
+         * hue to zero as well.
+         *
+         * @see https://github.com/casesandberg/react-color/issues/29#issuecomment-132686909.
+         */
+        oldHue?: number;
     }
 }
 declare const ColorPicker: ComponentType<ColorPicker.Props>;

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -174,10 +174,23 @@ let record: Value = {
     onChange={color => color && console.log(color.name)}
 />;
 
+<C.ColorPalette
+    disableCustomColors
+    clearable={false}
+    colors={[
+        { name: 'red', color: '#ff0000' },
+        { name: 'green', color: '#00ff00' },
+        { name: 'blue', color: '#0000ff' },
+    ]}
+    value={{ name: 'red', color: '#ff0000' }}
+    onChange={color => color && console.log(color.name)}
+/>;
+
 //
 // color-picker
 //
-<C.ColorPicker color="#ff0000" onChangeComplete={color => console.log(color.hex)} />;
+<C.ColorPicker color="#ff0000" onChangeComplete={color => console.log(color.hex)} oldHue={3} />;
+<C.ColorPicker onChangeComplete={color => console.log(color.hex)} disableAlpha />;
 
 //
 // dashicon


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/WordPress/gutenberg/tree/master/packages/components/src/color-palette> <https://github.com/WordPress/gutenberg/tree/master/packages/components/src/color-picker>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.