### PR TITLE
[react-stonecutter] Added type definitions for react-stonecutter library

### DIFF
--- a/types/react-stonecutter/index.d.ts
+++ b/types/react-stonecutter/index.d.ts
@@ -8,193 +8,193 @@ import * as React from 'react';
 
 export type Coordinates = [number, number];
 export interface Layout {
-	/**
-	 * an Array of [x, y] coordinate pairs like this: [[0, 0], [20, 0], [0, 30]]
-	 */
-	positions: Coordinates[];
+    /**
+     * an Array of [x, y] coordinate pairs like this: [[0, 0], [20, 0], [0, 30]]
+     */
+    positions: Coordinates[];
 
-	/**
-	 * width of the entire grid
-	 */
-	gridWidth: number;
+    /**
+     * width of the entire grid
+     */
+    gridWidth: number;
 
-	/**
-	 * height of the entire grid
-	 */
-	gridHeight: number;
+    /**
+     * height of the entire grid
+     */
+    gridHeight: number;
 }
 export type LengthUnit = "px" | "em" | "rem";
 export type AngleUnit = "deg";
 
 export type Easing = string;
 export interface Easings {
-	quadIn: Easing;
-	quadOut: Easing;
-	quadInOut: Easing;
-	cubicIn: Easing;
-	cubicOut: Easing;
-	cubicInOut: Easing;
-	quartIn: Easing;
-	quartOut: Easing;
-	quartInOut: Easing;
-	quintIn: Easing;
-	quintOut: Easing;
-	quintInOut: Easing;
-	sineIn: Easing;
-	sineOut: Easing;
-	sineInOut: Easing;
-	expoIn: Easing;
-	expoOut: Easing;
-	expoInOut: Easing;
-	circIn: Easing;
-	circOut: Easing;
-	circInOut: Easing;
-	backIn: Easing;
-	backOut: Easing;
-	backInOut: Easing;
+    quadIn: Easing;
+    quadOut: Easing;
+    quadInOut: Easing;
+    cubicIn: Easing;
+    cubicOut: Easing;
+    cubicInOut: Easing;
+    quartIn: Easing;
+    quartOut: Easing;
+    quartInOut: Easing;
+    quintIn: Easing;
+    quintOut: Easing;
+    quintInOut: Easing;
+    sineIn: Easing;
+    sineOut: Easing;
+    sineInOut: Easing;
+    expoIn: Easing;
+    expoOut: Easing;
+    expoInOut: Easing;
+    circIn: Easing;
+    circOut: Easing;
+    circInOut: Easing;
+    backIn: Easing;
+    backOut: Easing;
+    backInOut: Easing;
 }
 
 export interface CommonGridProps {
-	/**
-	 * Number of columns. Required.
-	 * You can wrap the Grid component in the `makeResponsive` higher-order component to set this dynamically.
-	 */
-	columns: number;
+    /**
+     * Number of columns. Required.
+     * You can wrap the Grid component in the `makeResponsive` higher-order component to set this dynamically.
+     */
+    columns: number;
 
-	/**
-	 * Width of a single column, by default in px units. Required.
-	 */
-	columnWidth: number;
+    /**
+     * Width of a single column, by default in px units. Required.
+     */
+    columnWidth: number;
 
-	/**
-	 * Width of space between columns. Default: 0.
-	 */
-	gutterWidth?: number;
+    /**
+     * Width of space between columns. Default: 0.
+     */
+    gutterWidth?: number;
 
-	/**
-	 * Height of vertical space between items. Default: 0.
-	 */
-	gutterHeight?: number;
+    /**
+     * Height of vertical space between items. Default: 0.
+     */
+    gutterHeight?: number;
 
-	/**
-	 * Change the HTML tagName of the Grid element, for example to 'ul' or 'ol' for a list. Default: 'div'.
-	 */
-	component?: string;
+    /**
+     * Change the HTML tagName of the Grid element, for example to 'ul' or 'ol' for a list. Default: 'div'.
+     */
+    component?: string;
 
-	/**
-	 * Use one of the included layouts, or create your own. Defaults to a 'simple' layout with items of fixed height.
-	 */
-	layout?: LayoutFunction;
+    /**
+     * Use one of the included layouts, or create your own. Defaults to a 'simple' layout with items of fixed height.
+     */
+    layout?: LayoutFunction;
 
-	/**
-	 * These allow you to change how items animate as they appear and disappear from the grid.
-	 * Supply functions that return objects with the opacity and transform values for an item's start and end states.
-	 * By default the item's scale and opacity go from 0 to 1 and back to 0 on exit
-	 */
-	enter?(itemProps: unknown[], gridProps: unknown[], gridState: unknown): unknown;
-	entered?(itemProps: unknown[], gridProps: unknown[], gridState: unknown): unknown;
-	exit?(itemProps: unknown[], gridProps: unknown[], gridState: unknown): unknown;
+    /**
+     * These allow you to change how items animate as they appear and disappear from the grid.
+     * Supply functions that return objects with the opacity and transform values for an item's start and end states.
+     * By default the item's scale and opacity go from 0 to 1 and back to 0 on exit
+     */
+    enter?(itemProps: unknown[], gridProps: unknown[], gridState: unknown): unknown;
+    entered?(itemProps: unknown[], gridProps: unknown[], gridState: unknown): unknown;
+    exit?(itemProps: unknown[], gridProps: unknown[], gridState: unknown): unknown;
 
-	/**
-	 * The perspective distance used for 3D transforms.
-	 * If you are using a transform function like rotateX, use this to strengthen the effect.
-	 * Default is no perspective applied.
-	 */
-	perspective?: number;
+    /**
+     * The perspective distance used for 3D transforms.
+     * If you are using a transform function like rotateX, use this to strengthen the effect.
+     * Default is no perspective applied.
+     */
+    perspective?: number;
 
-	/**
-	 * The length unit used throughout.
-	 * Default: 'px'. Experimental.
-	 * You could try using 'em' or 'rem' and then adjust the font-size for a fluid layout,
-	 * but it may not work well with the measureItems and makeResponsive higher-order components.
-	 * `%` does not work well due to the way CSS transforms work.
-	 */
-	lengthUnit?: LengthUnit;
+    /**
+     * The length unit used throughout.
+     * Default: 'px'. Experimental.
+     * You could try using 'em' or 'rem' and then adjust the font-size for a fluid layout,
+     * but it may not work well with the measureItems and makeResponsive higher-order components.
+     * `%` does not work well due to the way CSS transforms work.
+     */
+    lengthUnit?: LengthUnit;
 
-	/**
-	 * The angle unit. Affects transform-functions such as rotate. Default: 'deg'.
-	 */
-	angleUnit?: AngleUnit;
+    /**
+     * The angle unit. Affects transform-functions such as rotate. Default: 'deg'.
+     */
+    angleUnit?: AngleUnit;
 }
 
 export interface SpringGridProps extends CommonGridProps {
-	/**
-	 * Configuration of the React-Motion spring.
-	 * See the React-Motion docs for more info. Default: { stiffness: 60, damping: 14, precision: 0.1 }.
-	 */
-	springConfig?: unknown;
+    /**
+     * Configuration of the React-Motion spring.
+     * See the React-Motion docs for more info. Default: { stiffness: 60, damping: 14, precision: 0.1 }.
+     */
+    springConfig?: unknown;
 }
 
 export interface CSSGridProps extends CommonGridProps {
-	/**
-	 * Animation duration in ms. Required.
-	 */
-	duration: number;
+    /**
+     * Animation duration in ms. Required.
+     */
+    duration: number;
 
-	/**
-	 * Animation easing function in CSS transition-timing-function format.
-	 * Some Penner easings are included for convenience.
-	 * Default: easings.cubicOut.
-	 */
-	easing?: Easing;
+    /**
+     * Animation easing function in CSS transition-timing-function format.
+     * Some Penner easings are included for convenience.
+     * Default: easings.cubicOut.
+     */
+    easing?: Easing;
 }
 
 export class SpringGrid extends React.Component<SpringGridProps> {}
 export class CSSGrid extends React.Component<CSSGridProps> {}
 
 export interface MeasureItemsOptions {
-	/**
-	 * If set to true, waits for images to load before measuring items and adding them to the Grid.
-	 * This may be necessary if you don't know the height of your images ahead of time.
-	 * Powered by imagesLoaded.
-	 */
-	measureImages: boolean;
+    /**
+     * If set to true, waits for images to load before measuring items and adding them to the Grid.
+     * This may be necessary if you don't know the height of your images ahead of time.
+     * Powered by imagesLoaded.
+     */
+    measureImages: boolean;
 
-	/**
-	 * This option is passed through to the imagesLoaded library.
-	 * It allows you to wait for background images to load, in addition to <img> tags.
-	 */
-	background?: boolean | string;
+    /**
+     * This option is passed through to the imagesLoaded library.
+     * It allows you to wait for background images to load, in addition to <img> tags.
+     */
+    background?: boolean | string;
 }
 
 export function measureItems<T>(grid: T, options?: MeasureItemsOptions): T;
 
 export interface MakeResponsiveOptions {
-	/**
-	 * Maximum width for the Grid in px.
-	 */
-	maxWidth: number;
+    /**
+     * Maximum width for the Grid in px.
+     */
+    maxWidth: number;
 
-	/**
-	 * Minimum horizontal length between the edge of the Grid and the edge of the viewport in px. Default: 0.
-	 */
-	minPadding?: number;
+    /**
+     * Minimum horizontal length between the edge of the Grid and the edge of the viewport in px. Default: 0.
+     */
+    minPadding?: number;
 
-	/**
-	 * Default number of columns before the breakpoints kick in.
-	 * May be useful when rendering server-side in a universal app.
-	 * Default: 4.
-	 */
-	defaultColumns?: number;
+    /**
+     * Default number of columns before the breakpoints kick in.
+     * May be useful when rendering server-side in a universal app.
+     * Default: 4.
+     */
+    defaultColumns?: number;
 }
 
 export function makeResponsive<T>(grid: T, options: MakeResponsiveOptions): T;
 
 export type LayoutFunction = (itemProps: unknown[], gridProps: unknown[]) => Layout;
 export const layout: {
-	pinterest: LayoutFunction;
-	simple: LayoutFunction;
+    pinterest: LayoutFunction;
+    simple: LayoutFunction;
 };
 
 export const enterExitStyle: {
-	foldUp: unknown;
-	fromCenter: unknown;
-	fromLeftToRight: unknown;
-	fromTop: unknown;
-	fromBottom: unknown;
-	newspaper: unknown;
-	simple: unknown;
-	skew: unknown;
+    foldUp: unknown;
+    fromCenter: unknown;
+    fromLeftToRight: unknown;
+    fromTop: unknown;
+    fromBottom: unknown;
+    newspaper: unknown;
+    simple: unknown;
+    skew: unknown;
 };
 
 export const easings: Easings;

