### PR TITLE
[enzyme-react-intl] Add exports for getIntl and loadTranslationObject

### DIFF
--- a/types/enzyme-react-intl/enzyme-react-intl-tests.tsx
+++ b/types/enzyme-react-intl/enzyme-react-intl-tests.tsx
@@ -99,4 +99,13 @@ function shallowWithIntlTests() {
   stateComponentWrapper.state().constructed; // $ExpectType boolean
 }
 
+function getIntlTests() {
+  intl.getIntl(); // $ExpectType IntlProvider
+}
+
+function loadTranslationObjectTests() {
+  intl.loadTranslationObject({ A: 'aaaa', C: 'cccc' }).A; // $ExpectType string
+  intl.loadTranslationObject({ C: 'cccc', B: 'bbbb' }).B; // $ExpectType string
+}
+
 intl.setLocale('pl');

--- a/types/enzyme-react-intl/index.d.ts
+++ b/types/enzyme-react-intl/index.d.ts
@@ -2,9 +2,10 @@
 // Project: https://github.com/joetidee/enzyme-react-intl#readme
 // Definitions by: Mateusz Meller <https://github.com/mateusz-meller>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 3.5
 
 import { Component, ReactElement } from 'react';
+import { IntlProvider } from 'react-intl';
 import { ShallowRendererProps, MountRendererProps, ShallowWrapper, ReactWrapper } from 'enzyme';
 
 // shallow methods
@@ -34,6 +35,8 @@ export function renderWithIntl<P, S>(node: ReactElement<P>, options?: any): chee
 
 // other methods
 
+export function getIntl(): IntlProvider;
 export function getLocale(): string;
 export function setLocale(locale: string): void;
 export function loadTranslation(translationFilePath: string): any;
+export function loadTranslationObject<T extends { [key: string]: string }>(translations: T): T;

--- a/types/enzyme-react-intl/package.json
+++ b/types/enzyme-react-intl/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "react-intl": "^3"
+    }
+}


### PR DESCRIPTION
This commit adds types for exported functions missing from enzyme-react-intl.
Other changes:
- Add a dependency on `react-intl@3` (react-intl types moved out of DefinitelyTyped with v3)
- Bump typescript version to 3.5 (react-intl@3 depends on `Omit` which was added in TS 3.5)

PR template:
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/joetidee/enzyme-react-intl/blob/master/src/index.js#L92-L101
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.