### PR TITLE
add types for `fetch-headers`

### DIFF
--- a/types/fetch-headers/fetch-headers-tests.ts
+++ b/types/fetch-headers/fetch-headers-tests.ts
@@ -1,0 +1,7 @@
+/// <reference lib="dom" />
+
+import * as Headers from 'fetch-headers';
+import * as HeadersES5 from 'fetch-headers/headers-es5.min';
+
+const headers = new Headers();
+const headers2 = new HeadersES5();

--- a/types/fetch-headers/headers-es5.min.d.ts
+++ b/types/fetch-headers/headers-es5.min.d.ts
@@ -1,0 +1,4 @@
+/// <reference lib="dom" />
+
+declare const headers: typeof Headers;
+export = headers;

--- a/types/fetch-headers/index.d.ts
+++ b/types/fetch-headers/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for fetch-headers 2.0
+// Project: https://github.com/jimmywarting/fetch-headers#readme
+// Definitions by: Ben Grynhaus <https://github.com/bengry>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference lib="dom" />
+
+declare const headers: typeof Headers;
+export = headers;

--- a/types/fetch-headers/tsconfig.json
+++ b/types/fetch-headers/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "fetch-headers-tests.ts"
+    ]
+}

--- a/types/fetch-headers/tslint.json
+++ b/types/fetch-headers/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
