### PR TITLE
Added types for ink-gradient package

### DIFF
--- a/types/ink-gradient/index.d.ts
+++ b/types/ink-gradient/index.d.ts
@@ -1,0 +1,40 @@
+// Type definitions for ink-gradient 2.0.0
+// Project: https://github.com/sindresorhus/ink-gradient
+// Definitions by: aaronleopold <https://github.com/aaronleopold>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as React from 'react';
+
+// This needs to be updated when TypeScript enhances their support for mutual
+// exclusivity in properties. While I am defining the props as being either one with
+// name OR one with colors, and the type reflects this on hover, it doesnt throw any lint errors
+// when I disobey this type contstraint.
+type PropsColor =
+    | {
+          name:
+              | 'cristal'
+              | 'teen'
+              | 'mind'
+              | 'morning'
+              | 'vice'
+              | 'passion'
+              | 'fruit'
+              | 'instagram'
+              | 'atlas'
+              | 'retro'
+              | 'summer'
+              | 'pastel'
+              | 'rainbow';
+      }
+    | {
+          colors: string[] | object[];
+      };
+
+// note, object[] in this case refers to objects interpretable by tinycolor2
+
+type GradientProps = {
+    children: React.ReactNode;
+} & PropsColor;
+
+declare const Gradient: React.FC<GradientProps>;
+export = Gradient;

--- a/types/ink-gradient/index.d.ts
+++ b/types/ink-gradient/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ink-gradient 2.0.0
+// Type definitions for ink-gradient 2.0
 // Project: https://github.com/sindresorhus/ink-gradient
 // Definitions by: aaronleopold <https://github.com/aaronleopold>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/ink-gradient/ink-gradient-tests.tsx
+++ b/types/ink-gradient/ink-gradient-tests.tsx
@@ -1,15 +1,13 @@
 import * as React from 'react';
-import { render } from 'react-dom';
 import * as Box from 'ink-box';
 import * as Gradient from 'ink-gradient';
 
-const node = document.getElementById('main');
-
-render(
-    <Gradient name="rainbow">
-        <Box borderStyle="round" borderColor="cyan" float="center" padding={1}>
-            I Love TypeScript!
-        </Box>
-    </Gradient>,
-    node,
-);
+function test() {
+    return (
+        <Gradient name="rainbow">
+            <Box borderStyle="round" borderColor="cyan" float="center" padding={1}>
+                I Love TypeScript!
+            </Box>
+        </Gradient>
+    );
+}

--- a/types/ink-gradient/ink-gradient-tests.tsx
+++ b/types/ink-gradient/ink-gradient-tests.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { render } from 'react-dom';
+import * as Box from 'ink-box';
+import * as Gradient from 'ink-gradient';
+
+const node = document.getElementById('main');
+
+render(
+    <Gradient name="rainbow">
+        <Box borderStyle="round" borderColor="cyan" float="center" padding={1}>
+            I Love TypeScript!
+        </Box>
+    </Gradient>,
+    node,
+);

--- a/types/ink-gradient/tsconfig.json
+++ b/types/ink-gradient/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "jsx": "react",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ink-gradient-tests.tsx"
+    ]
+}

--- a/types/ink-gradient/tsconfig.json
+++ b/types/ink-gradient/tsconfig.json
@@ -3,8 +3,7 @@
         "module": "commonjs",
         "jsx": "react",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/ink-gradient/tslint.json
+++ b/types/ink-gradient/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Hey everyone! I added types for the `Gradient` react component from the [ink-gradient](https://www.npmjs.com/package/ink-gradient) package! I hope people get some use out of this 😄 