### PR TITLE
[tizen-accessory]: Add definitions for Samsung Accessory Protocol

### DIFF
--- a/types/tizen-accessory/index.d.ts
+++ b/types/tizen-accessory/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for tizen-accessory 1.0
+// Type definitions for non-npm package tizen-accessory-browser
 // Project: https://developer.samsung.com/galaxy-accessory/overview.html
 // Definitions by: Egor Shulga <https://github.com/egorshulga>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/tizen-accessory/index.d.ts
+++ b/types/tizen-accessory/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for tizen-accessory x.x
+// Type definitions for tizen-accessory 1.0
 // Project: https://developer.samsung.com/galaxy-accessory/overview.html
 // Definitions by: Egor Shulga <https://github.com/egorshulga>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/tizen-accessory/index.d.ts
+++ b/types/tizen-accessory/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package tizen-accessory-browser
+// Type definitions for non-npm package tizen-accessory-browser 1.0
 // Project: https://developer.samsung.com/galaxy-accessory/overview.html
 // Definitions by: Egor Shulga <https://github.com/egorshulga>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/tizen-accessory/index.d.ts
+++ b/types/tizen-accessory/index.d.ts
@@ -1,0 +1,116 @@
+// Type definitions for tizen-accessory x.x
+// Project: https://developer.samsung.com/galaxy-accessory/overview.html
+// Definitions by: Egor Shulga <https://github.com/egorshulga>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace webapis {
+    const sa: SAManager
+}
+
+interface SAManager {
+    requestSAAgent(success: (agents: SAAgent[]) => void, error?: (err: Error) => void): void
+    setDeviceStatusListener(callback: (type: SATransport, status: 'DETACHED' | 'ATTACHED') => void): void
+}
+
+interface SAAgent {
+    readonly id: string
+    readonly name: string
+    readonly role: 'consumer' | 'provider'
+    readonly channelIds: number[]
+
+    requestServiceConnection(peerAgent: SAPeerAgent): void
+    setServiceConnectionListener(callback: {
+        onrequest?: (peerAgent: SAPeerAgent) => void,
+        onconnect?: (socket: SASocket) => void,
+        onerror?: (errorCode: string, peerAgent: SAPeerAgent) => void,
+    }): void
+    authenticatePeerAgent(
+        peerAgent: SAPeerAgent,
+        success: (peerAgent: SAPeerAgent, authToken: SAAuthenticationToken) => void,
+        error?: (e: Error) => void
+    ): void
+    acceptServiceConnectionRequest(peerAgent: SAPeerAgent): void
+    rejectServiceConnectionRequest(peerAgent: SAPeerAgent): void
+    findPeerAgents(): void
+    setPeerAgentFindListener(callback: {
+        onpeeragentfound: (peerAgent: SAPeerAgent) => void,
+        onpeeragentupdated?: (peerAgent: SAPeerAgent, status: 'AVAILABLE' | 'UNAVAILABLE') => void,
+        onerror?: (errorCode: string) => void,
+    }): void
+    getSAFileTransfer(): SAFileTransfer
+    getSAMessage(): SAMessage
+}
+
+interface SAPeerAgent {
+    readonly peerAccessory: SAPeerAccessory
+    readonly appName: string
+    readonly maxAllowedDataSize: number
+    readonly peerId: string
+    readonly profileVersion: string
+    readonly feature: string[]
+}
+
+interface SAPeerAccessory {
+    readonly deviceAddress: string
+    readonly deviceName: string
+    readonly productId: string
+    readonly transportType: string
+    readonly vendorId: string
+    readonly accessoryId: string
+}
+
+interface SASocket {
+    readonly peerAgent: SAPeerAgent
+
+    close(): void
+    isConnected(): boolean
+    sendData(channelId: number, data: string): void
+    sendSecureData(channelId: number, data: string): void
+    setDataReceiveListener(dataReceiveCallback: (channelId: number, data: string) => void): void
+    setSocketStatusListener(socketStatusCallback: (reason: string) => void): void
+}
+
+interface SAAuthenticationToken {
+    readonly authenticationType: string
+    readonly key: string
+}
+
+interface SAFileTransfer {
+    readonly defaultReceivePath: string
+
+    sendFile(peerAgent: SAPeerAgent, filePath: string): number
+    setFileSendListener(callback: {
+        onprogress?: (id: string, progress: number) => void,
+        oncomplete?: (id: string, localPath: string) => void,
+        onerror?: (errorCode: string, id: string) => void,
+    }): void
+    setFileReceiveListener(callback: {
+        onreceive?: (id: string, fileName: string) => void,
+        onprogress?: (id: string, progress: number) => void,
+        oncomplete?: (id: string, localPath: string) => void,
+        onerror?: (errorCode: string, id: string) => void,
+    }): void
+    receiveFile(id: string, localPath: string): void
+    cancelFile(id: string): void
+    rejectFile(id: string): void
+}
+
+interface SAMessage {
+    sendData(peerAgent: SAPeerAgent, data: string, callback: {
+        onsent?: (peerAgent: SAPeerAgent, id: string) => void,
+        onerror?: (errorCode: string, peerAgent: SAPeerAgent, id: string) => void,
+    }): void
+    sendSecureData(peerAgent: SAPeerAgent, data: string, callback: {
+        onsent?: (peerAgent: SAPeerAgent, id: string) => void,
+        onerror?: (errorCode: string, peerAgent: SAPeerAgent, id: string) => void,
+    }): void
+    setMessageReceiveListener(receiveDataCallback: (peerAgent: SAPeerAgent, data: string) => void): void
+}
+
+declare enum SATransport {
+    TRANSPORT_WIFI = 'TRANSPORT_WIFI',
+    TRANSPORT_BT = 'TRANSPORT_BT',
+    TRANSPORT_BLE = 'TRANSPORT_BLE',
+    TRANSPORT_USB = 'TRANSPORT_USB',
+    TRANSPORT_MOBILE = 'TRANSPORT_MOBILE',
+}

