### PR TITLE
fix: update min ts version of `jest` & co to 3.8 to allow bumping dependencies

### DIFF
--- a/types/expect-puppeteer/index.d.ts
+++ b/types/expect-puppeteer/index.d.ts
@@ -4,7 +4,7 @@
 //                 Tanguy Krotoff <https://github.com/tkrotoff>
 //                 Jason Mong <https://github.com/jfm710>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 3.8
 
 /// <reference types="jest" />
 

--- a/types/frisby/index.d.ts
+++ b/types/frisby/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Christopher E. Woodland <https://github.com/cwoodland>
 //                 Johnny Li <https://github.com/johnny4753>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 3.8
 
 /// <reference types='jest'/>
 

--- a/types/heft-jest/index.d.ts
+++ b/types/heft-jest/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Pete Gonzalez <https://github.com/octogonz>
 //                 Ian Clanton-Thuon <https://github.com/iclanton>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.5
+// TypeScript Version: 3.8
 
 /// <reference types="jest" />
 /// <reference path="./mocked.d.ts" />

--- a/types/jest-axe/index.d.ts
+++ b/types/jest-axe/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Josh Goldberg <https://github.com/JoshuaKGoldberg>
 //                 erbridge <https://github.com/erbridge>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 3.8
 
 /// <reference types="jest" />
 

--- a/types/jest-expect-message/index.d.ts
+++ b/types/jest-expect-message/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Mike Davydov <https://github.com/mike-d-davydov>
 //                 Michael Bashurov <https://github.com/saitonakamura>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.4
+// TypeScript Version: 3.8
 
 /// <reference types="jest"/>
 

--- a/types/jest-image-snapshot/index.d.ts
+++ b/types/jest-image-snapshot/index.d.ts
@@ -4,7 +4,7 @@
 //                 erbridge <https://github.com/erbridge>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 3.8
 
 /// <reference types="jest" />
 import { PixelmatchOptions } from 'pixelmatch';

--- a/types/jest-image-snapshot/v2/index.d.ts
+++ b/types/jest-image-snapshot/v2/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Janeene Beeforth <https://github.com/dawnmist>
 //                 erbridge <https://github.com/erbridge>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 3.8
 
 /// <reference types="jest" />
 

--- a/types/jest-in-case/index.d.ts
+++ b/types/jest-in-case/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/thinkmill/jest-in-case#readme
 // Definitions by: Geovani de Souza <https://github.com/geovanisouza92>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 3.8
 
 /// <reference types="jest" />
 /// <reference types="node" />

--- a/types/jest-json-schema/index.d.ts
+++ b/types/jest-json-schema/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Igor Korolev <https://github.com/deadNightTiger>
 //                 Matt Scheurich <https://github.com/lvl99>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 3.8
 
 /// <reference types="jest" />
 import * as ajv from 'ajv';

--- a/types/jest-matcher-one-of/index.d.ts
+++ b/types/jest-matcher-one-of/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/d4nyll/jest-matcher-one-of#readme
 // Definitions by: Joe Mitchard <https://github.com/joemitchard>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 3.8
 
 /// <reference types="jest" />
 declare namespace jest {

--- a/types/jest-plugin-context/index.d.ts
+++ b/types/jest-plugin-context/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/negativetwelve/jest-plugins/tree/master/packages/jest-plugin-context, https://github.com/negativetwelve/jest-plugins
 // Definitions by: Jonas Heinrich <https://github.com/jonasheinrich>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 3.8
 
 /// <reference types="jest" />
 

--- a/types/jest-specific-snapshot/index.d.ts
+++ b/types/jest-specific-snapshot/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/igor-dv/jest-specific-snapshot#readme
 // Definitions by: Janeene Beeforth <https://github.com/dawnmist>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 3.8
 
 /// <reference types="jest" />
 

--- a/types/jest-when/index.d.ts
+++ b/types/jest-when/index.d.ts
@@ -5,7 +5,7 @@
 //                 Gregor Stamać <https://github.com/gstamac>
 //                 Valentin Stern <https://github.com/sehsyha>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 3.8
 
 /// <reference types="jest" />
 

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -28,6 +28,7 @@
 //                 Pawel Fajfer <https://github.com/pawfa>
 //                 Regev Brody <https://github.com/regevbr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.8
 
 declare var beforeAll: jest.Lifecycle;
 declare var beforeEach: jest.Lifecycle;

--- a/types/jest/package.json
+++ b/types/jest/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "jest-diff": "^25.2.1",
-        "pretty-format": "^25.2.1"
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
     }
 }

--- a/types/testing-library__jest-dom/index.d.ts
+++ b/types/testing-library__jest-dom/index.d.ts
@@ -4,7 +4,7 @@
 //                 John Gozde <https://github.com/jgoz>
 //                 Seth Macpherson <https://github.com/smacpherson64>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 3.8
 
 /// <reference types="jest" />
 

--- a/types/wordpress__jest-console/index.d.ts
+++ b/types/wordpress__jest-console/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/WordPress/gutenberg/blob/master/packages/jest-console/README.md
 // Definitions by: Damien Sorel <https://github.com/mistic100>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 3.8
 
 /// <reference types="jest" />
 


### PR DESCRIPTION
This is required in order to eventually switch to sourcing types from `jest` directly (#44365), and also to allow us to update our dependency ranges for `@types/jest` to pull in the right version - right now we're pulling in v24 packages, which in addition to being the wrong type means dependency trees tend to have some huge duplication as `@types` comes before `jest` (so package managers tend to put the v24 packages at the top level).

After this is merged, the minimal TS version supported by `@types/jest` & packages that reference `@types/jest` will need to be updated whenever `jest` ups their min TS version.

While this could be pretty breaking for some, we can't really avoid it as TS 3.8 doesn't become the min for DT until 2022 by which time `jest` might have a min version of TS 5 or something, so we'll be back in the exact same spot.

This pain should be once-off since afterwards we'll just be matching the min version as directed by `jest`.

Also: 

* if you're using < jest 26 then you shouldn't be using @types/jest@26 so you wouldn't be affected
* if you're using >= jest 26 then you're currently consuming some jest 24 types, which is wrong anyway, so the act of upgrading the dependencies in theory would cause breakages
* if you can't upgrade typescript then you can stay on the current version of the types you're using - while not ideal, typescript will need to be updated at some point anyway and we can only do so much in DT land

See #45603, #47545, #48426, and maybe a few other PRs & issues.

~Creating as a draft initially as I expect this to go somewhat horribly wrong for the first few CI runs 😬~