### PR TITLE
[@types/relay-runtime]: fix mutationConfig

### DIFF
--- a/types/relay-runtime/lib/mutations/commitMutation.d.ts
+++ b/types/relay-runtime/lib/mutations/commitMutation.d.ts
@@ -1,5 +1,5 @@
 import { PayloadError, UploadableMap } from '../network/RelayNetworkTypes';
-import { Disposable, Variables } from '../util/RelayRuntimeTypes';
+import { CacheConfig, Disposable, Variables } from '../util/RelayRuntimeTypes';
 import { DeclarativeMutationConfig } from './RelayDeclarativeMutationConfig';
 import { GraphQLTaggedNode } from '../query/RelayModernGraphQLTag';
 import { Environment, SelectorStoreUpdater } from '../store/RelayStoreTypes';
@@ -12,11 +12,13 @@ export interface MutationParameters {
 
 export interface MutationConfig<TOperation extends MutationParameters> {
     configs?: DeclarativeMutationConfig[];
+    cacheConfig?: CacheConfig;
     mutation: GraphQLTaggedNode;
     onError?: ((error: Error) => void) | null;
     onCompleted?:
         | ((response: TOperation['response'], errors: ReadonlyArray<PayloadError> | null | undefined) => void)
         | null;
+    onUnsubscribe?: () => void | null | undefined;
     optimisticResponse?: TOperation['response'];
     optimisticUpdater?: SelectorStoreUpdater<TOperation['response']> | null;
     updater?: SelectorStoreUpdater<TOperation['response']> | null;


### PR DESCRIPTION
In this PR I fix [mutationConfig](https://github.com/facebook/relay/blob/v10.0.1/packages/relay-runtime/mutations/commitMutation.js#L62-L84)

```js
export type MutationConfig<T: MutationParameters> = {|
  configs?: Array<DeclarativeMutationConfig>,
  cacheConfig?: CacheConfig,
  mutation: GraphQLTaggedNode,
  onError?: ?(error: Error) => void,
  onCompleted?: ?(
    response: $ElementType<T, 'response'>,
    errors: ?Array<PayloadError>,
  ) => void,
  onUnsubscribe?: ?() => void,
  optimisticResponse?: $ElementType<
    {
      +rawResponse?: {...},
      ...T,
      ...
    },
    'rawResponse',
  >,
  optimisticUpdater?: ?SelectorStoreUpdater,
  updater?: ?SelectorStoreUpdater,
  uploadables?: UploadableMap,
  variables: $ElementType<T, 'variables'>,
|};
```

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
[mutationConfig](https://github.com/facebook/relay/blob/v10.0.1/packages/relay-runtime/mutations/commitMutation.js#L62-L84)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
