### PR TITLE
fix(node/zlib): Unify signatures and fix comments

### DIFF
--- a/types/node/test/zlib.ts
+++ b/types/node/test/zlib.ts
@@ -121,14 +121,23 @@ brotliDecompress(compressMe, (err: Error | null, result: Buffer) => result);
 brotliDecompress(compressMe, { finishFlush: constants.BROTLI_OPERATION_FINISH }, (err: Error | null, result: Buffer) => result);
 
 {
+    // $ExpectType (buffer: InputType, options?: BrotliOptions | undefined) => Promise<Buffer>
     const pBrotliCompress = promisify(brotliCompress);
+    // $ExpectType (buffer: InputType, options?: BrotliOptions | undefined) => Promise<Buffer>
     const pBrotliDecompress = promisify(brotliDecompress);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pDeflate = promisify(deflate);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pDeflateRaw = promisify(deflateRaw);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pGzip = promisify(gzip);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pGunzip = promisify(gunzip);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pInflate = promisify(inflate);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pInflateRaw = promisify(inflateRaw);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pUnzip = promisify(unzip);
 
     (async () => {

--- a/types/node/v10/test/zlib.ts
+++ b/types/node/v10/test/zlib.ts
@@ -1,0 +1,55 @@
+import {
+    deflate,
+    inflate,
+    deflateRaw,
+    inflateRaw,
+    gunzip,
+    gzip,
+    unzip,
+    constants,
+    brotliCompress,
+    brotliDecompress,
+} from 'zlib';
+import { promisify } from 'util';
+
+{
+    // $ExpectType (buffer: InputType, options?: BrotliOptions) => Promise<Buffer>
+    const pBrotliCompress = promisify(brotliCompress);
+    // $ExpectType (buffer: InputType, options?: BrotliOptions) => Promise<Buffer>
+    const pBrotliDecompress = promisify(brotliDecompress);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions) => Promise<Buffer>
+    const pDeflate = promisify(deflate);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions) => Promise<Buffer>
+    const pDeflateRaw = promisify(deflateRaw);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions) => Promise<Buffer>
+    const pGzip = promisify(gzip);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions) => Promise<Buffer>
+    const pGunzip = promisify(gunzip);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions) => Promise<Buffer>
+    const pInflate = promisify(inflate);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions) => Promise<Buffer>
+    const pInflateRaw = promisify(inflateRaw);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions) => Promise<Buffer>
+    const pUnzip = promisify(unzip);
+
+    (async () => {
+        await pBrotliCompress(Buffer.from('buf')); // $ExpectType Buffer
+        await pBrotliCompress(Buffer.from('buf'), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
+        await pBrotliDecompress(Buffer.from('buf')); // $ExpectType Buffer
+        await pBrotliDecompress(Buffer.from('buf'), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
+        await pDeflate(Buffer.from('buf')); // $ExpectType Buffer
+        await pDeflate(Buffer.from('buf'), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
+        await pDeflateRaw(Buffer.from('buf')); // $ExpectType Buffer
+        await pDeflateRaw(Buffer.from('buf'), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
+        await pGzip(Buffer.from('buf')); // $ExpectType Buffer
+        await pGzip(Buffer.from('buf'), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
+        await pGunzip(Buffer.from('buf')); // $ExpectType Buffer
+        await pGunzip(Buffer.from('buf'), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
+        await pInflate(Buffer.from('buf')); // $ExpectType Buffer
+        await pInflate(Buffer.from('buf'), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
+        await pInflateRaw(Buffer.from('buf')); // $ExpectType Buffer
+        await pInflateRaw(Buffer.from('buf'), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
+        await pUnzip(Buffer.from('buf')); // $ExpectType Buffer
+        await pUnzip(Buffer.from('buf'), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
+    })();
+}

--- a/types/node/v10/tsconfig.json
+++ b/types/node/v10/tsconfig.json
@@ -1,8 +1,9 @@
 {
     "files": [
-        "index.d.ts",
         "node-tests.ts",
-        "test/url.ts"
+        "test/url.ts",
+        "test/zlib.ts",
+        "index.d.ts"
     ],
     "compilerOptions": {
         "module": "commonjs",

--- a/types/node/v10/zlib.d.ts
+++ b/types/node/v10/zlib.d.ts
@@ -40,7 +40,8 @@ declare module "zlib" {
         readonly bytesWritten: number;
         shell?: boolean | string;
         close(callback?: () => void): void;
-        flush(kind?: number | (() => void), callback?: () => void): void;
+        flush(kind?: number, callback?: () => void): void;
+        flush(callback?: () => void): void;
     }
 
     interface ZlibParams {
@@ -77,30 +78,74 @@ declare module "zlib" {
 
     function brotliCompress(buf: InputType, options: BrotliOptions, callback: CompressCallback): void;
     function brotliCompress(buf: InputType, callback: CompressCallback): void;
+    namespace brotliCompress {
+        function __promisify__(buffer: InputType, options?: BrotliOptions): Promise<Buffer>;
+    }
+
     function brotliCompressSync(buf: InputType, options?: BrotliOptions): Buffer;
+
     function brotliDecompress(buf: InputType, options: BrotliOptions, callback: CompressCallback): void;
     function brotliDecompress(buf: InputType, callback: CompressCallback): void;
+    namespace brotliDecompress {
+        function __promisify__(buffer: InputType, options?: BrotliOptions): Promise<Buffer>;
+    }
+
     function brotliDecompressSync(buf: InputType, options?: BrotliOptions): Buffer;
-    function deflate(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
-    function deflate(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
+
+    function deflate(buf: InputType, callback: CompressCallback): void;
+    function deflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    namespace deflate {
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+    }
+
     function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
-    function deflateRaw(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
-    function deflateRaw(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
+
+    function deflateRaw(buf: InputType, callback: CompressCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    namespace deflateRaw {
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+    }
+
     function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
-    function gzip(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
-    function gzip(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
+
+    function gzip(buf: InputType, callback: CompressCallback): void;
+    function gzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    namespace gzip {
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+    }
+
     function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
-    function gunzip(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
-    function gunzip(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
+
+    function gunzip(buf: InputType, callback: CompressCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    namespace gunzip {
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+    }
+
     function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
-    function inflate(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
-    function inflate(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
+
+    function inflate(buf: InputType, callback: CompressCallback): void;
+    function inflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    namespace inflate {
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+    }
+
     function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
-    function inflateRaw(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
-    function inflateRaw(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
+
+    function inflateRaw(buf: InputType, callback: CompressCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    namespace inflateRaw {
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+    }
+
     function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
-    function unzip(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
-    function unzip(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
+
+    function unzip(buf: InputType, callback: CompressCallback): void;
+    function unzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    namespace unzip {
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+    }
+
     function unzipSync(buf: InputType, options?: ZlibOptions): Buffer;
 
     namespace constants {
@@ -210,35 +255,73 @@ declare module "zlib" {
         const BROTLI_PARAM_SIZE_HINT: number;
     }
 
-    // Constants
+    // Allowed flush values.
+    /** @deprecated Use `constants.Z_NO_FLUSH` */
     const Z_NO_FLUSH: number;
+    /** @deprecated Use `constants.Z_PARTIAL_FLUSH` */
     const Z_PARTIAL_FLUSH: number;
+    /** @deprecated Use `constants.Z_SYNC_FLUSH` */
     const Z_SYNC_FLUSH: number;
+    /** @deprecated Use `constants.Z_FULL_FLUSH` */
     const Z_FULL_FLUSH: number;
+    /** @deprecated Use `constants.Z_FINISH` */
     const Z_FINISH: number;
+    /** @deprecated Use `constants.Z_BLOCK` */
     const Z_BLOCK: number;
+    /** @deprecated Use `constants.Z_TREES` */
     const Z_TREES: number;
+
+    // Return codes for the compression/decompression functions.
+    // Negative values are errors, positive values are used for special but normal events.
+    /** @deprecated Use `constants.Z_OK` */
     const Z_OK: number;
+    /** @deprecated Use `constants.Z_STREAM_END` */
     const Z_STREAM_END: number;
+    /** @deprecated Use `constants.Z_NEED_DICT` */
     const Z_NEED_DICT: number;
+    /** @deprecated Use `constants.Z_ERRNO` */
     const Z_ERRNO: number;
+    /** @deprecated Use `constants.Z_STREAM_ERROR` */
     const Z_STREAM_ERROR: number;
+    /** @deprecated Use `constants.Z_DATA_ERROR` */
     const Z_DATA_ERROR: number;
+    /** @deprecated Use `constants.Z_MEM_ERROR` */
     const Z_MEM_ERROR: number;
+    /** @deprecated Use `constants.Z_BUF_ERROR` */
     const Z_BUF_ERROR: number;
+    /** @deprecated Use `constants.Z_VERSION_ERROR` */
     const Z_VERSION_ERROR: number;
+
+    // Compression levels.
+    /** @deprecated Use `constants.Z_NO_COMPRESSION` */
     const Z_NO_COMPRESSION: number;
+    /** @deprecated Use `constants.Z_BEST_SPEED` */
     const Z_BEST_SPEED: number;
+    /** @deprecated Use `constants.Z_BEST_COMPRESSION` */
     const Z_BEST_COMPRESSION: number;
+    /** @deprecated Use `constants.Z_DEFAULT_COMPRESSION` */
     const Z_DEFAULT_COMPRESSION: number;
+
+    // Compression strategy.
+    /** @deprecated Use `constants.Z_FILTERED` */
     const Z_FILTERED: number;
+    /** @deprecated Use `constants.Z_HUFFMAN_ONLY` */
     const Z_HUFFMAN_ONLY: number;
+    /** @deprecated Use `constants.Z_RLE` */
     const Z_RLE: number;
+    /** @deprecated Use `constants.Z_FIXED` */
     const Z_FIXED: number;
+    /** @deprecated Use `constants.Z_DEFAULT_STRATEGY` */
     const Z_DEFAULT_STRATEGY: number;
+
+    /** @deprecated */
     const Z_BINARY: number;
+    /** @deprecated */
     const Z_TEXT: number;
+    /** @deprecated */
     const Z_ASCII: number;
+    /** @deprecated  */
     const Z_UNKNOWN: number;
+    /** @deprecated */
     const Z_DEFLATED: number;
 }

--- a/types/node/v12/test/zlib.ts
+++ b/types/node/v12/test/zlib.ts
@@ -121,14 +121,23 @@ brotliDecompress(compressMe, (err: Error | null, result: Buffer) => result);
 brotliDecompress(compressMe, { finishFlush: constants.BROTLI_OPERATION_FINISH }, (err: Error | null, result: Buffer) => result);
 
 {
+    // $ExpectType (buffer: InputType, options?: BrotliOptions | undefined) => Promise<Buffer>
     const pBrotliCompress = promisify(brotliCompress);
+    // $ExpectType (buffer: InputType, options?: BrotliOptions | undefined) => Promise<Buffer>
     const pBrotliDecompress = promisify(brotliDecompress);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pDeflate = promisify(deflate);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pDeflateRaw = promisify(deflateRaw);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pGzip = promisify(gzip);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pGunzip = promisify(gunzip);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pInflate = promisify(inflate);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pInflateRaw = promisify(inflateRaw);
+    // $ExpectType (buffer: InputType, options?: ZlibOptions | undefined) => Promise<Buffer>
     const pUnzip = promisify(unzip);
 
     (async () => {

--- a/types/node/v12/zlib.d.ts
+++ b/types/node/v12/zlib.d.ts
@@ -49,7 +49,8 @@ declare module "zlib" {
         readonly bytesWritten: number;
         shell?: boolean | string;
         close(callback?: () => void): void;
-        flush(kind?: number | (() => void), callback?: () => void): void;
+        flush(kind?: number, callback?: () => void): void;
+        flush(callback?: () => void): void;
     }
 
     interface ZlibParams {
@@ -86,68 +87,75 @@ declare module "zlib" {
 
     function brotliCompress(buf: InputType, options: BrotliOptions, callback: CompressCallback): void;
     function brotliCompress(buf: InputType, callback: CompressCallback): void;
+    namespace brotliCompress {
+        function __promisify__(buffer: InputType, options?: BrotliOptions): Promise<Buffer>;
+    }
+
     function brotliCompressSync(buf: InputType, options?: BrotliOptions): Buffer;
+
     function brotliDecompress(buf: InputType, options: BrotliOptions, callback: CompressCallback): void;
     function brotliDecompress(buf: InputType, callback: CompressCallback): void;
+    namespace brotliDecompress {
+        function __promisify__(buffer: InputType, options?: BrotliOptions): Promise<Buffer>;
+    }
+
     function brotliDecompressSync(buf: InputType, options?: BrotliOptions): Buffer;
+
     function deflate(buf: InputType, callback: CompressCallback): void;
     function deflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    namespace deflate {
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+    }
+
     function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+
     function deflateRaw(buf: InputType, callback: CompressCallback): void;
     function deflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    namespace deflateRaw {
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+    }
+
     function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+
     function gzip(buf: InputType, callback: CompressCallback): void;
     function gzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    namespace gzip {
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+    }
+
     function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+
     function gunzip(buf: InputType, callback: CompressCallback): void;
     function gunzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    namespace gunzip {
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+    }
+
     function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+
     function inflate(buf: InputType, callback: CompressCallback): void;
     function inflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    namespace inflate {
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+    }
+
     function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+
     function inflateRaw(buf: InputType, callback: CompressCallback): void;
     function inflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    namespace inflateRaw {
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+    }
+
     function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+
     function unzip(buf: InputType, callback: CompressCallback): void;
     function unzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
-    function unzipSync(buf: InputType, options?: ZlibOptions): Buffer;
-
-    namespace brotliCompress {
-        function __promisify__(buffer: InputType, options: BrotliOptions): Promise<Buffer>;
-        function __promisify__(buffer: InputType): Promise<Buffer>;
-    }
-    namespace brotliDecompress {
-        function __promisify__(buffer: InputType, options: BrotliOptions): Promise<Buffer>;
-        function __promisify__(buffer: InputType): Promise<Buffer>;
-    }
-    namespace deflate {
-        function __promisify__(buffer: InputType): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options: ZlibOptions): Promise<Buffer>;
-    }
-    namespace deflateRaw {
-        function __promisify__(buffer: InputType): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options: ZlibOptions): Promise<Buffer>;
-    }
-    namespace gzip {
-        function __promisify__(buffer: InputType): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options: ZlibOptions): Promise<Buffer>;
-    }
-    namespace gunzip {
-        function __promisify__(buffer: InputType): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options: ZlibOptions): Promise<Buffer>;
-    }
-    namespace inflate {
-        function __promisify__(buffer: InputType): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options: ZlibOptions): Promise<Buffer>;
-    }
-    namespace inflateRaw {
-        function __promisify__(buffer: InputType): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options: ZlibOptions): Promise<Buffer>;
-    }
     namespace unzip {
-        function __promisify__(buffer: InputType): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
+
+    function unzipSync(buf: InputType, options?: ZlibOptions): Buffer;
 
     namespace constants {
         const BROTLI_DECODE: number;
@@ -226,165 +234,121 @@ declare module "zlib" {
         const INFLATERAW: number;
         const UNZIP: number;
 
-        const Z_BEST_COMPRESSION: number;
-        const Z_BEST_SPEED: number;
-        const Z_BLOCK: number;
-        const Z_BUF_ERROR: number;
-        const Z_DATA_ERROR: number;
-
-        const Z_DEFAULT_CHUNK: number;
-        const Z_DEFAULT_COMPRESSION: number;
-        const Z_DEFAULT_LEVEL: number;
-        const Z_DEFAULT_MEMLEVEL: number;
-        const Z_DEFAULT_STRATEGY: number;
-        const Z_DEFAULT_WINDOWBITS: number;
-
-        const Z_ERRNO: number;
-        const Z_FILTERED: number;
-        const Z_FINISH: number;
-        const Z_FIXED: number;
-        const Z_FULL_FLUSH: number;
-        const Z_HUFFMAN_ONLY: number;
-        const Z_MAX_CHUNK: number;
-        const Z_MAX_LEVEL: number;
-        const Z_MAX_MEMLEVEL: number;
-        const Z_MAX_WINDOWBITS: number;
-        const Z_MEM_ERROR: number;
-        const Z_MIN_CHUNK: number;
-        const Z_MIN_LEVEL: number;
-        const Z_MIN_MEMLEVEL: number;
-        const Z_MIN_WINDOWBITS: number;
-        const Z_NEED_DICT: number;
-        const Z_NO_COMPRESSION: number;
         const Z_NO_FLUSH: number;
-        const Z_OK: number;
         const Z_PARTIAL_FLUSH: number;
-        const Z_RLE: number;
-        const Z_STREAM_END: number;
-        const Z_STREAM_ERROR: number;
         const Z_SYNC_FLUSH: number;
+        const Z_FULL_FLUSH: number;
+        const Z_FINISH: number;
+        const Z_BLOCK: number;
+        const Z_TREES: number;
+
+        const Z_OK: number;
+        const Z_STREAM_END: number;
+        const Z_NEED_DICT: number;
+        const Z_ERRNO: number;
+        const Z_STREAM_ERROR: number;
+        const Z_DATA_ERROR: number;
+        const Z_MEM_ERROR: number;
+        const Z_BUF_ERROR: number;
         const Z_VERSION_ERROR: number;
+
+        const Z_NO_COMPRESSION: number;
+        const Z_BEST_SPEED: number;
+        const Z_BEST_COMPRESSION: number;
+        const Z_DEFAULT_COMPRESSION: number;
+
+        const Z_FILTERED: number;
+        const Z_HUFFMAN_ONLY: number;
+        const Z_RLE: number;
+        const Z_FIXED: number;
+        const Z_DEFAULT_STRATEGY: number;
+
+        const Z_DEFAULT_WINDOWBITS: number;
+        const Z_MIN_WINDOWBITS: number;
+        const Z_MAX_WINDOWBITS: number;
+
+        const Z_MIN_CHUNK: number;
+        const Z_MAX_CHUNK: number;
+        const Z_DEFAULT_CHUNK: number;
+
+        const Z_MIN_MEMLEVEL: number;
+        const Z_MAX_MEMLEVEL: number;
+        const Z_DEFAULT_MEMLEVEL: number;
+
+        const Z_MIN_LEVEL: number;
+        const Z_MAX_LEVEL: number;
+        const Z_DEFAULT_LEVEL: number;
+
         const ZLIB_VERNUM: number;
     }
 
-    /**
-     * @deprecated
-     */
+    // Allowed flush values.
+    /** @deprecated Use `constants.Z_NO_FLUSH` */
     const Z_NO_FLUSH: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_PARTIAL_FLUSH` */
     const Z_PARTIAL_FLUSH: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_SYNC_FLUSH` */
     const Z_SYNC_FLUSH: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_FULL_FLUSH` */
     const Z_FULL_FLUSH: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_FINISH` */
     const Z_FINISH: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_BLOCK` */
     const Z_BLOCK: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_TREES` */
     const Z_TREES: number;
-    /**
-     * @deprecated
-     */
+
+    // Return codes for the compression/decompression functions.
+    // Negative values are errors, positive values are used for special but normal events.
+    /** @deprecated Use `constants.Z_OK` */
     const Z_OK: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_STREAM_END` */
     const Z_STREAM_END: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_NEED_DICT` */
     const Z_NEED_DICT: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_ERRNO` */
     const Z_ERRNO: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_STREAM_ERROR` */
     const Z_STREAM_ERROR: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_DATA_ERROR` */
     const Z_DATA_ERROR: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_MEM_ERROR` */
     const Z_MEM_ERROR: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_BUF_ERROR` */
     const Z_BUF_ERROR: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_VERSION_ERROR` */
     const Z_VERSION_ERROR: number;
-    /**
-     * @deprecated
-     */
+
+    // Compression levels.
+    /** @deprecated Use `constants.Z_NO_COMPRESSION` */
     const Z_NO_COMPRESSION: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_BEST_SPEED` */
     const Z_BEST_SPEED: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_BEST_COMPRESSION` */
     const Z_BEST_COMPRESSION: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_DEFAULT_COMPRESSION` */
     const Z_DEFAULT_COMPRESSION: number;
-    /**
-     * @deprecated
-     */
+
+    // Compression strategy.
+    /** @deprecated Use `constants.Z_FILTERED` */
     const Z_FILTERED: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_HUFFMAN_ONLY` */
     const Z_HUFFMAN_ONLY: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_RLE` */
     const Z_RLE: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_FIXED` */
     const Z_FIXED: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_DEFAULT_STRATEGY` */
     const Z_DEFAULT_STRATEGY: number;
-    /**
-     * @deprecated
-     */
+
+    /** @deprecated */
     const Z_BINARY: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated */
     const Z_TEXT: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated */
     const Z_ASCII: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated  */
     const Z_UNKNOWN: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated */
     const Z_DEFLATED: number;
 }

--- a/types/node/zlib.d.ts
+++ b/types/node/zlib.d.ts
@@ -1,3 +1,4 @@
+/* tslint:enable: unified-signatures */
 declare module "zlib" {
     import * as stream from "stream";
 
@@ -51,7 +52,8 @@ declare module "zlib" {
         readonly bytesWritten: number;
         shell?: boolean | string;
         close(callback?: () => void): void;
-        flush(kind?: number | (() => void), callback?: () => void): void;
+        flush(kind?: number, callback?: () => void): void;
+        flush(callback?: () => void): void;
     }
 
     interface ZlibParams {
@@ -88,68 +90,75 @@ declare module "zlib" {
 
     function brotliCompress(buf: InputType, options: BrotliOptions, callback: CompressCallback): void;
     function brotliCompress(buf: InputType, callback: CompressCallback): void;
+    namespace brotliCompress {
+        function __promisify__(buffer: InputType, options?: BrotliOptions): Promise<Buffer>;
+    }
+
     function brotliCompressSync(buf: InputType, options?: BrotliOptions): Buffer;
+
     function brotliDecompress(buf: InputType, options: BrotliOptions, callback: CompressCallback): void;
     function brotliDecompress(buf: InputType, callback: CompressCallback): void;
+    namespace brotliDecompress {
+        function __promisify__(buffer: InputType, options?: BrotliOptions): Promise<Buffer>;
+    }
+
     function brotliDecompressSync(buf: InputType, options?: BrotliOptions): Buffer;
+
     function deflate(buf: InputType, callback: CompressCallback): void;
     function deflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    namespace deflate {
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+    }
+
     function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+
     function deflateRaw(buf: InputType, callback: CompressCallback): void;
     function deflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    namespace deflateRaw {
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+    }
+
     function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+
     function gzip(buf: InputType, callback: CompressCallback): void;
     function gzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    namespace gzip {
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+    }
+
     function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+
     function gunzip(buf: InputType, callback: CompressCallback): void;
     function gunzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    namespace gunzip {
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+    }
+
     function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+
     function inflate(buf: InputType, callback: CompressCallback): void;
     function inflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    namespace inflate {
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+    }
+
     function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+
     function inflateRaw(buf: InputType, callback: CompressCallback): void;
     function inflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    namespace inflateRaw {
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
+    }
+
     function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+
     function unzip(buf: InputType, callback: CompressCallback): void;
     function unzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
-    function unzipSync(buf: InputType, options?: ZlibOptions): Buffer;
-
-    namespace brotliCompress {
-        function __promisify__(buffer: InputType, options: BrotliOptions): Promise<Buffer>;
-        function __promisify__(buffer: InputType): Promise<Buffer>;
-    }
-    namespace brotliDecompress {
-        function __promisify__(buffer: InputType, options: BrotliOptions): Promise<Buffer>;
-        function __promisify__(buffer: InputType): Promise<Buffer>;
-    }
-    namespace deflate {
-        function __promisify__(buffer: InputType): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options: ZlibOptions): Promise<Buffer>;
-    }
-    namespace deflateRaw {
-        function __promisify__(buffer: InputType): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options: ZlibOptions): Promise<Buffer>;
-    }
-    namespace gzip {
-        function __promisify__(buffer: InputType): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options: ZlibOptions): Promise<Buffer>;
-    }
-    namespace gunzip {
-        function __promisify__(buffer: InputType): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options: ZlibOptions): Promise<Buffer>;
-    }
-    namespace inflate {
-        function __promisify__(buffer: InputType): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options: ZlibOptions): Promise<Buffer>;
-    }
-    namespace inflateRaw {
-        function __promisify__(buffer: InputType): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options: ZlibOptions): Promise<Buffer>;
-    }
     namespace unzip {
-        function __promisify__(buffer: InputType): Promise<Buffer>;
-        function __promisify__(buffer: InputType, options: ZlibOptions): Promise<Buffer>;
+        function __promisify__(buffer: InputType, options?: ZlibOptions): Promise<Buffer>;
     }
+
+    function unzipSync(buf: InputType, options?: ZlibOptions): Buffer;
 
     namespace constants {
         const BROTLI_DECODE: number;
@@ -228,165 +237,126 @@ declare module "zlib" {
         const INFLATERAW: number;
         const UNZIP: number;
 
-        const Z_BEST_COMPRESSION: number;
-        const Z_BEST_SPEED: number;
-        const Z_BLOCK: number;
-        const Z_BUF_ERROR: number;
-        const Z_DATA_ERROR: number;
-
-        const Z_DEFAULT_CHUNK: number;
-        const Z_DEFAULT_COMPRESSION: number;
-        const Z_DEFAULT_LEVEL: number;
-        const Z_DEFAULT_MEMLEVEL: number;
-        const Z_DEFAULT_STRATEGY: number;
-        const Z_DEFAULT_WINDOWBITS: number;
-
-        const Z_ERRNO: number;
-        const Z_FILTERED: number;
-        const Z_FINISH: number;
-        const Z_FIXED: number;
-        const Z_FULL_FLUSH: number;
-        const Z_HUFFMAN_ONLY: number;
-        const Z_MAX_CHUNK: number;
-        const Z_MAX_LEVEL: number;
-        const Z_MAX_MEMLEVEL: number;
-        const Z_MAX_WINDOWBITS: number;
-        const Z_MEM_ERROR: number;
-        const Z_MIN_CHUNK: number;
-        const Z_MIN_LEVEL: number;
-        const Z_MIN_MEMLEVEL: number;
-        const Z_MIN_WINDOWBITS: number;
-        const Z_NEED_DICT: number;
-        const Z_NO_COMPRESSION: number;
+        // Allowed flush values.
         const Z_NO_FLUSH: number;
-        const Z_OK: number;
         const Z_PARTIAL_FLUSH: number;
-        const Z_RLE: number;
-        const Z_STREAM_END: number;
-        const Z_STREAM_ERROR: number;
         const Z_SYNC_FLUSH: number;
+        const Z_FULL_FLUSH: number;
+        const Z_FINISH: number;
+        const Z_BLOCK: number;
+        const Z_TREES: number;
+
+        // Return codes for the compression/decompression functions.
+        // Negative values are errors, positive values are used for special but normal events.
+        const Z_OK: number;
+        const Z_STREAM_END: number;
+        const Z_NEED_DICT: number;
+        const Z_ERRNO: number;
+        const Z_STREAM_ERROR: number;
+        const Z_DATA_ERROR: number;
+        const Z_MEM_ERROR: number;
+        const Z_BUF_ERROR: number;
         const Z_VERSION_ERROR: number;
+
+        // Compression levels.
+        const Z_NO_COMPRESSION: number;
+        const Z_BEST_SPEED: number;
+        const Z_BEST_COMPRESSION: number;
+        const Z_DEFAULT_COMPRESSION: number;
+
+        // Compression strategy.
+        const Z_FILTERED: number;
+        const Z_HUFFMAN_ONLY: number;
+        const Z_RLE: number;
+        const Z_FIXED: number;
+        const Z_DEFAULT_STRATEGY: number;
+
+        const Z_DEFAULT_WINDOWBITS: number;
+        const Z_MIN_WINDOWBITS: number;
+        const Z_MAX_WINDOWBITS: number;
+
+        const Z_MIN_CHUNK: number;
+        const Z_MAX_CHUNK: number;
+        const Z_DEFAULT_CHUNK: number;
+
+        const Z_MIN_MEMLEVEL: number;
+        const Z_MAX_MEMLEVEL: number;
+        const Z_DEFAULT_MEMLEVEL: number;
+
+        const Z_MIN_LEVEL: number;
+        const Z_MAX_LEVEL: number;
+        const Z_DEFAULT_LEVEL: number;
+
         const ZLIB_VERNUM: number;
     }
 
-    /**
-     * @deprecated
-     */
+    // Allowed flush values.
+    /** @deprecated Use `constants.Z_NO_FLUSH` */
     const Z_NO_FLUSH: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_PARTIAL_FLUSH` */
     const Z_PARTIAL_FLUSH: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_SYNC_FLUSH` */
     const Z_SYNC_FLUSH: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_FULL_FLUSH` */
     const Z_FULL_FLUSH: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_FINISH` */
     const Z_FINISH: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_BLOCK` */
     const Z_BLOCK: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_TREES` */
     const Z_TREES: number;
-    /**
-     * @deprecated
-     */
+
+    // Return codes for the compression/decompression functions.
+    // Negative values are errors, positive values are used for special but normal events.
+    /** @deprecated Use `constants.Z_OK` */
     const Z_OK: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_STREAM_END` */
     const Z_STREAM_END: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_NEED_DICT` */
     const Z_NEED_DICT: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_ERRNO` */
     const Z_ERRNO: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_STREAM_ERROR` */
     const Z_STREAM_ERROR: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_DATA_ERROR` */
     const Z_DATA_ERROR: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_MEM_ERROR` */
     const Z_MEM_ERROR: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_BUF_ERROR` */
     const Z_BUF_ERROR: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_VERSION_ERROR` */
     const Z_VERSION_ERROR: number;
-    /**
-     * @deprecated
-     */
+
+    // Compression levels.
+    /** @deprecated Use `constants.Z_NO_COMPRESSION` */
     const Z_NO_COMPRESSION: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_BEST_SPEED` */
     const Z_BEST_SPEED: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_BEST_COMPRESSION` */
     const Z_BEST_COMPRESSION: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_DEFAULT_COMPRESSION` */
     const Z_DEFAULT_COMPRESSION: number;
-    /**
-     * @deprecated
-     */
+
+    // Compression strategy.
+    /** @deprecated Use `constants.Z_FILTERED` */
     const Z_FILTERED: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_HUFFMAN_ONLY` */
     const Z_HUFFMAN_ONLY: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_RLE` */
     const Z_RLE: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_FIXED` */
     const Z_FIXED: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated Use `constants.Z_DEFAULT_STRATEGY` */
     const Z_DEFAULT_STRATEGY: number;
-    /**
-     * @deprecated
-     */
+
+    /** @deprecated */
     const Z_BINARY: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated */
     const Z_TEXT: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated */
     const Z_ASCII: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated  */
     const Z_UNKNOWN: number;
-    /**
-     * @deprecated
-     */
+    /** @deprecated */
     const Z_DEFLATED: number;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48548> <https://palantir.github.io/tslint/rules/unified-signatures/> <https://nodejs.org/api/zlib.html#zlib_zlib_flush_kind_callback>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.