### PR TITLE
[nodemailer-mailgun-transport]: add alias apiKey

### DIFF
--- a/types/nodemailer-mailgun-transport/index.d.ts
+++ b/types/nodemailer-mailgun-transport/index.d.ts
@@ -15,8 +15,13 @@ declare namespace mailgunTransport {
         domain?: string;
     }
 
+    interface AliasAuthOptions {
+        apiKey: string;
+        domain?: string;
+    }
+
     interface Options {
-        auth: AuthOptions;
+        auth: AuthOptions | AliasAuthOptions;
         proxy?: string | boolean;
         host?: string;
         protocol?: string;

--- a/types/nodemailer-mailgun-transport/nodemailer-mailgun-transport-tests.ts
+++ b/types/nodemailer-mailgun-transport/nodemailer-mailgun-transport-tests.ts
@@ -22,7 +22,29 @@ const optsWithHost: mailgunTransport.Options = {
     host: 'api.eu.mailgun.net'
 };
 
+const aliasOpts: mailgunTransport.Options = {
+    auth: {
+        apiKey: "harry"
+    }
+};
+
+const aliasOptsWithDomain: mailgunTransport.Options = {
+    auth: {
+        apiKey: "harry",
+        domain: "http://www.foo.com"
+    }
+};
+
+const aliasOptsWithHost: mailgunTransport.Options = {
+    auth: {
+        apiKey: "harry",
+        domain: "http://www.foo.com"
+    },
+    host: 'api.eu.mailgun.net'
+};
+
 const transport: nodemailer.Transporter = nodemailer.createTransport(mailgunTransport(optsWithHost));
+const transportWithAliasOptions: nodemailer.Transporter = nodemailer.createTransport(mailgunTransport(aliasOptsWithHost));
 
 // setup e-mail data with unicode symbols
 const mailOptions: nodemailer.SendMailOptions = {
@@ -34,5 +56,9 @@ const mailOptions: nodemailer.SendMailOptions = {
 };
 
 transport.sendMail(mailOptions, (error: Error | null, info: nodemailer.SentMessageInfo): void => {
+    // nothing
+});
+
+transportWithAliasOptions.sendMail(mailOptions, (error: Error | null, info: nodemailer.SentMessageInfo): void => {
     // nothing
 });


### PR DESCRIPTION
I usually use `eslint` to check my code convention, so I update the package `nodemailer-mailgun-transport` to support `apiKey` as alias of `api_key`

ref: https://github.com/orliesaurus/nodemailer-mailgun-transport/pull/98

I update this typing package to match with it