### PR TITLE
[node-telegram-bot-api] Optional event in removeAllListeners

### DIFF
--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -1365,7 +1365,7 @@ declare class TelegramBot extends EventEmitter {
     off(event: 'polling_error' | 'webhook_error' | 'error', listener: (error: Error) => void): this;
 
     removeAllListeners(
-        event:
+        event?:
             TelegramBot.MessageType |
             'message' |
             'callback_query' |

--- a/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
+++ b/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
@@ -163,6 +163,7 @@ MyTelegramBot.off('shipping_query', (query: TelegramBot.ShippingQuery) => { });
 MyTelegramBot.off('pre_checkout_query', (query: TelegramBot.PreCheckoutQuery) => { });
 MyTelegramBot.off('polling_error', (error: Error) => { });
 MyTelegramBot.removeAllListeners('message');
+MyTelegramBot.removeAllListeners();
 MyTelegramBot.listeners('message');
 MyTelegramBot.rawListeners('message');
 MyTelegramBot.listenerCount('message');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

    The `removeAllListeners` method is provided by the `eventemitter3` package. It allows passing a falsy value to `removeAllListeners` remove all the listeners and not only all of a specific event: https://github.com/primus/eventemitter3/blob/3d880e26b0f945f18b2facee17a6d12e3a8f8d43/index.js#L301-L313

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.