--- a/types/react-stonecutter/index.d.ts
+++ b/types/react-stonecutter/index.d.ts
@@ -1,0 +1,200 @@
+// Type definitions for react-stonecutter 0.3
+// Project: https://github.com/dantrain/react-stonecutter
+// Definitions by:  jzipfler <https://github.com/jzipfler>
+//                  Iswenzz <https://github.com/Iswenzz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as React from 'react';
+
+export type Coordinates = [number, number];
+export interface Layout {
+	/**
+	 * an Array of [x, y] coordinate pairs like this: [[0, 0], [20, 0], [0, 30]]
+	 */
+	positions: Coordinates[];
+
+	/**
+	 * width of the entire grid
+	 */
+	gridWidth: number;
+
+	/**
+	 * height of the entire grid
+	 */
+	gridHeight: number;
+}
+export type LengthUnit = "px" | "em" | "rem";
+export type AngleUnit = "deg";
+
+export type Easing = string;
+export interface Easings {
+	quadIn: Easing;
+	quadOut: Easing;
+	quadInOut: Easing;
+	cubicIn: Easing;
+	cubicOut: Easing;
+	cubicInOut: Easing;
+	quartIn: Easing;
+	quartOut: Easing;
+	quartInOut: Easing;
+	quintIn: Easing;
+	quintOut: Easing;
+	quintInOut: Easing;
+	sineIn: Easing;
+	sineOut: Easing;
+	sineInOut: Easing;
+	expoIn: Easing;
+	expoOut: Easing;
+	expoInOut: Easing;
+	circIn: Easing;
+	circOut: Easing;
+	circInOut: Easing;
+	backIn: Easing;
+	backOut: Easing;
+	backInOut: Easing;
+}
+
+export interface CommonGridProps {
+	/**
+	 * Number of columns. Required.
+	 * You can wrap the Grid component in the `makeResponsive` higher-order component to set this dynamically.
+	 */
+	columns: number;
+
+	/**
+	 * Width of a single column, by default in px units. Required.
+	 */
+	columnWidth: number;
+
+	/**
+	 * Width of space between columns. Default: 0.
+	 */
+	gutterWidth?: number;
+
+	/**
+	 * Height of vertical space between items. Default: 0.
+	 */
+	gutterHeight?: number;
+
+	/**
+	 * Change the HTML tagName of the Grid element, for example to 'ul' or 'ol' for a list. Default: 'div'.
+	 */
+	component?: string;
+
+	/**
+	 * Use one of the included layouts, or create your own. Defaults to a 'simple' layout with items of fixed height.
+	 */
+	layout?: LayoutFunction;
+
+	/**
+	 * These allow you to change how items animate as they appear and disappear from the grid.
+	 * Supply functions that return objects with the opacity and transform values for an item's start and end states.
+	 * By default the item's scale and opacity go from 0 to 1 and back to 0 on exit
+	 */
+	enter?(itemProps: unknown[], gridProps: unknown[], gridState: unknown): unknown;
+	entered?(itemProps: unknown[], gridProps: unknown[], gridState: unknown): unknown;
+	exit?(itemProps: unknown[], gridProps: unknown[], gridState: unknown): unknown;
+
+	/**
+	 * The perspective distance used for 3D transforms.
+	 * If you are using a transform function like rotateX, use this to strengthen the effect.
+	 * Default is no perspective applied.
+	 */
+	perspective?: number;
+
+	/**
+	 * The length unit used throughout.
+	 * Default: 'px'. Experimental.
+	 * You could try using 'em' or 'rem' and then adjust the font-size for a fluid layout,
+	 * but it may not work well with the measureItems and makeResponsive higher-order components.
+	 * `%` does not work well due to the way CSS transforms work.
+	 */
+	lengthUnit?: LengthUnit;
+
+	/**
+	 * The angle unit. Affects transform-functions such as rotate. Default: 'deg'.
+	 */
+	angleUnit?: AngleUnit;
+}
+
+export interface SpringGridProps extends CommonGridProps {
+	/**
+	 * Configuration of the React-Motion spring.
+	 * See the React-Motion docs for more info. Default: { stiffness: 60, damping: 14, precision: 0.1 }.
+	 */
+	springConfig?: unknown;
+}
+
+export interface CSSGridProps extends CommonGridProps {
+	/**
+	 * Animation duration in ms. Required.
+	 */
+	duration: number;
+
+	/**
+	 * Animation easing function in CSS transition-timing-function format.
+	 * Some Penner easings are included for convenience.
+	 * Default: easings.cubicOut.
+	 */
+	easing?: Easing;
+}
+
+export class SpringGrid extends React.Component<SpringGridProps> {}
+export class CSSGrid extends React.Component<CSSGridProps> {}
+
+export interface MeasureItemsOptions {
+	/**
+	 * If set to true, waits for images to load before measuring items and adding them to the Grid.
+	 * This may be necessary if you don't know the height of your images ahead of time.
+	 * Powered by imagesLoaded.
+	 */
+	measureImages: boolean;
+
+	/**
+	 * This option is passed through to the imagesLoaded library.
+	 * It allows you to wait for background images to load, in addition to <img> tags.
+	 */
+	background?: boolean | string;
+}
+
+export function measureItems<T>(grid: T, options?: MeasureItemsOptions): T;
+
+export interface MakeResponsiveOptions {
+	/**
+	 * Maximum width for the Grid in px.
+	 */
+	maxWidth: number;
+
+	/**
+	 * Minimum horizontal length between the edge of the Grid and the edge of the viewport in px. Default: 0.
+	 */
+	minPadding?: number;
+
+	/**
+	 * Default number of columns before the breakpoints kick in.
+	 * May be useful when rendering server-side in a universal app.
+	 * Default: 4.
+	 */
+	defaultColumns?: number;
+}
+
+export function makeResponsive<T>(grid: T, options: MakeResponsiveOptions): T;
+
+export type LayoutFunction = (itemProps: unknown[], gridProps: unknown[]) => Layout;
+export const layout: {
+	pinterest: LayoutFunction;
+	simple: LayoutFunction;
+};
+
+export const enterExitStyle: {
+	foldUp: unknown;
+	fromCenter: unknown;
+	fromLeftToRight: unknown;
+	fromTop: unknown;
+	fromBottom: unknown;
+	newspaper: unknown;
+	simple: unknown;
+	skew: unknown;
+};
+
+export const easings: Easings;

