### PR TITLE
ramda: infer zipObj keys

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -2143,10 +2143,11 @@ export function zip<K>(list1: readonly K[]): <V>(list2: readonly V[]) => Array<K
  * Creates a new object out of a list of keys and a list of values.
  */
 // TODO: Dictionary<T> as a return value is to specific, any seems to loose
-export function zipObj<T>(keys: readonly string[], values: readonly T[]): { [index: string]: T };
-export function zipObj(keys: readonly string[]): <T>(values: readonly T[]) => { [index: string]: T };
-export function zipObj<T>(keys: readonly number[], values: readonly T[]): { [index: number]: T };
-export function zipObj(keys: readonly number[]): <T>(values: readonly T[]) => { [index: number]: T };
+export function zipObj<T, K extends string>(keys: readonly K[], values: readonly T[]): { [P in K]: T };
+export function zipObj<K extends string>(keys: readonly K[]): <T>(values: readonly T[]) => { [P in K]: T };
+export function zipObj<T, K extends number>(keys: readonly K[], values: readonly T[]): { [P in K]: T };
+export function zipObj<K extends number>(keys: readonly K[]): <T>(values: readonly T[]) => { [P in K]: T };
+
 
 /**
  * Creates a new list out of the two supplied by applying the function to each

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -2148,7 +2148,6 @@ export function zipObj<K extends string>(keys: readonly K[]): <T>(values: readon
 export function zipObj<T, K extends number>(keys: readonly K[], values: readonly T[]): { [P in K]: T };
 export function zipObj<K extends number>(keys: readonly K[]): <T>(values: readonly T[]) => { [P in K]: T };
 
-
 /**
  * Creates a new list out of the two supplied by applying the function to each
  * equally-positioned pair in the lists.

--- a/types/ramda/test/zipObj-tests.ts
+++ b/types/ramda/test/zipObj-tests.ts
@@ -1,8 +1,17 @@
 import * as R from 'ramda';
 
 () => {
+  // $ExpectType { a: number; b: number; c: number; }
   R.zipObj(['a', 'b', 'c'], [1, 2, 3]); // => {a: 1, b: 2, c: 3}
+
+  // $ExpectType { a: number; b: number; c: number; }
   R.zipObj(['a', 'b', 'c'])([1, 2, 3]); // => {a: 1, b: 2, c: 3}
+
+  // Order of numeric keys matters. 2, 3, 1 ¯\_(ツ)_/¯
+  // $ExpectType { 2: string; 3: string; 1: string; }
   R.zipObj([1, 2, 3], ['a', 'b', 'c']); // => {1: 'a', 2: 'b', 3: 'c'}
+
+  // Order of numeric keys matters. 2, 3, 1 ¯\_(ツ)_/¯
+  // $ExpectType { 2: string; 3: string; 1: string; }
   R.zipObj([1, 2, 3])(['a', 'b', 'c']); // => {1: 'a', 2: 'b', 3: 'c'}
 };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

---

This PR adds type inference from the array of `keys` passed as the first argument to `zipObj`

Before this update the return type would be:

```ts
R.zipObj(["a", "b", "c"], [1, 2, 3]) // { [index: string]: number }
R.zipObj([1, 2, 3], ["a", "b", "c"]) // { [index: number]: string }
```

After this update, the return type is:

```ts
R.zipObj(["a", "b", "c"], [1, 2, 3]) // { a: number, b: number, c: number }
R.zipObj([1, 2, 3], ["a", "b", "c"]) // { 1: string, 2: string, 3: string }
```

~~I tried updating the tests for `zipObj` using `$ExpectType` but the order of the keys is not deterministic (as I'm sure you already knew) and is hence why I imagine these tests aren't using this annotation currently.~~

**UPDATE:** Added some `$ExpectType` tests. No idea why the numeric keys have to be ordered 2, 3, 1 though...hopefully it's the same across all machines ¯\\\_(ツ)\_/¯