### PR TITLE
Add missing hset signatures to ioredis

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -629,8 +629,8 @@ declare namespace IORedis {
         zrevrank(key: KeyType, member: string, callback: Callback<number | null>): void;
         zrevrank(key: KeyType, member: string): Promise<number | null>;
 
-        hset(key: KeyType, field: string, value: ValueType, callback: Callback<BooleanResponse>): void;
-        hset(key: KeyType, field: string, value: ValueType): Promise<BooleanResponse>;
+        hset: OverloadedKeyedHashCommand<ValueType, Ok>;
+
         hsetBuffer(key: KeyType, field: string, value: ValueType, callback: Callback<BooleanResponse>): void;
         hsetBuffer(key: KeyType, field: string, value: ValueType): Promise<Buffer>;
 
@@ -1195,6 +1195,8 @@ declare namespace IORedis {
 
         zrevrank(key: KeyType, member: string, callback?: Callback<number>): Pipeline;
 
+        hset(key: KeyType, ...args: ValueType[]): Pipeline;
+        hset(key: KeyType, data: object | Map<string, any>, callback?: Callback<BooleanResponse>): Pipeline;
         hset(key: KeyType, field: string, value: ValueType, callback?: Callback<BooleanResponse>): Pipeline;
         hsetBuffer(key: KeyType, field: string, value: ValueType, callback?: Callback<Buffer>): Pipeline;
 

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -152,7 +152,18 @@ redis.zscan('key', 0, 'MATCH', '*foo*', 'COUNT', 100, cb);
 redis.pfadd('key', 'a', 'b', 'c').then(console.log);
 redis.pfadd('key', 'a', 'b', 'c', cbNumber);
 
-// Test OverloadedKeyedHashCommand
+// Test OverloadedKeyedHashCommand for hset
+redis.hset('foo', '1', '2', '3', 4, '5', new Buffer([])).then(console.log);
+redis.hset('foo', '1', '2', '3', 4, '5', new Buffer([]), cb);
+redis.hset('foo', '1', '2', '3', 4).then(console.log);
+redis.hset('foo', '1', '2', '3', 4);
+redis.hset('foo', '1', '2').then(console.log);
+redis.hset('foo', '1', ['1', 2]);
+redis.hset('foo', { a: 'b', c: 4 }).then(console.log);
+redis.hset('foo', { a: 'b', c: 4 }, cb);
+redis.hset('foo', new Map<string, number>(), cb);
+
+// Test OverloadedKeyedHashCommand for hmset
 redis.hmset('foo', '1', '2', '3', 4, '5', new Buffer([])).then(console.log);
 redis.hmset('foo', '1', '2', '3', 4, '5', new Buffer([]), cb);
 redis.hmset('foo', '1', '2', '3', 4).then(console.log);


### PR DESCRIPTION
Adds additional signatures for HSET, so it can be used in place of the deprecated HMSET. Supported in ioredis since [4.15.0](https://github.com/luin/ioredis/blob/147e993c9636afece541ce39c0b9f1d3c8971893/Changelog.md#4150-2019-11-29). 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/luin/ioredis/blob/147e993c9636afece541ce39c0b9f1d3c8971893/Changelog.md#4150-2019-11-29
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

