### PR TITLE
Add types for create-torrent

### DIFF
--- a/types/create-torrent/create-torrent-tests.ts
+++ b/types/create-torrent/create-torrent-tests.ts
@@ -1,0 +1,34 @@
+import createTorrent = require('create-torrent');
+import fs = require('fs');
+
+createTorrent('test', (err, torrent) => {
+    if (err) {
+        return;
+    }
+
+    fs.writeFileSync('test.torrent', torrent);
+});
+
+createTorrent(
+    'test',
+    {
+        name: 'test',
+        comment: 'test',
+        createdBy: 'test',
+        creationDate: Date.now(),
+        private: true,
+        pieceLength: 100,
+        announceList: [['test']],
+        urlList: ['test'],
+        info: {
+            test: 'test',
+        },
+    },
+    (err, torrent) => {
+        if (err) {
+            return;
+        }
+
+        fs.writeFileSync('test.torrent', torrent);
+    },
+);

--- a/types/create-torrent/index.d.ts
+++ b/types/create-torrent/index.d.ts
@@ -1,0 +1,58 @@
+// Type definitions for create-torrent 4.4
+// Project: https://github.com/webtorrent/create-torrent#readme
+// Definitions by: Jesse Chan <https://github.com/jesec>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+interface CreateTorrentOptions {
+    // name of the torrent (default = basename of `path`, or 1st file's name)
+    name?: string;
+    // free-form textual comments of the author
+    comment?: string;
+    // name and version of program used to create torrent
+    createdBy?: string;
+    // creation time in UNIX epoch format (default = now)
+    creationDate?: number;
+    // is this a private .torrent? (default = false)
+    private?: boolean;
+    // force a custom piece length (number of bytes)
+    pieceLength?: number;
+    // custom trackers (array of arrays of strings) (see [bep12](http://www.bittorrent.org/beps/bep_0012.html))
+    announceList?: string[][];
+    // web seed urls (see [bep19](http://www.bittorrent.org/beps/bep_0019.html))
+    urlList?: string[];
+    // add non-standard info dict entries, e.g. info.source, a convention for cross-seeding
+    info?: Record<string, string>;
+}
+
+declare function createTorrent(
+    input:
+        | string
+        | string[]
+        | File
+        | File[]
+        | FileList
+        | Buffer
+        | Buffer[]
+        | NodeJS.ReadableStream
+        | NodeJS.ReadableStream[],
+    cb: (err: Error | null, torrent: Buffer) => any,
+): void;
+
+declare function createTorrent(
+    input:
+        | string
+        | string[]
+        | File
+        | File[]
+        | FileList
+        | Buffer
+        | Buffer[]
+        | NodeJS.ReadableStream
+        | NodeJS.ReadableStream[],
+    opts: CreateTorrentOptions,
+    cb: (err: Error | null, torrent: Buffer) => any,
+): void;
+
+export = createTorrent;

--- a/types/create-torrent/tsconfig.json
+++ b/types/create-torrent/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "create-torrent-tests.ts"
+    ]
+}

--- a/types/create-torrent/tslint.json
+++ b/types/create-torrent/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.