### PR TITLE
fix(stripe-v3): add optional on routing_number of bank account creation options

### DIFF
--- a/types/react-stripe-elements/react-stripe-elements-tests.tsx
+++ b/types/react-stripe-elements/react-stripe-elements-tests.tsx
@@ -186,7 +186,7 @@ class WrappedComponent extends React.Component<ComponentProps & InjectedStripePr
                 routing_number: '',
                 account_number: '',
                 account_holder_name: '',
-                account_holder_type: '',
+                account_holder_type: 'individual',
             })
             .then((response: TokenResponse) => this.props.tokenCallback(response));
     }

--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -159,12 +159,30 @@ declare namespace stripe {
     }
 
     interface BankAccountTokenOptions {
+        /**
+         * Two character country code (e.g., US).
+         */
         country: string;
+        /**
+         * Three character currency code (e.g., usd).
+         */
         currency: string;
-        routing_number: string;
+        /**
+         * The bank routing number (e.g., 111000025). Optional if the currency is eur, as the account number is an IBAN.
+         */
+        routing_number?: string;
+        /**
+         * The bank account number (e.g., 000123456789).
+         */
         account_number: string;
+        /**
+         * The name of the account holder.
+         */
         account_holder_name: string;
-        account_holder_type: string;
+        /**
+         * The type of entity that holds the account. Can be either individual or company.
+         */
+        account_holder_type: 'individual' | 'company';
     }
 
     interface PiiTokenOptions {

--- a/types/stripe-v3/stripe-v3-tests.ts
+++ b/types/stripe-v3/stripe-v3-tests.ts
@@ -162,13 +162,10 @@ describe("Stripe elements", () => {
             account_number: '110000000',
             account_holder_name: 'Jane Austen',
             account_holder_type: 'individual',
-        })
-            .then((result: stripe.TokenResponse) => {
-                console.log(result.token);
-            },
-                (error: stripe.Error) => {
-                    console.error(error);
-                });
+        }).then(
+            (result: stripe.TokenResponse) => console.log(result.token),
+            (error: stripe.Error) => console.error(error)
+        );
 
         stripe.createToken('bank_account', {
             country: 'US',
@@ -177,13 +174,23 @@ describe("Stripe elements", () => {
             account_number: '110000000',
             account_holder_name: 'Jane Austen',
             account_holder_type: 'individual',
-        })
-            .then((result: stripe.TokenResponse) => {
-                console.log(result.token);
-            },
-                (error: stripe.Error) => {
-                    console.error(error);
-                });
+        }).then(
+            (result: stripe.TokenResponse) => console.log(result.token),
+            (error: stripe.Error) => console.error(error)
+        );
+    });
+
+    it("should create a token from IBAN with routing_number not set", () => {
+        stripe.createToken('bank_account', {
+            country: 'FR',
+            currency: 'eur',
+            account_number: 'FR1420041010050500013M02606',
+            account_holder_name: 'Jean Martin',
+            account_holder_type: 'individual',
+        }).then(
+            (result: stripe.TokenResponse) => console.log(result.token),
+            (error: stripe.Error) => console.error(error)
+        );
     });
 
     it("should create an idealBank element", () => {


### PR DESCRIPTION
Add optional on property `routing_number` of bank account creation according to the doc https://stripe.com/docs/js/tokens_sources/create_token?type=bank_account.

This is especially useful because if you have no `routing_number` (for European IBAN for example), and still try to pass an empty string, the sdk failed:

> Error: You passed an empty string for 'bank_account[routing_number]'.
> We assume empty values are an attempt to unset a parameter; however 'bank_account[routing_number]' cannot be unset.
> You should remove 'bank_account[routing_number]' from your request or supply a non-empty value.

 So you need to do something like that to make the compilation works:

```
 routing_number: undefined as unknown as string,
```

Also:
 - copy/paste documentation from official Stripe doc
 - add string union on `account_holder_type`. This implies changing one test in `@types/react-stripe-elements`, I hope it's ok.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] URL of the documentation https://stripe.com/docs/js/tokens_sources/create_token?type=bank_account


