### PR TITLE
[jest-environment-puppeteer] Jest types dependency moved to peerDependencies

### DIFF
--- a/types/jest-environment-puppeteer/package.json
+++ b/types/jest-environment-puppeteer/package.json
@@ -1,7 +1,9 @@
 {
     "private": true,
+    "peerDependencies": {
+        "@jest/types": ">=24 && <=26"
+    },
     "dependencies": {
-        "@jest/types": ">=24 && <=26",
         "jest-environment-node": ">=24 && <=26"
     }
 }


### PR DESCRIPTION
## Description
Moved jest types from `dependencies` to `peerDependencies` as this otherwise breaks yarn workspaces/typescript monorepo installs when jest types are installed at the root level (for monorepos using `nohoist`).

I understand this ties in with the discussion [here](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20290).

## Context

### Setup
We are using yarn workspaces for an internal monorepo (`nohoist` enabled).
We are co-locating our e2e tests in this repo to help us gate builds in higher environments.
We are using typescript throughout the monorepo, where previously these tests were vanilla JS.

### Problem
The problem we encountered was that the `puppeteer` globals and `jest-puppeteer` expect assertions were not being found by the typescript compiler, despite having installed all relevant types in the workspace.

```
"devDependencies": {
    "@types/expect-puppeteer": "^4.4.3",
    "@types/jest-environment-puppeteer": "^4.4.0",
    "@types/puppeteer": "^3.0.2",
    ...
}
```

<img src="https://user-images.githubusercontent.com/2997151/95490740-8e2a2780-0990-11eb-9fd8-7b1c01609ab0.png" width="75%" />

Further investigation revealed that this is due to the `jest-environment-puppeteer` `index.d.ts` importing `{ Global as GlobalType } from '@jest/types';` from the workspace's `/node_modules` directory.

Instead, this should have used the root-level jest type definitions that are being used by the other workspaces.

The workaround I'm currently using is an extremely hacky `postinstall` lifecycle script which deletes the local jest types installed by `jest-environment-puppeteer` at the workspace level.

```json
{
  "scripts": {
    "postinstall": "rm -rf ./node_modules/@types/jest"
  }
}
```

In my opinion there shouldn't be a workspace-level jest types package that isn't explicitly installed by consumers - i.e. the hard `dependency` on jest should in fact be a `peerDependency` to support use of pre-specified packages by consumers.

## Checklists
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.) `peerDependencies` not allowed - [open issue here](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20290)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.) _No changes to existing tests required_
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). Fails for the same `peerDependencies` reason

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.