### PR TITLE
Add recent react-native-tvos types to react-native

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -967,7 +967,7 @@ export interface TextPropsAndroid {
      * Determines the types of data converted to clickable URLs in the text element.
      * By default no data types are detected.
      */
-    dataDetectorType?: null |'phoneNumber' | 'link' | 'email' | 'none' | 'all';
+    dataDetectorType?: null | 'phoneNumber' | 'link' | 'email' | 'none' | 'all';
 }
 
 // https://facebook.github.io/react-native/docs/text.html#props
@@ -6677,7 +6677,7 @@ export interface ScrollViewProps extends ViewProps, ScrollViewPropsIOS, ScrollVi
      *  - `'normal'`: 0.998 on iOS, 0.985 on Android (the default)
      *  - `'fast'`: 0.99 on iOS, 0.9 on Android
      */
-    decelerationRate?: 'fast' | 'normal' | number,
+    decelerationRate?: 'fast' | 'normal' | number;
 
     /**
      * When true the scroll view's children are arranged horizontally in a row

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -2093,7 +2093,7 @@ export type TVParallaxProperties = {
 
 export interface TVViewPropsIOS {
     /**
-     * *(Apple TV only)* When set to true, this view will be focusable
+     * *(react-native-tvos)* When set to true, this view will be focusable
      * and navigable using the Apple TV remote.
      *
      * @platform ios
@@ -2101,42 +2101,42 @@ export interface TVViewPropsIOS {
     isTVSelectable?: boolean;
 
     /**
-     * *(Apple TV only)* May be set to true to force the Apple TV focus engine to move focus to this view.
+     * *(react-native-tvos)* May be set to true to force the Apple TV focus engine to move focus to this view.
      *
      * @platform ios
      */
     hasTVPreferredFocus?: boolean;
 
     /**
-     * *(Apple TV only)* Object with properties to control Apple TV parallax effects.
+     * *(react-native-tvos)* Object with properties to control Apple TV parallax effects.
      *
      * @platform ios
      */
     tvParallaxProperties?: TVParallaxProperties;
 
     /**
-     * *(Apple TV only)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 2.0.
+     * *(react-native-tvos)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 2.0.
      *
      * @platform ios
      */
     tvParallaxShiftDistanceX?: number;
 
     /**
-     * *(Apple TV only)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 2.0.
+     * *(react-native-tvos)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 2.0.
      *
      * @platform ios
      */
     tvParallaxShiftDistanceY?: number;
 
     /**
-     * *(Apple TV only)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 0.05.
+     * *(react-native-tvos)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 0.05.
      *
      * @platform ios
      */
     tvParallaxTiltAngle?: number;
 
     /**
-     * *(Apple TV only)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 1.0.
+     * *(react-native-tvos)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 1.0.
      *
      * @platform ios
      */
