### PR TITLE
Add all documented properties to ErrorParam, fixes #48491

### DIFF
--- a/types/jwplayer/index.d.ts
+++ b/types/jwplayer/index.d.ts
@@ -157,7 +157,10 @@ declare namespace jwplayer {
     }
 
     interface ErrorParam {
+        code: number;
         message: string;
+        sourceError: object | null;
+        type: 'error';
     }
 
     interface FullscreenParam {


### PR DESCRIPTION
Properties are documented here:
https://developer.jwplayer.com/jwplayer/docs/jw8-javascript-api-reference#section-jwplayer-on-error.