### PR TITLE
Add types for geoip-country

### DIFF
--- a/types/geoip-country/geoip-country-tests.ts
+++ b/types/geoip-country/geoip-country-tests.ts
@@ -1,0 +1,21 @@
+// require geoip-country
+import geoip = require('geoip-country');
+
+// lookup an IP addres
+const stringLookup = geoip.lookup('199.16.156.125');
+
+const numberLookup = geoip.lookup(3339754621);
+
+// convert the ip block range to string
+if (stringLookup) {
+    const rangeStart = geoip.pretty(stringLookup.range[0]);
+    const rangeEnd = geoip.pretty(stringLookup.range[1]);
+}
+
+// start the data update watcher
+geoip.startWatchingDataUpdate();
+
+// stop the data update watcher
+geoip.stopWatchingDataUpdate();
+
+geoip.cmp(1, 2);

--- a/types/geoip-country/index.d.ts
+++ b/types/geoip-country/index.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for geoip-country 4.0
+// Project: https://github.com/sapics/geoip-country
+// Definitions by: Jesse Chan <https://github.com/jesec>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface Lookup {
+    /** [ <low bound of IP block>, <high bound of IP block> ] */
+    range: [number, number];
+    /** 2 letter ISO-3166-1 country code https://www.iban.com/country-codes */
+    country: string;
+}
+
+export type CmpArgs = number | [number];
+export type CmpResult = 1 | -1 | 0 | null;
+
+export function cmp(a: CmpArgs, b: CmpArgs): null | Lookup;
+export function lookup(ip: string | number): null | Lookup;
+export function pretty(ip: string | number | Array<string | number>): string;
+export function startWatchingDataUpdate(cb?: (err?: Error) => void): void;
+export function stopWatchingDataUpdate(): void;

--- a/types/geoip-country/tsconfig.json
+++ b/types/geoip-country/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "geoip-country-tests.ts"
+    ]
+}

--- a/types/geoip-country/tslint.json
+++ b/types/geoip-country/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