@@ -5125,14 +5125,14 @@ interface TouchableMixin {
 
 export interface TouchableWithoutFeedbackPropsIOS {
     /**
-     * *(Apple TV only)* TV preferred focus (see documentation for the View component).
+     * *(react-native-tvos)* TV preferred focus (see documentation for the View component).
      *
      * @platform ios
      */
     hasTVPreferredFocus?: boolean;
 
     /**
-     * *(Apple TV only)* Object with properties to control Apple TV parallax effects.
+     * *(react-native-tvos)* Object with properties to control Apple TV parallax effects.
      *
      * enabled: If true, parallax effects are enabled.  Defaults to true.
      * shiftDistanceX: Defaults to 2.0.
@@ -9348,6 +9348,109 @@ export interface KeyboardStatic extends NativeEventEmitter {
     dismiss: () => void;
     addListener(eventType: KeyboardEventName, listener: KeyboardEventListener): EmitterSubscription;
 }
+
+/**
+ * *(react-native-tvos)* Handle TV remote events
+ */
+export const useTVEventHandler: (handleEvent: (event: HWKeyEvent) => void) => void;
+
+/**
+ * *(react-native-tvos)* Enable/Disable navigation using the menu key on the
+ * TV remote.
+ *
+ * @platform ios
+ */
+export const TVMenuControl: {
+    enableTVMenuKey(): void;
+    disableTVMenuKey(): void;
+};
+
+interface HWFocusEvent {
+    eventType: 'blur' | 'focus';
+    eventKeyAction: -1;
+    tag: number;
+}
+
+export type HWKeyEvent =
+    | HWFocusEvent
+    | {
+          eventType: 'up' | 'down' | 'right' | 'left' | string;
+          eventKeyAction: -1 | 1 | 0 | number;
+          tag?: number;
+      };
+
+/**
+ * *(react-native-tvos)* Handle TV remote events
+ */
+export class TVEventHandler {
+    enable<T extends React.Component<unknown>>(
+        component?: T,
+        callback?: (component: T, data: HWKeyEvent) => void,
+    ): void;
+    disable(): void;
+}
+
+export interface FocusGuideProps extends ViewProps {
+    /**
+     * Array of `Component`s to register as destinations with `UIFocusGuide`
+     */
+    destinations?: (null | number | React.Component<any, any> | React.ComponentClass<any>)[];
+}
+
+/**
+ * This component provides support for Apple's `UIFocusGuide` API,
+ * to help ensure that focusable controls can be navigated to,
+ * even if they are not directly in line with other controls.
+ * An example is provided in `RNTester` that shows two different ways of using
+ * this component.
+ *
+ * https://github.com/react-native-community/react-native-tvos/blob/master/RNTester/js/TVFocusGuideExample.js
+ *
+ * @platform ios
+ */
+export class TVFocusGuideView extends React.Component<FocusGuideProps> {}
+
+export interface TVTextScrollViewProps extends ScrollViewProps {
+    /**
+     * The duration of the scroll animation when a swipe is detected.
+     * Default value is 0.3 s
+     */
+    scrollDuration?: number;
+    /**
+     * Scrolling distance when a swipe is detected
+     * Default value is half the visible height (vertical scroller)
+     * or width (horizontal scroller)
+     */
+    pageSize?: number;
+    /**
+     * If true, will scroll to start when focus moves out past the beginning
+     * of the scroller
+     * Defaults to true
+     */
+    snapToStart?: boolean;
+    /**
+     * If true, will scroll to end when focus moves out past the end of the
+     * scroller
+     * Defaults to true
+     */
+    snapToEnd?: boolean;
+    /**
+     * Called when the scroller comes into focus (e.g. for highlighting)
+     */
+    onFocus?(evt: HWKeyEvent): void;
+    /**
+     * Called when the scroller goes out of focus
+     */
+    onBlur?(evt: HWKeyEvent): void;
+}
+
+/**
+ * *(react-native-tvos)* A ScrollView for tvOS that supports scrolling a list
+ * with no focusable items inside/above/below.
+ *
+ * @platform ios
+ */
+export class TVTextScrollView extends React.Component<TVTextScrollViewProps> {}
 
 /**
  * The DevSettings module exposes methods for customizing settings for developers in development.


### PR DESCRIPTION
TV support for react-native has moved to a separate react-native-tvos. The current (and foreseeable) implementation is a fork of react-native, it supports the mobile platforms and TV additions. As such it's imported as `react-native` in TypeScript.  An attempt was made to keep the new TV specific types in the separate repo, but it didn't seem to work. See https://github.com/react-native-community/react-native-tvos/pull/102

The only viable option I could think of was to add the new types to `@types/react-native` too, there are already TV specific types there and it should be the least annoying/confusing way to get your react-native + TV typescript working properly. I have documented the types with **react-native-tvos** to indicate the dependency, and updated the old TV specific ones.

Credit for the types should be attributed to @Krisztiaan

- [✔] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/react-native-community/react-native-tvos/blob/tvos-v0.63.1/index.js

- [❓] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
How/where?

- [ ❌] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

I didn't 🤥

I am seeing the following unrelated errors in master present in this PR as well:

```
test/index.tsx:267:62 - error TS2345: Argument of type 'TextStyle' is not assignable to parameter of type 'false | ImageStyle | RegisteredStyle<ImageStyle> | RecursiveArray<false | ImageStyle | RegisteredStyle<ImageStyle> | null | undefined> | StyleProp<...>[] | null | undefined'.
  Type 'TextStyle' is not assignable to type 'ImageStyle'.
    Types of property 'overflow' are incompatible.
      Type '"hidden" | "visible" | "scroll" | undefined' is not assignable to type '"hidden" | "visible" | undefined'.
        Type '"scroll"' is not assignable to type '"hidden" | "visible" | undefined'.

267 const combinedStyle7 = StyleSheet.compose(composeImageStyle, composeTextStyle); // $ExpectError
                                                                 ~~~~~~~~~~~~~~~~

test/index.tsx:269:7 - error TS2322: Type 'StyleProp<TextStyle>' is not assignable to type 'StyleProp<ImageStyle>'.
  Type 'TextStyle' is not assignable to type 'StyleProp<ImageStyle>'.
    Type 'TextStyle' is not assignable to type 'ImageStyle'.

269 const combinedStyle8: StyleProp<ImageStyle> = StyleSheet.compose(composeTextStyle, composeTextStyle); // $ExpectError
          ~~~~~~~~~~~~~~

test/index.tsx:271:7 - error TS2322: Type 'StyleProp<TextStyle>' is not assignable to type 'StyleProp<ImageStyle>'.
  Type 'TextStyle' is not assignable to type 'StyleProp<ImageStyle>'.
    Type 'TextStyle' is not assignable to type 'ImageStyle'.

271 const combinedStyle9: StyleProp<ImageStyle> = StyleSheet.compose([composeTextStyle], null); // $ExpectError
          ~~~~~~~~~~~~~~

test/index.tsx:273:7 - error TS2322: Type 'StyleProp<TextStyle>' is not assignable to type 'StyleProp<ImageStyle>'.
  Type 'TextStyle' is not assignable to type 'StyleProp<ImageStyle>'.
    Type 'TextStyle' is not assignable to type 'ImageStyle'.

273 const combinedStyle10: StyleProp<ImageStyle> = StyleSheet.compose(Math.random() < 0.5 ? composeTextStyle : null, null); // $ExpectError
          ~~~~~~~~~~~~~~~

test/index.tsx:1286:9 - error TS2769: No overload matches this call.
  Overload 1 of 2, '(props: ViewProps | Readonly<ViewProps>): View', gave the following error.
    Type '{ backgroundColor: { resource_paths: string[]; }; }' is not assignable to type 'StyleProp<ViewStyle>'.
      Types of property 'backgroundColor' are incompatible.
        Type '{ resource_paths: string[]; }' is not assignable to type 'string | unique symbol | undefined'.
          Type '{ resource_paths: string[]; }' is not assignable to type 'unique symbol'.
  Overload 2 of 2, '(props: ViewProps, context: any): View', gave the following error.
    Type '{ backgroundColor: { resource_paths: string[]; }; }' is not assignable to type 'StyleProp<ViewStyle>'.
      Types of property 'backgroundColor' are incompatible.
        Type '{ resource_paths: string[]; }' is not assignable to type 'string | unique symbol | undefined'.
          Type '{ resource_paths: string[]; }' is not assignable to type 'unique symbol'.

1286         style={{
             ~~~~~

  index.d.ts:2522:5
    2522     style?: StyleProp<ViewStyle>;
             ~~~~~
    The expected type comes from property 'style' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<View> & Readonly<ViewProps> & Readonly<{ children?: ReactNode; }>'
  index.d.ts:2522:5
    2522     style?: StyleProp<ViewStyle>;
             ~~~~~
    The expected type comes from property 'style' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<View> & Readonly<ViewProps> & Readonly<{ children?: ReactNode; }>'

test/index.tsx:1297:9 - error TS2769: No overload matches this call.
  Overload 1 of 2, '(props: ViewProps | Readonly<ViewProps>): View', gave the following error.
    Type '{ backgroundColor: { semantic: string; dynamic: { light: string; dark: string; }; }; }' is not assignable to type 'StyleProp<ViewStyle>'.
      Types of property 'backgroundColor' are incompatible.
        Type '{ semantic: string; dynamic: { light: string; dark: string; }; }' is not assignable to type 'string | unique symbol | undefined'.
          Type '{ semantic: string; dynamic: { light: string; dark: string; }; }' is not assignable to type 'unique symbol'.
  Overload 2 of 2, '(props: ViewProps, context: any): View', gave the following error.
    Type '{ backgroundColor: { semantic: string; dynamic: { light: string; dark: string; }; }; }' is not assignable to type 'StyleProp<ViewStyle>'.
      Types of property 'backgroundColor' are incompatible.
        Type '{ semantic: string; dynamic: { light: string; dark: string; }; }' is not assignable to type 'string | unique symbol | undefined'.
          Type '{ semantic: string; dynamic: { light: string; dark: string; }; }' is not assignable to type 'unique symbol'.

1297         style={{
             ~~~~~

  index.d.ts:2522:5
    2522     style?: StyleProp<ViewStyle>;
             ~~~~~
    The expected type comes from property 'style' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<View> & Readonly<ViewProps> & Readonly<{ children?: ReactNode; }>'
  index.d.ts:2522:5
    2522     style?: StyleProp<ViewStyle>;
             ~~~~~
    The expected type comes from property 'style' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<View> & Readonly<ViewProps> & Readonly<{ children?: ReactNode; }>'

test/index.tsx:1310:43 - error TS2339: Property 'resource_paths' does not exist on type 'unique symbol'.

1310 PlatformColor('?attr/colorControlNormal').resource_paths.push('foo'); // $ExpectError
                                               ~~~~~~~~~~~~~~
```