### PR TITLE
[prop-types] Fix `RequiredKeys` which is not working correctly.

### DIFF
--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -33,7 +33,13 @@ export const nominalTypeHack: unique symbol;
 
 export type IsOptional<T> = undefined extends T ? true : false;
 
-export type RequiredKeys<V> = { [K in keyof V]: V[K] extends infer T ? T extends Requireable<any> ? never : K : never }[keyof V];
+// Unfortunately type definition for RequiredKeys changes
+// depending on the strict null check being on or off,
+// because IsOptional will return different values
+// (since when strict null checks are off, e.g. undefined extends string is true)
+export type RequiredKeys<V> = undefined extends string
+    ? { [K in keyof V]: V[K] extends infer T ? T extends Requireable<any> ? never : K : never }[keyof V]
+    : { [K in keyof V]-?: Exclude<V[K], undefined> extends Validator<infer T> ? IsOptional<T> extends true ? never : K : never }[keyof V];
 export type OptionalKeys<V> = Exclude<keyof V, RequiredKeys<V>>;
 export type InferPropsInner<V> = { [K in keyof V]-?: InferType<V[K]>; };
 

--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -33,7 +33,7 @@ export const nominalTypeHack: unique symbol;
 
 export type IsOptional<T> = undefined extends T ? true : false;
 
-export type RequiredKeys<V> = { [K in keyof V]-?: Exclude<V[K], undefined> extends Validator<infer T> ? IsOptional<T> extends true ? never : K : never }[keyof V];
+export type RequiredKeys<V> = { [K in keyof V]: V[K] extends infer T ? T extends Requireable<any> ? never : K : never }[keyof V];
 export type OptionalKeys<V> = Exclude<keyof V, RequiredKeys<V>>;
 export type InferPropsInner<V> = { [K in keyof V]-?: InferType<V[K]>; };
 


### PR DESCRIPTION
Currently `RequiredKeys` is not actually picking up anything, meaning props marked as `.isRequired` will be optional in the TS type yield by `InferProps`. This PR fixes that incorrect behaviour.


With the current code:
```ts
const propsTypes = {
  foo: PropTypes.string.isRequired,
  bar: PropTypes.bool,
};
type requiredKeys = PropTypes.RequiredKeys<typeof propsTypes>; // never
```

With the code in this PR:
```ts
const propsTypes = {
  foo: PropTypes.string.isRequired,
  bar: PropTypes.bool,
};
type requiredKeys = PropTypes.RequiredKeys<typeof propsTypes>; // "foo"
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] ~~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~~
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~
