### PR TITLE
Added type definitions for popup-window

### DIFF
--- a/types/popup-window/index.d.ts
+++ b/types/popup-window/index.d.ts
@@ -1,0 +1,52 @@
+// Type definitions for popup-window 1.0
+// Project: https://github.com/webdeveric/popup-window#readme
+// Definitions by: Aram Khachatrian <https://github.com/aramwram>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface PopupWindowConfig {
+    name?: string;
+    width?: number;
+    height?: number;
+    left?: number;
+    top?: number;
+    menubar?: boolean;
+    toolbar?: boolean;
+    location?: boolean;
+    status?: boolean;
+    resizable?: boolean;
+    scrollbars?: boolean;
+}
+
+declare class PopupWindow {
+    readonly url: string;
+    readonly name: string;
+
+    constructor(url?: string, config?: PopupWindowConfig);
+
+    /**
+     * Open a new browser window.
+     */
+    open(): PopupWindow;
+
+    /**
+     * Close the browser window.
+     */
+    close(): PopupWindow;
+
+    /**
+     * Accepts a callback - the callback is called when the window is opened.
+     */
+    opened(callback: (win: PopupWindow) => void): PopupWindow;
+
+    /**
+     * Accepts a callback - the callback is called when the window is closed.
+     */
+    blocked(callback: (win: PopupWindow) => void): PopupWindow;
+
+    /**
+     * Accepts a callback - the callback is called when the window is blocked from opening.
+     */
+    closed(callback: (win: PopupWindow) => void): PopupWindow;
+}
+
+export = PopupWindow;

--- a/types/popup-window/popup-window-tests.ts
+++ b/types/popup-window/popup-window-tests.ts
@@ -1,0 +1,39 @@
+import PopupWindow from 'popup-window';
+
+// Ensure we can use and instantiate PopupWindow class.
+const popup1 = new PopupWindow();
+// PopupWindow instance should have open() method.
+popup1.open();
+// PopupWindow instance should have close() method.
+popup1.close();
+
+const popup2 = new PopupWindow();
+// Test common use-case with passing opened, blocked and closed callbacks.
+popup2.opened(win => {
+  // The callback argument should be an instance of PopupWindow.
+  console.log(win.url);
+  console.log(win.name);
+}).blocked(win => {
+  // The callback argument should be an instance of PopupWindow.
+  console.log(win.url);
+  console.log(win.name);
+}).closed(win => {
+  // The callback argument should be an instance of PopupWindow.
+  console.log(win.url);
+  console.log(win.name);
+});
+
+// PopupWindow class should accept URL contructor argument.
+const popup3 = new PopupWindow('http://example.com');
+
+// PopupWindow class should accept both URL and configuration constructor arguments.
+const popup4 = new PopupWindow(
+  'http://example.com',
+  // Test configuration interface.
+  {
+    width: 350,
+    height: 250,
+    resizable: true,
+    menubar: false
+  }
+);

--- a/types/popup-window/tsconfig.json
+++ b/types/popup-window/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "popup-window-tests.ts"
+    ]
+}

--- a/types/popup-window/tslint.json
+++ b/types/popup-window/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Added type definitions for popup-window
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.