### PR TITLE
[koa] Fix response.set with object

### DIFF
--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -403,7 +403,7 @@ declare interface ContextDelegatedResponse {
      *    this.set('Accept', 'application/json');
      *    this.set({ Accept: 'text/plain', 'X-API-Key': 'tobi' });
      */
-    set(field: { [key: string]: string }): void;
+    set(field: { [key: string]: string | string[] }): void;
     set(field: string, val: string | string[]): void;
 
     /**

--- a/types/koa/test/default.ts
+++ b/types/koa/test/default.ts
@@ -48,6 +48,9 @@ app.use((ctx, next) => {
 app.use(ctx => {
     ctx.body = 'Hello World';
     ctx.body = ctx.URL.toString();
+    ctx.set({
+        link: ["<http://example.com>", "<http://example.org>"]
+    });
     ctx.attachment();
     ctx.attachment('path/to/tobi.png');
     ctx.attachment('path/to/tobi.png', {


### PR DESCRIPTION
When used with an object it just invokes the same method using the key/value pair as arguments so there's no reason not to allow a string array in both cases.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/koajs/koa/blob/master/lib/response.js#L459-L471
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
