### PR TITLE
[yandex-maps]: adds-some-types

### DIFF
--- a/types/yandex-maps/index.d.ts
+++ b/types/yandex-maps/index.d.ts
@@ -639,6 +639,61 @@ declare namespace ymaps {
             };
             state?: {};
         }
+
+        class ZoomControl implements IControl, ICustomizable {
+            constructor(parameters?: IZoomControlParameters);
+
+            events: IEventManager;
+            options: IOptionManager;
+            state: data.Manager;
+
+            getParent(): null | IControlParent;
+
+            setParent(parent: IControlParent): this;
+
+            clear(): void;
+
+            getMap(): Map;
+
+            getRequestString(): string;
+
+            getResponseMetaData(): object;
+
+            getResult(index: number): Promise<object>;
+
+            getResultsArray(): object[];
+
+            getResultsCount(): number;
+
+            getSelectedIndex(): number;
+
+            hideResult(): void;
+
+            search(request: string): Promise<void>;
+
+            showResult(index: number): this;
+        }
+
+        interface IZoomControlParameters {
+            options?: {
+                position?: {
+                    top?: number | string | 'auto';
+                    right?: number | string | 'auto';
+                    bottom?: number | string | 'auto';
+                    left?: number | string | 'auto';
+                }
+            };
+        }
+
+        class TypeSelector extends ListBox {
+            constructor(parameters?: ITypeSelectorParameters);
+        }
+
+        interface ITypeSelectorParameters {
+            options?: {
+                panoramasItemMode: 'on' | 'off' | 'ifMercator';
+            };
+        }
     }
 
     namespace data {
@@ -651,7 +706,7 @@ declare namespace ymaps {
 
             getAll(): object;
 
-            set(path: object | string, value: object): this;
+            set(path: object | string, value: object | number | string | null | undefined): this;
 
             setAll(): this;
 
@@ -680,10 +735,11 @@ declare namespace ymaps {
     }
 
     namespace event {
-        class Manager implements IEventManager {
+        class Manager<TargetGeometry = {}> implements IEventManager<TargetGeometry> {
             constructor(params?: { context?: object; controllers?: IEventWorkflowController[]; parent?: IEventManager });
 
-            add(types: string[][] | string[] | string, callback: (event: (object | IEvent)) => void, context?: object, priority?: number): this;
+            add(types: 'mousedown', callback: (event: (IEvent<MouseEvent, TargetGeometry>)) => void, context?: object, priority?: number): this;
+            add(types: string[][] | string[] | string, callback: (event: (IEvent<{}, TargetGeometry>)) => void, context?: object, priority?: number): this;
 
             getParent(): IEventManager | null;
 
@@ -732,7 +788,7 @@ declare namespace ymaps {
 
                 set(index: number, coordinates: number[]): ILineStringGeometryAccess;
 
-                setCoordinates(coordinates: number[]): ILineStringGeometryAccess;
+                setCoordinates(coordinates: number[][]): ILineStringGeometryAccess;
 
                 splice(index: number, length: number): number[][];
 
@@ -854,7 +910,7 @@ declare namespace ymaps {
 
             set(index: number, coordinates: number[]): ILineStringGeometryAccess;
 
-            setCoordinates(coordinates: number[]): ILineStringGeometryAccess;
+            setCoordinates(coordinates: number[][]): ILineStringGeometryAccess;
 
             splice(index: number, length: number): number[][];
 
@@ -1508,6 +1564,8 @@ declare namespace ymaps {
                 rebuild(): void;
             }
         }
+
+        const storage: util.Storage;
     }
 
     namespace map {
@@ -1574,6 +1632,8 @@ declare namespace ymaps {
                 remove(object: object): this;
 
                 getMap(): Map;
+
+                getAll(): Array<Collection<Layer>>;
             }
         }
 
@@ -1705,7 +1765,7 @@ declare namespace ymaps {
             options: IOptionManager;
             events: IEventManager;
 
-            add(child: IGeoObject, index?: number): this;
+            add(child: IGeoObject | ObjectManager, index?: number): this;
 
             each(callback: (object: IGeoObject) => void, context?: object): void;
 
@@ -1721,7 +1781,7 @@ declare namespace ymaps {
 
             indexOf(object: IGeoObject): number;
 
-            remove(child: IGeoObject): this;
+            remove(child: IGeoObject | ObjectManager): this;
 
             removeAll(): this;
 
@@ -2229,7 +2289,7 @@ declare namespace ymaps {
 
             resolve(key: string, name?: string): object;
 
-            set(key: object | string, value?: object): this;
+            set(key: object | string, value?: object | number | string | null): this;
 
             unset(keys: string[][] | string[] | string): this;
 
@@ -2255,6 +2315,8 @@ declare namespace ymaps {
 
             fire(type: string, eventobject: object | IEvent): this;
         }
+
+        const presetStorage: util.Storage;
     }
 
     namespace panorama {
@@ -2493,7 +2555,7 @@ declare namespace ymaps {
         }
     }
 
-    class Balloon extends Popup<Balloon> implements IBaloon<Balloon> {
+    class Balloon extends Popup<Balloon> implements IBaloon<Balloon>, IBalloonManager<Balloon> {
         constructor(map: Map, options?: IBalloonOptions);
 
         getData(): object;
@@ -2519,6 +2581,12 @@ declare namespace ymaps {
         remove(types: string[][] | string[] | string, callback: (event: (object | IEvent)) => void, context?: object, priority?: number): this;
 
         fire(type: string, eventobject: object | IEvent): this;
+
+        destroy(): void;
+
+        getOptions(): IOptionManager | null;
+
+        setOptions(options: object): Promise<Balloon>;
     }
 
     interface IBalloonOptions {
@@ -2544,7 +2612,7 @@ declare namespace ymaps {
         shadowOffset?: number[];
     }
 
-    class Circle implements GeoObject {
+    class Circle implements GeoObject<ICircleGeometry> {
         constructor(geometry: ICircleGeometry[][][][] | number[][] | object, properties?: object | IDataManager, options?: ICircleOptions)
 
         balloon: geoObject.Balloon;
@@ -2555,7 +2623,7 @@ declare namespace ymaps {
         properties: data.Manager;
         state: data.Manager;
 
-        geometry: IGeometry | null;
+        geometry: ICircleGeometry | null;
         indices: ArrayBuffer;
         vertices: ArrayBuffer;
 
@@ -2696,7 +2764,7 @@ declare namespace ymaps {
         zIndexHover?: number;
     }
 
-    class Collection implements ICollection, collection.Item {
+    class Collection<T = {}> implements ICollection, collection.Item {
         constructor(options?: object);
 
         events: IEventManager;
@@ -2722,7 +2790,7 @@ declare namespace ymaps {
 
         get(index: number): object;
 
-        getAll(): object[];
+        getAll(): T[];
 
         getLength(): number;
 
@@ -2731,16 +2799,17 @@ declare namespace ymaps {
         removeAll(): this;
     }
 
-    class Event implements IEvent {
+    class Event<OriginalEvent = {}, TargetGeometry = {}> implements IEvent<OriginalEvent, TargetGeometry> {
         constructor(originalEvent: object, sourceEvent: IEvent);
 
         allowMapEvent(): void;
 
         callMethod(name: string): void;
 
+        get<T extends {}, K extends keyof T= keyof T>(name: K): T[K];
         get(name: string): object;
 
-        getSourceEvent(): IEvent | null;
+        getSourceEvent(): IEvent<OriginalEvent> | null;
 
         isDefaultPrevented(): boolean;
 
@@ -2755,16 +2824,25 @@ declare namespace ymaps {
         stopImmediatePropagation(): boolean;
 
         stopPropagation(): boolean;
+
+        originalEvent: {
+            domEvent: {
+                originalEvent: OriginalEvent;
+            }
+            target: {
+                geometry?: TargetGeometry;
+            };
+        };
     }
 
-    class GeoObject implements IGeoObject {
+    class GeoObject<T = IGeometry, TargetGeometry = {}> implements IGeoObject<T> {
         constructor(feature?: IGeoObjectFeature, options?: IGeoObjectOptions);
 
-        geometry: IGeometry | null;
+        geometry: T | null;
         balloon: geoObject.Balloon;
         editor: IGeometryEditor;
         hint: geoObject.Hint;
-        events: event.Manager;
+        events: event.Manager<TargetGeometry>;
         options: option.Manager;
         properties: data.Manager;
         state: data.Manager;
@@ -2883,6 +2961,10 @@ declare namespace ymaps {
         setParent(parent: IControlParent): this;
 
         getMap(): Map;
+
+        getAlias(): string;
+
+        getElement(): HTMLElement;
     }
 
     class Map implements IDomEventEmitter {
@@ -2967,7 +3049,13 @@ declare namespace ymaps {
         behaviors?: string[];
         bounds?: number[][];
         center?: number[];
-        controls?: string[];
+        controls?: Array<
+            boolean
+            | string
+            | control.ZoomControl
+            | control.RulerControl
+            | control.TypeSelector
+        >;
         margin?: number[][] | number[];
         type?: "yandex#map" | "yandex#satellite" | "yandex#hybrid";
         zoom?: number;
@@ -2989,9 +3077,13 @@ declare namespace ymaps {
         suppressObsoleteBrowserNotifier?: boolean;
         yandexMapAutoSwitch?: boolean;
         yandexMapDisablePoiInteractivity?: boolean;
+
+        copyrightLogoVisible?: boolean;
+        copyrightProvidersVisible?: boolean;
+        copyrightUaVisible?: boolean;
     }
 
-    class Placemark extends GeoObject {
+    class Placemark extends GeoObject<IPointGeometry, geometry.Point> {
         constructor(geometry: number[] | object | IPointGeometry, properties: object | IDataManager, options?: IPlacemarkOptions)
     }
 
@@ -3020,7 +3112,7 @@ declare namespace ymaps {
         zIndexHover?: number;
     }
 
-    class Polygon extends GeoObject {
+    class Polygon extends GeoObject<IPolygonGeometry> {
         constructor(geometry: number[][][] | object| IPolygonGeometry, properties?: object | IDataManager, options?: IPolygonOptions)
     }
 
@@ -3057,8 +3149,8 @@ declare namespace ymaps {
         zIndexHover?: number;
     }
 
-    class Polyline extends GeoObject {
-        constructor(geometry: number[][]| object | ILineStringGeometry, properties?: object | IDataManager, options?: IPolylineOptions)
+    class Polyline extends GeoObject<ILineStringGeometry> {
+        constructor(geometry: number[][]| object | ILineStringGeometry, properties?: object | IDataManager, options?: IPolylineOptions);
     }
 
     interface IPolylineOptions {
@@ -3292,14 +3384,20 @@ declare namespace ymaps {
     interface IDomEventEmitter extends IEventEmitter { //tslint:disable-line no-empty-interface no-empty-interfaces
     }
 
-    interface IEvent {
+    interface IEvent<OriginalEvent = {}, TargetGeometry = {}> {
         allowMapEvent(): void;
 
         callMethod(name: string): void;
 
+        get<T extends {}, K extends keyof T = keyof T>(name: K): T[K];
+
+        get(name: 'type'): string;
+        get(name: 'objectId'): string | undefined;
+        get(name: 'newZoom' | 'oldZoom'): number | undefined;
+
         get(name: string): object;
 
-        getSourceEvent(): IEvent | null;
+        getSourceEvent(): IEvent<OriginalEvent> | null;
 
         isDefaultPrevented(): boolean;
 
@@ -3314,6 +3412,15 @@ declare namespace ymaps {
         stopImmediatePropagation(): boolean;
 
         stopPropagation(): boolean;
+
+        originalEvent: {
+            domEvent: {
+                originalEvent: OriginalEvent;
+            }
+            target: {
+                geometry?: TargetGeometry;
+            };
+        };
     }
 
     interface IEventController {
@@ -3334,8 +3441,9 @@ declare namespace ymaps {
         removeAll(): this;
     }
 
-    interface IEventManager extends IEventTrigger {
-        add(types: string[][] | string[] | string, callback: (event: object | IEvent) => void, context?: object, priority?: number): this;
+    interface IEventManager<TargetGeometry = {}> extends IEventTrigger {
+        add(types: 'mousedown', callback: (event: IEvent<MouseEvent, TargetGeometry>) => void, context?: object, priority?: number): this;
+        add(types: string[][] | string[] | string, callback: (event: IEvent) => void, context?: object, priority?: number): this;
 
         getParent(): object | null;
 
@@ -3414,8 +3522,8 @@ declare namespace ymaps {
         type: string;
     }
 
-    interface IGeoObject extends IChildOnMap, ICustomizable, IDomEventEmitter, IParentOnMap {
-        geometry: IGeometry | null;
+    interface IGeoObject<T = IGeometry> extends IChildOnMap, ICustomizable, IDomEventEmitter, IParentOnMap {
+        geometry: T | null;
         properties: IDataManager;
         state: IDataManager;
 
@@ -3552,7 +3660,7 @@ declare namespace ymaps {
 
         set(index: number, coordinates: number[]): ILineStringGeometryAccess;
 
-        setCoordinates(coordinates: number[]): ILineStringGeometryAccess;
+        setCoordinates(coordinates: number[][]): ILineStringGeometryAccess;
 
         splice(index: number, length: number): number[][];
     }
@@ -3939,6 +4047,54 @@ declare namespace ymaps {
         get(name: string): any;
         remove(name: string): Monitor;
         removeAll(): Monitor;
+    }
+
+    interface IObjectManagerOptions {
+        clusterize?: boolean;
+        syncOverlayInit?: boolean;
+        viewportMargin?: number | number[];
+        clusterHasBalloon?: boolean;
+        geoObjectOpenBalloonOnClick?: boolean;
+    }
+
+    class ObjectManager {
+        constructor(options: IObjectManagerOptions);
+
+        add(params: object): ObjectManager;
+
+        objects: objectManager.ObjectCollection;
+
+        removeAll(): this;
+    }
+
+    namespace objectManager {
+        class ObjectCollection implements ICollection, ICustomizable {
+            options: option.Manager;
+
+            events: IEventManager;
+
+            add(object: object): this;
+
+            getIterator(): IIterator;
+
+            remove(object: object): this;
+
+            getById(id: string | null | undefined): object | null;
+        }
+    }
+
+    namespace modules {
+        function require(modules: string | string[]): vow.Promise;
+    }
+
+    class Hotspot implements IHotspot {
+        constructor(shape: IShape, zIndex?: number);
+
+        events: IEventManager;
+    }
+
+    interface IHotspot extends IDomEventEmitter {
+        events: IEventManager;
     }
 }
 

--- a/types/yandex-maps/index.d.ts
+++ b/types/yandex-maps/index.d.ts
@@ -3050,8 +3050,7 @@ declare namespace ymaps {
         bounds?: number[][];
         center?: number[];
         controls?: Array<
-            boolean
-            | string
+            string
             | control.ZoomControl
             | control.RulerControl
             | control.TypeSelector

--- a/types/yandex-maps/yandex-maps-tests.ts
+++ b/types/yandex-maps/yandex-maps-tests.ts
@@ -65,5 +65,50 @@ map.setZoom(13);
 const shapeCircle = new ymaps.shape.Circle(
     new ymaps.geometry.pixel.Circle([0, 0], 10)
 );
-
 shapeCircle.getGeometry();
+
+const zoomControl = new ymaps.control.ZoomControl({
+    options: {
+        position: {
+            top: 108,
+            right: 10,
+            bottom: 'auto',
+            left: 'auto',
+        },
+    },
+});
+zoomControl.clear();
+
+const typeSelector = new window.ymaps.control.TypeSelector({
+    options: {
+        panoramasItemMode: 'off',
+    },
+});
+typeSelector.getParent()
+
+
+const placemark = new window.ymaps.Placemark([0, 1], {});
+placemark.events.add('dragend', (event) => {
+    const geometryPoint = event.originalEvent.target?.geometry;
+
+    const coordinates = geometryPoint?.getCoordinates();
+    coordinates?.map((d) => d)
+});
+
+const balloon = new ymaps.Balloon(map, {});
+balloon.destroy();
+
+const layersCollections = map.layers.getAll();
+const layers = layersCollections.reduce((acc, collection) => [...acc, ...collection.getAll()], []);
+const mapLayer = layers.find((layer) => {
+    if (!layer.getAlias) {
+      return;
+    }
+
+    return layer.getAlias() === 'map';
+  });
+
+  if (mapLayer) {
+    const htmlElement = mapLayer.getElement();
+    htmlElement.className = 'grey';
+  }

--- a/types/yandex-maps/yandex-maps-tests.ts
+++ b/types/yandex-maps/yandex-maps-tests.ts
@@ -79,15 +79,15 @@ const zoomControl = new ymaps.control.ZoomControl({
 });
 zoomControl.clear();
 
-const typeSelector = new window.ymaps.control.TypeSelector({
+const typeSelector = new ymaps.control.TypeSelector({
     options: {
         panoramasItemMode: 'off',
     },
 });
 typeSelector.getParent();
 
-const placemark = new window.ymaps.Placemark([0, 1], {});
-placemark.events.add('dragend', (event) => {
+const placemark = new ymaps.Placemark([0, 1], {});
+placemark.events.add('dragend', (event: ymaps.IEvent<{}, ymaps.geometry.Point>) => {
     const target = event.originalEvent.target;
     if (!target) {
         return;
@@ -112,10 +112,10 @@ const balloon = new ymaps.Balloon(map, {});
 balloon.destroy();
 
 const layersCollections = map.layers.getAll();
-const layers = layersCollections.reduce((acc, collection) => [...acc, ...collection.getAll()], []);
-const mapLayer = layers.find((layer) => {
+const layers = layersCollections.reduce((acc: ymaps.Layer[], collection: ymaps.Collection<ymaps.Layer>) => [...acc, ...collection.getAll()], []);
+const mapLayer = layers.find((layer: ymaps.Layer) => {
     if (!layer.getAlias) {
-      return;
+      return false;
     }
 
     return layer.getAlias() === 'map';

--- a/types/yandex-maps/yandex-maps-tests.ts
+++ b/types/yandex-maps/yandex-maps-tests.ts
@@ -1,11 +1,34 @@
 const defaultBehavior = ["drag", "scrollZoom", "dblClickZoom", "multiTouch", "rightMouseButtonMagnifier"];
 const element: HTMLDivElement = document.createElement("div");
+
+const zoomControl = new ymaps.control.ZoomControl({
+    options: {
+        position: {
+            top: 108,
+            right: 10,
+            bottom: 'auto',
+            left: 'auto',
+        },
+    },
+});
+zoomControl.clear();
+
+const typeSelector = new ymaps.control.TypeSelector({
+    options: {
+        panoramasItemMode: 'off',
+    },
+});
+
 const map = new ymaps.Map(
     element,
     {
         behaviors: defaultBehavior,
         center:    [55.76, 37.64],
-        controls:  [],
+        controls:  [
+            'trafficControl',
+            zoomControl,
+            typeSelector,
+        ],
         type:      "yandex#map",
         zoom:      10
     },
@@ -66,25 +89,6 @@ const shapeCircle = new ymaps.shape.Circle(
     new ymaps.geometry.pixel.Circle([0, 0], 10)
 );
 shapeCircle.getGeometry();
-
-const zoomControl = new ymaps.control.ZoomControl({
-    options: {
-        position: {
-            top: 108,
-            right: 10,
-            bottom: 'auto',
-            left: 'auto',
-        },
-    },
-});
-zoomControl.clear();
-
-const typeSelector = new ymaps.control.TypeSelector({
-    options: {
-        panoramasItemMode: 'off',
-    },
-});
-typeSelector.getParent();
 
 const placemark = new ymaps.Placemark([0, 1], {});
 placemark.events.add('dragend', (event: ymaps.IEvent<{}, ymaps.geometry.Point>) => {

--- a/types/yandex-maps/yandex-maps-tests.ts
+++ b/types/yandex-maps/yandex-maps-tests.ts
@@ -106,9 +106,10 @@ const mapLayer = layers.find((layer) => {
     }
 
     return layer.getAlias() === 'map';
-  });
+});
 
-  if (mapLayer) {
+if (mapLayer) {
     const htmlElement = mapLayer.getElement();
     htmlElement.className = 'grey';
-  }
+}
+  

--- a/types/yandex-maps/yandex-maps-tests.ts
+++ b/types/yandex-maps/yandex-maps-tests.ts
@@ -84,15 +84,23 @@ const typeSelector = new window.ymaps.control.TypeSelector({
         panoramasItemMode: 'off',
     },
 });
-typeSelector.getParent()
-
+typeSelector.getParent();
 
 const placemark = new window.ymaps.Placemark([0, 1], {});
 placemark.events.add('dragend', (event) => {
-    const geometryPoint = event.originalEvent.target?.geometry;
+    const target = event.originalEvent.target;
+    if (!target) {
+        return;
+    }
+
+    const geometryPoint = target.geometry;
 
     const coordinates = geometryPoint?.getCoordinates();
-    coordinates?.map((d) => d)
+    if (!coordinates) {
+        return;
+    }
+
+    coordinates.map((d: number) => d);
 });
 
 const balloon = new ymaps.Balloon(map, {});

--- a/types/yandex-maps/yandex-maps-tests.ts
+++ b/types/yandex-maps/yandex-maps-tests.ts
@@ -95,7 +95,12 @@ placemark.events.add('dragend', (event) => {
 
     const geometryPoint = target.geometry;
 
-    const coordinates = geometryPoint?.getCoordinates();
+    if (!geometryPoint) {
+        return;
+    }
+
+    const coordinates = geometryPoint.getCoordinates();
+
     if (!coordinates) {
         return;
     }
@@ -120,4 +125,3 @@ if (mapLayer) {
     const htmlElement = mapLayer.getElement();
     htmlElement.className = 'grey';
 }
-  


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
**ZoomControl** https://yandex.ru/dev/maps/jsapi/doc/2.1/ref/reference/control.ZoomControl.html/
**TypeSelector** https://yandex.ru/dev/maps/jsapi/doc/2.1/ref/reference/control.TypeSelector.html/
**data.Manager.set** https://yandex.ru/dev/maps/archive/doc/jsapi/2.0/ref/reference/data.Manager.html#method_detail__set  in docs only `object`, but can any
**LineString.setCoordinates** https://yandex.ru/dev/maps/jsapi/doc/2.1/ref/reference/ILineStringGeometryAccess.html/#method_detail__setCoordinates
**layout.storage** https://yandex.ru/dev/docs/search/?query=layout.storage
**map.Manager.getAll()** https://yandex.ru/dev/docs/search/?query=map.Manager.getAll
**option.presetStorage** https://yandex.ru/dev/maps/jsapi/doc/2.1/ref/reference/option.presetStorage.html/
**Balloon** https://yandex.ru/dev/maps/jsapi/doc/2.1/ref/reference/map.Balloon.html/?lang=ru
**ObjectManager** https://yandex.ru/dev/maps/jsapi/doc/2.1/ref/reference/ObjectManager.html
**Hotspots** https://yandex.ru/dev/maps/jsapi/doc/2.1/ref/reference/Hotspot.html/

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
