### PR TITLE
[next-auth] Updating authorize call credentials to be record of strings

### DIFF
--- a/types/next-auth/providers.d.ts
+++ b/types/next-auth/providers.d.ts
@@ -74,7 +74,7 @@ interface ProviderCredentialsOptions {
     id?: string;
     name: string;
     credentials: CredentialInput;
-    authorize(credentails: CredentialInput): Promise<GenericReturnConfig | null>;
+    authorize(credentials: Record<string, string>): Promise<GenericReturnConfig | null>;
 }
 
 interface CredentialInput {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://next-auth.js.org/providers/credentials

Hard to really test for this since it's so permissive, but the long story short here is that the `CredentialsInput` was reused in the `authorize` call when that isn't quite true: what gets passed into `authorize` is a key/value map of the credentials that maps what's in `CredentialsInput` but is in fact a record of strings rather than of objects that also may not necessarily match the shape of `CredentialsInput` if you're using a custom sign-in page.
