### PR TITLE
[@types/backbone.marionette] Add `viewFilter` to `CollectionViewOptions`

### DIFF
--- a/types/backbone.marionette/backbone.marionette-tests.ts
+++ b/types/backbone.marionette/backbone.marionette-tests.ts
@@ -192,9 +192,11 @@ class MyHtmlElRegion extends Marionette.Region {
     }
 }
 
-class MyCollectionView extends Marionette.CollectionView<MyModel, MyView | MyOtherView> {
-    constructor() {
-        super();
+type MyCollectionViewChildViews = MyView | MyOtherView;
+
+class MyCollectionView extends Marionette.CollectionView<MyModel, MyCollectionViewChildViews> {
+    constructor(options?: Marionette.CollectionViewOptions<MyModel>) {
+        super(options);
 
         this.childView = (model: MyModel) => {
             if (model.get('isFoo')) {
@@ -295,11 +297,15 @@ function ViewTests() {
 }
 
 function CollectionViewTests() {
-    const cv = new MyCollectionView();
+    const cvWithoutOptions = new MyCollectionView();
+    const cv = new MyCollectionView({
+        viewFilter: (_view?: MyCollectionViewChildViews, _index?: number, children?: MyCollectionViewChildViews[]) =>
+            true,
+    });
     cv.collection.add(new MyModel());
     app.mainRegion.show(cv);
     cv.emptyView = MyView;
-    const view: Marionette.CollectionView<MyModel, MyView | MyOtherView> = cv.destroy();
+    const view: Marionette.CollectionView<MyModel, MyCollectionViewChildViews> = cv.destroy();
 }
 
 class MyController {

--- a/types/backbone.marionette/index.d.ts
+++ b/types/backbone.marionette/index.d.ts
@@ -1314,7 +1314,7 @@ export interface CollectionViewOptions<
     /**
      * Prevent some of the underlying children from being attached to the DOM.
      */
-    viewFilter?: ((view?: typeof Backbone.View, index?: number, children?: any) => boolean) | Backbone.ObjectHash | string;
+    viewFilter?: ((view?: typeof Backbone.View, index?: number, children?: Backbone.View[]) => boolean) | Backbone.ObjectHash | string;
 
     /**
      * Specify a view to use if the collection has no children.

--- a/types/backbone.marionette/index.d.ts
+++ b/types/backbone.marionette/index.d.ts
@@ -1312,6 +1312,11 @@ export interface CollectionViewOptions<
     filter?(child?: TModel, index?: number, collection?: TCollection): boolean;
 
     /**
+     * Prevent some of the underlying children from being attached to the DOM.
+     */
+    viewFilter?: ((view?: typeof Backbone.View, index?: number, children?: any) => boolean) | Backbone.ObjectHash | string;
+
+    /**
      * Specify a view to use if the collection has no children.
      */
     emptyView?: (() => typeof Backbone.View) | typeof Backbone.View;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://marionettejs.com/docs/master/marionette.collectionview.html#defining-the-viewfilter
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Related issue #48912
