### PR TITLE
[@types/mathjs] Fix invalid chained filter() parameter

### DIFF
--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -4077,7 +4077,7 @@ declare namespace math {
         /**
          * Filter the items in an array or one dimensional matrix.
          */
-        filter(test: ((value: any, index: any, matrix: Matrix | MathArray) => Matrix | MathArray)| RegExp): MathJsChain;
+        filter(test: ((value: any, index: any, matrix: Matrix | MathArray) => boolean)| RegExp): MathJsChain;
 
         /**
          * Flatten a multi dimensional matrix into a single dimensional matrix.

--- a/types/mathjs/mathjs-tests.ts
+++ b/types/mathjs/mathjs-tests.ts
@@ -94,6 +94,13 @@ Chaining examples
         .subset(math.index(0, 0), 8)
         .multiply(3)
         .done();
+
+    // filtering
+    math.chain([-1, 0, 1.1, 2, 3, 1000])
+        .filter(math.isPositive)
+        .filter(math.isInteger)
+        .filter(n => n !== 1000)
+        .done(); // [2, 3]
 }
 
 /*

--- a/types/mathjs/mathjs-tests.ts
+++ b/types/mathjs/mathjs-tests.ts
@@ -94,6 +94,13 @@ Chaining examples
         .subset(math.index(0, 0), 8)
         .multiply(3)
         .done();
+
+    // filtering
+    math.chain([-1, 0, 1.1, 2, 3, 1000])
+        .filter(math.isPositive)
+        .filter(math.isInteger)
+        .filter(n => n !== 1000)
+        .done() // [2, 3]
 }
 
 /*


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://mathjs.org/docs/reference/functions/filter.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.