### PR TITLE
Wrong JobId definition in function requirements

### DIFF
--- a/types/bull/index.d.ts
+++ b/types/bull/index.d.ts
@@ -709,7 +709,7 @@ declare namespace Bull {
      * Returns a object with the logs according to the start and end arguments. The returned count
      * value is the total amount of logs, useful for implementing pagination.
      */
-    getJobLogs(jobId: string, start?: number, end?: number): Promise<{ logs: string[], count: number }>;
+    getJobLogs(jobId: JobId, start?: number, end?: number): Promise<{ logs: string[], count: number }>;
 
     /**
      * Returns a promise that resolves with the job counts for the given queue.


### PR DESCRIPTION
Fixing JobId requirement to "string | number"

Please fill in this template.

- [✔️] Use a meaningful title for the pull request. Include the name of the package modified.
- [✔️] Test the change in your own code. (Compile and run.)
- [❌] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [✔️] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [✔️] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [✔️] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
