### PR TITLE
fix(mongodb): support numeric types for Update

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -39,7 +39,7 @@
 /// <reference types="node" />
 /// <reference lib="esnext.asynciterable" />
 
-import { Binary, ObjectId, Timestamp } from 'bson';
+import { Binary, Decimal128, Double, Int32, Long, ObjectId, Timestamp } from 'bson';
 import { EventEmitter } from 'events';
 import { Readable, Writable } from 'stream';
 import { checkServerIdentity } from 'tls';
@@ -54,6 +54,8 @@ export function connect(uri: string, callback: MongoCallback<MongoClient>): void
 export function connect(uri: string, options: MongoClientOptions, callback: MongoCallback<MongoClient>): void;
 
 export { Binary, DBRef, Decimal128, Double, Int32, Long, MaxKey, MinKey, ObjectID, ObjectId, Timestamp } from 'bson';
+
+type NumericTypes = number | Decimal128 | Double | Int32 | Long;
 
 // Class documentation : http://mongodb.github.io/node-mongodb-native/3.1/api/MongoClient.html
 export class MongoClient extends EventEmitter {
@@ -1406,10 +1408,10 @@ export type PullAllOperator<TSchema> = ({
 export type UpdateQuery<TSchema> = {
     /** https://docs.mongodb.com/manual/reference/operator/update-field/ */
     $currentDate?: OnlyFieldsOfType<TSchema, Date, true | { $type: 'date' | 'timestamp' }>;
-    $inc?: OnlyFieldsOfType<TSchema, number | undefined>;
+    $inc?: OnlyFieldsOfType<TSchema, NumericTypes | undefined>;
     $min?: MatchKeysAndValues<TSchema>;
     $max?: MatchKeysAndValues<TSchema>;
-    $mul?: OnlyFieldsOfType<TSchema, number | undefined>;
+    $mul?: OnlyFieldsOfType<TSchema, NumericTypes | undefined>;
     $rename?: { [key: string]: string };
     $set?: MatchKeysAndValues<TSchema>;
     $setOnInsert?: MatchKeysAndValues<TSchema>;

--- a/types/mongodb/test/collection/updateX.ts
+++ b/types/mongodb/test/collection/updateX.ts
@@ -1,4 +1,4 @@
-import { connect, ObjectId, UpdateQuery } from 'mongodb';
+import { connect, Decimal128, Double, Int32, Long, ObjectId, UpdateQuery } from 'mongodb';
 import { connectionString } from '../index';
 
 // collection.updateX tests
@@ -18,6 +18,10 @@ async function run() {
     interface TestModel {
         stringField: string;
         numberField: number;
+        decimal128Field: Decimal128;
+        doubleField: Double;
+        int32Field: Int32;
+        longField: Long;
         optionalNumberField?: number;
         dateField: Date;
         otherDateField: Date;
@@ -46,6 +50,10 @@ async function run() {
     // buildUpdateQuery({ $currentDate: { stringField: true } }); // stringField is not a date Field
 
     buildUpdateQuery({ $inc: { numberField: 1 } });
+    buildUpdateQuery({ $inc: { decimal128Field: Decimal128.fromString('1.23') } });
+    buildUpdateQuery({ $inc: { doubleField: new Double(1.23) } });
+    buildUpdateQuery({ $inc: { int32Field: new Int32(10) } });
+    buildUpdateQuery({ $inc: { longField: Long.fromString('999') } });
     buildUpdateQuery({ $inc: { optionalNumberField: 1 } });
     buildUpdateQuery({ $inc: { 'dot.notation': 2 } });
     buildUpdateQuery({ $inc: { 'subInterfaceArray.$': -10 } });
@@ -53,6 +61,10 @@ async function run() {
     buildUpdateQuery({ $inc: { 'subInterfaceArray.$[]': 1000.2 } });
 
     buildUpdateQuery({ $min: { numberField: 1 } });
+    buildUpdateQuery({ $min: { decimal128Field: Decimal128.fromString('1.23') } });
+    buildUpdateQuery({ $min: { doubleField: new Double(1.23) } });
+    buildUpdateQuery({ $min: { int32Field: new Int32(10) } });
+    buildUpdateQuery({ $min: { longField: Long.fromString('999') } });
     buildUpdateQuery({ $min: { stringField: 'a' } });
     buildUpdateQuery({ $min: { 'dot.notation': 2 } });
     buildUpdateQuery({ $min: { 'subInterfaceArray.$': 'string' } });
@@ -62,6 +74,10 @@ async function run() {
     // buildUpdateQuery({ $min: { numberField: 'a' } }); // Matches the type of the keys
 
     buildUpdateQuery({ $max: { numberField: 1 } });
+    buildUpdateQuery({ $max: { decimal128Field: Decimal128.fromString('1.23') } });
+    buildUpdateQuery({ $max: { doubleField: new Double(1.23) } });
+    buildUpdateQuery({ $max: { int32Field: new Int32(10) } });
+    buildUpdateQuery({ $max: { longField: Long.fromString('999') } });
     buildUpdateQuery({ $max: { stringField: 'a' } });
     buildUpdateQuery({ $max: { 'dot.notation': 2 } });
     buildUpdateQuery({ $max: { 'subInterfaceArray.$': -10 } });
@@ -71,6 +87,10 @@ async function run() {
     // buildUpdateQuery({ $min: { numberField: 'a' } }); // Matches the type of the keys
 
     buildUpdateQuery({ $mul: { numberField: 1 } });
+    buildUpdateQuery({ $mul: { decimal128Field: Decimal128.fromString('1.23') } });
+    buildUpdateQuery({ $mul: { doubleField: new Double(1.23) } });
+    buildUpdateQuery({ $mul: { int32Field: new Int32(10) } });
+    buildUpdateQuery({ $mul: { longField: Long.fromString('999') } });
     buildUpdateQuery({ $mul: { optionalNumberField: 1 } });
     buildUpdateQuery({ $mul: { 'dot.notation': 2 } });
     buildUpdateQuery({ $mul: { 'subInterfaceArray.$': -10 } });
@@ -78,6 +98,10 @@ async function run() {
     buildUpdateQuery({ $mul: { 'subInterfaceArray.$[]': 1000.2 } });
 
     buildUpdateQuery({ $set: { numberField: 1 } });
+    buildUpdateQuery({ $set: { decimal128Field: Decimal128.fromString('1.23') } });
+    buildUpdateQuery({ $set: { doubleField: new Double(1.23) } });
+    buildUpdateQuery({ $set: { int32Field: new Int32(10) } });
+    buildUpdateQuery({ $set: { longField: Long.fromString('999') } });
     buildUpdateQuery({ $set: { stringField: 'a' } });
     // $ExpectError
     buildUpdateQuery({ $set: { stringField: 123 } });
@@ -87,6 +111,10 @@ async function run() {
     buildUpdateQuery({ $set: { 'subInterfaceArray.$[]': 1000.2 } });
 
     buildUpdateQuery({ $setOnInsert: { numberField: 1 } });
+    buildUpdateQuery({ $setOnInsert: { decimal128Field: Decimal128.fromString('1.23') } });
+    buildUpdateQuery({ $setOnInsert: { doubleField: new Double(1.23) } });
+    buildUpdateQuery({ $setOnInsert: { int32Field: new Int32(10) } });
+    buildUpdateQuery({ $setOnInsert: { longField: Long.fromString('999') } });
     buildUpdateQuery({ $setOnInsert: { stringField: 'a' } });
     // $ExpectError
     buildUpdateQuery({ $setOnInsert: { stringField: 123 } });
@@ -96,6 +124,10 @@ async function run() {
     buildUpdateQuery({ $setOnInsert: { 'subInterfaceArray.$[]': 1000.2 } });
 
     buildUpdateQuery({ $unset: { numberField: '' } });
+    buildUpdateQuery({ $unset: { decimal128Field: '' } });
+    buildUpdateQuery({ $unset: { doubleField: '' } });
+    buildUpdateQuery({ $unset: { int32Field: '' } });
+    buildUpdateQuery({ $unset: { longField: '' } });
     buildUpdateQuery({ $unset: { dateField: '' } });
     buildUpdateQuery({ $unset: { 'dot.notation': '' } });
     buildUpdateQuery({ $unset: { 'subInterfaceArray.$': '' } });
@@ -103,6 +135,10 @@ async function run() {
     buildUpdateQuery({ $unset: { 'subInterfaceArray.$[]': '' } });
 
     buildUpdateQuery({ $unset: { numberField: 1 } });
+    buildUpdateQuery({ $unset: { decimal128Field: 1 } });
+    buildUpdateQuery({ $unset: { doubleField: 1 } });
+    buildUpdateQuery({ $unset: { int32Field: 1 } });
+    buildUpdateQuery({ $unset: { longField: 1 } });
     buildUpdateQuery({ $unset: { dateField: 1 } });
     buildUpdateQuery({ $unset: { 'dot.notation': 1 } });
     buildUpdateQuery({ $unset: { 'subInterfaceArray.$': 1 } });


### PR DESCRIPTION
Both `$inc` and `$mul` support an amount that could be `Decimal128`,
`Double`, `Int32` or `Long` as type.
More information can be found on:
https://docs.mongodb.com/manual/reference/operator/update/inc/
https://docs.mongodb.com/manual/reference/operator/update/mul/

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (urls posted above - and part of the commit message).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
