### PR TITLE
Add async csv

### DIFF
--- a/types/async-csv/async-csv-tests.ts
+++ b/types/async-csv/async-csv-tests.ts
@@ -13,35 +13,31 @@ import {
 } from 'async-csv';
 import { readFileSync } from 'fs';
 
-( async (): Promise<void> => {
-    const csvString: string = 'foo,bar,baz\n1,2,3';
-    const csvBuffer: Buffer = readFileSync( 'data.csv' );
+(async (): Promise<void> => {
+    const csvString = 'foo,bar,baz\n1,2,3';
+    const csvBuffer: Buffer = readFileSync('data.csv');
 
-    const defaultAnyRows: any[] = await parse( csvString );
-    const numRows: number[][]   = await parse<number[]>( csvString );
+    const defaultAnyRows = await parse(csvString);
+    const numRows = await parse(csvString);
 
     const autoParseBoolean: CsvParseOptions = {
         auto_parse_date: false,
-        auto_parse:      true,
+        auto_parse: true,
     };
 
     const autoParseCastingFunction: CsvParseOptions = {
         auto_parse_date: false,
-        auto_parse:      ( value: string, context: CastingContext ): void => {
-        },
+        auto_parse: (value: string, context: CastingContext): void => {},
     };
 
-    const castingDateFunction: CastingDateFunction = (
-        value: string,
-        context: CastingContext,
-    ): Date => new Date( value );
+    const castingDateFunction: CastingDateFunction = (value: string, context: CastingContext): Date => new Date(value);
 
     const autoParseCastingDateFunction: CsvParseOptions = {
         auto_parse_date: castingDateFunction,
     };
 
     const castCastingFunction: CsvParseOptions = {
-        cast: ( value: string, context: CastingContext ): null => null,
+        cast: (value: string, context: CastingContext): null => null,
     };
 
     const castDateCastingFunction: CsvParseOptions = {
@@ -53,29 +49,25 @@ import { readFileSync } from 'fs';
     };
 
     const columnsArray: CsvParseOptions = {
-        columns: [
-            { name: 'foo' },
-            { name: 'bar' },
-            { name: 'baz' },
-        ],
+        columns: [{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }],
     };
 
     const columnsCallback: CsvParseOptions = {
-        columns: ( record: any ): ColumnOption[] => {
-            return [ '', undefined, null, false, { name: 'foo' } ];
+        columns: (record: any): ColumnOption[] => {
+            return ['', undefined, null, false, { name: 'foo' }];
         },
     };
 
     const delimiterBuffer: CsvParseOptions = {
-        delimiter: Buffer.from( [ 42 ] ),
+        delimiter: Buffer.from([42]),
     };
 
     const escapeBuffer: CsvParseOptions = {
-        escape: Buffer.from( [ 42 ] ),
+        escape: Buffer.from([42]),
     };
 
     const quoteBuffer: CsvParseOptions = {
-        quote: Buffer.from( [ 42 ] ),
+        quote: Buffer.from([42]),
     };
 
     const quoteBoolean: CsvParseOptions = {
@@ -87,81 +79,81 @@ import { readFileSync } from 'fs';
     };
 
     const recordDelimiterStringArray: CsvParseOptions = {
-        record_delimiter: [ 'foo', 'bar' ],
+        record_delimiter: ['foo', 'bar'],
     };
 
     const recordDelimiterBuffer: CsvParseOptions = {
-        record_delimiter: Buffer.from( [ 42 ] ),
+        record_delimiter: Buffer.from([42]),
     };
 
     const recordDelimiterBufferArray: CsvParseOptions = {
-        record_delimiter: [ Buffer.from( [ 42 ] ), Buffer.from( [ 21 ] ) ],
+        record_delimiter: [Buffer.from([42]), Buffer.from([21])],
     };
 
     const allParseOptions: CsvParseOptions = {
-        auto_parse:                   true,
-        auto_parse_date:              true,
-        bom:                          true,
-        cast:                         true,
-        cast_date:                    true,
-        columns:                      true,
-        comment:                      'foo',
-        delimiter:                    ',',
-        escape:                       '\\',
-        from:                         0,
-        from_line:                    0,
-        info:                         true,
-        ltrim:                        true,
-        max_record_size:              8192,
-        objname:                      'o',
-        quote:                        '"',
-        raw:                          true,
-        relax:                        true,
-        relax_column_count:           true,
-        record_delimiter:             [ '\r\n', '\n' ],
-        rtrim:                        true,
-        skip_empty_lines:             true,
-        skip_lines_with_error:        true,
+        auto_parse: true,
+        auto_parse_date: true,
+        bom: true,
+        cast: true,
+        cast_date: true,
+        columns: true,
+        comment: 'foo',
+        delimiter: ',',
+        escape: '\\',
+        from: 0,
+        from_line: 0,
+        info: true,
+        ltrim: true,
+        max_record_size: 8192,
+        objname: 'o',
+        quote: '"',
+        raw: true,
+        relax: true,
+        relax_column_count: true,
+        record_delimiter: ['\r\n', '\n'],
+        rtrim: true,
+        skip_empty_lines: true,
+        skip_lines_with_error: true,
         skip_lines_with_empty_values: true,
-        to:                           42,
-        to_line:                      42,
-        trim:                         true,
+        to: 42,
+        to_line: 42,
+        trim: true,
     };
 
     const castingContext: CastingContext = {
-        column:               42,
-        empty_lines:          42,
-        header:               true,
-        index:                42,
-        quoting:              true,
-        lines:                42,
-        records:              42,
+        column: 42,
+        empty_lines: 42,
+        header: true,
+        index: 42,
+        quoting: true,
+        lines: 42,
+        records: 42,
         invalid_field_length: 42,
     };
 
     const castingContextWithoutColumn: CastingContext = {
-        empty_lines:          42,
-        header:               true,
-        index:                42,
-        quoting:              true,
-        lines:                42,
-        records:              42,
+        empty_lines: 42,
+        header: true,
+        index: 42,
+        quoting: true,
+        lines: 42,
+        records: 42,
         invalid_field_length: 42,
     };
 
     const castingContextWithStringColumn: CastingContext = {
-        column:               'foo',
-        empty_lines:          42,
-        header:               true,
-        index:                42,
-        quoting:              true,
-        lines:                42,
-        records:              42,
+        column: 'foo',
+        empty_lines: 42,
+        header: true,
+        index: 42,
+        quoting: true,
+        lines: 42,
+        records: 42,
         invalid_field_length: 42,
     };
 
     const generateColumnsStringArray: CsvGenerateOptions = {
-        columns: [ 'foo', 'bar', 'baz' ],
+        columns: ['foo', 'bar', 'baz'],
     };
 
     const generateEndDate: CsvGenerateOptions = {
@@ -177,34 +169,34 @@ import { readFileSync } from 'fs';
     };
 
     const generateOptions: CsvGenerateOptions = {
-        columns:         42,
-        delimiter:       ',',
-        duration:        3600,
-        encoding:        'UTF-8',
-        end:             3600,
-        eof:             true,
-        fixed_size:      true,
-        fixedSize:       true,
+        columns: 42,
+        delimiter: ',',
+        duration: 3600,
+        encoding: 'UTF-8',
+        end: 3600,
+        eof: true,
+        fixed_size: true,
+        fixedSize: true,
         high_water_mark: 4092,
-        highWaterMark:   4092,
-        length:          400,
+        highWaterMark: 4092,
+        length: 400,
         max_word_length: 20,
-        maxWordLength:   20,
-        object_mode:     true,
-        objectMode:      true,
-        row_delimiter:   '\n',
-        seed:            true,
-        sleep:           42,
+        maxWordLength: 20,
+        object_mode: true,
+        objectMode: true,
+        row_delimiter: '\n',
+        seed: true,
+        sleep: 42,
     };
 
     const transformOptions: TransformOptions = {
-        consume:  true,
+        consume: true,
         parallel: 4,
-        params:   'test',
+        params: 'test',
     };
 
     const stringifyColumnsStringArray: CsvStringifyOptions = {
-        columns: [ 'foo', 'bar', 'baz' ],
+        columns: ['foo', 'bar', 'baz'],
     };
 
     const stringifyColumnsPlainObject: CsvStringifyOptions = {
@@ -212,19 +204,19 @@ import { readFileSync } from 'fs';
     };
 
     const stringifyColumnsColumnOptionArray: CsvStringifyOptions = {
-        columns: [ 'foo', undefined, null ],
+        columns: ['foo', undefined, null],
     };
 
     const stringifyBufferDelimiter: CsvStringifyOptions = {
-        delimiter: Buffer.from( [ 42 ] ),
+        delimiter: Buffer.from([42]),
     };
 
     const stringifyBufferEscape: CsvStringifyOptions = {
-        escape: Buffer.from( [ 42 ] ),
+        escape: Buffer.from([42]),
     };
 
     const stringifyBufferQuote: CsvStringifyOptions = {
-        quote: Buffer.from( [ 42 ] ),
+        quote: Buffer.from([42]),
     };
 
     const stringifyBooleanQuote: CsvStringifyOptions = {
@@ -236,51 +228,49 @@ import { readFileSync } from 'fs';
     };
 
     const stringifyRecordDelimiterBuffer: CsvStringifyOptions = {
-        record_delimiter: Buffer.from( [ 42 ] ),
+        record_delimiter: Buffer.from([42]),
     };
 
     const stringifyOptions: CsvStringifyOptions = {
-        cast:             {
-            boolean: ( value: boolean, context: CastingContext ): string => value ? 'yes' : 'no',
-            date:    ( value: Date, context: CastingContext ): string => value.toISOString(),
-            number:  ( value: number, context: CastingContext ): string => value.toString(),
-            object:  ( value: Record<string, any>, context: CastingContext ): string => JSON.stringify( value ),
-            string:  ( value: string, context: CastingContext ): string => value,
+        cast: {
+            boolean: (value: boolean, context: CastingContext): string => (value ? 'yes' : 'no'),
+            date: (value: Date, context: CastingContext): string => value.toISOString(),
+            number: (value: number, context: CastingContext): string => value.toString(),
+            object: (value: Record<string, any>, context: CastingContext): string => JSON.stringify(value),
+            string: (value: string, context: CastingContext): string => value,
         },
-        columns:          [],
-        delimiter:        ',',
-        eof:              true,
-        escape:           '\\',
-        header:           true,
-        quote:            true,
-        quoted:           true,
-        quoted_empty:     true,
-        quoted_match:     true,
-        quoted_string:    true,
+        columns: [],
+        delimiter: ',',
+        eof: true,
+        escape: '\\',
+        header: true,
+        quote: true,
+        quoted: true,
+        quoted_empty: true,
+        quoted_match: true,
+        quoted_string: true,
         record_delimiter: 'auto',
     };
 
     const resultGenerateWithoutOptions = await generate();
-    const resultGenerateWithOptions    = await generate( generateOptions );
+    const resultGenerateWithOptions = await generate(generateOptions);
 
-    const resultParseWithoutOptions: string[][] = await parse<string[]>( csvString );
-    const resultParseWithOptions: string[][]    = await parse<string[]>( csvString, allParseOptions );
+    const resultParseWithoutOptions: string[][] = (await parse(csvString)) as string[][];
+    const resultParseWithOptions: string[][] = (await parse(csvString, allParseOptions)) as string[][];
 
-    const cb = <T>( err?: Error | null, record?: T ): void => {
-    };
+    const cb = (err?: Error | null, record?: unknown): void => {};
 
     const resultTransformWithoutOptions: number[][] = await transform<string[], number[]>(
         resultParseWithOptions,
-        ( row: string[], cb, transformOptions ): number[] => [ 42 ],
+        (row: string[], cb, transformOptions): number[] => [42],
     );
 
     const resultTransformWithOptions: number[][] = await transform<string[], number[]>(
         resultParseWithOptions,
-        ( row: string[], cb, transformOptions ): number[] => [ 42 ],
+        (row: string[], cb, transformOptions): number[] => [42],
         transformOptions,
     );
 
-    const resultStringifyWithoutOptions: Promise<string> = stringify( resultParseWithOptions );
-    const resultStringifyWithOptions: Promise<string>    = stringify( resultParseWithOptions, stringifyOptions );
-} )();
-
+    const resultStringifyWithoutOptions: Promise<string> = stringify(resultParseWithOptions);
+    const resultStringifyWithOptions: Promise<string> = stringify(resultParseWithOptions, stringifyOptions);
+})();

--- a/types/async-csv/async-csv-tests.ts
+++ b/types/async-csv/async-csv-tests.ts
@@ -1,0 +1,286 @@
+import {
+    CastingContext,
+    CastingDateFunction,
+    ColumnOption,
+    CsvGenerateOptions,
+    CsvParseOptions,
+    CsvStringifyOptions,
+    generate,
+    parse,
+    stringify,
+    transform,
+    TransformOptions,
+} from 'async-csv';
+import { readFileSync } from 'fs';
+
+( async (): Promise<void> => {
+    const csvString: string = 'foo,bar,baz\n1,2,3';
+    const csvBuffer: Buffer = readFileSync( 'data.csv' );
+
+    const defaultAnyRows: any[] = await parse( csvString );
+    const numRows: number[][]   = await parse<number[]>( csvString );
+
+    const autoParseBoolean: CsvParseOptions = {
+        auto_parse_date: false,
+        auto_parse:      true,
+    };
+
+    const autoParseCastingFunction: CsvParseOptions = {
+        auto_parse_date: false,
+        auto_parse:      ( value: string, context: CastingContext ): void => {
+        },
+    };
+
+    const castingDateFunction: CastingDateFunction = (
+        value: string,
+        context: CastingContext,
+    ): Date => new Date( value );
+
+    const autoParseCastingDateFunction: CsvParseOptions = {
+        auto_parse_date: castingDateFunction,
+    };
+
+    const castCastingFunction: CsvParseOptions = {
+        cast: ( value: string, context: CastingContext ): null => null,
+    };
+
+    const castDateCastingFunction: CsvParseOptions = {
+        cast: castingDateFunction,
+    };
+
+    const columnsBoolean: CsvParseOptions = {
+        columns: true,
+    };
+
+    const columnsArray: CsvParseOptions = {
+        columns: [
+            { name: 'foo' },
+            { name: 'bar' },
+            { name: 'baz' },
+        ],
+    };
+
+    const columnsCallback: CsvParseOptions = {
+        columns: ( record: any ): ColumnOption[] => {
+            return [ '', undefined, null, false, { name: 'foo' } ];
+        },
+    };
+
+    const delimiterBuffer: CsvParseOptions = {
+        delimiter: Buffer.from( [ 42 ] ),
+    };
+
+    const escapeBuffer: CsvParseOptions = {
+        escape: Buffer.from( [ 42 ] ),
+    };
+
+    const quoteBuffer: CsvParseOptions = {
+        quote: Buffer.from( [ 42 ] ),
+    };
+
+    const quoteBoolean: CsvParseOptions = {
+        quote: false,
+    };
+
+    const recordDelimiterString: CsvParseOptions = {
+        record_delimiter: 'foo',
+    };
+
+    const recordDelimiterStringArray: CsvParseOptions = {
+        record_delimiter: [ 'foo', 'bar' ],
+    };
+
+    const recordDelimiterBuffer: CsvParseOptions = {
+        record_delimiter: Buffer.from( [ 42 ] ),
+    };
+
+    const recordDelimiterBufferArray: CsvParseOptions = {
+        record_delimiter: [ Buffer.from( [ 42 ] ), Buffer.from( [ 21 ] ) ],
+    };
+
+    const allParseOptions: CsvParseOptions = {
+        auto_parse:                   true,
+        auto_parse_date:              true,
+        bom:                          true,
+        cast:                         true,
+        cast_date:                    true,
+        columns:                      true,
+        comment:                      'foo',
+        delimiter:                    ',',
+        escape:                       '\\',
+        from:                         0,
+        from_line:                    0,
+        info:                         true,
+        ltrim:                        true,
+        max_record_size:              8192,
+        objname:                      'o',
+        quote:                        '"',
+        raw:                          true,
+        relax:                        true,
+        relax_column_count:           true,
+        record_delimiter:             [ '\r\n', '\n' ],
+        rtrim:                        true,
+        skip_empty_lines:             true,
+        skip_lines_with_error:        true,
+        skip_lines_with_empty_values: true,
+        to:                           42,
+        to_line:                      42,
+        trim:                         true,
+    };
+
+    const castingContext: CastingContext = {
+        column:               42,
+        empty_lines:          42,
+        header:               true,
+        index:                42,
+        quoting:              true,
+        lines:                42,
+        records:              42,
+        invalid_field_length: 42,
+    };
+
+    const castingContextWithoutColumn: CastingContext = {
+        empty_lines:          42,
+        header:               true,
+        index:                42,
+        quoting:              true,
+        lines:                42,
+        records:              42,
+        invalid_field_length: 42,
+    };
+
+    const castingContextWithStringColumn: CastingContext = {
+        column:               'foo',
+        empty_lines:          42,
+        header:               true,
+        index:                42,
+        quoting:              true,
+        lines:                42,
+        records:              42,
+        invalid_field_length: 42,
+    };
+
+    const generateColumnsStringArray: CsvGenerateOptions = {
+        columns: [ 'foo', 'bar', 'baz' ],
+    };
+
+    const generateEndDate: CsvGenerateOptions = {
+        end: new Date(),
+    };
+
+    const generateEofBoolean: CsvGenerateOptions = {
+        eof: false,
+    };
+
+    const generateEofString: CsvGenerateOptions = {
+        eof: 'foo',
+    };
+
+    const generateOptions: CsvGenerateOptions = {
+        columns:         42,
+        delimiter:       ',',
+        duration:        3600,
+        encoding:        'UTF-8',
+        end:             3600,
+        eof:             true,
+        fixed_size:      true,
+        fixedSize:       true,
+        high_water_mark: 4092,
+        highWaterMark:   4092,
+        length:          400,
+        max_word_length: 20,
+        maxWordLength:   20,
+        object_mode:     true,
+        objectMode:      true,
+        row_delimiter:   '\n',
+        seed:            true,
+        sleep:           42,
+    };
+
+    const transformOptions: TransformOptions = {
+        consume:  true,
+        parallel: 4,
+        params:   'test',
+    };
+
+    const stringifyColumnsStringArray: CsvStringifyOptions = {
+        columns: [ 'foo', 'bar', 'baz' ],
+    };
+
+    const stringifyColumnsPlainObject: CsvStringifyOptions = {
+        columns: { foo: 'bar' },
+    };
+
+    const stringifyColumnsColumnOptionArray: CsvStringifyOptions = {
+        columns: [ 'foo', undefined, null ],
+    };
+
+    const stringifyBufferDelimiter: CsvStringifyOptions = {
+        delimiter: Buffer.from( [ 42 ] ),
+    };
+
+    const stringifyBufferEscape: CsvStringifyOptions = {
+        escape: Buffer.from( [ 42 ] ),
+    };
+
+    const stringifyBufferQuote: CsvStringifyOptions = {
+        quote: Buffer.from( [ 42 ] ),
+    };
+
+    const stringifyBooleanQuote: CsvStringifyOptions = {
+        quote: false,
+    };
+
+    const stringifyRecordDelimiterString: CsvStringifyOptions = {
+        record_delimiter: 'foo',
+    };
+
+    const stringifyRecordDelimiterBuffer: CsvStringifyOptions = {
+        record_delimiter: Buffer.from( [ 42 ] ),
+    };
+
+    const stringifyOptions: CsvStringifyOptions = {
+        cast:             {
+            boolean: ( value: boolean, context: CastingContext ): string => value ? 'yes' : 'no',
+            date:    ( value: Date, context: CastingContext ): string => value.toISOString(),
+            number:  ( value: number, context: CastingContext ): string => value.toString(),
+            object:  ( value: Record<string, any>, context: CastingContext ): string => JSON.stringify( value ),
+            string:  ( value: string, context: CastingContext ): string => value,
+        },
+        columns:          [],
+        delimiter:        ',',
+        eof:              true,
+        escape:           '\\',
+        header:           true,
+        quote:            true,
+        quoted:           true,
+        quoted_empty:     true,
+        quoted_match:     true,
+        quoted_string:    true,
+        record_delimiter: 'auto',
+    };
+
+    const resultGenerateWithoutOptions = await generate();
+    const resultGenerateWithOptions    = await generate( generateOptions );
+
+    const resultParseWithoutOptions: string[][] = await parse<string[]>( csvString );
+    const resultParseWithOptions: string[][]    = await parse<string[]>( csvString, allParseOptions );
+
+    const cb = <T>( err?: Error | null, record?: T ): void => {
+    };
+
+    const resultTransformWithoutOptions: number[][] = await transform<string[], number[]>(
+        resultParseWithOptions,
+        ( row: string[], cb, transformOptions ): number[] => [ 42 ],
+    );
+
+    const resultTransformWithOptions: number[][] = await transform<string[], number[]>(
+        resultParseWithOptions,
+        ( row: string[], cb, transformOptions ): number[] => [ 42 ],
+        transformOptions,
+    );
+
+    const resultStringifyWithoutOptions: Promise<string> = stringify( resultParseWithOptions );
+    const resultStringifyWithOptions: Promise<string>    = stringify( resultParseWithOptions, stringifyOptions );
+} )();
+

--- a/types/async-csv/index.d.ts
+++ b/types/async-csv/index.d.ts
@@ -1,0 +1,444 @@
+// Type definitions for async-csv 2.1
+// Project: https://github.com/anton-bot/async-csv#readme
+// Definitions by: Anton Ivanov <https://github.com/anton-bot>
+// Definitions by: Moritz Friedrich <https://github.com/Radiergummi>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// For the `Buffer` reference
+/// <reference types="node" />
+
+declare module 'async-csv' {
+
+    export class CsvAsync {
+        /**
+         * @param options
+         */
+        static generate( options?: CsvGenerateOptions ): Promise<unknown>;
+
+        /**
+         * Parses a CSV file into an array of rows.
+         *
+         * @param input
+         * @param options
+         */
+        static parse<T = any[]>(
+            input: string,
+            options?: CsvParseOptions,
+        ): Promise<T[]>;
+
+        /**
+         *
+         * @param data
+         * @param handler
+         * @param options
+         */
+        static transform<T = any, U = any>(
+            data: T[],
+            handler: (
+                record: T,
+                callback: ( err?: Error | null, record?: T ) => void,
+                params?: any,
+            ) => U,
+            options?: TransformOptions,
+        ): Promise<U[]>;
+
+        /**
+         * Converts an array of rows into a CSV string.
+         *
+         * @param {string[][]} data
+         * @param {object} options
+         */
+        static stringify(
+            data: ( string | number | null | undefined )[][],
+            options?: CsvStringifyOptions,
+        ): Promise<string>;
+    }
+
+    export type CsvGenerateOptions = {
+
+        /**
+         * Define the number of generated fields and the generation method.
+         */
+        columns?: number | string[];
+
+        /**
+         * Set the field delimiter.
+         */
+        delimiter?: string;
+
+        /**
+         * Period to run in milliseconds.
+         */
+        duration?: number;
+
+        /**
+         * If specified, then buffers will be decoded to strings using the
+         * specified encoding.
+         */
+        encoding?: string;
+
+        /**
+         * When to stop the generation.
+         */
+        end?: number | Date;
+
+        /**
+         * One or multiple characters to print at the end of the file; only apply when
+         * objectMode is disabled.
+         */
+        eof?: boolean | string;
+
+        /**
+         * Generate buffers equals length as defined by the `highWaterMark` option.
+         */
+        fixed_size?: boolean;
+        fixedSize?: boolean;
+
+        /**
+         * The maximum number of bytes to store in the internal buffer before ceasing
+         * to read from the underlying resource.
+         */
+        high_water_mark?: number;
+        highWaterMark?: number;
+
+        /**
+         * Number of lines or records to generate.
+         */
+        length?: number;
+
+        /**
+         * Maximum number of characters per word.
+         */
+        max_word_length?: number;
+        maxWordLength?: number;
+
+        /**
+         * Whether this stream should behave as a stream of objects.
+         */
+        object_mode?: boolean;
+        objectMode?: boolean;
+
+        /**
+         * One or multiple characters used to delimit records.
+         */
+        row_delimiter?: string;
+
+        /**
+         * Generate idempotent random characters if a number provided.
+         */
+        seed?: boolean | number;
+
+        /**
+         * The time to wait between the generation of each records
+         */
+        sleep?: number;
+    };
+
+    export type CsvParseOptions = {
+
+        /**
+         * If true, the parser will attempt to convert read data types to
+         * native types.
+         *
+         * @deprecated Use {@link cast}
+         */
+        auto_parse?: boolean | CastingFunction;
+
+        /**
+         * If true, the parser will attempt to convert read data types to dates.
+         * It requires the "auto_parse" option.
+         *
+         * @deprecated Use {@link cast_date}
+         */
+        auto_parse_date?: boolean | CastingDateFunction;
+
+        /**
+         * If true, detect and exclude the byte order mark (BOM) from the CSV input
+         * if present.
+         */
+        bom?: boolean;
+
+        /**
+         * If true, the parser will attempt to convert input string to native types.
+         * If a function, receive the value as first argument, a context as second
+         * argument and return a new value. More information about the context
+         * properties is available below.
+         */
+        cast?: boolean | CastingFunction;
+
+        /**
+         * If true, the parser will attempt to convert input string to dates.
+         * If a function, receive the value as argument and return a new value.
+         * It requires the "auto_parse" option. Be careful, it relies on `Date.parse`.
+         */
+        cast_date?: boolean | CastingDateFunction;
+
+        /**
+         * List of fields as an array, a user defined callback accepting the first
+         * line and returning the column names or true if auto-discovered in the first
+         * CSV line. Defaults to null. Affects the result data set in the sense that
+         * records will be objects instead of arrays.
+         */
+        columns?: ColumnOption[] | boolean | ( ( record: any ) => ColumnOption[] );
+
+        /**
+         * Treat all the characters after this one as a comment.
+         * Default to '' (disabled).
+         */
+        comment?: string;
+
+        /**
+         * Set the field delimiter. One character only, defaults to comma.
+         */
+        delimiter?: string | Buffer;
+
+        /**
+         * Set the escape character, one character only, defaults to double quotes.
+         */
+        escape?: string | Buffer;
+
+        /**
+         * Start handling records from the requested number of records.
+         */
+        from?: number;
+
+        /**
+         * Start handling records from the requested line number.
+         */
+        from_line?: number;
+
+        /**
+         * Generate two properties `info` and `record` where `info` is a snapshot of
+         * the info object at the time the record was created and `record` is the
+         * parsed array or object.
+         */
+        info?: boolean;
+
+        /**
+         * If true, ignore whitespace immediately following the delimiter (i.e.
+         * left-trim all fields), defaults to false. Does not remove whitespace in a
+         * quoted field.
+         */
+        ltrim?: boolean;
+
+        /**
+         * Maximum number of characters to be contained in the field and line buffers
+         * before an exception is raised, used to guard against a wrong delimiter or
+         * `record_delimiter`, default to 128,000 characters.
+         */
+        max_record_size?: number;
+
+        /**
+         * Name of header-record title to name objects by.
+         */
+        objname?: string;
+
+        /**
+         * Optional character surrounding a field, one character only, defaults to
+         * double quotes.
+         */
+        quote?: string | boolean | Buffer;
+
+        /**
+         * Generate two properties raw and row where raw is the original CSV row
+         * content and row is the parsed array or object.
+         */
+        raw?: boolean;
+
+        /**
+         * Preserve quotes inside unquoted field.
+         */
+        relax?: boolean;
+
+        /**
+         * Discard inconsistent columns count, default to false.
+         */
+        relax_column_count?: boolean;
+
+        /**
+         * One or multiple characters used to delimit record rows; defaults to auto
+         * discovery if not provided. Supported auto discovery method are Linux
+         * ("\n"), Apple ("\r") and Windows ("\r\n") row delimiters.
+         */
+        record_delimiter?: string | string[] | Buffer | Buffer[];
+
+        /**
+         * If true, ignore whitespace immediately preceding the delimiter (i.e.
+         * right-trim all fields), defaults to false. Does not remove whitespace in a
+         * quoted field.
+         */
+        rtrim?: boolean;
+
+        /**
+         * Dont generate empty values for empty lines.
+         * Defaults to false
+         */
+        skip_empty_lines?: boolean;
+
+        /**
+         * Skip a line with error found inside and directly go process the next line.
+         */
+        skip_lines_with_error?: boolean;
+
+        /**
+         * Don't generate records for lines containing empty column values (column
+         * matching /\s*\/), defaults to false.
+         */
+        skip_lines_with_empty_values?: boolean;
+
+        /**
+         * Stop handling records after the requested number of records.
+         */
+        to?: number;
+
+        /**
+         * Stop handling records after the requested line number.
+         */
+        to_line?: number;
+
+        /**
+         * If true, ignore whitespace immediately around the delimiter, defaults to
+         * false. Does not remove whitespace in a quoted field.
+         */
+        trim?: boolean;
+    };
+
+    export type CastingFunction = (
+        value: string,
+        context: CastingContext,
+    ) => any;
+
+    export type CastingDateFunction = (
+        value: string,
+        context: CastingContext,
+    ) => Date;
+
+    export type ColumnOption = string | undefined | null | false | {
+        name: string;
+    };
+
+    export type ParseColumnOption = string | undefined | null;
+
+    export interface CastingContext {
+        readonly column?: number | string;
+        readonly empty_lines: number;
+        readonly header: boolean;
+        readonly index: number;
+        readonly quoting: boolean;
+        readonly lines: number;
+        readonly records: number;
+        readonly invalid_field_length: number;
+    }
+
+    export type Cast<T> = ( value: T, context: CastingContext ) => string;
+
+    export type PlainObject<T> = Record<string, T>;
+    export type CsvStringifyOptions = {
+
+        /**
+         * Key-value object which defines custom cast for certain data types
+         */
+        cast?: {
+            boolean?: Cast<boolean>;
+            date?: Cast<Date>;
+            number?: Cast<number>;
+
+            /**
+             * Custom formatter for generic object values
+             */
+            object?: Cast<Record<string, any>>;
+            string?: Cast<string>;
+        };
+
+        /**
+         * List of fields, applied when `transform` returns an object, the order
+         * matters. Read the transformer documentation for additional information.
+         * Columns are auto-discovered in the first record when the user write objects
+         * can refer to nested properties of the input JSON see the "header" option on
+         * how to print columns names on the first line.
+         */
+        columns?: string[] | PlainObject<string> | ParseColumnOption[];
+
+        /**
+         * Set the field delimiter, one character only, defaults to a comma.
+         */
+        delimiter?: string | Buffer;
+
+        /**
+         * Add the value of "options.RecordDelimiter" on the last line, default
+         * to true.
+         */
+        eof?: boolean;
+
+        /**
+         * Defaults to the escape read option.
+         */
+        escape?: string | Buffer;
+        header?: boolean;
+
+        /**
+         * The quote characters, defaults to the ", an empty quote value will preserve
+         * the original field.
+         */
+        quote?: string | Buffer | boolean;
+
+        /**
+         * Boolean, default to false, quote all the non-empty fields even if
+         * not required.
+         */
+        quoted?: boolean;
+
+        /**
+         * Boolean, no default, quote empty fields and overrides `quoted_string` on
+         * empty strings when defined.
+         */
+        quoted_empty?: boolean;
+
+        /**
+         * Boolean, default to false, quote all fields matching a regular expression.
+         */
+        quoted_match?: boolean;
+
+        /**
+         * Boolean, default to false, quote all fields of type string even if
+         * not required.
+         */
+        quoted_string?: boolean;
+
+        /**
+         * String used to delimit record rows or a special value. Special values are
+         * 'auto', 'unix', 'mac', 'windows', 'ascii', 'unicode'. Defaults to 'auto'
+         * (discovered in source or 'unix' if no source is specified).
+         */
+        record_delimiter?: RecordDelimiter;
+    };
+
+    export type RecordDelimiter = string | Buffer | 'auto' | 'unix' | 'mac' | 'windows' | 'ascii' | 'unicode';
+
+    export type TransformOptions = {
+
+        /**
+         * In the absence of a consumer, like a `stream.Readable`, trigger the
+         * consumption of the stream.
+         */
+        consume?: boolean;
+
+        /**
+         * The number of transformation callbacks to run in parallel; only apply
+         * with asynchronous handlers; default to "100".
+         */
+        parallel?: number;
+
+        /**
+         * Pass user defined parameters to the user handler as last argument.
+         */
+        params?: any;
+    }
+
+    export default CsvAsync;
+
+    export const generate: typeof CsvAsync.generate;
+    export const parse: typeof CsvAsync.parse;
+    export const transform: typeof CsvAsync.transform;
+    export const stringify: typeof CsvAsync.stringify;
+}

--- a/types/async-csv/index.d.ts
+++ b/types/async-csv/index.d.ts
@@ -9,7 +9,7 @@ declare const CsvAsync: {
     /**
      * @param options
      */
-    generate(options?: CsvAsync.CsvGenerateOptions): Promise<unknown>;
+    generate(options?: CsvAsync.CsvGenerateOptions): Promise<unknown[]>;
 
     /**
      * Parses a CSV file into an array of rows.
@@ -17,7 +17,7 @@ declare const CsvAsync: {
      * @param input
      * @param options
      */
-    parse(input: string, options?: CsvAsync.CsvParseOptions): Promise<unknown>;
+    parse(input: string, options?: CsvAsync.CsvParseOptions): Promise<unknown[]>;
 
     /**
      *

--- a/types/async-csv/index.d.ts
+++ b/types/async-csv/index.d.ts
@@ -3,14 +3,13 @@
 // Definitions by: Moritz Friedrich <https://github.com/Radiergummi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// For the `Buffer` reference
 /// <reference types="node" />
 
-declare namespace CsvAsync {
+declare const CsvAsync: {
     /**
      * @param options
      */
-    function generate(options?: CsvGenerateOptions): Promise<unknown>;
+    generate(options?: CsvAsync.CsvGenerateOptions): Promise<unknown>;
 
     /**
      * Parses a CSV file into an array of rows.
@@ -18,7 +17,7 @@ declare namespace CsvAsync {
      * @param input
      * @param options
      */
-    function parse(input: string, options?: CsvParseOptions): Promise<unknown>;
+    parse(input: string, options?: CsvAsync.CsvParseOptions): Promise<unknown>;
 
     /**
      *
@@ -26,10 +25,10 @@ declare namespace CsvAsync {
      * @param handler
      * @param options
      */
-    function transform<T = any, U = any>(
+    transform<T = any, U = any>(
         data: T[],
         handler: (record: T, callback: (err?: Error | null, record?: T) => void, params?: any) => U,
-        options?: TransformOptions,
+        options?: CsvAsync.TransformOptions,
     ): Promise<U[]>;
 
     /**
@@ -38,10 +37,37 @@ declare namespace CsvAsync {
      * @param data
      * @param options
      */
-    function stringify(
+    stringify(
         data: Array<Array<string | number | null | undefined>>,
-        options?: CsvStringifyOptions,
+        options?: CsvAsync.CsvStringifyOptions,
     ): Promise<string>;
+};
+
+declare namespace CsvAsync {
+    type CastingFunction = (value: string, context: CastingContext) => any;
+
+    type CastingDateFunction = (value: string, context: CastingContext) => Date;
+
+    type ColumnOption = string | undefined | null | false | { name: string };
+
+    type ParseColumnOption = string | undefined | null;
+
+    type Cast<T> = (value: T, context: CastingContext) => string;
+
+    type PlainObject<T> = Record<string, T>;
+
+    type RecordDelimiter = string | Buffer | 'auto' | 'unix' | 'mac' | 'windows' | 'ascii' | 'unicode';
+
+    interface CastingContext {
+        readonly column?: number | string;
+        readonly empty_lines: number;
+        readonly header: boolean;
+        readonly index: number;
+        readonly quoting: boolean;
+        readonly lines: number;
+        readonly records: number;
+        readonly invalid_field_length: number;
+    }
 
     interface CsvGenerateOptions {
         /**
@@ -294,29 +320,6 @@ declare namespace CsvAsync {
         trim?: boolean;
     }
 
-    type CastingFunction = (value: string, context: CastingContext) => any;
-
-    type CastingDateFunction = (value: string, context: CastingContext) => Date;
-
-    type ColumnOption = string | undefined | null | false | { name: string };
-
-    type ParseColumnOption = string | undefined | null;
-
-    interface CastingContext {
-        readonly column?: number | string;
-        readonly empty_lines: number;
-        readonly header: boolean;
-        readonly index: number;
-        readonly quoting: boolean;
-        readonly lines: number;
-        readonly records: number;
-        readonly invalid_field_length: number;
-    }
-
-    type Cast<T> = (value: T, context: CastingContext) => string;
-
-    type PlainObject<T> = Record<string, T>;
-
     interface CsvStringifyOptions {
         /**
          * Key-value object which defines custom cast for certain data types
@@ -397,8 +400,6 @@ declare namespace CsvAsync {
          */
         record_delimiter?: RecordDelimiter;
     }
-
-    type RecordDelimiter = string | Buffer | 'auto' | 'unix' | 'mac' | 'windows' | 'ascii' | 'unicode';
 
     interface TransformOptions {
         /**

--- a/types/async-csv/index.d.ts
+++ b/types/async-csv/index.d.ts
@@ -1,61 +1,49 @@
 // Type definitions for async-csv 2.1
 // Project: https://github.com/anton-bot/async-csv#readme
-// Definitions by: Anton Ivanov <https://github.com/anton-bot>
 // Definitions by: Moritz Friedrich <https://github.com/Radiergummi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // For the `Buffer` reference
 /// <reference types="node" />
 
-declare module 'async-csv' {
+declare namespace CsvAsync {
+    /**
+     * @param options
+     */
+    function generate(options?: CsvGenerateOptions): Promise<unknown>;
 
-    export class CsvAsync {
-        /**
-         * @param options
-         */
-        static generate( options?: CsvGenerateOptions ): Promise<unknown>;
+    /**
+     * Parses a CSV file into an array of rows.
+     *
+     * @param input
+     * @param options
+     */
+    function parse(input: string, options?: CsvParseOptions): Promise<unknown>;
 
-        /**
-         * Parses a CSV file into an array of rows.
-         *
-         * @param input
-         * @param options
-         */
-        static parse<T = any[]>(
-            input: string,
-            options?: CsvParseOptions,
-        ): Promise<T[]>;
+    /**
+     *
+     * @param data
+     * @param handler
+     * @param options
+     */
+    function transform<T = any, U = any>(
+        data: T[],
+        handler: (record: T, callback: (err?: Error | null, record?: T) => void, params?: any) => U,
+        options?: TransformOptions,
+    ): Promise<U[]>;
 
-        /**
-         *
-         * @param data
-         * @param handler
-         * @param options
-         */
-        static transform<T = any, U = any>(
-            data: T[],
-            handler: (
-                record: T,
-                callback: ( err?: Error | null, record?: T ) => void,
-                params?: any,
-            ) => U,
-            options?: TransformOptions,
-        ): Promise<U[]>;
+    /**
+     * Converts an array of rows into a CSV string.
+     *
+     * @param data
+     * @param options
+     */
+    function stringify(
+        data: Array<Array<string | number | null | undefined>>,
+        options?: CsvStringifyOptions,
+    ): Promise<string>;
 
-        /**
-         * Converts an array of rows into a CSV string.
-         *
-         * @param {string[][]} data
-         * @param {object} options
-         */
-        static stringify(
-            data: ( string | number | null | undefined )[][],
-            options?: CsvStringifyOptions,
-        ): Promise<string>;
-    }
-
-    export type CsvGenerateOptions = {
-
+    interface CsvGenerateOptions {
         /**
          * Define the number of generated fields and the generation method.
          */
@@ -83,20 +71,21 @@ declare module 'async-csv' {
         end?: number | Date;
 
         /**
-         * One or multiple characters to print at the end of the file; only apply when
-         * objectMode is disabled.
+         * One or multiple characters to print at the end of the file; only
+         * apply when objectMode is disabled.
          */
         eof?: boolean | string;
 
         /**
-         * Generate buffers equals length as defined by the `highWaterMark` option.
+         * Generate buffers equals length as defined by the
+         * `highWaterMark` option.
          */
         fixed_size?: boolean;
         fixedSize?: boolean;
 
         /**
-         * The maximum number of bytes to store in the internal buffer before ceasing
-         * to read from the underlying resource.
+         * The maximum number of bytes to store in the internal buffer before
+         * ceasing to read from the underlying resource.
          */
         high_water_mark?: number;
         highWaterMark?: number;
@@ -132,10 +121,9 @@ declare module 'async-csv' {
          * The time to wait between the generation of each records
          */
         sleep?: number;
-    };
+    }
 
-    export type CsvParseOptions = {
-
+    interface CsvParseOptions {
         /**
          * If true, the parser will attempt to convert read data types to
          * native types.
@@ -153,33 +141,34 @@ declare module 'async-csv' {
         auto_parse_date?: boolean | CastingDateFunction;
 
         /**
-         * If true, detect and exclude the byte order mark (BOM) from the CSV input
-         * if present.
+         * If true, detect and exclude the byte order mark (BOM) from the CSV
+         * input, if present.
          */
         bom?: boolean;
 
         /**
-         * If true, the parser will attempt to convert input string to native types.
-         * If a function, receive the value as first argument, a context as second
-         * argument and return a new value. More information about the context
-         * properties is available below.
+         * If true, the parser will attempt to convert input string to native
+         * types. If a function, receive the value as first argument, a context
+         * as second argument and return a new value. More information about the
+         * context properties is available below.
          */
         cast?: boolean | CastingFunction;
 
         /**
          * If true, the parser will attempt to convert input string to dates.
          * If a function, receive the value as argument and return a new value.
-         * It requires the "auto_parse" option. Be careful, it relies on `Date.parse`.
+         * It requires the "auto_parse" option. Be careful, it relies
+         * on `Date.parse`.
          */
         cast_date?: boolean | CastingDateFunction;
 
         /**
-         * List of fields as an array, a user defined callback accepting the first
-         * line and returning the column names or true if auto-discovered in the first
-         * CSV line. Defaults to null. Affects the result data set in the sense that
-         * records will be objects instead of arrays.
+         * List of fields as an array, a user defined callback accepting the
+         * first line and returning the column names or true if auto-discovered
+         * in the first CSV line. Defaults to null. Affects the result data set
+         * in the sense that records will be objects instead of arrays.
          */
-        columns?: ColumnOption[] | boolean | ( ( record: any ) => ColumnOption[] );
+        columns?: ColumnOption[] | boolean | ((record: any) => ColumnOption[]);
 
         /**
          * Treat all the characters after this one as a comment.
@@ -193,7 +182,8 @@ declare module 'async-csv' {
         delimiter?: string | Buffer;
 
         /**
-         * Set the escape character, one character only, defaults to double quotes.
+         * Set the escape character, one character only.
+         * Defaults to double quotes.
          */
         escape?: string | Buffer;
 
@@ -208,23 +198,23 @@ declare module 'async-csv' {
         from_line?: number;
 
         /**
-         * Generate two properties `info` and `record` where `info` is a snapshot of
-         * the info object at the time the record was created and `record` is the
-         * parsed array or object.
+         * Generate two properties `info` and `record` where `info` is a
+         * snapshot of the info object at the time the record was created and
+         * `record` is the parsed array or object.
          */
         info?: boolean;
 
         /**
          * If true, ignore whitespace immediately following the delimiter (i.e.
-         * left-trim all fields), defaults to false. Does not remove whitespace in a
-         * quoted field.
+         * left-trim all fields), defaults to false. Does not remove whitespace
+         * in a quoted field.
          */
         ltrim?: boolean;
 
         /**
-         * Maximum number of characters to be contained in the field and line buffers
-         * before an exception is raised, used to guard against a wrong delimiter or
-         * `record_delimiter`, default to 128,000 characters.
+         * Maximum number of characters to be contained in the field and line
+         * buffers before an exception is raised, used to guard against a wrong
+         * delimiter or `record_delimiter`, default to 128,000 characters.
          */
         max_record_size?: number;
 
@@ -234,8 +224,8 @@ declare module 'async-csv' {
         objname?: string;
 
         /**
-         * Optional character surrounding a field, one character only, defaults to
-         * double quotes.
+         * Optional character surrounding a field, one character only, defaults
+         * to double quotes.
          */
         quote?: string | boolean | Buffer;
 
@@ -256,16 +246,16 @@ declare module 'async-csv' {
         relax_column_count?: boolean;
 
         /**
-         * One or multiple characters used to delimit record rows; defaults to auto
-         * discovery if not provided. Supported auto discovery method are Linux
-         * ("\n"), Apple ("\r") and Windows ("\r\n") row delimiters.
+         * One or multiple characters used to delimit record rows; defaults to
+         * auto discovery if not provided. Supported auto discovery method are
+         * Linux ("\n"), Apple ("\r") and Windows ("\r\n") row delimiters.
          */
         record_delimiter?: string | string[] | Buffer | Buffer[];
 
         /**
          * If true, ignore whitespace immediately preceding the delimiter (i.e.
-         * right-trim all fields), defaults to false. Does not remove whitespace in a
-         * quoted field.
+         * right-trim all fields), defaults to false. Does not remove whitespace
+         * in a quoted field.
          */
         rtrim?: boolean;
 
@@ -276,13 +266,14 @@ declare module 'async-csv' {
         skip_empty_lines?: boolean;
 
         /**
-         * Skip a line with error found inside and directly go process the next line.
+         * Skip a line with error found inside and directly go process the
+         * next line.
          */
         skip_lines_with_error?: boolean;
 
         /**
-         * Don't generate records for lines containing empty column values (column
-         * matching /\s*\/), defaults to false.
+         * Don't generate records for lines containing empty column values
+         * (column matching /\s*\/), defaults to false.
          */
         skip_lines_with_empty_values?: boolean;
 
@@ -297,29 +288,21 @@ declare module 'async-csv' {
         to_line?: number;
 
         /**
-         * If true, ignore whitespace immediately around the delimiter, defaults to
-         * false. Does not remove whitespace in a quoted field.
+         * If `true`, ignore whitespace immediately around the delimiter,
+         * defaults to `false`. Does not remove whitespace in a quoted field.
          */
         trim?: boolean;
-    };
+    }
 
-    export type CastingFunction = (
-        value: string,
-        context: CastingContext,
-    ) => any;
+    type CastingFunction = (value: string, context: CastingContext) => any;
 
-    export type CastingDateFunction = (
-        value: string,
-        context: CastingContext,
-    ) => Date;
+    type CastingDateFunction = (value: string, context: CastingContext) => Date;
 
-    export type ColumnOption = string | undefined | null | false | {
-        name: string;
-    };
+    type ColumnOption = string | undefined | null | false | { name: string };
 
-    export type ParseColumnOption = string | undefined | null;
+    type ParseColumnOption = string | undefined | null;
 
-    export interface CastingContext {
+    interface CastingContext {
         readonly column?: number | string;
         readonly empty_lines: number;
         readonly header: boolean;
@@ -330,11 +313,11 @@ declare module 'async-csv' {
         readonly invalid_field_length: number;
     }
 
-    export type Cast<T> = ( value: T, context: CastingContext ) => string;
+    type Cast<T> = (value: T, context: CastingContext) => string;
 
-    export type PlainObject<T> = Record<string, T>;
-    export type CsvStringifyOptions = {
+    type PlainObject<T> = Record<string, T>;
 
+    interface CsvStringifyOptions {
         /**
          * Key-value object which defines custom cast for certain data types
          */
@@ -352,10 +335,11 @@ declare module 'async-csv' {
 
         /**
          * List of fields, applied when `transform` returns an object, the order
-         * matters. Read the transformer documentation for additional information.
-         * Columns are auto-discovered in the first record when the user write objects
-         * can refer to nested properties of the input JSON see the "header" option on
-         * how to print columns names on the first line.
+         * matters. Read the transformer documentation for additional
+         * information. Columns are auto-discovered in the first record when the
+         * user write objects can refer to nested properties of the input JSON
+         * see the "header" option on how to print columns names on the
+         * first line.
          */
         columns?: string[] | PlainObject<string> | ParseColumnOption[];
 
@@ -377,8 +361,8 @@ declare module 'async-csv' {
         header?: boolean;
 
         /**
-         * The quote characters, defaults to the ", an empty quote value will preserve
-         * the original field.
+         * The quote characters, defaults to the ", an empty quote value will
+         * preserve the original field.
          */
         quote?: string | Buffer | boolean;
 
@@ -389,13 +373,14 @@ declare module 'async-csv' {
         quoted?: boolean;
 
         /**
-         * Boolean, no default, quote empty fields and overrides `quoted_string` on
-         * empty strings when defined.
+         * Boolean, no default, quote empty fields and overrides `quoted_string`
+         * on empty strings when defined.
          */
         quoted_empty?: boolean;
 
         /**
-         * Boolean, default to false, quote all fields matching a regular expression.
+         * Boolean, default to false, quote all fields matching a
+         * regular expression.
          */
         quoted_match?: boolean;
 
@@ -406,17 +391,16 @@ declare module 'async-csv' {
         quoted_string?: boolean;
 
         /**
-         * String used to delimit record rows or a special value. Special values are
-         * 'auto', 'unix', 'mac', 'windows', 'ascii', 'unicode'. Defaults to 'auto'
-         * (discovered in source or 'unix' if no source is specified).
+         * String used to delimit record rows or a special value. Special values
+         * are 'auto', 'unix', 'mac', 'windows', 'ascii', 'unicode'. Defaults
+         * to 'auto' (discovered in source or 'unix' if no source is specified).
          */
         record_delimiter?: RecordDelimiter;
-    };
+    }
 
-    export type RecordDelimiter = string | Buffer | 'auto' | 'unix' | 'mac' | 'windows' | 'ascii' | 'unicode';
+    type RecordDelimiter = string | Buffer | 'auto' | 'unix' | 'mac' | 'windows' | 'ascii' | 'unicode';
 
-    export type TransformOptions = {
-
+    interface TransformOptions {
         /**
          * In the absence of a consumer, like a `stream.Readable`, trigger the
          * consumption of the stream.
@@ -434,11 +418,6 @@ declare module 'async-csv' {
          */
         params?: any;
     }
-
-    export default CsvAsync;
-
-    export const generate: typeof CsvAsync.generate;
-    export const parse: typeof CsvAsync.parse;
-    export const transform: typeof CsvAsync.transform;
-    export const stringify: typeof CsvAsync.stringify;
 }
+
+export = CsvAsync;

--- a/types/async-csv/tsconfig.json
+++ b/types/async-csv/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "async-csv-tests.ts"
+    ]
+}

--- a/types/async-csv/tslint.json
+++ b/types/async-csv/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/async-csv/tslint.json
+++ b/types/async-csv/tslint.json
@@ -1,6 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "export-just-namespace": false
-    }
+    "extends": "dtslint/dt.json"
 }

--- a/types/async-csv/tslint.json
+++ b/types/async-csv/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "export-just-namespace": false
+    }
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present)

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration` (**Note: Not in the currently published version on NPM, but on master**)
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

----

This adds types for the [`async-csv`](https://www.npmjs.com/package/async-csv) package. While the maintainer has started working on a new version with typescript support, requests to finish or publish the current state have not received an answer for a while, so it makes sense to publish types for the current stable package.  
The types are in parts copied from the existing types in the repository; I tested them in my own project to verify they work with the currently released code.
