### PR TITLE
types/node: Remove function `AsyncLocalStorage.runSyncAndReturn()` not available in Node v12

### DIFF
--- a/types/node/v12/async_hooks.d.ts
+++ b/types/node/v12/async_hooks.d.ts
@@ -210,20 +210,6 @@ declare module "async_hooks" {
         exit(callback: (...args: any[]) => void, ...args: any[]): void;
 
         /**
-         * This methods runs a function synchronously within a context and return its
-         * return value. The store is not accessible outside of the callback function or
-         * the asynchronous operations created within the callback.
-         *
-         * Optionally, arguments can be passed to the function. They will be passed to
-         * the callback function.
-         *
-         * If the callback function throws an error, it will be thrown by
-         * `runSyncAndReturn` too. The stacktrace will not be impacted by this call and
-         * the context will be exited.
-         */
-        runSyncAndReturn<R>(store: T, callback: (...args: any[]) => R, ...args: any[]): R;
-
-        /**
          * This methods runs a function synchronously outside of a context and return its
          * return value. The store is not accessible within the callback function or
          * the asynchronous operations created within the callback.

--- a/types/node/v12/test/async_hooks.ts
+++ b/types/node/v12/test/async_hooks.ts
@@ -61,8 +61,5 @@ import { AsyncResource, createHook, triggerAsyncId, executionAsyncId, executionA
     ctx.run('test', (a: number) => {
         const store: string | undefined = ctx.getStore();
     }, 1);
-    const rsSet = ctx.runSyncAndReturn('test', (a: number) => {
-        return 123;
-    }, 1);
     ctx.enterWith('test');
 }


### PR DESCRIPTION
Remove function `AsyncLocalStorage.runSyncAndReturn()` not available in Node v12:

- https://nodejs.org/dist/latest-v12.x/docs/api/async_hooks.html#async_hooks_class_asynclocalstorage

This partially resolves https://github.com/DefinitelyTyped/DefinitelyTyped/issues/48688.
