### PR TITLE
[cookiejar] Fix `.getCookie` and `setCookies` return types

### DIFF
--- a/types/cookiejar/cookiejar-tests.ts
+++ b/types/cookiejar/cookiejar-tests.ts
@@ -4,7 +4,7 @@ const { Cookie, CookieAccessInfo, CookieJar } = cookiejarLib;
 
 // Original test: https://github.com/bmeck/node-cookiejar/blob/master/tests/test.js
 
-let testCookie = new Cookie("a=1;domain=.test.com;path=/");
+let testCookie: cookiejarLib.Cookie | undefined = new Cookie("a=1;domain=.test.com;path=/");
 // assert.equal(testCookie.name, "a");
 // assert.equal(testCookie.value, "1");
 // assert.equal(testCookie.domain, ".test.com");
@@ -90,3 +90,15 @@ testCookieJar2.setCookie(new Cookie("sub=5;path=/", "test.com", "/accounts"));
 testCookie = testCookieJar2.getCookie('sub', CookieAccessInfo.All);
 // assert(testCookie);
 // assert.equal(testCookie.name, 'sub');
+
+// Test that `CookieJar.getCookie` may return `undefined`
+{
+    const cookieJar = new CookieJar();
+    let cookie = cookieJar.getCookie("a", new CookieAccessInfo("test.com", "/"));
+    cookie = undefined;
+}
+// Test that `CookieJar.setCookies` returns a mutable array
+{
+    const cookieJar = new CookieJar();
+    const updatedCookies: cookiejarLib.Cookie[] = cookieJar.setCookies([]);
+}

--- a/types/cookiejar/index.d.ts
+++ b/types/cookiejar/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for CookieJar 2.1
 // Project: https://github.com/bmeck/node-cookiejar
-// Definitions by: Rafal Proszowski <https://github.com/paroxp>
+// Definitions by: Rafal Proszowski <https://github.com/paroxp>, Charles Samborski <https://github.com/demurgos>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -99,14 +99,14 @@ export class CookieJar {
      * @param requestDomain string argument is used to default the domain if it is not explicit in the cookie string
      * @param requestPath string argument is used to set the path if it is not explicit in a cookie String
      */
-    setCookies(cookie: string | ReadonlyArray<string>, requestDomain?: string, requestPath?: string): ReadonlyArray<Cookie> | false;
+    setCookies(cookie: string | ReadonlyArray<string>, requestDomain?: string, requestPath?: string): Cookie[];
 
     /**
      * get a cookie with the name and access_info matching
      * @param cookieName string to be parsed into a Cookie
      * @param accessInfo CookieAccessInfo
      */
-    getCookie(cookieName: string, accessInfo: CookieAccessInfo): Cookie;
+    getCookie(cookieName: string, accessInfo: CookieAccessInfo): Cookie | undefined;
 
     /**
      * grab all cookies matching this access_info


### PR DESCRIPTION
This commit adds the following two fixes:
- `CookieJar.getCookie` returns `undefined` when the cookie is not found. The return type is thus `Cookie | undefined` instead of only `Cookie`. This helps when strict null checks are enabled.
- `CookieJar.setCookies` never returns `false`, but a fresh array with the updated cookies. This result array is returned to the caller without any restrictions on its usage: it is safe to mutate the returned array. This is why the return type was updated from `ReadonlyArray<Cookie>` to `Cookie[]`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
      - https://github.com/bmeck/node-cookiejar/blob/fbed912b7c84211ebcb5fadea0ce0b423853b365/cookiejar.js#L211
      - https://github.com/bmeck/node-cookiejar/blob/fbed912b7c84211ebcb5fadea0ce0b423853b365/cookiejar.js#L258
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
