### PR TITLE
fix(@babel/core): correct type for `pre`/`post`

### DIFF
--- a/types/babel__core/babel__core-tests.ts
+++ b/types/babel__core/babel__core-tests.ts
@@ -1,4 +1,5 @@
 import * as babel from '@babel/core';
+import * as t from '@babel/types';
 
 const options: babel.TransformOptions = {
     ast: true,
@@ -134,3 +135,12 @@ if (partialConfig) {
 function withPluginPass(state: babel.PluginPass) {
     state.file.hub.addHelper('something');
 }
+
+const plugin: babel.PluginObj = {
+    pre({ path }) {
+        visitBlock(path);
+
+        function visitBlock(block: babel.NodePath<t.Program>) {}
+    },
+    visitor: {},
+};

--- a/types/babel__core/index.d.ts
+++ b/types/babel__core/index.d.ts
@@ -434,7 +434,7 @@ export interface BabelFile {
     opts: TransformOptions;
     hub: Hub;
     metadata: object;
-    path: NodePath<Program>;
+    path: NodePath<t.Program>;
     scope: Scope;
     inputMap: object | null;
     code: string;

--- a/types/babel__core/index.d.ts
+++ b/types/babel__core/index.d.ts
@@ -423,9 +423,9 @@ export function transformFromAstAsync(
 export interface PluginObj<S = PluginPass> {
     name?: string;
     manipulateOptions?(opts: any, parserOpts: any): void;
-    pre?(this: S, state: S): void;
+    pre?(this: S, file: BabelFile): void;
     visitor: Visitor<S>;
-    post?(this: S, state: S): void;
+    post?(this: S, file: BabelFile): void;
     inherits?: any;
 }
 

--- a/types/babel__core/index.d.ts
+++ b/types/babel__core/index.d.ts
@@ -434,7 +434,7 @@ export interface BabelFile {
     opts: TransformOptions;
     hub: Hub;
     metadata: object;
-    path: NodePath;
+    path: NodePath<Program>;
     scope: Scope;
     inputMap: object | null;
     code: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44515#discussion_r467392625
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.