### PR TITLE
[ReactNative] Add dataDetectorType to android text props component

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -962,6 +962,12 @@ export interface TextPropsAndroid {
      * default is `highQuality`.
      */
     textBreakStrategy?: 'simple' | 'highQuality' | 'balanced';
+
+    /**
+     * Determines the types of data converted to clickable URLs in the text element.
+     * By default no data types are detected.
+     */
+    dataDetectorType?: 'phoneNumber' | 'link' | 'email' | 'none' | 'all';
 }
 
 // https://facebook.github.io/react-native/docs/text.html#props

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -967,7 +967,7 @@ export interface TextPropsAndroid {
      * Determines the types of data converted to clickable URLs in the text element.
      * By default no data types are detected.
      */
-    dataDetectorType?: 'phoneNumber' | 'link' | 'email' | 'none' | 'all';
+    dataDetectorType?: null |'phoneNumber' | 'link' | 'email' | 'none' | 'all';
 }
 
 // https://facebook.github.io/react-native/docs/text.html#props

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -1525,3 +1525,17 @@ export class DrawerLayoutAndroidTest extends React.Component {
         );
     }
 }
+
+// DataDetectorType for Text component
+const DataDetectorTypeTest = () => {
+    return (
+        <>
+            <Text dataDetectorType={'all'}>http://test.com test@test.com +33123456789</Text>
+            <Text dataDetectorType={'email'}>test@test.com</Text>
+            <Text dataDetectorType={'link'}>http://test.com</Text>
+            <Text dataDetectorType={'none'}>Hi there !</Text>
+            <Text dataDetectorType={'phoneNumber'}>+33123456789</Text>
+            <Text dataDetectorType={null}>Must allow null value</Text>
+        </>
+    )
+}


### PR DESCRIPTION
# Description
Hi there 👋🏻 

It seems that `dataDetectorType` type is missing on text component.
![Screenshot_20201003_125205](https://user-images.githubusercontent.com/22751731/94989827-cdfba400-0577-11eb-942f-405029503fa0.png)

A `dataDetectorTypes` already exists but its for the TextInput component (only available for iOS), the one for android (with the Text component) is missing.

After : 

![Screenshot_20201003_134117](https://user-images.githubusercontent.com/22751731/94990701-6006ab00-057e-11eb-80ee-fa3b452443ea.png)

![Screenshot_20201003_134125](https://user-images.githubusercontent.com/22751731/94990703-6137d800-057e-11eb-8035-433e0b95f19f.png)


# More info
Impacted file : https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-native/index.d.ts
Specs for Text component : https://reactnative.dev/docs/text.html#datadetectortype

Thanks you guys :)

# Template
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactnative.dev/docs/text.html#datadetectortype
