### PR TITLE
[encoding-japanese] Enhance type inference from argument type and revise tests

### DIFF
--- a/types/encoding-japanese/encoding-japanese-tests.ts
+++ b/types/encoding-japanese/encoding-japanese-tests.ts
@@ -1,94 +1,148 @@
-
 import * as Encoding from 'encoding-japanese';
 
 // Convert character encoding to Shift_JIS from UTF-8.
-var utf8Array_1 = new Uint8Array([1, 2, 3]);
-var utf8Array_2 = [1, 2, 3];
-var utf8Array_3 = new Buffer([1, 2, 3]);
-var sjisArray = Encoding.convert(utf8Array_1, 'SJIS', 'UTF8');
-var sjisArray = Encoding.convert(utf8Array_2, 'UTF16', 'UTF8');
-var sjisArray = Encoding.convert(utf8Array_3, 'EUCJP', 'UTF8');
+const utf8Array_1 = new Uint8Array([1, 2, 3]);
+const utf8Array_2 = [1, 2, 3];
+const utf8Array_3 = new Buffer([1, 2, 3]);
+const utf8Array_4 = new Uint16Array([1, 2, 3]);
+const utf8Array_5 = new Uint32Array([1, 2, 3]);
+const utf8Array_6 = new Int16Array([1, 2, 3]);
+const utf8Array_7 = new Int32Array([1, 2, 3]);
+Encoding.convert(utf8Array_1, 'SJIS', 'UTF8'); // $ExpectType number[]
+Encoding.convert(utf8Array_2, 'UTF16', 'UTF8'); // $ExpectType number[]
+Encoding.convert(utf8Array_3, 'UTF16LE', 'UTF8'); // $ExpectType number[]
+Encoding.convert(utf8Array_4, 'UTF16BE', 'UTF8'); // $ExpectType number[]
+Encoding.convert(utf8Array_5, 'BINARY', 'UTF8'); // $ExpectType number[]
+Encoding.convert(utf8Array_6, 'UTF32', 'UTF8'); // $ExpectType number[]
+Encoding.convert(utf8Array_7, 'AUTO', 'UTF8'); // $ExpectType number[]
+Encoding.convert('string value', 'UTF16', 'UTF8'); // $ExpectType string
 
 // Convert character encoding by automatic detection (AUTO detect).
-var utf8Array = utf8Array_1;
-var sjisArray1 = Encoding.convert(utf8Array, 'SJIS');
-// or  
-var sjisArray2 = Encoding.convert(utf8Array, 'SJIS', 'AUTO');
+const utf8Array = utf8Array_1;
+const sjisArray1 = Encoding.convert(utf8Array, 'SJIS'); // $ExpectType number[]
+// or
+const sjisArray2 = Encoding.convert(utf8Array, 'SJIS', 'AUTO'); // $ExpectType number[]
 
 // Detect the character encoding.
 // The return value be one of the "Available Encodings" below.
-var detected = Encoding.detect(utf8Array);
+const detected = Encoding.detect(utf8Array); // $ExpectType EncodingDetection
 if (detected === 'UTF8') {
-  console.log('Encoding is UTF-8');
+    // Encoding is UTF-8'
 }
 
