### PR TITLE
Add autoCurveness from echarts 4.9.0

### DIFF
--- a/types/echarts/echarts-tests.ts
+++ b/types/echarts/echarts-tests.ts
@@ -17,3 +17,11 @@ const testChartTitlePadding = (options: echarts.EChartTitleOption) => {
 
 // id, type, and name are defined for every series type
 const map = option.series!.map(s => [s.id, s.name, s.type]);
+
+const seriesGraph: echarts.EChartOption.SeriesGraph = { };
+// $ExpectType number | number[] | undefined
+seriesGraph.autoCurveness;
+seriesGraph.autoCurveness = 10;
+seriesGraph.autoCurveness = [1, 2, 3, 4];
+// $ExpectError
+seriesGraph.autoCurveness = 'error';

--- a/types/echarts/index.d.ts
+++ b/types/echarts/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ECharts 4.8.0
+// Type definitions for ECharts 4.9.0
 // Project: http://echarts.apache.org
 // Definitions by: Xie Jingyang <https://github.com/xieisabug>
 //                 AntiMoron <https://github.com/AntiMoron>

--- a/types/echarts/options/series/graph.d.ts
+++ b/types/echarts/options/series/graph.d.ts
@@ -3924,6 +3924,19 @@ declare namespace echarts {
             categories?: SeriesGraph.CategoryObject[];
 
             /**
+             * For the situation where there are multiple links between nodes, the curveness of each link is automatically calculated.
+             * When set to number, it indicates the length of the edge curvenness array between two nodes, and the calculation result is given by the internal algorithm.
+             * When set to Array, it means that the curveness array is directly specified, and the multilateral curveness is directly selected from the array.
+             * Notice： if lineStyle.curveness has been set, this property is invalid.
+             *
+             * [see doc](https://echarts.apache.org/en/option.html#series-graph.autoCurveness)
+             *
+             *
+             * @see https://echarts.apache.org/en/option.html#series-graph.autoCurveness
+             */
+            autoCurveness?: number | number[];
+
+            /**
              * Nodes list of graph.
              *
              * [see doc](https://echarts.apache.org/en/option.html#series-graph.graph)


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [echarts 4.9.0](https://github.com/apache/incubator-echarts/releases/tag/4.9.0) by [#12590](https://github.com/apache/incubator-echarts/pull/12590)

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
**It brings this specific typedef in line with version 4.9.0, other definitions will have to be checked and added. So I haven't updated the version number**
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
