### PR TITLE
[react-native] Add common PressableStateCallbackTypes

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -472,8 +472,8 @@ export interface Insets {
 
 export type PressableStateCallbackType = Readonly<{
     pressed: boolean;
-    hovered: boolean;
-    focused: boolean;
+    hovered?: boolean;
+    focused?: boolean;
 }>;
 
 export interface PressableAndroidRippleConfig {

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -472,6 +472,8 @@ export interface Insets {
 
 export type PressableStateCallbackType = Readonly<{
     pressed: boolean;
+    hovered: boolean;
+    focused: boolean;
 }>;
 
 export interface PressableAndroidRippleConfig {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.) **`master` dead on fork:**
```
Error: Errors in typescript@4.1 for external dependencies:
../react/index.d.ts(38,22): error TS2307: Cannot find module 'csstype' or its corresponding type declarations.
```
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). **`master` dead on fork:** same output as in testing

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

