### PR TITLE
hls.js: fix incorrect type for programDateTime

### DIFF
--- a/types/hls.js/hls.js-tests.ts
+++ b/types/hls.js/hls.js-tests.ts
@@ -83,6 +83,7 @@ if (Hls.isSupported()) {
 
     hls.on(Hls.Events.FRAG_LOAD_EMERGENCY_ABORTED, (event: "hlsFragLoadEmergencyAborted", data: Hls.fragLoadEmergencyAbortedData) => {
         console.log('frag: ', data.frag);
+        console.log(data.frag.programDateTime + 10);
     });
 
     hls.on(Hls.Events.ERROR, (event: "hlsError", data: Hls.errorData) => {

--- a/types/hls.js/index.d.ts
+++ b/types/hls.js/index.d.ts
@@ -322,7 +322,7 @@ declare namespace Hls {
         /**
          * stream start date and time
          */
-        programDateTime: Date;
+        programDateTime: number;
         /**
          * continuity count
          */


### PR DESCRIPTION
From https://github.com/video-dev/hls.js/blob/master/src/loader/fragment.ts#L27, the type is a number, not a Date.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
Here's an example where I try to treat `programDateTime` as a date:
<img width="854" alt="Screen Shot 2020-10-07 at 2 51 44 PM" src="https://user-images.githubusercontent.com/2320890/95391897-b50f2d80-08ac-11eb-8b1d-b6be70320ce1.png">

- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/video-dev/hls.js/blob/master/src/loader/fragment.ts#L27,
