### PR TITLE
[twig] - Feature / fix requested - allow empty options '{}' for renderFile function

### DIFF
--- a/types/twig/index.d.ts
+++ b/types/twig/index.d.ts
@@ -4,6 +4,7 @@
 //                 Tim Schumacher <https://github.com/enko>
 //                 Maik Tizziani <https://github.com/mtizziani>
 //                 Daniel Melcer <https://github.com/dmelcer9>
+//                 Chris Frewin <https://github.com/princefishthrower>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Imported from: https://github.com/soywiz/typescript-node-definitions/twig.d.ts
@@ -37,7 +38,10 @@ export interface Template {
 
 export interface CompileOptions {
     filename: string;
-    settings: any;
+    settings: {
+        views: any;
+        'twig options': any;
+    };
 }
 
 export function twig(params: Parameters): Template;
@@ -46,6 +50,7 @@ export function extendFunction(name: string, definition: (...params: any[]) => s
 export function extendTest(name: string, definition: (value: any) => boolean): void;
 export function extendTag(definition: any): void;
 export function compile(markup: string, options: CompileOptions): (context: any) => any;
-export function renderFile(path: string, options: CompileOptions, fn: (err: Error, result: any) => void): void;
+export function renderFile(path: string, options: (err: Error, result: any) => void, fn: null): void;
+export function renderFile(path: string, options: {} | CompileOptions, fn: (err: Error, result: any) => void): void;
 export function __express(path: string, options: CompileOptions, fn: (err: Error, result: any) => void): void;
 export function cache(value: boolean): void;

--- a/types/twig/twig-tests.ts
+++ b/types/twig/twig-tests.ts
@@ -2,7 +2,6 @@ import twig = require('twig');
 
 const value: any = "";
 const str = "";
-const num = 0;
 const bool = false;
 
 const params: twig.Parameters = {
@@ -33,7 +32,10 @@ twig_async_param(false);
 
 const compOpts: twig.CompileOptions = {
     filename: str,
-    settings: value
+    settings: {
+        views: value,
+        'twig options': value
+    }
 };
 
 twig.extendFilter(str, (left: any, ...params: any[]) => {
@@ -51,6 +53,12 @@ const compiled = twig.compile(str, compOpts);
 
 twig.renderFile(str, compOpts, (err, result) => {
 });
+
+twig.renderFile(str, {}, (err, result) => {
+});
+
+twig.renderFile(str, (err, result) => {
+}, null);
 
 twig.__express(str, compOpts, (err, result) => {
 });


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Dug into the source code at https://github.com/twigjs/twig.js/blob/master/src/twig.exports.js , I found that not only can options be an empty object {}, but also become the callback, in which the third parameter (the default parameter for the callback), is set to `null`. Used TypeScript's [overloading functionality](https://www.tutorialsteacher.com/typescript/function-overloading) to accomplish this. 

Also strengthened the types of CompileOptions.settings - though they may be _too_ strong. Not sure if I missed anything here. @soywiz @enko @mtizziani @dmelcer9 - any critique here?