### PR TITLE
[line-navigator] Add types for line-navigator

### DIFF
--- a/types/line-navigator/index.d.ts
+++ b/types/line-navigator/index.d.ts
@@ -1,0 +1,56 @@
+// Type definitions for line-navigator 2.1
+// Project: https://github.com/anpur/client-line-navigator
+// Definitions by: Vladimir Poluch <https://github.com/vlapo>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace LineNavigator {
+    interface Options {
+        /**
+         * Encoding
+         * @default 'utf8'
+         */
+        encoding?: string;
+        /**
+         * Size of chunk
+         * @default 4096
+         */
+        chunkSize?: number;
+        /**
+         * Return error when line is longer than chunkSize, otherwise it will be threated as several lines.
+         * @default false
+         */
+        throwOnLongLines?: boolean;
+    }
+
+    interface FindMatch {
+        line: string;
+        offset: number;
+        length: number;
+    }
+
+    interface FindAllResult extends FindMatch {
+        index: string;
+    }
+
+    type ReadLinesCallback = (err: any, index: number, lines: string[] | undefined, isEof: boolean | undefined, progress: number | undefined) => void;
+    type FindCallback = (err: any, index: number | undefined, match: FindMatch | undefined) => void;
+    type FindAllCallback = (err: any, index: number, limitHit: boolean | undefined, results: FindAllResult[] | undefined) => void;
+}
+
+declare class LineNavigator {
+    /**
+     * Creates an instance of LineNavigator.
+     * @param file HTML5 File for client side or a string with file path for server side.
+     * @param [options]
+     */
+    constructor(file: File | string, options?: LineNavigator.Options);
+
+    readSomeLines(indexToStartWith: number, callback: LineNavigator.ReadLinesCallback): void;
+    readLines(indexToStartWith: number, numberOfLines: number, callback: LineNavigator.ReadLinesCallback): void;
+
+    find(regex: RegExp, indexToStartWith: number, callback: LineNavigator.FindCallback): void;
+    findAll(regex: RegExp, indexToStartWith: number, limit: number, callback: LineNavigator.FindAllCallback): void;
+}
+
+export as namespace LineNavigator;
+export = LineNavigator;

--- a/types/line-navigator/line-navigator-tests.ts
+++ b/types/line-navigator/line-navigator-tests.ts
@@ -1,0 +1,19 @@
+import * as LineNavigator from 'line-navigator';
+
+const file = new File(['test'], 'test.txt');
+
+let lineNavigator = new LineNavigator(file);
+lineNavigator = new LineNavigator(file, {});
+lineNavigator = new LineNavigator(file, { chunkSize: 12345 });
+lineNavigator = new LineNavigator(file, { encoding: 'cp-1250' });
+lineNavigator = new LineNavigator(file, { throwOnLongLines: false });
+lineNavigator = new LineNavigator(file, { chunkSize: 12345, encoding: 'cp-1250', throwOnLongLines: false });
+
+const findCallback: LineNavigator.FindCallback = (err: any, index: number | undefined, match: LineNavigator.FindMatch | undefined) => { };
+const findAllCallback: LineNavigator.FindAllCallback = (err: any, index: number, limitHit: boolean | undefined, results: LineNavigator.FindAllResult[] | undefined) => { };
+const readLinesCallback: LineNavigator.ReadLinesCallback = (err: any, index: number, lines: string[] | undefined, isEof: boolean | undefined, progress: number | undefined) => { };
+
+lineNavigator.find(new RegExp('test'), 12, findCallback);
+lineNavigator.findAll(new RegExp('test'), 12, 12, findAllCallback);
+lineNavigator.readLines(12, 12, readLinesCallback);
+lineNavigator.readSomeLines(12, readLinesCallback);

--- a/types/line-navigator/tsconfig.json
+++ b/types/line-navigator/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "line-navigator-tests.ts"
+    ]
+}

--- a/types/line-navigator/tslint.json
+++ b/types/line-navigator/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
