### PR TITLE
[crawler] Add types for crawler

### DIFF
--- a/types/crawler/crawler-tests.ts
+++ b/types/crawler/crawler-tests.ts
@@ -142,3 +142,21 @@ new Crawler({
         },
     },
 });
+
+// Fixed vs rotating User-Agent strings
+
+new Crawler({
+    userAgent: 'UA-1',
+});
+
+const uaArray = ['UA-1', 'UA-2'];
+
+new Crawler({
+    rotateUA: true,
+    userAgent: uaArray,
+}).direct({
+    uri: 'http://www.google.com',
+    callback: (error, response) => {},
+});
+
+console.log(uaArray[0]); // is now 'UA-2'

--- a/types/crawler/crawler-tests.ts
+++ b/types/crawler/crawler-tests.ts
@@ -1,0 +1,144 @@
+import { CrawlerRequestResponse } from 'crawler';
+import Crawler = require('crawler');
+
+// Examples taken from README, edited
+
+const c = new Crawler({
+    maxConnections: 10,
+    callback: (error, res, done) => {
+        if (error) {
+            console.log(error);
+        } else {
+            const typedRes: CrawlerRequestResponse = res;
+            const $ = typedRes.$;
+            console.log($('title').text());
+        }
+        done();
+    },
+});
+
+c.queue('http://www.amazon.com');
+c.queue(['http://www.google.com/', 'http://www.yahoo.com']);
+c.queue([
+    {
+        uri: 'http://parishackers.org/',
+        jQuery: false,
+        callback: (error, res, done) => {
+            if (error) {
+                console.log(error);
+            } else {
+                console.log('Grabbed', res.body.length, 'bytes');
+            }
+            done();
+        },
+    },
+]);
+c.queue([
+    {
+        html: '<p>This is a <strong>test</strong></p>',
+    },
+]);
+
+// Another example
+
+c.queue({
+    uri: 'http://www.google.com',
+    parameter1: 'value1',
+    parameter2: 'value2',
+    parameter3: 'value3',
+    callback: (error, res, done) => {
+        if (!error) {
+            console.log(res.options.parameter1);
+        }
+        done();
+    },
+});
+
+// Another example
+
+new Crawler({
+    encoding: null,
+    jQuery: false,
+    callback: (err, res, done) => {
+        if (err) {
+            console.error(err.stack);
+        } else {
+            console.log(res.options.filename, res.body);
+        }
+        done();
+    },
+});
+
+// Another example
+
+new Crawler({
+    preRequest: (options, done) => {
+        console.log(options);
+        done();
+    },
+    callback: (err, res, done) => {
+        if (err) {
+            console.log(err);
+        } else {
+            console.log(res.statusCode);
+        }
+    },
+});
+
+c.queue({
+    uri: 'http://www.google.com',
+    preRequest: (options, done) => {
+        setTimeout(() => {
+            console.log(options);
+            done();
+        }, 1000);
+    },
+});
+
+// Another example
+
+c.direct({
+    uri: 'http://www.google.com',
+    skipEventRequest: false,
+    callback: (error, response) => {
+        if (error) {
+            console.log(error);
+        } else {
+            console.log(response.statusCode);
+        }
+    },
+});
+
+// More snippets from README
+
+c.setLimiterProperty('limiterName', 'propertyName', 'value');
+
+c.on('schedule', options => {
+    options.proxy = 'http://proxy:port';
+});
+
+c.on('request', options => {
+    options.qs.timestamp = new Date().getTime();
+});
+
+c.on('drain', () => {
+    console.log('For example, release a connection to database.');
+});
+
+new Crawler({
+    jQuery: true,
+});
+
+new Crawler({
+    jQuery: 'cheerio',
+});
+
+new Crawler({
+    jQuery: {
+        name: 'cheerio',
+        options: {
+            normalizeWhitespace: true,
+            xmlMode: true,
+        },
+    },
+});

