### PR TITLE
Added integration option to Serverless framework Http interface

### DIFF
--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -293,6 +293,7 @@ declare namespace Aws {
         async?: boolean;
         authorizer?: HttpAuthorizer;
         request?: HttpRequestValidation;
+        integration?: "lambda" | "mock"
     }
 
     interface NamedHttpApiEventAuthorizer {

--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -293,7 +293,7 @@ declare namespace Aws {
         async?: boolean;
         authorizer?: HttpAuthorizer;
         request?: HttpRequestValidation;
-        integration?: "lambda" | "mock"
+        integration?: "lambda" | "mock";
     }
 
     interface NamedHttpApiEventAuthorizer {


### PR DESCRIPTION
Added option for setting a integration type of either "lambda" or "mock" for use with non-proxy lambdas (custom integration lambdas) and/or mock integrations.

Valid according to Serverless documentation: https://www.serverless.com/framework/docs/providers/aws/events/apigateway/#lambda-integration