### PR TITLE
[webpack-bundle-analyzer] webpack@5 compatibility

### DIFF
--- a/types/webpack-bundle-analyzer/index.d.ts
+++ b/types/webpack-bundle-analyzer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for webpack-bundle-analyzer 3.8
+// Type definitions for webpack-bundle-analyzer 3.9
 // Project: https://github.com/webpack-contrib/webpack-bundle-analyzer
 // Definitions by: Michael Strobel <https://github.com/kryops>
 //                 Vladimir Grenaderov <https://github.com/VladimirGrenaderov>
@@ -41,6 +41,12 @@ export namespace BundleAnalyzerPlugin {
          * @default 'report.html'
          */
         reportFilename?: string;
+
+        /**
+         * Content of the HTML title element; or a function of the form () => string that provides the content.
+         * @default function that returns pretty printed current date and time.
+         */
+        reportTitle?: string | (() => string);
 
         /**
          * Module sizes to show in report by default.

--- a/types/webpack-bundle-analyzer/index.d.ts
+++ b/types/webpack-bundle-analyzer/index.d.ts
@@ -6,9 +6,101 @@
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Plugin, Compiler, Stats } from 'webpack';
+import { WebpackPluginInstance, Compiler } from 'webpack';
 
 export namespace BundleAnalyzerPlugin {
+    // Copied from @types/webpack@4 as webpack@5 only has `any` defined at the moment.
+    // See https://github.com/webpack/webpack/issues/11630
+    namespace Stats {
+        type Preset
+            = boolean
+            | 'errors-only'
+            | 'errors-warnings'
+            | 'minimal'
+            | 'none'
+            | 'normal'
+            | 'verbose';
+
+        interface ToJsonOptionsObject {
+            /** fallback value for stats options when an option is not defined (has precedence over local webpack defaults) */
+            all?: boolean;
+            /** Add asset Information */
+            assets?: boolean;
+            /** Sort assets by a field */
+            assetsSort?: string;
+            /** Add built at time information */
+            builtAt?: boolean;
+            /** Add information about cached (not built) modules */
+            cached?: boolean;
+            /** Show cached assets (setting this to `false` only shows emitted files) */
+            cachedAssets?: boolean;
+            /** Add children information */
+            children?: boolean;
+            /** Add information about the `namedChunkGroups` */
+            chunkGroups?: boolean;
+            /** Add built modules information to chunk information */
+            chunkModules?: boolean;
+            /** Add the origins of chunks and chunk merging info */
+            chunkOrigins?: boolean;
+            /** Add chunk information (setting this to `false` allows for a less verbose output) */
+            chunks?: boolean;
+            /** Sort the chunks by a field */
+            chunksSort?: string;
+            /** Context directory for request shortening */
+            context?: string;
+            /** Display the distance from the entry point for each module */
+            depth?: boolean;
+            /** Display the entry points with the corresponding bundles */
+            entrypoints?: boolean;
+            /** Add --env information */
+            env?: boolean;
+            /** Add errors */
+            errors?: boolean;
+            /** Add details to errors (like resolving log) */
+            errorDetails?: boolean;
+            /** Exclude assets from being displayed in stats */
+            excludeAssets?: StatsExcludeFilter;
+            /** Exclude modules from being displayed in stats */
+            excludeModules?: StatsExcludeFilter;
+            /** See excludeModules */
+            exclude?: StatsExcludeFilter;
+            /** Add the hash of the compilation */
+            hash?: boolean;
+            /** Set the maximum number of modules to be shown */
+            maxModules?: number;
+            /** Add built modules information */
+            modules?: boolean;
+            /** Sort the modules by a field */
+            modulesSort?: string;
+            /** Show dependencies and origin of warnings/errors */
+            moduleTrace?: boolean;
+            /** Add public path information */
+            publicPath?: boolean;
+            /** Add information about the reasons why modules are included */
+            reasons?: boolean;
+            /** Add the source code of modules */
+            source?: boolean;
+            /** Add timing information */
+            timings?: boolean;
+            /** Add webpack version information */
+            version?: boolean;
+            /** Add warnings */
+            warnings?: boolean;
+            /** Show which exports of a module are used */
+            usedExports?: boolean;
+            /** Filter warnings to be shown */
+            warningsFilter?: string | RegExp | Array<string | RegExp> | ((warning: string) => boolean);
+            /** Show performance hint when file size exceeds `performance.maxAssetSize` */
+            performance?: boolean;
+            /** Show the exports of the modules */
+            providedExports?: boolean;
+        }
+
+        type ToJsonOptions = Preset | ToJsonOptionsObject;
+
+        type StatsExcludeFilter = string | string[] | RegExp | RegExp[] | ((assetName: string) => boolean) | Array<(assetName: string) => boolean>;
+    }
+
     type ExcludeAssetsPatternFn = (assetName: string) => boolean;
     type ExcludeAssetsPattern = string | RegExp | ExcludeAssetsPatternFn;
 