--- a/types/tizen-accessory/index.d.ts
+++ b/types/tizen-accessory/index.d.ts
@@ -4,107 +4,115 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace webapis {
-    const sa: SAManager
+    const sa: SAManager;
 }
 
 interface SAManager {
-    requestSAAgent(success: (agents: SAAgent[]) => void, error?: (err: Error) => void): void
-    setDeviceStatusListener(callback: (type: SATransport, status: 'DETACHED' | 'ATTACHED') => void): void
+    requestSAAgent(success: (agents: SAAgent[]) => void, error?: (err: Error) => void): void;
+    setDeviceStatusListener(callback: (type: SATransport, status: 'DETACHED' | 'ATTACHED') => void): void;
 }
 
 interface SAAgent {
-    readonly id: string
-    readonly name: string
-    readonly role: 'consumer' | 'provider'
-    readonly channelIds: number[]
+    readonly id: string;
+    readonly name: string;
+    readonly role: 'consumer' | 'provider';
+    readonly channelIds: number[];
 
-    requestServiceConnection(peerAgent: SAPeerAgent): void
+    requestServiceConnection(peerAgent: SAPeerAgent): void;
     setServiceConnectionListener(callback: {
-        onrequest?: (peerAgent: SAPeerAgent) => void,
-        onconnect?: (socket: SASocket) => void,
-        onerror?: (errorCode: string, peerAgent: SAPeerAgent) => void,
-    }): void
+        onrequest?: (peerAgent: SAPeerAgent) => void;
+        onconnect?: (socket: SASocket) => void;
+        onerror?: (errorCode: string, peerAgent: SAPeerAgent) => void;
+    }): void;
     authenticatePeerAgent(
         peerAgent: SAPeerAgent,
         success: (peerAgent: SAPeerAgent, authToken: SAAuthenticationToken) => void,
-        error?: (e: Error) => void
-    ): void
-    acceptServiceConnectionRequest(peerAgent: SAPeerAgent): void
-    rejectServiceConnectionRequest(peerAgent: SAPeerAgent): void
-    findPeerAgents(): void
+        error?: (e: Error) => void,
+    ): void;
+    acceptServiceConnectionRequest(peerAgent: SAPeerAgent): void;
+    rejectServiceConnectionRequest(peerAgent: SAPeerAgent): void;
+    findPeerAgents(): void;
     setPeerAgentFindListener(callback: {
-        onpeeragentfound: (peerAgent: SAPeerAgent) => void,
-        onpeeragentupdated?: (peerAgent: SAPeerAgent, status: 'AVAILABLE' | 'UNAVAILABLE') => void,
-        onerror?: (errorCode: string) => void,
-    }): void
-    getSAFileTransfer(): SAFileTransfer
-    getSAMessage(): SAMessage
+        onpeeragentfound: (peerAgent: SAPeerAgent) => void;
+        onpeeragentupdated?: (peerAgent: SAPeerAgent, status: 'AVAILABLE' | 'UNAVAILABLE') => void;
+        onerror?: (errorCode: string) => void;
+    }): void;
+    getSAFileTransfer(): SAFileTransfer;
+    getSAMessage(): SAMessage;
 }
 
 interface SAPeerAgent {
-    readonly peerAccessory: SAPeerAccessory
-    readonly appName: string
-    readonly maxAllowedDataSize: number
-    readonly peerId: string
-    readonly profileVersion: string
-    readonly feature: string[]
+    readonly peerAccessory: SAPeerAccessory;
+    readonly appName: string;
+    readonly maxAllowedDataSize: number;
+    readonly peerId: string;
+    readonly profileVersion: string;
+    readonly feature: string[];
 }
 
 interface SAPeerAccessory {
-    readonly deviceAddress: string
-    readonly deviceName: string
-    readonly productId: string
-    readonly transportType: string
-    readonly vendorId: string
-    readonly accessoryId: string
+    readonly deviceAddress: string;
+    readonly deviceName: string;
+    readonly productId: string;
+    readonly transportType: string;
+    readonly vendorId: string;
+    readonly accessoryId: string;
 }
 
 interface SASocket {
-    readonly peerAgent: SAPeerAgent
+    readonly peerAgent: SAPeerAgent;
 
-    close(): void
-    isConnected(): boolean
-    sendData(channelId: number, data: string): void
-    sendSecureData(channelId: number, data: string): void
-    setDataReceiveListener(dataReceiveCallback: (channelId: number, data: string) => void): void
-    setSocketStatusListener(socketStatusCallback: (reason: string) => void): void
+    close(): void;
+    isConnected(): boolean;
+    sendData(channelId: number, data: string): void;
+    sendSecureData(channelId: number, data: string): void;
+    setDataReceiveListener(dataReceiveCallback: (channelId: number, data: string) => void): void;
+    setSocketStatusListener(socketStatusCallback: (reason: string) => void): void;
 }
 
 interface SAAuthenticationToken {
-    readonly authenticationType: string
-    readonly key: string
+    readonly authenticationType: string;
+    readonly key: string;
 }
 
 interface SAFileTransfer {
-    readonly defaultReceivePath: string
+    readonly defaultReceivePath: string;
 
-    sendFile(peerAgent: SAPeerAgent, filePath: string): number
+    sendFile(peerAgent: SAPeerAgent, filePath: string): number;
     setFileSendListener(callback: {
-        onprogress?: (id: string, progress: number) => void,
-        oncomplete?: (id: string, localPath: string) => void,
-        onerror?: (errorCode: string, id: string) => void,
-    }): void
+        onprogress?: (id: string, progress: number) => void;
+        oncomplete?: (id: string, localPath: string) => void;
+        onerror?: (errorCode: string, id: string) => void;
+    }): void;
     setFileReceiveListener(callback: {
-        onreceive?: (id: string, fileName: string) => void,
-        onprogress?: (id: string, progress: number) => void,
-        oncomplete?: (id: string, localPath: string) => void,
-        onerror?: (errorCode: string, id: string) => void,
-    }): void
-    receiveFile(id: string, localPath: string): void
-    cancelFile(id: string): void
-    rejectFile(id: string): void
+        onreceive?: (id: string, fileName: string) => void;
+        onprogress?: (id: string, progress: number) => void;
+        oncomplete?: (id: string, localPath: string) => void;
+        onerror?: (errorCode: string, id: string) => void;
+    }): void;
+    receiveFile(id: string, localPath: string): void;
+    cancelFile(id: string): void;
+    rejectFile(id: string): void;
 }
 
 interface SAMessage {
-    sendData(peerAgent: SAPeerAgent, data: string, callback: {
-        onsent?: (peerAgent: SAPeerAgent, id: string) => void,
-        onerror?: (errorCode: string, peerAgent: SAPeerAgent, id: string) => void,
-    }): void
-    sendSecureData(peerAgent: SAPeerAgent, data: string, callback: {
-        onsent?: (peerAgent: SAPeerAgent, id: string) => void,
-        onerror?: (errorCode: string, peerAgent: SAPeerAgent, id: string) => void,
-    }): void
-    setMessageReceiveListener(receiveDataCallback: (peerAgent: SAPeerAgent, data: string) => void): void
+    sendData(
+        peerAgent: SAPeerAgent,
+        data: string,
+        callback: {
+            onsent?: (peerAgent: SAPeerAgent, id: string) => void;
+            onerror?: (errorCode: string, peerAgent: SAPeerAgent, id: string) => void;
+        },
+    ): void;
+    sendSecureData(
+        peerAgent: SAPeerAgent,
+        data: string,
+        callback: {
+            onsent?: (peerAgent: SAPeerAgent, id: string) => void;
+            onerror?: (errorCode: string, peerAgent: SAPeerAgent, id: string) => void;
+        },
+    ): void;
+    setMessageReceiveListener(receiveDataCallback: (peerAgent: SAPeerAgent, data: string) => void): void;
 }
 
 declare enum SATransport {

--- a/types/tizen-accessory/tizen-accessory-tests.ts
+++ b/types/tizen-accessory/tizen-accessory-tests.ts
@@ -13,7 +13,7 @@ function handleSAAgent(agents: SAAgent[]): void {
     }
 }
 function handleSAAgentError(e: Error): void {
-    const errorMessage = 'requestSAAgent Error' + 'Error name : ' + e.name + 'Error message : ' + e.message;
+    const errorMessage = `requestSAAgent Error name : ${e.name} Error message : ${e.message}`;
 }
 
 declare const peer: SAPeerAgent;

