### PR TITLE
[jquery] Refinement for `parents()` types

### DIFF
--- a/types/jquery/JQuery.d.ts
+++ b/types/jquery/JQuery.d.ts
@@ -8703,7 +8703,8 @@ $( "span" ).click(function() {
      */
     parents<K extends keyof HTMLElementTagNameMap>(selector: K | JQuery<K>): JQuery<HTMLElementTagNameMap[K]>;
     parents<K extends keyof SVGElementTagNameMap>(selector: K | JQuery<K>): JQuery<SVGElementTagNameMap[K]>;
-    parents<E extends HTMLElement>(selector?: JQuery.Selector): JQuery<E>; // tslint:disable-line
+    // tslint:disable-next-line:no-unnecessary-generics
+    parents<E extends HTMLElement>(selector?: JQuery.Selector): JQuery<E>;
     /**
      * Get the ancestors of each element in the current set of matched elements, up to but not including the element matched by the selector, DOM node, or jQuery object.
      * @param selector_element _&#x40;param_ `selector_element`

--- a/types/jquery/JQuery.d.ts
+++ b/types/jquery/JQuery.d.ts
@@ -8703,7 +8703,7 @@ $( "span" ).click(function() {
      */
     parents<K extends keyof HTMLElementTagNameMap>(selector: K | JQuery<K>): JQuery<HTMLElementTagNameMap[K]>;
     parents<K extends keyof SVGElementTagNameMap>(selector: K | JQuery<K>): JQuery<SVGElementTagNameMap[K]>;
-    parents(selector?: JQuery.Selector): JQuery;
+    parents<E extends HTMLElement>(selector?: JQuery.Selector): JQuery<E>; // tslint:disable-line
     /**
      * Get the ancestors of each element in the current set of matched elements, up to but not including the element matched by the selector, DOM node, or jQuery object.
      * @param selector_element _&#x40;param_ `selector_element`

--- a/types/jquery/JQuery.d.ts
+++ b/types/jquery/JQuery.d.ts
@@ -8703,7 +8703,7 @@ $( "span" ).click(function() {
      */
     parents<K extends keyof HTMLElementTagNameMap>(selector: K | JQuery<K>): JQuery<HTMLElementTagNameMap[K]>;
     parents<K extends keyof SVGElementTagNameMap>(selector: K | JQuery<K>): JQuery<SVGElementTagNameMap[K]>;
-    parents(selector?: JQuery.Selector): this;
+    parents(selector?: JQuery.Selector): JQuery;
     /**
      * Get the ancestors of each element in the current set of matched elements, up to but not including the element matched by the selector, DOM node, or jQuery object.
      * @param selector_element _&#x40;param_ `selector_element`

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -6113,6 +6113,9 @@ function JQuery() {
             $(document).find('select').parents('div');
 
             // $ExpectType JQuery<HTMLElement>
+            $(document).find('select').parents('.container');
+
+            // $ExpectType JQuery<HTMLElement>
             $('p').parents('.container');
         }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.jquery.com/parents/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This is a follow-up to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48716. Calling `.parents()` on a `JQuery<HTMLSelectElement>` with a selector that isn't one of the entries of the `HTMLElementTagNameMap` should just return `JQuery` (implicitely `JQuery<HTMLElement>`).

There's also https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44268 but I'm not sure what to make of it.