### PR TITLE
[@chenfengyuan/datepicker] Add types for options

### DIFF
--- a/types/chenfengyuan__datepicker/chenfengyuan__datepicker-tests.ts
+++ b/types/chenfengyuan__datepicker/chenfengyuan__datepicker-tests.ts
@@ -1,0 +1,201 @@
+import { DatePickerEvent } from "chenfengyuan__datepicker";
+
+$('[data-toggle="datepicker"]').datepicker();
+
+$().datepicker({
+    autoShow: false,
+});
+
+$().datepicker({
+    autoHide: false,
+});
+
+$().datepicker({
+    autoPick: false,
+});
+
+$().datepicker({
+    inline: false,
+});
+
+$().datepicker({
+    container: '.my-container',
+});
+
+$().datepicker({
+    container: document.querySelector('.my-container'),
+});
+
+$().datepicker({
+    container: $('.my-container'),
+});
+
+$().datepicker({
+    trigger: '.my-container',
+});
+
+$().datepicker({
+    trigger: document.querySelector('.my-container'),
+});
+
+$().datepicker({
+    trigger: $('.my-container'),
+});
+
+$().datepicker({
+    language: 'en-GB',
+});
+
+$().datepicker({
+    format: 'yyyy-mm-dd',
+});
+
+$().datepicker({
+    date: new Date(2014, 1, 14),
+});
+
+$().datepicker({
+    date: '02/14/2014',
+});
+
+$().datepicker({
+    startDate: new Date(2014, 1, 14),
+});
+
+$().datepicker({
+    startDate: '02/14/2014',
+});
+
+$().datepicker({
+    endDate: new Date(2014, 1, 14),
+});
+
+$().datepicker({
+    endDate: '02/14/2014',
+});
+
+$().datepicker({
+    startView: 0,
+});
+
+$().datepicker({
+    startView: 3, // $ExpectError
+});
+
+$().datepicker({
+    weekStart: 1,
+});
+
+$().datepicker({
+    weekStart: 7, // $ExpectError
+});
+
+$().datepicker({
+    yearFirst: false,
+});
+
+$().datepicker({
+    yearSuffix: '年',
+});
+
+$().datepicker({
+    days: ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'],
+});
+
+$().datepicker({
+    daysShort: ['Son', 'Mon', 'Die', 'Mit', 'Don', 'Fre', 'Sam'],
+});
+
+$().datepicker({
+    daysMin: ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'],
+});
+
+$().datepicker({
+    months: [
+        'Jänner',
+        'Februar',
+        'März',
+        'April',
+        'Mai',
+        'Juni',
+        'Juli',
+        'August',
+        'September',
+        'Oktober',
+        'November',
+        'Dezember',
+    ],
+});
+
+$().datepicker({
+    monthsShort: ['Jän', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'],
+});
+
+$().datepicker({
+    template: '<div class="invalid-template">See documentation</div>',
+});
+
+$().datepicker({
+    itemTag: 'span',
+});
+
+$().datepicker({
+    pickedClass: 'chosen',
+});
+
+$().datepicker({
+    disabledClass: 'inactive',
+});
+
+$().datepicker({
+    highlightedClass: 'emphasized',
+});
+
+$().datepicker({
+    offset: 42,
+});
+
+$().datepicker({
+    zIndex: 42,
+});
+
+const now = Date.now();
+$().datepicker({
+    filter: (date, view) => {
+        if (date.getDay() === 0 && view === 'day') {
+            return false; // Disable all Sundays, but still leave months/years, whose first day is a Sunday, enabled.
+        }
+    },
+});
+
+$().datepicker({
+    filter: (date, view) => {
+        // prettier-ignore
+        if (date.getDay() === 0 && view === 'invalid') { // $ExpectError
+            return false; // Disable all Sundays, but still leave months/years, whose first day is a Sunday, enabled.
+        }
+    },
+});
+
+$().datepicker({
+    show: (e: DatePickerEvent) => {
+        console.debug(e.type);
+        console.debug(e.namespace);
+    },
+});
+
+$().datepicker({
+    hide: (e: DatePickerEvent) => {
+        console.debug(e.type);
+        console.debug(e.namespace);
+    },
+});
+
+$().datepicker({
+    pick: (e: DatePickerEvent) => {
+        console.debug(e.type);
+        console.debug(e.namespace);
+        console.debug(e.date);
+        console.debug(e.view);
+    },
+});

--- a/types/chenfengyuan__datepicker/index.d.ts
+++ b/types/chenfengyuan__datepicker/index.d.ts
@@ -1,0 +1,272 @@
+// Type definitions for @chenfengyuan/datepicker 1.0
+// Project: https://fengyuanchen.github.io/datepicker
+// Definitions by: Anton Rieder <https://github.com/aried3r>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.8
+
+/// <reference types="jquery"/>
+
+export interface DatepickerPlugin<TElement = HTMLElement> {
+    (): JQuery<TElement>;
+}
+
+export interface DatePickerEvent extends Event {
+    namespace: 'datepicker';
+    view: string;
+    date: Date;
+}
+export interface DatepickerOptions {
+    /**
+     * Show the datepicker automatically when initialized.
+     *
+     * Default: `false`
+     */
+    autoShow?: boolean;
+
+    /**
+     * Hide the datepicker automatically when picked.
+     *
+     * Default: `false`
+     */
+    autoHide?: boolean;
+
+    /**
+     * Pick the initial date automatically when initialized.
+     *
+     * Default: `false`
+     */
+    autoPick?: boolean;
+
+    /**
+     * Enable inline mode.
+     *
+     * If the element is not an input element, will append the datepicker to the element.
+     * If the `container` option is set, will append the datepicker to the container.
+     */
+    inline?: boolean;
+
+    /**
+     * A element for putting the datepicker. If not set, the datepicker will be appended to
+     * `document.body` by default.
+     *
+     * > Only works when the `inline` option set to `true`.
+     */
+    container?: Element | JQuery | string | null;
+
+    /**
+     * A element for triggering the datepicker.
+     */
+    trigger?: Element | JQuery | string | null;
+
+    /**
+     * The ISO language code. If not set, will use the built-in language (`en-US`) by default.
+     */
+    language?: string;
+
+    /**
+     * The date string format.
+     *
+     * Default: `mm/dd/yyyy`
+     *
+     * Available date placeholders:
+     * * Year: `yyyy`, `yy`
+     * * Month: `mm`, `m`
+     * * Day: `dd`, `d`
+     */
+    format?: string;
+
+    /**
+     * The initial date. If not set, will use the current date by default.
+     */
+    date?: Date | string;
+
+    /**
+     * The start view date. All the dates before this date will be disabled.
+     */
+    startDate?: Date | string;
+
+    /**
+     * The end view date. All the dates after this date will be disabled.
+     */
+    endDate?: Date | string;
+
+    /**
+     * The start view when initialized.
+     *
+     * Default: `0`
+     *
+     * Options:
+     * * `0`: days
+     * * `1`: months
+     * * `2`: years
+     */
+    startView?: 0 | 1 | 2;
+
+    /**
+     * The start day of the week.
+     *
+     * Default: `0`
+     * Options:
+     * * `0`: Sunday
+     * * `1`: Monday
+     * * `2`: Tuesday
+     * * `3`: Wednesday
+     * * `4`: Thursday
+     * * `5`: Friday
+     * * `6`: Saturday
+     */
+    weekStart?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+    /**
+     * Show year before month on the datepicker header.
+     *
+     * Default: `false`
+     */
+    yearFirst?: boolean;
+
+    /**
+     * A string suffix to the year number.
+     */
+    yearSuffix?: string;
+
+    /**
+     * Days' name of the week.
+     *
+     * Default: `['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']`
+     */
+    days?: string[];
+
+    /**
+     * Shorter days' name.
+     *
+     * Default: `['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']`
+     */
+    daysShort?: string[];
+
+    /**
+     * Shortest days' name.
+     *
+     * Default: `['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']`
+     */
+    daysMin?: string[];
+
+    /**
+     * Months' name.
+     *
+     * Default: `['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']`
+     */
+    months?: string[];
+
+    /**
+     * Shorter months' name.
+     *
+     * Default: `['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']`
+     */
+    monthsShort?: string[];
+
+    /**
+     * A element tag for each item of years, months and days.
+     *
+     * Default: `li`
+     */
+    itemTag?: string;
+
+    /**
+     * CSS class for a muted item.
+     *
+     * Default: `picked`
+     */
+    pickedClass?: string;
+
+    /**
+     * CSS class for a disabled item.
+     *
+     * Default: `disabled`
+     */
+    disabledClass?: string;
+
+    /**
+     * CSS class for highlight date item.
+     *
+     * Default: `highlighted`
+     */
+    highlightedClass?: string;
+
+    /**
+     * The template of the datepicker.
+     *
+     * Default:
+     * ```
+     * <div class="datepicker-container">
+     *   <div class="datepicker-panel" data-view="years picker">
+     *     <ul>
+     *     <li data-view="years prev">&lsaquo;</li>
+     *     <li data-view="years current"></li>
+     *     <li data-view="years next">&rsaquo;</li>
+     *     </ul>
+     *     <ul data-view="years"></ul>
+     *   </div>
+     *   <div class="datepicker-panel" data-view="months picker">
+     *     <ul>
+     *     <li data-view="year prev">&lsaquo;</li>
+     *     <li data-view="year current"></li>
+     *     <li data-view="year next">&rsaquo;</li>
+     *     </ul>
+     *     <ul data-view="months"></ul>
+     *   </div>
+     *   <div class="datepicker-panel" data-view="days picker">
+     *     <ul>
+     *     <li data-view="month prev">&lsaquo;</li>
+     *     <li data-view="month current"></li>
+     *     <li data-view="month next">&rsaquo;</li>
+     *     </ul>
+     *     <ul data-view="week"></ul>
+     *     <ul data-view="days"></ul>
+     *   </div>
+     *  </div>
+     * ```
+     *
+     * **Note**: All the data-view attributes must be set when you customize it.
+     */
+    template?: string;
+
+    /**
+     * The offset top or bottom of the datepicker from the element.
+     *
+     * Default: `10`
+     */
+    offset?: number;
+
+    /**
+     * The CSS `z-index` style for the datepicker.
+     *
+     * Default: `1`
+     */
+    zIndex?: number;
+
+    /**
+     * Filter each date item. If it returns `false`, the related date will be disabled.
+     */
+    filter?: (date: Date, view: 'day' | 'month' | 'year') => boolean | undefined;
+
+    /**
+     * A shortcut of the "show.datepicker" event.
+     */
+    show?: (event: DatePickerEvent) => void;
+
+    /**
+     * A shortcut of the "hide.datepicker" event.
+     */
+    hide?: (event: DatePickerEvent) => void;
+
+    /**
+     * A shortcut of the "pick.datepicker" event.
+     */
+    pick?: (event: DatePickerEvent) => void;
+}
+
+declare global {
+    interface JQuery<TElement = HTMLElement> {
+        datepicker(options?: DatepickerOptions): DatepickerPlugin<TElement>;
+    }
+}

--- a/types/chenfengyuan__datepicker/tsconfig.json
+++ b/types/chenfengyuan__datepicker/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "chenfengyuan__datepicker-tests.ts"
+    ]
+}

--- a/types/chenfengyuan__datepicker/tslint.json
+++ b/types/chenfengyuan__datepicker/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.


Only adds types for options.

https://github.com/fengyuanchen/datepicker#options
https://github.com/fengyuanchen/datepicker/blob/b233093ba7922a3a2d9d1c4aad6457a50cc7b080/docs/js/main.js#L8-L16
https://github.com/fengyuanchen/datepicker/blob/b233093ba7922a3a2d9d1c4aad6457a50cc7b080/test/events/pick.js#L17-L20
