### PR TITLE
Fix [@types/pkijs]: CertificateRevocationList.crlExtensions name and type

### DIFF
--- a/types/pkijs/index.d.ts
+++ b/types/pkijs/index.d.ts
@@ -464,7 +464,7 @@ declare module "pkijs/src/CertificateRevocationList" {
     import RelativeDistinguishedNames from "pkijs/src/RelativeDistinguishedNames";
     import RevokedCertificate from "pkijs/src/RevokedCertificate";
     import Time from "pkijs/src/Time";
-    import Extension from "pkijs/src/Extension";
+    import Extensions from "pkijs/src/Extensions";
     import PublicKeyInfo from "pkijs/src/PublicKeyInfo";
     import Certificate from "pkijs/src/Certificate";
     import { BitString, Sequence } from "asn1js";
@@ -477,7 +477,7 @@ declare module "pkijs/src/CertificateRevocationList" {
         thisUpdate: Time;
         nextUpdate?: Time;
         revokedCertificates?: RevokedCertificate[];
-        crlExtension?: Extension[];
+        crlExtensions?: Extensions;
         signatureAlgorithm: AlgorithmIdentifier;
         signatureValue: BitString;
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [CertificateRevocationList class definition](https://github.com/PeculiarVentures/PKI.js/blob/master/src/CertificateRevocationList.js#L203).