--- a/types/tizen-accessory/tizen-accessory-tests.ts
+++ b/types/tizen-accessory/tizen-accessory-tests.ts
@@ -1,0 +1,86 @@
+webapis.sa.requestSAAgent(handleSAAgent)
+webapis.sa.requestSAAgent(handleSAAgent, handleSAAgentError)
+
+declare let agent: SAAgent
+function handleSAAgent(agents: SAAgent[]): void {
+    agent = agents[0]
+    agent.channelIds.forEach(x => x !== -1)
+    if (agent.id === 'id') { }
+    if (agent.name === 'name') { }
+    if (agent.role === 'consumer') { }
+}
+function handleSAAgentError(e: Error): void {
+    const errorMessage = "requestSAAgent Error" +
+        "Error name : " + e.name +
+        "Error message : " + e.message
+}
+
+declare const peer: SAPeerAgent
+agent.requestServiceConnection(peer)
+agent.setServiceConnectionListener({
+    onrequest: (peer: SAPeerAgent) => peer.peerId,
+    onconnect: (socket: SASocket) => {
+        socket.isConnected
+        socket.close()
+        socket.peerAgent === peer
+        socket.setDataReceiveListener((channelId: number, data: string) => { })
+        socket.setSocketStatusListener((reas: string) => { })
+        socket.sendData(123, 'test')
+        socket.sendSecureData(123, 'secure test')
+    },
+    onerror: (errorCode: string, peerAgent: SAPeerAgent) => { },
+})
+agent.authenticatePeerAgent(peer, (peer: SAPeerAgent, token: SAAuthenticationToken) => {
+    token.authenticationType === '14'
+    token.key === 'key'
+})
+agent.acceptServiceConnectionRequest(peer)
+agent.rejectServiceConnectionRequest(peer)
+agent.findPeerAgents()
+agent.setPeerAgentFindListener({
+    onpeeragentfound: (peer: SAPeerAgent) => { },
+    onpeeragentupdated: (peer: SAPeerAgent, status: string) => { },
+    onerror: (errorCode: string) => { },
+})
+
+const saFileTransfer = agent.getSAFileTransfer()
+saFileTransfer.setFileReceiveListener({
+    onreceive: (id: string, fileName: string) => {
+        if (fileName === 'aaa')
+            saFileTransfer.receiveFile(id, 'local path')
+        else
+            saFileTransfer.rejectFile(id)
+        saFileTransfer.cancelFile(id)
+    },
+    oncomplete: (id: string, localPath: string) => { },
+})
+saFileTransfer.setFileSendListener({
+    onprogress: (id: string, progress: number) => { },
+    oncomplete: (id: string, localPath: string) => { },
+})
+const fileId: number = saFileTransfer.sendFile(peer, 'file')
+
+const saMessage: SAMessage = agent.getSAMessage()
+saMessage.setMessageReceiveListener((peer: SAPeerAgent, data: string) => {
+    peer.peerAccessory.accessoryId
+    data === 'test'
+})
+saMessage.sendData(peer, 'Hello World', {
+    onsent: (peer, id: string) => { },
+})
+saMessage.sendSecureData(peer, 'Hello Secure World', {
+    onsent: (peer, id: string) => { },
+})
+
+webapis.sa.setDeviceStatusListener(deviceStatusListener)
+function deviceStatusListener(type: SATransport, status: 'DETACHED' | 'ATTACHED'): void {
+    switch (type) {
+        case SATransport.TRANSPORT_BLE: break
+        case SATransport.TRANSPORT_BT: break
+        case SATransport.TRANSPORT_MOBILE: break
+        case SATransport.TRANSPORT_USB: break
+        case SATransport.TRANSPORT_WIFI: break
+    }
+    if (status === 'DETACHED') { }
+    if (status === 'ATTACHED') { }
+}

