### PR TITLE
[ramda] propEq type fixed

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1547,11 +1547,11 @@ export function prop<P extends string, T>(p: P): (obj: Record<P, T>) => T;
  * value according to strict equality (`===`).  Most likely used to
  * filter a list.
  */
-export function propEq<K extends string | number, V>(name: K, val: V, obj: Record<K, V>): boolean;
-export function propEq<K extends string | number, V>(name: K, val: V): (obj: Record<K, V>) => boolean;
+export function propEq<K extends string | number>(name: K, val: any, obj: Record<K, any>): boolean;
+export function propEq<K extends string | number>(name: K, val: any): (obj: Record<K, any>) => boolean;
 export function propEq<K extends string | number>(name: K): {
-    <V>(val: V, obj: Record<K, V>): boolean;
-    <V>(val: V): (obj: Record<K, V>) => boolean;
+    (val: any, obj: Record<K, any>): boolean;
+    (val: any): (obj: Record<K, any>) => boolean;
 };
 
 /**

--- a/types/ramda/test/propEq-tests.ts
+++ b/types/ramda/test/propEq-tests.ts
@@ -20,12 +20,28 @@ import * as R from 'ramda';
 };
 
 interface Obj {
-  a: number;
-  b: number;
+    a: number;
+    b: number;
 }
 
 () => {
-  const xs: Obj = {a: 1, b: 0};
-  R.propEq("a", 1, xs); // => true
-  R.propEq("a", 4, xs); // => false
+    const xs: Obj = { a: 1, b: 0 };
+    R.propEq('a', 1, xs); // => true
+    R.propEq('a', 4, xs); // => false
+};
+
+() => {
+    interface A {
+        foo: string | null;
+    }
+
+    const obj: A = {
+        foo: 'bar',
+    };
+    const value = '';
+
+    R.propEq('foo', value)(obj);
+
+    // $ExpectError
+    R.propEq('bar', value)(obj);
 };


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Removed unnecessary type matching for comparable value and object field in propEq