### PR TITLE
[node] v12.19.0 released

### DIFF
--- a/types/graceful-fs/graceful-fs-tests.ts
+++ b/types/graceful-fs/graceful-fs-tests.ts
@@ -5,7 +5,7 @@ import * as fse from 'fs-extra';
 import { promisify } from 'util';
 
 const str = '';
-const buf = new Buffer('');
+const buf = Buffer.from('');
 
 // verify that interfaces & types are correctly re-exported
 const watcher: gfs.FSWatcher | null = null;
@@ -21,7 +21,6 @@ promisify(gracefulified.lutimes); // $ExpectType (path: PathLike, atime: string 
 const fseGrace = gfs.gracefulify(fse);
 fseGrace.lutimes; // $ExpectType typeof lutimes
 
-fs.lutimes(buf, str, str);
 fs.lutimes(buf, str, str, err => {
     err; // $ExpectType ErrnoException | null
 });

--- a/types/graceful-fs/index.d.ts
+++ b/types/graceful-fs/index.d.ts
@@ -7,8 +7,6 @@
 
 /// <reference types="node" />
 
-import * as fs from 'fs';
-
 export * from 'fs';
 
 /**
@@ -18,63 +16,4 @@ export * from 'fs';
  * it can cause unexpected delays in other parts of the program.
  * @param fsModule The reference to the fs module or an fs-like module.
  */