--- a/types/react-stonecutter/react-stonecutter-tests.tsx
+++ b/types/react-stonecutter/react-stonecutter-tests.tsx
@@ -1,0 +1,43 @@
+import { SpringGrid, SpringGridProps, makeResponsive, layout } from "react-stonecutter";
+import * as React from "react";
+
+const ResponsiveGrid: typeof SpringGrid = makeResponsive(SpringGrid, {
+	maxWidth: 1920,
+	minPadding: 100
+});
+
+const gridConfig: SpringGridProps = {
+	component: "ul",
+	columns: 5,
+	perspective: 600,
+	columnWidth:  200,
+	gutterWidth: 30,
+	gutterHeight:  0,
+	layout: layout.pinterest,
+	springConfig: {
+		stiffness: 100,
+		damping: 12
+	},
+};
+
+const gridElems: JSX.Element[] = [
+	<p>A</p>,
+	<p>B</p>,
+	<p>C</p>,
+	<p>D</p>,
+	<p>E</p>,
+	<p>F</p>,
+	<p>G</p>,
+];
+
+const StonecutterGrid: JSX.Element = (
+	<SpringGrid {...gridConfig}>
+		{gridElems}
+	</SpringGrid>
+);
+
+const StonecutterGridResponsive: JSX.Element = (
+	<ResponsiveGrid {...gridConfig}>
+		{gridElems}
+	</ResponsiveGrid>
+);

