### PR TITLE
[eccrypto] verify function was called sign

### DIFF
--- a/types/eccrypto/index.d.ts
+++ b/types/eccrypto/index.d.ts
@@ -19,7 +19,7 @@ export function getPublicCompressed(privateKey: Buffer): Buffer;
 export function sign(key: Buffer, msg: Buffer): Promise<Buffer>;
 
 // Verify an ECDSA signature.
-export function sign(publicKey: Buffer, msg: Buffer, sig: Buffer): Promise<null>;
+export function verify(publicKey: Buffer, msg: Buffer, sig: Buffer): Promise<null>;
 
 // Derive shared secret for given private and public keys.
 export function derive(privateKeyA: Buffer, publicKeyB: Buffer): Promise<Buffer>;


### PR DESCRIPTION
The verify function was incorrectly called sign, which made this an overload of the actual sign function.

Source: https://github.com/bitchan/eccrypto/blob/master/index.js#L157

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

