### PR TITLE
Fix update/In function's argument type in SeamlessImmutable

### DIFF
--- a/types/seamless-immutable/index.d.ts
+++ b/types/seamless-immutable/index.d.ts
@@ -69,8 +69,8 @@ declare namespace SeamlessImmutable {
 
         merge(part: DeepPartial<T | Immutable<T>>, config?: MergeConfig): Immutable<T>;
 
-        update<K extends keyof T>(property: K, updaterFunction: (value: T[K], ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
-        update<TValue>(property: string, updaterFunction: (value: TValue, ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
+        update<K extends keyof T>(property: K, updaterFunction: (value: Immutable<T[K]>, ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
+        update<TValue>(property: string, updaterFunction: (value: Immutable<TValue>, ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
 
         updateIn<K extends keyof T>(
             propertyPath: [ K ], updaterFunction: (value: Immutable<T[K]>, ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;

--- a/types/seamless-immutable/index.d.ts
+++ b/types/seamless-immutable/index.d.ts
@@ -73,15 +73,15 @@ declare namespace SeamlessImmutable {
         update<TValue>(property: string, updaterFunction: (value: TValue, ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
 
         updateIn<K extends keyof T>(
-            propertyPath: [ K ], updaterFunction: (value: T[K], ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
+            propertyPath: [ K ], updaterFunction: (value: Immutable<T[K]>, ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
         updateIn<K extends keyof T, L extends keyof T[K]>(
-            propertyPath: [ K, L ], updaterFunction: (value: T[K][L], ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
+            propertyPath: [ K, L ], updaterFunction: (value: Immutable<T[K][L]>, ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
         updateIn<K extends keyof T, L extends keyof T[K], M extends keyof T[K][L]>(
-            propertyPath: [ K, L, M ], updaterFunction: (value: T[K][L][M], ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
+            propertyPath: [ K, L, M ], updaterFunction: (value: Immutable<T[K][L][M]>, ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
         updateIn<K extends keyof T, L extends keyof T[K], M extends keyof T[K][L], N extends keyof T[K][L][M]>(
-            propertyPath: [ K, L, M, N ], updaterFunction: (value: T[K][L][M][N], ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
+            propertyPath: [ K, L, M, N ], updaterFunction: (value: Immutable<T[K][L][M][N]>, ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
         updateIn<K extends keyof T, L extends keyof T[K], M extends keyof T[K][L], N extends keyof T[K][L][M], O extends keyof T[K][L][M][N]>(
-            propertyPath: [ K, L, M, N, O ], updaterFunction: (value: T[K][L][M][N][O], ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
+            propertyPath: [ K, L, M, N, O ], updaterFunction: (value: Immutable<T[K][L][M][N][O]>, ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
         updateIn<TValue = any>(propertyPath: string[], updaterFunction: (value: TValue, ...additionalParameters: any[]) => any, ...additionalArguments: any[]): Immutable<T>;
 
         without<K extends keyof T>(property: K): Immutable<T>;

--- a/types/seamless-immutable/seamless-immutable-tests.ts
+++ b/types/seamless-immutable/seamless-immutable-tests.ts
@@ -283,6 +283,8 @@ interface NonDeepMutableExtendedUser {
     const updatedUser41: Immutable.Immutable<User> = immutableUser.update('firstName', x => x.toLowerCase() + ' Whirlwind');
     // the type of the updated value must be explicity specified in case of fallback
     const updatedUser42: Immutable.Immutable<User> = immutableUser.update<string>(data.propertyId, x => x.toLowerCase() + ' Whirlwind');
+    // updater function is always called with Immutable object
+    const updatedUser43: Immutable.Immutable<User> = immutableUserEx.update('address', address => address.set('line1', 'Small house'));
 
     // updateIn: property path is strongly checked for up to 5 arguments (helps with refactoring and intellisense)
     // but will fall back to any[] if there are dynamic arguments on the way

--- a/types/seamless-immutable/seamless-immutable-tests.ts
+++ b/types/seamless-immutable/seamless-immutable-tests.ts
@@ -289,6 +289,8 @@ interface NonDeepMutableExtendedUser {
     const updatedUser51: Immutable.Immutable<User> = immutableUserEx.updateIn([ 'address', 'line1' ], x => x.toLowerCase() + ' 43');
     // the type of the updated value must be explicity specified in case of fallback
     const updatedUser52: Immutable.Immutable<User> = immutableUserEx.updateIn<string>([ data.propertyId, 'line1' ], x => x.toLowerCase() + ' 43');
+    // updater function is always called with Immutable object
+    const updatedUser53: Immutable.Immutable<User> = immutableUserEx.updateIn([ 'address' ], address => address.set('line1', 'Small house'));
 
     // without
     const simpleUser1: Immutable.Immutable<User> = immutableUserEx.without('address');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (https://github.com/rtfeldman/seamless-immutable/blob/2d870b14a01e222493c686a7644181185f859558/src/seamless-immutable.js#L536 & https://github.com/rtfeldman/seamless-immutable/blob/2d870b14a01e222493c686a7644181185f859558/src/seamless-immutable.js#L552 - no `asMutableObject` is called)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
