### PR TITLE
Update canvas-confetti to v1.3: Add gravity,scalar, disableForReducedMotion

### DIFF
--- a/types/canvas-confetti/index.d.ts
+++ b/types/canvas-confetti/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for canvas-confetti 1.0
+// Type definitions for canvas-confetti 1.3.0
 // Project: https://github.com/catdad/canvas-confetti#readme
 // Definitions by: Martin Tracey <https://github.com/matracey>
 //                 Josh Batley <https://github.com/joshbatley>
@@ -76,6 +76,21 @@ declare namespace confetti {
          * @default 100
          */
         zIndex?: number;
+        /**
+         * Scale factor for each confetti particle. Use decimals to make the confetti smaller.
+         * @default 1
+         */
+        scalar?: number;
+        /**
+         * How quickly the particles are pulled down. 1 is full gravity, 0.5 is half gravity, etc., but there are no limits.
+         * @default 1
+         */
+        gravity?: number;
+        /**
+         * Disables confetti entirely for users that prefer reduced motion. The confetti() promise will resolve immediately in this case.
+         * @default false
+         */
+        disableForReducedMotion?: boolean;
     }
 
     interface Origin {

--- a/types/canvas-confetti/index.d.ts
+++ b/types/canvas-confetti/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for canvas-confetti 1.3.0
+// Type definitions for canvas-confetti 1.3
 // Project: https://github.com/catdad/canvas-confetti#readme
 // Definitions by: Martin Tracey <https://github.com/matracey>
 //                 Josh Batley <https://github.com/joshbatley>


### PR DESCRIPTION
`gravity` was added in v1.1.0
`scalar` was added in v1.3.0
`disableForReducedMotion` added in v1.2.0
see https://github.com/catdad/canvas-confetti/releases

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/catdad/canvas-confetti/releases
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
