### PR TITLE
[node] v14.14.0 released

### DIFF
--- a/types/mz/fs.d.ts
+++ b/types/mz/fs.d.ts
@@ -6,7 +6,7 @@ import {
     FSWatcher,
     NoParamCallback,
     PathLike,
-    RmDirAsyncOptions,
+    RmDirOptions,
     WriteFileOptions,
     Stats,
     symlink as symlinkNS,
@@ -574,7 +574,7 @@ export function rmdir(path: PathLike, callback: NoParamCallback): void;
  *
  * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
  */
-export function rmdir(path: PathLike, options: RmDirAsyncOptions, callback: NoParamCallback): void;
+export function rmdir(path: PathLike, options: RmDirOptions, callback: NoParamCallback): void;
 
 /**
  * Asynchronous `rmdir(2)`
@@ -583,7 +583,7 @@ export function rmdir(path: PathLike, options: RmDirAsyncOptions, callback: NoPa
  *
  * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
  */
-export function rmdir(path: PathLike, options?: RmDirAsyncOptions): Promise<void>;
+export function rmdir(path: PathLike, options?: RmDirOptions): Promise<void>;
 
 /**
  * Asynchronous `mkdir(2)`.

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -821,22 +821,62 @@ declare module "fs" {
 
     export interface RmDirOptions {
         /**
+         * If an `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, or
+         * `EPERM` error is encountered, Node.js will retry the operation with a linear
+         * backoff wait of `retryDelay` ms longer on each try. This option represents the
+         * number of retries. This option is ignored if the `recursive` option is not
+         * `true`.
+         * @default 0
+         */
+        maxRetries?: number;
+        /**
+         * @deprecated since v14.14.0 In future versions of Node.js,
+         * `fs.rmdir(path, { recursive: true })` will throw on nonexistent
+         * paths, or when given a file as a target.
+         * Use `fs.rm(path, { recursive: true, force: true })` instead.
+         *
          * If `true`, perform a recursive directory removal. In
          * recursive mode, errors are not reported if `path` does not exist, and
          * operations are retried on failure.
-         * @experimental
          * @default false
          */
         recursive?: boolean;
-    }
-
-    export interface RmDirAsyncOptions extends RmDirOptions {
         /**
          * The amount of time in milliseconds to wait between retries.
          * This option is ignored if the `recursive` option is not `true`.
          * @default 100
          */
         retryDelay?: number;
+    }
+
+    /**
+     * Asynchronous rmdir(2) - delete a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     */
+    export function rmdir(path: PathLike, callback: NoParamCallback): void;
+    export function rmdir(path: PathLike, options: RmDirOptions, callback: NoParamCallback): void;
+
+    // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+    export namespace rmdir {
+        /**
+         * Asynchronous rmdir(2) - delete a directory.
+         * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+         */
+        function __promisify__(path: PathLike, options?: RmDirOptions): Promise<void>;
+    }
+
+    /**
+     * Synchronous rmdir(2) - delete a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     */
+    export function rmdirSync(path: PathLike, options?: RmDirOptions): void;
+
+    export interface RmOptions {
+        /**
+         * When `true`, exceptions will be ignored if `path` does not exist.
+         * @default false
+         */
+        force?: boolean;
         /**
          * If an `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, or
          * `EPERM` error is encountered, Node.js will retry the operation with a linear
@@ -846,29 +886,39 @@ declare module "fs" {
          * @default 0
          */
         maxRetries?: number;
+        /**
+         * If `true`, perform a recursive directory removal. In
+         * recursive mode, errors are not reported if `path` does not exist, and
+         * operations are retried on failure.
+         * @default false
+         */
+        recursive?: boolean;
+        /**
+         * The amount of time in milliseconds to wait between retries.
+         * This option is ignored if the `recursive` option is not `true`.
+         * @default 100
+         */
+        retryDelay?: number;
     }
 
     /**
-     * Asynchronous rmdir(2) - delete a directory.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * Asynchronously removes files and directories (modeled on the standard POSIX `rm` utility).
      */
