### PR TITLE
Create a new package '@adeira/graphql-global-id'

### DIFF
--- a/types/adeira__graphql-global-id/adeira__graphql-global-id-tests.ts
+++ b/types/adeira__graphql-global-id/adeira__graphql-global-id-tests.ts
@@ -1,0 +1,16 @@
+import { GraphQLObjectType } from 'graphql';
+import GlobalID, { fromGlobalId, toGlobalId } from '@adeira/graphql-global-id';
+
+new GraphQLObjectType({
+    name: 'TypeName',
+    fields: {
+        id: GlobalID(({ id }) => id),
+    },
+});
+
+fromGlobalId('TG9jYXRpb246bG9uZG9uX2di');
+fromGlobalId(42); // $ExpectError
+
+toGlobalId('SomeType', 123);
+toGlobalId('SomeType', '123');
+toGlobalId(123, '123'); // $ExpectError

--- a/types/adeira__graphql-global-id/index.d.ts
+++ b/types/adeira__graphql-global-id/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for @adeira/graphql-global-id 1.1
+// Project: https://github.com/adeira/universe/tree/master/src/graphql-global-id
+// Definitions by: Martin Zlámal <https://github.com/mrtnzlml>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.4
+
+import { GraphQLFieldConfig, GraphQLResolveInfo } from 'graphql';
+
+export function fromGlobalId(opaqueID: string): string;
+
+export function toGlobalId(type: string, id: string | number): string;
+
+export function isTypeOf(type: string, opaqueID: unknown): boolean;
+
+type FetchFnType = (object: any, context: any, info: GraphQLResolveInfo) => string | number;
+
+export default function globalIdField(
+    idFetcher: FetchFnType,
+    unmaskedIdFetcher?: FetchFnType,
+): GraphQLFieldConfig<any, any>;
+
+export {};

--- a/types/adeira__graphql-global-id/package.json
+++ b/types/adeira__graphql-global-id/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "graphql": "^14.5.8"
+    }
+}

--- a/types/adeira__graphql-global-id/tsconfig.json
+++ b/types/adeira__graphql-global-id/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es2018"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@adeira/*": ["adeira__*"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "adeira__graphql-global-id-tests.ts"
+    ]
+}

--- a/types/adeira__graphql-global-id/tslint.json
+++ b/types/adeira__graphql-global-id/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
See: https://github.com/adeira/universe/tree/master/src/graphql-global-id

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.