### PR TITLE
[carbon-react-components] remove excluded attributes on OverflowMenu

### DIFF
--- a/types/carbon-components-react/lib/components/OverflowMenu/OverflowMenu.d.ts
+++ b/types/carbon-components-react/lib/components/OverflowMenu/OverflowMenu.d.ts
@@ -11,7 +11,7 @@ import {
 type GetMenuOffsetFn = ((menuBody: HTMLElement, direction: Direction, trigger?: HTMLElement, flip?: boolean) => (MenuOffsetData | undefined));
 export declare const getMenuOffset: GetMenuOffsetFn;
 
-type ExcludedAttributes = "aria-expanded" | "aria-haspopup" | "aria-label" | "onBlur" | "onClick" | "onKeyDown" | "onKeyPress" | "role";
+type ExcludedAttributes = "aria-expanded" | "aria-haspopup" | "aria-label" | "onBlur" | "onKeyPress" | "role";
 interface InheritedProps extends
     Omit<ReactButtonAttr, ExcludedAttributes>,
     EmbeddedIconProps,

--- a/types/carbon-components-react/lib/components/OverflowMenu/OverflowMenu.d.ts
+++ b/types/carbon-components-react/lib/components/OverflowMenu/OverflowMenu.d.ts
@@ -19,7 +19,6 @@ interface InheritedProps extends
     ThemeProps
 {
     ariaLabel?: React.AriaAttributes["aria-label"],
-    onClick?(e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>): void,
 }
 
 export type MenuOffsetValue = MenuOffsetData | GetMenuOffsetFn;


### PR DESCRIPTION
These attributes are supported via props here https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/OverflowMenu/OverflowMenu.js#L226-L227