### PR TITLE
Add `instantiate()` to WebAssembly

### DIFF
--- a/types/webassembly-web-api/index.d.ts
+++ b/types/webassembly-web-api/index.d.ts
@@ -22,4 +22,5 @@ declare namespace WebAssembly {
 
     function compileStreaming(source: Response | Promise<Response>): Promise<Module>;
     function instantiateStreaming(source: Response | Promise<Response>, importObject?: object): Promise<ResultObject>;
+    function instantiate(bufferSource: Response | Promise<Response>, importObject?: object): Promise<ResultObject>;
 }

--- a/types/webassembly-web-api/webassembly-web-api-tests.ts
+++ b/types/webassembly-web-api/webassembly-web-api-tests.ts
@@ -16,3 +16,11 @@ WebAssembly.instantiateStreaming(response);
 // InstantiateStreaming - taking Promise<Response>
 // $ExpectType Promise<ResultObject>
 WebAssembly.instantiateStreaming(promise);
+
+// Instante - taking Response
+// $ExpectType Promise<ResultObject>
+WebAssembly.instantiate(response);
+
+// Instantiate - taking Promise<Response>
+// $ExpectType Promise<ResultObject>
+WebAssembly.instantiate(promise);


### PR DESCRIPTION
Added definition of `instantidate()` method of `WebAssembly`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiate>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.