### PR TITLE
Added types for grumbler-scripts

### DIFF
--- a/types/grumbler-scripts/config/constants.d.ts
+++ b/types/grumbler-scripts/config/constants.d.ts
@@ -1,0 +1,8 @@
+export enum ENV {
+    LOCAL = 'local',
+    STAGE = 'stage',
+    SANDBOX = 'sandbox',
+    PRODUCTION = 'production',
+    TEST = 'test',
+    DEMO = 'demo',
+}

--- a/types/grumbler-scripts/config/index.d.ts
+++ b/types/grumbler-scripts/config/index.d.ts
@@ -1,0 +1,4 @@
+export * from './constants';
+export * from './types';
+export * from './karma.conf';
+export * from './webpack.config';

--- a/types/grumbler-scripts/config/karma.conf.d.ts
+++ b/types/grumbler-scripts/config/karma.conf.d.ts
@@ -1,0 +1,2 @@
+export function getKarmaConfig(karma: object, cfg?: object): object;
+export default function karma(karma: object): object;

--- a/types/grumbler-scripts/config/types.d.ts
+++ b/types/grumbler-scripts/config/types.d.ts
@@ -1,0 +1,24 @@
+export interface WebpackConfigOptions {
+    context?: string;
+    entry?: string | ReadonlyArray<string>;
+    filename?: string;
+    modulename?: string;
+    minify?: boolean;
+    test?: boolean;
+    options?: object;
+    vars?: object;
+    alias?: { [key: string]: string };
+    libraryTarget?: string;
+    web?: boolean;
+    debug?: boolean;
+    env?: string;
+    path?: string;
+    sourcemaps?: boolean;
+    cache?: boolean;
+    analyze?: boolean;
+    dynamic?: boolean;
+    babelConfig?: string;
+}
+
+// tslint:disable-next-line:no-empty-interface
+export interface WebpackConfig {}

--- a/types/grumbler-scripts/config/webpack.config.d.ts
+++ b/types/grumbler-scripts/config/webpack.config.d.ts
@@ -1,0 +1,5 @@
+import { WebpackConfigOptions } from './types';
+
+export function getCurrentVersion(pkg: { version: string }): string;
+export function getNextVersion(pkg: { version: string }, level?: string): string;
+export function getWebpackConfig(options?: WebpackConfigOptions): object;

--- a/types/grumbler-scripts/declarations.d.ts
+++ b/types/grumbler-scripts/declarations.d.ts
@@ -1,0 +1,17 @@
+import { ENV } from './config/constants';
+
+export type $Values<O extends object> = O[keyof O];
+
+export const __TEST__: boolean;
+export const __WEB__: boolean;
+export const __MIN__: boolean;
+export const __DEBUG__: boolean;
+export const __ENV__: $Values<typeof ENV>;
+export const __TREE_SHAKE__: boolean;
+export const __WINDOW__: any;
+export const __GLOBAL__: any;
+export const __LOCAL__: boolean;
+export const __STAGE__: boolean;
+export const __SANDBOX__: boolean;
+export const __PRODUCTION__: boolean;
+export const __UID__: string;

--- a/types/grumbler-scripts/grumbler-scripts-tests.ts
+++ b/types/grumbler-scripts/grumbler-scripts-tests.ts
@@ -1,12 +1,22 @@
-import grumbler_scripts = require('grumbler-scripts');
+import { getKarmaConfig } from 'grumbler-scripts/config/karma.conf';
+import {
+    getCurrentVersion,
+    getNextVersion,
+    getWebpackConfig,
+    WebpackConfigOptions,
+} from 'grumbler-scripts/config/webpack.config';
 
-grumbler_scripts.getCurrentVersion({ version: 'foo' });
-grumbler_scripts.getNextVersion({ version: 'foo' }, 'bar');
+// $ExpectError
+getCurrentVersion();
+getCurrentVersion({ version: 'foo' });
+// $ExpectError
+getNextVersion({ version: 'foo' }, 2);
+getNextVersion({ version: 'foo' }, 'bar');
 
 const FILE_NAME = 'mylibrary';
 const MODULE_NAME = 'mylibrary';
 
