### PR TITLE
cookie-session: Make session property optional again

### DIFF
--- a/types/cookie-session/index.d.ts
+++ b/types/cookie-session/index.d.ts
@@ -103,7 +103,7 @@ declare namespace CookieSessionInterfaces {
         /**
          * Represents the session for the given request.
          */
-        session: CookieSessionObject | null;
+        session?: CookieSessionObject | null;
 
         /**
          * Represents the session options for the current request. These options are a shallow clone of what was provided at middleware construction and can be altered to change cookie setting behavior on a per-request basis.


### PR DESCRIPTION
Having the `session` property of `CookieSessionOptions` as non-optional is conflicting with the `Express.Request` interface.

This was introduce by PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44983.

Related issues:
- https://github.com/DefinitelyTyped/DefinitelyTyped/issues/27288
