### PR TITLE
feat: add kube-probe typings

### DIFF
--- a/types/kube-probe/index.d.ts
+++ b/types/kube-probe/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for kube-probe 1.0
+// Project: https://github.com/nodeshift/kube-probe
+// Definitions by: Ash McBride <https://github.com/emacsified>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import { Express } from 'express';
+
+interface Options {
+    readinessUrl?: string;
+    livenessUrl?: string;
+    readinessCallback: () => void;
+    livenessCallback: () => void;
+    bypassProtection: boolean;
+    protectionConfig: Record<string, unknown>;
+}
+declare function probe(app: Express, options?: Options): void;
+
+export = probe;

--- a/types/kube-probe/index.d.ts
+++ b/types/kube-probe/index.d.ts
@@ -3,14 +3,15 @@
 // Definitions by: Ash McBride <https://github.com/emacsified>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 import { Express } from 'express';
+import { ProtectionConfig } from 'overload-protection';
 
 interface Options {
     readinessUrl?: string;
     livenessUrl?: string;
-    readinessCallback: () => void;
-    livenessCallback: () => void;
-    bypassProtection: boolean;
-    protectionConfig: Record<string, unknown>;
+    readinessCallback?: () => void;
+    livenessCallback?: () => void;
+    bypassProtection?: boolean;
+    protectionConfig?: ProtectionConfig;
 }
 declare function probe(app: Express, options?: Options): void;
 

--- a/types/kube-probe/kube-probe-tests.ts
+++ b/types/kube-probe/kube-probe-tests.ts
@@ -1,0 +1,15 @@
+import express from 'express';
+import probe from 'kube-probe';
+
+// import express
+const app = express();
+
+// add kube-probe to express app
+probe(app, {
+    readinessUrl: '/api/ready',
+    livenessUrl: '/api/live',
+    readinessCallback: () => console.log('ready'),
+    livenessCallback: () => console.log('live'),
+    bypassProtection: false,
+    protectionConfig: {},
+});

--- a/types/kube-probe/tsconfig.json
+++ b/types/kube-probe/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": ["index.d.ts", "kube-probe-tests.ts"]
+}

--- a/types/kube-probe/tslint.json
+++ b/types/kube-probe/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.