--- a/types/tizen-accessory/tizen-accessory-tests.ts
+++ b/types/tizen-accessory/tizen-accessory-tests.ts
@@ -1,86 +1,92 @@
-webapis.sa.requestSAAgent(handleSAAgent)
-webapis.sa.requestSAAgent(handleSAAgent, handleSAAgentError)
+webapis.sa.requestSAAgent(handleSAAgent);
+webapis.sa.requestSAAgent(handleSAAgent, handleSAAgentError);
 
-declare let agent: SAAgent
+declare let agent: SAAgent;
 function handleSAAgent(agents: SAAgent[]): void {
-    agent = agents[0]
-    agent.channelIds.forEach(x => x !== -1)
-    if (agent.id === 'id') { }
-    if (agent.name === 'name') { }
-    if (agent.role === 'consumer') { }
+    agent = agents[0];
+    agent.channelIds.forEach(x => x !== -1);
+    if (agent.id === 'id') {
+    }
+    if (agent.name === 'name') {
+    }
+    if (agent.role === 'consumer') {
+    }
 }
 function handleSAAgentError(e: Error): void {
-    const errorMessage = "requestSAAgent Error" +
-        "Error name : " + e.name +
-        "Error message : " + e.message
+    const errorMessage = 'requestSAAgent Error' + 'Error name : ' + e.name + 'Error message : ' + e.message;
 }
 
