### PR TITLE
Use prettier to autoformat dogapi files based on the existing prettier config

### DIFF
--- a/types/dogapi/dogapi-tests.ts
+++ b/types/dogapi/dogapi-tests.ts
@@ -22,11 +22,13 @@ dogapi.event.create(
 // one metric
 // single point without date
 dogapi.metric.send_all(
-    [{
-        metric: 'metricName',
-        points: 500,
-    }],
-    (err: Error | null, res: dogapi.EventCreateResponse) => {}
+    [
+        {
+            metric: 'metricName',
+            points: 500,
+        },
+    ],
+    (err: Error | null, res: dogapi.EventCreateResponse) => {},
 );
 
 // multiple metric
@@ -39,29 +41,36 @@ dogapi.metric.send_all(
         {
             metric: 'metricTwo',
             points: 200,
-        }
+        },
     ],
-    (err: Error | null, res: dogapi.EventCreateResponse) => {}
+    (err: Error | null, res: dogapi.EventCreateResponse) => {},
 );
 
 // multi point without date
 // tags
 dogapi.metric.send_all(
-    [{
-        metric: 'metricName',
-        points: [500, 600],
-        tags: ['tag1', 'tag2'],
-    }],
-    (err: Error | null, res: dogapi.EventCreateResponse) => {}
+    [
+        {
+            metric: 'metricName',
+            points: [500, 600],
+            tags: ['tag1', 'tag2'],
+        },
+    ],
+    (err: Error | null, res: dogapi.EventCreateResponse) => {},
 );
 
 // multi point with date
 // metric_type
 dogapi.metric.send_all(
-    [{
-        metric: 'metricName',
-        points: [['123', 500], ['124', 600]],
-        metric_type: 'type',
-    }],
-    (err: Error | null, res: dogapi.EventCreateResponse) => {}
+    [
+        {
+            metric: 'metricName',
+            points: [
+                ['123', 500],
+                ['124', 600],
+            ],
+            metric_type: 'type',
+        },
+    ],
+    (err: Error | null, res: dogapi.EventCreateResponse) => {},
 );

--- a/types/dogapi/index.d.ts
+++ b/types/dogapi/index.d.ts
@@ -4,35 +4,53 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.2
 
-export function initialize(opts: {
-    api_key: string,
-    app_key: string,
-    api_host?: string
-}): void;
+export function initialize(opts: { api_key: string; app_key: string; api_host?: string }): void;
 
 interface event {
     create(title: string, text: string, callback: (err: Error | null, res: EventCreateResponse) => void): void;
-    create(title: string, text: string, properties: {
-        date_happened?: number,
-        priority?: 'normal' | 'low',
-        host?: string,
-        tags?: ReadonlyArray<string>,
-        alert_type?: 'error' | 'warning' | 'info' | 'success',
-        aggregation_key?: string,
-        source_type_name?: 'nagios' | 'hudson' | 'jenkins' | 'user' | 'my apps' | 'feed' | 'chef' | 'puppet' | 'git' | 'bitbucket' | 'fabric' | 'capistrano',
-    }, callback: (err: Error | null, res: EventCreateResponse) => void): void;
+    create(
+        title: string,
+        text: string,
+        properties: {
+            date_happened?: number;
+            priority?: 'normal' | 'low';
+            host?: string;
+            tags?: ReadonlyArray<string>;
+            alert_type?: 'error' | 'warning' | 'info' | 'success';
+            aggregation_key?: string;
+            source_type_name?:
+                | 'nagios'
+                | 'hudson'
+                | 'jenkins'
+                | 'user'
+                | 'my apps'
+                | 'feed'
+                | 'chef'
+                | 'puppet'
+                | 'git'
+                | 'bitbucket'
+                | 'fabric'
+                | 'capistrano';
+        },
+        callback: (err: Error | null, res: EventCreateResponse) => void,
+    ): void;
 }
 
 export const event: event;
 
 interface metric {
-    send(metric: string, points: number | number[], callback: (err: Error | null, res: "ok") => void): void;
-    send(metric: string, points: number | number[], extra: {
-            type?: 'gauge' | 'rate' | 'count',
-            metric_type?: 'gauge' | 'count',
-            host?: string,
-            tags?: ReadonlyArray<string>,
-        }, callback: (err: Error | null, res: "ok") => void): void;
+    send(metric: string, points: number | number[], callback: (err: Error | null, res: 'ok') => void): void;
+    send(
+        metric: string,
+        points: number | number[],
+        extra: {
+            type?: 'gauge' | 'rate' | 'count';
+            metric_type?: 'gauge' | 'count';
+            host?: string;
+            tags?: ReadonlyArray<string>;
+        },
+        callback: (err: Error | null, res: 'ok') => void,
+    ): void;
     send_all(
         metrics: Array<{
             metric: string;
@@ -41,7 +59,7 @@ interface metric {
             type?: string;
             metric_type?: string;
         }>,
-        callback: (err: Error | null, res: EventCreateResponse) => void
+        callback: (err: Error | null, res: EventCreateResponse) => void,
     ): void;
 }
 


### PR DESCRIPTION
This repo has an existing [prettier config file](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/.prettierrc.json). Editing files with an editor that supports prettier auto-formatting will find this file and autoformat on every save (if configured to do so). 

I've run prettier on types/dogapi/ and these are the results.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

This is a *formatting-only* change.