### PR TITLE
Added device-uuid package types

### DIFF
--- a/types/device-uuid/device-uuid-tests.ts
+++ b/types/device-uuid/device-uuid-tests.ts
@@ -1,0 +1,30 @@
+import { DeviceUUID, Agent } from 'device-uuid';
+
+/**
+ * Example from the README
+ */
+
+const du: Agent = new DeviceUUID().parse();
+const dua: Array<string | number | boolean> = [
+    du.language,
+    du.platform,
+    du.os,
+    du.cpuCores,
+    du.isAuthoritative,
+    du.silkAccelerated,
+    du.isKindleFire,
+    du.isDesktop,
+    du.isMobile,
+    du.isTablet,
+    du.isWindows,
+    du.isLinux,
+    du.isLinux64,
+    du.isMac,
+    du.isiPad,
+    du.isiPhone,
+    du.isiPod,
+    du.isSmartTV,
+    du.pixelDepth,
+    du.isTouchScreen,
+];
+const uuid: string = du.hashMD5(dua.join(':'));

--- a/types/device-uuid/index.d.ts
+++ b/types/device-uuid/index.d.ts
@@ -1,0 +1,118 @@
+// Type definitions for device-uuid 1.0
+// Project: https://github.com/biggora/device-uuid/
+// Definitions by: Dariusz Czajkowski <https://github.com/DCzajkowski>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace DeviceUUID;
+
+export type Headers = Record<string, string>;
+
+export interface CommonOptions {
+    isAuthoritative: boolean;
+    silkAccelerated: boolean;
+    isKindleFire: boolean;
+    isDesktop: boolean;
+    isMobile: boolean;
+    isTablet: boolean;
+    isWindows: boolean;
+    isLinux: boolean;
+    isLinux64: boolean;
+    isChromeOS: boolean;
+    isMac: boolean;
+    isiPad: boolean;
+    isiPhone: boolean;
+    isiPod: boolean;
+    isAndroid: boolean;
+    isSamsung: boolean;
+    isSmartTV: boolean;
+    isRaspberry: boolean;
+    isBlackberry: boolean;
+    isTouchScreen: boolean;
+    isOpera: boolean;
+    isIE: boolean;
+    isEdge: boolean;
+    isIECompatibilityMode: boolean;
+    isSafari: boolean;
+    isFirefox: boolean;
+    isWebkit: boolean;
+    isChrome: boolean;
+    isKonqueror: boolean;
+    isOmniWeb: boolean;
+    isSeaMonkey: boolean;
+    isFlock: boolean;
+    isAmaya: boolean;
+    isPhantomJS: boolean;
+    isEpiphany: boolean;
+}
+
+export interface Options extends CommonOptions {
+    version: boolean;
+    language: boolean;
+    platform: boolean;
+    os: boolean;
+    pixelDepth: boolean;
+    colorDepth: boolean;
+    resolution: boolean;
+    source: boolean;
+    cpuCores: boolean;
+}
+
+export interface Agent extends CommonOptions {
+    isBada: boolean;
+    isBot: boolean;
+    isCurl: boolean;
+    isAndroidTablet: boolean;
+    isWinJs: boolean;
+    isSilk: boolean;
+    isCaptive: boolean;
+    isUC: boolean;
+    colorDepth: number;
+    pixelDepth: number;
+    resolution: [number, number];
+    cpuCores: number;
+    language: string;
+    browser: string;
+    version: string;
+    os: string;
+    platform: string;
+    geoIp: Headers;
+    source: string;
+
+    hashInt(s: string): string;
+    hashMD5(s: string): string;
+}
+
+export class DeviceUUID {
+    options: Options;
+    version: string;
+    DefaultAgent: Agent;
+    Agent: Agent;
+
+    getBrowser(s: string): string;
+    getBrowserVersion(s: string): string | undefined;
+    getOS(s: string): string;
+    getPlatform(s: string): string;
+    get(customData?: Record<string, string | boolean>): string;
+
+    testCompatibilityMode(): void;
+    testSilk(): false | 'Silk';
+    testKindleFire(): string | false;
+    testCaptiveNetwork(): false | 'CaptiveNetwork';
+    testMobile(): void;
+    testTablet(): void;
+    testNginxGeoIP(headers: Headers): void;
+    testBot(): void;
+    testSmartTV(): void;
+    testAndroidTablet(): void;
+    testTouchSupport(): void;
+
+    /** [sic] */
+    getLaguage(): void;
+    getColorDepth(): void;
+    getScreenResolution(): void;
+    getPixelDepth(): void;
+    getCPU(): void;
+
+    reset(): DeviceUUID;
+    parse(source?: string): Agent;
+}

--- a/types/device-uuid/tsconfig.json
+++ b/types/device-uuid/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "device-uuid-tests.ts"
+    ]
+}

--- a/types/device-uuid/tslint.json
+++ b/types/device-uuid/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
