### PR TITLE
[carbon-components-react] Fix definitions for FileUploaderItem and FileUploaderDropContainer

### DIFF
--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -539,6 +539,7 @@ const fileUploaderItem = (
         iconDescription="Clear file"
         name="README.md"
         onDelete={(event, content) => {}}
+        size="field"
         status="edit"
         uuid="id1"
     />

--- a/types/carbon-components-react/lib/components/FileUploader/FileUploaderDropContainer.d.ts
+++ b/types/carbon-components-react/lib/components/FileUploader/FileUploaderDropContainer.d.ts
@@ -56,7 +56,7 @@ export interface FileUploaderDropContainerProps extends FileUploaderDropContaine
      * Event handler that is called after files are added to the uploader
      * The event handler signature looks like `onAddFiles(evt, { addedFiles })`
      */
-    onAddFiles?: (event: React.MouseEvent<HTMLElement>, content: { addedFiles: string[] }) => void;
+    onAddFiles?: (event: React.DragEvent<HTMLElement>, content: { addedFiles: File[] }) => void;
 }
 
 declare const FileUploaderDropContainer: React.FC<FileUploaderDropContainerProps>;

--- a/types/carbon-components-react/lib/components/FileUploader/FileUploaderItem.d.ts
+++ b/types/carbon-components-react/lib/components/FileUploader/FileUploaderItem.d.ts
@@ -28,7 +28,7 @@ export interface FileUploaderItemProps extends FileUploaderItemInheritedProps {
      * Specify the size of the uploaded items, from a list of available
      * sizes. For `default` size, this prop can remain unspecified.
      */
-    size: "default" | "field" | "small";
+    size?: "default" | "field" | "small";
 
     /**
      * Status of the file upload

--- a/types/carbon-components-react/lib/components/FileUploader/FileUploaderItem.d.ts
+++ b/types/carbon-components-react/lib/components/FileUploader/FileUploaderItem.d.ts
@@ -25,6 +25,12 @@ export interface FileUploaderItemProps extends FileUploaderItemInheritedProps {
     name?: string;
 
     /**
+     * Specify the size of the uploaded items, from a list of available
+     * sizes. For `default` size, this prop can remain unspecified.
+     */
+    size: "default" | "field" | "small";
+
+    /**
      * Status of the file upload
      */
     status?: FileStatus;


### PR DESCRIPTION
Found a few small issues in carbon-components-react:
- `FileUploaderItem` was missing the `size` prop
- `FileUploaderDropContainer`'s `onAddFiles` handler incorrectly claims to return a `string[]`, when this is going to be a `File[]`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [FileUploaderItem](https://github.com/carbon-design-system/carbon/blob/12b1828e9230a446d79e9e6c2e4ed426e9af962f/packages/react/src/components/FileUploader/FileUploaderItem.js#L110), [FileUploaderDropContainer](https://github.com/carbon-design-system/carbon/blob/12b1828e9230a446d79e9e6c2e4ed426e9af962f/packages/react/src/components/FileUploader/FileUploaderDropContainer.js#L45)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

