### PR TITLE
[sql-query-identifier] add new typing

### DIFF
--- a/types/sql-query-identifier/index.d.ts
+++ b/types/sql-query-identifier/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for sql-query-identifier 1.1
+// Project: https://github.com/maxcnunes/sql-query-identifier
+// Definitions by: Matthew Peveler <https://github.com/MasterOdin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface Options {
+    /**
+     * Disables strict mode which will ignore unknown types (defaults to true).
+     */
+    strict: boolean;
+}
+
+export interface Result {
+    start: number;
+    end: number;
+    text: string;
+    type: 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE' | 'CREATE_TABLE' | 'CREATE_DATABASE' | 'DROP_TABLE' | 'DROP_DATABASE' | 'TRUNCATE' | 'UNKNOWN';
+    executionType: 'LISTING' | 'MODIFICATION' | 'UNKNOWN';
+}
+
+export function identify(query: string, options?: Options): Result[];

--- a/types/sql-query-identifier/sql-query-identifier-tests.ts
+++ b/types/sql-query-identifier/sql-query-identifier-tests.ts
@@ -1,0 +1,8 @@
+import { identify } from 'sql-query-identifier';
+
+identify(`
+  INSERT INTO Persons (PersonID, Name) VALUES (1, 'Jack');
+  SELECT * FROM Persons;
+`);
+
+identify(`CREATE INDEX part_of_name ON customer (name(10));`, {strict: false});

--- a/types/sql-query-identifier/tsconfig.json
+++ b/types/sql-query-identifier/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "sql-query-identifier-tests.ts"
+    ]
+}

--- a/types/sql-query-identifier/tslint.json
+++ b/types/sql-query-identifier/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Adds typings for https://github.com/maxcnunes/sql-query-identifier (https://www.npmjs.com/package/sql-query-identifier)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.