### PR TITLE
fix: add missing font-weights to echarts

### DIFF
--- a/types/echarts/echarts-tests.ts
+++ b/types/echarts/echarts-tests.ts
@@ -1,19 +1,19 @@
-import * as echarts from 'echarts'
+import * as echarts from 'echarts';
 
 const option: echarts.EChartOption = {
-    series:[],
+    series: [],
     title: {
-        padding: 5
-    }
+        padding: 5,
+    },
 };
 
 const testChartTitlePadding = (options: echarts.EChartTitleOption) => {
     options.padding = 5;
-    options.padding = [5]
+    options.padding = [5];
     options.padding = [5, 10];
     options.padding = [5, 10, 15];
     options.padding = [5, 10, 15, 20];
-}
+};
 
 // id, type, and name are defined for every series type
-const map = option.series!.map( s => [s.id, s.name, s.type]);
+const map = option.series!.map(s => [s.id, s.name, s.type]);

--- a/types/echarts/index.d.ts
+++ b/types/echarts/index.d.ts
@@ -1678,7 +1678,20 @@ declare namespace echarts {
                     margin?: number;
                     color?: string;
                     fontStyle?: 'normal' | 'italic' | 'oblique';
-                    fontWeight?: 'normal' | 'bold' | 'bolder' | 'lighter' | '100' | '200' | '300' | '400';
+                    fontWeight?:
+                        | 'normal'
+                        | 'bold'
+                        | 'bolder'
+                        | 'lighter'
+                        | 100
+                        | 200
+                        | 300
+                        | 400
+                        | 500
+                        | 600
+                        | 700
+                        | 800
+                        | 900;
                     fontFamily?: string;
                     fontSize?: number;
                     lineHeight?: number;

--- a/types/echarts/options/calendar.d.ts
+++ b/types/echarts/options/calendar.d.ts
@@ -69,7 +69,7 @@ declare namespace echarts {
              *
              * @default 'auto'
              */
-            bottom?: number |string;
+            bottom?: number | string;
             /**
              * The height of calendar coordinates.
              * Note: cellSize is 20 by default.
@@ -204,7 +204,7 @@ declare namespace echarts {
                 (params: MonthLabelFormatterParams): string;
             }
             interface MonthLabelFormatterParams {
-                nameMap?: string | number | (string|number)[];
+                nameMap?: string | number | (string | number)[];
                 yyyy?: number;
                 yy?: number;
                 MM?: number;
@@ -228,7 +228,7 @@ declare namespace echarts {
                 (params: YearLabelFormatterParams): string;
             }
             interface YearLabelFormatterParams {
-                nameMap?: string | number | (string|number)[];
+                nameMap?: string | number | (string | number)[];
                 start?: number;
                 end?: number;
             }

--- a/types/echarts/options/data-zoom.d.ts
+++ b/types/echarts/options/data-zoom.d.ts
@@ -14,8 +14,7 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#dataZoom-inside
          * @see https://echarts.apache.org/en/option.html#dataZoom-slider
          */
-        type DataZoom = DataZoom.Inside
-            | DataZoom.Slider;
+        type DataZoom = DataZoom.Inside | DataZoom.Slider;
 
         namespace DataZoom {
             /**

--- a/types/echarts/options/legend.d.ts
+++ b/types/echarts/options/legend.d.ts
@@ -85,7 +85,7 @@ declare namespace echarts {
              *
              * @default 'auto'
              */
-            bottom? :string | number;
+            bottom?: string | number;
             /**
              * Width of legend component. Adaptive by default.
              *

--- a/types/echarts/options/series/bar.d.ts
+++ b/types/echarts/options/series/bar.d.ts
@@ -283,7 +283,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-bar.label.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -568,12 +568,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-bar.label.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-bar.label.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -619,7 +617,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-bar.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -922,28 +920,31 @@ declare namespace echarts {
                  * "auto"
                  * @see https://echarts.apache.org/en/option.html#series-bar.itemStyle.color
                  */
-                color?: string | {
-                    type: 'linear',
-                    x: number,
-                    y: number,
-                    x2: number,
-                    y2: number,
-                    colorStops: {
-                        offset: number,
-                        color: string
-                    }[],
-                    global: boolean
-                } | {
-                    type: 'radial',
-                    x: number,
-                    y: number,
-                    r: number,
-                    colorStops: {
-                        offset: number,
-                        color: string
-                    }[],
-                    global: boolean
-                };
+                color?:
+                    | string
+                    | {
+                          type: 'linear';
+                          x: number;
+                          y: number;
+                          x2: number;
+                          y2: number;
+                          colorStops: {
+                              offset: number;
+                              color: string;
+                          }[];
+                          global: boolean;
+                      }
+                    | {
+                          type: 'radial';
+                          x: number;
+                          y: number;
+                          r: number;
+                          colorStops: {
+                              offset: number;
+                              color: string;
+                          }[];
+                          global: boolean;
+                      };
 
                 /**
                  * The bodrder color of bar.
@@ -1031,12 +1032,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-bar.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-bar.emphasis.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -1209,7 +1208,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-bar.emphasis.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -1495,12 +1494,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-bar.emphasis.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-bar.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -1546,7 +1543,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-bar.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -1831,7 +1828,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-bar.emphasis.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * Bar color..
                      *
@@ -2358,10 +2354,9 @@ declare namespace echarts {
              *
              * @see https://echarts.apache.org/en/option.html#series-bar.data
              */
-            data?: (
-                (void | string | number | SeriesBar.DataObject)[]
-                | (void | string | number | SeriesBar.DataObject)[][]
-            );
+            data?:
+                | (void | string | number | SeriesBar.DataObject)[]
+                | (void | string | number | SeriesBar.DataObject)[][];
 
             /**
              * Mark point in a chart.
@@ -2370,7 +2365,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-bar.markPoint
              */
             markPoint?: {
-
                 /**
                  * Symbol of .
                  *
@@ -2500,7 +2494,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -2675,7 +2668,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -2961,12 +2954,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -3012,7 +3003,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -3296,7 +3287,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -3471,7 +3461,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -3761,12 +3751,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -3812,7 +3800,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -4113,7 +4101,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -4213,7 +4200,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -4348,7 +4334,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.data
                  */
                 data?: {
-
                     /**
                      * Mark point name.
                      *
@@ -4571,7 +4556,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.data.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -4673,7 +4657,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.data.itemStyle.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * color.
                              *
@@ -4780,7 +4763,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.data.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -4909,7 +4891,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.data.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -5199,12 +5181,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.data.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -5250,7 +5230,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -5546,7 +5526,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.data.label.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -5675,7 +5654,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.data.label.emphasis.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -5967,12 +5946,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.data.label.emphasis.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -6018,7 +5995,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-bar.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -6430,7 +6407,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-bar.markLine
              */
             markLine?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -6483,7 +6459,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-bar.markLine.label
                  */
                 label?: {
-
                     /**
                      * Whether show label or not.
                      *
@@ -6557,7 +6532,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-bar.markLine.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether show label or not.
                          *
@@ -6638,7 +6612,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-bar.markLine.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -6744,7 +6717,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-bar.markLine.lineStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Line color.
                          *
@@ -6888,7 +6860,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-bar.markLine.data
                  */
                 data?: {
-
                     /**
                      * Data of the starting point.
                      *
@@ -6896,7 +6867,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-bar.markLine.data.0
                      */
                     0?: {
-
                         /**
                          * Special label types, are used to label maximum value,
                          * minimum value and so on.
@@ -7125,7 +7095,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-bar.markLine.data.0.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -7235,7 +7204,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-bar.markLine.data.0.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -7353,7 +7321,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-bar.markLine.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -7429,7 +7396,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-bar.markLine.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -7511,7 +7477,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-bar.markLine.data.1
                      */
                     1?: {
-
                         /**
                          * Special label types, are used to label maximum value,
                          * minimum value and so on.
@@ -7740,7 +7705,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-bar.markLine.data.1.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -7850,7 +7814,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-bar.markLine.data.1.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -7968,7 +7931,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-bar.markLine.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -8044,7 +8006,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-bar.markLine.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -8235,7 +8196,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-bar.markArea
              */
             markArea?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -8253,7 +8213,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-bar.markArea.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -8382,7 +8341,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-bar.markArea.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -8668,12 +8627,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-bar.markArea.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-bar.markArea.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -8719,7 +8676,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-bar.markArea.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -9003,7 +8960,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-bar.markArea.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -9132,7 +9088,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-bar.markArea.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -9422,12 +9378,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-bar.markArea.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-bar.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -9473,7 +9427,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-bar.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -9774,7 +9728,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-bar.markArea.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -9874,7 +9827,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-bar.markArea.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -10021,7 +9973,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data
                  */
                 data?: {
-
                     /**
                      * Specify the left-top point.
                      *
@@ -10029,7 +9980,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.0
                      */
                     0?: {
-
                         /**
                          * Specify this item is on min or max or average value.
                          *
@@ -10128,7 +10078,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.0.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -10233,7 +10182,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.0.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -10347,7 +10295,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -10476,7 +10423,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.0.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -10768,12 +10715,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.0.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -10819,7 +10764,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -11116,7 +11061,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -11247,7 +11191,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.0.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -11551,12 +11495,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.0.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -11603,7 +11545,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -11913,7 +11855,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.1
                      */
                     1?: {
-
                         /**
                          * Specify this item is on min or max or average value.
                          *
@@ -12012,7 +11953,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.1.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -12117,7 +12057,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.1.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -12231,7 +12170,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -12360,7 +12298,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.1.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -12652,12 +12590,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.1.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -12703,7 +12639,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -13000,7 +12936,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -13131,7 +13066,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.1.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -13435,12 +13370,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.1.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -13487,7 +13420,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-bar.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -14049,7 +13982,6 @@ declare namespace echarts {
 
         namespace SeriesBar {
             interface DataObject {
-
                 /**
                  * The name of data item.
                  *
@@ -14073,7 +14005,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-bar.data.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -14204,7 +14135,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-bar.data.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -14490,12 +14421,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-bar.data.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-bar.data.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -14541,7 +14470,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-bar.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -14825,7 +14754,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-bar.data.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -14954,7 +14882,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-bar.data.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -15244,12 +15172,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-bar.data.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-bar.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -15295,7 +15221,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-bar.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -15593,7 +15519,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-bar.data.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * Bar color..
                      *
@@ -15689,7 +15614,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-bar.data.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Bar color..
                          *

--- a/types/echarts/options/series/boxplot.d.ts
+++ b/types/echarts/options/series/boxplot.d.ts
@@ -18,7 +18,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-boxplot
          */
         interface SeriesBoxplot {
-
             /**
              * @default
              * "boxplot"
@@ -147,7 +146,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-boxplot.itemStyle
              */
             itemStyle?: {
-
                 /**
                  * boxplot color. Color is taken from
                  * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -255,12 +253,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-boxplot.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-boxplot.emphasis.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * boxplot color. Color is taken from
                      * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -500,7 +496,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint
              */
             markPoint?: {
-
                 /**
                  * Symbol of .
                  *
@@ -630,7 +625,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -805,7 +799,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -1091,12 +1085,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -1142,7 +1134,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -1426,7 +1418,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -1601,7 +1592,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -1891,12 +1882,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -1942,7 +1931,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -2243,7 +2232,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -2343,7 +2331,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -2478,7 +2465,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.data
                  */
                 data?: {
-
                     /**
                      * Mark point name.
                      *
@@ -2701,7 +2687,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.data.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -2803,7 +2788,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.data.itemStyle.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * color.
                              *
@@ -2910,7 +2894,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.data.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -3039,7 +3022,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.data.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -3329,12 +3312,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.data.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -3380,7 +3361,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -3676,7 +3657,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.data.label.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -3805,7 +3785,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.data.label.emphasis.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -4097,12 +4077,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.data.label.emphasis.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -4148,7 +4126,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -4560,7 +4538,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-boxplot.markLine
              */
             markLine?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -4613,7 +4590,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-boxplot.markLine.label
                  */
                 label?: {
-
                     /**
                      * Whether show label or not.
                      *
@@ -4687,7 +4663,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markLine.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether show label or not.
                          *
@@ -4768,7 +4743,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-boxplot.markLine.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -4874,7 +4848,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markLine.lineStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Line color.
                          *
@@ -5018,7 +4991,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-boxplot.markLine.data
                  */
                 data?: {
-
                     /**
                      * Data of the starting point.
                      *
@@ -5026,7 +4998,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markLine.data.0
                      */
                     0?: {
-
                         /**
                          * Special label types, are used to label maximum value,
                          * minimum value and so on.
@@ -5269,7 +5240,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markLine.data.0.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -5379,7 +5349,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-boxplot.markLine.data.0.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -5497,7 +5466,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markLine.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -5573,7 +5541,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-boxplot.markLine.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -5655,7 +5622,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markLine.data.1
                      */
                     1?: {
-
                         /**
                          * Special label types, are used to label maximum value,
                          * minimum value and so on.
@@ -5898,7 +5864,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markLine.data.1.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -6008,7 +5973,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-boxplot.markLine.data.1.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -6126,7 +6090,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markLine.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -6202,7 +6165,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-boxplot.markLine.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -6393,7 +6355,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea
              */
             markArea?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -6411,7 +6372,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -6540,7 +6500,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -6826,12 +6786,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -6877,7 +6835,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -7161,7 +7119,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -7290,7 +7247,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -7580,12 +7537,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -7631,7 +7586,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -7932,7 +7887,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -8032,7 +7986,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -8179,7 +8132,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data
                  */
                 data?: {
-
                     /**
                      * Specify the left-top point.
                      *
@@ -8187,7 +8139,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.0
                      */
                     0?: {
-
                         /**
                          * Specify this item is on min or max or average value.
                          *
@@ -8286,7 +8237,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.0.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -8391,7 +8341,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.0.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -8505,7 +8454,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -8634,7 +8582,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.0.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -8926,12 +8874,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.0.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -8977,7 +8923,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -9274,7 +9220,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -9405,7 +9350,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.0.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -9709,12 +9654,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.0.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -9761,7 +9704,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -10071,7 +10014,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.1
                      */
                     1?: {
-
                         /**
                          * Specify this item is on min or max or average value.
                          *
@@ -10170,7 +10112,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.1.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -10275,7 +10216,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.1.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -10389,7 +10329,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -10518,7 +10457,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.1.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -10810,12 +10749,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.1.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -10861,7 +10798,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -11158,7 +11095,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -11289,7 +11225,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.1.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -11593,12 +11529,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.1.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -11645,7 +11579,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-boxplot.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -12155,7 +12089,6 @@ declare namespace echarts {
 
         namespace SeriesBoxplot {
             interface DataObject {
-
                 /**
                  * Name of data item.
                  *
@@ -12181,7 +12114,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-boxplot.data.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * boxplot color. Color is taken from
                      * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -12290,12 +12222,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-boxplot.data.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-boxplot.data.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * boxplot color. Color is taken from
                          * [option.color Palette](https://echarts.apache.org/en/option.html#color)

--- a/types/echarts/options/series/candlestick.d.ts
+++ b/types/echarts/options/series/candlestick.d.ts
@@ -43,7 +43,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-candlestick
          */
         interface SeriesCandlestick {
-
             /**
              * @default
              * "candlestick"
@@ -190,7 +189,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-candlestick.itemStyle
              */
             itemStyle?: {
-
                 /**
                  * Fill color of bullish candle stick.
                  *
@@ -338,12 +336,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-candlestick.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-candlestick.emphasis.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * Fill color of bullish candle stick.
                      *
@@ -665,7 +661,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint
              */
             markPoint?: {
-
                 /**
                  * Symbol of .
                  *
@@ -795,7 +790,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -970,7 +964,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -1256,12 +1250,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -1307,7 +1299,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -1591,7 +1583,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -1766,7 +1757,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -2056,12 +2047,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -2107,7 +2096,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -2408,7 +2397,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -2508,7 +2496,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -2643,7 +2630,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.data
                  */
                 data?: {
-
                     /**
                      * Mark point name.
                      *
@@ -2866,7 +2852,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.data.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -2968,7 +2953,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.data.itemStyle.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * color.
                              *
@@ -3075,7 +3059,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.data.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -3204,7 +3187,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.data.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -3494,12 +3477,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.data.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -3545,7 +3526,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -3841,7 +3822,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.data.label.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -3970,7 +3950,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.data.label.emphasis.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -4262,12 +4242,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.data.label.emphasis.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -4313,7 +4291,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -4725,7 +4703,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-candlestick.markLine
              */
             markLine?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -4778,7 +4755,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-candlestick.markLine.label
                  */
                 label?: {
-
                     /**
                      * Whether show label or not.
                      *
@@ -4852,7 +4828,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markLine.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether show label or not.
                          *
@@ -4933,7 +4908,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-candlestick.markLine.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -5039,7 +5013,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markLine.lineStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Line color.
                          *
@@ -5183,7 +5156,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-candlestick.markLine.data
                  */
                 data?: {
-
                     /**
                      * Data of the starting point.
                      *
@@ -5191,7 +5163,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markLine.data.0
                      */
                     0?: {
-
                         /**
                          * Special label types, are used to label maximum value,
                          * minimum value and so on.
@@ -5420,7 +5391,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markLine.data.0.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -5530,7 +5500,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-candlestick.markLine.data.0.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -5648,7 +5617,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markLine.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -5724,7 +5692,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-candlestick.markLine.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -5806,7 +5773,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markLine.data.1
                      */
                     1?: {
-
                         /**
                          * Special label types, are used to label maximum value,
                          * minimum value and so on.
@@ -6035,7 +6001,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markLine.data.1.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -6145,7 +6110,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-candlestick.markLine.data.1.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -6263,7 +6227,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markLine.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -6339,7 +6302,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-candlestick.markLine.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -6530,7 +6492,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea
              */
             markArea?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -6548,7 +6509,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -6677,7 +6637,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -6963,12 +6923,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -7014,7 +6972,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -7298,7 +7256,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -7427,7 +7384,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -7717,12 +7674,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -7768,7 +7723,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -8069,7 +8024,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -8169,7 +8123,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -8316,7 +8269,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data
                  */
                 data?: {
-
                     /**
                      * Specify the left-top point.
                      *
@@ -8324,7 +8276,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.0
                      */
                     0?: {
-
                         /**
                          * Specify this item is on min or max or average value.
                          *
@@ -8423,7 +8374,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.0.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -8528,7 +8478,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.0.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -8642,7 +8591,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -8771,7 +8719,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.0.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -9063,12 +9011,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.0.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -9114,7 +9060,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -9411,7 +9357,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -9542,7 +9487,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.0.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -9846,12 +9791,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.0.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -9898,7 +9841,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -10208,7 +10151,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.1
                      */
                     1?: {
-
                         /**
                          * Specify this item is on min or max or average value.
                          *
@@ -10307,7 +10249,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.1.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -10412,7 +10353,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.1.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -10526,7 +10466,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -10655,7 +10594,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.1.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -10947,12 +10886,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.1.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -10998,7 +10935,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -11295,7 +11232,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -11426,7 +11362,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.1.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -11730,12 +11666,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.1.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -11782,7 +11716,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-candlestick.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -12292,7 +12226,6 @@ declare namespace echarts {
 
         namespace SeriesCandlestick {
             interface DataObject {
-
                 /**
                  * Name of data item.
                  *
@@ -12318,7 +12251,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-candlestick.data.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * Fill color of bullish candle stick.
                      *
@@ -12466,12 +12398,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-candlestick.data.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-candlestick.data.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * Fill color of bullish candle stick.
                          *

--- a/types/echarts/options/series/custom.d.ts
+++ b/types/echarts/options/series/custom.d.ts
@@ -134,7 +134,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-custom
          */
         interface SeriesCustom {
-
             /**
              * @default
              * "custom"
@@ -331,7 +330,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-custom.renderItem
              */
             renderItem?: {
-
                 /**
                  * Parameters of `renderItem`.
                  *
@@ -339,7 +337,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.arguments
                  */
                 arguments?: {
-
                     /**
                      * The first parameter of `renderItem`, including:
                      *
@@ -371,7 +368,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.arguments.api
                      */
                     api?: {
-
                         /**
                          * Get value on the given dimension.
                          *
@@ -579,7 +575,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_group
                  */
                 return_group?: {
-
                     /**
                      * Must be specified when define a graphic element at the
                      * first time.
@@ -933,7 +928,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_path
                  */
                 return_path?: {
-
                     /**
                      * Must be specified when define a graphic element at the
                      * first time.
@@ -1202,7 +1196,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_path.shape
                      */
                     shape?: {
-
                         /**
                          * [SVG PathData](http://www.w3.org/TR/SVG/paths.html#PathData)
                          * .
@@ -1332,7 +1325,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_path.style
                      */
                     style?: {
-
                         /**
                          * Color filled in this element.
                          *
@@ -1416,7 +1408,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_image
                  */
                 return_image?: {
-
                     /**
                      * Must be specified when define a graphic element at the
                      * first time.
@@ -1685,7 +1676,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_image.style
                      */
                     style?: {
-
                         /**
                          * Specify contant of the image, can be a URL, or
                          * [dataURI](https://tools.ietf.org/html/rfc2397)
@@ -1838,7 +1828,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_text
                  */
                 return_text?: {
-
                     /**
                      * Must be specified when define a graphic element at the
                      * first time.
@@ -2107,7 +2096,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_text.style
                      */
                     style?: {
-
                         /**
                          * Text content. `\n` can be used as a line break.
                          *
@@ -2287,7 +2275,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_rect
                  */
                 return_rect?: {
-
                     /**
                      * Must be specified when define a graphic element at the
                      * first time.
@@ -2556,7 +2543,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_rect.shape
                      */
                     shape?: {
-
                         /**
                          * The x value of the left-top corner of the element
                          * in the coordinate system of its parent.
@@ -2637,7 +2623,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_rect.style
                      */
                     style?: {
-
                         /**
                          * Color filled in this element.
                          *
@@ -2724,7 +2709,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_circle
                  */
                 return_circle?: {
-
                     /**
                      * Must be specified when define a graphic element at the
                      * first time.
@@ -2993,7 +2977,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_circle.shape
                      */
                     shape?: {
-
                         /**
                          * The x value of the center of the element in the coordinate
                          * system of its parent.
@@ -3048,7 +3031,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_circle.style
                      */
                     style?: {
-
                         /**
                          * Color filled in this element.
                          *
@@ -3135,7 +3117,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_ring
                  */
                 return_ring?: {
-
                     /**
                      * Must be specified when define a graphic element at the
                      * first time.
@@ -3404,7 +3385,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_ring.shape
                      */
                     shape?: {
-
                         /**
                          * The x value of the center of the element in the coordinate
                          * system of its parent.
@@ -3467,7 +3447,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_ring.style
                      */
                     style?: {
-
                         /**
                          * Color filled in this element.
                          *
@@ -3554,7 +3533,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_sector
                  */
                 return_sector?: {
-
                     /**
                      * Must be specified when define a graphic element at the
                      * first time.
@@ -3823,7 +3801,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_sector.shape
                      */
                     shape?: {
-
                         /**
                          * The x value of the center of the element in the coordinate
                          * system of its parent.
@@ -3914,7 +3891,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_sector.style
                      */
                     style?: {
-
                         /**
                          * Color filled in this element.
                          *
@@ -4001,7 +3977,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_arc
                  */
                 return_arc?: {
-
                     /**
                      * Must be specified when define a graphic element at the
                      * first time.
@@ -4270,7 +4245,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_arc.shape
                      */
                     shape?: {
-
                         /**
                          * The x value of the center of the element in the coordinate
                          * system of its parent.
@@ -4361,7 +4335,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_arc.style
                      */
                     style?: {
-
                         /**
                          * Color filled in this element.
                          *
@@ -4450,7 +4423,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_polygon
                  */
                 return_polygon?: {
-
                     /**
                      * Must be specified when define a graphic element at the
                      * first time.
@@ -4719,7 +4691,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_polygon.shape
                      */
                     shape?: {
-
                         /**
                          * A list of points, which defines the shape, like `[[22,
                          * 44], [44, 55], [11, 44], ...]`.
@@ -4784,7 +4755,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_polygon.style
                      */
                     style?: {
-
                         /**
                          * Color filled in this element.
                          *
@@ -4871,7 +4841,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_polyline
                  */
                 return_polyline?: {
-
                     /**
                      * Must be specified when define a graphic element at the
                      * first time.
@@ -5140,7 +5109,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_polyline.shape
                      */
                     shape?: {
-
                         /**
                          * A list of points, which defines the shape, like `[[22,
                          * 44], [44, 55], [11, 44], ...]`.
@@ -5205,7 +5173,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_polyline.style
                      */
                     style?: {
-
                         /**
                          * Color filled in this element.
                          *
@@ -5294,7 +5261,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_line
                  */
                 return_line?: {
-
                     /**
                      * Must be specified when define a graphic element at the
                      * first time.
@@ -5563,7 +5529,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_line.shape
                      */
                     shape?: {
-
                         /**
                          * x value of the start point.
                          *
@@ -5636,7 +5601,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_line.style
                      */
                     style?: {
-
                         /**
                          * Color filled in this element.
                          *
@@ -5725,7 +5689,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_bezierCurve
                  */
                 return_bezierCurve?: {
-
                     /**
                      * Must be specified when define a graphic element at the
                      * first time.
@@ -5994,7 +5957,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_bezierCurve.shape
                      */
                     shape?: {
-
                         /**
                          * x value of the start point.
                          *
@@ -6107,7 +6069,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-custom.renderItem.return_bezierCurve.style
                      */
                     style?: {
-
                         /**
                          * Color filled in this element.
                          *
@@ -6196,7 +6157,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-custom.itemStyle
              */
             itemStyle?: {
-
                 /**
                  * color. Color is taken from
                  * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -6299,12 +6259,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-custom.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-custom.emphasis.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -6657,10 +6615,9 @@ declare namespace echarts {
              *
              * @see https://echarts.apache.org/en/option.html#series-custom.data
              */
-            data?: (
-                (void | string | number | SeriesCustom.DataObject)[]
-                | (void | string | number | SeriesCustom.DataObject)[][]
-            );
+            data?:
+                | (void | string | number | SeriesCustom.DataObject)[]
+                | (void | string | number | SeriesCustom.DataObject)[][];
 
             /**
              * `zlevel` value of all graghical elements in custom series.
@@ -6823,7 +6780,6 @@ declare namespace echarts {
 
         namespace SeriesCustom {
             interface DataObject {
-
                 /**
                  * Name of data item.
                  *
@@ -6844,7 +6800,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-custom.data.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -6945,12 +6900,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-custom.data.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-custom.data.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *

--- a/types/echarts/options/series/effect-scatter.d.ts
+++ b/types/echarts/options/series/effect-scatter.d.ts
@@ -17,7 +17,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-effectScatter
          */
         interface SeriesEffectScatter {
-
             /**
              * @default
              * "effectScatter"
@@ -92,7 +91,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-effectScatter.rippleEffect
              */
             rippleEffect?: {
-
                 /**
                  * The period duration of animation, in seconds.
                  *
@@ -329,7 +327,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-effectScatter.label
              */
             label?: {
-
                 /**
                  * Whether to show label.
                  *
@@ -503,7 +500,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.label.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -788,12 +785,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.label.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.label.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -839,7 +834,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -1126,7 +1121,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-effectScatter.itemStyle
              */
             itemStyle?: {
-
                 /**
                  * color. Color is taken from
                  * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -1239,12 +1233,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-effectScatter.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.emphasis.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -1417,7 +1409,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.emphasis.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -1703,12 +1695,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.emphasis.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -1754,7 +1744,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -2039,7 +2029,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.emphasis.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color. Color is taken from
                      * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -2404,10 +2393,9 @@ declare namespace echarts {
              *
              * @see https://echarts.apache.org/en/option.html#series-effectScatter.data
              */
-            data?: (
-                (void | number | string | SeriesEffectScatter.DataObject)[]
-                | (void | number | string | SeriesEffectScatter.DataObject)[][]
-            );
+            data?:
+                | (void | number | string | SeriesEffectScatter.DataObject)[]
+                | (void | number | string | SeriesEffectScatter.DataObject)[][];
 
             /**
              * Mark point in a chart.
@@ -2416,7 +2404,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint
              */
             markPoint?: {
-
                 /**
                  * Symbol of .
                  *
@@ -2546,7 +2533,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -2721,7 +2707,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -3007,12 +2993,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -3058,7 +3042,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -3342,7 +3326,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -3517,7 +3500,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -3807,12 +3790,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -3858,7 +3839,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -4159,7 +4140,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -4259,7 +4239,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -4394,7 +4373,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.data
                  */
                 data?: {
-
                     /**
                      * Mark point name.
                      *
@@ -4617,7 +4595,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.data.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -4719,7 +4696,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.data.itemStyle.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * color.
                              *
@@ -4826,7 +4802,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.data.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -4955,7 +4930,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.data.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -5245,12 +5220,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.data.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -5296,7 +5269,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -5592,7 +5565,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.data.label.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -5721,7 +5693,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.data.label.emphasis.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -6013,12 +5985,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.data.label.emphasis.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -6064,7 +6034,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -6476,7 +6446,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markLine
              */
             markLine?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -6529,7 +6498,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.markLine.label
                  */
                 label?: {
-
                     /**
                      * Whether show label or not.
                      *
@@ -6603,7 +6571,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markLine.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether show label or not.
                          *
@@ -6684,7 +6651,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.markLine.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -6790,7 +6756,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markLine.lineStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Line color.
                          *
@@ -6934,7 +6899,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.markLine.data
                  */
                 data?: {
-
                     /**
                      * Data of the starting point.
                      *
@@ -6942,7 +6906,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markLine.data.0
                      */
                     0?: {
-
                         /**
                          * Special label types, are used to label maximum value,
                          * minimum value and so on.
@@ -7171,7 +7134,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markLine.data.0.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -7281,7 +7243,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markLine.data.0.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -7399,7 +7360,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markLine.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -7475,7 +7435,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markLine.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -7557,7 +7516,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markLine.data.1
                      */
                     1?: {
-
                         /**
                          * Special label types, are used to label maximum value,
                          * minimum value and so on.
@@ -7786,7 +7744,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markLine.data.1.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -7896,7 +7853,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markLine.data.1.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -8014,7 +7970,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markLine.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -8090,7 +8045,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markLine.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -8281,7 +8235,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea
              */
             markArea?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -8299,7 +8252,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -8428,7 +8380,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -8714,12 +8666,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -8765,7 +8715,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -9049,7 +8999,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -9178,7 +9127,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -9468,12 +9417,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -9519,7 +9466,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -9820,7 +9767,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -9920,7 +9866,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -10067,7 +10012,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data
                  */
                 data?: {
-
                     /**
                      * Specify the left-top point.
                      *
@@ -10075,7 +10019,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.0
                      */
                     0?: {
-
                         /**
                          * Specify this item is on min or max or average value.
                          *
@@ -10174,7 +10117,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.0.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -10279,7 +10221,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.0.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -10393,7 +10334,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -10522,7 +10462,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.0.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -10814,12 +10754,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.0.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -10865,7 +10803,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -11162,7 +11100,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -11293,7 +11230,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.0.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -11597,12 +11534,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.0.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -11649,7 +11584,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -11959,7 +11894,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.1
                      */
                     1?: {
-
                         /**
                          * Specify this item is on min or max or average value.
                          *
@@ -12058,7 +11992,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.1.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -12163,7 +12096,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.1.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -12277,7 +12209,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -12406,7 +12337,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.1.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -12698,12 +12629,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.1.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -12749,7 +12678,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -13046,7 +12975,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -13177,7 +13105,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.1.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -13481,12 +13409,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.1.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -13533,7 +13459,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -14095,7 +14021,6 @@ declare namespace echarts {
 
         namespace SeriesEffectScatter {
             interface DataObject {
-
                 /**
                  * Symbol of single data.
                  *
@@ -14199,7 +14124,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.data.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -14330,7 +14254,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.data.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -14616,12 +14540,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.data.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.data.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -14667,7 +14589,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -14952,7 +14874,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.data.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -15053,12 +14974,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.data.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.data.emphasis.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -15187,7 +15106,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.data.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -15477,12 +15396,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-effectScatter.data.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-effectScatter.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -15528,7 +15445,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-effectScatter.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -15825,7 +15742,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-effectScatter.data.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *

--- a/types/echarts/options/series/funnel.d.ts
+++ b/types/echarts/options/series/funnel.d.ts
@@ -11,7 +11,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-funnel
          */
         interface SeriesFunnel {
-
             /**
              * @default
              * "funnel"
@@ -148,7 +147,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-funnel.label
              */
             label?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-funnel.label.show
                  */
@@ -274,7 +272,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-funnel.label.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -550,12 +548,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-funnel.label.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-funnel.label.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -598,7 +594,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-funnel.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -877,7 +873,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-funnel.labelLine
              */
             labelLine?: {
-
                 /**
                  * Whether to show visual guide line.
                  *
@@ -898,7 +893,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-funnel.labelLine.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -999,7 +993,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-funnel.labelLine.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * Whether to show visual guide line.
                      *
@@ -1012,7 +1005,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.labelLine.emphasis.lineStyle
                      */
                     lineStyle?: {
-
                         /**
                          * Line color.
                          *
@@ -1117,7 +1109,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-funnel.itemStyle
              */
             itemStyle?: {
-
                 /**
                  * color. Color is taken from
                  * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -1230,12 +1221,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-funnel.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-funnel.emphasis.label
                  */
                 label?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-funnel.emphasis.label.show
                      */
@@ -1328,7 +1317,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-funnel.emphasis.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -1605,12 +1594,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.emphasis.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-funnel.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -1653,7 +1640,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-funnel.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -1929,7 +1916,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-funnel.emphasis.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -2030,7 +2016,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-funnel.emphasis.labelLine
                  */
                 labelLine?: {
-
                     /**
                      * Whether to show visual guide line.
                      *
@@ -2051,7 +2036,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.emphasis.labelLine.lineStyle
                      */
                     lineStyle?: {
-
                         /**
                          * Line color.
                          *
@@ -2153,7 +2137,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.emphasis.labelLine.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show visual guide line.
                          *
@@ -2166,7 +2149,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-funnel.emphasis.labelLine.emphasis.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -2337,11 +2319,7 @@ declare namespace echarts {
              *
              * @see https://echarts.apache.org/en/option.html#series-funnel.data
              */
-            data?: (
-                number[]
-                | number[][]
-                | SeriesFunnel.DataObject[]
-            );
+            data?: number[] | number[][] | SeriesFunnel.DataObject[];
 
             /**
              * Mark point in a chart.
@@ -2350,7 +2328,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint
              */
             markPoint?: {
-
                 /**
                  * Symbol of .
                  *
@@ -2480,7 +2457,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -2655,7 +2631,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -2941,12 +2917,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -2992,7 +2966,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -3276,7 +3250,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -3451,7 +3424,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -3741,12 +3714,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -3792,7 +3763,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -4093,7 +4064,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -4193,7 +4163,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -4314,7 +4283,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.data
                  */
                 data?: {
-
                     /**
                      * Mark point name.
                      *
@@ -4451,7 +4419,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.data.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -4553,7 +4520,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.data.itemStyle.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * color.
                              *
@@ -4660,7 +4626,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.data.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -4789,7 +4754,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.data.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -5079,12 +5044,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.data.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -5130,7 +5093,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -5426,7 +5389,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.data.label.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -5555,7 +5517,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.data.label.emphasis.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -5847,12 +5809,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.data.label.emphasis.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -5898,7 +5858,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-funnel.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -6310,7 +6270,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-funnel.markLine
              */
             markLine?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -6363,7 +6322,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-funnel.markLine.label
                  */
                 label?: {
-
                     /**
                      * Whether show label or not.
                      *
@@ -6437,7 +6395,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.markLine.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether show label or not.
                          *
@@ -6518,7 +6475,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-funnel.markLine.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -6624,7 +6580,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.markLine.lineStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Line color.
                          *
@@ -6743,7 +6698,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-funnel.markLine.data
                  */
                 data?: {
-
                     /**
                      * Data of the starting point.
                      *
@@ -6751,7 +6705,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.markLine.data.0
                      */
                     0?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -6891,7 +6844,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-funnel.markLine.data.0.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -7001,7 +6953,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-funnel.markLine.data.0.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -7119,7 +7070,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-funnel.markLine.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -7195,7 +7145,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-funnel.markLine.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -7277,7 +7226,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.markLine.data.1
                      */
                     1?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -7417,7 +7365,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-funnel.markLine.data.1.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -7527,7 +7474,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-funnel.markLine.data.1.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -7645,7 +7591,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-funnel.markLine.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -7721,7 +7666,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-funnel.markLine.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -7912,7 +7856,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-funnel.markArea
              */
             markArea?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -7930,7 +7873,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -8059,7 +8001,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -8345,12 +8287,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -8396,7 +8336,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -8680,7 +8620,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -8809,7 +8748,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -9099,12 +9038,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -9150,7 +9087,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -9451,7 +9388,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -9551,7 +9487,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -9675,7 +9610,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data
                  */
                 data?: {
-
                     /**
                      * Specify the left-top point.
                      *
@@ -9683,7 +9617,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.0
                      */
                     0?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -9727,7 +9660,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.0.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -9832,7 +9764,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.0.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -9946,7 +9877,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -10075,7 +10005,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.0.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -10367,12 +10297,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.0.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -10418,7 +10346,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -10715,7 +10643,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -10846,7 +10773,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.0.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -11150,12 +11077,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.0.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -11202,7 +11127,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -11512,7 +11437,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.1
                      */
                     1?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -11556,7 +11480,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.1.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -11661,7 +11584,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.1.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -11775,7 +11697,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -11904,7 +11825,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.1.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -12196,12 +12117,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.1.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -12247,7 +12166,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -12544,7 +12463,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -12675,7 +12593,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.1.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -12979,12 +12897,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.1.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -13031,7 +12947,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-funnel.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -13558,7 +13474,6 @@ declare namespace echarts {
 
         namespace SeriesFunnel {
             interface DataObject {
-
                 /**
                  * the name of data item.
                  *
@@ -13583,7 +13498,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-funnel.data.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -13687,7 +13601,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-funnel.data.label
                  */
                 label?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-funnel.data.label.show
                      */
@@ -13769,7 +13682,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-funnel.data.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -14046,12 +13959,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.data.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-funnel.data.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -14094,7 +14005,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-funnel.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -14370,7 +14281,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-funnel.data.labelLine
                  */
                 labelLine?: {
-
                     /**
                      * Whether to show visual guide line.
                      *
@@ -14391,7 +14301,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.data.labelLine.lineStyle
                      */
                     lineStyle?: {
-
                         /**
                          * Line color.
                          *
@@ -14493,7 +14402,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.data.labelLine.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show visual guide line.
                          *
@@ -14506,7 +14414,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-funnel.data.labelLine.emphasis.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -14609,12 +14516,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-funnel.data.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-funnel.data.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -14717,7 +14622,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.data.emphasis.label
                      */
                     label?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-funnel.data.emphasis.label.show
                          */
@@ -14765,7 +14669,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-funnel.data.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -15046,12 +14950,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-funnel.data.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-funnel.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -15094,7 +14996,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-funnel.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -15382,7 +15284,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-funnel.data.emphasis.labelLine
                      */
                     labelLine?: {
-
                         /**
                          * Whether to show visual guide line.
                          *
@@ -15403,7 +15304,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-funnel.data.emphasis.labelLine.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -15507,7 +15407,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-funnel.data.emphasis.labelLine.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * Whether to show visual guide line.
                              *
@@ -15520,7 +15419,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-funnel.data.emphasis.labelLine.emphasis.lineStyle
                              */
                             lineStyle?: {
-
                                 /**
                                  * Line color.
                                  *

--- a/types/echarts/options/series/gauge.d.ts
+++ b/types/echarts/options/series/gauge.d.ts
@@ -11,7 +11,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-gauge
          */
         interface SeriesGauge {
-
             /**
              * @default
              * "gauge"
@@ -102,10 +101,9 @@ declare namespace echarts {
              *
              * @see https://echarts.apache.org/en/option.html#series-gauge.data
              */
-            data?: (
-                (void | string | number | SeriesGauge.DataObject)[]
-                | (void | string | number | SeriesGauge.DataObject)[][]
-            );
+            data?:
+                | (void | string | number | SeriesGauge.DataObject)[]
+                | (void | string | number | SeriesGauge.DataObject)[][];
 
             /**
              * The minimum data value which map to
@@ -146,7 +144,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-gauge.axisLine
              */
             axisLine?: {
-
                 /**
                  * Whether to show the axis line of gauge chart.
                  *
@@ -164,7 +161,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-gauge.axisLine.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * The axis line of gauge chart can be divided to several
                      * segments in different colors.
@@ -250,7 +246,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-gauge.splitLine
              */
             splitLine?: {
-
                 /**
                  * Whether to show the split line.
                  *
@@ -276,7 +271,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-gauge.splitLine.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -380,7 +374,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-gauge.axisTick
              */
             axisTick?: {
-
                 /**
                  * Whether to show the scale.
                  *
@@ -416,7 +409,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-gauge.axisTick.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -520,7 +512,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-gauge.axisLabel
              */
             axisLabel?: {
-
                 /**
                  * Whether to show the label.
                  *
@@ -584,7 +575,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-gauge.axisLabel.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -822,12 +813,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-gauge.axisLabel.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-gauge.axisLabel.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -870,7 +859,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-gauge.axisLabel.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -1147,7 +1136,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-gauge.pointer
              */
             pointer?: {
-
                 /**
                  * Whether to show the pointer.
                  *
@@ -1189,7 +1177,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-gauge.itemStyle
              */
             itemStyle?: {
-
                 /**
                  * The color of pointer. Defaults to use
                  * [the color of section](https://echarts.apache.org/en/option.html#series-gauge.axisLine.lineStyle.color)
@@ -1284,12 +1271,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-gauge.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-gauge.emphasis.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -1394,7 +1379,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-gauge.title
              */
             title?: {
-
                 /**
                  * Whether to show the title.
                  *
@@ -1461,7 +1445,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-gauge.title.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -1699,12 +1683,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-gauge.title.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-gauge.title.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -1747,7 +1729,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-gauge.title.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -2024,7 +2006,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-gauge.detail
              */
             detail?: {
-
                 /**
                  * Whether to show the details.
                  *
@@ -2168,7 +2149,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-gauge.detail.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -2346,7 +2327,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-gauge.detail.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -2389,7 +2369,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-gauge.detail.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -2666,7 +2646,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint
              */
             markPoint?: {
-
                 /**
                  * Symbol of .
                  *
@@ -2796,7 +2775,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -2971,7 +2949,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -3257,12 +3235,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -3308,7 +3284,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -3592,7 +3568,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -3767,7 +3742,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -4057,12 +4032,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -4108,7 +4081,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -4409,7 +4382,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -4509,7 +4481,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -4630,7 +4601,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.data
                  */
                 data?: {
-
                     /**
                      * Mark point name.
                      *
@@ -4767,7 +4737,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.data.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -4869,7 +4838,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.data.itemStyle.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * color.
                              *
@@ -4976,7 +4944,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.data.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -5105,7 +5072,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.data.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -5395,12 +5362,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.data.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -5446,7 +5411,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -5742,7 +5707,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.data.label.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -5871,7 +5835,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.data.label.emphasis.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -6163,12 +6127,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.data.label.emphasis.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -6214,7 +6176,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-gauge.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -6626,7 +6588,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-gauge.markLine
              */
             markLine?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -6679,7 +6640,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-gauge.markLine.label
                  */
                 label?: {
-
                     /**
                      * Whether show label or not.
                      *
@@ -6753,7 +6713,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-gauge.markLine.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether show label or not.
                          *
@@ -6834,7 +6793,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-gauge.markLine.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -6940,7 +6898,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-gauge.markLine.lineStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Line color.
                          *
@@ -7059,7 +7016,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-gauge.markLine.data
                  */
                 data?: {
-
                     /**
                      * Data of the starting point.
                      *
@@ -7067,7 +7023,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-gauge.markLine.data.0
                      */
                     0?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -7207,7 +7162,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-gauge.markLine.data.0.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -7317,7 +7271,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-gauge.markLine.data.0.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -7435,7 +7388,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-gauge.markLine.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -7511,7 +7463,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-gauge.markLine.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -7593,7 +7544,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-gauge.markLine.data.1
                      */
                     1?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -7733,7 +7683,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-gauge.markLine.data.1.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -7843,7 +7792,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-gauge.markLine.data.1.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -7961,7 +7909,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-gauge.markLine.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -8037,7 +7984,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-gauge.markLine.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -8228,7 +8174,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-gauge.markArea
              */
             markArea?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -8246,7 +8191,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -8375,7 +8319,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -8661,12 +8605,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -8712,7 +8654,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -8996,7 +8938,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -9125,7 +9066,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -9415,12 +9356,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -9466,7 +9405,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -9767,7 +9706,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -9867,7 +9805,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -9991,7 +9928,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data
                  */
                 data?: {
-
                     /**
                      * Specify the left-top point.
                      *
@@ -9999,7 +9935,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.0
                      */
                     0?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -10043,7 +9978,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.0.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -10148,7 +10082,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.0.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -10262,7 +10195,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -10391,7 +10323,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.0.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -10683,12 +10615,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.0.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -10734,7 +10664,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -11031,7 +10961,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -11162,7 +11091,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.0.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -11466,12 +11395,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.0.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -11518,7 +11445,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -11828,7 +11755,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.1
                      */
                     1?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -11872,7 +11798,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.1.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -11977,7 +11902,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.1.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -12091,7 +12015,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -12220,7 +12143,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.1.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -12512,12 +12435,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.1.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -12563,7 +12484,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -12860,7 +12781,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -12991,7 +12911,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.1.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -13295,12 +13215,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.1.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -13347,7 +13265,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-gauge.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family

--- a/types/echarts/options/series/graph.d.ts
+++ b/types/echarts/options/series/graph.d.ts
@@ -24,7 +24,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-graph
          */
         interface SeriesGraph {
-
             /**
              * @default
              * "graph"
@@ -201,7 +200,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-graph.circular
              */
             circular?: {
-
                 /**
                  * Whether to rotate the label automatically.
                  *
@@ -230,7 +228,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-graph.force
              */
             force?: {
-
                 /**
                  * The initial layout before force-directed layout, which will
                  * influence on the result of force-directed layout.
@@ -527,7 +524,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-graph.itemStyle
              */
             itemStyle?: {
-
                 /**
                  * color. Color is taken from
                  * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -646,7 +642,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-graph.lineStyle
              */
             lineStyle?: {
-
                 /**
                  * Line color.
                  *
@@ -765,7 +760,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-graph.label
              */
             label?: {
-
                 /**
                  * Whether to show label.
                  *
@@ -940,7 +934,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-graph.label.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -1225,12 +1219,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.label.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-graph.label.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -1276,7 +1268,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-graph.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -1559,7 +1551,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-graph.edgeLabel
              */
             edgeLabel?: {
-
                 /**
                  * If show label on edge.
                  *
@@ -1667,7 +1658,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-graph.edgeLabel.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -1943,12 +1934,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.edgeLabel.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-graph.edgeLabel.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -1991,7 +1980,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-graph.edgeLabel.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -2265,12 +2254,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-graph.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-graph.emphasis.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -2371,7 +2358,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.emphasis.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -2469,7 +2455,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.emphasis.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -2598,7 +2583,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-graph.emphasis.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -2884,12 +2869,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.emphasis.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-graph.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -2935,7 +2918,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-graph.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -3220,7 +3203,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.emphasis.edgeLabel
                  */
                 edgeLabel?: {
-
                     /**
                      * If show label on edge.
                      *
@@ -3329,7 +3311,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-graph.emphasis.edgeLabel.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -3606,12 +3588,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.emphasis.edgeLabel.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-graph.emphasis.edgeLabel.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -3654,7 +3634,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-graph.emphasis.edgeLabel.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -3988,7 +3968,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-graph.markPoint
              */
             markPoint?: {
-
                 /**
                  * Symbol of .
                  *
@@ -4118,7 +4097,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -4293,7 +4271,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -4579,12 +4557,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -4630,7 +4606,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -4914,7 +4890,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -5089,7 +5064,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -5379,12 +5354,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -5430,7 +5403,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -5731,7 +5704,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -5831,7 +5803,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -5966,7 +5937,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.data
                  */
                 data?: {
-
                     /**
                      * Mark point name.
                      *
@@ -6189,7 +6159,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.data.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -6291,7 +6260,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.data.itemStyle.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * color.
                              *
@@ -6398,7 +6366,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.data.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -6527,7 +6494,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.data.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -6817,12 +6784,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.data.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -6868,7 +6833,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -7164,7 +7129,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.data.label.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -7293,7 +7257,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.data.label.emphasis.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -7585,12 +7549,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.data.label.emphasis.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -7636,7 +7598,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-graph.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -8048,7 +8010,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-graph.markLine
              */
             markLine?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -8101,7 +8062,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.markLine.label
                  */
                 label?: {
-
                     /**
                      * Whether show label or not.
                      *
@@ -8175,7 +8135,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.markLine.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether show label or not.
                          *
@@ -8256,7 +8215,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.markLine.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -8362,7 +8320,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.markLine.lineStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Line color.
                          *
@@ -8506,7 +8463,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.markLine.data
                  */
                 data?: {
-
                     /**
                      * Data of the starting point.
                      *
@@ -8514,7 +8470,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.markLine.data.0
                      */
                     0?: {
-
                         /**
                          * Special label types, are used to label maximum value,
                          * minimum value and so on.
@@ -8743,7 +8698,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-graph.markLine.data.0.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -8853,7 +8807,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-graph.markLine.data.0.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -8971,7 +8924,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-graph.markLine.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -9047,7 +8999,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-graph.markLine.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -9129,7 +9080,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.markLine.data.1
                      */
                     1?: {
-
                         /**
                          * Special label types, are used to label maximum value,
                          * minimum value and so on.
@@ -9358,7 +9308,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-graph.markLine.data.1.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -9468,7 +9417,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-graph.markLine.data.1.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -9586,7 +9534,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-graph.markLine.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -9662,7 +9609,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-graph.markLine.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -9853,7 +9799,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-graph.markArea
              */
             markArea?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -9871,7 +9816,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.markArea.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -10000,7 +9944,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-graph.markArea.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -10286,12 +10230,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.markArea.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-graph.markArea.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -10337,7 +10279,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-graph.markArea.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -10621,7 +10563,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.markArea.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -10750,7 +10691,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-graph.markArea.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -11040,12 +10981,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-graph.markArea.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-graph.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -11091,7 +11030,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-graph.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -11392,7 +11331,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.markArea.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -11492,7 +11430,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.markArea.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -11639,7 +11576,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data
                  */
                 data?: {
-
                     /**
                      * Specify the left-top point.
                      *
@@ -11647,7 +11583,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.0
                      */
                     0?: {
-
                         /**
                          * Specify this item is on min or max or average value.
                          *
@@ -11746,7 +11681,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.0.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -11851,7 +11785,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.0.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -11965,7 +11898,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -12094,7 +12026,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.0.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -12386,12 +12318,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.0.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -12437,7 +12367,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -12734,7 +12664,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -12865,7 +12794,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.0.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -13169,12 +13098,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.0.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -13221,7 +13148,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -13531,7 +13458,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.1
                      */
                     1?: {
-
                         /**
                          * Specify this item is on min or max or average value.
                          *
@@ -13630,7 +13556,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.1.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -13735,7 +13660,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.1.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -13849,7 +13773,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -13978,7 +13901,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.1.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -14270,12 +14193,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.1.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -14321,7 +14242,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -14618,7 +14539,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -14749,7 +14669,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.1.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -15053,12 +14973,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.1.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -15105,7 +15023,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-graph.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -15761,7 +15679,6 @@ declare namespace echarts {
 
         namespace SeriesGraph {
             interface CategoryObject {
-
                 /**
                  * Name of category, which is used to correspond with
                  * [legend](https://echarts.apache.org/en/option.html#legend)
@@ -15877,7 +15794,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.categories.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color. Color is taken from
                      * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -15983,7 +15899,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.categories.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -16159,7 +16074,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-graph.categories.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -16445,12 +16360,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.categories.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-graph.categories.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -16496,7 +16409,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-graph.categories.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -16781,12 +16694,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.categories.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-graph.categories.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -16889,7 +16800,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.categories.emphasis.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -17018,7 +16928,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-graph.categories.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -17308,12 +17218,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-graph.categories.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-graph.categories.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -17359,7 +17267,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-graph.categories.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -17655,7 +17563,6 @@ declare namespace echarts {
             }
 
             interface DataObject {
-
                 /**
                  * Name of data item.
                  *
@@ -17807,7 +17714,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.data.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color. Color is taken from
                      * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -17913,7 +17819,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.data.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -18042,7 +17947,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-graph.data.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -18328,12 +18233,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.data.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-graph.data.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -18379,7 +18282,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-graph.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -18664,12 +18567,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.data.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-graph.data.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -18772,7 +18673,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.data.emphasis.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -18901,7 +18801,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-graph.data.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -19191,12 +19091,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-graph.data.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-graph.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -19242,7 +19140,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-graph.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -19546,7 +19444,6 @@ declare namespace echarts {
             }
 
             interface LinkObject {
-
                 /**
                  * [name of source node](https://echarts.apache.org/en/option.html#series-graph.data.name)
                  * on edge
@@ -19580,7 +19477,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.links.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -19687,7 +19583,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.links.label
                  */
                 label?: {
-
                     /**
                      * If show label on edge.
                      *
@@ -19796,7 +19691,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-graph.links.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -20073,12 +19968,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.links.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-graph.links.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -20121,7 +20014,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-graph.links.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -20397,12 +20290,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-graph.links.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-graph.links.emphasis.label
                      */
                     label?: {
-
                         /**
                          * If show label on edge.
                          *
@@ -20513,7 +20404,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-graph.links.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -20794,12 +20685,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-graph.links.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-graph.links.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -20842,7 +20731,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-graph.links.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -21130,7 +21019,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-graph.links.emphasis.lineStyle
                      */
                     lineStyle?: {
-
                         /**
                          * Line color.
                          *

--- a/types/echarts/options/series/heatmap.d.ts
+++ b/types/echarts/options/series/heatmap.d.ts
@@ -31,7 +31,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-heatmap
          */
         interface SeriesHeatmap {
-
             /**
              * @default
              * "heatmap"
@@ -171,7 +170,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-heatmap.label
              */
             label?: {
-
                 /**
                  * Whether to show label.
                  *
@@ -302,7 +300,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-heatmap.label.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -587,12 +585,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-heatmap.label.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.label.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -638,7 +634,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -926,7 +922,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-heatmap.itemStyle
              */
             itemStyle?: {
-
                 /**
                  * color.
                  *
@@ -1027,12 +1022,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-heatmap.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-heatmap.emphasis.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -1133,7 +1126,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-heatmap.emphasis.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -1264,7 +1256,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.emphasis.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -1550,12 +1542,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.emphasis.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -1601,7 +1591,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -2015,10 +2005,9 @@ declare namespace echarts {
              *
              * @see https://echarts.apache.org/en/option.html#series-heatmap.data
              */
-            data?: (
-                (void | number | string | SeriesHeatmap.DataObject)[]
-                | (void | number | string | SeriesHeatmap.DataObject)[][]
-            );
+            data?:
+                | (void | number | string | SeriesHeatmap.DataObject)[]
+                | (void | number | string | SeriesHeatmap.DataObject)[][];
 
             /**
              * Mark point in a chart.
@@ -2027,7 +2016,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint
              */
             markPoint?: {
-
                 /**
                  * Symbol of .
                  *
@@ -2157,7 +2145,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -2332,7 +2319,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -2618,12 +2605,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -2669,7 +2654,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -2953,7 +2938,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -3128,7 +3112,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -3418,12 +3402,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -3469,7 +3451,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -3770,7 +3752,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -3870,7 +3851,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -3991,7 +3971,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.data
                  */
                 data?: {
-
                     /**
                      * Mark point name.
                      *
@@ -4128,7 +4107,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.data.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -4230,7 +4208,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.data.itemStyle.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * color.
                              *
@@ -4337,7 +4314,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.data.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -4466,7 +4442,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.data.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -4756,12 +4732,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.data.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -4807,7 +4781,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -5103,7 +5077,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.data.label.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -5232,7 +5205,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.data.label.emphasis.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -5524,12 +5497,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.data.label.emphasis.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -5575,7 +5546,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -5987,7 +5958,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-heatmap.markLine
              */
             markLine?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -6040,7 +6010,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-heatmap.markLine.label
                  */
                 label?: {
-
                     /**
                      * Whether show label or not.
                      *
@@ -6114,7 +6083,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markLine.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether show label or not.
                          *
@@ -6195,7 +6163,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-heatmap.markLine.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -6301,7 +6268,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markLine.lineStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Line color.
                          *
@@ -6420,7 +6386,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-heatmap.markLine.data
                  */
                 data?: {
-
                     /**
                      * Data of the starting point.
                      *
@@ -6428,7 +6393,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markLine.data.0
                      */
                     0?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -6568,7 +6532,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markLine.data.0.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -6678,7 +6641,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.markLine.data.0.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -6796,7 +6758,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markLine.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -6872,7 +6833,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.markLine.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -6954,7 +6914,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markLine.data.1
                      */
                     1?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -7094,7 +7053,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markLine.data.1.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -7204,7 +7162,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.markLine.data.1.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -7322,7 +7279,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markLine.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -7398,7 +7354,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.markLine.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -7589,7 +7544,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea
              */
             markArea?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -7607,7 +7561,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -7736,7 +7689,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -8022,12 +7975,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -8073,7 +8024,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -8357,7 +8308,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -8486,7 +8436,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -8776,12 +8726,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -8827,7 +8775,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -9128,7 +9076,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -9228,7 +9175,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -9352,7 +9298,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data
                  */
                 data?: {
-
                     /**
                      * Specify the left-top point.
                      *
@@ -9360,7 +9305,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.0
                      */
                     0?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -9404,7 +9348,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.0.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -9509,7 +9452,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.0.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -9623,7 +9565,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -9752,7 +9693,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.0.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -10044,12 +9985,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.0.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -10095,7 +10034,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -10392,7 +10331,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -10523,7 +10461,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.0.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -10827,12 +10765,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.0.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -10879,7 +10815,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -11189,7 +11125,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.1
                      */
                     1?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -11233,7 +11168,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.1.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -11338,7 +11272,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.1.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -11452,7 +11385,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -11581,7 +11513,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.1.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -11873,12 +11805,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.1.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -11924,7 +11854,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -12221,7 +12151,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -12352,7 +12281,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.1.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -12656,12 +12585,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.1.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -12708,7 +12635,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-heatmap.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -13175,7 +13102,6 @@ declare namespace echarts {
 
         namespace SeriesHeatmap {
             interface DataObject {
-
                 /**
                  * Name of data item.
                  *
@@ -13201,7 +13127,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-heatmap.data.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -13332,7 +13257,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.data.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -13618,12 +13543,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.data.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.data.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -13669,7 +13592,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -13959,7 +13882,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-heatmap.data.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -14060,12 +13982,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-heatmap.data.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.data.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -14168,7 +14088,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-heatmap.data.emphasis.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -14299,7 +14218,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.data.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -14589,12 +14508,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-heatmap.data.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-heatmap.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -14640,7 +14557,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-heatmap.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family

--- a/types/echarts/options/series/line.d.ts
+++ b/types/echarts/options/series/line.d.ts
@@ -7,28 +7,32 @@ declare namespace echarts {
          * + Radial gradient. First three parameters are x and y positions of center, and radius, similar to linear gradient.
          * + Fill with texture
          */
-        type Color = string | {
-            type: 'linear';
-            x: number;
-            y: number;
-            x2: number;
-            y2: number;
-            colorStops: Array<{offset: number; color: string}>;
-            global?: boolean
-        } | {
-            type: 'radial';
-            x: number;
-            y: number;
-            r: number;
-            colorStops: Array<{offset: number, color: string}>;
-            global?: boolean;
-        } | {
-            /**
-             * HTMLImageElement, and HTMLCanvasElement are supported, while string path is not supported
-             */
-            image: HTMLImageElement | HTMLCanvasElement,
-            repeat?: 'repeat' | 'repeat-x' | 'repeat-y' | 'no-repeat' // 是否平铺, 可以是 'repeat-x', 'repeat-y', 'no-repeat'
-        }
+        type Color =
+            | string
+            | {
+                  type: 'linear';
+                  x: number;
+                  y: number;
+                  x2: number;
+                  y2: number;
+                  colorStops: Array<{ offset: number; color: string }>;
+                  global?: boolean;
+              }
+            | {
+                  type: 'radial';
+                  x: number;
+                  y: number;
+                  r: number;
+                  colorStops: Array<{ offset: number; color: string }>;
+                  global?: boolean;
+              }
+            | {
+                  /**
+                   * HTMLImageElement, and HTMLCanvasElement are supported, while string path is not supported
+                   */
+                  image: HTMLImageElement | HTMLCanvasElement;
+                  repeat?: 'repeat' | 'repeat-x' | 'repeat-y' | 'no-repeat'; // 是否平铺, 可以是 'repeat-x', 'repeat-y', 'no-repeat'
+              };
         /**
          * **broken line chart**
          *
@@ -56,7 +60,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-line
          */
         interface SeriesLine {
-
             /**
              * @default
              * "line"
@@ -379,7 +382,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-line.label
              */
             label?: {
-
                 /**
                  * Whether to show label.
                  *
@@ -553,7 +555,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-line.label.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -838,12 +840,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-line.label.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-line.label.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -889,7 +889,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-line.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -1296,7 +1296,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-line.lineStyle
              */
             lineStyle?: {
-
                 /**
                  * Line color.
                  *
@@ -1399,7 +1398,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-line.areaStyle
              */
             areaStyle?: {
-
                 /**
                  * Fill color.
                  *
@@ -1499,12 +1497,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-line.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-line.emphasis.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -1677,7 +1673,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-line.emphasis.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -1963,12 +1959,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-line.emphasis.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-line.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -2014,7 +2008,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-line.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -2299,7 +2293,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-line.emphasis.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -2730,10 +2723,9 @@ declare namespace echarts {
              *
              * @see https://echarts.apache.org/en/option.html#series-line.data
              */
-            data?: (
-                (void | string | number | SeriesLine.DataObject)[]
-                | (void | string | number | SeriesLine.DataObject)[][]
-            );
+            data?:
+                | (void | string | number | SeriesLine.DataObject)[]
+                | (void | string | number | SeriesLine.DataObject)[][];
 
             /**
              * Mark point in a chart.
@@ -2742,7 +2734,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-line.markPoint
              */
             markPoint?: {
-
                 /**
                  * Symbol of .
                  *
@@ -2872,7 +2863,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-line.markPoint.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -3047,7 +3037,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-line.markPoint.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -3333,12 +3323,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-line.markPoint.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-line.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -3384,7 +3372,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-line.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -3668,7 +3656,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-line.markPoint.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -3843,7 +3830,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-line.markPoint.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -4133,12 +4120,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-line.markPoint.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-line.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -4184,7 +4169,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-line.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -4485,7 +4470,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-line.markPoint.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -4585,7 +4569,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-line.markPoint.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -4720,7 +4703,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-line.markPoint.data
                  */
                 data?: {
-
                     /**
                      * Mark point name.
                      *
@@ -4943,7 +4925,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-line.markPoint.data.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -5045,7 +5026,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-line.markPoint.data.itemStyle.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * color.
                              *
@@ -5152,7 +5132,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-line.markPoint.data.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -5281,7 +5260,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-line.markPoint.data.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -5571,12 +5550,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-line.markPoint.data.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-line.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -5622,7 +5599,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-line.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -5918,7 +5895,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-line.markPoint.data.label.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -6047,7 +6023,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-line.markPoint.data.label.emphasis.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -6339,12 +6315,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-line.markPoint.data.label.emphasis.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-line.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -6390,7 +6364,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-line.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -6802,7 +6776,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-line.markLine
              */
             markLine?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -6855,7 +6828,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-line.markLine.label
                  */
                 label?: {
-
                     /**
                      * Whether show label or not.
                      *
@@ -6929,7 +6901,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-line.markLine.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether show label or not.
                          *
@@ -7010,7 +6981,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-line.markLine.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -7116,7 +7086,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-line.markLine.lineStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Line color.
                          *
@@ -7260,7 +7229,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-line.markLine.data
                  */
                 data?: {
-
                     /**
                      * Data of the starting point.
                      *
@@ -7268,7 +7236,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-line.markLine.data.0
                      */
                     0?: {
-
                         /**
                          * Special label types, are used to label maximum value,
                          * minimum value and so on.
@@ -7497,7 +7464,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-line.markLine.data.0.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -7607,7 +7573,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-line.markLine.data.0.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -7725,7 +7690,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-line.markLine.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -7801,7 +7765,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-line.markLine.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -7883,7 +7846,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-line.markLine.data.1
                      */
                     1?: {
-
                         /**
                          * Special label types, are used to label maximum value,
                          * minimum value and so on.
@@ -8112,7 +8074,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-line.markLine.data.1.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -8222,7 +8183,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-line.markLine.data.1.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -8340,7 +8300,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-line.markLine.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -8416,7 +8375,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-line.markLine.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -8607,7 +8565,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-line.markArea
              */
             markArea?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -8625,7 +8582,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-line.markArea.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -8754,7 +8710,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-line.markArea.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -9040,12 +8996,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-line.markArea.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-line.markArea.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -9091,7 +9045,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-line.markArea.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -9375,7 +9329,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-line.markArea.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -9504,7 +9457,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-line.markArea.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -9794,12 +9747,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-line.markArea.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-line.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -9845,7 +9796,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-line.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -10146,7 +10097,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-line.markArea.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -10246,7 +10196,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-line.markArea.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -10393,7 +10342,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-line.markArea.data
                  */
                 data?: {
-
                     /**
                      * Specify the left-top point.
                      *
@@ -10401,7 +10349,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.0
                      */
                     0?: {
-
                         /**
                          * Specify this item is on min or max or average value.
                          *
@@ -10500,7 +10447,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.0.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -10605,7 +10551,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.0.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -10719,7 +10664,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -10848,7 +10792,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.0.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -11140,12 +11084,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.0.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -11191,7 +11133,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -11488,7 +11430,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -11619,7 +11560,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.0.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -11923,12 +11864,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.0.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -11975,7 +11914,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -12285,7 +12224,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.1
                      */
                     1?: {
-
                         /**
                          * Specify this item is on min or max or average value.
                          *
@@ -12384,7 +12322,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.1.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -12489,7 +12426,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.1.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -12603,7 +12539,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -12732,7 +12667,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.1.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -13024,12 +12959,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.1.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -13075,7 +13008,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -13372,7 +13305,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -13503,7 +13435,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.1.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -13807,12 +13739,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.1.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -13859,7 +13789,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-line.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -14431,7 +14361,6 @@ declare namespace echarts {
 
         namespace SeriesLine {
             interface DataObject {
-
                 /**
                  * The name of data item.
                  *
@@ -14554,7 +14483,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-line.data.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -14685,7 +14613,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-line.data.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -14971,12 +14899,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-line.data.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-line.data.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -15022,7 +14948,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-line.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -15310,7 +15236,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-line.data.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * Bar color..
                      *
@@ -15392,12 +15317,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-line.data.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-line.data.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * Bar color..
                          *
@@ -15480,7 +15403,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-line.data.emphasis.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -15609,7 +15531,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-line.data.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -15899,12 +15821,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-line.data.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-line.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -15950,7 +15870,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-line.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family

--- a/types/echarts/options/series/lines.d.ts
+++ b/types/echarts/options/series/lines.d.ts
@@ -19,7 +19,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-lines
          */
         interface SeriesLines {
-
             /**
              * @default
              * "lines"
@@ -139,7 +138,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-lines.effect
              */
             effect?: {
-
                 /**
                  * Whether to show special effect.
                  *
@@ -339,7 +337,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-lines.lineStyle
              */
             lineStyle?: {
-
                 /**
                  * Line color. Color is taken from
                  * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -466,7 +463,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-lines.label
              */
             label?: {
-
                 /**
                  * Whether to show label.
                  *
@@ -575,7 +571,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-lines.label.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -851,12 +847,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-lines.label.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-lines.label.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -899,7 +893,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-lines.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -1176,12 +1170,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-lines.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-lines.emphasis.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -1279,7 +1271,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-lines.emphasis.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -1389,7 +1380,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-lines.emphasis.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -1666,12 +1657,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-lines.emphasis.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-lines.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -1714,7 +1703,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-lines.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -2031,7 +2020,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-lines.markPoint
              */
             markPoint?: {
-
                 /**
                  * Symbol of .
                  *
@@ -2161,7 +2149,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -2336,7 +2323,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -2622,12 +2609,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -2673,7 +2658,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -2957,7 +2942,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -3132,7 +3116,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -3422,12 +3406,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -3473,7 +3455,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -3774,7 +3756,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -3874,7 +3855,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -3995,7 +3975,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.data
                  */
                 data?: {
-
                     /**
                      * Mark point name.
                      *
@@ -4132,7 +4111,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.data.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -4234,7 +4212,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.data.itemStyle.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * color.
                              *
@@ -4341,7 +4318,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.data.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -4470,7 +4446,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.data.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -4760,12 +4736,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.data.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -4811,7 +4785,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -5107,7 +5081,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.data.label.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -5236,7 +5209,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.data.label.emphasis.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -5528,12 +5501,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.data.label.emphasis.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -5579,7 +5550,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-lines.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -5991,7 +5962,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-lines.markLine
              */
             markLine?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -6044,7 +6014,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-lines.markLine.label
                  */
                 label?: {
-
                     /**
                      * Whether show label or not.
                      *
@@ -6118,7 +6087,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-lines.markLine.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether show label or not.
                          *
@@ -6199,7 +6167,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-lines.markLine.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -6305,7 +6272,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-lines.markLine.lineStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Line color.
                          *
@@ -6424,7 +6390,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-lines.markLine.data
                  */
                 data?: {
-
                     /**
                      * Data of the starting point.
                      *
@@ -6432,7 +6397,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-lines.markLine.data.0
                      */
                     0?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -6572,7 +6536,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-lines.markLine.data.0.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -6682,7 +6645,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-lines.markLine.data.0.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -6800,7 +6762,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-lines.markLine.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -6876,7 +6837,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-lines.markLine.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -6958,7 +6918,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-lines.markLine.data.1
                      */
                     1?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -7098,7 +7057,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-lines.markLine.data.1.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -7208,7 +7166,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-lines.markLine.data.1.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -7326,7 +7283,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-lines.markLine.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -7402,7 +7358,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-lines.markLine.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -7593,7 +7548,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-lines.markArea
              */
             markArea?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -7611,7 +7565,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-lines.markArea.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -7740,7 +7693,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-lines.markArea.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -8026,12 +7979,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-lines.markArea.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-lines.markArea.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -8077,7 +8028,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-lines.markArea.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -8361,7 +8312,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-lines.markArea.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -8490,7 +8440,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-lines.markArea.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -8780,12 +8730,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-lines.markArea.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-lines.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -8831,7 +8779,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-lines.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -9132,7 +9080,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-lines.markArea.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -9232,7 +9179,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-lines.markArea.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -9356,7 +9302,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data
                  */
                 data?: {
-
                     /**
                      * Specify the left-top point.
                      *
@@ -9364,7 +9309,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.0
                      */
                     0?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -9408,7 +9352,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.0.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -9513,7 +9456,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.0.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -9627,7 +9569,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -9756,7 +9697,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.0.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -10048,12 +9989,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.0.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -10099,7 +10038,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -10396,7 +10335,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -10527,7 +10465,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.0.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -10831,12 +10769,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.0.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -10883,7 +10819,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -11193,7 +11129,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.1
                      */
                     1?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -11237,7 +11172,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.1.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -11342,7 +11276,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.1.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -11456,7 +11389,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -11585,7 +11517,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.1.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -11877,12 +11809,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.1.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -11928,7 +11858,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -12225,7 +12155,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -12356,7 +12285,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.1.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -12660,12 +12589,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.1.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -12712,7 +12639,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-lines.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -13276,7 +13203,6 @@ declare namespace echarts {
 
         namespace SeriesLines {
             interface DataObject {
-
                 /**
                  * the name of data.
                  *
@@ -13305,7 +13231,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-lines.data.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -13412,7 +13337,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-lines.data.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -13522,7 +13446,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-lines.data.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -13799,12 +13723,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-lines.data.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-lines.data.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -13847,7 +13769,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-lines.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -14123,12 +14045,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-lines.data.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-lines.data.emphasis.lineStyle
                      */
                     lineStyle?: {
-
                         /**
                          * Line color.
                          *
@@ -14236,7 +14156,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-lines.data.emphasis.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -14348,7 +14267,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-lines.data.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -14629,12 +14548,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-lines.data.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-lines.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -14677,7 +14594,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-lines.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family

--- a/types/echarts/options/series/map.d.ts
+++ b/types/echarts/options/series/map.d.ts
@@ -23,7 +23,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-map
          */
         interface SeriesMap {
-
             /**
              * @default
              * "map"
@@ -165,7 +164,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-map.scaleLimit
              */
             scaleLimit?: {
-
                 /**
                  * Minimum scaling
                  *
@@ -221,7 +219,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-map.label
              */
             label?: {
-
                 /**
                  * Whether to show label.
                  *
@@ -393,7 +390,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-map.label.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -678,12 +675,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-map.label.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-map.label.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -729,7 +724,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-map.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -1011,7 +1006,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-map.label.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -1184,7 +1178,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-map.label.emphasis.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -1470,12 +1464,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-map.label.emphasis.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-map.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -1521,7 +1513,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-map.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -1812,7 +1804,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-map.itemStyle
              */
             itemStyle?: {
-
                 /**
                  * Area filling color.
                  *
@@ -1822,7 +1813,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-map.itemStyle.areaColor
                  */
                 areaColor?: {
-
                     /**
                      * color.
                      *
@@ -1926,7 +1916,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-map.itemStyle.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * Area filling color.
                      *
@@ -2303,7 +2292,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-map.markPoint
              */
             markPoint?: {
-
                 /**
                  * Symbol of .
                  *
@@ -2433,7 +2421,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-map.markPoint.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -2608,7 +2595,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-map.markPoint.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -2894,12 +2881,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-map.markPoint.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-map.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -2945,7 +2930,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-map.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -3229,7 +3214,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-map.markPoint.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -3404,7 +3388,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-map.markPoint.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -3694,12 +3678,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-map.markPoint.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-map.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -3745,7 +3727,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-map.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -4046,7 +4028,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-map.markPoint.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -4146,7 +4127,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-map.markPoint.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -4272,7 +4252,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-map.markPoint.data
                  */
                 data?: {
-
                     /**
                      * Mark point name.
                      *
@@ -4480,7 +4459,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-map.markPoint.data.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -4582,7 +4560,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-map.markPoint.data.itemStyle.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * color.
                              *
@@ -4689,7 +4666,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-map.markPoint.data.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -4818,7 +4794,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-map.markPoint.data.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -5108,12 +5084,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-map.markPoint.data.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-map.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -5159,7 +5133,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-map.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -5455,7 +5429,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-map.markPoint.data.label.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -5584,7 +5557,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-map.markPoint.data.label.emphasis.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -5876,12 +5849,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-map.markPoint.data.label.emphasis.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-map.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -5927,7 +5898,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-map.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -6339,7 +6310,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-map.markLine
              */
             markLine?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -6392,7 +6362,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-map.markLine.label
                  */
                 label?: {
-
                     /**
                      * Whether show label or not.
                      *
@@ -6466,7 +6435,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-map.markLine.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether show label or not.
                          *
@@ -6547,7 +6515,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-map.markLine.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -6653,7 +6620,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-map.markLine.lineStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Line color.
                          *
@@ -6777,7 +6743,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-map.markLine.data
                  */
                 data?: {
-
                     /**
                      * Data of the starting point.
                      *
@@ -6785,7 +6750,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-map.markLine.data.0
                      */
                     0?: {
-
                         /**
                          * Works only when
                          * [type](https://echarts.apache.org/en/option.html#series-.markLine.data.type)
@@ -6999,7 +6963,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-map.markLine.data.0.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -7109,7 +7072,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-map.markLine.data.0.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -7227,7 +7189,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-map.markLine.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -7303,7 +7264,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-map.markLine.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -7385,7 +7345,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-map.markLine.data.1
                      */
                     1?: {
-
                         /**
                          * Works only when
                          * [type](https://echarts.apache.org/en/option.html#series-.markLine.data.type)
@@ -7599,7 +7558,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-map.markLine.data.1.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -7709,7 +7667,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-map.markLine.data.1.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -7827,7 +7784,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-map.markLine.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -7903,7 +7859,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-map.markLine.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -8094,7 +8049,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-map.markArea
              */
             markArea?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -8112,7 +8066,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-map.markArea.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -8241,7 +8194,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-map.markArea.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -8527,12 +8480,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-map.markArea.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-map.markArea.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -8578,7 +8529,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-map.markArea.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -8862,7 +8813,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-map.markArea.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -8991,7 +8941,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-map.markArea.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -9281,12 +9231,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-map.markArea.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-map.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -9332,7 +9280,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-map.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -9633,7 +9581,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-map.markArea.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -9733,7 +9680,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-map.markArea.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -9865,7 +9811,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-map.markArea.data
                  */
                 data?: {
-
                     /**
                      * Specify the left-top point.
                      *
@@ -9873,7 +9818,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.0
                      */
                     0?: {
-
                         /**
                          * Specify the dimension on which min, max, average
                          * are calculated, available when
@@ -9958,7 +9902,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.0.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -10063,7 +10006,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.0.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -10177,7 +10119,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -10306,7 +10247,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.0.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -10598,12 +10539,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.0.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -10649,7 +10588,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -10946,7 +10885,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -11077,7 +11015,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.0.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -11381,12 +11319,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.0.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -11433,7 +11369,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -11743,7 +11679,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.1
                      */
                     1?: {
-
                         /**
                          * Specify the dimension on which min, max, average
                          * are calculated, available when
@@ -11828,7 +11763,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.1.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -11933,7 +11867,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.1.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -12047,7 +11980,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -12176,7 +12108,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.1.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -12468,12 +12400,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.1.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -12519,7 +12449,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -12816,7 +12746,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -12947,7 +12876,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.1.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -13251,12 +13180,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.1.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -13303,7 +13230,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-map.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -13735,7 +13662,6 @@ declare namespace echarts {
 
         namespace SeriesMap {
             interface DataObject {
-
                 /**
                  * The name of the map area where the data belongs to, such
                  * as `'China'` or `'United Kingdom'` .
@@ -13768,7 +13694,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-map.data.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * Color of the area.
                      *
@@ -13776,7 +13701,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-map.data.itemStyle.areaColor
                      */
                     areaColor?: {
-
                         /**
                          * color.
                          *
@@ -13888,7 +13812,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-map.data.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -14063,7 +13986,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-map.data.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -14311,12 +14234,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-map.data.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-map.data.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -14362,7 +14283,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-map.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -14647,12 +14568,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-map.data.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-map.data.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-map.data.emphasis.itemStyle.areaColor
                          */
@@ -14760,7 +14679,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-map.data.emphasis.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -14935,7 +14853,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-map.data.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -15187,12 +15105,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-map.data.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-map.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -15238,7 +15154,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-map.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family

--- a/types/echarts/options/series/parallel.d.ts
+++ b/types/echarts/options/series/parallel.d.ts
@@ -114,7 +114,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-parallel
          */
         interface SeriesParallel {
-
             /**
              * @default
              * "parallel"
@@ -178,7 +177,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-parallel.lineStyle
              */
             lineStyle?: {
-
                 /**
                  * Line color.
                  *
@@ -280,12 +278,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-parallel.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-parallel.emphasis.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -487,10 +483,7 @@ declare namespace echarts {
              *
              * @see https://echarts.apache.org/en/option.html#series-parallel.data
              */
-            data?: (
-                (number | string | SeriesParallel.DataObject)[]
-                | (number | string | SeriesParallel.DataObject)[][]
-            );
+            data?: (number | string | SeriesParallel.DataObject)[] | (number | string | SeriesParallel.DataObject)[][];
 
             /**
              * `zlevel` value of all graghical elements in parallel.
@@ -653,7 +646,6 @@ declare namespace echarts {
 
         namespace SeriesParallel {
             interface DataObject {
-
                 /**
                  * The name of a data item.
                  *
@@ -778,12 +770,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-parallel.data.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-parallel.data.emphasis.lineStyle
                      */
                     lineStyle?: {
-
                         /**
                          * Line color.
                          *

--- a/types/echarts/options/series/pictorial-bar.d.ts
+++ b/types/echarts/options/series/pictorial-bar.d.ts
@@ -82,7 +82,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-pictorialBar
          */
         interface SeriesPictorialBar {
-
             /**
              * @default
              * "pictorialBar"
@@ -186,7 +185,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.label
              */
             label?: {
-
                 /**
                  * Whether to show label.
                  *
@@ -360,7 +358,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.label.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -645,12 +643,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.label.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.label.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -696,7 +692,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -983,7 +979,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.itemStyle
              */
             itemStyle?: {
-
                 /**
                  * color. Color is taken from
                  * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -1086,12 +1081,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.emphasis.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -1264,7 +1257,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.emphasis.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -1550,12 +1543,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.emphasis.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -1601,7 +1592,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -1886,7 +1877,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.emphasis.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -2624,7 +2614,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.hoverAnimation
              */
             hoverAnimation?: {
-
                 /**
                  * Whether to enable animation.
                  *
@@ -2952,10 +2941,9 @@ declare namespace echarts {
              *
              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.data
              */
-            data?: (
-                (void | number | string | SeriesPictorialBar.DataObject)[]
-                | (void | number | string | SeriesPictorialBar.DataObject)[][]
-            );
+            data?:
+                | (void | number | string | SeriesPictorialBar.DataObject)[]
+                | (void | number | string | SeriesPictorialBar.DataObject)[][];
 
             /**
              * Mark point in a chart.
@@ -2964,7 +2952,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint
              */
             markPoint?: {
-
                 /**
                  * Symbol of .
                  *
@@ -3094,7 +3081,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -3269,7 +3255,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -3555,12 +3541,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -3606,7 +3590,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -3890,7 +3874,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -4065,7 +4048,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -4355,12 +4338,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -4406,7 +4387,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -4707,7 +4688,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -4807,7 +4787,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -4942,7 +4921,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.data
                  */
                 data?: {
-
                     /**
                      * Mark point name.
                      *
@@ -5165,7 +5143,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.data.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -5267,7 +5244,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.data.itemStyle.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * color.
                              *
@@ -5374,7 +5350,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.data.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -5503,7 +5478,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.data.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -5793,12 +5768,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.data.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -5844,7 +5817,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -6140,7 +6113,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.data.label.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -6269,7 +6241,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.data.label.emphasis.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -6561,12 +6533,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.data.label.emphasis.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -6612,7 +6582,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -7024,7 +6994,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markLine
              */
             markLine?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -7077,7 +7046,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markLine.label
                  */
                 label?: {
-
                     /**
                      * Whether show label or not.
                      *
@@ -7151,7 +7119,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markLine.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether show label or not.
                          *
@@ -7232,7 +7199,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markLine.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -7338,7 +7304,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markLine.lineStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Line color.
                          *
@@ -7482,7 +7447,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markLine.data
                  */
                 data?: {
-
                     /**
                      * Data of the starting point.
                      *
@@ -7490,7 +7454,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markLine.data.0
                      */
                     0?: {
-
                         /**
                          * Special label types, are used to label maximum value,
                          * minimum value and so on.
@@ -7719,7 +7682,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markLine.data.0.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -7829,7 +7791,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markLine.data.0.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -7947,7 +7908,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markLine.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -8023,7 +7983,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markLine.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -8105,7 +8064,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markLine.data.1
                      */
                     1?: {
-
                         /**
                          * Special label types, are used to label maximum value,
                          * minimum value and so on.
@@ -8334,7 +8292,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markLine.data.1.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -8444,7 +8401,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markLine.data.1.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -8562,7 +8518,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markLine.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -8638,7 +8593,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markLine.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -8829,7 +8783,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea
              */
             markArea?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -8847,7 +8800,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -8976,7 +8928,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -9262,12 +9214,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -9313,7 +9263,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -9597,7 +9547,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -9726,7 +9675,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -10016,12 +9965,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -10067,7 +10014,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -10368,7 +10315,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -10468,7 +10414,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -10615,7 +10560,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data
                  */
                 data?: {
-
                     /**
                      * Specify the left-top point.
                      *
@@ -10623,7 +10567,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.0
                      */
                     0?: {
-
                         /**
                          * Specify this item is on min or max or average value.
                          *
@@ -10722,7 +10665,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.0.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -10827,7 +10769,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.0.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -10941,7 +10882,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -11070,7 +11010,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.0.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -11362,12 +11302,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.0.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -11413,7 +11351,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -11710,7 +11648,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -11841,7 +11778,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.0.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -12145,12 +12082,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.0.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -12197,7 +12132,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -12507,7 +12442,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.1
                      */
                     1?: {
-
                         /**
                          * Specify this item is on min or max or average value.
                          *
@@ -12606,7 +12540,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.1.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -12711,7 +12644,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.1.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -12825,7 +12757,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -12954,7 +12885,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.1.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -13246,12 +13177,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.1.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -13297,7 +13226,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -13594,7 +13523,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -13725,7 +13653,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.1.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -14029,12 +13957,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.1.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -14081,7 +14007,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -14607,7 +14533,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.animationEasingUpdate
              */
             animationEasingUpdate?: {
-
                 /**
                  * Specify the delay time before animation start.
                  * Callback function can be used, where different delay time
@@ -14656,7 +14581,6 @@ declare namespace echarts {
 
         namespace SeriesPictorialBar {
             interface DataObject {
-
                 /**
                  * The name of data item.
                  *
@@ -15364,7 +15288,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.data.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -15495,7 +15418,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.data.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -15781,12 +15704,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.data.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.data.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -15832,7 +15753,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -16117,7 +16038,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.data.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -16218,12 +16138,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.data.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.data.emphasis.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -16352,7 +16270,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.data.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -16642,12 +16560,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pictorialBar.data.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-pictorialBar.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -16693,7 +16609,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-pictorialBar.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -16990,7 +16906,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pictorialBar.data.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *

--- a/types/echarts/options/series/pie.d.ts
+++ b/types/echarts/options/series/pie.d.ts
@@ -27,7 +27,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-pie
          */
         interface SeriesPie {
-
             /**
              * @default
              * "pie"
@@ -335,7 +334,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-pie.label.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -611,12 +610,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pie.label.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-pie.label.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -659,7 +656,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-pie.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -984,7 +981,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pie.labelLine.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -1085,7 +1081,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pie.labelLine.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * Whether to show the visual guide line in emphasis status.
                      *
@@ -1098,7 +1093,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.labelLine.emphasis.lineStyle
                      */
                     lineStyle?: {
-
                         /**
                          * Line color.
                          *
@@ -1321,12 +1315,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-pie.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-pie.emphasis.label
                  */
                 label?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-pie.emphasis.label.show
                      */
@@ -1419,7 +1411,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-pie.emphasis.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -1696,12 +1688,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.emphasis.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-pie.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -1744,7 +1734,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-pie.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -2020,7 +2010,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pie.emphasis.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -2264,11 +2253,7 @@ declare namespace echarts {
              *
              * @see https://echarts.apache.org/en/option.html#series-pie.data
              */
-            data?: (
-                number[]
-                | number[][]
-                | SeriesPie.DataObject[]
-            );
+            data?: number[] | number[][] | SeriesPie.DataObject[];
 
             /**
              * Mark point in a chart.
@@ -2277,7 +2262,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-pie.markPoint
              */
             markPoint?: {
-
                 /**
                  * Symbol of .
                  *
@@ -2407,7 +2391,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -2582,7 +2565,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -2868,12 +2851,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -2919,7 +2900,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -3203,7 +3184,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -3378,7 +3358,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -3668,12 +3648,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -3719,7 +3697,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -4020,7 +3998,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -4120,7 +4097,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -4241,7 +4217,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.data
                  */
                 data?: {
-
                     /**
                      * Mark point name.
                      *
@@ -4378,7 +4353,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.data.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -4480,7 +4454,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.data.itemStyle.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * color.
                              *
@@ -4587,7 +4560,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.data.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -4716,7 +4688,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.data.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -5006,12 +4978,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.data.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -5057,7 +5027,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -5353,7 +5323,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.data.label.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -5482,7 +5451,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.data.label.emphasis.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -5774,12 +5743,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.data.label.emphasis.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -5825,7 +5792,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-pie.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -6237,7 +6204,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-pie.markLine
              */
             markLine?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -6290,7 +6256,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pie.markLine.label
                  */
                 label?: {
-
                     /**
                      * Whether show label or not.
                      *
@@ -6364,7 +6329,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.markLine.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether show label or not.
                          *
@@ -6445,7 +6409,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pie.markLine.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -6551,7 +6514,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.markLine.lineStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Line color.
                          *
@@ -6670,7 +6632,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pie.markLine.data
                  */
                 data?: {
-
                     /**
                      * Data of the starting point.
                      *
@@ -6678,7 +6639,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.markLine.data.0
                      */
                     0?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -6818,7 +6778,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pie.markLine.data.0.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -6928,7 +6887,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pie.markLine.data.0.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -7046,7 +7004,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pie.markLine.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -7122,7 +7079,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pie.markLine.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -7204,7 +7160,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.markLine.data.1
                      */
                     1?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -7344,7 +7299,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pie.markLine.data.1.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -7454,7 +7408,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pie.markLine.data.1.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -7572,7 +7525,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pie.markLine.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -7648,7 +7600,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pie.markLine.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -7839,7 +7790,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-pie.markArea
              */
             markArea?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -7857,7 +7807,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pie.markArea.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -7986,7 +7935,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-pie.markArea.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -8272,12 +8221,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.markArea.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-pie.markArea.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -8323,7 +8270,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-pie.markArea.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -8607,7 +8554,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.markArea.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -8736,7 +8682,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-pie.markArea.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -9026,12 +8972,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pie.markArea.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-pie.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -9077,7 +9021,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-pie.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -9378,7 +9322,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pie.markArea.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -9478,7 +9421,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.markArea.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -9602,7 +9544,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data
                  */
                 data?: {
-
                     /**
                      * Specify the left-top point.
                      *
@@ -9610,7 +9551,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.0
                      */
                     0?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -9654,7 +9594,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.0.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -9759,7 +9698,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.0.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -9873,7 +9811,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -10002,7 +9939,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.0.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -10294,12 +10231,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.0.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -10345,7 +10280,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -10642,7 +10577,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -10773,7 +10707,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.0.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -11077,12 +11011,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.0.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -11129,7 +11061,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -11439,7 +11371,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.1
                      */
                     1?: {
-
                         /**
                          * Name of the marker, which will display as a label.
                          *
@@ -11483,7 +11414,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.1.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -11588,7 +11518,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.1.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -11702,7 +11631,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -11831,7 +11759,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.1.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -12123,12 +12051,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.1.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -12174,7 +12100,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -12471,7 +12397,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -12602,7 +12527,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.1.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -12906,12 +12831,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.1.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -12958,7 +12881,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-pie.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -13510,7 +13433,6 @@ declare namespace echarts {
 
         namespace SeriesPie {
             interface DataObject {
-
                 /**
                  * The name of data item.
                  *
@@ -13542,7 +13464,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pie.data.label
                  */
                 label?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-pie.data.label.show
                      */
@@ -13620,7 +13541,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-pie.data.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -13897,12 +13818,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.data.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-pie.data.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -13945,7 +13864,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-pie.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -14224,7 +14143,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pie.data.labelLine
                  */
                 labelLine?: {
-
                     /**
                      * Whether to show the visual guide ine.
                      *
@@ -14263,7 +14181,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.data.labelLine.lineStyle
                      */
                     lineStyle?: {
-
                         /**
                          * Line color.
                          *
@@ -14365,7 +14282,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.data.labelLine.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show the visual guide line in emphasis
                          * status.
@@ -14379,7 +14295,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pie.data.labelLine.emphasis.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -14486,7 +14401,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pie.data.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -14587,12 +14501,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-pie.data.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-pie.data.emphasis.label
                      */
                     label?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-pie.data.emphasis.label.show
                          */
@@ -14640,7 +14552,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-pie.data.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -14921,12 +14833,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-pie.data.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-pie.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -14969,7 +14879,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-pie.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -15257,7 +15167,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-pie.data.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *

--- a/types/echarts/options/series/radar.d.ts
+++ b/types/echarts/options/series/radar.d.ts
@@ -16,7 +16,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-radar
          */
         interface SeriesRadar {
-
             /**
              * @default
              * "radar"
@@ -178,7 +177,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-radar.label
              */
             label?: {
-
                 /**
                  * Whether to show label.
                  *
@@ -352,7 +350,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-radar.label.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -637,12 +635,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-radar.label.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-radar.label.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -688,7 +684,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-radar.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -974,7 +970,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-radar.itemStyle
              */
             itemStyle?: {
-
                 /**
                  * color. Color is taken from
                  * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -1090,7 +1085,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-radar.lineStyle
              */
             lineStyle?: {
-
                 /**
                  * Line color.
                  *
@@ -1191,7 +1185,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-radar.areaStyle
              */
             areaStyle?: {
-
                 /**
                  * Fill color.
                  *
@@ -1265,12 +1258,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-radar.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-radar.emphasis.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -1371,7 +1362,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-radar.emphasis.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -1544,7 +1534,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-radar.emphasis.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -1830,12 +1820,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-radar.emphasis.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-radar.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -1881,7 +1869,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-radar.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -2166,7 +2154,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-radar.emphasis.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -2264,7 +2251,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-radar.emphasis.areaStyle
                  */
                 areaStyle?: {
-
                     /**
                      * Fill color.
                      *
@@ -2512,7 +2498,6 @@ declare namespace echarts {
 
         namespace SeriesRadar {
             interface DataObject {
-
                 /**
                  * Data item name
                  *
@@ -2635,7 +2620,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-radar.data.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -2766,7 +2750,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-radar.data.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -3052,12 +3036,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-radar.data.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-radar.data.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -3103,7 +3085,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-radar.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -3391,7 +3373,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-radar.data.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * Bar color..
                      *
@@ -3476,7 +3457,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-radar.data.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -3577,7 +3557,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-radar.data.areaStyle
                  */
                 areaStyle?: {
-
                     /**
                      * Fill color.
                      *
@@ -3651,12 +3630,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-radar.data.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-radar.data.emphasis.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -3787,7 +3764,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-radar.data.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -4077,12 +4054,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-radar.data.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-radar.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -4128,7 +4103,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-radar.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -4425,7 +4400,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-radar.data.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * Bar color..
                          *
@@ -4508,7 +4482,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-radar.data.emphasis.lineStyle
                      */
                     lineStyle?: {
-
                         /**
                          * Line color.
                          *
@@ -4607,7 +4580,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-radar.data.emphasis.areaStyle
                      */
                     areaStyle?: {
-
                         /**
                          * Fill color.
                          *

--- a/types/echarts/options/series/sankey.d.ts
+++ b/types/echarts/options/series/sankey.d.ts
@@ -33,7 +33,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-sankey
          */
         interface SeriesSankey {
-
             /**
              * @default
              * "sankey"
@@ -279,7 +278,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-sankey.label
              */
             label?: {
-
                 /**
                  * Whether to show label.
                  *
@@ -456,7 +454,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-sankey.label.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -741,12 +739,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sankey.label.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-sankey.label.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -792,7 +788,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-sankey.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -1078,7 +1074,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-sankey.itemStyle
              */
             itemStyle?: {
-
                 /**
                  * color. Color is taken from
                  * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -1190,7 +1185,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-sankey.lineStyle
              */
             lineStyle?: {
-
                 /**
                  * The color of the edge in sankey graphs.
                  *
@@ -1264,12 +1258,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-sankey.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-sankey.emphasis.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -1443,7 +1435,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-sankey.emphasis.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -1729,12 +1721,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sankey.emphasis.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-sankey.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -1780,7 +1770,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-sankey.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -2065,7 +2055,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sankey.emphasis.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -2166,7 +2155,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sankey.emphasis.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * The color of the edge in sankey graphs.
                      *
@@ -2272,10 +2260,7 @@ declare namespace echarts {
              *
              * @see https://echarts.apache.org/en/option.html#series-sankey.data
              */
-            data?: (
-                (number | SeriesSankey.DataObject)[]
-                | (number | SeriesSankey.DataObject)[][]
-            );
+            data?: (number | SeriesSankey.DataObject)[] | (number | SeriesSankey.DataObject)[][];
 
             /**
              * Equals to
@@ -2433,7 +2418,6 @@ declare namespace echarts {
 
         namespace SeriesSankey {
             interface DataObject {
-
                 /**
                  * The name of data item.
                  *
@@ -2457,7 +2441,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sankey.data.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color. Color is taken from
                      * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -2563,7 +2546,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sankey.data.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -2692,7 +2674,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-sankey.data.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -2978,12 +2960,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sankey.data.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-sankey.data.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -3029,7 +3009,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-sankey.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -3314,12 +3294,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sankey.data.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-sankey.data.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -3422,7 +3400,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sankey.data.emphasis.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -3551,7 +3528,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-sankey.data.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -3841,12 +3818,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-sankey.data.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-sankey.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -3892,7 +3867,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-sankey.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -4196,7 +4171,6 @@ declare namespace echarts {
             }
 
             interface LinkObject {
-
                 /**
                  * The
                  * [name of source node](https://echarts.apache.org/en/option.html#series-graph.data.name)
@@ -4232,7 +4206,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sankey.links.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * The color of the edge in sankey graphs.
                      *
@@ -4306,12 +4279,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sankey.links.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-sankey.links.emphasis.lineStyle
                      */
                     lineStyle?: {
-
                         /**
                          * The color of the edge in sankey graphs.
                          *

--- a/types/echarts/options/series/scatter.d.ts
+++ b/types/echarts/options/series/scatter.d.ts
@@ -26,7 +26,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-scatter
          */
         interface SeriesScatter {
-
             /**
              * @default
              * "scatter"
@@ -318,7 +317,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-scatter.label
              */
             label?: {
-
                 /**
                  * Whether to show label.
                  *
@@ -492,7 +490,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-scatter.label.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -777,12 +775,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-scatter.label.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-scatter.label.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -828,7 +824,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-scatter.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -1115,7 +1111,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-scatter.itemStyle
              */
             itemStyle?: {
-
                 /**
                  * color. Color is taken from
                  * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -1228,12 +1223,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-scatter.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-scatter.emphasis.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -1406,7 +1399,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-scatter.emphasis.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -1692,12 +1685,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-scatter.emphasis.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-scatter.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -1743,7 +1734,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-scatter.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -2028,7 +2019,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-scatter.emphasis.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -2410,10 +2400,9 @@ declare namespace echarts {
              *
              * @see https://echarts.apache.org/en/option.html#series-scatter.data
              */
-            data?: (
-                (void | number | string | SeriesScatter.DataObject)[]
-                | (void | number | string | SeriesScatter.DataObject)[][]
-            );
+            data?:
+                | (void | number | string | SeriesScatter.DataObject)[]
+                | (void | number | string | SeriesScatter.DataObject)[][];
 
             /**
              * Mark point in a chart.
@@ -2422,7 +2411,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint
              */
             markPoint?: {
-
                 /**
                  * Symbol of .
                  *
@@ -2552,7 +2540,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -2727,7 +2714,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -3013,12 +3000,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -3064,7 +3049,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -3348,7 +3333,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -3523,7 +3507,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -3813,12 +3797,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -3864,7 +3846,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -4165,7 +4147,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -4265,7 +4246,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -4400,7 +4380,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.data
                  */
                 data?: {
-
                     /**
                      * Mark point name.
                      *
@@ -4623,7 +4602,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.data.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -4725,7 +4703,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.data.itemStyle.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * color.
                              *
@@ -4832,7 +4809,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.data.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -4961,7 +4937,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.data.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -5251,12 +5227,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.data.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -5302,7 +5276,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -5598,7 +5572,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.data.label.emphasis
                          */
                         emphasis?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -5727,7 +5700,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.data.label.emphasis.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -6019,12 +5992,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.data.label.emphasis.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -6070,7 +6041,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-scatter.markPoint.data.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -6482,7 +6453,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-scatter.markLine
              */
             markLine?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -6535,7 +6505,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-scatter.markLine.label
                  */
                 label?: {
-
                     /**
                      * Whether show label or not.
                      *
@@ -6609,7 +6578,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-scatter.markLine.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether show label or not.
                          *
@@ -6690,7 +6658,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-scatter.markLine.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * Line color.
                      *
@@ -6796,7 +6763,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-scatter.markLine.lineStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Line color.
                          *
@@ -6940,7 +6906,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-scatter.markLine.data
                  */
                 data?: {
-
                     /**
                      * Data of the starting point.
                      *
@@ -6948,7 +6913,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-scatter.markLine.data.0
                      */
                     0?: {
-
                         /**
                          * Special label types, are used to label maximum value,
                          * minimum value and so on.
@@ -7177,7 +7141,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-scatter.markLine.data.0.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -7287,7 +7250,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-scatter.markLine.data.0.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -7405,7 +7367,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-scatter.markLine.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -7481,7 +7442,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-scatter.markLine.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -7563,7 +7523,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-scatter.markLine.data.1
                      */
                     1?: {
-
                         /**
                          * Special label types, are used to label maximum value,
                          * minimum value and so on.
@@ -7792,7 +7751,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-scatter.markLine.data.1.lineStyle
                          */
                         lineStyle?: {
-
                             /**
                              * Line color.
                              *
@@ -7902,7 +7860,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-scatter.markLine.data.1.lineStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Line color.
                                  *
@@ -8020,7 +7977,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-scatter.markLine.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether show label or not.
                              *
@@ -8096,7 +8052,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-scatter.markLine.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether show label or not.
                                  *
@@ -8287,7 +8242,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-scatter.markArea
              */
             markArea?: {
-
                 /**
                  * Whether to ignore mouse events.
                  * Default value is false, for triggering and responding to
@@ -8305,7 +8259,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -8434,7 +8387,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -8720,12 +8673,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -8771,7 +8722,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -9055,7 +9006,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.label.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -9184,7 +9134,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.label.emphasis.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -9474,12 +9424,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.label.emphasis.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -9525,7 +9473,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -9826,7 +9774,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -9926,7 +9873,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.itemStyle.emphasis
                      */
                     emphasis?: {
-
                         /**
                          * color.
                          *
@@ -10073,7 +10019,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data
                  */
                 data?: {
-
                     /**
                      * Specify the left-top point.
                      *
@@ -10081,7 +10026,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.0
                      */
                     0?: {
-
                         /**
                          * Specify this item is on min or max or average value.
                          *
@@ -10180,7 +10124,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.0.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -10285,7 +10228,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.0.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -10399,7 +10341,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.0.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -10528,7 +10469,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.0.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -10820,12 +10761,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.0.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -10871,7 +10810,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.0.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -11168,7 +11107,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.0.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -11299,7 +11237,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.0.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -11603,12 +11541,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.0.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -11655,7 +11591,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.0.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -11965,7 +11901,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.1
                      */
                     1?: {
-
                         /**
                          * Specify this item is on min or max or average value.
                          *
@@ -12064,7 +11999,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.1.itemStyle
                          */
                         itemStyle?: {
-
                             /**
                              * color.
                              *
@@ -12169,7 +12103,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.1.itemStyle.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * color.
                                  *
@@ -12283,7 +12216,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.1.label
                          */
                         label?: {
-
                             /**
                              * Whether to show label.
                              *
@@ -12412,7 +12344,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.1.label.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -12704,12 +12636,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.1.label.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -12755,7 +12685,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.1.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -13052,7 +12982,6 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.1.label.emphasis
                              */
                             emphasis?: {
-
                                 /**
                                  * Whether to show label.
                                  *
@@ -13183,7 +13112,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.1.label.emphasis.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -13487,12 +13416,10 @@ declare namespace echarts {
                                  * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.1.label.emphasis.rich
                                  */
                                 rich?: {
-
                                     /**
                                      * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E
                                      */
                                     [userStyle: string]: {
-
                                         /**
                                          * text color.
                                          *
@@ -13539,7 +13466,7 @@ declare namespace echarts {
                                          * "normal"
                                          * @see https://echarts.apache.org/en/option.html#series-scatter.markArea.data.1.label.emphasis.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                          */
-                                        fontWeight?: string;
+                                        fontWeight?: string | number;
 
                                         /**
                                          * font family
@@ -14111,7 +14038,6 @@ declare namespace echarts {
 
         namespace SeriesScatter {
             interface DataObject {
-
                 /**
                  * the name of data item.
                  *
@@ -14227,7 +14153,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-scatter.data.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -14358,7 +14283,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-scatter.data.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -14644,12 +14569,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-scatter.data.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-scatter.data.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -14695,7 +14618,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-scatter.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -14983,7 +14906,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-scatter.data.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -15084,12 +15006,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-scatter.data.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-scatter.data.emphasis.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -15218,7 +15138,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-scatter.data.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -15508,12 +15428,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-scatter.data.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-scatter.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -15559,7 +15477,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-scatter.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -15856,7 +15774,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-scatter.data.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *

--- a/types/echarts/options/series/sunburst.d.ts
+++ b/types/echarts/options/series/sunburst.d.ts
@@ -29,7 +29,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-sunburst
          */
         interface SeriesSunburst {
-
             /**
              * @default
              * "sunburst"
@@ -166,7 +165,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-sunburst.label
              */
             label?: {
-
                 /**
                  * If it is `number` type, then is stands for rotation, from
                  * -90 degrees to 90 degrees, and positive values stand for
@@ -375,7 +373,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-sunburst.label.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -641,12 +639,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sunburst.label.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.label.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -692,7 +688,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-sunburst.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -1007,7 +1003,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-sunburst.itemStyle
              */
             itemStyle?: {
-
                 /**
                  * color. Color is taken from
                  * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -1193,7 +1188,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-sunburst.emphasis
              */
             emphasis?: {
-
                 /**
                  * `label` sets the text style for every sectors.
                  *
@@ -1216,7 +1210,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sunburst.emphasis.label
                  */
                 label?: {
-
                     /**
                      * If it is `number` type, then is stands for rotation,
                      * from -90 degrees to 90 degrees, and positive values stand
@@ -1428,7 +1421,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.emphasis.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -1695,12 +1688,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.emphasis.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-sunburst.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -1746,7 +1737,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-sunburst.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -2063,7 +2054,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sunburst.emphasis.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color. Color is taken from
                      * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -2176,7 +2166,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-sunburst.highlight
              */
             highlight?: {
-
                 /**
                  * `label` sets the text style for every sectors.
                  *
@@ -2199,7 +2188,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sunburst.highlight.label
                  */
                 label?: {
-
                     /**
                      * If it is `number` type, then is stands for rotation,
                      * from -90 degrees to 90 degrees, and positive values stand
@@ -2411,7 +2399,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.highlight.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -2678,12 +2666,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.highlight.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-sunburst.highlight.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -2729,7 +2715,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-sunburst.highlight.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -3046,7 +3032,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sunburst.highlight.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color. Color is taken from
                      * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -3159,7 +3144,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-sunburst.downplay
              */
             downplay?: {
-
                 /**
                  * `label` sets the text style for every sectors.
                  *
@@ -3182,7 +3166,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sunburst.downplay.label
                  */
                 label?: {
-
                     /**
                      * If it is `number` type, then is stands for rotation,
                      * from -90 degrees to 90 degrees, and positive values stand
@@ -3394,7 +3377,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.downplay.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -3661,12 +3644,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.downplay.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-sunburst.downplay.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -3712,7 +3693,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-sunburst.downplay.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -4029,7 +4010,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sunburst.downplay.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color. Color is taken from
                      * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -4155,7 +4135,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-sunburst.levels
              */
             levels?: {
-
                 /**
                  * `label` sets the text style for every sectors.
                  *
@@ -4178,7 +4157,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.label
                  */
                 label?: {
-
                     /**
                      * If it is `number` type, then is stands for rotation,
                      * from -90 degrees to 90 degrees, and positive values stand
@@ -4390,7 +4368,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -4657,12 +4635,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -4708,7 +4684,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -5025,7 +5001,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color. Color is taken from
                      * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -5137,7 +5112,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * `label` sets the text style for every sectors.
                      *
@@ -5160,7 +5134,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.emphasis.label
                      */
                     label?: {
-
                         /**
                          * If it is `number` type, then is stands for rotation,
                          * from -90 degrees to 90 degrees, and positive values
@@ -5374,7 +5347,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -5645,12 +5618,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -5696,7 +5667,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -6026,7 +5997,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color. Color is taken from
                          * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -6141,7 +6111,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.highlight
                  */
                 highlight?: {
-
                     /**
                      * `label` sets the text style for every sectors.
                      *
@@ -6164,7 +6133,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.highlight.label
                      */
                     label?: {
-
                         /**
                          * If it is `number` type, then is stands for rotation,
                          * from -90 degrees to 90 degrees, and positive values
@@ -6378,7 +6346,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.highlight.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -6649,12 +6617,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.highlight.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.highlight.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -6700,7 +6666,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.highlight.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -7030,7 +6996,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.highlight.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color. Color is taken from
                          * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -7145,7 +7110,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.downplay
                  */
                 downplay?: {
-
                     /**
                      * `label` sets the text style for every sectors.
                      *
@@ -7168,7 +7132,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.downplay.label
                      */
                     label?: {
-
                         /**
                          * If it is `number` type, then is stands for rotation,
                          * from -90 degrees to 90 degrees, and positive values
@@ -7382,7 +7345,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.downplay.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -7653,12 +7616,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.downplay.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.downplay.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -7704,7 +7665,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.downplay.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -8034,7 +7995,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.levels.downplay.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color. Color is taken from
                          * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -8249,7 +8209,6 @@ declare namespace echarts {
 
         namespace SeriesSunburst {
             interface DataObject {
-
                 /**
                  * Value for each item.
                  * If contains children, value can be left unset, and sum of
@@ -8318,7 +8277,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sunburst.data.label
                  */
                 label?: {
-
                     /**
                      * If it is `number` type, then is stands for rotation,
                      * from -90 degrees to 90 degrees, and positive values stand
@@ -8530,7 +8488,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.data.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -8797,12 +8755,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.data.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-sunburst.data.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -8848,7 +8804,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-sunburst.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -9165,7 +9121,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sunburst.data.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color. Color is taken from
                      * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -9277,7 +9232,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sunburst.data.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * `label` sets the text style for every sectors.
                      *
@@ -9300,7 +9254,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.data.emphasis.label
                      */
                     label?: {
-
                         /**
                          * If it is `number` type, then is stands for rotation,
                          * from -90 degrees to 90 degrees, and positive values
@@ -9514,7 +9467,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-sunburst.data.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -9785,12 +9738,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-sunburst.data.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-sunburst.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -9836,7 +9787,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-sunburst.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -10166,7 +10117,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.data.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color. Color is taken from
                          * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -10281,7 +10231,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sunburst.data.highlight
                  */
                 highlight?: {
-
                     /**
                      * `label` sets the text style for every sectors.
                      *
@@ -10304,7 +10253,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.data.highlight.label
                      */
                     label?: {
-
                         /**
                          * If it is `number` type, then is stands for rotation,
                          * from -90 degrees to 90 degrees, and positive values
@@ -10518,7 +10466,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-sunburst.data.highlight.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -10789,12 +10737,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-sunburst.data.highlight.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-sunburst.data.highlight.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -10840,7 +10786,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-sunburst.data.highlight.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -11170,7 +11116,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.data.highlight.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color. Color is taken from
                          * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -11285,7 +11230,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-sunburst.data.downplay
                  */
                 downplay?: {
-
                     /**
                      * `label` sets the text style for every sectors.
                      *
@@ -11308,7 +11252,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.data.downplay.label
                      */
                     label?: {
-
                         /**
                          * If it is `number` type, then is stands for rotation,
                          * from -90 degrees to 90 degrees, and positive values
@@ -11522,7 +11465,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-sunburst.data.downplay.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -11793,12 +11736,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-sunburst.data.downplay.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-sunburst.data.downplay.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -11844,7 +11785,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-sunburst.data.downplay.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -12174,7 +12115,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-sunburst.data.downplay.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color. Color is taken from
                          * [option.color Palette](https://echarts.apache.org/en/option.html#color)

--- a/types/echarts/options/series/theme-river.d.ts
+++ b/types/echarts/options/series/theme-river.d.ts
@@ -23,7 +23,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-themeRiver
          */
         interface SeriesThemeRiver {
-
             /**
              * @default
              * "themeRiver"
@@ -209,7 +208,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-themeRiver.label
              */
             label?: {
-
                 /**
                  * Whether to show label.
                  *
@@ -589,12 +587,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-themeRiver.label.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-themeRiver.label.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -640,7 +636,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-themeRiver.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -926,7 +922,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-themeRiver.itemStyle
              */
             itemStyle?: {
-
                 /**
                  * color.
                  *
@@ -1027,12 +1022,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-themeRiver.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-themeRiver.emphasis.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -1163,7 +1156,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-themeRiver.emphasis.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -1411,12 +1404,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-themeRiver.emphasis.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-themeRiver.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -1462,7 +1453,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-themeRiver.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -1747,7 +1738,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-themeRiver.emphasis.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -1981,10 +1971,9 @@ declare namespace echarts {
              *
              * @see https://echarts.apache.org/en/option.html#series-themeRiver.data
              */
-            data?: (
-                (void | number | string | SeriesThemeRiver.DataObject)[]
-                | (void | number | string | SeriesThemeRiver.DataObject)[][]
-            );
+            data?:
+                | (void | number | string | SeriesThemeRiver.DataObject)[]
+                | (void | number | string | SeriesThemeRiver.DataObject)[][];
 
             /**
              * tooltip settings in this series.
@@ -1997,7 +1986,6 @@ declare namespace echarts {
 
         namespace SeriesThemeRiver {
             interface DataObject {
-
                 /**
                  * the time attribute of time and theme.
                  *

--- a/types/echarts/options/series/tree.d.ts
+++ b/types/echarts/options/series/tree.d.ts
@@ -23,7 +23,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-tree
          */
         interface SeriesTree {
-
             /**
              * @default
              * "tree"
@@ -383,7 +382,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-tree.itemStyle
              */
             itemStyle?: {
-
                 /**
                  * color. Color is taken from
                  * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -492,7 +490,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-tree.label
              */
             label?: {
-
                 /**
                  * Whether to show label.
                  *
@@ -667,7 +664,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-tree.label.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -952,12 +949,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-tree.label.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-tree.label.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -1003,7 +998,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-tree.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -1289,7 +1284,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-tree.lineStyle
              */
             lineStyle?: {
-
                 /**
                  * The color of the tree edge.
                  *
@@ -1363,12 +1357,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-tree.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-tree.emphasis.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color.
                      *
@@ -1469,7 +1461,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-tree.emphasis.lineStyle
                  */
                 lineStyle?: {
-
                     /**
                      * The color of the tree edge.
                      *
@@ -1543,7 +1534,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-tree.emphasis.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -1717,7 +1707,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-tree.emphasis.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -2003,12 +1993,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-tree.emphasis.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-tree.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -2054,7 +2042,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-tree.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -2344,7 +2332,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-tree.leaves
              */
             leaves?: {
-
                 /**
                  * Describes the style of the text label corresponding to the
                  * leaf node.
@@ -2353,7 +2340,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-tree.leaves.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -2529,7 +2515,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-tree.leaves.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -2815,12 +2801,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-tree.leaves.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-tree.leaves.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -2866,7 +2850,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-tree.leaves.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -3154,7 +3138,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-tree.leaves.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color. Color is taken from
                      * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -3257,12 +3240,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-tree.leaves.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-tree.leaves.emphasis.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -3438,7 +3419,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-tree.leaves.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -3728,12 +3709,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-tree.leaves.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-tree.leaves.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -3779,7 +3758,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-tree.leaves.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -4076,7 +4055,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-tree.leaves.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *
@@ -4224,7 +4202,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-tree.data.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * color. Color is taken from
                      * [option.color Palette](https://echarts.apache.org/en/option.html#color)
@@ -4330,7 +4307,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-tree.data.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -4459,7 +4435,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-tree.data.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -4745,12 +4721,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-tree.data.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-tree.data.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -4796,7 +4770,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-tree.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -5081,12 +5055,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-tree.data.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-tree.data.emphasis.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -5215,7 +5187,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-tree.data.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -5505,12 +5477,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-tree.data.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-tree.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -5556,7 +5526,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-tree.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -5853,7 +5823,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-tree.data.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * color.
                          *

--- a/types/echarts/options/series/treemap.d.ts
+++ b/types/echarts/options/series/treemap.d.ts
@@ -62,7 +62,6 @@ declare namespace echarts {
          * @see https://echarts.apache.org/en/option.html#series-treemap
          */
         interface SeriesTreemap {
-
             /**
              * @default
              * "treemap"
@@ -399,7 +398,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-treemap.levels
              */
             levels?: {
-
                 /**
                  * `treemap` is able to map any dimensions of data to visual.
                  *
@@ -717,7 +715,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-treemap.levels.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -892,7 +889,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-treemap.levels.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -1178,12 +1175,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-treemap.levels.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-treemap.levels.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -1229,7 +1224,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-treemap.levels.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -1568,7 +1563,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-treemap.levels.upperLabel
                  */
                 upperLabel?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -1743,7 +1737,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-treemap.levels.upperLabel.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -2023,12 +2017,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-treemap.levels.upperLabel.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-treemap.levels.upperLabel.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -2074,7 +2066,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-treemap.levels.upperLabel.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -2388,7 +2380,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-treemap.levels.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * The color of a node. It use global palette
                      * [option.color](https://echarts.apache.org/en/option.html#color)
@@ -2504,12 +2495,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-treemap.levels.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-treemap.levels.emphasis.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -2686,7 +2675,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-treemap.levels.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -2976,12 +2965,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-treemap.levels.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-treemap.levels.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -3027,7 +3014,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-treemap.levels.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -3335,7 +3322,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-treemap.levels.emphasis.upperLabel
                      */
                     upperLabel?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -3512,7 +3498,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-treemap.levels.emphasis.upperLabel.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -3802,12 +3788,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-treemap.levels.emphasis.upperLabel.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-treemap.levels.emphasis.upperLabel.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -3853,7 +3837,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-treemap.levels.emphasis.upperLabel.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -4161,7 +4145,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-treemap.levels.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * The color of a node. It use global palette
                          * [option.color](https://echarts.apache.org/en/option.html#color)
@@ -4184,7 +4167,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-treemap.silent
              */
             silent?: {
-
                 /**
                  * Enable hyperlink jump when clicking on node.
                  * It is avaliable when
@@ -4518,7 +4500,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-treemap.label
              */
             label?: {
-
                 /**
                  * Whether to show label.
                  *
@@ -4692,7 +4673,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-treemap.label.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -4977,12 +4958,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-treemap.label.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-treemap.label.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -5028,7 +5007,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-treemap.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -5364,7 +5343,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-treemap.upperLabel
              */
             upperLabel?: {
-
                 /**
                  * Whether to show label.
                  *
@@ -5538,7 +5516,7 @@ declare namespace echarts {
                  * "normal"
                  * @see https://echarts.apache.org/en/option.html#series-treemap.upperLabel.fontWeight
                  */
-                fontWeight?: string;
+                fontWeight?: string | number;
 
                 /**
                  * font family
@@ -5817,12 +5795,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-treemap.upperLabel.rich
                  */
                 rich?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-treemap.upperLabel.rich.%3Cuser%20defined%20style%20name%3E
                      */
                     [userStyle: string]: {
-
                         /**
                          * text color.
                          *
@@ -5868,7 +5844,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-treemap.upperLabel.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -6180,7 +6156,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-treemap.itemStyle
              */
             itemStyle?: {
-
                 /**
                  * The color of a node. It use global palette
                  * [option.color](https://echarts.apache.org/en/option.html#color)
@@ -6295,12 +6270,10 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-treemap.emphasis
              */
             emphasis?: {
-
                 /**
                  * @see https://echarts.apache.org/en/option.html#series-treemap.emphasis.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -6475,7 +6448,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-treemap.emphasis.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -6761,12 +6734,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-treemap.emphasis.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-treemap.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -6812,7 +6783,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-treemap.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -7108,7 +7079,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-treemap.emphasis.upperLabel
                  */
                 upperLabel?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -7283,7 +7253,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-treemap.emphasis.upperLabel.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -7569,12 +7539,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-treemap.emphasis.upperLabel.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-treemap.emphasis.upperLabel.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -7620,7 +7588,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-treemap.emphasis.upperLabel.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -7916,7 +7884,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-treemap.emphasis.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * The color of a node. It use global palette
                      * [option.color](https://echarts.apache.org/en/option.html#color)
@@ -7936,7 +7903,6 @@ declare namespace echarts {
              * @see https://echarts.apache.org/en/option.html#series-treemap.breadcrumb
              */
             breadcrumb?: {
-
                 /**
                  * Whether to show the breadcrumb.
                  *
@@ -8045,7 +8011,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-treemap.breadcrumb.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * boxplot color.
                      *
@@ -8155,7 +8120,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-treemap.breadcrumb.itemStyle.textStyle
                      */
                     textStyle?: {
-
                         /**
                          * text color.
                          *
@@ -8198,7 +8162,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-treemap.breadcrumb.itemStyle.textStyle.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -8479,12 +8443,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-treemap.breadcrumb.itemStyle.textStyle.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-treemap.breadcrumb.itemStyle.textStyle.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -8527,7 +8489,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-treemap.breadcrumb.itemStyle.textStyle.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -8816,12 +8778,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-treemap.breadcrumb.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-treemap.breadcrumb.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * boxplot color.
                          *
@@ -8932,7 +8892,6 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-treemap.breadcrumb.emphasis.itemStyle.textStyle
                          */
                         textStyle?: {
-
                             /**
                              * text color.
                              *
@@ -8975,7 +8934,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-treemap.breadcrumb.emphasis.itemStyle.textStyle.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -9258,12 +9217,10 @@ declare namespace echarts {
                              * @see https://echarts.apache.org/en/option.html#series-treemap.breadcrumb.emphasis.itemStyle.textStyle.rich
                              */
                             rich?: {
-
                                 /**
                                  * @see https://echarts.apache.org/en/option.html#series-treemap.breadcrumb.emphasis.itemStyle.textStyle.rich.%3Cuser%20defined%20style%20name%3E
                                  */
                                 [userStyle: string]: {
-
                                     /**
                                      * text color.
                                      *
@@ -9306,7 +9263,7 @@ declare namespace echarts {
                                      * "normal"
                                      * @see https://echarts.apache.org/en/option.html#series-treemap.breadcrumb.emphasis.itemStyle.textStyle.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                      */
-                                    fontWeight?: string;
+                                    fontWeight?: string | number;
 
                                     /**
                                      * font family
@@ -10010,7 +9967,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-treemap.data.label
                  */
                 label?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -10185,7 +10141,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-treemap.data.label.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -10471,12 +10427,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-treemap.data.label.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-treemap.data.label.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -10522,7 +10476,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-treemap.data.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -10861,7 +10815,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-treemap.data.upperLabel
                  */
                 upperLabel?: {
-
                     /**
                      * Whether to show label.
                      *
@@ -11036,7 +10989,7 @@ declare namespace echarts {
                      * "normal"
                      * @see https://echarts.apache.org/en/option.html#series-treemap.data.upperLabel.fontWeight
                      */
-                    fontWeight?: string;
+                    fontWeight?: string | number;
 
                     /**
                      * font family
@@ -11316,12 +11269,10 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-treemap.data.upperLabel.rich
                      */
                     rich?: {
-
                         /**
                          * @see https://echarts.apache.org/en/option.html#series-treemap.data.upperLabel.rich.%3Cuser%20defined%20style%20name%3E
                          */
                         [userStyle: string]: {
-
                             /**
                              * text color.
                              *
@@ -11367,7 +11318,7 @@ declare namespace echarts {
                              * "normal"
                              * @see https://echarts.apache.org/en/option.html#series-treemap.data.upperLabel.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                              */
-                            fontWeight?: string;
+                            fontWeight?: string | number;
 
                             /**
                              * font family
@@ -11681,7 +11632,6 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-treemap.data.itemStyle
                  */
                 itemStyle?: {
-
                     /**
                      * The color of a node. It use global palette
                      * [option.color](https://echarts.apache.org/en/option.html#color)
@@ -11797,12 +11747,10 @@ declare namespace echarts {
                  * @see https://echarts.apache.org/en/option.html#series-treemap.data.emphasis
                  */
                 emphasis?: {
-
                     /**
                      * @see https://echarts.apache.org/en/option.html#series-treemap.data.emphasis.label
                      */
                     label?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -11979,7 +11927,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-treemap.data.emphasis.label.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -12269,12 +12217,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-treemap.data.emphasis.label.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-treemap.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -12320,7 +12266,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-treemap.data.emphasis.label.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -12628,7 +12574,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-treemap.data.emphasis.upperLabel
                      */
                     upperLabel?: {
-
                         /**
                          * Whether to show label.
                          *
@@ -12805,7 +12750,7 @@ declare namespace echarts {
                          * "normal"
                          * @see https://echarts.apache.org/en/option.html#series-treemap.data.emphasis.upperLabel.fontWeight
                          */
-                        fontWeight?: string;
+                        fontWeight?: string | number;
 
                         /**
                          * font family
@@ -13095,12 +13040,10 @@ declare namespace echarts {
                          * @see https://echarts.apache.org/en/option.html#series-treemap.data.emphasis.upperLabel.rich
                          */
                         rich?: {
-
                             /**
                              * @see https://echarts.apache.org/en/option.html#series-treemap.data.emphasis.upperLabel.rich.%3Cuser%20defined%20style%20name%3E
                              */
                             [userStyle: string]: {
-
                                 /**
                                  * text color.
                                  *
@@ -13146,7 +13089,7 @@ declare namespace echarts {
                                  * "normal"
                                  * @see https://echarts.apache.org/en/option.html#series-treemap.data.emphasis.upperLabel.rich.%3Cuser%20defined%20style%20name%3E.fontWeight
                                  */
-                                fontWeight?: string;
+                                fontWeight?: string | number;
 
                                 /**
                                  * font family
@@ -13454,7 +13397,6 @@ declare namespace echarts {
                      * @see https://echarts.apache.org/en/option.html#series-treemap.data.emphasis.itemStyle
                      */
                     itemStyle?: {
-
                         /**
                          * The color of a node. It use global palette
                          * [option.color](https://echarts.apache.org/en/option.html#color)

--- a/types/echarts/options/text-style.d.ts
+++ b/types/echarts/options/text-style.d.ts
@@ -1,14 +1,12 @@
 declare namespace echarts {
     namespace EChartOption {
-
         /**
          * @see https://echarts.apache.org/en/option.html#textStyle
          */
         interface BaseTextStyle {
             color?: string;
             fontStyle?: 'normal' | 'italic' | 'oblique';
-            fontWeight?: 'normal' | 'bold' | 'bolder' | 'lighter'
-                            | '100' | '200' | '300' | '400';
+            fontWeight?: 'normal' | 'bold' | 'bolder' | 'lighter' | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;
             fontFamily?: string;
             fontSize?: number;
             lineHeight?: number;

--- a/types/echarts/options/tooltip.d.ts
+++ b/types/echarts/options/tooltip.d.ts
@@ -1,8 +1,6 @@
 declare namespace echarts {
     namespace EChartOption {
-
         interface BaseTooltip {
-
             /**
              * The position of the tooltip's floating layer,
              * which would follow the position of mouse by default.
@@ -367,11 +365,7 @@ declare namespace echarts {
              * }
              */
             interface Formatter {
-                (
-                    params: Format | Format[],
-                    ticket: string,
-                    callback: (ticket: string, html: string) => void,
-                ): string;
+                (params: Format | Format[], ticket: string, callback: (ticket: string, html: string) => void): string;
             }
 
             interface Format {
@@ -417,11 +411,11 @@ declare namespace echarts {
                 encode?: object;
 
                 // dimension names list
-                dimensionNames?: string[],
+                dimensionNames?: string[];
 
                 // data dimension index, for example 0 or 1 or 2 ...
                 // Only work in `radar` series.
-                dimensionIndex?: number,
+                dimensionIndex?: number;
 
                 // Color of data
                 color?: string;
@@ -447,14 +441,14 @@ declare namespace echarts {
                 };
                 // It is valid when axisPointer.type is 'cross'.
                 crossStyle?: LineStyle;
-                animation?: boolean,
-                animationThreshold?: number,
-                animationDuration?: number,
-                animationEasing?: string,
-                animationDelay?: number | Function,
-                animationDurationUpdate?: number | Function,
-                animationEasingUpdate?: string,
-                animationDelayUpdate?: number | Function,
+                animation?: boolean;
+                animationThreshold?: number;
+                animationDuration?: number;
+                animationEasing?: string;
+                animationDelay?: number | Function;
+                animationDurationUpdate?: number | Function;
+                animationEasingUpdate?: string;
+                animationDelayUpdate?: number | Function;
             }
         }
     }

--- a/types/echarts/options/visual-map.d.ts
+++ b/types/echarts/options/visual-map.d.ts
@@ -35,7 +35,7 @@ declare namespace echarts {
             right?: number | string;
             bottom?: number | string;
             orient?: 'vertical' | 'horizontal';
-            padding?:  number | number[];
+            padding?: number | number[];
             backgroundColor?: string;
             borderColor?: string;
             borderWidth?: number;
@@ -81,7 +81,7 @@ declare namespace echarts {
             right?: number | string;
             bottom?: number | string;
             orient?: 'vertical' | 'horizontal';
-            padding?:  number | number[];
+            padding?: number | number[];
             backgroundColor?: string;
             borderColor?: string;
             borderWidth?: number;
@@ -91,7 +91,7 @@ declare namespace echarts {
         }
         interface RangeObject {
             symbol?: string | string[];
-            symbolSize?: number |  number[];
+            symbolSize?: number | number[];
             color?: string | string[];
             colorAlpha?: number | number[];
             opacity?: number | number[];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight

