### PR TITLE
Update typings for AngularJS 1.8.1 (packages: `angular`, `angular-sanitize`)

### DIFF
--- a/types/angular-sanitize/index.d.ts
+++ b/types/angular-sanitize/index.d.ts
@@ -23,7 +23,7 @@ declare module 'angular' {
          * All safe tokens (from a whitelist) are then serialized back to a properly escaped HTML string.
          * This means that no unsafe input can make it into the returned string.
          *
-         * The whitelist for URL sanitization of attribute values is configured using the functions aHrefSanitizationTrustedUri and imgSrcSanitizationTrustedUri of $compileProvider.
+         * URLs allowed in attribute values are configured using the methods aHrefSanitizationTrustedUri and imgSrcSanitizationTrustedUri of $compileProvider.
          * The input may also contain SVG markup if this is enabled via $sanitizeProvider.
          *
          * @param html HTML input.

--- a/types/angular-sanitize/index.d.ts
+++ b/types/angular-sanitize/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Angular JS (ngSanitize module) 1.7
+// Type definitions for Angular JS (ngSanitize module) 1.8
 // Project: http://angularjs.org
 // Definitions by: Diego Vilar <https://github.com/diegovilar>
 //                 Michał Lipiński <https://github.com/falsyvalues>
@@ -23,7 +23,7 @@ declare module 'angular' {
          * All safe tokens (from a whitelist) are then serialized back to a properly escaped HTML string.
          * This means that no unsafe input can make it into the returned string.
          *
-         * The whitelist for URL sanitization of attribute values is configured using the functions aHrefSanitizationWhitelist and imgSrcSanitizationWhitelist of $compileProvider.
+         * The whitelist for URL sanitization of attribute values is configured using the functions aHrefSanitizationTrustedUri and imgSrcSanitizationTrustedUri of $compileProvider.
          * The input may also contain SVG markup if this is enabled via $sanitizeProvider.
          *
          * @param html HTML input.
@@ -62,7 +62,7 @@ declare module 'angular' {
             /**
              * Extends the built-in list of valid attributes, i.e. attributes that are considered safe and are not stripped off during sanitization.
              *
-             * Note: The new attributes will not be treated as URI attributes, which means their values will not be sanitized as URIs using $compileProvider's aHrefSanitizationWhitelist and imgSrcSanitizationWhitelist.
+             * Note: The new attributes will not be treated as URI attributes, which means their values will not be sanitized as URIs using $compileProvider's aHrefSanitizationTrustedUri and imgSrcSanitizationTrustedUri.
              * @see https://code.angularjs.org/1.7.0/docs/api/ngSanitize/provider/$sanitizeProvider#addValidAttrs
              * @param attrs A list of valid attributes.
              */

--- a/types/angular-sanitize/index.d.ts
+++ b/types/angular-sanitize/index.d.ts
@@ -20,10 +20,12 @@ declare module 'angular' {
          * Sanitizes an html string by stripping all potentially dangerous tokens.
          *
          * The input is sanitized by parsing the HTML into tokens.
-         * All safe tokens (from a whitelist) are then serialized back to a properly escaped HTML string.
+         * All safe tokens (from a trusted list) are then serialized back to a properly
+         * escaped HTML string.
          * This means that no unsafe input can make it into the returned string.
          *
-         * URLs allowed in attribute values are configured using the methods aHrefSanitizationTrustedUri and imgSrcSanitizationTrustedUri of $compileProvider.
+         * URLs allowed in attribute values are configured using the methods aHrefSanitizationTrustedUrlList
+         * and imgSrcSanitizationTrustedUrlList of $compileProvider.
          * The input may also contain SVG markup if this is enabled via $sanitizeProvider.
          *
          * @param html HTML input.
@@ -62,7 +64,9 @@ declare module 'angular' {
             /**
              * Extends the built-in list of valid attributes, i.e. attributes that are considered safe and are not stripped off during sanitization.
              *
-             * Note: The new attributes will not be treated as URI attributes, which means their values will not be sanitized as URIs using $compileProvider's aHrefSanitizationTrustedUri and imgSrcSanitizationTrustedUri.
+             * Note: The new attributes will not be treated as URI attributes, which means their
+             * values will not be sanitized as URIs using $compileProvider's
+             * aHrefSanitizationTrustedUrlList and imgSrcSanitizationTrustedUrlList.
              * @see https://code.angularjs.org/1.7.0/docs/api/ngSanitize/provider/$sanitizeProvider#addValidAttrs
              * @param attrs A list of valid attributes.
              */

--- a/types/angular/angular-tests.ts
+++ b/types/angular/angular-tests.ts
@@ -254,6 +254,34 @@ angular.module('qprovider-test', [])
         const currentValue: boolean = $qProvider.errorOnUnhandledRejections();
     }]);
 
+let $compileProvider: ng.ICompileProvider;
+let urlListRegex: RegExp;
+
+urlListRegex = $compileProvider.aHrefSanitizationWhitelist();
+$compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|mailto):/);
+urlListRegex = $compileProvider.aHrefSanitizationTrustedUrlList();
+$compileProvider.aHrefSanitizationTrustedUrlList(/^\s*(https?|mailto):/);
+
+urlListRegex = $compileProvider.imgSrcSanitizationWhitelist();
+$compileProvider.imgSrcSanitizationWhitelist(/^\s*(https?|mailto):/);
+urlListRegex = $compileProvider.imgSrcSanitizationTrustedUrlList();
+$compileProvider.imgSrcSanitizationTrustedUrlList(/^\s*(https?|mailto):/);
+
+let $httpProvider: ng.IHttpProvider;
+$httpProvider.xsrfWhitelistedOrigins = ['https://example.com'];
+$httpProvider.xsrfTrustedOrigins = ['https://example.com'];
+
+let $sceDelegateProvider: ng.ISCEDelegateProvider;
+let urlList: any[];
+urlList = $sceDelegateProvider.resourceUrlBlacklist();
+$sceDelegateProvider.resourceUrlBlacklist(['https://example.com']);
+urlList = $sceDelegateProvider.bannedResourceUrlList();
+$sceDelegateProvider.bannedResourceUrlList(['https://example.com']);
+urlList = $sceDelegateProvider.resourceUrlWhitelist();
+$sceDelegateProvider.resourceUrlWhitelist(['https://example.com']);
+urlList = $sceDelegateProvider.trustedResourceUrlList();
+$sceDelegateProvider.trustedResourceUrlList(['https://example.com']);
+
 // Promise signature tests
 let foo: ng.IPromise<number>;
 foo.then((x) => {

--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -1410,21 +1410,21 @@ declare namespace angular {
         component(name: string, options: IComponentOptions): ICompileProvider;
         component(object: {[componentName: string]: IComponentOptions}): ICompileProvider;
 
-        /** @deprecated The old name ofaHrefSanitizationTrustedUri. Kept for compatibility. */
+        /** @deprecated The old name of aHrefSanitizationTrustedUrlList. Kept for compatibility. */
         aHrefSanitizationWhitelist(): RegExp;
-        /** @deprecated The old name ofaHrefSanitizationTrustedUri. Kept for compatibility. */
+        /** @deprecated The old name of aHrefSanitizationTrustedUrlList. Kept for compatibility. */
         aHrefSanitizationWhitelist(regexp: RegExp): ICompileProvider;
 
-        aHrefSanitizationTrustedUri(): RegExp;
-        aHrefSanitizationTrustedUri(regexp: RegExp): ICompileProvider;
+        aHrefSanitizationTrustedUrlList(): RegExp;
+        aHrefSanitizationTrustedUrlList(regexp: RegExp): ICompileProvider;
 
-        /** @deprecated The old name imgSrcSanitizationTrustedUri. Kept for compatibility. */
+        /** @deprecated The old name of imgSrcSanitizationTrustedUrlList. Kept for compatibility. */
         imgSrcSanitizationWhitelist(): RegExp;
-        /** @deprecated The old name imgSrcSanitizationTrustedUri. Kept for compatibility. */
+        /** @deprecated The old name of imgSrcSanitizationTrustedUrlList. Kept for compatibility. */
         imgSrcSanitizationWhitelist(regexp: RegExp): ICompileProvider;
 
-        imgSrcSanitizationTrustedUri(): RegExp;
-        imgSrcSanitizationTrustedUri(regexp: RegExp): ICompileProvider;
+        imgSrcSanitizationTrustedUrlList(): RegExp;
+        imgSrcSanitizationTrustedUrlList(regexp: RegExp): ICompileProvider;
 
         debugInfoEnabled(): boolean;
         debugInfoEnabled(enabled: boolean): ICompileProvider;
@@ -1810,7 +1810,7 @@ declare namespace angular {
         useApplyAsync(): boolean;
         useApplyAsync(value: boolean): IHttpProvider;
 
-        /** @deprecated The old name xsrfTrustedOrigins. Kept for compatibility. */
+        /** @deprecated The old name of xsrfTrustedOrigins. Kept for compatibility. */
         xsrfWhitelistedOrigins: string[];
         /**
          * Array containing URLs whose origins are trusted to receive the XSRF token.

--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Angular JS 1.7
+// Type definitions for Angular JS 1.8
 // Project: http://angularjs.org
 // Definitions by: Diego Vilar <https://github.com/diegovilar>
 //                 Georgii Dolzhykov <https://github.com/thorn0>
@@ -1410,11 +1410,21 @@ declare namespace angular {
         component(name: string, options: IComponentOptions): ICompileProvider;
         component(object: {[componentName: string]: IComponentOptions}): ICompileProvider;
 
+        /** @deprecated The old name ofaHrefSanitizationTrustedUri. Kept for compatibility. */
         aHrefSanitizationWhitelist(): RegExp;
+        /** @deprecated The old name ofaHrefSanitizationTrustedUri. Kept for compatibility. */
         aHrefSanitizationWhitelist(regexp: RegExp): ICompileProvider;
 
+        aHrefSanitizationTrustedUri(): RegExp;
+        aHrefSanitizationTrustedUri(regexp: RegExp): ICompileProvider;
+
+        /** @deprecated The old name imgSrcSanitizationTrustedUri. Kept for compatibility. */
         imgSrcSanitizationWhitelist(): RegExp;
+        /** @deprecated The old name imgSrcSanitizationTrustedUri. Kept for compatibility. */
         imgSrcSanitizationWhitelist(regexp: RegExp): ICompileProvider;
+
+        imgSrcSanitizationTrustedUri(): RegExp;
+        imgSrcSanitizationTrustedUri(regexp: RegExp): ICompileProvider;
 
         debugInfoEnabled(): boolean;
         debugInfoEnabled(enabled: boolean): ICompileProvider;
@@ -1800,12 +1810,12 @@ declare namespace angular {
         useApplyAsync(): boolean;
         useApplyAsync(value: boolean): IHttpProvider;
 
+        /** @deprecated The old name xsrfTrustedOrigins. Kept for compatibility. */
+        xsrfWhitelistedOrigins: string[];
         /**
-         * @param value If true, `$http` will return a normal promise without the `success` and `error` methods.
-         * @returns If a value is specified, returns the $httpProvider for chaining.
-         *    otherwise, returns the current configured value.
+         * Array containing URLs whose origins are trusted to receive the XSRF token.
          */
-        useLegacyPromiseExtensions(value: boolean): boolean | IHttpProvider;
+        xsrfTrustedOrigins: string[];
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1895,9 +1905,13 @@ declare namespace angular {
     ///////////////////////////////////////////////////////////////////////////
     interface ISCEDelegateProvider extends IServiceProvider {
         resourceUrlBlacklist(): any[];
-        resourceUrlBlacklist(blacklist: any[]): void;
+        resourceUrlBlacklist(bannedList: any[]): void;
+        bannedResourceUrlList(): any[];
+        bannedResourceUrlList(bannedList: any[]): void;
         resourceUrlWhitelist(): any[];
-        resourceUrlWhitelist(whitelist: any[]): void;
+        resourceUrlWhitelist(trustedList: any[]): void;
+        trustedResourceUrlList(): any[];
+        trustedResourceUrlList(trustedList: any[]): void;
     }
 
     /**


### PR DESCRIPTION
AngularJS 1.8.1 added alternative APIs for ones that may be considered offensive
and deprecated the old ones:
https://github.com/angular/angular.js/blob/master/CHANGELOG.md#181-mutually-supporting-2020-09-30

The `IHttpProvider` type was outdated as well. The `useLegacyPromiseExtensions`
method has been removed in AngularJS 1.6.0:
https://code.angularjs.org/1.5.11/docs/api/ng/provider/$httpProvider#useLegacyPromiseExtensions
`xsrfWhitelistedOrigins` and `xsrfTrustedOrigins` were missing:
https://docs.angularjs.org/api/ng/provider/$httpProvider#xsrfTrustedOrigins

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/angular/angular.js/blob/master/CHANGELOG.md#181-mutually-supporting-2020-09-30, https://docs.angularjs.org/api/ng/provider/$httpProvider#xsrfTrustedOrigins
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.