### PR TITLE
update(serve-favicon): correct `maxAge` type and other minor updates

### DIFF
--- a/types/serve-favicon/index.d.ts
+++ b/types/serve-favicon/index.d.ts
@@ -1,8 +1,8 @@
-// Type definitions for serve-favicon 2.5.0
+// Type definitions for serve-favicon 2.5
 // Project: https://github.com/expressjs/serve-favicon
 // Definitions by: Uros Smolnik <https://github.com/urossmolnik>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 /* =================== USAGE ===================
 
@@ -11,21 +11,20 @@
 
  =============================================== */
 
-
-
-
 import express = require('express');
 
 /**
  * Node.js middleware for serving a favicon.
  */
-declare function serveFavicon(path: string | Buffer, options?: {
-    /**
-    * The cache-control max-age directive in ms, defaulting to 1 day. This can also be a string accepted by the ms module.
-    */
-    maxAge?: number;
-}): express.RequestHandler;
-
-declare namespace serveFavicon { }
+declare function serveFavicon(
+    path: string | Buffer,
+    options?: {
+        /**
+         * The cache-control max-age directive in ms, defaulting to 1 day.
+         * This can also be a string accepted by the `ms` module.
+         */
+        maxAge?: number | string;
+    },
+): express.RequestHandler;
 
 export = serveFavicon;

--- a/types/serve-favicon/serve-favicon-tests.ts
+++ b/types/serve-favicon/serve-favicon-tests.ts
@@ -1,8 +1,22 @@
-
 import express = require('express');
 import favicon = require('serve-favicon');
-var app = express();
 
-app.use(favicon(__dirname + '/public/favicon.ico', {
-    maxAge: 86400000
-}));
+const app = express();
+
+app.use(
+    favicon(__dirname + '/public/favicon.ico', {
+        maxAge: 86400000,
+    }),
+);
+
+app.use(
+    favicon(__dirname + '/public/favicon.ico', {
+        maxAge: '2 days',
+    }),
+);
+
+app.use(
+    favicon(__dirname + '/public/favicon.ico', {
+        maxAge: '2d',
+    }),
+);

--- a/types/serve-favicon/tslint.json
+++ b/types/serve-favicon/tslint.json
@@ -1,11 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "dt-header": false,
-        "jsdoc-format": false,
-        "no-consecutive-blank-lines": false,
-        "no-var-keyword": false,
-        "prefer-const": false,
-        "trim-file": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
- the `maxAge` can be a string:
https://github.com/expressjs/serve-favicon/blob/master/test/test.js#L67
https://github.com/expressjs/serve-favicon#maxage
- amend tests
- add mantainer
- DT lint fixes

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.