### PR TITLE
fix: typos for URL in workbox-webpack-plugin

### DIFF
--- a/types/workbox-webpack-plugin/index.d.ts
+++ b/types/workbox-webpack-plugin/index.d.ts
@@ -301,7 +301,7 @@ export interface CommonOptions {
      * @default null
      * @example modifyURLPrefix: { '/dist': '' }
      */
-    c?: { [url: string]: string } | null;
+    modifyURLPrefix?: { [url: string]: string } | null;
 
     /**
      * One or more [`ManifestTransform`](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.ManifestTransform)

--- a/types/workbox-webpack-plugin/index.d.ts
+++ b/types/workbox-webpack-plugin/index.d.ts
@@ -287,9 +287,9 @@ export interface CommonOptions {
      * as it will reduce the amount of bandwidth consumed when precaching.
      *
      * @default null
-     * @example dontCacheBustUrlsMatching: /\.\w{8}\./
+     * @example dontCacheBustURLsMatching: /\.\w{8}\./
      */
-    dontCacheBustUrlsMatching?: RegExp | null;
+    dontCacheBustURLsMatching?: RegExp | null;
 
     /**
      * A mapping of prefixes that, if present in an entry in the precache manifest, will be replaced with the corresponding value.
@@ -299,15 +299,15 @@ export interface CommonOptions {
      * As an alternative with more flexibility, you can use the `manifestTransforms` option and provide a function that modifies the entries in the manifest using whatever logic you provide.
      *
      * @default null
-     * @example modifyUrlPrefix: { '/dist': '' }
+     * @example modifyURLPrefix: { '/dist': '' }
      */
-    modifyUrlPrefix?: { [url: string]: string } | null;
+    c?: { [url: string]: string } | null;
 
     /**
      * One or more [`ManifestTransform`](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.ManifestTransform)
      * functions, which will be applied sequentially against the generated manifest.
      *
-     * If `modifyUrlPrefix` or `dontCacheBustUrlsMatching` are also specified, their corresponding transformations will be applied first.
+     * If `modifyURLPrefix` or `dontCacheBustURLsMatching` are also specified, their corresponding transformations will be applied first.
      */
     manifestTransforms?: Array<(originalManifest: ReadonlyArray<ManifestEntry>) => { manifest: ManifestEntry[], warnings?: string[] }> | null;
 }

--- a/types/workbox-webpack-plugin/workbox-webpack-plugin-tests.ts
+++ b/types/workbox-webpack-plugin/workbox-webpack-plugin-tests.ts
@@ -117,9 +117,9 @@ import webpack = require('webpack');
     },
     // Increase the limit to 4mb:
     maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
-    dontCacheBustUrlsMatching: /\.\w{8}\./,
+    dontCacheBustURLsMatching: /\.\w{8}\./,
     mode: 'production',
-    modifyUrlPrefix: {
+    modifyURLPrefix: {
       // Remove a '/dist' prefix from the URLs:
       '/dist': ''
     },
@@ -184,9 +184,9 @@ import webpack = require('webpack');
     },
     // Increase the limit to 4mb:
     maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
-    dontCacheBustUrlsMatching: /\.\w{8}\./,
+    dontCacheBustURLsMatching: /\.\w{8}\./,
     mode: 'production',
-    modifyUrlPrefix: {
+    modifyURLPrefix: {
       // Remove a '/dist' prefix from the URLs:
       '/dist': ''
     },


### PR DESCRIPTION
`Url` shoud be `URL` for both `dontCacheBustURLsMatching` and `modifyURLPrefix` as you can find in the documentation https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-webpack-plugin.InjectManifest#InjectManifest

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
