### PR TITLE
Add types for @rails/activestorage

### DIFF
--- a/types/rails__activestorage/index.d.ts
+++ b/types/rails__activestorage/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for @rails/activestorage 6.0
+// Project: https://github.com/rails/rails/tree/master/activestorage/app/javascript, http://rubyonrails.org/
+// Definitions by: Ilgiz Mustafin <https://github.com/imustafin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace ActiveStorage;
+
+export function start(): void;
+
+export class DirectUpload {
+    id: number;
+    file: File;
+    url: string;
+
+    constructor(file: File, url: string, delegate?: DirectUploadDelegate);
+
+    create(callback: (error: Error, blob: Blob) => void): void;
+}
+
+export interface DirectUploadDelegate {
+    directUploadWillCreateBlobWithXHR?: (xhr: XMLHttpRequest) => void;
+
+    directUploadWillStoreFileWithXHR?: (xhr: XMLHttpRequest) => void;
+}
+
+export interface Blob {
+    byte_size: number;
+    checksum: string;
+    content_type: string;
+    filename: string;
+    signed_id: string;
+}

--- a/types/rails__activestorage/index.d.ts
+++ b/types/rails__activestorage/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for @rails/activestorage 6.0
 // Project: https://github.com/rails/rails/tree/master/activestorage/app/javascript, http://rubyonrails.org/
-// Definitions by: Ilgiz Mustafin <https://github.com/imustafin>
+// Definitions by: Ilgiz Mustafin <https://github.com/imustafin>, Cameron Bothner <https://github.com/cbothner>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export as namespace ActiveStorage;

--- a/types/rails__activestorage/rails__activestorage-tests.ts
+++ b/types/rails__activestorage/rails__activestorage-tests.ts
@@ -1,0 +1,28 @@
+import * as ActiveStorage from '@rails/activestorage';
+
+ActiveStorage.start();
+
+const delegate: ActiveStorage.DirectUploadDelegate = {
+    directUploadWillCreateBlobWithXHR(xhr) {
+        console.log(xhr.status);
+    },
+
+    directUploadWillStoreFileWithXHR(xhr) {
+        console.log(xhr.status);
+    },
+};
+
+const d = new ActiveStorage.DirectUpload(
+    new File([], 'blank.txt'),
+    '/rails/active_storage/direct_uploads',
+    delegate
+);
+
+d.create((error, blob) => {
+    if (error) {
+        console.log(error.message);
+    } else {
+        const { byte_size, checksum, content_type, filename, signed_id } = blob;
+        console.log({ byte_size, checksum, content_type, filename, signed_id });
+    }
+});

--- a/types/rails__activestorage/rails__activestorage-tests.ts
+++ b/types/rails__activestorage/rails__activestorage-tests.ts
@@ -1,4 +1,5 @@
 import * as ActiveStorage from '@rails/activestorage';
+import { FileChecksum } from '@rails/activestorage/src/file_checksum';
 
 ActiveStorage.start();
 
@@ -24,5 +25,13 @@ d.create((error, blob) => {
     } else {
         const { byte_size, checksum, content_type, filename, signed_id } = blob;
         console.log({ byte_size, checksum, content_type, filename, signed_id });
+    }
+});
+
+FileChecksum.create(new File([], 'blank.txt'), (error, checksum) => {
+    if (error) {
+        console.log(error);
+    } else {
+        console.log(checksum);
     }
 });

--- a/types/rails__activestorage/rails__activestorage-tests.ts
+++ b/types/rails__activestorage/rails__activestorage-tests.ts
@@ -1,5 +1,6 @@
 import * as ActiveStorage from '@rails/activestorage';
 import { FileChecksum } from '@rails/activestorage/src/file_checksum';
+import { BlobUpload } from '@rails/activestorage/src/blob_upload';
 
 ActiveStorage.start();
 
@@ -33,5 +34,23 @@ FileChecksum.create(new File([], 'blank.txt'), (error, checksum) => {
         console.log(error);
     } else {
         console.log(checksum);
+    }
+});
+
+const upload = new BlobUpload({
+    file: new File([], 'blank.txt'),
+    directUploadData: {
+        headers: { 'X-CSRF-Token': 'qweasdzxc' },
+        url: '/rails/active_storage/direct_uploads/xyz'
+    },
+});
+
+upload.xhr.addEventListener('progress', event => console.log(event));
+
+upload.create((error, response) => {
+    if (error) {
+        console.log(error);
+    } else {
+        console.log(response);
     }
 });

--- a/types/rails__activestorage/src/blob_upload.d.ts
+++ b/types/rails__activestorage/src/blob_upload.d.ts
@@ -1,0 +1,13 @@
+export class BlobUpload {
+  constructor(blob: {
+    file: File;
+    directUploadData: {
+      headers: Record<string, string>;
+      url: string;
+    };
+  });
+
+  create(callback: (error: Error, blob: Blob) => void): void;
+
+  xhr: XMLHttpRequest;
+}

--- a/types/rails__activestorage/src/file_checksum.d.ts
+++ b/types/rails__activestorage/src/file_checksum.d.ts
@@ -1,0 +1,3 @@
+export namespace FileChecksum {
+  function create(file: File, callback: (error: Error, checksum: string) => void): void;
+}

--- a/types/rails__activestorage/tsconfig.json
+++ b/types/rails__activestorage/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@rails/*": ["rails__*"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "rails__activestorage-tests.ts"
+    ]
+}

--- a/types/rails__activestorage/tslint.json
+++ b/types/rails__activestorage/tslint.json
@@ -1,0 +1,17 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": [
+            true,
+            {
+                "errors": [
+                    [
+                        "NeedsExportEquals",
+                        false
+                    ]
+                ],
+                "mode": "code"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Rails Active Storage npm package was renamed to `@rails/activestorage`. In this PR I copy relevant types from old `@types/activestorage` and add several definitions myself.

I added 
```
    "rules": {
        "npm-naming": [
            true,
            {
                "errors": [
                    [
                        "NeedsExportEquals",
                        false
                    ]
                ],
                "mode": "code"
            }
        ]
    }
```
to `tslint.json` just as it was done in old `activerecord`. Is this right? If not, how should this be done?

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.