### PR TITLE
Add types for webshot-node

### DIFF
--- a/types/webshot-node/index.d.ts
+++ b/types/webshot-node/index.d.ts
@@ -38,8 +38,8 @@ declare namespace webshot {
         defaultWhiteBackground?: boolean;
         customCSS?: string;
         quality?: number;
-        streamType?:	'png' | 'jpg' | 'jpeg';
-        siteType?: 'url'	| 'file' | 'html';
+        streamType?: 'png' | 'jpg' | 'jpeg';
+        siteType?: 'url' | 'file' | 'html';
         renderDelay?: number;
         timeout?: number;
         takeShotOnCallback?: boolean;

--- a/types/webshot-node/index.d.ts
+++ b/types/webshot-node/index.d.ts
@@ -1,0 +1,50 @@
+// Type definitions for webshot-node 0.18
+// Project: https://github.com/architjn/node-webshot#readme
+// Definitions by: Logan Kearsley <https://github.com/gliese1337>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference types="node"/>
+
+export = webshot;
+
+declare function webshot(src: string, dst: string, options: webshot.Options, cb?: (e: Error | null) => void): void;
+declare function webshot(src: string, dst: string, cb?: (e: Error | null) => void): void;
+declare function webshot(src: string, options: webshot.Options, cb?: (e: Error | null) => void): NodeJS.ReadableStream;
+declare function webshot(src: string, cb?: (e: Error | null) => void): NodeJS.ReadableStream;
+
+declare namespace webshot {
+    interface Options {
+        windowSize?: {
+            width: number;
+            height: number;
+        };
+        screenSize?: {
+            width: number;
+            height: number;
+        };
+        shotSize?: {
+            width: 'window' | 'all' | number;
+            height: 'window' | 'all' | number;
+        };
+        shotOffset?: {
+            left: number;
+            right: number;
+            top: number;
+            bottom: number;
+        };
+        phantomPath?: string;
+        phantomConfig?: {[key: string]: any};
+        cookies?: Array<{[key: string]: any}> | null;
+        customHeaders?: Array<{[key: string]: any}> | null;
+        defaultWhiteBackground?: boolean;
+        customCSS?: string;
+        quality?: number;
+        streamType?:	'png' | 'jpg' | 'jpeg';
+        siteType?: 'url'	| 'file' | 'html';
+        renderDelay?: number;
+        timeout?: number;
+        takeShotOnCallback?: boolean;
+        errorIfStatusIsNot200?: boolean;
+        errorIfJSException?: boolean;
+        captureSelector?: boolean;
+    }
+}

--- a/types/webshot-node/tsconfig.json
+++ b/types/webshot-node/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "webshot-node-tests.ts"
+    ]
+}

--- a/types/webshot-node/tslint.json
+++ b/types/webshot-node/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/webshot-node/webshot-node-tests.ts
+++ b/types/webshot-node/webshot-node-tests.ts
@@ -1,0 +1,10 @@
+import webshot = require("webshot-node");
+
+webshot('', '', {}); // $ExpectType void
+webshot('', '', {}, e => {}); // $ExpectType void
+webshot('', ''); // $ExpectType void
+webshot('', '', e => {}); // $ExpectType void
+webshot('', {}); // $ExpectType ReadableStream
+webshot('', {}, e => {}); // $ExpectType ReadableStream
+webshot(''); // $ExpectType ReadableStream
+webshot('', e => {}); // $ExpectType ReadableStream


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test webshot-node`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.