-export function gracefulify<T>(fsModule: T): T & Lutimes;
-
-export interface Lutimes {
-    /**
-     * Asynchronously change file timestamps of the file referenced by the supplied path.
-     * If path refers to a symbolic link, then the link is not dereferenced: instead, the timestamps
-     * of the symbolic link are changed.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * @param atime The last access time. If a string is provided, it will be coerced to number.
-     * @param mtime The last modified time. If a string is provided, it will be coerced to number.
-     */
-    lutimes: typeof fs.lutimes;
-    /**
-     * Synchronously change file timestamps of the file referenced by the supplied path.
-     * If path refers to a symbolic link, then the link is not dereferenced: instead, the timestamps
-     * of the symbolic link are changed.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * @param atime The last access time. If a string is provided, it will be coerced to number.
-     * @param mtime The last modified time. If a string is provided, it will be coerced to number.
-     */
-    lutimesSync: typeof fs.lutimesSync;
-}
-
-declare module 'fs' {
-    /**
-     * Asynchronously change file timestamps of the file referenced by the supplied path.
-     * If path refers to a symbolic link, then the link is not dereferenced: instead, the timestamps
-     * of the symbolic link are changed.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * @param atime The last access time. If a string is provided, it will be coerced to number.
-     * @param mtime The last modified time. If a string is provided, it will be coerced to number.
-     */
-    function lutimes(path: PathLike,
-                     atime: string | number | Date,
-                     mtime: string | number | Date,
-                     callback?: (err: NodeJS.ErrnoException | null) => void): void;
-
-    // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    namespace lutimes {
-        /**
-         * Asynchronously change file timestamps of the file referenced by the supplied path.
-         * If path refers to a symbolic link, then the link is not dereferenced: instead, the timestamps
-         * of the symbolic link are changed.
-         * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-         * @param atime The last access time. If a string is provided, it will be coerced to number.
-         * @param mtime The last modified time. If a string is provided, it will be coerced to number.
-         */
-        function __promisify__(path: PathLike, atime: string | number | Date, mtime: string | number | Date): Promise<void>;
-    }
-
-    /**
-     * Synchronously change file timestamps of the file referenced by the supplied path.
-     * If path refers to a symbolic link, then the link is not dereferenced: instead, the timestamps
-     * of the symbolic link are changed.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * @param atime The last access time. If a string is provided, it will be coerced to number.
-     * @param mtime The last modified time. If a string is provided, it will be coerced to number.
-     */
-    function lutimesSync(path: PathLike, atime: string | number | Date, mtime: string | number | Date): void;
-}
+export function gracefulify<T>(fsModule: T): T;

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -428,6 +428,39 @@ declare module "fs" {
     export function lchownSync(path: PathLike, uid: number, gid: number): void;
 
     /**
+     * Changes the access and modification times of a file in the same way as `fs.utimes()`,
+     * with the difference that if the path refers to a symbolic link, then the link is not
+     * dereferenced: instead, the timestamps of the symbolic link itself are changed.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param atime The last access time. If a string is provided, it will be coerced to number.
+     * @param mtime The last modified time. If a string is provided, it will be coerced to number.
+     */
+    export function lutimes(path: PathLike, atime: string | number | Date, mtime: string | number | Date, callback: NoParamCallback): void;
+
+    // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+    export namespace lutimes {
+        /**
+         * Changes the access and modification times of a file in the same way as `fsPromises.utimes()`,
+         * with the difference that if the path refers to a symbolic link, then the link is not
+         * dereferenced: instead, the timestamps of the symbolic link itself are changed.
+         * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+         * @param atime The last access time. If a string is provided, it will be coerced to number.
+         * @param mtime The last modified time. If a string is provided, it will be coerced to number.
+         */
+        function __promisify__(path: PathLike, atime: string | number | Date, mtime: string | number | Date): Promise<void>;
+    }
+
+    /**
+     * Change the file system timestamps of the symbolic link referenced by `path`. Returns `undefined`,
+     * or throws an exception when parameters are incorrect or the operation fails.
+     * This is the synchronous version of `fs.lutimes()`.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param atime The last access time. If a string is provided, it will be coerced to number.
+     * @param mtime The last modified time. If a string is provided, it will be coerced to number.
+     */
+    export function lutimesSync(path: PathLike, atime: string | number | Date, mtime: string | number | Date): void;
+
+    /**
      * Asynchronous chmod(2) - Change permissions of a file.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param mode A file mode. If a string is passed, it is parsed as an octal integer.

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -410,6 +410,16 @@ declare module 'fs/promises' {
     function lchown(path: PathLike, uid: number, gid: number): Promise<void>;
 
     /**
+     * Changes the access and modification times of a file in the same way as `fsPromises.utimes()`,
+     * with the difference that if the path refers to a symbolic link, then the link is not
+     * dereferenced: instead, the timestamps of the symbolic link itself are changed.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param atime The last access time. If a string is provided, it will be coerced to number.
+     * @param mtime The last modified time. If a string is provided, it will be coerced to number.
+     */
+    function lutimes(path: PathLike, atime: string | number | Date, mtime: string | number | Date): Promise<void>;
+
+    /**
      * Asynchronous fchown(2) - Change ownership of a file.
      * @param handle A `FileHandle`.
      */

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -541,6 +541,7 @@ declare namespace NodeJS {
     interface Timer extends RefCounted {
         hasRef(): boolean;
         refresh(): this;
+        [Symbol.toPrimitive](): number;
     }
 
     interface Immediate extends RefCounted {
@@ -551,6 +552,7 @@ declare namespace NodeJS {
     interface Timeout extends Timer {
         hasRef(): boolean;
         refresh(): this;
+        [Symbol.toPrimitive](): number;
     }
 
     type TypedArray = Uint8Array | Uint8ClampedArray | Uint16Array | Uint32Array | Int8Array | Int16Array | Int32Array | Float32Array | Float64Array;

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -205,7 +205,9 @@ declare module "http" {
 
     // https://github.com/nodejs/node/blob/master/lib/_http_client.js#L77
     class ClientRequest extends OutgoingMessage {
-        aborted: number;
+        aborted: boolean;
+        host: string;
+        protocol: string;
 
         constructor(url: string | URL | ClientRequestArgs, cb?: (res: IncomingMessage) => void);
 
@@ -370,6 +372,7 @@ declare module "http" {
     class Agent {
         maxFreeSockets: number;
         maxSockets: number;
+        maxTotalSockets: number;
         readonly freeSockets: NodeJS.ReadOnlyDict<Socket[]>;
         readonly sockets: NodeJS.ReadOnlyDict<Socket[]>;
         readonly requests: NodeJS.ReadOnlyDict<IncomingMessage[]>;

--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -271,7 +271,7 @@ declare module "process" {
                 /**
                  * Can only be set if not in worker thread.
                  */
-                umask(mask: number): number;
+                umask(mask: string | number): number;
                 uptime(): number;
                 hrtime: HRTime;
                 domain: Domain;

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -707,12 +707,14 @@ declare module "tls" {
          */
         sessionIdContext?: string;
         /**
-         * 48 bytes of cryptographically strong pseudo-random data.
+         * 48-bytes of cryptographically strong pseudo-random data.
+         * See Session Resumption for more information.
          */
         ticketKeys?: Buffer;
         /**
-         * The number of seconds after which a TLS session created by the server
-         * will no longer be resumable.
+         * The number of seconds after which a TLS session created by the
+         * server will no longer be resumable. See Session Resumption for more
+         * information. Default: 300.
          */
         sessionTimeout?: number;
     }
@@ -738,7 +740,7 @@ declare module "tls" {
      * @deprecated since v0.11.3 Use `tls.TLSSocket` instead.
      */
     function createSecurePair(credentials?: SecureContext, isServer?: boolean, requestCert?: boolean, rejectUnauthorized?: boolean): SecurePair;
-    function createSecureContext(details: SecureContextOptions): SecureContext;
+    function createSecureContext(options?: SecureContextOptions): SecureContext;
     function getCiphers(): string[];
 
     /**

--- a/types/node/v10/tls.d.ts
+++ b/types/node/v10/tls.d.ts
@@ -447,7 +447,7 @@ declare module "tls" {
     function connect(port: number, host?: string, options?: ConnectionOptions, secureConnectListener?: () => void): TLSSocket;
     function connect(port: number, options?: ConnectionOptions, secureConnectListener?: () => void): TLSSocket;
     function createSecurePair(credentials?: crypto.Credentials, isServer?: boolean, requestCert?: boolean, rejectUnauthorized?: boolean): SecurePair;
-    function createSecureContext(details: SecureContextOptions): SecureContext;
+    function createSecureContext(options?: SecureContextOptions): SecureContext;
     function getCiphers(): string[];
 
     /**

--- a/types/node/v11/http.d.ts
+++ b/types/node/v11/http.d.ts
@@ -165,7 +165,7 @@ declare module "http" {
     class ClientRequest extends OutgoingMessage {
         connection: Socket;
         socket: Socket;
-        aborted: number;
+        aborted: boolean;
 
         constructor(url: string | URL | ClientRequestArgs, cb?: (res: IncomingMessage) => void);
 

--- a/types/node/v11/tls.d.ts
+++ b/types/node/v11/tls.d.ts
@@ -391,7 +391,7 @@ declare module "tls" {
      * @deprecated
      */
     function createSecurePair(credentials?: SecureContext, isServer?: boolean, requestCert?: boolean, rejectUnauthorized?: boolean): SecurePair;
-    function createSecureContext(details: SecureContextOptions): SecureContext;
+    function createSecureContext(options?: SecureContextOptions): SecureContext;
     function getCiphers(): string[];
 
     const DEFAULT_ECDH_CURVE: string;

--- a/types/node/v12/assert.d.ts
+++ b/types/node/v12/assert.d.ts
@@ -19,6 +19,24 @@ declare module 'assert' {
             });
         }
 
+        class CallTracker {
+            calls(exact?: number): () => void;
+            calls<Func extends (...args: any[]) => any>(fn?: Func, exact?: number): Func;
+            report(): CallTrackerReportInformation[];
+            verify(): void;
+        }
+        interface CallTrackerReportInformation {
+            message: string;
+            /** The actual number of times the function was called. */
+            actual: number;
+            /** The number of times the function was expected to be called. */
+            expected: number;
+            /** The name of the function that is wrapped. */
+            operator: string;
+            /** A stack trace of the function. */
+            stack: object;
+        }
+
         function fail(message?: string | Error): never;
         /** @deprecated since v10.0.0 - use fail([message]) or other assert functions instead. */
         function fail(

--- a/types/node/v12/async_hooks.d.ts
+++ b/types/node/v12/async_hooks.d.ts
@@ -116,6 +116,19 @@ declare module "async_hooks" {
         constructor(type: string, triggerAsyncId?: number|AsyncResourceOptions);
 
         /**
+         * Binds the given function to the current execution context.
+         * @param fn The function to bind to the current execution context.
+         * @param type An optional name to associate with the underlying `AsyncResource`.
+         */
+        static bind<Func extends (...args: any[]) => any>(fn: Func, type?: string): Func & { asyncResource: AsyncResource };
+
+        /**
+         * Binds the given function to execute to this `AsyncResource`'s scope.
+         * @param fn The function to bind to the current `AsyncResource`.
+         */
+        bind<Func extends (...args: any[]) => any>(fn: Func): Func & { asyncResource: AsyncResource };
+
+        /**
          * Call the provided function with the provided arguments in the
          * execution context of the async resource. This will establish the
          * context, trigger the AsyncHooks before callbacks, call the function,

--- a/types/node/v12/crypto.d.ts
+++ b/types/node/v12/crypto.d.ts
@@ -368,6 +368,11 @@ declare module "crypto" {
     function pseudoRandomBytes(size: number): Buffer;
     function pseudoRandomBytes(size: number, callback: (err: Error | null, buf: Buffer) => void): void;
 
+    function randomInt(max: number): number;
+    function randomInt(min: number, max: number): number;
+    function randomInt(max: number, callback: (err: Error | null, value: number) => void): void;
+    function randomInt(min: number, max: number, callback: (err: Error | null, value: number) => void): void;
+
     function randomFillSync<T extends NodeJS.ArrayBufferView>(buffer: T, offset?: number, size?: number): T;
     function randomFill<T extends NodeJS.ArrayBufferView>(buffer: T, callback: (err: Error | null, buf: T) => void): void;
     function randomFill<T extends NodeJS.ArrayBufferView>(buffer: T, offset: number, callback: (err: Error | null, buf: T) => void): void;

--- a/types/node/v12/fs.d.ts
+++ b/types/node/v12/fs.d.ts
@@ -347,6 +347,39 @@ declare module "fs" {
     function lchownSync(path: PathLike, uid: number, gid: number): void;
 
     /**
+     * Changes the access and modification times of a file in the same way as `fs.utimes()`,
+     * with the difference that if the path refers to a symbolic link, then the link is not
+     * dereferenced: instead, the timestamps of the symbolic link itself are changed.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param atime The last access time. If a string is provided, it will be coerced to number.
+     * @param mtime The last modified time. If a string is provided, it will be coerced to number.
+     */
+    function lutimes(path: PathLike, atime: string | number | Date, mtime: string | number | Date, callback: NoParamCallback): void;
+
+    // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+    namespace lutimes {
+        /**
+         * Changes the access and modification times of a file in the same way as `fsPromises.utimes()`,
+         * with the difference that if the path refers to a symbolic link, then the link is not
+         * dereferenced: instead, the timestamps of the symbolic link itself are changed.
+         * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+         * @param atime The last access time. If a string is provided, it will be coerced to number.
+         * @param mtime The last modified time. If a string is provided, it will be coerced to number.
+         */
+        function __promisify__(path: PathLike, atime: string | number | Date, mtime: string | number | Date): Promise<void>;
+    }
+
+    /**
+     * Change the file system timestamps of the symbolic link referenced by `path`. Returns `undefined`,
+     * or throws an exception when parameters are incorrect or the operation fails.
+     * This is the synchronous version of `fs.lutimes()`.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param atime The last access time. If a string is provided, it will be coerced to number.
+     * @param mtime The last modified time. If a string is provided, it will be coerced to number.
+     */
+    function lutimesSync(path: PathLike, atime: string | number | Date, mtime: string | number | Date): void;
+
+    /**
      * Asynchronous chmod(2) - Change permissions of a file.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
@@ -2326,6 +2359,16 @@ declare module "fs" {
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
         function lchown(path: PathLike, uid: number, gid: number): Promise<void>;
+
+        /**
+         * Changes the access and modification times of a file in the same way as `fsPromises.utimes()`,
+         * with the difference that if the path refers to a symbolic link, then the link is not
+         * dereferenced: instead, the timestamps of the symbolic link itself are changed.
+         * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+         * @param atime The last access time. If a string is provided, it will be coerced to number.
+         * @param mtime The last modified time. If a string is provided, it will be coerced to number.
+         */
+        function lutimes(path: PathLike, atime: string | number | Date, mtime: string | number | Date): Promise<void>;
 
         /**
          * Asynchronous fchown(2) - Change ownership of a file.

--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -935,9 +935,15 @@ declare namespace NodeJS {
             tls: boolean;
         };
         /**
+         * @deprecated since v12.19.0 - Calling process.umask() with no argument causes
+         * the process-wide umask to be written twice. This introduces a race condition between threads,
+         * and is a potential security vulnerability. There is no safe, cross-platform alternative API.
+         */
+        umask(): number;
+        /**
          * Can only be set if not in worker thread.
          */
-        umask(mask?: number): number;
+        umask(mask: string | number): number;
         uptime(): number;
         hrtime: HRTime;
         domain: Domain;
@@ -1140,6 +1146,7 @@ declare namespace NodeJS {
         ref(): this;
         refresh(): this;
         unref(): this;
+        [Symbol.toPrimitive](): number;
     }
 
     class Immediate {
@@ -1154,6 +1161,7 @@ declare namespace NodeJS {
         ref(): this;
         refresh(): this;
         unref(): this;
+        [Symbol.toPrimitive](): number;
     }
 
     class Module {
@@ -1174,7 +1182,8 @@ declare namespace NodeJS {
         id: string;
         filename: string;
         loaded: boolean;
-        parent: Module | null;
+        /** @deprecated since 12.19.0 Please use `require.main` and `module.children` instead. */
+        parent: Module | null | undefined;
         children: Module[];
         /**
          * @since 11.14.0

--- a/types/node/v12/http.d.ts
+++ b/types/node/v12/http.d.ts
@@ -177,7 +177,9 @@ declare module "http" {
     class ClientRequest extends OutgoingMessage {
         connection: Socket;
         socket: Socket;
-        aborted: number;
+        aborted: boolean;
+        host: string;
+        protocol: string;
 
         constructor(url: string | URL | ClientRequestArgs, cb?: (res: IncomingMessage) => void);
 
@@ -318,6 +320,10 @@ declare module "http" {
          */
         maxSockets?: number;
         /**
+         * Maximum number of sockets allowed for all hosts in total. Each request will use a new socket until the maximum is reached. Default: Infinity.
+         */
+        maxTotalSockets?: number;
+        /**
          * Maximum number of sockets to leave open in a free state. Only relevant if keepAlive is set to true. Default = 256.
          */
         maxFreeSockets?: number;
@@ -330,6 +336,7 @@ declare module "http" {
     class Agent {
         maxFreeSockets: number;
         maxSockets: number;
+        maxTotalSockets: number;
         readonly sockets: {
             readonly [key: string]: Socket[];
         };

--- a/types/node/v12/index.d.ts
+++ b/types/node/v12/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Node.js 12.12
+// Type definitions for non-npm package Node.js 12.19
 // Project: http://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>

--- a/types/node/v12/perf_hooks.d.ts
+++ b/types/node/v12/perf_hooks.d.ts
@@ -46,6 +46,11 @@ declare module "perf_hooks" {
         readonly environment: number;
 
         /**
+         * The high resolution millisecond timestamp at which the Node.js environment was initialized.
+         */
+        readonly idleTime: number;
+
+        /**
          * The high resolution millisecond timestamp at which the Node.js event loop exited.
          * If the event loop has not yet exited, the property has the value of -1.
          * It can only have a value of not -1 in a handler of the 'exit' event.
@@ -67,6 +72,12 @@ declare module "perf_hooks" {
          * The high resolution millisecond timestamp at which the V8 platform was initialized.
          */
         readonly v8Start: number;
+    }
+
+    interface EventLoopUtilization {
+        idle: number;
+        active: number;
+        utilization: number;
     }
 
     interface Performance {
@@ -124,6 +135,16 @@ declare module "perf_hooks" {
          * @param fn
          */
         timerify<T extends (...optionalParams: any[]) => any>(fn: T): T;
+
+        /**
+         * eventLoopUtilization is similar to CPU utilization except that it is calculated using high precision wall-clock time.
+         * It represents the percentage of time the event loop has spent outside the event loop's event provider (e.g. epoll_wait).
+         * No other CPU idle time is taken into consideration.
+         *
+         * @param util1 The result of a previous call to eventLoopUtilization()
+         * @param util2 The result of a previous call to eventLoopUtilization() prior to util1
+         */
+        eventLoopUtilization(util1?: EventLoopUtilization, util2?: EventLoopUtilization): EventLoopUtilization;
     }
 
     interface PerformanceObserverEntryList {

--- a/types/node/v12/test/crypto.ts
+++ b/types/node/v12/test/crypto.ts
@@ -690,6 +690,16 @@ import { promisify } from 'util';
     const decp: Buffer = crypto.privateDecrypt(key, bufP);
 }
 
+// crypto.randomInt
+{
+    const callback = (error: Error|null, value: number): void => {};
+
+    const a: number = crypto.randomInt(10);
+    const b: number = crypto.randomInt(1, 10);
+    crypto.randomInt(10, callback);
+    crypto.randomInt(1, 10, callback);
+}
+
 {
     const key = crypto.createPrivateKey('pkey');
     crypto.sign('sha256', Buffer.from('asd'), {

--- a/types/node/v12/tls.d.ts
+++ b/types/node/v12/tls.d.ts
@@ -641,6 +641,17 @@ declare module "tls" {
          * shared between applications. Unused by clients.
          */
         sessionIdContext?: string;
+        /**
+         * 48-bytes of cryptographically strong pseudo-random data.
+         * See Session Resumption for more information.
+         */
+        ticketKeys?: Buffer;
+        /**
+         * The number of seconds after which a TLS session created by the
+         * server will no longer be resumable. See Session Resumption for more
+         * information. Default: 300.
+         */
+        sessionTimeout?: number;
     }
 
     interface SecureContext {
@@ -664,7 +675,7 @@ declare module "tls" {
      * @deprecated
      */
     function createSecurePair(credentials?: SecureContext, isServer?: boolean, requestCert?: boolean, rejectUnauthorized?: boolean): SecurePair;
-    function createSecureContext(details: SecureContextOptions): SecureContext;
+    function createSecureContext(options?: SecureContextOptions): SecureContext;
     function getCiphers(): string[];
 
     /**

--- a/types/node/v12/worker_threads.d.ts
+++ b/types/node/v12/worker_threads.d.ts
@@ -2,6 +2,7 @@ declare module "worker_threads" {
     import { Context } from "vm";
     import { EventEmitter } from "events";
     import { Readable, Writable } from "stream";
+    import { promises } from "fs";
 
     const isMainThread: boolean;
     const parentPort: null | MessagePort;
@@ -15,7 +16,7 @@ declare module "worker_threads" {
         readonly port2: MessagePort;
     }
 
-    type TransferListItem = ArrayBuffer | MessagePort;
+    type TransferListItem = ArrayBuffer | MessagePort | promises.FileHandle;
 
     class MessagePort extends EventEmitter {
         close(): void;
@@ -70,6 +71,7 @@ declare module "worker_threads" {
          * Additional data to send in the first worker message.
          */
         transferList?: TransferListItem[];
+        trackUnmanagedFds?: boolean;
     }
 
     interface ResourceLimits {
@@ -85,6 +87,11 @@ declare module "worker_threads" {
          * The size of a pre-allocated memory range used for generated code.
          */
         codeRangeSizeMb?: number;
+        /**
+         * The default maximum stack size for the thread. Small values may lead to unusable Worker instances.
+         * @default 4
+         */
+        stackSizeMb?: number;
     }
 
     class Worker extends EventEmitter {
@@ -92,6 +99,7 @@ declare module "worker_threads" {
         readonly stdout: Readable;
         readonly stderr: Readable;
         readonly threadId: number;
+        readonly resourceLimits?: ResourceLimits;
 
         constructor(filename: string, options?: WorkerOptions);
 
@@ -107,51 +115,71 @@ declare module "worker_threads" {
         addListener(event: "error", listener: (err: Error) => void): this;
         addListener(event: "exit", listener: (exitCode: number) => void): this;
         addListener(event: "message", listener: (value: any) => void): this;
+        addListener(event: "messageerror", listener: (error: Error) => void): this;
         addListener(event: "online", listener: () => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
         emit(event: "error", err: Error): boolean;
         emit(event: "exit", exitCode: number): boolean;
         emit(event: "message", value: any): boolean;
+        emit(event: "messageerror", error: Error): boolean;
         emit(event: "online"): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
 
         on(event: "error", listener: (err: Error) => void): this;
         on(event: "exit", listener: (exitCode: number) => void): this;
         on(event: "message", listener: (value: any) => void): this;
+        on(event: "messageerror", listener: (error: Error) => void): this;
         on(event: "online", listener: () => void): this;
         on(event: string | symbol, listener: (...args: any[]) => void): this;
 
         once(event: "error", listener: (err: Error) => void): this;
         once(event: "exit", listener: (exitCode: number) => void): this;
         once(event: "message", listener: (value: any) => void): this;
+        once(event: "messageerror", listener: (error: Error) => void): this;
         once(event: "online", listener: () => void): this;
         once(event: string | symbol, listener: (...args: any[]) => void): this;
 
         prependListener(event: "error", listener: (err: Error) => void): this;
         prependListener(event: "exit", listener: (exitCode: number) => void): this;
         prependListener(event: "message", listener: (value: any) => void): this;
+        prependListener(event: "messageerror", listener: (error: Error) => void): this;
         prependListener(event: "online", listener: () => void): this;
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
         prependOnceListener(event: "error", listener: (err: Error) => void): this;
         prependOnceListener(event: "exit", listener: (exitCode: number) => void): this;
         prependOnceListener(event: "message", listener: (value: any) => void): this;
+        prependOnceListener(event: "messageerror", listener: (error: Error) => void): this;
         prependOnceListener(event: "online", listener: () => void): this;
         prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
         removeListener(event: "error", listener: (err: Error) => void): this;
         removeListener(event: "exit", listener: (exitCode: number) => void): this;
         removeListener(event: "message", listener: (value: any) => void): this;
+        removeListener(event: "messageerror", listener: (error: Error) => void): this;
         removeListener(event: "online", listener: () => void): this;
         removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
         off(event: "error", listener: (err: Error) => void): this;
         off(event: "exit", listener: (exitCode: number) => void): this;
         off(event: "message", listener: (value: any) => void): this;
+        off(event: "messageerror", listener: (error: Error) => void): this;
         off(event: "online", listener: () => void): this;
         off(event: string | symbol, listener: (...args: any[]) => void): this;
     }
+
+    /**
+     * Mark an object as not transferable.
+     * If `object` occurs in the transfer list of a `port.postMessage()` call, it will be ignored.
+     *
+     * In particular, this makes sense for objects that can be cloned, rather than transferred,
+     * and which are used by other objects on the sending side. For example, Node.js marks
+     * the `ArrayBuffer`s it uses for its Buffer pool with this.
+     *
+     * This operation cannot be undone.
+     */
+    function markAsUntransferable(object: object): void;
 
     /**
      * Transfer a `MessagePort` to a different `vm` Context. The original `port`

--- a/types/node/v12/zlib.d.ts
+++ b/types/node/v12/zlib.d.ts
@@ -20,6 +20,7 @@ declare module "zlib" {
         strategy?: number; // compression only
         dictionary?: NodeJS.ArrayBufferView | ArrayBuffer; // deflate/inflate only, empty dictionary by default
         info?: boolean;
+        maxOutputLength?: number;
     }
 
     interface BrotliOptions {
@@ -41,6 +42,7 @@ declare module "zlib" {
              */
             [key: number]: boolean | number;
         };
+        maxOutputLength?: number;
     }
 
     interface Zlib {

--- a/types/node/v13/globals.d.ts
+++ b/types/node/v13/globals.d.ts
@@ -870,7 +870,7 @@ declare namespace NodeJS {
         /**
          * Can only be set if not in worker thread.
          */
-        umask(mask?: number): number;
+        umask(mask?: string | number): number;
         uptime(): number;
         hrtime: HRTime;
         domain: Domain;

--- a/types/node/v13/http.d.ts
+++ b/types/node/v13/http.d.ts
@@ -200,9 +200,12 @@ declare module "http" {
 
     // https://github.com/nodejs/node/blob/master/lib/_http_client.js#L77
     class ClientRequest extends OutgoingMessage {
+        /**
+         * @deprecate Use `socket` instead.
+         */
         connection: Socket;
         socket: Socket;
-        aborted: number;
+        aborted: boolean;
 
         constructor(url: string | URL | ClientRequestArgs, cb?: (res: IncomingMessage) => void);
 

--- a/types/node/v13/tls.d.ts
+++ b/types/node/v13/tls.d.ts
@@ -729,7 +729,7 @@ declare module "tls" {
      * @deprecated
      */
     function createSecurePair(credentials?: SecureContext, isServer?: boolean, requestCert?: boolean, rejectUnauthorized?: boolean): SecurePair;
-    function createSecureContext(details: SecureContextOptions): SecureContext;
+    function createSecureContext(options?: SecureContextOptions): SecureContext;
     function getCiphers(): string[];
 
     /**


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v12.19.0
Release changes:
- crypto: add randomInt function
- module: deprecate module.parent
- deprecate process.umask() with no arguments
- async_hooks: add AsyncResource.bind utility
- assert: port common.mustCall() to assert
- fs: implement lutimes
- http: add maxTotalSockets to agent class
- http: expose host and protocol on ClientRequest
- perf_hooks: add idleTime and event loop util
- timers: allow timers to be used as primitives
- tls: make 'createSecureContext' honor more options
- zlib: add maxOutputLength option
- worker: add stack size resource limit option
- worker: add option to track unmanaged file descriptors
- worker: emit 'messagerror' events for failed deserialization
- worker: add public method for marking objects as untransferable
- worker: make FileHandle transferable

Additional changes:
- `process.umask` can take string since v12
- `options` is optional in `tls.createSecureContext` since v10
- `aborted` is boolean in `http.ClientRequest` since v11
