### PR TITLE
[react-boostrap-table-next] Add support for sortCaret, headerClasses …

### DIFF
--- a/types/react-bootstrap-table-next/index.d.ts
+++ b/types/react-bootstrap-table-next/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/react-bootstrap-table/react-bootstrap-table2#readme
 // Definitions by: Wlad Meixner <https://github.com/gosticks>
 //                 Valentin Slobozanin <https://github.com/ignefolio>
+//                 Jakub Różbicki <https://github.com/jrozbicki>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -66,6 +67,20 @@ export type ColumnSortFunc<T, E extends keyof T = any> = (
     rowB: T,
 ) => number;
 
+export type ColumnSortCaret<T extends object = any, E = any> = (
+    order: 'asc' | 'desc' | undefined,
+    column: ColumnDescription<T, E>,
+) => JSX.Element | string | null;
+
+export type HeaderSortingClasses<T extends object = any, E = any> =
+    | string
+    | ((
+          column: ColumnDescription<T, E>,
+          sortOrder: 'asc' | 'desc',
+          isLastSorting: boolean,
+          colIndex: number,
+      ) => string);
+
 export interface TableChangeState<T> {
     page: number;
     sizePerPage: number;
@@ -109,11 +124,13 @@ export interface ColumnDescription<T extends object = any, E = any> {
      */
     text: string;
     classes?: string | ((cell: T[keyof T], row: T, rowIndex: number, colIndex: number) => string);
+    headerClasses?: string | ((column: ColumnDescription<T, E>, colIndex: number) => string);
     style?:
         | React.CSSProperties
         | ((cell: T[keyof T], row: T, rowIndex: number, colIndex: number) => React.CSSProperties);
     sort?: boolean;
     sortFunc?: ColumnSortFunc<T>;
+    sortCaret?: ColumnSortCaret<T, E>;
     searchable?: boolean;
     align?: CellAlignment;
     headerStyle?: React.CSSProperties | (() => React.CSSProperties);
@@ -125,6 +142,7 @@ export interface ColumnDescription<T extends object = any, E = any> {
     filterValue?: (cell: T[keyof T], row: T) => string;
     headerAlign?: CellAlignment;
     headerFormatter?: HeaderFormatter<T>;
+    headerSortingClasses?: HeaderSortingClasses<T, E>;
     formatExtraData?: {
         tooltipFormatter?: (row: T) => JSX.Element;
     } & E;

--- a/types/react-bootstrap-table-next/react-bootstrap-table-next-tests.tsx
+++ b/types/react-bootstrap-table-next/react-bootstrap-table-next-tests.tsx
@@ -8,6 +8,8 @@ import BootstrapTable, {
     RowSelectionType,
     ROW_SELECT_SINGLE,
     ExpandRowProps,
+    ColumnSortCaret,
+    HeaderSortingClasses,
 } from 'react-bootstrap-table-next';
 
 interface Product {
@@ -49,6 +51,22 @@ const priceFormatter: ColumnFormatter<Product, { indexSquare: number }> = (cell,
     );
 };
 
+const SortCaret: ColumnSortCaret = (order, column) => {
+    switch (order) {
+        case 'asc':
+            return '&#9650;';
+
+        case 'desc':
+            return '&#9660;';
+
+        default:
+            return null;
+    }
+};
+
+const headerSortingClasses: HeaderSortingClasses = (column, sortOrder, isLastSorting, colIndex) =>
+    sortOrder === 'asc' || sortOrder === 'desc' ? 'sort-active' : '';
+
 const productColumns: Array<ColumnDescription<Product>> = [
     { dataField: 'id', align: 'center', sort: true, text: 'Product ID' },
     { dataField: 'name', align: 'center', sort: true, text: 'Product Name' },
@@ -56,7 +74,9 @@ const productColumns: Array<ColumnDescription<Product>> = [
         isDummyField: true,
         dataField: '',
         sort: true,
+        sortCaret: SortCaret,
         text: 'Product Name',
+        headerSortingClasses,
     },
     {
         dataField: 'price',
@@ -154,7 +174,7 @@ render(
         data={products}
         bootstrap4
         keyField="id"
-        noDataIndication={() => "No data available"}
+        noDataIndication={() => 'No data available'}
         columns={productColumns}
     />,
     document.getElementById('app'),
@@ -226,9 +246,7 @@ render(
 
 const expandRow: ExpandRowProps<Product> = {
     renderer: (row: Product) => {
-        return (
-            <div></div>
-        );
+        return <div></div>;
     },
     expanded: [1, 2],
     onExpand: (row, isExpand, rowIndex, e) => <div></div>,


### PR DESCRIPTION
…and headerSortingClasses in ColumnDescription

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://react-bootstrap-table.github.io/react-bootstrap-table2/docs/column-props.html>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
