### PR TITLE
[redis] add 1 overload to SET command

### DIFF
--- a/types/redis/index.d.ts
+++ b/types/redis/index.d.ts
@@ -1003,10 +1003,12 @@ export interface Commands<R> {
     set(key: string, value: string, flag: string, cb?: Callback<'OK'>): R;
     set(key: string, value: string, mode: string, duration: number, cb?: Callback<'OK' | undefined>): R;
     set(key: string, value: string, mode: string, duration: number, flag: string, cb?: Callback<'OK' | undefined>): R;
+    set(key: string, value: string, flag: string, mode: string, duration: number, cb?: Callback<'OK' | undefined>): R;
     SET(key: string, value: string, cb?: Callback<'OK'>): R;
     SET(key: string, value: string, flag: string, cb?: Callback<'OK'>): R;
     SET(key: string, value: string, mode: string, duration: number, cb?: Callback<'OK' | undefined>): R;
     SET(key: string, value: string, mode: string, duration: number, flag: string, cb?: Callback<'OK' | undefined>): R;
+    SET(key: string, value: string, flag: string, mode: string, duration: number, cb?: Callback<'OK' | undefined>): R;
 
     /**
      * Sets or clears the bit at offset in the string value stored at key.

--- a/types/redis/redis-tests.ts
+++ b/types/redis/redis-tests.ts
@@ -84,6 +84,13 @@ client.once(str, messageHandler);
 
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 
+// set
+client.set('key', 'value', resCallback);
+client.set('key', 'value', 'NX', resCallback);
+client.set('key', 'value', 'EX', 1000, resCallback);
+client.set('key', 'value', 'NX', 'EX', 1000, resCallback);
+client.set('key', 'value', 'EX', 1000, 'NX', resCallback);
+
 // some of the bulk methods
 client.get('test');
 client.get('test', resCallback);


### PR DESCRIPTION
adding support to redis SET command when sending arguments in this format
```js
client.set('key', 'value', 'NX', 'EX', 1000, cb);
```

fixes #39051