### PR TITLE
[carbon-components-react] add missing input attributes

### DIFF
--- a/types/carbon-components-react/lib/components/FileUploader/FileUploader.d.ts
+++ b/types/carbon-components-react/lib/components/FileUploader/FileUploader.d.ts
@@ -18,7 +18,8 @@ export type FileUploaderSize = "default" | "field" | "small";
 
 interface FileUploaderButtonInheritedProps extends
     Omit<ReactLabelAttr, "onChange">,
-    SharedProps
+    SharedProps,
+    ReactInputAttr
 {
     onChange?(event: React.ChangeEvent<HTMLInputElement>): void,
 }


### PR DESCRIPTION
Passing in a `name` prop to `FileUploaderButton` was resulting in the following error.

```
No overload matches this call.
  Overload 1 of 2, '(props: Readonly<FileUploaderButtonProps>): FileUploaderButton', gave the following error.
    Type '{ className: string; labelText: string | (string & {}) | (string & ReactElement<any, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<...>)>) | (string & ReactNodeArray) | (string & ReactPortal); ... 7 more ...; "data-...' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<FileUploaderButton> & Readonly<FileUploaderButtonProps> & Readonly<...>'.
      Property 'name' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<FileUploaderButton> & Readonly<FileUploaderButtonProps> & Readonly<...>'.
  Overload 2 of 2, '(props: FileUploaderButtonProps, context?: any): FileUploaderButton', gave the following error.
    Type '{ className: string; labelText: string | (string & {}) | (string & ReactElement<any, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<...>)>) | (string & ReactNodeArray) | (string & ReactPortal); ... 7 more ...; "data-...' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<FileUploaderButton> & Readonly<FileUploaderButtonProps> & Readonly<...>'.
      Property 'name' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<FileUploaderButton> & Readonly<FileUploaderButtonProps> & Readonly<...>'.ts(2769)
```

The carbon react component does support this prop and passes it to a native `input` under the hood: https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/FileUploader/FileUploaderButton.js#L97