### PR TITLE
argparse: add 'version' to ArgumentOptions according to v2

### DIFF
--- a/types/argparse/argparse-tests.ts
+++ b/types/argparse/argparse-tests.ts
@@ -347,3 +347,8 @@ console.log('-----------');
 args = constExample.parse_args('--foo x --bar --baz y --qux z a b c d e'.split(' '));
 console.dir(args);
 console.log('-----------');
+
+const versionExample = new ArgumentParser({description: 'Add version'});
+versionExample.add_argument('-v', '--v', {action: 'version', version: '1.0.0'});
+versionExample.print_help();
+console.log('-----------');

--- a/types/argparse/index.d.ts
+++ b/types/argparse/index.d.ts
@@ -105,6 +105,7 @@ export interface ArgumentOptions {
     required?: boolean;
     help?: string;
     metavar?: string | string[];
+    version?: string;
 }
 
 export const SUPPRESS: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodeca/argparse/blob/master/doc/migrate_v1_to_v2.md#5-version-option-of-argparseargumentparser-is-deprecated
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.