### PR TITLE
[react-stickynode] Update types to match version 3.0.4

### DIFF
--- a/types/react-stickynode/index.d.ts
+++ b/types/react-stickynode/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Tim Stirrat <https://github.com/tstirrat>
 //                 Kamil Socha <https://github.com/ksocha>
 //                 Mirek Ciastek <https://github.com/mciastek>
+//                 Yanick Dickbauer <https://github.com/yanickdi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -71,6 +72,12 @@ declare namespace Sticky {
          * Class name to be applied to the inner element ('' by default).
          */
         innerClass?: string;
+
+        /**
+         * Class name to be applied to the element independent of the
+         * sticky state.
+         */
+        className?: string;
 
         /**
          * Class name to be applied to the element when the sticky state is

--- a/types/react-stickynode/react-stickynode-tests.tsx
+++ b/types/react-stickynode/react-stickynode-tests.tsx
@@ -9,6 +9,7 @@ const StickyAllOptions: JSX.Element = (
         innerZ={1000}
         enableTransforms={true}
         activeClass="active"
+        className="className"
         releasedClass="released"
         innerClass="innerClass"
         onStateChange={s => s.status === Sticky.StatusCode.STATUS_ORIGINAL}


### PR DESCRIPTION
This PR added the optional prop _className_ to Sticky component.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/yahoo/react-stickynode/compare/v3.0.3...v3.0.4 and https://github.com/yahoo/react-stickynode
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
       Minor version change -> react-stickynode is still on 3.0
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~
