### PR TITLE
[pino-multi-stream] add missing options argument for multistream fn

### DIFF
--- a/types/pino-multi-stream/index.d.ts
+++ b/types/pino-multi-stream/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pino-multi-stream 5.1.1
+// Type definitions for pino-multi-stream 5.1
 // Project: https://github.com/pinojs/pino-multi-stream#readme
 // Definitions by: Jake Ginnivan <https://github.com/JakeGinnivan>
 //                 Slava Obukhov <https://github.com/vyobukhov>

--- a/types/pino-multi-stream/index.d.ts
+++ b/types/pino-multi-stream/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for pino-multi-stream 5.0
+// Type definitions for pino-multi-stream 5.1.1
 // Project: https://github.com/pinojs/pino-multi-stream#readme
 // Definitions by: Jake Ginnivan <https://github.com/JakeGinnivan>
+//                 Slava Obukhov <https://github.com/vyobukhov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 import {
@@ -25,10 +26,13 @@ declare namespace pinoms {
         prettifier?: any;
         dest?: PinoDestinationStream | NodeJS.WritableStream;
     }
+    interface MultiStreamOptions {
+        dedupe?: boolean;
+    }
 
     const stdSerializers: typeof pinoStdSerializers;
 
-    function multistream(streams: Streams): stream.Writable;
+    function multistream(streams: Streams, opts?: MultiStreamOptions): stream.Writable;
     function prettyStream(opts?: PrettyStreamOptions): PinoDestinationStream;
     type Level = PinoLevel;
     type Logger = PinoLogger;

--- a/types/pino-multi-stream/pino-multi-stream-tests.ts
+++ b/types/pino-multi-stream/pino-multi-stream-tests.ts
@@ -11,6 +11,9 @@ const streams: pinoms.Streams = [
     { stream: pinoms.prettyStream() },
     { stream: pinoms.prettyStream({ prettyPrint: { colorize: true } }) }
 ];
+const opts: pinoms.MultiStreamOptions = {
+    dedupe: true
+};
 const logger = pinoms({
     level: 'warn',
     streams
@@ -20,5 +23,5 @@ const log = pino(
     {
         level: 'debug',
     },
-    pinoms.multistream(streams)
+    pinoms.multistream(streams, opts)
 );


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pinojs/pino-multi-stream/pull/38/files
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
