### PR TITLE
update(terser-webpack-plugin): v5 updates

### DIFF
--- a/types/terser-webpack-plugin/index.d.ts
+++ b/types/terser-webpack-plugin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for terser-webpack-plugin 4.2
+// Type definitions for terser-webpack-plugin 5.0
 // Project: https://github.com/webpack-contrib/terser-webpack-plugin
 // Definitions by: Daniel Schopf <https://github.com/Danscho>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
@@ -56,32 +56,11 @@ declare namespace TerserPlugin {
         exclude?: string | RegExp | Array<string | RegExp>;
 
         /**
-         * ⚠ Ignored in webpack 5! Please use {@link webpack.js.org/configuration/other-options/#cache.}
-         * Enable/disable file caching.
-         * Default path to cache directory: `node_modules/.cache/terser-webpack-plugin`.
-         * @default true
-         */
-        cache?: boolean | string;
-
-        /**
-         * ⚠ Ignored in webpack 5! Please use {@link webpack.js.org/configuration/other-options/#cache}.
-         * Allows you to override default cache keys.
-         */
-        cacheKeys?: (defaultCacheKeys: any, file: any) => object;
-
-        /**
          * Enable/disable multi-process parallel running.
          * Use multi-process parallel running to improve the build speed. Default number of concurrent runs: os.cpus().length - 1.
          * @default true
          */
         parallel?: boolean | number;
-
-        /**
-         * Use source maps to map error message locations to modules (this slows down the compilation).
-         * If you use your own minify function please read the minify section for handling source maps correctly.
-         * @default false
-         */
-        sourceMap?: boolean;
 
         /**
          * Allows you to override default minify function.

--- a/types/terser-webpack-plugin/package.json
+++ b/types/terser-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "terser": "^4.6.13"
+    "terser": "^5.3.5"
   }
 }

--- a/types/terser-webpack-plugin/terser-webpack-plugin-tests.ts
+++ b/types/terser-webpack-plugin/terser-webpack-plugin-tests.ts
@@ -19,31 +19,12 @@ const _ = webpack({
             new TerserPlugin({
                 exclude: /\/excludes/,
             }),
-            // cache
-            new TerserPlugin({
-                cache: true,
-            }),
-            new TerserPlugin({
-                cache: 'path/to/cache',
-            }),
-            // cacheKeys
-            new TerserPlugin({
-                cache: true,
-                cacheKeys: (defaultCacheKeys, file) => {
-                    defaultCacheKeys.myCacheKey = 'myCacheKeyValue';
-                    return defaultCacheKeys;
-                },
-            }),
             // parallel
             new TerserPlugin({
                 parallel: true,
             }),
             new TerserPlugin({
                 parallel: 4,
-            }),
-            // sourceMap
-            new TerserPlugin({
-                sourceMap: true,
             }),
             // minify
             new TerserPlugin({
@@ -61,7 +42,6 @@ const _ = webpack({
             new TerserPlugin({
                 terserOptions: {
                     ecma: undefined,
-                    warnings: false,
                     parse: {},
                     compress: {},
                     mangle: true, // Note `mangle.properties` is `false` by default.
@@ -130,20 +110,20 @@ const _ = webpack({
             }),
             new TerserPlugin({
                 terserOptions: {
-                  ecma: undefined,
-                  parse: {},
-                  compress: {},
-                  mangle: true, // Note `mangle.properties` is `false` by default.
-                  module: false,
-                  output: undefined,
-                  toplevel: false,
-                  nameCache: undefined,
-                  ie8: false,
-                  keep_classnames: undefined,
-                  keep_fnames: false,
-                  safari10: false,
+                    ecma: undefined,
+                    parse: {},
+                    compress: {},
+                    mangle: true, // Note `mangle.properties` is `false` by default.
+                    module: false,
+                    output: undefined,
+                    toplevel: false,
+                    nameCache: undefined,
+                    ie8: false,
+                    keep_classnames: undefined,
+                    keep_fnames: false,
+                    safari10: false,
                 },
-              }),
+            }),
         ],
     },
 });


### PR DESCRIPTION
- `cache` option removed
- `cacheKeys` option removed
- `sourceMaps` option removed
- `terser` dependency bump
- minor fix in tests (unsupported option)
- minor formatting clenaup

https://github.com/webpack-contrib/terser-webpack-plugin/compare/v4.2.3...v5.0.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)