### PR TITLE
codemirror: Fixed hint incorrectly being required for the showHint function

### DIFF
--- a/types/codemirror/addon/hint/show-hint.d.ts
+++ b/types/codemirror/addon/hint/show-hint.d.ts
@@ -55,7 +55,7 @@ declare module 'codemirror' {
 
     interface ShowHintOptions {
         completeSingle?: boolean;
-        hint: HintFunction | AsyncHintFunction;
+        hint?: HintFunction | AsyncHintFunction;
         alignWithWord?: boolean;
         closeCharacters?: RegExp;
         closeOnUnfocus?: boolean;

--- a/types/codemirror/test/addon/hint/show-hint.ts
+++ b/types/codemirror/test/addon/hint/show-hint.ts
@@ -46,3 +46,8 @@ cm.showHint({
     completeSingle: false,
     hint: asyncHintFunc,
 });
+
+cm.showHint({
+    completeSingle: false,
+    container: document.body,
+});


### PR DESCRIPTION
This fixes a minor issue with the `codemirror` show hint add-on, whereby the `hint` option was specified as being required, whereas in the actual code and documentation it mentions it's not required.

Supporting documentation to show `hint` in  `ShowHintOptions` is optional:
- Codemirror will default to using the `Codemirror.hint.auto` hint function if not specified, as can be seen in the default options: https://github.com/codemirror/CodeMirror/blob/master/addon/hint/show-hint.js#L467 and https://github.com/codemirror/CodeMirror/blob/master/addon/hint/show-hint.js#L154
- Codemirror [documentation](https://codemirror.net/doc/manual.html#addon_show-hint) states:
  > If no hinting function is given, the addon will use CodeMirror.hint.auto, which calls getHelpers with the "hint" type to find applicable hinting functions, and tries them one by one. If that fails, it looks for a "hintWords" helper to fetch a list of completable words for the mode, and uses CodeMirror.hint.fromList to complete from those.
- Codemirror demo not passing the `hint` option: https://github.com/codemirror/CodeMirror/blob/master/demo/xmlcomplete.html#L85

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
