### PR TITLE
chore(node): apply `prettier` to `assert` types

### DIFF
--- a/types/node/assert.d.ts
+++ b/types/node/assert.d.ts
@@ -1,4 +1,4 @@
-declare module "assert" {
+declare module 'assert' {
     /** An alias of `assert.ok()`. */
     function assert(value: any, message?: string | Error): asserts value;
     namespace assert {
@@ -21,7 +21,7 @@ declare module "assert" {
                 /** The `operator` property on the error instance. */
                 operator?: string;
                 /** If provided, the generated stack trace omits frames before this function. */
-                stackStartFn?: Function
+                stackStartFn?: Function;
             });
         }
 
@@ -43,11 +43,17 @@ declare module "assert" {
             stack: object;
         }
 
-        type AssertPredicate = RegExp | (new() => object) | ((thrown: any) => boolean) | object | Error;
+        type AssertPredicate = RegExp | (new () => object) | ((thrown: any) => boolean) | object | Error;
 
         function fail(message?: string | Error): never;
         /** @deprecated since v10.0.0 - use fail([message]) or other assert functions instead. */
-        function fail(actual: any, expected: any, message?: string | Error, operator?: string, stackStartFn?: Function): never;
+        function fail(
+            actual: any,
+            expected: any,
+            message?: string | Error,
+            operator?: string,
+            stackStartFn?: Function,
+        ): never;
         function ok(value: any, message?: string | Error): asserts value;
         /** @deprecated since v9.9.0 - use strictEqual() instead. */
         function equal(actual: any, expected: any, message?: string | Error): void;
@@ -70,9 +76,17 @@ declare module "assert" {
         function ifError(value: any): asserts value is null | undefined;
 
         function rejects(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
-        function rejects(block: (() => Promise<any>) | Promise<any>, error: AssertPredicate, message?: string | Error): Promise<void>;
+        function rejects(
+            block: (() => Promise<any>) | Promise<any>,
+            error: AssertPredicate,
+            message?: string | Error,
+        ): Promise<void>;
         function doesNotReject(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
-        function doesNotReject(block: (() => Promise<any>) | Promise<any>, error: RegExp | Function, message?: string | Error): Promise<void>;
+        function doesNotReject(
+            block: (() => Promise<any>) | Promise<any>,
+            error: RegExp | Function,
+            message?: string | Error,
+        ): Promise<void>;
 
         function match(value: string, regExp: RegExp, message?: string | Error): void;
         function doesNotMatch(value: string, regExp: RegExp, message?: string | Error): void;

--- a/types/node/ts3.4/assert.d.ts
+++ b/types/node/ts3.4/assert.d.ts
@@ -1,4 +1,4 @@
-declare module "assert" {
+declare module 'assert' {
     function assert(value: any, message?: string | Error): void;
     namespace assert {
         class AssertionError implements Error {
@@ -11,16 +11,25 @@ declare module "assert" {
             code: 'ERR_ASSERTION';
 
             constructor(options?: {
-                message?: string; actual?: any; expected?: any;
-                operator?: string; stackStartFn?: Function
+                message?: string;
+                actual?: any;
+                expected?: any;
+                operator?: string;
+                stackStartFn?: Function;
             });
         }
 
-        type AssertPredicate = RegExp | (new() => object) | ((thrown: any) => boolean) | object | Error;
+        type AssertPredicate = RegExp | (new () => object) | ((thrown: any) => boolean) | object | Error;
 
         function fail(message?: string | Error): never;
         /** @deprecated since v10.0.0 - use `fail([message])` or other assert functions instead. */
-        function fail(actual: any, expected: any, message?: string | Error, operator?: string, stackStartFn?: Function): never;
+        function fail(
+            actual: any,
+            expected: any,
+            message?: string | Error,
+            operator?: string,
+            stackStartFn?: Function,
+        ): never;
         function ok(value: any, message?: string | Error): void;
         /** @deprecated since v9.9.0 - use `strictEqual()` instead. */
         function equal(actual: any, expected: any, message?: string | Error): void;
@@ -43,9 +52,17 @@ declare module "assert" {
         function ifError(value: any): void;
 
         function rejects(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
-        function rejects(block: (() => Promise<any>) | Promise<any>, error: AssertPredicate, message?: string | Error): Promise<void>;
+        function rejects(
+            block: (() => Promise<any>) | Promise<any>,
+            error: AssertPredicate,
+            message?: string | Error,
+        ): Promise<void>;
         function doesNotReject(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
-        function doesNotReject(block: (() => Promise<any>) | Promise<any>, error: RegExp | Function, message?: string | Error): Promise<void>;
+        function doesNotReject(
+            block: (() => Promise<any>) | Promise<any>,
+            error: RegExp | Function,
+            message?: string | Error,
+        ): Promise<void>;
 
         function match(value: string, regExp: RegExp, message?: string | Error): void;
         function doesNotMatch(value: string, regExp: RegExp, message?: string | Error): void;

--- a/types/node/v10/assert.d.ts
+++ b/types/node/v10/assert.d.ts
@@ -1,4 +1,4 @@
-declare module "assert" {
+declare module 'assert' {
     function assert(value: any, message?: string | Error): asserts value;
     namespace assert {
         class AssertionError implements Error {
@@ -11,14 +11,23 @@ declare module "assert" {
             code: 'ERR_ASSERTION';
 
             constructor(options?: {
-                message?: string; actual?: any; expected?: any;
-                operator?: string; stackStartFn?: Function
+                message?: string;
+                actual?: any;
+                expected?: any;
+                operator?: string;
+                stackStartFn?: Function;
             });
         }
 
         function fail(message?: string | Error): never;
         /** @deprecated since v10.0.0 - use fail([message]) or other assert functions instead. */
-        function fail(actual: any, expected: any, message?: string | Error, operator?: string, stackStartFn?: Function): never;
+        function fail(
+            actual: any,
+            expected: any,
+            message?: string | Error,
+            operator?: string,
+            stackStartFn?: Function,
+        ): never;
         function ok(value: any, message?: string | Error): asserts value;
         /** @deprecated since v9.9.0 - use strictEqual() instead. */
         function equal(actual: any, expected: any, message?: string | Error): void;
@@ -41,9 +50,17 @@ declare module "assert" {
         function ifError(value: any): asserts value is null | undefined;
 
         function rejects(block: Function | Promise<any>, message?: string | Error): Promise<void>;
-        function rejects(block: Function | Promise<any>, error: RegExp | Function | Object | Error, message?: string | Error): Promise<void>;
+        function rejects(
+            block: Function | Promise<any>,
+            error: RegExp | Function | Object | Error,
+            message?: string | Error,
+        ): Promise<void>;
         function doesNotReject(block: Function | Promise<any>, message?: string | Error): Promise<void>;
-        function doesNotReject(block: Function | Promise<any>, error: RegExp | Function, message?: string | Error): Promise<void>;
+        function doesNotReject(
+            block: Function | Promise<any>,
+            error: RegExp | Function,
+            message?: string | Error,
+        ): Promise<void>;
 
         const strict: typeof assert;
     }

--- a/types/node/v10/ts3.6/assert.d.ts
+++ b/types/node/v10/ts3.6/assert.d.ts
@@ -1,4 +1,4 @@
-declare module "assert" {
+declare module 'assert' {
     function assert(value: any, message?: string | Error): void;
     namespace assert {
         class AssertionError implements Error {
@@ -11,14 +11,23 @@ declare module "assert" {
             code: 'ERR_ASSERTION';
 
             constructor(options?: {
-                message?: string; actual?: any; expected?: any;
-                operator?: string; stackStartFn?: Function
+                message?: string;
+                actual?: any;
+                expected?: any;
+                operator?: string;
+                stackStartFn?: Function;
             });
         }
 
         function fail(message?: string | Error): never;
         /** @deprecated since v10.0.0 - use fail([message]) or other assert functions instead. */
-        function fail(actual: any, expected: any, message?: string | Error, operator?: string, stackStartFn?: Function): never;
+        function fail(
+            actual: any,
+            expected: any,
+            message?: string | Error,
+            operator?: string,
+            stackStartFn?: Function,
+        ): never;
         function ok(value: any, message?: string | Error): void;
         /** @deprecated since v9.9.0 - use strictEqual() instead. */
         function equal(actual: any, expected: any, message?: string | Error): void;
@@ -41,9 +50,17 @@ declare module "assert" {
         function ifError(value: any): void;
 
         function rejects(block: Function | Promise<any>, message?: string | Error): Promise<void>;
-        function rejects(block: Function | Promise<any>, error: RegExp | Function | Object | Error, message?: string | Error): Promise<void>;
+        function rejects(
+            block: Function | Promise<any>,
+            error: RegExp | Function | Object | Error,
+            message?: string | Error,
+        ): Promise<void>;
         function doesNotReject(block: Function | Promise<any>, message?: string | Error): Promise<void>;
-        function doesNotReject(block: Function | Promise<any>, error: RegExp | Function, message?: string | Error): Promise<void>;
+        function doesNotReject(
+            block: Function | Promise<any>,
+            error: RegExp | Function,
+            message?: string | Error,
+        ): Promise<void>;
 
         const strict: typeof assert;
     }

--- a/types/node/v11/assert.d.ts
+++ b/types/node/v11/assert.d.ts
@@ -1,4 +1,4 @@
-declare module "assert" {
+declare module 'assert' {
     function assert(value: any, message?: string | Error): asserts value;
     namespace assert {
         class AssertionError implements Error {
@@ -11,14 +11,23 @@ declare module "assert" {
             code: 'ERR_ASSERTION';
 
             constructor(options?: {
-                message?: string; actual?: any; expected?: any;
-                operator?: string; stackStartFn?: Function
+                message?: string;
+                actual?: any;
+                expected?: any;
+                operator?: string;
+                stackStartFn?: Function;
             });
         }
 
         function fail(message?: string | Error): never;
         /** @deprecated since v10.0.0 - use fail([message]) or other assert functions instead. */
-        function fail(actual: any, expected: any, message?: string | Error, operator?: string, stackStartFn?: Function): never;
+        function fail(
+            actual: any,
+            expected: any,
+            message?: string | Error,
+            operator?: string,
+            stackStartFn?: Function,
+        ): never;
         function ok(value: any, message?: string | Error): asserts value;
         /** @deprecated since v9.9.0 - use strictEqual() instead. */
         function equal(actual: any, expected: any, message?: string | Error): void;
@@ -41,9 +50,17 @@ declare module "assert" {
         function ifError(value: any): asserts value is null | undefined;
 
         function rejects(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
-        function rejects(block: (() => Promise<any>) | Promise<any>, error: RegExp | Function | Object | Error, message?: string | Error): Promise<void>;
+        function rejects(
+            block: (() => Promise<any>) | Promise<any>,
+            error: RegExp | Function | Object | Error,
+            message?: string | Error,
+        ): Promise<void>;
         function doesNotReject(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
-        function doesNotReject(block: (() => Promise<any>) | Promise<any>, error: RegExp | Function, message?: string | Error): Promise<void>;
+        function doesNotReject(
+            block: (() => Promise<any>) | Promise<any>,
+            error: RegExp | Function,
+            message?: string | Error,
+        ): Promise<void>;
 
         const strict: typeof assert;
     }

--- a/types/node/v11/test/assert.ts
+++ b/types/node/v11/test/assert.ts
@@ -2,16 +2,22 @@ import * as assert from 'assert';
 
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 
-assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, "DEEP WENT DERP");
+assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, 'DEEP WENT DERP');
 
-assert.deepStrictEqual({ a: 1 }, { a: 1 }, "uses === comparator");
+assert.deepStrictEqual({ a: 1 }, { a: 1 }, 'uses === comparator');
 
-assert.doesNotThrow(() => {
-    const b = false;
-    if (b) { throw new Error("a hammer at your face"); }
-}, () => 1, "What the...*crunch*");
+assert.doesNotThrow(
+    () => {
+        const b = false;
+        if (b) {
+            throw new Error('a hammer at your face');
+        }
+    },
+    () => 1,
+    'What the...*crunch*',
+);
 
-assert.equal(3, "3", "uses == comparator");
+assert.equal(3, '3', 'uses == comparator');
 
 assert.fail('stuff broke');
 
@@ -21,18 +27,24 @@ assert.fail(1, 2, undefined, '>');
 
 assert.ifError(0);
 
-assert.notDeepStrictEqual({ x: { y: "3" } }, { x: { y: 3 } }, "uses !== comparator");
+assert.notDeepStrictEqual({ x: { y: '3' } }, { x: { y: 3 } }, 'uses !== comparator');
 
-assert.notEqual(1, 2, "uses != comparator");
+assert.notEqual(1, 2, 'uses != comparator');
 
-assert.notStrictEqual(2, "2", "uses === comparator");
+assert.notStrictEqual(2, '2', 'uses === comparator');
 
 assert.ok(true);
 assert.ok(1);
 
-assert.strictEqual(1, 1, "uses === comparator");
+assert.strictEqual(1, 1, 'uses === comparator');
 
-assert.throws(() => { throw new Error("a hammer at your face"); }, Error, "DODGED IT");
+assert.throws(
+    () => {
+        throw new Error('a hammer at your face');
+    },
+    Error,
+    'DODGED IT',
+);
 
 assert.rejects(async () => 1);
 assert.rejects(Promise.resolve(1));

--- a/types/node/v11/ts3.6/assert.d.ts
+++ b/types/node/v11/ts3.6/assert.d.ts
@@ -1,4 +1,4 @@
-declare module "assert" {
+declare module 'assert' {
     function assert(value: any, message?: string | Error): void;
     namespace assert {
         class AssertionError implements Error {
@@ -11,14 +11,23 @@ declare module "assert" {
             code: 'ERR_ASSERTION';
 
             constructor(options?: {
-                message?: string; actual?: any; expected?: any;
-                operator?: string; stackStartFn?: Function
+                message?: string;
+                actual?: any;
+                expected?: any;
+                operator?: string;
+                stackStartFn?: Function;
             });
         }
 
         function fail(message?: string | Error): never;
         /** @deprecated since v10.0.0 - use fail([message]) or other assert functions instead. */
-        function fail(actual: any, expected: any, message?: string | Error, operator?: string, stackStartFn?: Function): never;
+        function fail(
+            actual: any,
+            expected: any,
+            message?: string | Error,
+            operator?: string,
+            stackStartFn?: Function,
+        ): never;
         function ok(value: any, message?: string | Error): void;
         /** @deprecated since v9.9.0 - use strictEqual() instead. */
         function equal(actual: any, expected: any, message?: string | Error): void;
@@ -41,9 +50,17 @@ declare module "assert" {
         function ifError(value: any): void;
 
         function rejects(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
-        function rejects(block: (() => Promise<any>) | Promise<any>, error: RegExp | Function | Object | Error, message?: string | Error): Promise<void>;
+        function rejects(
+            block: (() => Promise<any>) | Promise<any>,
+            error: RegExp | Function | Object | Error,
+            message?: string | Error,
+        ): Promise<void>;
         function doesNotReject(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
-        function doesNotReject(block: (() => Promise<any>) | Promise<any>, error: RegExp | Function, message?: string | Error): Promise<void>;
+        function doesNotReject(
+            block: (() => Promise<any>) | Promise<any>,
+            error: RegExp | Function,
+            message?: string | Error,
+        ): Promise<void>;
 
         const strict: typeof assert;
     }

--- a/types/node/v12/assert.d.ts
+++ b/types/node/v12/assert.d.ts
@@ -1,4 +1,4 @@
-declare module "assert" {
+declare module 'assert' {
     function assert(value: any, message?: string | Error): asserts value;
     namespace assert {
         class AssertionError implements Error {
@@ -11,14 +11,23 @@ declare module "assert" {
             code: 'ERR_ASSERTION';
 
             constructor(options?: {
-                message?: string; actual?: any; expected?: any;
-                operator?: string; stackStartFn?: Function
+                message?: string;
+                actual?: any;
+                expected?: any;
+                operator?: string;
+                stackStartFn?: Function;
             });
         }
 
         function fail(message?: string | Error): never;
         /** @deprecated since v10.0.0 - use fail([message]) or other assert functions instead. */
-        function fail(actual: any, expected: any, message?: string | Error, operator?: string, stackStartFn?: Function): never;
+        function fail(
+            actual: any,
+            expected: any,
+            message?: string | Error,
+            operator?: string,
+            stackStartFn?: Function,
+        ): never;
         function ok(value: any, message?: string | Error): asserts value;
         /** @deprecated since v9.9.0 - use strictEqual() instead. */
         function equal(actual: any, expected: any, message?: string | Error): void;
@@ -41,9 +50,17 @@ declare module "assert" {
         function ifError(value: any): asserts value is null | undefined;
 
         function rejects(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
-        function rejects(block: (() => Promise<any>) | Promise<any>, error: RegExp | Function | Object | Error, message?: string | Error): Promise<void>;
+        function rejects(
+            block: (() => Promise<any>) | Promise<any>,
+            error: RegExp | Function | Object | Error,
+            message?: string | Error,
+        ): Promise<void>;
         function doesNotReject(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
-        function doesNotReject(block: (() => Promise<any>) | Promise<any>, error: RegExp | Function, message?: string | Error): Promise<void>;
+        function doesNotReject(
+            block: (() => Promise<any>) | Promise<any>,
+            error: RegExp | Function,
+            message?: string | Error,
+        ): Promise<void>;
 
         const strict: typeof assert;
     }

--- a/types/node/v12/test/assert.ts
+++ b/types/node/v12/test/assert.ts
@@ -2,16 +2,22 @@ import * as assert from 'assert';
 
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 
-assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, "DEEP WENT DERP");
+assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, 'DEEP WENT DERP');
 
-assert.deepStrictEqual({ a: 1 }, { a: 1 }, "uses === comparator");
+assert.deepStrictEqual({ a: 1 }, { a: 1 }, 'uses === comparator');
 
-assert.doesNotThrow(() => {
-    const b = false;
-    if (b) { throw new Error("a hammer at your face"); }
-}, () => 1, "What the...*crunch*");
+assert.doesNotThrow(
+    () => {
+        const b = false;
+        if (b) {
+            throw new Error('a hammer at your face');
+        }
+    },
+    () => 1,
+    'What the...*crunch*',
+);
 
-assert.equal(3, "3", "uses == comparator");
+assert.equal(3, '3', 'uses == comparator');
 
 assert.fail('stuff broke');
 
@@ -21,18 +27,24 @@ assert.fail(1, 2, undefined, '>');
 
 assert.ifError(0);
 
-assert.notDeepStrictEqual({ x: { y: "3" } }, { x: { y: 3 } }, "uses !== comparator");
+assert.notDeepStrictEqual({ x: { y: '3' } }, { x: { y: 3 } }, 'uses !== comparator');
 
-assert.notEqual(1, 2, "uses != comparator");
+assert.notEqual(1, 2, 'uses != comparator');
 
-assert.notStrictEqual(2, "2", "uses === comparator");
+assert.notStrictEqual(2, '2', 'uses === comparator');
 
 assert.ok(true);
 assert.ok(1);
 
-assert.strictEqual(1, 1, "uses === comparator");
+assert.strictEqual(1, 1, 'uses === comparator');
 
-assert.throws(() => { throw new Error("a hammer at your face"); }, Error, "DODGED IT");
+assert.throws(
+    () => {
+        throw new Error('a hammer at your face');
+    },
+    Error,
+    'DODGED IT',
+);
 
 assert.rejects(async () => 1);
 assert.rejects(Promise.resolve(1));

--- a/types/node/v12/ts3.3/assert.d.ts
+++ b/types/node/v12/ts3.3/assert.d.ts
@@ -1,4 +1,4 @@
-declare module "assert" {
+declare module 'assert' {
     function assert(value: any, message?: string | Error): void;
     namespace assert {
         class AssertionError implements Error {
@@ -11,14 +11,23 @@ declare module "assert" {
             code: 'ERR_ASSERTION';
 
             constructor(options?: {
-                message?: string; actual?: any; expected?: any;
-                operator?: string; stackStartFn?: Function
+                message?: string;
+                actual?: any;
+                expected?: any;
+                operator?: string;
+                stackStartFn?: Function;
             });
         }
 
         function fail(message?: string | Error): never;
         /** @deprecated since v10.0.0 - use fail([message]) or other assert functions instead. */
-        function fail(actual: any, expected: any, message?: string | Error, operator?: string, stackStartFn?: Function): never;
+        function fail(
+            actual: any,
+            expected: any,
+            message?: string | Error,
+            operator?: string,
+            stackStartFn?: Function,
+        ): never;
         function ok(value: any, message?: string | Error): void;
         /** @deprecated since v9.9.0 - use strictEqual() instead. */
         function equal(actual: any, expected: any, message?: string | Error): void;
@@ -41,9 +50,17 @@ declare module "assert" {
         function ifError(value: any): void;
 
         function rejects(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
-        function rejects(block: (() => Promise<any>) | Promise<any>, error: RegExp | Function | Object | Error, message?: string | Error): Promise<void>;
+        function rejects(
+            block: (() => Promise<any>) | Promise<any>,
+            error: RegExp | Function | Object | Error,
+            message?: string | Error,
+        ): Promise<void>;
         function doesNotReject(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
-        function doesNotReject(block: (() => Promise<any>) | Promise<any>, error: RegExp | Function, message?: string | Error): Promise<void>;
+        function doesNotReject(
+            block: (() => Promise<any>) | Promise<any>,
+            error: RegExp | Function,
+            message?: string | Error,
+        ): Promise<void>;
 
         const strict: typeof assert;
     }

--- a/types/node/v13/assert.d.ts
+++ b/types/node/v13/assert.d.ts
@@ -1,4 +1,4 @@
-declare module "assert" {
+declare module 'assert' {
     function assert(value: any, message?: string | Error): asserts value;
     namespace assert {
         class AssertionError implements Error {
@@ -11,16 +11,25 @@ declare module "assert" {
             code: 'ERR_ASSERTION';
 
             constructor(options?: {
-                message?: string; actual?: any; expected?: any;
-                operator?: string; stackStartFn?: Function
+                message?: string;
+                actual?: any;
+                expected?: any;
+                operator?: string;
+                stackStartFn?: Function;
             });
         }
 
-        type AssertPredicate = RegExp | (new() => object) | ((thrown: any) => boolean) | object | Error;
+        type AssertPredicate = RegExp | (new () => object) | ((thrown: any) => boolean) | object | Error;
 
         function fail(message?: string | Error): never;
         /** @deprecated since v10.0.0 - use fail([message]) or other assert functions instead. */
-        function fail(actual: any, expected: any, message?: string | Error, operator?: string, stackStartFn?: Function): never;
+        function fail(
+            actual: any,
+            expected: any,
+            message?: string | Error,
+            operator?: string,
+            stackStartFn?: Function,
+        ): never;
         function ok(value: any, message?: string | Error): asserts value;
         /** @deprecated since v9.9.0 - use strictEqual() instead. */
         function equal(actual: any, expected: any, message?: string | Error): void;
@@ -43,9 +52,17 @@ declare module "assert" {
         function ifError(value: any): asserts value is null | undefined;
 
         function rejects(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
-        function rejects(block: (() => Promise<any>) | Promise<any>, error: AssertPredicate, message?: string | Error): Promise<void>;
+        function rejects(
+            block: (() => Promise<any>) | Promise<any>,
+            error: AssertPredicate,
+            message?: string | Error,
+        ): Promise<void>;
         function doesNotReject(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
-        function doesNotReject(block: (() => Promise<any>) | Promise<any>, error: RegExp | Function, message?: string | Error): Promise<void>;
+        function doesNotReject(
+            block: (() => Promise<any>) | Promise<any>,
+            error: RegExp | Function,
+            message?: string | Error,
+        ): Promise<void>;
 
         function match(value: string, regExp: RegExp, message?: string | Error): void;
         function doesNotMatch(value: string, regExp: RegExp, message?: string | Error): void;

--- a/types/node/v13/test/assert.ts
+++ b/types/node/v13/test/assert.ts
@@ -2,32 +2,50 @@ import * as assert from 'assert';
 
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 
-assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, "DEEP WENT DERP");
+assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, 'DEEP WENT DERP');
 
-assert.deepStrictEqual({ a: 1 }, { a: 1 }, "uses === comparator");
+assert.deepStrictEqual({ a: 1 }, { a: 1 }, 'uses === comparator');
 
-assert.doesNotThrow(() => {
-    const b = false;
-    if (b) { throw new Error("a hammer at your face"); }
-}, () => 1, "What the...*crunch*");
+assert.doesNotThrow(
+    () => {
+        const b = false;
+        if (b) {
+            throw new Error('a hammer at your face');
+        }
+    },
+    () => 1,
+    'What the...*crunch*',
+);
 
-assert.equal(3, "3", "uses == comparator");
+assert.equal(3, '3', 'uses == comparator');
 
 assert.ifError(0);
 
-assert.notDeepStrictEqual({ x: { y: "3" } }, { x: { y: 3 } }, "uses !== comparator");
+assert.notDeepStrictEqual({ x: { y: '3' } }, { x: { y: 3 } }, 'uses !== comparator');
 
-assert.notEqual(1, 2, "uses != comparator");
+assert.notEqual(1, 2, 'uses != comparator');
 
-assert.notStrictEqual(2, "2", "uses === comparator");
+assert.notStrictEqual(2, '2', 'uses === comparator');
 
 assert.ok(true);
 assert.ok(1);
 
-assert.strictEqual(1, 1, "uses === comparator");
+assert.strictEqual(1, 1, 'uses === comparator');
 
-assert.throws(() => { throw new Error("a hammer at your face"); }, Error, "DODGED IT");
-assert.throws(() => { throw new Error("a hammer at your face"); }, (err: Error) => true, "DODGED IT");
+assert.throws(
+    () => {
+        throw new Error('a hammer at your face');
+    },
+    Error,
+    'DODGED IT',
+);
+assert.throws(
+    () => {
+        throw new Error('a hammer at your face');
+    },
+    (err: Error) => true,
+    'DODGED IT',
+);
 
 assert.rejects(async () => 1);
 assert.rejects(Promise.resolve(1));

--- a/types/node/v13/ts3.4/assert.d.ts
+++ b/types/node/v13/ts3.4/assert.d.ts
@@ -1,4 +1,4 @@
-declare module "assert" {
+declare module 'assert' {
     function assert(value: any, message?: string | Error): void;
     namespace assert {
         class AssertionError implements Error {
@@ -11,16 +11,25 @@ declare module "assert" {
             code: 'ERR_ASSERTION';
 
             constructor(options?: {
-                message?: string; actual?: any; expected?: any;
-                operator?: string; stackStartFn?: Function
+                message?: string;
+                actual?: any;
+                expected?: any;
+                operator?: string;
+                stackStartFn?: Function;
             });
         }
 
-        type AssertPredicate = RegExp | (new() => object) | ((thrown: any) => boolean) | object | Error;
+        type AssertPredicate = RegExp | (new () => object) | ((thrown: any) => boolean) | object | Error;
 
         function fail(message?: string | Error): never;
         /** @deprecated since v10.0.0 - use fail([message]) or other assert functions instead. */
-        function fail(actual: any, expected: any, message?: string | Error, operator?: string, stackStartFn?: Function): never;
+        function fail(
+            actual: any,
+            expected: any,
+            message?: string | Error,
+            operator?: string,
+            stackStartFn?: Function,
+        ): never;
         function ok(value: any, message?: string | Error): void;
         /** @deprecated since v9.9.0 - use strictEqual() instead. */
         function equal(actual: any, expected: any, message?: string | Error): void;
@@ -43,9 +52,17 @@ declare module "assert" {
         function ifError(value: any): void;
 
         function rejects(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
-        function rejects(block: (() => Promise<any>) | Promise<any>, error: AssertPredicate, message?: string | Error): Promise<void>;
+        function rejects(
+            block: (() => Promise<any>) | Promise<any>,
+            error: AssertPredicate,
+            message?: string | Error,
+        ): Promise<void>;
         function doesNotReject(block: (() => Promise<any>) | Promise<any>, message?: string | Error): Promise<void>;
-        function doesNotReject(block: (() => Promise<any>) | Promise<any>, error: RegExp | Function, message?: string | Error): Promise<void>;
+        function doesNotReject(
+            block: (() => Promise<any>) | Promise<any>,
+            error: RegExp | Function,
+            message?: string | Error,
+        ): Promise<void>;
 
         function match(value: string, regExp: RegExp, message?: string | Error): void;
         function doesNotMatch(value: string, regExp: RegExp, message?: string | Error): void;


### PR DESCRIPTION
This is a thing we're doing right?

I've only done it to the `assert` types because it seems most of the files in `types/node` have not been prettified, and so felt this would make it more reviewable.