### PR TITLE
[@types/node-pdftk] Extend `input` function params

### DIFF
--- a/types/node-pdftk/index.d.ts
+++ b/types/node-pdftk/index.d.ts
@@ -8,34 +8,34 @@
 
 export type Input = string | Buffer;
 
-export interface InputMap {
-    A?: Input;
-    B?: Input;
-    C?: Input;
-    D?: Input;
-    E?: Input;
-    F?: Input;
-    G?: Input;
-    H?: Input;
-    I?: Input;
-    J?: Input;
-    K?: Input;
-    L?: Input;
-    M?: Input;
-    N?: Input;
-    O?: Input;
-    P?: Input;
-    Q?: Input;
-    R?: Input;
-    S?: Input;
-    T?: Input;
-    U?: Input;
-    V?: Input;
-    W?: Input;
-    X?: Input;
-    Y?: Input;
-    Z?: Input;
-}
+export type InputMap = Partial<{
+    A: Input;
+    B: Input;
+    C: Input;
+    D: Input;
+    E: Input;
+    F: Input;
+    G: Input;
+    H: Input;
+    I: Input;
+    J: Input;
+    K: Input;
+    L: Input;
+    M: Input;
+    N: Input;
+    O: Input;
+    P: Input;
+    Q: Input;
+    R: Input;
+    S: Input;
+    T: Input;
+    U: Input;
+    V: Input;
+    W: Input;
+    X: Input;
+    Y: Input;
+    Z: Input;
+}>;
 
 export type Permission =
     | 'Printing' // – Top Quality Printing

--- a/types/node-pdftk/index.d.ts
+++ b/types/node-pdftk/index.d.ts
@@ -6,36 +6,33 @@
 
 /// <reference types="node" />
 
-export type Input = string | Buffer;
-
-export type InputMap = Partial<{
-    A: Input;
-    B: Input;
-    C: Input;
-    D: Input;
-    E: Input;
-    F: Input;
-    G: Input;
-    H: Input;
-    I: Input;
-    J: Input;
-    K: Input;
-    L: Input;
-    M: Input;
-    N: Input;
-    O: Input;
-    P: Input;
-    Q: Input;
-    R: Input;
-    S: Input;
-    T: Input;
-    U: Input;
-    V: Input;
-    W: Input;
-    X: Input;
-    Y: Input;
-    Z: Input;
-}>;
+export type Letter =
+    | 'A'
+    | 'B'
+    | 'C'
+    | 'D'
+    | 'E'
+    | 'F'
+    | 'G'
+    | 'H'
+    | 'I'
+    | 'J'
+    | 'K'
+    | 'L'
+    | 'M'
+    | 'N'
+    | 'O'
+    | 'P'
+    | 'Q'
+    | 'R'
+    | 'S'
+    | 'T'
+    | 'U'
+    | 'V'
+    | 'W'
+    | 'X'
+    | 'Y'
+    | 'Z';
 
 export type Permission =
     | 'Printing' // – Top Quality Printing
@@ -286,5 +283,5 @@ export interface ConfigureOptions {
     tempDir: string;
 }
 
-export function input(file: string | Buffer | Buffer[] | InputMap): PDFTK;
+export function input(file: string | Buffer | Buffer[] | Partial<Record<Letter, string | Buffer>>): PDFTK;
 export function configure(opts: ConfigureOptions): void;

--- a/types/node-pdftk/index.d.ts
+++ b/types/node-pdftk/index.d.ts
@@ -1,10 +1,41 @@
 // Type definitions for node-pdftk 2.1
 // Project: https://github.com/jjwilly16/node-pdftk#readme
 // Definitions by: Andrea Ascari <https://github.com/ascariandrea>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped/types/node-pdftk
 // Minimum TypeScript Version: 3.0
 
 /// <reference types="node" />
+
+export type Input = string | Buffer;
+
+export interface InputMap {
+    A?: Input;
+    B?: Input;
+    C?: Input;
+    D?: Input;
+    E?: Input;
+    F?: Input;
+    G?: Input;
+    H?: Input;
+    I?: Input;
+    J?: Input;
+    K?: Input;
+    L?: Input;
+    M?: Input;
+    N?: Input;
+    O?: Input;
+    P?: Input;
+    Q?: Input;
+    R?: Input;
+    S?: Input;
+    T?: Input;
+    U?: Input;
+    V?: Input;
+    W?: Input;
+    X?: Input;
+    Y?: Input;
+    Z?: Input;
+}
 
 export type Permission =
     | 'Printing' // – Top Quality Printing
@@ -255,5 +286,5 @@ export interface ConfigureOptions {
     tempDir: string;
 }
 
-export function input(file: string | Buffer): PDFTK;
+export function input(file: string | Buffer | Buffer[] | InputMap): PDFTK;
 export function configure(opts: ConfigureOptions): void;

--- a/types/node-pdftk/node-pdftk-tests.ts
+++ b/types/node-pdftk/node-pdftk-tests.ts
@@ -15,7 +15,8 @@ PDFTK.configure({
         input: Buffer.from('buffer'),
     },
 ].forEach(scenario => {
-    const pdftk = PDFTK.input(scenario.input); // $ExpectType PDFTK
+    const { input } = scenario;
+    const pdftk = PDFTK.input(input); // $ExpectType PDFTK
 
     pdftk.allow(['FillIn']).attachFiles(['./file1.pdf', './file2.pdf']); // $ExpectType PDFTK
 
@@ -23,6 +24,28 @@ PDFTK.configure({
     pdftk.allow(['FillIn']).compress().output('./fileoutput.pdf', './destination/folder'); // $ExpectType Promise<string>
     pdftk.allow(['FillIn']).compress().output(); // $ExpectType Promise<Buffer>
 
-    PDFTK.input(scenario.input).flatten().ignoreWarnings().inputPw('password').burst('page_%02d.pdf'); // $ExpectType Promise<string>
-    PDFTK.input(scenario.input).flatten().ignoreWarnings().inputPw('password').burst(); // $ExpectType Promise<Buffer>
+    PDFTK.input(input).flatten().ignoreWarnings().inputPw('password').burst('page_%02d.pdf'); // $ExpectType Promise<string>
+    PDFTK.input(input).flatten().ignoreWarnings().inputPw('password').burst(); // $ExpectType Promise<Buffer>
+});
+
+[{ input: [Buffer.from('buffer'), Buffer.from('buffer')] }].forEach(scenario => {
+    const { input } = scenario;
+    const pdftk = PDFTK.input(input);
+
+    pdftk.output(); // $ExpectType Promise<Buffer>
+});
+
+[
+    {
+        input: {
+            A: Buffer.from('buffer'),
+            B: Buffer.from('buffer'),
+            C: Buffer.from('buffer'),
+        },
+    },
+].forEach(scenario => {
+    const { input } = scenario;
+    const pdftk = PDFTK.input(input);
+
+    pdftk.cat('A B C').output(); // $ExpectType Promise<Buffer>
 });


### PR DESCRIPTION
`input` now accepts an array of `Buffer` and an object whose key is any letter from uppercase A to uppercase Z

`node-pdftk` accepts an object as a param of the `input` function, which is not currently supported by this module.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jjwilly16/node-pdftk#concatenate-pages
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
