### PR TITLE
Create type definitions for markdown-it-plantuml

### DIFF
--- a/types/markdown-it-plantuml/index.d.ts
+++ b/types/markdown-it-plantuml/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for markdown-it-plantuml 1.4
+// Project: https://github.com/gmunguia/markdown-it-plantuml#readme
+// Definitions by: Gerardo Munguia <https://github.com/gmunguia>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import MarkdownIt = require('markdown-it');
+import Renderer = require('markdown-it/lib/renderer');
+
+declare namespace markdownItPlantuml {
+    interface Options {
+        closeMarker?: string;
+        diagramName?: string;
+        generateSource?: (umlCode: string, pluginOptions: Options) => string;
+        imageFormat?: string;
+        openMarker?: string;
+        render?: Renderer.RenderRule;
+        server?: string;
+    }
+}
+
+declare const markdownItPlantuml: MarkdownIt.PluginWithOptions<markdownItPlantuml.Options>;
+export = markdownItPlantuml;

--- a/types/markdown-it-plantuml/markdown-it-plantuml-tests.ts
+++ b/types/markdown-it-plantuml/markdown-it-plantuml-tests.ts
@@ -1,0 +1,32 @@
+import MarkdownIt = require('markdown-it');
+import MarkdownItPlantuml = require('markdown-it-plantuml');
+
+const options: MarkdownItPlantuml.Options = {
+    closeMarker: '@endditaa',
+    diagramName: 'ditaa',
+    generateSource: function generateSource(umlCode: string) {
+        return `https://your.server/plant-uml/${umlCode}`;
+    },
+    imageFormat: 'png',
+    openMarker: '@startditaa',
+    render: function renderDiagram(tokens, index, options, _, self) {
+        return self.renderToken(tokens, index, options);
+    },
+    server: 'https://your.server/plat-uml/',
+};
+
+const md = MarkdownIt().use(MarkdownItPlantuml, options);
+
+const source = `@startditaa
++--------+   +-------+    +-------+
+|        +---+ ditaa +--> |       |
+|  Text  |   +-------+    |diagram|
+|Document|   |!magic!|    |       |
+|     {d}|   |       |    |       |
++---+----+   +-------+    +-------+
+    :                         ^
+    |       Lots of work      |
+    +-------------------------+
+@endditaa`;
+
+md.render(source);

--- a/types/markdown-it-plantuml/tsconfig.json
+++ b/types/markdown-it-plantuml/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "markdown-it-plantuml-tests.ts"
+    ]
+}

--- a/types/markdown-it-plantuml/tslint.json
+++ b/types/markdown-it-plantuml/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
