### PR TITLE
Add types for postcss-normalize

### DIFF
--- a/types/postcss-normalize/index.d.ts
+++ b/types/postcss-normalize/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for postcss-normalize 9.0
+// Project: https://github.com/csstools/postcss-normalize#readme
+// Definitions by: Piotr Kuczynski <https://github.com/pkuczynski>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Plugin } from 'postcss';
+
+declare namespace Normalize {
+    interface Options {
+        /**
+         * @default false
+         */
+        allowDuplicates?: boolean;
+
+        /**
+         * @default null
+         */
+        forceImport?: boolean | string;
+
+        /**
+         * @default null
+         */
+        browsers?: string;
+    }
+
+    type NormalizePlugin = Plugin<Options>;
+}
+
+declare const normalize: Normalize.NormalizePlugin;
+
+export = normalize;

--- a/types/postcss-normalize/package.json
+++ b/types/postcss-normalize/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "^7.0.27"
+    }
+}

--- a/types/postcss-normalize/postcss-normalize-tests.ts
+++ b/types/postcss-normalize/postcss-normalize-tests.ts
@@ -1,0 +1,12 @@
+import postcss = require('postcss');
+import postcssNormalize = require('postcss-normalize');
+
+postcssNormalize.process('.some-css {}');
+
+postcss([
+    postcssNormalize({
+        allowDuplicates: true,
+        forceImport: 'style.css',
+        browsers: 'last 2 versions'
+    }),
+]).process('.some-css {}');

--- a/types/postcss-normalize/tsconfig.json
+++ b/types/postcss-normalize/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "postcss-normalize-tests.ts"
+    ]
+}

--- a/types/postcss-normalize/tslint.json
+++ b/types/postcss-normalize/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
