### PR TITLE
Add missing types for meteor/server-render

### DIFF
--- a/types/meteor/server-render.d.ts
+++ b/types/meteor/server-render.d.ts
@@ -12,8 +12,13 @@ declare module "meteor/server-render" {
         appendToElementById?(id: string, html: string): void;
         renderIntoElementById?(id: string, html: string): void;
         renderIntoElementById?(id: string, html: NodeJS.ReadableStream): void;
+        redirect?(location: string, code?: number): void;
+        setStatusCode?(code: number): void;
+        setHeader?(key: string, value: number | string | string[]): void;
+        getHeaders?(): http.IncomingHttpHeaders;
+        getCookies?(): { [key: string]: string };
     }
-    
+
     type Callback = (sink: Sink) => Promise <any> | any;
     export function onPageLoad<T extends Callback>(callback: T): T;
 }

--- a/types/meteor/test/server-render.tsx
+++ b/types/meteor/test/server-render.tsx
@@ -16,10 +16,10 @@ onPageLoad(sink => {
 
 onPageLoad(sink => {
   if (sink.getCookies) {
-    sink.getCookies(); // $ExpectType { [key: string]: string }
+    sink.getCookies(); // $ExpectType { [key: string]: string; }
   }
   if (sink.getHeaders) {
-    sink.getHeaders(); // $ExpectType http.IncomingHttpHeaders
+    sink.getHeaders(); // $ExpectType IncomingHttpHeaders
   }
   if (sink.setHeader) {
     sink.setHeader('cache-control', 'no-cache');

--- a/types/meteor/test/server-render.tsx
+++ b/types/meteor/test/server-render.tsx
@@ -12,4 +12,23 @@ onPageLoad(sink => {
   if (sink.renderIntoElementById) {
     sink.renderIntoElementById("app", renderToNodeStream(<div>Hello World</div>));
   }
-}); 
+});
+
+onPageLoad(sink => {
+  if (sink.getCookies) {
+    sink.getCookies(); // $ExpectType { [key: string]: string }
+  }
+  if (sink.getHeaders) {
+    sink.getHeaders(); // $ExpectType http.IncomingHttpHeaders
+  }
+  if (sink.setHeader) {
+    sink.setHeader('cache-control', 'no-cache');
+  }
+  if (sink.setStatusCode) {
+    sink.setStatusCode(200);
+  }
+  if (sink.redirect) {
+    sink.redirect('/');
+    sink.redirect('/', 301);
+  }
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/meteor/meteor/blob/master/packages/server-render/server-sink.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