-const BASE_CONFIG: grumbler_scripts.WebpackConfigOptions = {
+const BASE_CONFIG: WebpackConfigOptions = {
     entry: './foo/bar.js',
     filename: `${FILE_NAME}.min.js`,
     modulename: MODULE_NAME,
@@ -17,7 +27,6 @@ const BASE_CONFIG: grumbler_scripts.WebpackConfigOptions = {
     minify: true,
 };
 
-grumbler_scripts.getWebpackConfig(BASE_CONFIG);
+getWebpackConfig(BASE_CONFIG);
 
-(karma: object) =>
-    grumbler_scripts.getKarmaConfig(karma, { basePath: 'foo', webpack: grumbler_scripts.getWebpackConfig() });
+(karma: object) => getKarmaConfig(karma, { basePath: 'foo', webpack: getWebpackConfig() });

--- a/types/grumbler-scripts/grumbler-scripts-tests.ts
+++ b/types/grumbler-scripts/grumbler-scripts-tests.ts
@@ -1,10 +1,6 @@
+import { WebpackConfigOptions, WebpackConfig } from 'grumbler-scripts/config/types';
+import { getCurrentVersion, getNextVersion, getWebpackConfig } from 'grumbler-scripts/config/webpack.config';
 import karma, { getKarmaConfig } from 'grumbler-scripts/config/karma.conf';
-import {
-    getCurrentVersion,
-    getNextVersion,
-    getWebpackConfig,
-    WebpackConfigOptions,
-} from 'grumbler-scripts/config/webpack.config';
 
 // $ExpectError
 getCurrentVersion();
@@ -16,6 +12,7 @@ getNextVersion({ version: 'foo' }, 'bar');
 const FILE_NAME = 'mylibrary';
 const MODULE_NAME = 'mylibrary';
 
+const WEBPACK_CONFIG: WebpackConfig = {};
 const BASE_CONFIG: WebpackConfigOptions = {
     entry: './foo/bar.js',
     filename: `${FILE_NAME}.min.js`,

--- a/types/grumbler-scripts/grumbler-scripts-tests.ts
+++ b/types/grumbler-scripts/grumbler-scripts-tests.ts
@@ -1,0 +1,23 @@
+import grumbler_scripts = require('grumbler-scripts');
+
+grumbler_scripts.getCurrentVersion({ version: 'foo' });
+grumbler_scripts.getNextVersion({ version: 'foo' }, 'bar');
+
+const FILE_NAME = 'mylibrary';
+const MODULE_NAME = 'mylibrary';
+
+const BASE_CONFIG: grumbler_scripts.WebpackConfigOptions = {
+    entry: './foo/bar.js',
+    filename: `${FILE_NAME}.min.js`,
+    modulename: MODULE_NAME,
+    libraryTarget: 'window',
+    path: './foo',
+    test: true,
+    debug: true,
+    minify: true,
+};
+
+grumbler_scripts.getWebpackConfig(BASE_CONFIG);
+
+(karma: object) =>
+    grumbler_scripts.getKarmaConfig(karma, { basePath: 'foo', webpack: grumbler_scripts.getWebpackConfig() });

--- a/types/grumbler-scripts/grumbler-scripts-tests.ts
+++ b/types/grumbler-scripts/grumbler-scripts-tests.ts
@@ -1,4 +1,4 @@
-import { getKarmaConfig } from 'grumbler-scripts/config/karma.conf';
+import karma, { getKarmaConfig } from 'grumbler-scripts/config/karma.conf';
 import {
     getCurrentVersion,
     getNextVersion,
@@ -29,4 +29,5 @@ const BASE_CONFIG: WebpackConfigOptions = {
 
 getWebpackConfig(BASE_CONFIG);
 
-(karma: object) => getKarmaConfig(karma, { basePath: 'foo', webpack: getWebpackConfig() });
+karma({});
+(k: any) => k.set(getKarmaConfig(k, { basePath: 'foo', webpack: getWebpackConfig() }));

--- a/types/grumbler-scripts/index.d.ts
+++ b/types/grumbler-scripts/index.d.ts
@@ -33,4 +33,5 @@ declare module 'grumbler-scripts/config/webpack.config' {
 
 declare module 'grumbler-scripts/config/karma.conf' {
     function getKarmaConfig(karma: object, cfg?: object): object;
+    export default function karma(karma: object): object;
 }

--- a/types/grumbler-scripts/index.d.ts
+++ b/types/grumbler-scripts/index.d.ts
@@ -3,29 +3,34 @@
 // Definitions by: German Ruiz <https://github.com/gruiz90>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export function getCurrentVersion(pkg: { version: string }): string;
-export function getNextVersion(pkg: { version: string }, level?: string): string;
-export function getWebpackConfig(options?: WebpackConfigOptions): object;
-export function getKarmaConfig(karma: object, cfg?: object): object;
+declare module 'grumbler-scripts/config/webpack.config' {
+    function getCurrentVersion(pkg: { version: string }): string;
+    function getNextVersion(pkg: { version: string }, level?: string): string;
+    function getWebpackConfig(options?: WebpackConfigOptions): object;
 
-export interface WebpackConfigOptions {
-    context?: string;
-    entry?: string | ReadonlyArray<string>;
-    filename?: string;
-    modulename?: string;
-    minify?: boolean;
-    test?: boolean;
-    options?: object;
-    vars?: object;
-    alias?: { [key: string]: string };
-    libraryTarget?: string;
-    web?: boolean;
-    debug?: boolean;
-    env?: string;
-    path?: string;
-    sourcemaps?: boolean;
-    cache?: boolean;
-    analyze?: boolean;
-    dynamic?: boolean;
-    babelConfig?: string;
+    interface WebpackConfigOptions {
+        context?: string;
+        entry?: string | ReadonlyArray<string>;
+        filename?: string;
+        modulename?: string;
+        minify?: boolean;
+        test?: boolean;
+        options?: object;
+        vars?: object;
+        alias?: { [key: string]: string };
+        libraryTarget?: string;
+        web?: boolean;
+        debug?: boolean;
+        env?: string;
+        path?: string;
+        sourcemaps?: boolean;
+        cache?: boolean;
+        analyze?: boolean;
+        dynamic?: boolean;
+        babelConfig?: string;
+    }
+}
+
+declare module 'grumbler-scripts/config/karma.conf' {
+    function getKarmaConfig(karma: object, cfg?: object): object;
 }

--- a/types/grumbler-scripts/index.d.ts
+++ b/types/grumbler-scripts/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for grumbler-scripts 3.0
+// Project: https://github.com/krakenjs/grumbler-scripts
+// Definitions by: German Ruiz <https://github.com/gruiz90>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function getCurrentVersion(pkg: { version: string }): string;
+export function getNextVersion(pkg: { version: string }, level?: string): string;
+export function getWebpackConfig(options?: WebpackConfigOptions): object;
+export function getKarmaConfig(karma: object, cfg?: object): object;
+
+export interface WebpackConfigOptions {
+    context?: string;
+    entry?: string | ReadonlyArray<string>;
+    filename?: string;
+    modulename?: string;
+    minify?: boolean;
+    test?: boolean;
+    options?: object;
+    vars?: object;
+    alias?: { [key: string]: string };
+    libraryTarget?: string;
+    web?: boolean;
+    debug?: boolean;
+    env?: string;
+    path?: string;
+    sourcemaps?: boolean;
+    cache?: boolean;
+    analyze?: boolean;
+    dynamic?: boolean;
+    babelConfig?: string;
+}

--- a/types/grumbler-scripts/index.d.ts
+++ b/types/grumbler-scripts/index.d.ts
@@ -3,35 +3,5 @@
 // Definitions by: German Ruiz <https://github.com/gruiz90>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module 'grumbler-scripts/config/webpack.config' {
-    function getCurrentVersion(pkg: { version: string }): string;
-    function getNextVersion(pkg: { version: string }, level?: string): string;
-    function getWebpackConfig(options?: WebpackConfigOptions): object;
-
-    interface WebpackConfigOptions {
-        context?: string;
-        entry?: string | ReadonlyArray<string>;
-        filename?: string;
-        modulename?: string;
-        minify?: boolean;
-        test?: boolean;
-        options?: object;
-        vars?: object;
-        alias?: { [key: string]: string };
-        libraryTarget?: string;
-        web?: boolean;
-        debug?: boolean;
-        env?: string;
-        path?: string;
-        sourcemaps?: boolean;
-        cache?: boolean;
-        analyze?: boolean;
-        dynamic?: boolean;
-        babelConfig?: string;
-    }
-}
-
-declare module 'grumbler-scripts/config/karma.conf' {
-    function getKarmaConfig(karma: object, cfg?: object): object;
-    export default function karma(karma: object): object;
-}
+export * from './config/index';
+export * from './declarations';

--- a/types/grumbler-scripts/tsconfig.json
+++ b/types/grumbler-scripts/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "grumbler-scripts-tests.ts"
+    ]
+}

--- a/types/grumbler-scripts/tslint.json
+++ b/types/grumbler-scripts/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/grumbler-scripts/tslint.json
+++ b/types/grumbler-scripts/tslint.json
@@ -1,6 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "no-declare-current-package": false
-    }
+    "extends": "dtslint/dt.json"
 }

--- a/types/grumbler-scripts/tslint.json
+++ b/types/grumbler-scripts/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-declare-current-package": false
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.