-declare const peer: SAPeerAgent
-agent.requestServiceConnection(peer)
+declare const peer: SAPeerAgent;
+agent.requestServiceConnection(peer);
 agent.setServiceConnectionListener({
     onrequest: (peer: SAPeerAgent) => peer.peerId,
     onconnect: (socket: SASocket) => {
-        socket.isConnected
-        socket.close()
-        socket.peerAgent === peer
-        socket.setDataReceiveListener((channelId: number, data: string) => { })
-        socket.setSocketStatusListener((reas: string) => { })
-        socket.sendData(123, 'test')
-        socket.sendSecureData(123, 'secure test')
+        socket.isConnected;
+        socket.close();
+        socket.peerAgent === peer;
+        socket.setDataReceiveListener((channelId: number, data: string) => {});
+        socket.setSocketStatusListener((reas: string) => {});
+        socket.sendData(123, 'test');
+        socket.sendSecureData(123, 'secure test');
     },
-    onerror: (errorCode: string, peerAgent: SAPeerAgent) => { },
-})
+    onerror: (errorCode: string, peerAgent: SAPeerAgent) => {},
+});
 agent.authenticatePeerAgent(peer, (peer: SAPeerAgent, token: SAAuthenticationToken) => {
-    token.authenticationType === '14'
-    token.key === 'key'
-})
-agent.acceptServiceConnectionRequest(peer)
-agent.rejectServiceConnectionRequest(peer)
-agent.findPeerAgents()
+    token.authenticationType === '14';
+    token.key === 'key';
+});
+agent.acceptServiceConnectionRequest(peer);
+agent.rejectServiceConnectionRequest(peer);
+agent.findPeerAgents();
 agent.setPeerAgentFindListener({
-    onpeeragentfound: (peer: SAPeerAgent) => { },
-    onpeeragentupdated: (peer: SAPeerAgent, status: string) => { },
-    onerror: (errorCode: string) => { },
-})
+    onpeeragentfound: (peer: SAPeerAgent) => {},
+    onpeeragentupdated: (peer: SAPeerAgent, status: string) => {},
+    onerror: (errorCode: string) => {},
+});
 
