### PR TITLE
Keep vue dependents on Vue 2

### DIFF
--- a/types/chenfengyuan__vue-qrcode/package.json
+++ b/types/chenfengyuan__vue-qrcode/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "vue": ">=2.0.0"
+    "vue": "^2.0.0"
   }
 }

--- a/types/fullcalendar__vue/package.json
+++ b/types/fullcalendar__vue/package.json
@@ -1,6 +1,6 @@
 {
-    "private": true,
-    "dependencies": {
-        "vue": ">=2.0.0"
-    }
+  "private": true,
+  "dependencies": {
+    "vue": "^2.0.0"
+  }
 }

--- a/types/splitpanes/package.json
+++ b/types/splitpanes/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "vue": ">=2.0.0"
+    "vue": "^2.0.0"
   }
 }

--- a/types/v-chart-plugin/package.json
+++ b/types/v-chart-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "vue": ">=2.0.0"
+    "vue": "^2.0.0"
   }
 }

--- a/types/vue-chartkick/package.json
+++ b/types/vue-chartkick/package.json
@@ -1,6 +1,6 @@
 {
-    "private": true,
-    "dependencies": {
-        "vue": ">=2.0.0"
-    }
+  "private": true,
+  "dependencies": {
+    "vue": "^2.0.0"
+  }
 }

--- a/types/vue-color/package.json
+++ b/types/vue-color/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "vue": ">=2.0.0"
+    "vue": "^2.0.0"
   }
 }

--- a/types/vue-cropperjs/package.json
+++ b/types/vue-cropperjs/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "vue": ">=2.0.0"
+    "vue": "^2.0.0"
   }
 }

--- a/types/vue-datetime/package.json
+++ b/types/vue-datetime/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "vue": ">=2.0.0"
+    "vue": "^2.0.0"
   }
 }

--- a/types/vue-feather-icons/package.json
+++ b/types/vue-feather-icons/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "vue": ">=2.0.0"
+    "vue": "^2.0.0"
   }
 }

--- a/types/vue-ls/package.json
+++ b/types/vue-ls/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "vue": ">=2.0.0"
+    "vue": "^2.0.0"
   }
 }

--- a/types/vue-moment/package.json
+++ b/types/vue-moment/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "vue": ">=2.6.10",
+    "vue": "^2.6.10",
     "moment": ">=2.24.0"
   }
 }

--- a/types/vue-select/package.json
+++ b/types/vue-select/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "vue": ">=2.0.0"
+    "vue": "^2.0.0"
   }
 }

--- a/types/vue-splitpane/package.json
+++ b/types/vue-splitpane/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "vue": ">=2.0.0"
+    "vue": "^2.0.0"
   }
 }

--- a/types/vue-tel-input/package.json
+++ b/types/vue-tel-input/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "vue": ">=2.0.0"
+    "vue": "^2.0.0"
   }
 }

--- a/types/vue-the-mask/package.json
+++ b/types/vue-the-mask/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "vue": ">=2.6.10"
+    "vue": "^2.6.10"
   }
 }

--- a/types/vue2-editor/package.json
+++ b/types/vue2-editor/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "vue": ">=2.0.0"
+    "vue": "^2.0.0"
   }
 }

--- a/types/vue2-hammer/package.json
+++ b/types/vue2-hammer/package.json
@@ -1,6 +1,6 @@
 {
-    "private": true,
-    "dependencies": {
-        "vue": ">=2.0.0"
-    }
+  "private": true,
+  "dependencies": {
+    "vue": "^2.0.0"
+  }
 }

--- a/types/vuedraggable/package.json
+++ b/types/vuedraggable/package.json
@@ -1,6 +1,6 @@
 {
-    "private": true,
-    "dependencies": {
-        "vue": ">=2.0.0"
-    }
+  "private": true,
+  "dependencies": {
+    "vue": "^2.0.0"
+  }
 }


### PR DESCRIPTION
Vue 3 requires the compile target to be es2020 in order to access Symbol.matchAll and Symbol.asyncIterator. I guess this is not appropriate for
packages that probably don't intend to support Vue 3 anyway.

I'm not an expert on Vue, so please let me know if there's a different way to fix this.