### PR TITLE
reconnectTimer doesn't use anymore.

### DIFF
--- a/types/simple-peer/index.d.ts
+++ b/types/simple-peer/index.d.ts
@@ -20,7 +20,6 @@ declare namespace SimplePeer {
         constraints?: {}; // custom webrtc video/voice constraints (used by RTCPeerConnection constructor)
         offerConstraints?: {}; // custom offer constraints (used by createOffer method)
         answerConstraints?: {}; // custom answer constraints (used by createAnswer method)
-        reconnectTimer?: boolean | number; // wait __ milliseconds after ICE 'disconnect' for reconnect attempt before emitting 'close'
         sdpTransform?<T extends any>(sdp: T): T; // function to transform the generated SDP signaling data (for advanced users)
         stream?: MediaStream; // if video/voice is desired, pass stream returned from getUserMedia
         trickle?: boolean; // set to false to disable trickle ICE and get a single 'signal' event (slower)


### PR DESCRIPTION
reconnectTimer doesn't use anymore.
package: simple-peer
removed reconnectTimer config.
https://github.com/feross/simple-peer/commit/f3cb23e8fc867a17fc45e38505996d601b90a595