### PR TITLE
@types/webrtc remove deprecated types

### DIFF
--- a/types/webrtc/RTCPeerConnection.d.ts
+++ b/types/webrtc/RTCPeerConnection.d.ts
@@ -317,26 +317,6 @@ interface RTCPeerConnection extends EventTarget {
 
     // Extension: https://www.w3.org/TR/webrtc/#h-rtcpeerconnection-interface-extensions-2
     getStats(selector?: MediaStreamTrack | null): Promise<RTCStatsReport>;
-
-    // Extension: https://www.w3.org/TR/webrtc/#legacy-interface-extensions
-    // Deprecated!
-    createOffer(successCallback: RTCSessionDescriptionCallback,
-        failureCallback: RTCPeerConnectionErrorCallback,
-        options?: RTCOfferOptions): Promise<void>;
-    setLocalDescription(description: RTCSessionDescriptionInit,
-        successCallback: () => void,
-        failureCallback: RTCPeerConnectionErrorCallback): Promise<void>;
-    createAnswer(successCallback: RTCSessionDescriptionCallback,
-        failureCallback: RTCPeerConnectionErrorCallback): Promise<void>;
-    setRemoteDescription(description: RTCSessionDescriptionInit,
-        successCallback: () => void,
-        failureCallback: RTCPeerConnectionErrorCallback): Promise<void>;
-    addIceCandidate(candidate: RTCIceCandidateInit | RTCIceCandidate,
-        successCallback: () => void,
-        failureCallback: RTCPeerConnectionErrorCallback): Promise<void>;
-    getStats(selector: MediaStreamTrack | null,
-        successCallback: RTCStatsCallback,
-        failureCallback: RTCPeerConnectionErrorCallback): Promise<void>;
 }
 interface RTCPeerConnectionStatic {
     new(configuration?: RTCConfiguration, options?: any): RTCPeerConnection;


### PR DESCRIPTION
Removing these types enables overloading these functions new signatures. Right now it is not possible to extend `RTCPeerConnection` and overload, for example, `createOffer`.

This aligns with the existing readme which states: 
> The definitions track the currently published working draft. Deprecated features are dropped.

@dbrgn 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.w3.org/TR/webrtc/#legacy-interface-extensions
