### PR TITLE
Improve types for Meteor observeChanges

### DIFF
--- a/types/meteor/index.d.ts
+++ b/types/meteor/index.d.ts
@@ -16,6 +16,7 @@
 //                 Evan Broder <https://github.com/ebroder>
 //                 Radosław Miernik <https://github.com/radekmie>
 //                 Wojciech Adamek <https://github.com/wadamek65>
+//                 Maciej Stasieluk <https://github.com/MacRusher>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.7
 

--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -216,7 +216,7 @@ declare module "meteor/mongo" {
             forEach(callback: (doc: T, index: number, cursor: Cursor<T>) => void, thisArg?: any): void;
             map<U>(callback: (doc: T, index: number, cursor: Cursor<T>) => U, thisArg?: any): Array<U>;
             observe(callbacks: ObserveCallbacks<T>): Meteor.LiveQueryHandle;
-            observeChanges(callbacks: ObserveChangesCallbacks<T>): Meteor.LiveQueryHandle;
+            observeChanges(callbacks: ObserveChangesCallbacks<T>, options?: { nonMutatingCallbacks?: boolean }): Meteor.LiveQueryHandle;
         }
 
         var ObjectID: ObjectIDStatic;

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -421,6 +421,7 @@ var handle = query.observeChanges({
         console.log("Lost one. We're now down to " + count1 + " admins.");
     }
 });
+query.observeChanges({}, { nonMutatingCallbacks: true }); // $ExpectType LiveQueryHandle
 
 let cursor: Mongo.Cursor<Object>;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/meteor/meteor/blob/d9db4f52f2ea6d706a25156768ea42e1fbb8f599/packages/mongo/mongo_driver.js#L957-L980
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
