### PR TITLE
Correctly infer yup.string() as string | undefined instead of an any type

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -106,14 +106,14 @@ export interface MixedSchema<T extends any = {} | null | undefined, C = object> 
         arrayOfValues: ReadonlyArray<U | Ref>,
         message?: MixedLocale['oneOf'],
     ): MixedSchema<MaintainOptionality<T, U>, C>;
+    test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>, C>): MixedSchema<U, C>;
+    test(options: TestOptions<Record<string, any>, C>): this;
     test<U extends T = T>(
         name: string,
         message: TestOptionsMessage,
         test: AssertingTestFunction<U, C>,
     ): MixedSchema<U, C>;
     test(name: string, message: TestOptionsMessage, test: TestFunction<unknown, C>): this;
-    test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>, C>): MixedSchema<U, C>;
-    test(options: TestOptions<Record<string, any>, C>): this;
 }
 
 export interface StringSchemaConstructor {

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -827,6 +827,7 @@ const personSchema = yup.object({
         .boolean()
         .nullable()
         .notRequired(),
+	optionalString: yup.string(),
     mustBeAString: yup
         .string()
         .nullable(true)
@@ -918,6 +919,8 @@ person.gender = 1;
 person.firstName = null;
 // $ExpectError
 person.firstName = undefined;
+// $ExpectError
+person.optionalString = 1;
 // $ExpectError
 person.mustBeAString = null;
 // $ExpectError


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://codesandbox.io/s/romantic-tesla-0slki?file=/src/index.ts
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~

if an object with a simple string defined as `yup.string()` was included that property would be inferred as `any`. For example:

```ts
const formSchema = Yup.object({
  optionalString: Yup.string(),
  definedString: Yup.string().defined()
}).required();

type FormSchema = Yup.InferType<typeof formSchema>;

const test: FormSchema = {
  definedString: ""
};
```

The `optionalString` would incorrectly be inferred as `any`.

With this change it is inferred as `string | undefined`.

This PR replaces #47653
