### PR TITLE
[@types/prettier] Fix ArraySupportOption defaults

### DIFF
--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -365,7 +365,7 @@ export interface IntSupportOption extends BaseSupportOption<'int'> {
 }
 
 export interface IntArraySupportOption extends BaseSupportOption<'int'> {
-    default: number[];
+    default: Array<{ value: number[] }>;
     array: true;
 }
 
@@ -377,7 +377,7 @@ export interface BooleanSupportOption extends BaseSupportOption<'boolean'> {
 }
 
 export interface BooleanArraySupportOption extends BaseSupportOption<'boolean'> {
-    default: boolean[];
+    default: Array<{ value: boolean[] }>;
     array: true;
 }
 
@@ -397,7 +397,7 @@ export interface PathSupportOption extends BaseSupportOption<'path'> {
 }
 
 export interface PathArraySupportOption extends BaseSupportOption<'path'> {
-    default: string[];
+    default: Array<{ value: string[] }>;
     array: true;
 }
 


### PR DESCRIPTION
Followup of #47626

Context: https://github.com/prettier/plugin-pug/blob/6cb0cd36e0932316ee3ad3b0ac2dd3a94f9d4dcb/src/options/attribute-sorting/index.ts#L9