### PR TITLE
Add types for Skilja package (array chunker)

### DIFF
--- a/types/skilja/index.d.ts
+++ b/types/skilja/index.d.ts
@@ -3,4 +3,4 @@
 // Definitions by: StScoundrel <https://github.com/stscoundrel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export function chunkArray(original: any[], limit: number): any[][];
+export function chunkArray<T>(original: ReadonlyArray<T>, limit: number): T[][];

--- a/types/skilja/index.d.ts
+++ b/types/skilja/index.d.ts
@@ -1,0 +1,6 @@
+// Type definitions for skilja 0.9
+// Project: https://github.com/stscoundrel/skilja
+// Definitions by: StScoundrel <https://github.com/stscoundrel>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function chunkArray(original: any[], limit: number): any[][];

--- a/types/skilja/skilja-tests.ts
+++ b/types/skilja/skilja-tests.ts
@@ -1,6 +1,6 @@
 import { chunkArray } from 'skilja';
 
-// $ExpectType any[][]
+// $ExpectType number[][]
 const result = chunkArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2);
 
 // $ExpectError

--- a/types/skilja/skilja-tests.ts
+++ b/types/skilja/skilja-tests.ts
@@ -1,0 +1,10 @@
+import { chunkArray } from 'skilja';
+
+// $ExpectType any[][]
+const result = chunkArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2);
+
+// $ExpectError
+const result2 = chunkArray();
+
+// $ExpectError
+const result3 = chunkArray(1);

--- a/types/skilja/tsconfig.json
+++ b/types/skilja/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "skilja-tests.ts"
+    ]
+}

--- a/types/skilja/tslint.json
+++ b/types/skilja/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Add types to npm package [skilja](https://www.npmjs.com/package/skilja)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.