### PR TITLE
feat(spdx-expression-parse): new definition

### DIFF
--- a/types/spdx-expression-parse/index.d.ts
+++ b/types/spdx-expression-parse/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for spdx-expression-parse 3.0
+// Project: https://github.com/jslicense/spdx-expression-parse.js#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * This package parses SPDX license expression strings describing license terms, like `package.json` license strings,
+ * into consistently structured ECMAScript object
+ */
+declare function parse(source: string): parse.Info;
+
+declare namespace parse {
+    type Info = LicenseInfo | ConjuctionInfo;
+
+    interface LicenseInfo {
+        license: string;
+        plus?: true;
+    }
+
+    interface ConjuctionInfo {
+        conjunction: 'and' | 'or';
+        left: LicenseInfo | ConjuctionInfo;
+        right: LicenseInfo | ConjuctionInfo;
+    }
+
+    interface Token {
+        type: 'OPERATOR' | 'LICENSE' | 'DOCUMENTREF' | 'LICENSEREF' | 'EXCEPTION';
+        string: string;
+    }
+}
+
+export = parse;

--- a/types/spdx-expression-parse/parse.d.ts
+++ b/types/spdx-expression-parse/parse.d.ts
@@ -1,0 +1,5 @@
+import { Info, Token } from './';
+
+declare function parse(tokens: Token[]): Info;
+
+export = parse;

--- a/types/spdx-expression-parse/scan.d.ts
+++ b/types/spdx-expression-parse/scan.d.ts
@@ -1,0 +1,5 @@
+import { Token } from './';
+
+declare function scan(source: string): Token[];
+
+export = scan;

--- a/types/spdx-expression-parse/spdx-expression-parse-tests.ts
+++ b/types/spdx-expression-parse/spdx-expression-parse-tests.ts
@@ -1,0 +1,40 @@
+import parse = require('spdx-expression-parse');
+import parseTokens = require('spdx-expression-parse/parse');
+import scan = require('spdx-expression-parse/scan');
+import { Info } from 'spdx-expression-parse';
+
+const source = '(MIT AND (LGPL-2.1+ AND BSD-3-Clause))';
+scan(source); // $ExpectType Token[]
+parseTokens(scan(source)); // $ExpectType Info
+parse(source); // $ExpectType Info
+
+const infos: Info[] = [
+    {
+        license: 'MIT',
+    },
+    {
+        left: {
+            license: 'MIT',
+        },
+        conjunction: 'and',
+        right: {
+            left: {
+                license: 'LGPL-2.1',
+                plus: true,
+            },
+            conjunction: 'and',
+            right: {
+                license: 'BSD-3-Clause',
+            },
+        },
+    },
+    {
+        left: { license: 'LGPL-2.1' },
+        conjunction: 'or',
+        right: {
+            left: { license: 'BSD-3-Clause' },
+            conjunction: 'and',
+            right: { license: 'MIT' },
+        },
+    },
+];

--- a/types/spdx-expression-parse/tsconfig.json
+++ b/types/spdx-expression-parse/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "spdx-expression-parse-tests.ts"
+    ]
+}

--- a/types/spdx-expression-parse/tslint.json
+++ b/types/spdx-expression-parse/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
SPDX expression parser:
- definition type
- tests

https://github.com/jslicense/spdx-expression-parse.js

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.