### PR TITLE
[meteor] Export the Subscription type.

### DIFF
--- a/types/meteor/meteor.d.ts
+++ b/types/meteor/meteor.d.ts
@@ -231,7 +231,7 @@ declare module "meteor/meteor" {
         function _debug(...args: any[]): void;
     }
 
-    interface Subscription {
+    export interface Subscription {
         added(collection: string, id: string, fields: Object): void;
         changed(collection: string, id: string, fields: Object): void;
         connection: Meteor.Connection;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

All this change does is make the `Subscription` type public. This is needed because it is important when trying to implement a wrapper over publishing (e.g. ValidatedPublish). It seems that there's isn't any direct way to import the type otherwise.