--- a/types/crawler/index.d.ts
+++ b/types/crawler/index.d.ts
@@ -40,8 +40,7 @@ export = Crawler;
 
 declare namespace Crawler {
     // Following 2 types are taken from `request` definitions.
-    // `crawler` uses ancient version of `request` (v2.88.2),
-    // which causes typing problems due to `form-data` v2.3.
+    // as importing `request` v2.88.2 definitions cause DT tests to fail.
     interface Headers {
         [key: string]: any;
     }

--- a/types/crawler/index.d.ts
+++ b/types/crawler/index.d.ts
@@ -1,10 +1,10 @@
 // Type definitions for crawler 1.2
 // Project: https://github.com/bda-research/node-crawler
-// Definitions by: Ruben Rizzi <https://github.com/raynor85>
-//                 wakhh <https://github.com/wakhh>
-//                 Paweł Zmarzły <https://github.com/pzmarzly>
+// Definitions by: Paweł Zmarzły <https://github.com/pzmarzly>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.5
+
+// Based on https://github.com/bda-research/node-crawler/issues/297
 
 /// <reference types="cheerio" />
 

--- a/types/crawler/index.d.ts
+++ b/types/crawler/index.d.ts
@@ -93,7 +93,7 @@ declare namespace Crawler {
         timeout?: number;
         skipDuplicates?: boolean;
         rotateUA?: boolean;
-        userAgent?: string | ReadonlyArray<string>;
+        userAgent?: string | string[];
         homogeneous?: boolean;
         debug?: boolean;
         logger?: {

--- a/types/crawler/index.d.ts
+++ b/types/crawler/index.d.ts
@@ -9,7 +9,7 @@
 /// <reference types="cheerio" />
 
 import { EventEmitter } from 'events';
-import { Headers, RequestAsJSON } from 'request';
+import { Url } from 'url';
 
 declare class Crawler extends EventEmitter {
     constructor(options: Crawler.CreateCrawlerOptions);
@@ -32,6 +32,19 @@ declare class Crawler extends EventEmitter {
 export = Crawler;
 
 declare namespace Crawler {
+    // Following 2 types are taken from `request` definitions.
+    // `crawler` uses ancient version of `request` (v2.88.2),
+    // which causes typing problems due to `form-data` v2.3.
+    export interface Headers {
+        [key: string]: any;
+    }
+
+    export interface RequestAsJSON {
+        uri: Url;
+        method: string;
+        headers: Headers;
+    }
+
     export interface CrawlerRequestOptions {
         uri?: string;
         html?: string;

--- a/types/crawler/index.d.ts
+++ b/types/crawler/index.d.ts
@@ -14,13 +14,16 @@ import { Url } from 'url';
 declare class Crawler extends EventEmitter {
     constructor(options: Crawler.CreateCrawlerOptions);
     queueSize: number;
-    on(channel: 'schedule', listener: (options: Crawler.CrawlerRequestOptions) => void): this;
+    on(channel: 'schedule' | 'request', listener: (options: Crawler.CrawlerRequestOptions) => void): this;
     on(channel: 'limiterChange', listener: (options: Crawler.CrawlerRequestOptions, limiter: string) => void): this;
-    on(channel: 'request', listener: (options: Crawler.CrawlerRequestOptions) => void): this;
     on(channel: 'drain', listener: () => void): this;
-    queue(uri: string): void;
-    queue(uri: ReadonlyArray<string>): void;
-    queue(options: Crawler.CrawlerRequestOptions | ReadonlyArray<Crawler.CrawlerRequestOptions>): void;
+    queue(
+        urisOrOptions:
+            | string
+            | ReadonlyArray<string>
+            | Crawler.CrawlerRequestOptions
+            | ReadonlyArray<Crawler.CrawlerRequestOptions>,
+    ): void;
     direct(
         options: Omit<Crawler.CrawlerRequestOptions, 'callback'> & {
             callback: (error: Error, response: Crawler.CrawlerRequestResponse) => void;
@@ -35,17 +38,17 @@ declare namespace Crawler {
     // Following 2 types are taken from `request` definitions.
     // `crawler` uses ancient version of `request` (v2.88.2),
     // which causes typing problems due to `form-data` v2.3.
-    export interface Headers {
+    interface Headers {
         [key: string]: any;
     }
 
-    export interface RequestAsJSON {
+    interface RequestAsJSON {
         uri: Url;
         method: string;
         headers: Headers;
     }
 
-    export interface CrawlerRequestOptions {
+    interface CrawlerRequestOptions {
         uri?: string;
         html?: string;
         proxy?: any;
@@ -59,7 +62,7 @@ declare namespace Crawler {
         [x: string]: any;
     }
 
-    export interface CrawlerRequestResponse {
+    interface CrawlerRequestResponse {
         body: Buffer | string;
         request: RequestAsJSON;
         options: CrawlerRequestOptions;
@@ -67,7 +70,7 @@ declare namespace Crawler {
         [x: string]: any;
     }
 
-    export interface CreateCrawlerOptions {
+    interface CreateCrawlerOptions {
         autoWindowClose?: boolean;
         forceUTF8?: boolean;
         gzip?: boolean;

--- a/types/crawler/index.d.ts
+++ b/types/crawler/index.d.ts
@@ -13,10 +13,12 @@ import { Url } from 'url';
 
 declare class Crawler extends EventEmitter {
     constructor(options: Crawler.CreateCrawlerOptions);
-    queueSize: number;
+    readonly queueSize: number;
+
     on(channel: 'schedule' | 'request', listener: (options: Crawler.CrawlerRequestOptions) => void): this;
     on(channel: 'limiterChange', listener: (options: Crawler.CrawlerRequestOptions, limiter: string) => void): this;
     on(channel: 'drain', listener: () => void): this;
+
     queue(
         urisOrOptions:
             | string
@@ -24,11 +26,13 @@ declare class Crawler extends EventEmitter {
             | Crawler.CrawlerRequestOptions
             | ReadonlyArray<Crawler.CrawlerRequestOptions>,
     ): void;
+
     direct(
         options: Omit<Crawler.CrawlerRequestOptions, 'callback'> & {
             callback: (error: Error, response: Crawler.CrawlerRequestResponse) => void;
         },
     ): void;
+
     setLimiterProperty(limiter: string, property?: string, value?: any): void;
 }
 
@@ -56,6 +60,7 @@ declare namespace Crawler {
         limiter?: string;
         encoding?: string;
         priority?: number;
+        jquery?: any;
         jQuery?: any;
         preRequest?: (options: CrawlerRequestOptions, doRequest: (err?: Error) => void) => void;
         callback?: (err: Error, res: CrawlerRequestResponse, done: () => void) => void;

--- a/types/crawler/index.d.ts
+++ b/types/crawler/index.d.ts
@@ -1,0 +1,87 @@
+// Type definitions for crawler 1.2
+// Project: https://github.com/bda-research/node-crawler
+// Definitions by: Ruben Rizzi <https://github.com/raynor85>
+//                 wakhh <https://github.com/wakhh>
+//                 Paweł Zmarzły <https://github.com/pzmarzly>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.5
+
+/// <reference types="cheerio" />
+
+import { EventEmitter } from 'events';
+import { Headers, RequestAsJSON } from 'request';
+
+declare class Crawler extends EventEmitter {
+    constructor(options: Crawler.CreateCrawlerOptions);
+    queueSize: number;
+    on(channel: 'schedule', listener: (options: Crawler.CrawlerRequestOptions) => void): this;
+    on(channel: 'limiterChange', listener: (options: Crawler.CrawlerRequestOptions, limiter: string) => void): this;
+    on(channel: 'request', listener: (options: Crawler.CrawlerRequestOptions) => void): this;
+    on(channel: 'drain', listener: () => void): this;
+    queue(uri: string): void;
+    queue(uri: ReadonlyArray<string>): void;
+    queue(options: Crawler.CrawlerRequestOptions | ReadonlyArray<Crawler.CrawlerRequestOptions>): void;
+    direct(
+        options: Omit<Crawler.CrawlerRequestOptions, 'callback'> & {
+            callback: (error: Error, response: Crawler.CrawlerRequestResponse) => void;
+        },
+    ): void;
+    setLimiterProperty(limiter: string, property?: string, value?: any): void;
+}
+
+export = Crawler;
+
+declare namespace Crawler {
+    export interface CrawlerRequestOptions {
+        uri?: string;
+        html?: string;
+        proxy?: any;
+        proxies?: any[];
+        limiter?: string;
+        encoding?: string;
+        priority?: number;
+        jQuery?: any;
+        preRequest?: (options: CrawlerRequestOptions, doRequest: (err?: Error) => void) => void;
+        callback?: (err: Error, res: CrawlerRequestResponse, done: () => void) => void;
+        [x: string]: any;
+    }
+
+    export interface CrawlerRequestResponse {
+        body: Buffer | string;
+        request: RequestAsJSON;
+        options: CrawlerRequestOptions;
+        $: cheerio.CheerioAPI;
+        [x: string]: any;
+    }
+
+    export interface CreateCrawlerOptions {
+        autoWindowClose?: boolean;
+        forceUTF8?: boolean;
+        gzip?: boolean;
+        incomingEncoding?: string;
+        jquery?: any;
+        jQuery?: any;
+        maxConnections?: number;
+        method?: string;
+        priority?: number;
+        priorityRange?: number;
+        rateLimit?: number;
+        referer?: false | string;
+        retries?: number;
+        retryTimeout?: number;
+        timeout?: number;
+        skipDuplicates?: boolean;
+        rotateUA?: boolean;
+        userAgent?: string | ReadonlyArray<string>;
+        homogeneous?: boolean;
+        debug?: boolean;
+        logger?: {
+            log: (level: string, ...args: ReadonlyArray<any>) => void;
+        };
+        seenreq?: any;
+        headers?: Headers;
+        preRequest?: (options: CrawlerRequestOptions, doRequest: (err?: Error) => void) => void;
+        callback?: (err: Error, res: CrawlerRequestResponse, done: () => void) => void;
+        [x: string]: any;
+    }
+}

--- a/types/crawler/package.json
+++ b/types/crawler/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "@types/form-data": "=2.2.1"
-    }
-}

--- a/types/crawler/package.json
+++ b/types/crawler/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "@types/form-data": "=2.2.1"
+    }
+}

--- a/types/crawler/tsconfig.json
+++ b/types/crawler/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "crawler-tests.ts"
+    ]
+}

--- a/types/crawler/tslint.json
+++ b/types/crawler/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR adds types for crawler ([npm](https://www.npmjs.com/package/crawler), [GitHub](https://github.com/bda-research/node-crawler)). Most of its development happened in the years 2014-2016. Later, @raynor85 and @wakhh [published their TS augmentation](https://github.com/bda-research/node-crawler/issues/297), which I took and updated to get it to work on modern TS compilers.

The types are not 100% accurate:
- there are some options that library accepts but are not typed here,
- user can choose not to use `cheerio`, in which case `$` is of different type.

---

By the way, it seems like packages that types for `request` are broken, which causes its dependents' tests to fail. For an example, run `npm test artillery` in the DT repo.

```bash
$ npm test artillery

> definitely-typed@0.0.3 test /home/pzmarzly/Projects/DefinitelyTyped
> dtslint types "artillery"

Error: Errors in typescript@4.1 for external dependencies:
../request/index.d.ts(24,27): error TS7016: Could not find a declaration file for module 'form-data'. '/home/pzmarzly/Projects/DefinitelyTyped/node_modules/form-data/lib/form_data.js' implicitly has an 'any' type.
```

---

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
