### PR TITLE
[jquery] Update return type for height function

### DIFF
--- a/types/jquery/JQuery.d.ts
+++ b/types/jquery/JQuery.d.ts
@@ -4761,7 +4761,7 @@ $( "#getw" ).click(function() {
 </html>
 ```
      */
-    height(): number | undefined;
+    height(): number;
     /**
      * Hide the matched elements.
      * @param duration A string or number determining how long the animation will run.

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -2807,7 +2807,7 @@ function JQuery() {
                 return 400;
             });
 
-            // $ExpectType number | undefined
+            // $ExpectType number
             $('p').height();
         }
 

--- a/types/jquery/test/example-tests.ts
+++ b/types/jquery/test/example-tests.ts
@@ -1832,7 +1832,7 @@ function examples() {
 
     function finish_0() {
         var horiz = $('#path').width()! - 20,
-            vert = $('#path').height()! - 20;
+            vert = $('#path').height() - 20;
 
         var btns: { [key: string]: () => void; } = {
             bstt: function() {
@@ -2001,13 +2001,13 @@ function examples() {
         }
 
         $('#getp').click(function() {
-            showHeight('paragraph', $('p').height()!);
+            showHeight('paragraph', $('p').height());
         });
         $('#getd').click(function() {
-            showHeight('document', $(document).height()!);
+            showHeight('document', $(document).height());
         });
         $('#getw').click(function() {
-            showHeight('window', $(window).height()!);
+            showHeight('window', $(window).height());
         });
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

according to the documentation, the function always returns only the number 
https://api.jquery.com/height/
