### PR TITLE
types for @rdfjs/serializer-rdfjs

### DIFF
--- a/types/rdfjs__serializer-rdfjs/index.d.ts
+++ b/types/rdfjs__serializer-rdfjs/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for @rdfjs/serializer-rdfjs 0.0
+// Project: https://github.com/rdfjs-base/serializer-rdfjs
+// Definitions by: tpluscode <https://github.com/tpluscode>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { EventEmitter } from 'events';
+import { Sink, Stream, BaseQuad, Quad } from 'rdf-js';
+
+declare namespace Serializer {
+    interface SerializerOptions {
+        module?: 'esm' | 'ts' | string;
+    }
+}
+
+declare class Serializer<Q extends BaseQuad = Quad> implements Sink<Stream<Q>, EventEmitter> {
+    constructor(options?: Serializer.SerializerOptions);
+
+    import(stream: Stream<Q>, options?: Serializer.SerializerOptions): EventEmitter;
+    transform(quads: Q[]): string;
+}
+
+export = Serializer;

--- a/types/rdfjs__serializer-rdfjs/index.d.ts
+++ b/types/rdfjs__serializer-rdfjs/index.d.ts
@@ -16,7 +16,7 @@ declare class Serializer<Q extends BaseQuad = Quad> implements Sink<Stream<Q>, E
     constructor(options?: Serializer.SerializerOptions);
 
     import(stream: Stream<Q>, options?: Serializer.SerializerOptions): EventEmitter;
-    transform(quads: Q[]): string;
+    transform(quads: Iterable<Q>): string;
 }
 
 export = Serializer;

--- a/types/rdfjs__serializer-rdfjs/rdfjs__serializer-rdfjs-tests.ts
+++ b/types/rdfjs__serializer-rdfjs/rdfjs__serializer-rdfjs-tests.ts
@@ -1,0 +1,25 @@
+import Serializer = require('@rdfjs/serializer-rdfjs');
+import { Quad, Stream } from 'rdf-js';
+import { EventEmitter } from 'events';
+
+const quads: Quad[] = <any> {};
+const quadStream: Stream = <any> {};
+
+const serializer = new Serializer();
+const serializer2 = new Serializer({});
+const serializerTypescript = new Serializer({
+    module: 'ts'
+});
+const serializerEsm = new Serializer({
+    module: 'esm'
+});
+const serializerAny = new Serializer({
+    module: 'custom'
+});
+
+const code: string = serializer.transform(quads);
+
+const stream: EventEmitter = serializer.import(quadStream);
+const typescriptStream: EventEmitter = serializer.import(quadStream, {
+    module: 'ts'
+});

--- a/types/rdfjs__serializer-rdfjs/rdfjs__serializer-rdfjs-tests.ts
+++ b/types/rdfjs__serializer-rdfjs/rdfjs__serializer-rdfjs-tests.ts
@@ -1,7 +1,8 @@
 import Serializer = require('@rdfjs/serializer-rdfjs');
-import { Quad, Stream } from 'rdf-js';
+import { Quad, Stream, DatasetCore } from 'rdf-js';
 import { EventEmitter } from 'events';
 
+const dataset: DatasetCore = <any> {};
 const quads: Quad[] = <any> {};
 const quadStream: Stream = <any> {};
 
@@ -18,6 +19,7 @@ const serializerAny = new Serializer({
 });
 
 const code: string = serializer.transform(quads);
+const codeFromDataset: string = serializer.transform(dataset);
 
 const stream: EventEmitter = serializer.import(quadStream);
 const typescriptStream: EventEmitter = serializer.import(quadStream, {

--- a/types/rdfjs__serializer-rdfjs/tsconfig.json
+++ b/types/rdfjs__serializer-rdfjs/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@rdfjs/*": [
+                "rdfjs__*"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "rdfjs__serializer-rdfjs-tests.ts"
+    ]
+}

--- a/types/rdfjs__serializer-rdfjs/tslint.json
+++ b/types/rdfjs__serializer-rdfjs/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.