### PR TITLE
[amqplib] Change consume callback return type to void

### DIFF
--- a/types/amqplib/callback_api.d.ts
+++ b/types/amqplib/callback_api.d.ts
@@ -32,7 +32,7 @@ export interface Channel extends events.EventEmitter {
     publish(exchange: string, routingKey: string, content: Buffer, options?: Options.Publish): boolean;
     sendToQueue(queue: string, content: Buffer, options?: Options.Publish): boolean;
 
-    consume(queue: string, onMessage: (msg: Message | null) => any, options?: Options.Consume, callback?: (err: any, ok: Replies.Consume) => void): void;
+    consume(queue: string, onMessage: (msg: Message | null) => void, options?: Options.Consume, callback?: (err: any, ok: Replies.Consume) => void): void;
 
     cancel(consumerTag: string, callback?: (err: any, ok: Replies.Empty) => void): void;
     get(queue: string, options?: Options.Get, callback?: (err: any, ok: Message | false) => void): void;

--- a/types/amqplib/index.d.ts
+++ b/types/amqplib/index.d.ts
@@ -41,7 +41,7 @@ export interface Channel extends events.EventEmitter {
     publish(exchange: string, routingKey: string, content: Buffer, options?: Options.Publish): boolean;
     sendToQueue(queue: string, content: Buffer, options?: Options.Publish): boolean;
 
-    consume(queue: string, onMessage: (msg: ConsumeMessage | null) => any, options?: Options.Consume): Promise<Replies.Consume>;
+    consume(queue: string, onMessage: (msg: ConsumeMessage | null) => void, options?: Options.Consume): Promise<Replies.Consume>;
 
     cancel(consumerTag: string): Promise<Replies.Empty>;
     get(queue: string, options?: Options.Get): Promise<GetMessage | false>;


### PR DESCRIPTION
Changes the return type of the `onMessage` handler in the `consume` function from `any` to `void` because amqplib does not need and does not handle any returned value. 

This will also make `@typescript-eslint/no-misused-promises` rule warn about `onMessage` handlers that return a `Promise`, which might result in an `UnhandledPromiseRejectionWarning` because amqplib is not handling a rejected Promise.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing): Tests are already only using void functions as `onMessage` handler
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

