### PR TITLE
[carbon-components-react] add missing light property to Search

### DIFF
--- a/types/carbon-components-react/lib/components/Search/Search.d.ts
+++ b/types/carbon-components-react/lib/components/Search/Search.d.ts
@@ -16,6 +16,7 @@ export interface SearchProps extends InheritedProps {
     placeHolderText?: string,
     size?: CarbonInputSize,
     value?: string | number,
+    light?: boolean,
 }
 
 declare class Search extends React.Component<SearchProps> { }


### PR DESCRIPTION
This is prop accepted on the `Search` component found here: https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/Search/Search.js#L52