### PR TITLE
Minor DX improvements to wicg-file-system-access typings

### DIFF
--- a/types/wicg-file-system-access/index.d.ts
+++ b/types/wicg-file-system-access/index.d.ts
@@ -1,9 +1,33 @@
-// Type definitions for non-npm package File System Access API 2020.09
+// Type definitions for non-npm package File System Access API 2020.10
 // Project: https://github.com/WICG/file-system-access
 // Definitions by: Ingvar Stepanyan <https://github.com/RReverser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.5
 
+export {};
+
+declare class BaseFileSystemHandle {
+    protected constructor();
+
+    readonly kind: FileSystemHandleKind;
+    readonly name: string;
+
+    isSameEntry(other: FileSystemHandle): Promise<boolean>;
+    queryPermission(descriptor?: FileSystemHandlePermissionDescriptor): Promise<PermissionState>;
+    requestPermission(descriptor?: FileSystemHandlePermissionDescriptor): Promise<PermissionState>;
+
+    /**
+     * @deprecated Old property just for Chromium <=85. Use `kind` property in the new API.
+     */
+    readonly isFile: this['kind'] extends 'file' ? true : false;
+
+    /**
+     * @deprecated Old property just for Chromium <=85. Use `kind` property in the new API.
+     */
+    readonly isDirectory: this['kind'] extends 'directory' ? true : false;
+}
+
+declare global {
 interface FilePickerAcceptType {
     description?: string;
     accept: Record<string, string | string[]>;
@@ -66,31 +90,23 @@ interface WritableStream {
     close(): Promise<void>;
 }
 
-declare class FileSystemWritableFileStream extends WritableStream {
+class FileSystemWritableFileStream extends WritableStream {
     write(data: FileSystemWriteChunkType): Promise<void>;
     seek(position: number): Promise<void>;
     truncate(size: number): Promise<void>;
 }
 
-declare class BaseFileSystemHandle {
-    protected constructor();
+const FileSystemHandle: typeof BaseFileSystemHandle;
+type FileSystemHandle = FileSystemFileHandle | FileSystemDirectoryHandle;
 
-    readonly kind: FileSystemHandleKind;
-    readonly name: string;
-
-    isSameEntry(other: FileSystemHandle): Promise<boolean>;
-    queryPermission(descriptor?: FileSystemHandlePermissionDescriptor): Promise<PermissionState>;
-    requestPermission(descriptor?: FileSystemHandlePermissionDescriptor): Promise<PermissionState>;
-}
-
-declare class FileSystemFileHandle extends BaseFileSystemHandle {
+class FileSystemFileHandle extends FileSystemHandle {
     readonly kind: 'file';
 
     getFile(): Promise<File>;
     createWritable(options?: FileSystemCreateWritableOptions): Promise<FileSystemWritableFileStream>;
 }
 
-declare class FileSystemDirectoryHandle extends BaseFileSystemHandle {
+class FileSystemDirectoryHandle extends BaseFileSystemHandle {
     readonly kind: 'directory';
 
     getFileHandle(name: string, options?: FileSystemGetFileOptions): Promise<FileSystemFileHandle>;
@@ -103,7 +119,9 @@ declare class FileSystemDirectoryHandle extends BaseFileSystemHandle {
     entries(): AsyncIterableIterator<[string, FileSystemHandle]>;
     [Symbol.asyncIterator]: FileSystemDirectoryHandle['entries'];
 
-    // Old method available on stable Chrome instead of `navigator.storage.getDirectory`.
+    /**
+     * @deprecated Old method just for Chromium <=85. Use `navigator.storage.getDirectory()` in the new API.
+     */
     static getSystemDirectory(options: GetSystemDirectoryOptions): Promise<FileSystemDirectoryHandle>;
 }
 
@@ -115,16 +133,14 @@ interface StorageManager {
     getDirectory(): Promise<FileSystemDirectoryHandle>;
 }
 
-type FileSystemHandle = FileSystemFileHandle | FileSystemDirectoryHandle;
-
-declare function showOpenFilePicker(
+function showOpenFilePicker(
     options?: OpenFilePickerOptions & { multiple?: false },
 ): Promise<[FileSystemFileHandle]>;
-declare function showOpenFilePicker(options?: OpenFilePickerOptions): Promise<FileSystemFileHandle[]>;
-declare function showSaveFilePicker(options?: SaveFilePickerOptions): Promise<FileSystemFileHandle>;
-declare function showDirectoryPicker(options?: DirectoryPickerOptions): Promise<FileSystemDirectoryHandle>;
+function showOpenFilePicker(options?: OpenFilePickerOptions): Promise<FileSystemFileHandle[]>;
+function showSaveFilePicker(options?: SaveFilePickerOptions): Promise<FileSystemFileHandle>;
+function showDirectoryPicker(options?: DirectoryPickerOptions): Promise<FileSystemDirectoryHandle>;
 
-// Old methods available on stable Chrome instead of the ones above.
+// Old methods available on Chromium 85 instead of the ones above.
 
 interface ChooseFileSystemEntriesOptionsAccepts {
     description?: string;
@@ -137,40 +153,62 @@ interface ChooseFileSystemEntriesFileOptions {
     excludeAcceptAllOption?: boolean;
 }
 
-declare function chooseFileSystemEntries(
+/**
+ * @deprecated Old method just for Chromium <=85. Use `showOpenFilePicker()` in the new API.
+ */
+function chooseFileSystemEntries(
     options?: ChooseFileSystemEntriesFileOptions & {
         type?: 'open-file';
         multiple?: false;
     },
 ): Promise<FileSystemFileHandle>;
-declare function chooseFileSystemEntries(
+/**
+ * @deprecated Old method just for Chromium <=85. Use `showOpenFilePicker()` in the new API.
+ */
+function chooseFileSystemEntries(
     options: ChooseFileSystemEntriesFileOptions & {
         type?: 'open-file';
         multiple: true;
     },
 ): Promise<FileSystemFileHandle[]>;
-declare function chooseFileSystemEntries(
+/**
+ * @deprecated Old method just for Chromium <=85. Use `showSaveFilePicker()` in the new API.
+ */
+function chooseFileSystemEntries(
     options: ChooseFileSystemEntriesFileOptions & {
         type: 'save-file';
     },
 ): Promise<FileSystemFileHandle>;
-declare function chooseFileSystemEntries(options: { type: 'open-directory' }): Promise<FileSystemDirectoryHandle>;
+/**
+ * @deprecated Old method just for Chromium <=85. Use `showDirectoryPicker()` in the new API.
+ */
+function chooseFileSystemEntries(options: { type: 'open-directory' }): Promise<FileSystemDirectoryHandle>;
 
 interface GetSystemDirectoryOptions {
     type: 'sandbox';
 }
 
-interface BaseFileSystemHandle {
-    readonly isFile: this['kind'] extends 'file' ? true : false;
-    readonly isDirectory: this['kind'] extends 'directory' ? true : false;
-}
-
 interface FileSystemDirectoryHandle {
+    /**
+     * @deprecated Old property just for Chromium <=85. Use `.getFileHandle()` in the new API.
+     */
     getFile: FileSystemDirectoryHandle['getFileHandle'];
+
+    /**
+     * @deprecated Old property just for Chromium <=85. Use `.getDirectoryHandle()` in the new API.
+     */
     getDirectory: FileSystemDirectoryHandle['getDirectoryHandle'];
+
+    /**
+     * @deprecated Old property just for Chromium <=85. Use `.keys()`, `.values()`, `.entries()`, or the directory itself as an async iterable in the new API.
+     */
     getEntries: FileSystemDirectoryHandle['values'];
 }
 
 interface FileSystemHandlePermissionDescriptor {
+    /**
+     * @deprecated Old property just for Chromium <=85. Use `mode: ...` in the new API.
+     */
     writable?: boolean;
+}
 }

--- a/types/wicg-file-system-access/index.d.ts
+++ b/types/wicg-file-system-access/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package File System Access API 2020.10
+// Type definitions for non-npm package File System Access API 2020.09
 // Project: https://github.com/WICG/file-system-access
 // Definitions by: Ingvar Stepanyan <https://github.com/RReverser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/wicg-file-system-access/wicg-file-system-access-tests.ts
+++ b/types/wicg-file-system-access/wicg-file-system-access-tests.ts
@@ -19,7 +19,8 @@
     await w.close();
 
     let permissionState: PermissionState = await fileHandle.queryPermission();
-    permissionState = await fileHandle.requestPermission({ writable: true });
+    permissionState = await fileHandle.requestPermission({ mode: 'read' });
+    permissionState = await fileHandle.requestPermission({ mode: 'readwrite' });
 
     fileHandle = await showSaveFilePicker();
     fileHandle = await showSaveFilePicker({
@@ -60,7 +61,7 @@
 
     dirHandle = await navigator.storage.getDirectory();
 
-    // Testing old / stable Chrome methods, remove when they're removed.
+    // Testing Chromium <=85 methods, remove when all Chromium-based browsers have upgraded.
 
     fileHandle = await chooseFileSystemEntries();
     fileHandle = await chooseFileSystemEntries({
@@ -75,8 +76,8 @@
     dirHandle = await dirHandle.getDirectory('subdir', { create: true });
     fileHandle = await dirHandle.getFile('file.txt');
 
-    permissionState = await fileHandle.requestPermission({ mode: 'readwrite' });
-    permissionState = await fileHandle.requestPermission({ mode: 'read' });
+    permissionState = await fileHandle.requestPermission({ writable: false });
+    permissionState = await fileHandle.requestPermission({ writable: true });
 
     (async function* recursivelyWalkDir(dirHandle: FileSystemDirectoryHandle): AsyncIterable<File> {
         for await (const handle of dirHandle.getEntries()) {


### PR DESCRIPTION
Noticed an issue with the way I've defined `FileSystemHandle` + Chromium 86 started rolling out to stable Chrome, so decided to make a couple of DX improvements:

 - Mark Chromium <=85 properties and APIs as @deprecated with hints on what to switch to (this looks particularly nicely in VSCode after recent updates).
 - Hide BaseFileSystemHandle helper from users (this is an internal typings implementation detail).
 - Expose FileSystemHandle as a `const` instead. This allows it to be simultaneously a type union as well as a proper global class (fixes an error for polyfills, where previously TS would complain that a type is accessed as a variable).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (Chromium 86 with new API is rolling out to stable channel; there are no functional changes to those typings, but marking old methods as deprecated helps to more easily distinguish them from the new ones and migrate once ready)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
