### PR TITLE
[needle] Add uri_modifier and follow_if_same_location to needle options

### DIFF
--- a/types/needle/index.d.ts
+++ b/types/needle/index.d.ts
@@ -234,6 +234,10 @@ declare namespace core {
          * false by default.
          */
         follow_if_same_protocol?: boolean;
+        /**
+         * Unless true, Needle will not follow redirects that point to same location (as set in the response header) as the original request URL. false by default.
+         */
+        follow_if_same_location?: boolean;
     }
 
     interface KeyValue {

--- a/types/needle/index.d.ts
+++ b/types/needle/index.d.ts
@@ -114,7 +114,7 @@ declare namespace core {
          * IP address. Passed to http/https request. Local interface from which the request should be emitted.
          */
         localAddress?: string;
-        
+
         /**
          * Anonymous function taking request (or redirect location if following redirects) URI as an argument and modifying it given logic.
          * It has to return a valid URI string for successful request.

--- a/types/needle/index.d.ts
+++ b/types/needle/index.d.ts
@@ -114,6 +114,12 @@ declare namespace core {
          * IP address. Passed to http/https request. Local interface from which the request should be emitted.
          */
         localAddress?: string;
+        
+        /**
+         * Anonymous function taking request (or redirect location if following redirects) URI as an argument and modifying it given logic.
+         * It has to return a valid URI string for successful request.
+         */
+        uri_modifier?: (uri: string) => string;
 
         // These properties are overwritten by those in the 'headers' field
         /**

--- a/types/needle/needle-tests.ts
+++ b/types/needle/needle-tests.ts
@@ -312,6 +312,12 @@ async function LocalAddress() {
     });
 }
 
+async function UriModifier() {
+    await needle('get', 'http://test.com/', null, {
+        uri_modifier: s => s.replace('test', ''),
+    });
+}
+
 function Multipart() {
     const buffer = fs.readFileSync('/path/to/package.zip');
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - https://github.com/tomas/needle/blob/cb53f295428adacbf048d348d037b15adf003447/README.md#request-options
    - https://github.com/tomas/needle/commit/fb07a5d7208570b9abad401f8a6977079a9ef353
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.