### PR TITLE
mapbox-gl: adding missing Lookup ExpressionName and fix by moving a misplaced property from RasterPaint to CircleLayout

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -2156,10 +2156,11 @@ declare namespace mapboxgl {
         'raster-contrast-transition'?: Transition;
         'raster-fade-duration'?: number | Expression;
         'raster-resampling'?: 'linear' | 'nearest';
-        'circle-sort-key'?: number;
     }
 
-    export interface CircleLayout extends Layout {}
+    export interface CircleLayout extends Layout {
+        'circle-sort-key'?: number;
+    }
 
     export interface CirclePaint {
         'circle-radius'?: number | StyleFunction | Expression;

--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -73,7 +73,13 @@ declare namespace mapboxgl {
 
     type PluginStatus = 'unavailable' | 'loading' | 'loaded' | 'error';
 
-    type LngLatLike = [number, number] | LngLat | { lng: number; lat: number } | { lon: number; lat: number } | [number, number];
+    type LngLatLike =
+        | [number, number]
+        | LngLat
+        | { lng: number; lat: number }
+        | { lon: number; lat: number }
+        | [number, number];
+
     type LngLatBoundsLike = LngLatBounds | [LngLatLike, LngLatLike] | [number, number, number, number] | LngLatLike;
     type PointLike = Point | [number, number];
 
@@ -103,7 +109,10 @@ declare namespace mapboxgl {
         | 'at'
         | 'get'
         | 'has'
+        | 'in'
+        | 'index-of'
         | 'length'
+        | 'slice'
         // Decision
         | '!'
         | '!='

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -1519,11 +1519,11 @@ const rasterPaint: mapboxgl.RasterPaint = {
     'raster-contrast-transition': transition,
     'raster-fade-duration': eitherType(0, expression),
     'raster-resampling': eitherType('linear', 'nearest'),
-    'circle-sort-key': 0,
 };
 
 const circleLayout: mapboxgl.CircleLayout = {
     visibility: eitherType('visible', 'none'),
+    'circle-sort-key': 0,
 };
 
 const circlePaint: mapboxgl.CirclePaint = {


### PR DESCRIPTION
Updating ExpressionName definition and moving a misplaced property in RasterPaint

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
feat => https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/#lookup
fix => https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#layout-circle-circle-sort-key
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
