### PR TITLE
Support SQS arn as object

### DIFF
--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -373,7 +373,7 @@ declare namespace Aws {
     }
 
     interface Sqs {
-        arn: string;
+        arn: string | { [key: string]: any };
         batchSize?: number | string;
         maximumRetryAttempts?: number | string;
         enabled?: boolean;


### PR DESCRIPTION
SQS ARN can be specified as a string or as an object.

```
- sqs: arn:aws:sqs:us-east-1:xxxxx:queue
```
and 

```
- sqs:
     arn:
        Fn::GetAtt:
          - MyQueue
          - Arn
```
are valid settings.

This PR extends definition of the `Sqs` interface.


If changing an existing definition:
- 

- [x]  Provide a URL to documentation or source code which provides context for the suggested changes: [Documentation](https://www.serverless.com/framework/docs/providers/aws/events/sqs/)



