### PR TITLE
[fast-html-parser] Make the value returned by `querySelector` nullable, and fix code format

### DIFF
--- a/types/fast-html-parser/fast-html-parser-tests.ts
+++ b/types/fast-html-parser/fast-html-parser-tests.ts
@@ -12,7 +12,7 @@ const root = parse(
 
 const firstDiv = root.querySelector('div');
 const paragraph = parse('<p>This is a paragraph</p>');
-const firstDivWithParagraph = firstDiv.appendChild(paragraph);
+const firstDivWithParagraph = firstDiv ? firstDiv.appendChild(paragraph) : null;
 
 console.log(root.nodeType);
 console.log(firstDiv);

--- a/types/fast-html-parser/fast-html-parser-tests.ts
+++ b/types/fast-html-parser/fast-html-parser-tests.ts
@@ -1,13 +1,13 @@
 import { NodeType, parse } from 'fast-html-parser';
 
 const root = parse(
-  '<!doctype html><html lang="en-us"><html><body><div id="firstdiv">   first-div   </div><div>  second-div  </div></body></html>',
-  {
-    lowerCaseTagName: true,
-    pre: true,
-    script: true,
-    style: true,
-  },
+    '<!doctype html><html lang="en-us"><html><body><div id="firstdiv">   first-div   </div><div>  second-div  </div></body></html>',
+    {
+        lowerCaseTagName: true,
+        pre: true,
+        script: true,
+        style: true,
+    },
 );
 
 const firstDiv = root.querySelector('div');

--- a/types/fast-html-parser/index.d.ts
+++ b/types/fast-html-parser/index.d.ts
@@ -32,7 +32,7 @@ export interface HTMLElement {
     readonly text: string;
     readonly tagName: string;
     appendChild(node: HTMLElement): HTMLElement;
-    querySelector(selector: string): HTMLElement;
+    querySelector(selector: string): HTMLElement | null;
     querySelectorAll(selector: string): HTMLElement[];
     removeWhitespace(): HTMLElement;
     trimRight(pattern?: RegExp): HTMLElement;

--- a/types/fast-html-parser/index.d.ts
+++ b/types/fast-html-parser/index.d.ts
@@ -7,40 +7,40 @@
 export function parse(data: string, options?: ParseOptions): HTMLElement;
 
 export enum NodeType {
-  ELEMENT_NODE = 1,
-  TEXT_NODE = 3,
+    ELEMENT_NODE = 1,
+    TEXT_NODE = 3,
 }
 
 export interface Attributes {
-  [key: string]: string;
+    [key: string]: string;
 }
 
 export interface HTMLElement {
-  readonly attributes: Attributes;
-  readonly childNodes: HTMLElement[];
-  readonly classNames: string[];
-  readonly firstChild: HTMLElement;
-  readonly id: string;
-  readonly isWhitespace: boolean;
-  readonly lastChild: HTMLElement;
-  readonly nodeType: NodeType;
-  readonly rawAttrs: string;
-  readonly rawAttributes: Attributes;
-  readonly rawText: string;
-  readonly structure: string;
-  readonly structuredText: string;
-  readonly text: string;
-  readonly tagName: string;
-  appendChild(node: HTMLElement): HTMLElement;
-  querySelector(selector: string): HTMLElement;
-  querySelectorAll(selector: string): HTMLElement[];
-  removeWhitespace(): HTMLElement;
-  trimRight(pattern?: RegExp): HTMLElement;
+    readonly attributes: Attributes;
+    readonly childNodes: HTMLElement[];
+    readonly classNames: string[];
+    readonly firstChild: HTMLElement;
+    readonly id: string;
+    readonly isWhitespace: boolean;
+    readonly lastChild: HTMLElement;
+    readonly nodeType: NodeType;
+    readonly rawAttrs: string;
+    readonly rawAttributes: Attributes;
+    readonly rawText: string;
+    readonly structure: string;
+    readonly structuredText: string;
+    readonly text: string;
+    readonly tagName: string;
+    appendChild(node: HTMLElement): HTMLElement;
+    querySelector(selector: string): HTMLElement;
+    querySelectorAll(selector: string): HTMLElement[];
+    removeWhitespace(): HTMLElement;
+    trimRight(pattern?: RegExp): HTMLElement;
 }
 
 export interface ParseOptions {
-  lowerCaseTagName?: boolean;
-  pre?: boolean;
-  script?: boolean;
-  style?: boolean;
+    lowerCaseTagName?: boolean;
+    pre?: boolean;
+    script?: boolean;
+    style?: boolean;
 }

--- a/types/fast-html-parser/tsconfig.json
+++ b/types/fast-html-parser/tsconfig.json
@@ -1,24 +1,16 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": [
-            "es6",
-            "dom"
-        ],
+        "lib": ["es6", "dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
+        "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-    "files": [
-        "index.d.ts",
-        "fast-html-parser-tests.ts"
-    ]
+    "files": ["index.d.ts", "fast-html-parser-tests.ts"]
 }


### PR DESCRIPTION

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ashi009/node-fast-html-parser/blob/6fadd44e5c6de4eb534f92793ddfe7d469f9a925/index.js#L320

~~- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~

- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

