### PR TITLE
async - Add missing types for concat functions which return Promise

### DIFF
--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -193,7 +193,9 @@ export const all: typeof every;
 export const allSeries: typeof every;
 export const allLimit: typeof everyLimit;
 
+export function concat<T, R, E = Error>(arr: IterableCollection<T>, iterator: AsyncResultIterator<T, R[], E>): Promise<R[]>;
 export function concat<T, R, E = Error>(arr: IterableCollection<T>, iterator: AsyncResultIterator<T, R[], E>, callback?: AsyncResultArrayCallback<R, E>): void;
+export function concatLimit<T, R, E = Error>(arr: IterableCollection<T>, limit: number, iterator: AsyncResultIterator<T, R[], E>): Promise<R[]>;
 export function concatLimit<T, R, E = Error>(arr: IterableCollection<T>, limit: number, iterator: AsyncResultIterator<T, R[], E>, callback?: AsyncResultArrayCallback<R, E>): void;
 export const concatSeries: typeof concat;
 

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -96,6 +96,9 @@ async.all(['file1', 'file2', 'file3'], funcStringCbErrBoolean, (err: Error, resu
 
 async.concat(['dir1', 'dir2', 'dir3'], fs.readdir, (err, files) => { });
 async.concatSeries(['dir1', 'dir2', 'dir3'], fs.readdir, (err, files) => { });
+const cp: Promise<Array<string|undefined>> = async.concat(['dir1', 'dir2', 'dir3'], fs.readdir);
+const csp: Promise<Array<string|undefined>> = async.concatSeries(['dir1', 'dir2', 'dir3'], fs.readdir);
+const clp: Promise<Array<string|undefined>> = async.concatLimit(['dir1', 'dir2', 'dir3'], 1, fs.readdir);
 
 // Control Flow //
 


### PR DESCRIPTION
concat and concatLimit return promises if no callback is provided

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://caolan.github.io/async/v3/docs.html#concat>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
