### PR TITLE
feat(string.prototype.matchall): new definition

### DIFF
--- a/types/string.prototype.matchall/index.d.ts
+++ b/types/string.prototype.matchall/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for string.prototype.matchall 4.0
+// Project: https://github.com/ljharb/String.prototype.matchAll#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Matches a string with a regular expression, and returns an iterable of matches
+ * containing the results of that search.
+ * @param str string to match
+ * @param regexp A variable name or string literal containing the regular expression pattern and flags.
+ */
+declare function matchAll(str: string, regexp: string | RegExp): IterableIterator<RegExpMatchArray>;
+
+declare namespace matchAll {
+    function shim(): void;
+}
+
+export = matchAll;

--- a/types/string.prototype.matchall/package.json
+++ b/types/string.prototype.matchall/package.json
@@ -1,0 +1,11 @@
+{
+    "private": true,
+    "types": "index",
+    "typesVersions": {
+        "<=3.7": {
+            "*": [
+                "ts3.7/*"
+            ]
+        }
+    }
+}

--- a/types/string.prototype.matchall/string.prototype.matchall-tests.ts
+++ b/types/string.prototype.matchall/string.prototype.matchall-tests.ts
@@ -1,0 +1,12 @@
+import matchAll = require('string.prototype.matchall');
+
+const str = 'aabc';
+const nonRegexStr = 'ab';
+const globalRegex = /[ac]/g;
+
+matchAll(str, nonRegexStr); // $ExpectType IterableIterator<RegExpMatchArray>
+matchAll(str, new RegExp(nonRegexStr, 'g')); // $ExpectType IterableIterator<RegExpMatchArray>
+matchAll(str, globalRegex); // $ExpectType IterableIterator<RegExpMatchArray>
+matchAll.shim(); // $ExpectType void
+str.matchAll(globalRegex); // $ExpectType IterableIterator<RegExpMatchArray>
+str.matchAll(new RegExp(nonRegexStr, 'g')); // $ExpectType IterableIterator<RegExpMatchArray>

--- a/types/string.prototype.matchall/ts3.7/index.d.ts
+++ b/types/string.prototype.matchall/ts3.7/index.d.ts
@@ -1,0 +1,24 @@
+/**
+ * Matches a string with a regular expression, and returns an iterable of matches
+ * containing the results of that search.
+ * @param str string to match
+ * @param regexp A variable name or string literal containing the regular expression pattern and flags.
+ */
+declare function matchAll(str: string, regexp: string | RegExp): IterableIterator<RegExpMatchArray>;
+
+declare namespace matchAll {
+    function shim(): void;
+}
+
+declare global {
+    interface String {
+        /**
+         * Matches a string with a regular expression, and returns an iterable of matches
+         * containing the results of that search.
+         * @param regexp A variable name or string literal containing the regular expression pattern and flags.
+         */
+        matchAll(regexp: RegExp): IterableIterator<RegExpMatchArray>;
+    }
+}
+
+export = matchAll;

--- a/types/string.prototype.matchall/ts3.7/string.prototype.matchall-tests.ts
+++ b/types/string.prototype.matchall/ts3.7/string.prototype.matchall-tests.ts
@@ -1,0 +1,12 @@
+import matchAll = require('string.prototype.matchall');
+
+const str = 'aabc';
+const nonRegexStr = 'ab';
+const globalRegex = /[ac]/g;
+
+matchAll(str, nonRegexStr); // $ExpectType IterableIterator<RegExpMatchArray>
+matchAll(str, new RegExp(nonRegexStr, 'g')); // $ExpectType IterableIterator<RegExpMatchArray>
+matchAll(str, globalRegex); // $ExpectType IterableIterator<RegExpMatchArray>
+matchAll.shim(); // $ExpectType void
+str.matchAll(globalRegex); // $ExpectType IterableIterator<RegExpMatchArray>
+str.matchAll(new RegExp(nonRegexStr, 'g')); // $ExpectType IterableIterator<RegExpMatchArray>

--- a/types/string.prototype.matchall/ts3.7/tsconfig.json
+++ b/types/string.prototype.matchall/ts3.7/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "string.prototype.matchall-tests.ts"
+    ]
+}

--- a/types/string.prototype.matchall/ts3.7/tslint.json
+++ b/types/string.prototype.matchall/ts3.7/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/string.prototype.matchall/tsconfig.json
+++ b/types/string.prototype.matchall/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "ES2020"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "string.prototype.matchall-tests.ts"
+    ]
+}

--- a/types/string.prototype.matchall/tslint.json
+++ b/types/string.prototype.matchall/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- definition file
- tests
https://www.npmjs.com/package/string.prototype.matchall

Note that definition for native method is aligned to current ES2020 DT
definition (single type of RegExp argument only).
This could be amended in future.

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.