-var sjisArray3 = Encoding.convert(utf8Array, {
-  to: 'SJIS', // to_encoding
-  from: 'UTF8' // from_encoding
+const sjisArray3 = Encoding.convert(utf8Array, {
+    to: 'SJIS', // to_encoding
+    from: 'UTF8', // from_encoding
 });
+sjisArray3; // $ExpectType number[]
 
-var utf8String = 'ã\u0081\u0093ã\u0082\u0093ã\u0081«ã\u0081¡ã\u0081¯';
-var unicodeString = Encoding.convert(utf8String, {
-  to: 'UNICODE',
-  from: 'UTF8',
-  type: 'string' // Specify 'string' type. (Return as string)
+const utf8String = 'ã\u0081\u0093ã\u0082\u0093ã\u0081«ã\u0081¡ã\u0081¯';
+const unicodeString = Encoding.convert(utf8String, {
+    to: 'UNICODE',
+    from: 'UTF8',
+    type: 'string', // Specify 'string' type. (Return as string)
 });
-console.log(unicodeString); // こんにちは
+unicodeString; // $ExpectType string
 
-var utf16Array = Encoding.convert(utf8Array, {
-  to: 'UTF16', // to_encoding
-  from: 'UTF8', // from_encoding
-  bom: true // With BOM
+const unicodeString2 = Encoding.convert(utf8String, {
+    to: 'UNICODE',
+    from: 'UTF8', // Unspecified type. Inferred from 1st argument
 });
+unicodeString2; // $ExpectType string
 
-var utf16leArray = Encoding.convert(utf8Array, {
-  to: 'UTF16', // to_encoding
-  from: 'UTF8', // from_encoding
-  bom: 'LE' // With BOM (little-endian)
+const utf16Array = Encoding.convert(utf8Array, {
+    to: 'UTF16', // to_encoding
+    from: 'UTF8', // from_encoding
+    bom: true, // With BOM
 });
+utf16Array; // $ExpectType number[]
 
-var utf16beArray = Encoding.convert(utf8Array, {
-  to: 'UTF16BE',
-  from: 'UTF8'
+const utf16leArray = Encoding.convert(utf8Array, {
+    to: 'UTF16', // to_encoding
+    from: 'UTF8', // from_encoding
+    bom: 'LE', // With BOM (little-endian)
 });
+utf16leArray; // $ExpectType number[]
+
+const utf16beArray = Encoding.convert(utf8Array, {
+    to: 'UTF16BE',
+    from: 'UTF8',
+});
+utf16beArray; // $ExpectType number[]
+
+const utf16Array2 = Encoding.convert(utf8Array, {
+    to: 'UTF16', // to_encoding
+    from: 'UTF8', // from_encoding
+    type: 'array',
+    bom: true, // With BOM
+});
+utf16Array2; // $ExpectType number[]
+
+const utf16Array3 = Encoding.convert(utf8Array, {
+    to: 'UTF16', // to_encoding
+    from: 'UTF8', // from_encoding
+    type: 'arraybuffer',
+    bom: true, // With BOM
+});
+utf16Array3; // $ExpectType ArrayBuffer
+
+const utf16Array4 = Encoding.convert(utf8Array, {
+    to: 'UTF16', // to_encoding
+    from: 'UTF8', // from_encoding
+    type: 'string',
+    bom: true, // With BOM
+});
+utf16Array4; // $ExpectType string
 
 // Detect character encoding by automatic. (AUTO detect).
-var detected2 = Encoding.detect(utf8Array);
+const detected2 = Encoding.detect(utf8Array); // $ExpectType EncodingDetection
 if (detected2 === 'UTF8') {
-  console.log('Encoding is UTF-8');
+    // Encoding is UTF-8'
 }
 
 // Detect character encoding by specific encoding name.
-var isSJIS = Encoding.detect(sjisArray, 'SJIS');
+const isSJIS = Encoding.detect(sjisArray1, 'SJIS'); // $ExpectType EncodingDetection
 if (isSJIS) {
-  console.log('Encoding is SJIS');
+    // Encoding is SJIS'
 }
 
-var sjisArray4 = [
-  130, 177, 130, 241, 130, 201, 130, 191, 130, 205, 129,
-  65, 130, 217, 130, 176, 129, 153, 130, 210, 130, 230
+const sjisArray4 = [
+    130,
+    177,
+    130,
+    241,
+    130,
+    201,
+    130,
+    191,
+    130,
+    205,
+    129,
+    65,
+    130,
+    217,
+    130,
+    176,
+    129,
+    153,
+    130,
+    210,
+    130,
+    230,
 ];
 
-var encoded = Encoding.urlEncode(sjisArray4);
-console.log(encoded);
-// output:
-// '%82%B1%82%F1%82%C9%82%BF%82%CD%81A%82%D9%82%B0%81%99%82%D2%82%E6'
+const encoded = Encoding.urlEncode(sjisArray4); // $ExpectType string
+// encoded: '%82%B1%82%F1%82%C9%82%BF%82%CD%81A%82%D9%82%B0%81%99%82%D2%82%E6'
 
-var decoded = Encoding.urlDecode(encoded);
-console.log(decoded);
-// output: [
+const decoded = Encoding.urlDecode(encoded); // $ExpectType number[]
+// decoded: [
 //   130, 177, 130, 241, 130, 201, 130, 191, 130, 205, 129,
 //    65, 130, 217, 130, 176, 129, 153, 130, 210, 130, 230
 // ]
 
-var sjisArray5 = [
-  130, 177, 130, 241, 130, 201, 130, 191, 130, 205
-];
-var encoded2 = Encoding.base64Encode(sjisArray5);
-console.log(encoded2); // 'grGC8YLJgr+CzQ=='
+const sjisArray5 = [130, 177, 130, 241, 130, 201, 130, 191, 130, 205];
+const encoded2 = Encoding.base64Encode(sjisArray5); // $ExpectType string
+// encoded2: 'grGC8YLJgr+CzQ=='
 
-var decoded2 = Encoding.base64Decode(encoded2);
-console.log(decoded2);
-// [130, 177, 130, 241, 130, 201, 130, 191, 130, 205]
-
-
+const decoded2 = Encoding.base64Decode(encoded2); // $ExpectType number[]
+// decoded2: [130, 177, 130, 241, 130, 201, 130, 191, 130, 205]

--- a/types/encoding-japanese/encoding-japanese-tests.ts
+++ b/types/encoding-japanese/encoding-japanese-tests.ts
@@ -146,3 +146,5 @@ const encoded2 = Encoding.base64Encode(sjisArray5); // $ExpectType string
 
 const decoded2 = Encoding.base64Decode(encoded2); // $ExpectType number[]
 // decoded2: [130, 177, 130, 241, 130, 201, 130, 191, 130, 205]
+
+Encoding.orders; // $ExpectType string[]

--- a/types/encoding-japanese/index.d.ts
+++ b/types/encoding-japanese/index.d.ts
@@ -92,3 +92,5 @@ export declare function toHankakuSpace(data: ReadonlyArray<number>): number[];
 export declare function toHankakuSpace(data: string): string;
 export declare function toZenkakuSpace(data: ReadonlyArray<number>): number[];
 export declare function toZenkakuSpace(data: string): string;
+
+export declare const orders: string[];

--- a/types/encoding-japanese/index.d.ts
+++ b/types/encoding-japanese/index.d.ts
@@ -1,47 +1,55 @@
-// Type definitions for encoding-japanese v1.0.24
+// Type definitions for encoding-japanese v1.0
 // Project: https://github.com/polygonplanet/encoding.js
-// Definitions by: rhysd <https://rhysd.github.io>
+// Definitions by: rhysd <https://github.com/rhysd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
 
-
 export type Encoding =
-    "UTF32" | "UTF16" | "UTF16BE" |
-    "UTF16LE" | "BINARY" | "ASCII" |
-    "JIS" | "UTF8" | "EUCJP" |
-    "SJIS" | "UNICODE" | "AUTO";
-type RawType = string | Uint8Array | number[] | Buffer;
+    | 'UTF32'
+    | 'UTF16'
+    | 'UTF16BE'
+    | 'UTF16LE'
+    | 'BINARY'
+    | 'ASCII'
+    | 'JIS'
+    | 'UTF8'
+    | 'EUCJP'
+    | 'SJIS'
+    | 'UNICODE'
+    | 'AUTO';
+type IntArrayType = ReadonlyArray<number> | Uint8Array | Uint16Array | Int8Array | Int16Array | Int32Array;
+type RawType = string | IntArrayType | ReadonlyArray<number> | Buffer;
 
 interface ConvertOptions {
     to: Encoding;
     from?: Encoding;
-    type?: "string" | "arraybuffer" | "array";
+    type?: 'string' | 'arraybuffer' | 'array';
     bom?: boolean | string;
 }
 
 export declare function detect(data: RawType, encodings?: Encoding | Encoding[]): Encoding;
 export declare function convert(data: RawType, to: Encoding, from?: Encoding): number[];
 export declare function convert(data: RawType, options: ConvertOptions): string | ArrayBuffer | number[];
-export declare function urlEncode(data: number[] | Uint8Array): string;
+export declare function urlEncode(data: IntArrayType): string;
 export declare function urlDecode(data: string): number[];
-export declare function base64Encode(data: number[] | Uint8Array): string;
+export declare function base64Encode(data: IntArrayType): string;
 export declare function base64Decode(data: string): number[];
-export declare function codeToString(data: number[] | Uint8Array): string;
+export declare function codeToString(data: IntArrayType): string;
 export declare function stringToCode(data: string): number[];
-export declare function toHankakuCase(data: number[]): number[];
+export declare function toHankakuCase(data: ReadonlyArray<number>): number[];
 export declare function toHankakuCase(data: string): string;
-export declare function toZenkakuCase(data: number[]): number[];
+export declare function toZenkakuCase(data: ReadonlyArray<number>): number[];
 export declare function toZenkakuCase(data: string): string;
-export declare function toHiraganaCase(data: number[]): number[];
+export declare function toHiraganaCase(data: ReadonlyArray<number>): number[];
 export declare function toHiraganaCase(data: string): string;
-export declare function toKatakanaCase(data: number[]): number[];
+export declare function toKatakanaCase(data: ReadonlyArray<number>): number[];
 export declare function toKatakanaCase(data: string): string;
-export declare function toHankanaCase(data: number[]): number[];
+export declare function toHankanaCase(data: ReadonlyArray<number>): number[];
 export declare function toHankanaCase(data: string): string;
-export declare function toZenkanaCase(data: number[]): number[];
+export declare function toZenkanaCase(data: ReadonlyArray<number>): number[];
 export declare function toZenkanaCase(data: string): string;
-export declare function toHankakuSpace(data: number[]): number[];
+export declare function toHankakuSpace(data: ReadonlyArray<number>): number[];
 export declare function toHankakuSpace(data: string): string;
-export declare function toZenkakuSpace(data: number[]): number[];
+export declare function toZenkakuSpace(data: ReadonlyArray<number>): number[];
 export declare function toZenkakuSpace(data: string): string;

--- a/types/encoding-japanese/index.d.ts
+++ b/types/encoding-japanese/index.d.ts
@@ -19,18 +19,37 @@ export type Encoding =
     | 'UNICODE'
     | 'AUTO';
 type IntArrayType = ReadonlyArray<number> | Uint8Array | Uint16Array | Int8Array | Int16Array | Int32Array;
-type RawType = string | IntArrayType | ReadonlyArray<number> | Buffer;
+type RawType = IntArrayType | ReadonlyArray<number> | Buffer;
 
-interface ConvertOptions {
+export type ConvertOptions = ConvertStringOptions | ConvertArrayBufferOptions | ConvertArrayOptions;
+
+export interface ConvertStringOptions {
     to: Encoding;
     from?: Encoding;
-    type?: 'string' | 'arraybuffer' | 'array';
+    type?: 'string';
     bom?: boolean | string;
 }
 
-export declare function detect(data: RawType, encodings?: Encoding | Encoding[]): Encoding;
+export interface ConvertArrayBufferOptions {
+    to: Encoding;
+    from?: Encoding;
+    type?: 'arraybuffer';
+    bom?: boolean | string;
+}
+
+export interface ConvertArrayOptions {
+    to: Encoding;
+    from?: Encoding;
+    type?: 'array';
+    bom?: boolean | string;
+}
+
+export declare function detect(data: RawType | string, encodings?: Encoding | Encoding[]): Encoding;
 export declare function convert(data: RawType, to: Encoding, from?: Encoding): number[];
-export declare function convert(data: RawType, options: ConvertOptions): string | ArrayBuffer | number[];
+export declare function convert(data: string, to: Encoding, from?: Encoding): string;
+export declare function convert(data: RawType | string, options: ConvertStringOptions): string;
+export declare function convert(data: RawType | string, options: ConvertArrayBufferOptions): ArrayBuffer;
+export declare function convert(data: RawType | string, options: ConvertArrayOptions): number[];
 export declare function urlEncode(data: IntArrayType): string;
 export declare function urlDecode(data: string): number[];
 export declare function base64Encode(data: IntArrayType): string;

--- a/types/encoding-japanese/index.d.ts
+++ b/types/encoding-japanese/index.d.ts
@@ -18,38 +18,58 @@ export type Encoding =
     | 'SJIS'
     | 'UNICODE'
     | 'AUTO';
-type IntArrayType = ReadonlyArray<number> | Uint8Array | Uint16Array | Int8Array | Int16Array | Int32Array;
+type IntArrayType =
+    | ReadonlyArray<number>
+    | Uint8Array
+    | Uint16Array
+    | Uint32Array
+    | Int8Array
+    | Int16Array
+    | Int32Array;
 type RawType = IntArrayType | ReadonlyArray<number> | Buffer;
+type EncodingDetection = Encoding | false;
 
-export type ConvertOptions = ConvertStringOptions | ConvertArrayBufferOptions | ConvertArrayOptions;
+export type ConvertOptions =
+    | ConvertStringOptions
+    | ConvertArrayBufferOptions
+    | ConvertArrayOptions
+    | ConvertUnknownOptions;
 
 export interface ConvertStringOptions {
     to: Encoding;
     from?: Encoding;
-    type?: 'string';
+    type: 'string';
     bom?: boolean | string;
 }
 
 export interface ConvertArrayBufferOptions {
     to: Encoding;
     from?: Encoding;
-    type?: 'arraybuffer';
+    type: 'arraybuffer';
     bom?: boolean | string;
 }
 
 export interface ConvertArrayOptions {
     to: Encoding;
     from?: Encoding;
-    type?: 'array';
+    type: 'array';
     bom?: boolean | string;
 }
 
-export declare function detect(data: RawType | string, encodings?: Encoding | Encoding[]): Encoding;
+export interface ConvertUnknownOptions {
+    to: Encoding;
+    from?: Encoding;
+    bom?: boolean | string;
+}
+
+export declare function detect(data: RawType | string, encodings?: Encoding | Encoding[]): EncodingDetection;
 export declare function convert(data: RawType, to: Encoding, from?: Encoding): number[];
 export declare function convert(data: string, to: Encoding, from?: Encoding): string;
 export declare function convert(data: RawType | string, options: ConvertStringOptions): string;
 export declare function convert(data: RawType | string, options: ConvertArrayBufferOptions): ArrayBuffer;
 export declare function convert(data: RawType | string, options: ConvertArrayOptions): number[];
+export declare function convert(data: string, options: ConvertUnknownOptions): string;
+export declare function convert(data: RawType, options: ConvertUnknownOptions): number[];
 export declare function urlEncode(data: IntArrayType): string;
 export declare function urlDecode(data: string): number[];
 export declare function base64Encode(data: IntArrayType): string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/polygonplanet/encoding.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This PR does not add new API, but enhances following points:

- Better type inference on return type of `convert()` function looking at its arguments
- Revise tests using `$ExpectType` which checks more
- Prefer `ReadonlyArray<number>` to `number[]` following 'common mistakes' document
- Fix the return type of `detect()` (it should include `false`)
- Add missing `orders` property