### PR TITLE
[hull.js] Add typing for hull.js

### DIFF
--- a/types/hull.js/hull.js-tests.ts
+++ b/types/hull.js/hull.js-tests.ts
@@ -1,0 +1,10 @@
+import hull = require('hull.js');
+
+const numberPointSet = [[236, 126], [234, 115], [238, 109], [247, 102]];
+const objectPointSet = [{ lng: -0.2067, lat: 51.4911 }, { lng: -0.2070, lat: 51.4915 }];
+
+hull(numberPointSet);
+
+hull(numberPointSet, 50);
+
+hull(objectPointSet, 50, ['.lng', '.lat']);

--- a/types/hull.js/index.d.ts
+++ b/types/hull.js/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for hull.js 1.0
+// Project: https://github.com/AndriiHeonia/hull
+// Definitions by: Adam Zerella <https://github.com/adamzerella>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Builds concave hull by a set of points.
+ *
+ * @param pointSet - Array of coordinates
+ * @param concavity
+ * @param format Points format
+ */
+declare function hull(
+    pointSet: number[][] | object[],
+    concavity?: number,
+    format?: string[]
+): number[];
+
+export = hull;

--- a/types/hull.js/tsconfig.json
+++ b/types/hull.js/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "baseUrl": "../",
+    "typeRoots": [
+      "../"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts",
+    "hull.js-tests.ts"
+  ]
+}

--- a/types/hull.js/tslint.json
+++ b/types/hull.js/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.