### PR TITLE
fix(@types/chroma-js): allow LRGB interpolation mode

### DIFF
--- a/types/chroma-js/chroma-js-tests.ts
+++ b/types/chroma-js/chroma-js-tests.ts
@@ -34,11 +34,12 @@ function test_chroma() {
     chroma.mix('red', 'blue', 0.5, 'rgb');
     chroma.mix('red', 'blue', 0.5, 'hsl');
     chroma.mix('red', 'blue', 0.5, 'lab');
-    chroma.mix('red', 'blue', 0.5, 'lch');
+    chroma.mix('red', 'blue', 0.5, 'lrgb');
     chroma.blend('4CBBFC', 'EEEE22', 'multiply');
     chroma.blend('4CBBFC', 'EEEE22', 'darken');
     chroma.blend('4CBBFC', 'EEEE22', 'lighten');
     chroma.average(['4CBBFC', 'yellow'], 'lch', [1, 1, 2, 1]);
+    chroma.average(['4CBBFC', 'yellow'], 'lrgb', [1, 1, 2, 1]);
     chroma.random();
     chroma.contrast('pink', 'hotpink');
     chroma.contrast('pink', 'purple');

--- a/types/chroma-js/index.d.ts
+++ b/types/chroma-js/index.d.ts
@@ -88,22 +88,22 @@ declare namespace chroma {
 
         /**
          * Mixes two colors. The mix ratio is a value between 0 and 1.
-         * The color mixing produces different results based the color space used for interpolation.
+         * The color mixing produces different results based the color space used for interpolation. Defaults to LRGB.
          * @example chroma.mix('red', 'blue', 0.25) // => #bf0040
          * @example chroma.mix('red', 'blue', 0.5, 'hsl') // => #ff00ff
          */
-        mix(color1: string | Color, color2: string | Color, f?: number, colorSpace?: keyof ColorSpaces): Color;
+        mix(color1: string | Color, color2: string | Color, f?: number, colorSpace?: InterpolationMode): Color;
 
         /**
          * Alias for {@see mix}.
          */
-        interpolate(color1: string | Color, color2: string | Color, f?: number, colorSpace?: keyof ColorSpaces): Color;
+        interpolate(color1: string | Color, color2: string | Color, f?: number, colorSpace?: InterpolationMode): Color;
 
         /**
          * Similar to {@link mix}, but accepts more than two colors. Simple averaging of R,G,B components and the alpha
          * channel.
          */
-        average(colors: Array<string | Color>, colorSpace?: keyof ColorSpaces, weights?: number[]): Color;
+        average(colors: Array<string | Color>, colorSpace?: InterpolationMode, weights?: number[]): Color;
 
         /**
          * Blends two colors using RGB channel-wise blend functions.
@@ -261,7 +261,7 @@ declare namespace chroma {
          * Set luminance of color. The source color will be interpolated with black or white until the correct luminance is found.
          * The color space used defaults to RGB.
          */
-        luminance(l: number, colorSpace?: keyof ColorSpaces): Color;
+        luminance(l: number, colorSpace?: InterpolationMode): Color;
 
         /**
          * Get color as hexadecimal string.


### PR DESCRIPTION
The current typings do not allow for `mode='lrgb'` in `mix`, `average`, and `luminance`. Ordinarily, this isn't a problem since `lrgb` is the default value since version 2.0 but there are cases when it's needed.

Closes #48518. See that issue for context.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://vis4.net/chromajs/#chroma-average>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
