### PR TITLE
react: Export type representing second argument of ForwardRefRenderFunction

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -561,8 +561,10 @@ declare namespace React {
         displayName?: string;
     }
 
+    type ForwardedRef<T> = ((instance: T | null) => void) | MutableRefObject<T | null> | null;
+
     interface ForwardRefRenderFunction<T, P = {}> {
-        (props: PropsWithChildren<P>, ref: ((instance: T | null) => void) | MutableRefObject<T | null> | null): ReactElement | null;
+        (props: PropsWithChildren<P>, ref: ForwardedRef<T>): ReactElement | null;
         displayName?: string;
         // explicit rejected with `never` required due to
         // https://github.com/microsoft/TypeScript/issues/36826

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -412,6 +412,12 @@ const ForwardingRefComponent = React.forwardRef((props: ForwardingRefComponentPr
     return React.createElement(RefComponent, { ref });
 });
 
+// Declaring forwardRef render function separately (not inline).
+const ForwardRefRenderFunction = (props: ForwardingRefComponentProps, ref: React.ForwardedRef<RefComponent>)  => {
+    return React.createElement(RefComponent, { ref });
+};
+React.forwardRef(ForwardRefRenderFunction);
+
 const ForwardingRefComponentPropTypes: React.WeakValidationMap<ForwardingRefComponentProps> = {};
 ForwardingRefComponent.propTypes = ForwardingRefComponentPropTypes;
 


### PR DESCRIPTION
The type is not the same as `Ref`, this one allows `MutableRefObject` instead of the readonly `RefObject`.

Not sure why the original type didn't use `RefCallback`. Is there any particular reason?

# Motivation

```jsx
const Root = "div";

interface Props extends React.ComponentPropsWithoutRef<typeof Root> {
}

function Component(props: Props, ref: ???) {
  return <Root ref={ref} {...props} />;
}

export default React.forwardRef(Component);
```

There is currently no easy way to express the type of the `ref` function argument, `React.Ref<React.ElementRef<typeof Root>>` isn't correct. After this change I can use `React.ForwardedRef<React.ElementRef<typeof Root>>`.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
