### PR TITLE
fix(frisby): remove unneeded reference to `jest` types

### DIFF
--- a/types/frisby/frisby-tests.ts
+++ b/types/frisby/frisby-tests.ts
@@ -6,21 +6,10 @@ frisby.globalSetup({
     }
 });
 
-describe('Test Suite 1', () => {
-    it('should be a teapot get', (done) => {
-        frisby.get(URL + '/users/3.json')
-            .expect('status', 418)
-            .done(done);
-    });
+frisby.get(URL + '/users/3.json')
+  .expect('status', 418)
+  .done(() => {});
 
-    it('should be a teapot post', (done) => {
-        frisby.post(URL + '/users/3.json')
-            .expect('status', 418)
-            .done(done);
-    });
-
-    it('should handle jest matchers', () => {
-      const str = 'bar';
-      expect(str).toHaveLength(3);
-    });
-});
+frisby.post(URL + '/users/3.json')
+  .expect('status', 418)
+  .done(() => {});

--- a/types/frisby/index.d.ts
+++ b/types/frisby/index.d.ts
@@ -5,8 +5,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.8
 
-/// <reference types='jest'/>
-
 // #region Imports
 export import nodeFetch = require('node-fetch'); // Import all definitions from node-fetch.
 //#endregion


### PR DESCRIPTION
Found during #48473

Per my comment [here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48473#discussion_r499196333):

> It seems that the original reference was to jasmine, and was because it was argumenting the global jasmine namespace.
>
> However, while v2 of @types/frisby removed this argumenting, the reference was kept in because the author wanted to have @types/jasmine pulled in because the library used jasmine?
>
> I can understand why, and am not against it, but I think it would be better to remove this reference since frisby.js doesn't list jest as a dependency (not even as a peerDependency) nor does it require/import it anywhere, and because people using TypeScript will need to install @types/jest anyway as they'll be consuming them directly.
>
> Additionally, the source code of frisby still references jasmine rather than jest, and was originally switched to jest as the jasmine types were causing problems (#32191).