@@ -99,7 +191,7 @@ export namespace BundleAnalyzerPlugin {
     }
 }
 
-export class BundleAnalyzerPlugin extends Plugin {
+export class BundleAnalyzerPlugin implements WebpackPluginInstance {
     constructor(options?: BundleAnalyzerPlugin.Options);
 
     apply(compiler: Compiler): void;

--- a/types/webpack-bundle-analyzer/webpack-bundle-analyzer-tests.ts
+++ b/types/webpack-bundle-analyzer/webpack-bundle-analyzer-tests.ts
@@ -10,12 +10,14 @@ const config: webpack.Configuration = {
         new BundleAnalyzerPlugin({
             analyzerMode: 'json',
             analyzerPort: 'auto',
+            reportTitle: () => 'title',
         }),
         new BundleAnalyzerPlugin({
             analyzerMode: 'server',
             analyzerHost: '127.0.0.1',
             analyzerPort: 8888,
             reportFilename: 'report.html',
+            reportTitle: 'title',
             defaultSizes: 'parsed',
             openAnalyzer: true,
             generateStatsFile: true,

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1447,6 +1447,10 @@ declare namespace webpack {
         apply(compiler: Compiler): void;
     }
 
+    // Compatibility with webpack@5's own types
+    // See https://github.com/webpack/webpack/issues/11630
+    interface WebpackPluginInstance extends Plugin {}
+
     abstract class ResolvePlugin implements Tapable.Plugin {
         apply(resolver: any /* EnhancedResolve.Resolver */): void;
     }

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1449,6 +1449,7 @@ declare namespace webpack {
 
     // Compatibility with webpack@5's own types
     // See https://github.com/webpack/webpack/issues/11630
+    // tslint:disable-next-line no-empty-interface
     interface WebpackPluginInstance extends Plugin {}
 
     abstract class ResolvePlugin implements Tapable.Plugin {


### PR DESCRIPTION
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/48807

This is a bit of a tricky one: webpack@5's own types declare a `WebpackPluginInstance`  interface, while the webpack@4 types / `@types/webpack` maintained here have an abstract `Plugin` class, which is used by type definitions for webpack plugins. There are plans to extend webpack@5's own types and maybe add a `Plugin` alias there (see https://github.com/webpack/webpack/issues/11630 and https://github.com/webpack/webpack/pull/11698), but they are not in yet.

I tried it the other way around and added a `WebpackPluginInstance`  interface to the webpack@4 types defined here, which makes the `webpack-bundle-analyzer` types compatible with  both `@types/webpack` and `webpack@5` at its current state.

Asking the maintainers of `@types/webpack` (who the Bot will hopefully ping): Do you think this is ok or should we rather wait until webpack aligns their own types with the existing ecosystem?

Same goes with the `Stats` options, which are currently defined as `any` in webpack@5: I copied them into the plugin's type definition for now. What should plugin type definitions do with types that webpack@5 currently does not offer or export?

Did other webpack plugin definitions already add webpack@5 compatibility or is this the first attempt?
_______

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack-contrib/webpack-bundle-analyzer#options-for-plugin
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)