### PR TITLE
[ramda] complement function argument types inferring

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -281,7 +281,7 @@ export function comparator<T>(pred: (a: T, b: T) => boolean): (x: T, y: T) => nu
  * - applying g to zero or more arguments will give false if applying the same arguments to f gives
  *   a logical true value.
  */
-export function complement(pred: (...args: readonly any[]) => boolean): (...args: readonly any[]) => boolean;
+export function complement<As extends any[]>(pred: (...args: As) => boolean): (...args: As) => boolean;
 
 /**
  * Performs right-to-left function composition. The rightmost function may have any arity; the remaining

--- a/types/ramda/test/complement-tests.ts
+++ b/types/ramda/test/complement-tests.ts
@@ -5,7 +5,21 @@ import * as R from 'ramda';
     return n % 2 === 0;
   }
 
+  // $ExpectType (n: number) => boolean
   const isOdd = R.complement(isEven);
   isOdd(21); // => true
   isOdd(42); // => false
+
+  function isLengthEqual(value: string, length: number): boolean {
+    return value.length === length;
+  }
+
+  const isLengthNotEqual = R.complement(isLengthEqual);
+
+  // $ExpectError
+  isLengthNotEqual("FOO", "BAR");
+  isLengthNotEqual("BAZ", 4); // => true
+
+  // $ExpectType (value: any) => boolean
+  R.complement(R.isNil);
 };


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://ramdajs.com/docs/#complement
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
