### PR TITLE
[ramda] composeWith composer args type fixed

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -359,8 +359,8 @@ export function composeP<V0, T1, T2, T3, T4, T5, T6>(fn5: (x: T5) => Promise<T6>
  * Performs right-to-left function composition using transforming function.
  * With the current typings, all functions must be unary.
  */
-export function composeWith<V0, T>(composer: (a: any) => any, fns: ComposeWithFns<V0, T>): (x0: V0) => T;
-export function composeWith(composer: (a: any) => any): <V0, T>(fns: ComposeWithFns<V0, T>) => (x: V0) => T;
+export function composeWith<V0, T>(composer: (...args: any[]) => any, fns: ComposeWithFns<V0, T>): (x0: V0) => T;
+export function composeWith(composer: (...args: any[]) => any): <V0, T>(fns: ComposeWithFns<V0, T>) => (x: V0) => T;
 
 /**
  * Returns the result of concatenating the given lists or strings.

--- a/types/ramda/test/composeWith-tests.ts
+++ b/types/ramda/test/composeWith-tests.ts
@@ -40,3 +40,9 @@ import * as R from 'ramda';
     nextThree,
   ]);
 };
+
+() => {
+  const composeWhileNotNil = R.composeWith((f, res) => R.isNil(res) ? res : f(res));
+
+  composeWhileNotNil([R.inc, R.prop('age')])({age: 1}); // => 2
+};


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://ramdajs.com/docs/#composeWith
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Example for composeWith function from ramda documentation didn't work, because of incorrect composer function argument types.

