### PR TITLE
Update react-copy-to-clipboard

### DIFF
--- a/types/react-copy-to-clipboard/index.d.ts
+++ b/types/react-copy-to-clipboard/index.d.ts
@@ -1,31 +1,30 @@
-// Type definitions for react-copy-to-clipboard 4.3
+// Type definitions for react-copy-to-clipboard 5.0
 // Project: https://github.com/nkbt/react-copy-to-clipboard
 // Definitions by: Meno Abels <https://github.com/mabels>
 //                 Bernabe <https://github.com/BernabeFelix>
 //                 Ward Delabastita <https://github.com/wdlb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
 
-import * as React from "react";
+import * as React from 'react';
 
 export as namespace CopyToClipboard;
 
-export = CopyToClipboard;
+declare class CopyToClipboard extends React.PureComponent<CopyToClipboard.Props> {}
 
 declare namespace CopyToClipboard {
-  interface Options {
-    debug?: boolean;
-    format?: "text/html" | "text/plain";
-    message?: string;
-  }
+    class CopyToClipboard extends React.PureComponent<Props> {}
 
-  interface Props {
-    children: React.ReactNode;
-    text: string;
-    onCopy?(text: string, result: boolean): void;
-    options?: Options;
-  }
+    interface Options {
+        debug?: boolean;
+        message?: string;
+        format?: string; // MIME type
+    }
+
+    interface Props {
+        text: string;
+        onCopy?(text: string, result: boolean): void;
+        options?: Options;
+    }
 }
 
-declare class CopyToClipboard extends React.Component<CopyToClipboard.Props> {
-}
+export = CopyToClipboard;

--- a/types/react-copy-to-clipboard/react-copy-to-clipboard-tests.tsx
+++ b/types/react-copy-to-clipboard/react-copy-to-clipboard-tests.tsx
@@ -1,24 +1,22 @@
-import * as React from "react";
-import CopyToClipboard = require("react-copy-to-clipboard");
+import * as React from 'react';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
 
-export class OnlyRequiredProps extends React.Component {
-    render() {
-        return (
-          <CopyToClipboard text={"Hello World"}>
-              <button>Copy to clipboard with button</button>
-          </CopyToClipboard>
-        );
-    }
+function OnlyRequiredProps() {
+    return (
+        <CopyToClipboard text={'Hello World'}>
+            <button>Copy to clipboard with button</button>
+        </CopyToClipboard>
+    );
 }
 
-export class AllProps extends React.Component {
-    render() {
-        return (
-          <CopyToClipboard text={"Hello World"}
-                onCopy={() => {}}
-                options={{debug: true, message: "message", format: "text/plain"}}>
+function AllProps() {
+    return (
+        <CopyToClipboard
+            text={'Hello World'}
+            onCopy={() => {}}
+            options={{ debug: true, message: 'message', format: 'text/plain' }}
+        >
             <span>Copy to clipboard with span</span>
-          </CopyToClipboard>
-        );
-    }
+        </CopyToClipboard>
+    );
 }


### PR DESCRIPTION
Relates to @dotBeFoRE's https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45248, https://github.com/nkbt/react-copy-to-clipboard/pull/133.

Summary of changes:

* Add `CopyToClipboard` property to export (in addition to default export), supporting:

    ```ts
    import { CopyToClipboard } from 'react-copy-to-clipboard';
    ```

* Loosen `Options.format` to match dependent [`copy-to-clipboard`'s definition](https://github.com/sudodoki/copy-to-clipboard/blob/v3.3.1/index.d.ts#L8)
* Move tests to function components

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nkbt/react-copy-to-clipboard/blob/v5.0.2/src/index.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
