### PR TITLE
chore(papaparse): add missing escapeFormulae unparse option

### DIFF
--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -9,6 +9,7 @@
 //                 Janne Liuhtonen <https://github.com/jliuhtonen>
 //                 Raphaël Barbazza <https://github.com/rbarbazz>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+//                 Emmanuel Gautier <https://github.com/emmanuelgautier>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -126,6 +127,7 @@ export interface UnparseConfig {
     quotes?: boolean | boolean[] | ((value: any) => boolean); // default: false
     quoteChar?: string; // default: '"'
     escapeChar?: string; // default: '"'
+    escapeFormulae?: boolean; // default: false
     delimiter?: string; // default: ","
     /**
      * If defined and the download property is true,

--- a/types/papaparse/papaparse-tests.ts
+++ b/types/papaparse/papaparse-tests.ts
@@ -107,8 +107,10 @@ Papa.unparse({
     data: [],
 });
 
+Papa.unparse([{ a: 1, b: 1, c: 1 }], {});
 Papa.unparse([{ a: 1, b: 1, c: 1 }], { quotes: false });
 Papa.unparse([{ a: 1, b: 1, c: 1 }], { quotes: [false, true, true] });
+Papa.unparse([{ a: 1, b: 1, c: 1 }], { escapeFormulae: false });
 Papa.unparse(
     [
         [1, 2, 3],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mholt/PapaParse/commit/6f997ef4fb6d34b38f8eb9aa97b120b954446a9a
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.