### PR TITLE
[meteor] The `userId` from the Subscription may be null

### DIFF
--- a/types/meteor/globals/meteor.d.ts
+++ b/types/meteor/globals/meteor.d.ts
@@ -53,7 +53,7 @@ declare module Meteor {
     }
     interface TypedError extends global_Error {
         message: string;
-        errorType: string;          
+        errorType: string;
     }
     /** Error **/
 
@@ -71,14 +71,14 @@ declare module Meteor {
     function call(name: string, ...args: any[]): any;
 
     function apply<Result extends EJSONable | EJSONable[] | EJSONableProperty | EJSONableProperty[]>(
-        name: string, 
-        args: ReadonlyArray<EJSONable | EJSONableProperty>, 
+        name: string,
+        args: ReadonlyArray<EJSONable | EJSONableProperty>,
         options?: {
             wait?: boolean;
             onResultReceived?: (error: global_Error | Meteor.Error | undefined, result?: Result) => void;
             returnStubValue?: boolean;
             throwStubExceptions?: boolean;
-        }, 
+        },
         asyncCallback?: (error: global_Error | Meteor.Error | undefined, result?: Result) => void): any;
     /** Method **/
 
@@ -235,7 +235,7 @@ declare interface Subscription {
     ready(): void;
     removed(collection: string, id: string): void;
     stop(): void;
-    userId: string;
+    userId: string | null;
 }
 
 declare module Meteor {

--- a/types/meteor/meteor.d.ts
+++ b/types/meteor/meteor.d.ts
@@ -58,7 +58,7 @@ declare module "meteor/meteor" {
         }
         interface TypedError extends global_Error {
             message: string;
-            errorType: string;          
+            errorType: string;
         }
         /** Error **/
 
@@ -76,14 +76,14 @@ declare module "meteor/meteor" {
         function call(name: string, ...args: any[]): any;
 
         function apply<Result extends EJSONable | EJSONable[] | EJSONableProperty | EJSONableProperty[]>(
-            name: string, 
-            args: ReadonlyArray<EJSONable | EJSONableProperty>, 
+            name: string,
+            args: ReadonlyArray<EJSONable | EJSONableProperty>,
             options?: {
                 wait?: boolean;
                 onResultReceived?: (error: global_Error | Meteor.Error | undefined, result?: Result) => void;
                 returnStubValue?: boolean;
                 throwStubExceptions?: boolean;
-            }, 
+            },
             asyncCallback?: (error: global_Error | Meteor.Error | undefined, result?: Result) => void): any;
         /** Method **/
 
@@ -240,7 +240,7 @@ declare module "meteor/meteor" {
         ready(): void;
         removed(collection: string, id: string): void;
         stop(): void;
-        userId: string;
+        userId: string | null;
     }
 
     module Meteor {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [?] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [?] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

As per [the documentation](https://docs.meteor.com/api/pubsub.html#Subscription-userId) the `userId` in a Subscription can be `null`.

I'm not sure why the test doesn't pass, it seems that whatever I do, the `null` is removed from the `userId` type and the test fails because userId has just a type of `string`. Replacing `null` with number maintains the type correctly yet if I try to add `null` it disappears.

I also had problems with the `globals` folder. I'm not sure if we're still maintaining the script that generates the globals since it doesn't seem to work for me. I remember there were problems with the script but I'm not sure if the `globals` folder is even used by someone.