### PR TITLE
feat: [request] new RequestOptions

### DIFF
--- a/types/needle/index.d.ts
+++ b/types/needle/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for needle 2.0
+// Type definitions for needle 2.5
 // Project: https://github.com/tomas/needle
 // Definitions by: San Chen <https://github.com/bigsan>,
 //                 Niklas Mollenhauer <https://github.com/nikeee>,
@@ -47,6 +47,12 @@ declare namespace core {
          * Alias for open_timeout
          */
         timeout?: RequestOptions['open_timeout'];
+
+        /**
+         * Returns error if no response headers are received in X milisecs,
+         * counting from when the connection is opened. Defaults to `0` (no response timeout).
+         */
+        response_timeout?: number;
 
         /**
          * Returns error if data transfer takes longer than X milisecs,
@@ -103,6 +109,11 @@ declare namespace core {
          * which is no Content-Length header for stream payloads.
          */
         stream_length?: number;
+
+        /**
+         * IP address. Passed to http/https request. Local interface from which the request should be emitted.
+         */
+        localAddress?: string;
 
         // These properties are overwritten by those in the 'headers' field
         /**

--- a/types/needle/needle-tests.ts
+++ b/types/needle/needle-tests.ts
@@ -297,6 +297,21 @@ function FileUpload() {
     });
 }
 
+async function Timeout() {
+    await needle('get', 'http://test.com/', null, {
+        timeout: 7,
+        open_timeout: 8,
+        read_timeout: 9,
+        response_timeout: 10,
+    });
+}
+
+async function LocalAddress() {
+    await needle('get', 'http://test.com/', null, {
+        localAddress: '169.254.6.9',
+    });
+}
+
 function Multipart() {
     const buffer = fs.readFileSync('/path/to/package.zip');
 


### PR DESCRIPTION
Add two missing RequestOptions, `response_timeout` (which is pretty critical as `read_timeout` doesn't.. time out your requests, ever, even if the server never replies), which seems to have been missed.

`localAddress` is new.in 2.5.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

 * https://github.com/tomas/needle/blob/cb53f295428adacbf048d348d037b15adf003447/README.md#request-options

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

url modification is new in 2.5: https://github.com/tomas/needle/commit/fb07a5d7208570b9abad401f8a6977079a9ef353

- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

