### PR TITLE
@types/node: Remove "set-cookie" from IncomingHttpHeaders

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -51,7 +51,6 @@ declare module "http" {
         'range'?: string;
         'referer'?: string;
         'retry-after'?: string;
-        'set-cookie'?: string[];
         'strict-transport-security'?: string;
         'tk'?: string;
         'trailer'?: string;

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -210,8 +210,7 @@ import * as net from 'net';
 // http headers
 {
     const headers: http.IncomingHttpHeaders = {
-        'content-type': 'application/json',
-        'set-cookie': [ 'type=ninja', 'language=javascript' ]
+        'content-type': 'application/json'
     };
 
     headers["access-control-request-headers"] = "content-type, x-custom-header";

--- a/types/node/v10/http.d.ts
+++ b/types/node/v10/http.d.ts
@@ -51,7 +51,6 @@ declare module "http" {
         'range'?: string;
         'referer'?: string;
         'retry-after'?: string;
-        'set-cookie'?: string[];
         'strict-transport-security'?: string;
         'tk'?: string;
         'trailer'?: string;

--- a/types/node/v11/http.d.ts
+++ b/types/node/v11/http.d.ts
@@ -52,7 +52,6 @@ declare module "http" {
         'range'?: string;
         'referer'?: string;
         'retry-after'?: string;
-        'set-cookie'?: string[];
         'strict-transport-security'?: string;
         'tk'?: string;
         'trailer'?: string;

--- a/types/node/v11/test/http.ts
+++ b/types/node/v11/test/http.ts
@@ -189,8 +189,7 @@ import * as net from 'net';
 // http headers
 {
     const headers: http.IncomingHttpHeaders = {
-        'content-type': 'application/json',
-        'set-cookie': [ 'type=ninja', 'language=javascript' ]
+        'content-type': 'application/json'
     };
 
     headers["access-control-request-headers"] = "content-type, x-custom-header";

--- a/types/node/v12/http.d.ts
+++ b/types/node/v12/http.d.ts
@@ -52,7 +52,6 @@ declare module "http" {
         'range'?: string;
         'referer'?: string;
         'retry-after'?: string;
-        'set-cookie'?: string[];
         'strict-transport-security'?: string;
         'tk'?: string;
         'trailer'?: string;

--- a/types/node/v12/test/http.ts
+++ b/types/node/v12/test/http.ts
@@ -195,8 +195,7 @@ import * as net from 'net';
 // http headers
 {
     const headers: http.IncomingHttpHeaders = {
-        'content-type': 'application/json',
-        'set-cookie': [ 'type=ninja', 'language=javascript' ]
+        'content-type': 'application/json'
     };
 
     headers["access-control-request-headers"] = "content-type, x-custom-header";

--- a/types/node/v13/http.d.ts
+++ b/types/node/v13/http.d.ts
@@ -52,7 +52,6 @@ declare module "http" {
         'range'?: string;
         'referer'?: string;
         'retry-after'?: string;
-        'set-cookie'?: string[];
         'strict-transport-security'?: string;
         'tk'?: string;
         'trailer'?: string;

--- a/types/node/v13/test/http.ts
+++ b/types/node/v13/test/http.ts
@@ -200,8 +200,7 @@ import * as net from 'net';
 // http headers
 {
     const headers: http.IncomingHttpHeaders = {
-        'content-type': 'application/json',
-        'set-cookie': [ 'type=ninja', 'language=javascript' ]
+        'content-type': 'application/json'
     };
 
     headers["access-control-request-headers"] = "content-type, x-custom-header";

--- a/types/node/v4/index.d.ts
+++ b/types/node/v4/index.d.ts
@@ -702,7 +702,6 @@ declare module "http" {
         'proxy-authenticate'?: string;
         'public-key-pins'?: string;
         'retry-after'?: string;
-        'set-cookie'?: string[];
         'strict-transport-security'?: string;
         'tk'?: string;
         'trailer'?: string;

--- a/types/node/v4/node-tests.ts
+++ b/types/node/v4/node-tests.ts
@@ -532,8 +532,7 @@ namespace http_tests {
     // http headers
     {
         const headers: http.IncomingHttpHeaders = {
-            'content-type': 'application/json',
-            'set-cookie': [ 'type=ninja', 'language=javascript' ]
+            'content-type': 'application/json'
         };
     }
 }

--- a/types/node/v6/base.d.ts
+++ b/types/node/v6/base.d.ts
@@ -736,7 +736,6 @@ declare module "http" {
         'proxy-authenticate'?: string;
         'public-key-pins'?: string;
         'retry-after'?: string;
-        'set-cookie'?: string[];
         'strict-transport-security'?: string;
         'tk'?: string;
         'trailer'?: string;

--- a/types/node/v6/node-tests.ts
+++ b/types/node/v6/node-tests.ts
@@ -1110,8 +1110,7 @@ namespace http_tests {
     // http headers
     {
         const headers: http.IncomingHttpHeaders = {
-            'content-type': 'application/json',
-            'set-cookie': [ 'type=ninja', 'language=javascript' ]
+            'content-type': 'application/json'
         };
     }
 }

--- a/types/node/v7/base.d.ts
+++ b/types/node/v7/base.d.ts
@@ -739,7 +739,6 @@ declare module "http" {
         'proxy-authenticate'?: string;
         'public-key-pins'?: string;
         'retry-after'?: string;
-        'set-cookie'?: string[];
         'strict-transport-security'?: string;
         'tk'?: string;
         'trailer'?: string;

--- a/types/node/v7/node-tests.ts
+++ b/types/node/v7/node-tests.ts
@@ -1101,8 +1101,7 @@ namespace http_tests {
     // http headers
     {
         const headers: http.IncomingHttpHeaders = {
-            'content-type': 'application/json',
-            'set-cookie': [ 'type=ninja', 'language=javascript' ]
+            'content-type': 'application/json'
         };
     }
 }

--- a/types/node/v8/base.d.ts
+++ b/types/node/v8/base.d.ts
@@ -953,7 +953,6 @@ declare module "http" {
         'proxy-authenticate'?: string;
         'public-key-pins'?: string;
         'retry-after'?: string;
-        'set-cookie'?: string[];
         'strict-transport-security'?: string;
         'tk'?: string;
         'trailer'?: string;

--- a/types/node/v8/node-tests.ts
+++ b/types/node/v8/node-tests.ts
@@ -1505,8 +1505,7 @@ namespace http_tests {
     // http headers
     {
         const headers: http.IncomingHttpHeaders = {
-            'content-type': 'application/json',
-            'set-cookie': [ 'type=ninja', 'language=javascript' ]
+            'content-type': 'application/json'
         };
     }
 }

--- a/types/node/v9/base.d.ts
+++ b/types/node/v9/base.d.ts
@@ -1035,7 +1035,6 @@ declare module "http" {
         'proxy-authenticate'?: string;
         'public-key-pins'?: string;
         'retry-after'?: string;
-        'set-cookie'?: string[];
         'strict-transport-security'?: string;
         'tk'?: string;
         'trailer'?: string;

--- a/types/node/v9/node-tests.ts
+++ b/types/node/v9/node-tests.ts
@@ -1531,8 +1531,7 @@ namespace http_tests {
     // http headers
     {
         const headers: http.IncomingHttpHeaders = {
-            'content-type': 'application/json',
-            'set-cookie': [ 'type=ninja', 'language=javascript' ]
+            'content-type': 'application/json'
         };
     }
 }


### PR DESCRIPTION
`@types/node` contains the interface `IncomingHttpHeaders`. This interface supports setting cookies, although there's no way to do this on an *incoming* request in the real world.

This closes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/48895.

I've removed the property across all Node-versions as there's no reason for it to be there. If this breaks a compatibility-policy of sorts, please let me know, and point me in the right direction for the appropriate way of handling that.