### PR TITLE
Add missing index argument to SeamlessImmutable array filter

### DIFF
--- a/types/seamless-immutable/index.d.ts
+++ b/types/seamless-immutable/index.d.ts
@@ -109,7 +109,7 @@ declare namespace SeamlessImmutable {
         interface Overrides<T> {
             forEach(callbackfn: (value: Immutable<T>, index: number, array: Immutable<T[]>) => void, thisArg?: any): void;
             map<TTarget>(mapFuction: (item: Immutable<T>, index: number, array: Immutable<T[]>) => TTarget): Immutable<TTarget[]>;
-            filter(filterFunction: (item: Immutable<T>) => boolean): Immutable<T[]>;
+            filter(filterFunction: (item: Immutable<T>, index: number) => boolean): Immutable<T[]>;
             slice(start?: number, end?: number): Immutable<T[]>;
             concat(...arr: Array<T|T[]|Immutable<T>|Array<Immutable<T>>|Immutable<T[]>>): Immutable<T[]>;
             reduce(callbackfn: (previousValue: Immutable<T>, currentValue: Immutable<T>, currentIndex: number, array: Immutable<T[]>) => T): Immutable<T>;

--- a/types/seamless-immutable/seamless-immutable-tests.ts
+++ b/types/seamless-immutable/seamless-immutable-tests.ts
@@ -151,7 +151,7 @@ interface NonDeepMutableExtendedUser {
 
     // filter. Call the mutable array's 'filter' with the same function to ensure compatability. Make sure the output array is immutable.
     array.asMutable().filter((value: User) => value.firstName === 'test');
-    const filter: Immutable.Immutable<User[]> = array.filter((value: User) => value.firstName === 'test');
+    const filter: Immutable.Immutable<User[]> = array.filter((value: User, index: number) => value.firstName === 'test');
     filter.asMutable();
 
     // slice. Call the mutable array's 'slice' with the same args to ensure compatability. Make sure the output array is immutable.


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rtfeldman/seamless-immutable/blob/master/src/seamless-immutable.js#L91-L93 (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
