### PR TITLE
[react-vis] Update onNearestXY callback type

### DIFF
--- a/types/react-vis/index.d.ts
+++ b/types/react-vis/index.d.ts
@@ -243,7 +243,7 @@ export interface AbstractSeriesProps<T extends AbstractSeriesPoint> {
     getY?: RVGet<T, 'y'>;
     height?: number;
     onNearestX?: RVNearestXEventHandler<T>;
-    onNearestXY?: RVNearestXEventHandler<T>;
+    onNearestXY?: RVNearestXYEventHandler<T>;
     onSeriesClick?: RVMouseEventHandler;
     onSeriesMouseOut?: RVMouseEventHandler;
     onSeriesMouseOver?: RVMouseEventHandler;


### PR DESCRIPTION
Fix prop callback onNearestXY to implement correct interface (RVNearestXYEventHandler), not (RVNearestXEventHandler). This ensures that the arguments expected in the callback are accurate with the documentation.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://uber.github.io/react-vis/documentation/series-reference/line-series (onNearestXY section)