### PR TITLE
fix(serve-static): make response generic

### DIFF
--- a/types/serve-static/index.d.ts
+++ b/types/serve-static/index.d.ts
@@ -6,6 +6,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
+/// <reference types="node" />
 import * as m from "mime";
 import * as http from "http";
 

--- a/types/serve-static/index.d.ts
+++ b/types/serve-static/index.d.ts
@@ -2,33 +2,28 @@
 // Project: https://github.com/expressjs/serve-static
 // Definitions by: Uros Smolnik <https://github.com/urossmolnik>
 //                 Linus Unnebäck <https://github.com/LinusU>
+//                 Devansh Jethmalani <https://github.com/devanshj>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-/* =================== USAGE ===================
-
-    import * as serveStatic from "serve-static";
-    app.use(serveStatic("public/ftp", {"index": ["default.html", "default.htm"]}))
-
- =============================================== */
-
-/// <reference types="express-serve-static-core" />
-
-import * as express from "express-serve-static-core";
 import * as m from "mime";
+import * as http from "http";
 
 /**
  * Create a new middleware function to serve files from within a given root directory.
  * The file to serve will be determined by combining req.url with the provided root directory.
  * When a file is not found, instead of sending a 404 response, this module will instead call next() to move on to the next middleware, allowing for stacking and fall-backs.
  */
-declare function serveStatic(root: string, options?: serveStatic.ServeStaticOptions): express.Handler;
+declare function serveStatic<R extends http.OutgoingMessage>(
+    root: string,
+    options?: serveStatic.ServeStaticOptions<R>
+): serveStatic.RequestHandler<R>;
 
 declare namespace serveStatic {
     var mime: typeof m;
-    interface ServeStaticOptions {
+    interface ServeStaticOptions<R extends http.OutgoingMessage = http.OutgoingMessage> {
         /**
-         * Enable or disable setting Cache-Control response header, defaults to true. 
+         * Enable or disable setting Cache-Control response header, defaults to true.
          * Disabling this will ignore the immutable and maxAge options.
          */
         cacheControl?: boolean;
@@ -96,9 +91,12 @@ declare namespace serveStatic {
          * path the file path that is being sent
          * stat the stat object of the file that is being sent
          */
-        setHeaders?: (res: express.Response, path: string, stat: any) => any;
+        setHeaders?: (res: R, path: string, stat: any) => any;
     }
-    function serveStatic(root: string, options?: ServeStaticOptions): express.Handler;
+
+    interface RequestHandler<R extends http.OutgoingMessage> {
+        (request: http.IncomingMessage, response: R, next: () => void): any;
+    }
 }
 
 export = serveStatic;

--- a/types/serve-static/serve-static-tests.ts
+++ b/types/serve-static/serve-static-tests.ts
@@ -15,6 +15,8 @@ app.use(serveStatic('/3', {
     maxAge: 0,
     redirect: true,
     setHeaders: function(res, path: string, stat: any) {
+        // $ExpectType Response<any, number>
+        res;
         res.setHeader('Server', 'server-static middleware');
     }
 }));
@@ -41,6 +43,8 @@ http.createServer((req, res) => {
 
 app.use(serveStatic('/infers-express-response-when-passed-to-express-use', {
     setHeaders: function(res) {
+        // $ExpectType Response<any, number>
+        res;
         res.set('foo', 'bar');
     }
 }));

--- a/types/serve-static/serve-static-tests.ts
+++ b/types/serve-static/serve-static-tests.ts
@@ -1,5 +1,6 @@
 import express = require('express');
 import serveStatic = require('serve-static');
+import http = require('http');
 var app = express();
 
 app.use(serveStatic('/1'));
@@ -13,7 +14,7 @@ app.use(serveStatic('/3', {
     lastModified: true,
     maxAge: 0,
     redirect: true,
-    setHeaders: function(res: express.Response, path: string, stat: any) {
+    setHeaders: function(res, path: string, stat: any) {
         res.setHeader('Server', 'server-static middleware');
     }
 }));
@@ -27,8 +28,19 @@ serveStatic.mime.define({
     'application/fx': ['fx']
 });
 
-serveStatic('/assumes-express', {
+serveStatic('/does-not-assume-express', {
     setHeaders: function(res) {
-        res.set("foo", "bar")
+        // $ExpectError
+        res.set("foo", "bar");
     }
-})
+});
+
+http.createServer((req, res) => {
+    serveStatic('/works-with-node-server')(req, res, () => {});
+});
+
+app.use(serveStatic('/infers-express-response-when-passed-to-express-use', {
+    setHeaders: function(res) {
+        res.set('foo', 'bar');
+    }
+}));

--- a/types/serve-static/serve-static-tests.ts
+++ b/types/serve-static/serve-static-tests.ts
@@ -26,3 +26,9 @@ serveStatic.mime.define({
     'application/babylonmeshdata': ['babylonmeshdata'],
     'application/fx': ['fx']
 });
+
+serveStatic('/assumes-express', {
+    setHeaders: function(res) {
+        res.set("foo", "bar")
+    }
+})


### PR DESCRIPTION
Right now the types are as if the library is coupled to express, which is not the case as the readme shows an example of it [running with node server](https://github.com/expressjs/serve-static#serve-files-with-vanilla-nodejs-http-server) and nowhere in the source code it uses express-specific methods on the response or request.

So because the types of `request` and `response` are that of express (which is not needed) the example from the readme [doesn't compile](https://www.typescriptlang.org/play?#code/PTAEFMA8EMFsAcA25QDMBOB7WoAWAXfeAZwC4QBzAS31wFcAjAOgGNtgp51xjiArYsGLh0AN3ABaYvmj4qLAMTCxk1FWTEJAdxq4Jo6ADt1iaBMOYAJuAESCRKSPHoAUCFDFcmOokug2COrgLi5UCJjo+GhUhtCIuEaWyOhoWDgA5Gqx8YnJ6aHhkXiE8KnYoOn28Plh8BFRyuIAyjJyLGUZjZLSsvLpANwh7k1OKHSl8IyI8sCoRGiYviIuBildoAC8HqMtvSwAFOmTDNMss0TpADSgAN4VMdaQ6aSgANrpD1BMBLCIV-eGR7ffCwdIAXVAAF8AJRDMAAYW4shQXVcq22KhSWyqrCR+HAI0x+1QdEMLDkmEMoEpACVwABHOg8KL7bj067cYjQ24uUAY8SshkcnjXLJxBKA5KC9mgTnQ2EwuGgAAyVGk4EMLlRTGm6sM+wAzAAGE3QoA). So to fix it, I've made the types adhere to the implementation ie the request and response can be anything as long as they extend `http.IncomingMessage` and `http.OutgoingMessage` respectively. Response needs to be generic as it's used in `setHeaders` option.

So it indeed is a breaking change but only for people who invoke the `serveStatic` with `setHeaders` option using express apis and the invocation is not directly passed to `use` (which makes the response not infer to `express.Response`). The first commit adds test case to indicate breaking change.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expressjs/serve-static#serve-files-with-vanilla-nodejs-http-server
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.