### PR TITLE
[netlify-identity-widget] added init opts and refresh types

### DIFF
--- a/types/netlify-identity-widget/index.d.ts
+++ b/types/netlify-identity-widget/index.d.ts
@@ -20,6 +20,9 @@ export interface InitOptions {
 
     // Initial language
     locale?: string;
+
+    // custom placeholder for name input form
+    namePlaceholder?: string;
 }
 
 export interface Token {
@@ -107,3 +110,8 @@ export function logout(): Promise<void> | undefined;
  * Set current language
  */
 export function setLocale(locale: string): void;
+
+/**
+ * Refresh the user's JWT.
+ */
+export function refresh(force?: boolean): Promise<string>;

--- a/types/netlify-identity-widget/netlify-identity-widget-tests.ts
+++ b/types/netlify-identity-widget/netlify-identity-widget-tests.ts
@@ -27,6 +27,7 @@ NetlifyIdentityWidget.init({
     container: 'body',
     logo: true,
     locale: 'en',
+    namePlaceholder: 'some-placeholder-for-Name',
 });
 
 // Open widget modal to let users login
@@ -87,3 +88,9 @@ if (logoutPromise) {
         // You can now do clean up after successful logout
     });
 }
+
+// Type 0: Refresh without option
+NetlifyIdentityWidget.refresh();
+
+// Type 1: Force refresh
+NetlifyIdentityWidget.refresh(true);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/netlify/netlify-identity-widget#netlifyidentityinitopts
  - https://github.com/netlify/netlify-identity-widget#module-api
    > refresh the user's JWT
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.