-    export function rmdir(path: PathLike, callback: NoParamCallback): void;
-    export function rmdir(path: PathLike, options: RmDirAsyncOptions, callback: NoParamCallback): void;
+    export function rm(path: PathLike, callback: NoParamCallback): void;
+    export function rm(path: PathLike, options: RmOptions, callback: NoParamCallback): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace rmdir {
+    export namespace rm {
         /**
-         * Asynchronous rmdir(2) - delete a directory.
-         * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+         * Asynchronously removes files and directories (modeled on the standard POSIX `rm` utility).
          */
-        function __promisify__(path: PathLike, options?: RmDirAsyncOptions): Promise<void>;
+        function __promisify__(path: PathLike, options?: RmOptions): Promise<void>;
     }
 
     /**
-     * Synchronous rmdir(2) - delete a directory.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * Synchronously removes files and directories (modeled on the standard POSIX `rm` utility).
      */
-    export function rmdirSync(path: PathLike, options?: RmDirOptions): void;
+    export function rmSync(path: PathLike, options?: RmOptions): void;
 
     export interface MakeDirectoryOptions {
         /**

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -4,7 +4,8 @@ declare module 'fs/promises' {
         WriteVResult,
         ReadVResult,
         PathLike,
-        RmDirAsyncOptions,
+        RmDirOptions,
+        RmOptions,
         MakeDirectoryOptions,
         Dirent,
         OpenDirOptions,
@@ -255,7 +256,12 @@ declare module 'fs/promises' {
      * Asynchronous rmdir(2) - delete a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function rmdir(path: PathLike, options?: RmDirAsyncOptions): Promise<void>;
+    function rmdir(path: PathLike, options?: RmDirOptions): Promise<void>;
+
+    /**
+     * Asynchronously removes files and directories (modeled on the standard POSIX `rm` utility).
+     */
+    function rm(path: PathLike, options?: RmOptions): Promise<void>;
 
     /**
      * Asynchronous fdatasync(2) - synchronize a file's in-core state with storage device.

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -65,7 +65,9 @@ declare module "http" {
     }
 
     // outgoing headers allows numbers (as they are converted internally to strings)
-    interface OutgoingHttpHeaders extends NodeJS.Dict<number | string | string[]> {
+    type OutgoingHttpHeader = number | string | string[];
+
+    interface OutgoingHttpHeaders extends NodeJS.Dict<OutgoingHttpHeader> {
     }
 
     interface ClientRequestArgs {
@@ -188,8 +190,8 @@ declare module "http" {
         // https://github.com/nodejs/node/blob/master/test/parallel/test-http-write-callbacks.js#L53
         // no args in writeContinue callback
         writeContinue(callback?: () => void): void;
-        writeHead(statusCode: number, reasonPhrase?: string, headers?: OutgoingHttpHeaders): this;
-        writeHead(statusCode: number, headers?: OutgoingHttpHeaders): this;
+        writeHead(statusCode: number, reasonPhrase?: string, headers?: OutgoingHttpHeaders | OutgoingHttpHeader[]): this;
+        writeHead(statusCode: number, headers?: OutgoingHttpHeaders | OutgoingHttpHeader[]): this;
         writeProcessing(): void;
     }
 

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Node.js 14.11
+// Type definitions for non-npm package Node.js 14.14
 // Project: http://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -316,6 +316,11 @@ async function testPromisify() {
         await fs.promises.rmdir('some/test/path');
         await fs.promises.rmdir('some/test/path', { recursive: true, maxRetries: 123, retryDelay: 123 });
     } catch (e) {}
+
+    try {
+        await fs.promises.rmdir('some/test/file');
+        await fs.promises.rmdir('some/test/file', { recursive: true, maxRetries: 123, retryDelay: 123 });
+    } catch (e) {}
 })();
 
 {

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -71,6 +71,7 @@ import * as net from 'net';
     // writeHead
     res.writeHead(200, 'OK\r\nContent-Type: text/html\r\n').end();
     res.writeHead(200, { 'Transfer-Encoding': 'chunked' });
+    res.writeHead(200, ['Transfer-Encoding', 'chunked']);
     res.writeHead(200);
 
     // writeProcessing

--- a/types/node/v12/fs.d.ts
+++ b/types/node/v12/fs.d.ts
@@ -740,6 +740,14 @@ declare module "fs" {
 
     interface RmDirOptions {
         /**
+         * If an `EBUSY`, `ENOTEMPTY`, or `EPERM` error is
+         * encountered, Node.js will retry the operation with a linear backoff wait of
+         * 100ms longer on each try. This option represents the number of retries. This
+         * option is ignored if the `recursive` option is not `true`.
+         * @default 3
+         */
+        maxRetries?: number;
+        /**
          * If `true`, perform a recursive directory removal. In
          * recursive mode, errors are not reported if `path` does not exist, and
          * operations are retried on failure.
@@ -747,9 +755,6 @@ declare module "fs" {
          * @default false
          */
         recursive?: boolean;
-    }
-
-    interface RmDirAsyncOptions extends RmDirOptions {
         /**
          * If an `EMFILE` error is encountered, Node.js will
          * retry the operation with a linear backoff of 1ms longer on each try until the
@@ -758,14 +763,6 @@ declare module "fs" {
          * @default 1000
          */
         emfileWait?: number;
-        /**
-         * If an `EBUSY`, `ENOTEMPTY`, or `EPERM` error is
-         * encountered, Node.js will retry the operation with a linear backoff wait of
-         * 100ms longer on each try. This option represents the number of retries. This
-         * option is ignored if the `recursive` option is not `true`.
-         * @default 3
-         */
-        maxBusyTries?: number;
     }
 
     /**
@@ -773,7 +770,7 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
     function rmdir(path: PathLike, callback: NoParamCallback): void;
-    function rmdir(path: PathLike, options: RmDirAsyncOptions, callback: NoParamCallback): void;
+    function rmdir(path: PathLike, options: RmDirOptions, callback: NoParamCallback): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     namespace rmdir {
@@ -781,7 +778,7 @@ declare module "fs" {
          * Asynchronous rmdir(2) - delete a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function __promisify__(path: PathLike, options?: RmDirAsyncOptions): Promise<void>;
+        function __promisify__(path: PathLike, options?: RmDirOptions): Promise<void>;
     }
 
     /**
@@ -2189,7 +2186,7 @@ declare module "fs" {
          * Asynchronous rmdir(2) - delete a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function rmdir(path: PathLike, options?: RmDirAsyncOptions): Promise<void>;
+        function rmdir(path: PathLike, options?: RmDirOptions): Promise<void>;
 
         /**
          * Asynchronous fdatasync(2) - synchronize a file's in-core state with storage device.

--- a/types/node/v13/fs.d.ts
+++ b/types/node/v13/fs.d.ts
@@ -809,23 +809,6 @@ declare module "fs" {
 
     interface RmDirOptions {
         /**
-         * If `true`, perform a recursive directory removal. In
-         * recursive mode, errors are not reported if `path` does not exist, and
-         * operations are retried on failure.
-         * @experimental
-         * @default false
-         */
-        recursive?: boolean;
-    }
-
-    interface RmDirAsyncOptions extends RmDirOptions {
-        /**
-         * The amount of time in milliseconds to wait between retries.
-         * This option is ignored if the `recursive` option is not `true`.
-         * @default 100
-         */
-        retryDelay?: number;
-        /**
          * If an `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, or
          * `EPERM` error is encountered, Node.js will retry the operation with a linear
          * backoff wait of `retryDelay` ms longer on each try. This option represents the
@@ -834,6 +817,20 @@ declare module "fs" {
          * @default 0
          */
         maxRetries?: number;
+        /**
+         * If `true`, perform a recursive directory removal. In
+         * recursive mode, errors are not reported if `path` does not exist, and
+         * operations are retried on failure.
+         * @experimental
+         * @default false
+         */
+        recursive?: boolean;
+        /**
+         * The amount of time in milliseconds to wait between retries.
+         * This option is ignored if the `recursive` option is not `true`.
+         * @default 100
+         */
+        retryDelay?: number;
     }
 
     /**
@@ -841,7 +838,7 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
     function rmdir(path: PathLike, callback: NoParamCallback): void;
-    function rmdir(path: PathLike, options: RmDirAsyncOptions, callback: NoParamCallback): void;
+    function rmdir(path: PathLike, options: RmDirOptions, callback: NoParamCallback): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     namespace rmdir {
@@ -849,7 +846,7 @@ declare module "fs" {
          * Asynchronous rmdir(2) - delete a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function __promisify__(path: PathLike, options?: RmDirAsyncOptions): Promise<void>;
+        function __promisify__(path: PathLike, options?: RmDirOptions): Promise<void>;
     }
 
     /**
@@ -2365,7 +2362,7 @@ declare module "fs" {
          * Asynchronous rmdir(2) - delete a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function rmdir(path: PathLike, options?: RmDirAsyncOptions): Promise<void>;
+        function rmdir(path: PathLike, options?: RmDirOptions): Promise<void>;
 
         /**
          * Asynchronous fdatasync(2) - synchronize a file's in-core state with storage device.

--- a/types/promise-fs/index.d.ts
+++ b/types/promise-fs/index.d.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="node" />
 
-import { PathLike, WriteFileOptions, RmDirAsyncOptions, MakeDirectoryOptions, Dirent, Stats } from "fs";
+import { PathLike, WriteFileOptions, RmDirOptions, MakeDirectoryOptions, Dirent, Stats } from "fs";
 
 export * from "fs";
 
@@ -138,7 +138,7 @@ export function rename(oldPath: PathLike, newPath: PathLike): Promise<void>;
  * Asynchronous rmdir(2) - delete a directory.
  * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
  */
-export function rmdir(path: PathLike, options?: RmDirAsyncOptions): Promise<void>;
+export function rmdir(path: PathLike, options?: RmDirOptions): Promise<void>;
 
 /**
  * Asynchronous mkdir(2) - create a directory.


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v14.14.0
Release changes:
- fs: add rm method ([doc](https://nodejs.org/docs/latest/api/fs.html#fs_fs_rm_path_options_callback))
- http: allow passing array of key/val into writeHead ([doc](https://nodejs.org/docs/latest/api/http.html#http_response_writehead_statuscode_statusmessage_headers))
- DEP0147: fs.rmdir(path, { recursive: true })

Additional changes:
- fs: `rmdir` and `rmdirSync` have the same options
- fs: `maxBusyTries` option was renamed to `maxRetries` in v12.16.0
