### PR TITLE
[react-select] Export type definition for Select

### DIFF
--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -19,7 +19,7 @@ export { mergeStyles, Styles, StylesConfig } from './src/styles';
 export { defaultTheme } from './src/theme';
 
 export { NonceProvider } from './src/NonceProvider';
-export { Props, FormatOptionLabelMeta } from './src/Select';
+export { Props, FormatOptionLabelMeta, NamedProps } from './src/Select';
 
 export { components, SelectComponentsConfig, IndicatorComponentType } from './src/components';
 export { IndicatorProps } from './src/components/indicators';

--- a/types/react-select/src/Select.d.ts
+++ b/types/react-select/src/Select.d.ts
@@ -53,7 +53,7 @@ export interface FormatOptionLabelMeta<OptionType extends OptionTypeBase> {
 
 export type SelectComponentsProps = { [key in string]: any };
 
-export interface Props<OptionType extends OptionTypeBase = { label: string; value: string }> extends SelectComponentsProps {
+export interface NamedProps<OptionType extends OptionTypeBase = { label: string; value: string }> {
   /* Aria label (for assistive tech) */
   'aria-label'?: string;
   /* HTML ID of an element that should be used as the label (for assistive tech) */
@@ -208,6 +208,10 @@ export interface Props<OptionType extends OptionTypeBase = { label: string; valu
   defaultMenuIsOpen?: boolean;
   defaultValue?: ValueType<OptionType>;
 }
+
+export interface Props<OptionType extends OptionTypeBase = { label: string; value: string }>
+    extends NamedProps<OptionType>,
+        SelectComponentsProps {}
 
 export const defaultProps: Props<any>;
 


### PR DESCRIPTION
Carve out the base props as a separate interface so that users can use
it with other utility types like Omit

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34959>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