--- a/types/react-stonecutter/react-stonecutter-tests.tsx
+++ b/types/react-stonecutter/react-stonecutter-tests.tsx
@@ -2,42 +2,42 @@ import { SpringGrid, SpringGridProps, makeResponsive, layout } from "react-stone
 import * as React from "react";
 
 const ResponsiveGrid: typeof SpringGrid = makeResponsive(SpringGrid, {
-	maxWidth: 1920,
-	minPadding: 100
+    maxWidth: 1920,
+    minPadding: 100
 });
 
 const gridConfig: SpringGridProps = {
-	component: "ul",
-	columns: 5,
-	perspective: 600,
-	columnWidth:  200,
-	gutterWidth: 30,
-	gutterHeight:  0,
-	layout: layout.pinterest,
-	springConfig: {
-		stiffness: 100,
-		damping: 12
-	},
+    component: "ul",
+    columns: 5,
+    perspective: 600,
+    columnWidth:  200,
+    gutterWidth: 30,
+    gutterHeight:  0,
+    layout: layout.pinterest,
+    springConfig: {
+        stiffness: 100,
+        damping: 12
+    },
 };
 
 const gridElems: JSX.Element[] = [
-	<p>A</p>,
-	<p>B</p>,
-	<p>C</p>,
-	<p>D</p>,
-	<p>E</p>,
-	<p>F</p>,
-	<p>G</p>,
+    <p>A</p>,
+    <p>B</p>,
+    <p>C</p>,
+    <p>D</p>,
+    <p>E</p>,
+    <p>F</p>,
+    <p>G</p>,
 ];
 
 const StonecutterGrid: JSX.Element = (
-	<SpringGrid {...gridConfig}>
-		{gridElems}
-	</SpringGrid>
+    <SpringGrid {...gridConfig}>
+        {gridElems}
+    </SpringGrid>
 );
 
 const StonecutterGridResponsive: JSX.Element = (
-	<ResponsiveGrid {...gridConfig}>
-		{gridElems}
-	</ResponsiveGrid>
+    <ResponsiveGrid {...gridConfig}>
+        {gridElems}
+    </ResponsiveGrid>
 );

