### PR TITLE
[jsrsasign] Fixed `verifyJWT` to make all `acceptField` keys optional

### DIFF
--- a/types/jsrsasign/modules/KJUR/jws/JWS.d.ts
+++ b/types/jsrsasign/modules/KJUR/jws/JWS.d.ts
@@ -357,11 +357,11 @@ declare namespace jsrsasign.KJUR.jws {
             sJWT: string,
             key: string,
             acceptField?: {
-                alg: string[];
-                aud: string[];
-                iss: string[];
+                alg?: string[];
+                aud?: string[];
+                iss?: string[];
                 jti?: string;
-                sub: string[];
+                sub?: string[];
                 verifyAt?: string | number;
             },
         ): boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://kjur.github.io/jsrsasign/api/symbols/KJUR.jws.JWS.html#.verifyJWT
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
