### PR TITLE
Add new reasons param to react-autosuggest ShouldRenderSuggestions

### DIFF
--- a/types/react-autosuggest/index.d.ts
+++ b/types/react-autosuggest/index.d.ts
@@ -35,14 +35,25 @@ declare namespace Autosuggest {
     /** @internal */
     type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
+    type FetchRequestedReasons =
+        | 'input-changed'
+        | 'input-focused'
+        | 'escape-pressed'
+        | 'suggestions-revealed'
+        | 'suggestion-selected';
+
+    type ShouldRenderReasons =
+        | 'input-changed'
+        | 'input-focused'
+        | 'input-blurred'
+        | 'escape-pressed'
+        | 'suggestions-revealed'
+        | 'suggestions-updated'
+        | 'render';
+
     interface SuggestionsFetchRequestedParams {
         value: string;
-        reason:
-            | 'input-changed'
-            | 'input-focused'
-            | 'escape-pressed'
-            | 'suggestions-revealed'
-            | 'suggestion-selected';
+        reason: FetchRequestedReasons;
     }
 
     interface RenderSuggestionParams {
@@ -128,17 +139,7 @@ declare namespace Autosuggest {
         suggestion: TSuggestion,
         params: RenderSuggestionParams,
     ) => React.ReactNode;
-    type ShouldRenderSuggestions = (
-        value: string,
-        reason:
-            | 'input-changed'
-            | 'input-focused'
-            | 'input-blurred'
-            | 'escape-pressed'
-            | 'suggestions-revealed'
-            | 'suggestions-updated'
-            | 'render'
-    ) => boolean;
+    type ShouldRenderSuggestions = (value: string, reason: ShouldRenderReasons) => boolean;
 
     interface AutosuggestPropsBase<TSuggestion> {
         /**

--- a/types/react-autosuggest/index.d.ts
+++ b/types/react-autosuggest/index.d.ts
@@ -128,7 +128,17 @@ declare namespace Autosuggest {
         suggestion: TSuggestion,
         params: RenderSuggestionParams,
     ) => React.ReactNode;
-    type ShouldRenderSuggestions = (value: string) => boolean;
+    type ShouldRenderSuggestions = (
+        value: string,
+        reason:
+            | 'input-changed'
+            | 'input-focused'
+            | 'input-blurred'
+            | 'escape-pressed'
+            | 'suggestions-revealed'
+            | 'suggestions-updated'
+            | 'render'
+    ) => boolean;
 
     interface AutosuggestPropsBase<TSuggestion> {
         /**

--- a/types/react-autosuggest/react-autosuggest-tests.tsx
+++ b/types/react-autosuggest/react-autosuggest-tests.tsx
@@ -88,6 +88,7 @@ export class ReactAutosuggestBasicTest extends React.Component<any, any> {
             renderSuggestion={this.renderSuggestion}
             onSuggestionSelected={this.onSuggestionsSelected}
             alwaysRenderSuggestions={true}
+            shouldRenderSuggestions={(value, reason) => reason !== 'input-focused'}
             inputProps={{
                 placeholder: `Type 'c'`,
                 value,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/moroshko/react-autosuggest/pull/773
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header~~ Brings up to date with 10.0.3, but patch versions aren't allowed in the header
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~ already in place