-const saFileTransfer = agent.getSAFileTransfer()
+const saFileTransfer = agent.getSAFileTransfer();
 saFileTransfer.setFileReceiveListener({
     onreceive: (id: string, fileName: string) => {
-        if (fileName === 'aaa')
-            saFileTransfer.receiveFile(id, 'local path')
-        else
-            saFileTransfer.rejectFile(id)
-        saFileTransfer.cancelFile(id)
+        if (fileName === 'aaa') saFileTransfer.receiveFile(id, 'local path');
+        else saFileTransfer.rejectFile(id);
+        saFileTransfer.cancelFile(id);
     },
-    oncomplete: (id: string, localPath: string) => { },
-})
+    oncomplete: (id: string, localPath: string) => {},
+});
 saFileTransfer.setFileSendListener({
-    onprogress: (id: string, progress: number) => { },
-    oncomplete: (id: string, localPath: string) => { },
-})
-const fileId: number = saFileTransfer.sendFile(peer, 'file')
+    onprogress: (id: string, progress: number) => {},
+    oncomplete: (id: string, localPath: string) => {},
+});
+const fileId: number = saFileTransfer.sendFile(peer, 'file');
 
-const saMessage: SAMessage = agent.getSAMessage()
+const saMessage: SAMessage = agent.getSAMessage();
 saMessage.setMessageReceiveListener((peer: SAPeerAgent, data: string) => {
-    peer.peerAccessory.accessoryId
-    data === 'test'
-})
+    peer.peerAccessory.accessoryId;
+    data === 'test';
+});
 saMessage.sendData(peer, 'Hello World', {
-    onsent: (peer, id: string) => { },
-})
+    onsent: (peer, id: string) => {},
+});
 saMessage.sendSecureData(peer, 'Hello Secure World', {
-    onsent: (peer, id: string) => { },
-})
+    onsent: (peer, id: string) => {},
+});
 
-webapis.sa.setDeviceStatusListener(deviceStatusListener)
+webapis.sa.setDeviceStatusListener(deviceStatusListener);
 function deviceStatusListener(type: SATransport, status: 'DETACHED' | 'ATTACHED'): void {
     switch (type) {
-        case SATransport.TRANSPORT_BLE: break
-        case SATransport.TRANSPORT_BT: break
-        case SATransport.TRANSPORT_MOBILE: break
-        case SATransport.TRANSPORT_USB: break
-        case SATransport.TRANSPORT_WIFI: break
+        case SATransport.TRANSPORT_BLE:
+            break;
+        case SATransport.TRANSPORT_BT:
+            break;
+        case SATransport.TRANSPORT_MOBILE:
+            break;
+        case SATransport.TRANSPORT_USB:
+            break;
+        case SATransport.TRANSPORT_WIFI:
+            break;
     }
-    if (status === 'DETACHED') { }
-    if (status === 'ATTACHED') { }
+    if (status === 'DETACHED') {
+    }
+    if (status === 'ATTACHED') {
+    }
 }

--- a/types/tizen-accessory/tsconfig.json
+++ b/types/tizen-accessory/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "tizen-accessory-tests.ts"
+    ]
+}

--- a/types/tizen-accessory/tslint.json
+++ b/types/tizen-accessory/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Overview: https://developer.samsung.com/galaxy-accessory/overview.html
Programming guide: https://developer.samsung.com/galaxy-accessory/programming-guide.html (it was very useful while reverse engineering tizen-side web API)