### PR TITLE
PACKAGE object-hash | Added BufferEncoding type for Browser

### DIFF
--- a/types/object-hash/index.d.ts
+++ b/types/object-hash/index.d.ts
@@ -7,7 +7,7 @@ interface IStream {
     update?(chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
     write?(chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
 }
-
+type BufferEncoding = "ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" | "ucs-2" | "base64" | "latin1" | "binary" | "hex";
 import HashStatic = ObjectHash.HashStatic;
 export = HashStatic;
 export as namespace objectHash;


### PR DESCRIPTION
When bundling this library for the browser the type `BufferEncoding` is missing since it is from the node runtime. Adding explicitly the type in de declaration allows the compiler to avoid errors.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

When bundling `object-hash` library for the browser the type `BufferEncoding` is missing since it is from the NodeJS runtime. Adding explicitly the type in declaration allows the compiler to avoid errors.
