### PR TITLE
nova-editor: Fix commitChars on completion item

### DIFF
--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -114,7 +114,7 @@ declare class CompletionItem {
     insertText?: string;
     insertTextFormat?: InsertTextFormat;
     range?: Range;
-    commitCharacters?: string[];
+    commitChars?: Charset;
 }
 
 declare enum CompletionItemKind {

--- a/types/nova-editor-node/nova-editor-node-tests.ts
+++ b/types/nova-editor-node/nova-editor-node-tests.ts
@@ -70,6 +70,7 @@ nova.clipboard.readText();
 const completionItem = new CompletionItem("label", CompletionItemKind.Struct);
 completionItem.insertTextFormat = InsertTextFormat.Snippet;
 completionItem.insertText = "text to insert";
+completionItem.commitChars = new Charset("-");
 
 /// https://novadocs.panic.com/api-reference/emitter/
 


### PR DESCRIPTION
This must have changed since the beta.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.nova.app/api-reference/completion-item/#commitchars
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~