--- a/types/react-stonecutter/tsconfig.json
+++ b/types/react-stonecutter/tsconfig.json
@@ -1,0 +1,24 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": [
+			"es6"
+		],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictNullChecks": true,
+		"strictFunctionTypes": true,
+		"jsx": "react",
+		"baseUrl": "../",
+		"typeRoots": [
+			"../"
+		],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.d.ts",
+		"react-stonecutter-tests.tsx"
+	]
+}

--- a/types/react-stonecutter/tsconfig.json
+++ b/types/react-stonecutter/tsconfig.json
@@ -1,24 +1,24 @@
 {
-	"compilerOptions": {
-		"module": "commonjs",
-		"lib": [
-			"es6"
-		],
-		"noImplicitAny": true,
-		"noImplicitThis": true,
-		"strictNullChecks": true,
-		"strictFunctionTypes": true,
-		"jsx": "react",
-		"baseUrl": "../",
-		"typeRoots": [
-			"../"
-		],
-		"types": [],
-		"noEmit": true,
-		"forceConsistentCasingInFileNames": true
-	},
-	"files": [
-		"index.d.ts",
-		"react-stonecutter-tests.tsx"
-	]
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "jsx": "react",
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-stonecutter-tests.tsx"
+    ]
 }

--- a/types/react-stonecutter/tslint.json
+++ b/types/react-stonecutter/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:

- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.