### PR TITLE
Added type declaration for isDate function for Validator package

### DIFF
--- a/types/validator/es/lib/isDate.d.ts
+++ b/types/validator/es/lib/isDate.d.ts
@@ -1,0 +1,2 @@
+import validator from '../../';
+export default validator.isDate;

--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -334,7 +334,7 @@ declare namespace validator {
          *
          * @default ['/', '-']
          */
-        delimiters?: Array<string>;
+        delimiters?: string[];
     }
 
     /**

--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -317,10 +317,30 @@ declare namespace validator {
      */
     function isDataURI(str: string): boolean;
 
+    interface IsDateOptions {
+        /**
+         * @default false
+         */
+        format?: string;
+        /**
+         * If strictMode is set to true,
+         * the validator will reject inputs different from format.
+         *
+         * @default false
+         */
+        strictMode?: boolean;
+        /**
+         * `delimiters` is an array of allowed date delimiters
+         *
+         * @default ['/', '-']
+         */
+        delimiters?: Array<string>;
+    }
+
     /**
      * Check if the string is a valid date.
      */
-    function isDate(str: string): boolean;
+    function isDate(str: string, options?: IsDateOptions): boolean;
 
     type DecimalLocale = FloatLocale;
 

--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -317,6 +317,11 @@ declare namespace validator {
      */
     function isDataURI(str: string): boolean;
 
+    /**
+     * Check if the string is a valid date.
+     */
+    function isDate(str: string): boolean;
+
     type DecimalLocale = FloatLocale;
 
     interface IsDecimalOptions {

--- a/types/validator/lib/isDate.d.ts
+++ b/types/validator/lib/isDate.d.ts
@@ -1,0 +1,2 @@
+import validator from '../';
+export default validator.isDate;

--- a/types/validator/validator-tests.ts
+++ b/types/validator/validator-tests.ts
@@ -568,7 +568,9 @@ const any: any = null;
 
     result = validator.isDataURI('sample');
 
+    const isDateOptions: validator.IsDateOptions = {};
     result = validator.isDate('sample');
+    result = validator.isDate('sample', isDateOptions);
 
     const isDecimalOptions: validator.IsDecimalOptions = {};
     result = validator.isDecimal('sample');

--- a/types/validator/validator-tests.ts
+++ b/types/validator/validator-tests.ts
@@ -24,6 +24,7 @@ import isCurrencyFunc from 'validator/lib/isCurrency';
 import isEthereumAddressFunc from 'validator/lib/isEthereumAddress';
 import isBtcAddressFunc from 'validator/lib/isBtcAddress';
 import isDataURIFunc from 'validator/lib/isDataURI';
+import isDateFunc from 'validator/lib/isDate';
 import isDecimalFunc from 'validator/lib/isDecimal';
 import isDivisibleByFunc from 'validator/lib/isDivisibleBy';
 import isEmailFunc from 'validator/lib/isEmail';
@@ -143,6 +144,9 @@ import isSlugFunc from 'validator/lib/isSlug';
 
     let _isDataURI = validator.isDataURI;
     _isDataURI = isDataURIFunc;
+
+    let _isDate = validator.isDate;
+    _isDate = isDateFunc;
 
     let _isDecimal = validator.isDecimal;
     _isDecimal = isDecimalFunc;
@@ -352,6 +356,7 @@ import isCurrencyFuncEs from 'validator/es/lib/isCurrency';
 import isEthereumAddressFuncEs from 'validator/es/lib/isEthereumAddress';
 import isBtcAddressFuncEs from 'validator/es/lib/isBtcAddress';
 import isDataURIFuncEs from 'validator/es/lib/isDataURI';
+import isDateFuncEs from 'validator/es/lib/isDate';
 import isDecimalFuncEs from 'validator/es/lib/isDecimal';
 import isDivisibleByFuncEs from 'validator/es/lib/isDivisibleBy';
 import isEmailFuncEs from 'validator/es/lib/isEmail';
@@ -562,6 +567,8 @@ const any: any = null;
     result = validator.isBtcAddress('sample');
 
     result = validator.isDataURI('sample');
+
+    result = validator.isDate('sample');
 
     const isDecimalOptions: validator.IsDecimalOptions = {};
     result = validator.isDecimal('sample');


### PR DESCRIPTION
Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [x ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/validatorjs/validator.js/blob/master/src/lib/isDate.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.