### PR TITLE
Fix typo -- "credentails" to "credentials" in node-auth Providers type

### DIFF
--- a/types/next-auth/providers.d.ts
+++ b/types/next-auth/providers.d.ts
@@ -74,7 +74,7 @@ interface ProviderCredentialsOptions {
     id?: string;
     name: string;
     credentials: unknown;
-    authorize(credentails: unknown): Promise<unknown | null>;
+    authorize(credentials: unknown): Promise<unknown | null>;
 }
 
 /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nextauthjs/next-auth/blob/main/src/providers/credentials.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This just fixes a simple typo and causes makes no other changes.