### PR TITLE
update(mini-css-extract-plugin): v1 updates

### DIFF
--- a/types/mini-css-extract-plugin/index.d.ts
+++ b/types/mini-css-extract-plugin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mini-css-extract-plugin 0.9
+// Type definitions for mini-css-extract-plugin 1.0
 // Project: https://github.com/webpack-contrib/mini-css-extract-plugin
 // Definitions by: JounQin <https://github.com/JounQin>
 //                 Katsuya Hino <https://github.com/dobogo>
@@ -6,7 +6,7 @@
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { compilation, Plugin } from 'webpack';
+import { ChunkData, Plugin } from 'webpack';
 
 /**
  * Lightweight CSS extraction webpack plugin
@@ -25,8 +25,11 @@ declare namespace MiniCssExtractPlugin {
         /**
          * Options similar to the same options in webpackOptions.output, both options are optional
          * May contain `[name]`, `[id]`, `hash` and `[chunkhash]`
+         * With the filename option you can use chunk data to customize the filename.
+         * This is particularly useful when dealing with multiple entry points and wanting to get more control out of the filename for a given entry point/chunk.
+         * In the example below, we'll use filename to output the generated css into a different directory.
          */
-        filename?: string;
+        filename?: string | ((chunkData: ChunkData) => string);
         chunkFilename?: string;
         /**
          * For projects where CSS ordering has been mitigated through consistent
@@ -35,17 +38,12 @@ declare namespace MiniCssExtractPlugin {
          */
         ignoreOrder?: boolean;
         /**
-         * By default, mini-css-extract-plugin generates JS modules that use the CommonJS
-         * modules syntax. There are some cases in which using ES modules is beneficial,
+         * By default, `mini-css-extract-plugin` generates JS modules that use the ES modules syntax.
+         * There are some cases in which using ES modules is beneficial,
          * like in the case of module concatenation and tree shaking.
+         * @default true
          */
         esModule?: boolean;
-        /**
-         * With the `moduleFilename` option you can use chunk data to customize the filename.
-         * This is particularly useful when dealing with multiple entry points
-         * and wanting to get more control out of the filename for a given entry point/chunk
-         */
-        moduleFilename?: (chunk: compilation.Chunk) => string;
     }
 }
 

--- a/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
+++ b/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
@@ -49,7 +49,7 @@ configuration = {
 
 configuration = {
     // ...
-    plugins: [new MiniCssExtractPlugin({})],
+    plugins: [new MiniCssExtractPlugin(), new MiniCssExtractPlugin({})],
 };
 
 configuration = {

--- a/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
+++ b/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
@@ -49,14 +49,14 @@ configuration = {
 
 configuration = {
     // ...
-    plugins: [new MiniCssExtractPlugin()],
+    plugins: [new MiniCssExtractPlugin({})],
 };
 
 configuration = {
     // ...
     plugins: [
         new MiniCssExtractPlugin({
-            filename: 'styles.css',
+            filename: ({ chunk }) => `${chunk.name.replace('/js/', '/css/')}.css`,
             chunkFilename: 'style.css',
         }),
     ],
@@ -78,15 +78,6 @@ configuration = {
     plugins: [
         new MiniCssExtractPlugin({
             esModule: true,
-        }),
-    ],
-};
-
-configuration = {
-    // ...
-    plugins: [
-        new MiniCssExtractPlugin({
-            moduleFilename: ({ name }) => `${name.replace('/js/', '/css/')}.css`,
         }),
     ],
 };


### PR DESCRIPTION
- `esModule` now defaults to true
- `filename` option as function
- `moduleFilename` removed
- version bump
- tests amended

https://github.com/webpack-contrib/mini-css-extract-plugin/compare/v0.12.0...v1.0.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)