### PR TITLE
@types/mui-datatables - Add missing types for ExpandButton

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -372,6 +372,7 @@ type RenderCustomComponent<P> = (props: P) => React.ReactNode;
 export interface MUIDataTableProps {
     columns: MUIDataTableColumnDef[];
     components?: Partial<{
+        ExpandButton: RenderCustomComponent<MUIDataTableExpandButton> | React.ReactNode;
         TableBody: RenderCustomComponent<MUIDataTableBody> | React.ReactNode;
         TableFooter: RenderCustomComponent<MUIDataTableFooter> | React.ReactNode;
         TableHead: RenderCustomComponent<MUIDataTableHead> | React.ReactNode;
@@ -384,6 +385,18 @@ export interface MUIDataTableProps {
     data: Array<object | number[] | string[]>;
     options?: MUIDataTableOptions;
     title: string | React.ReactNode;
+}
+
+export interface MUIDataTableExpandButton {
+    areAllRowsExpanded: () => boolean;
+    buttonClass: string;
+    dataIndex?: number;
+    expandableRowsHeader: boolean;
+    expandedRows?: any;
+    iconClass: string;
+    iconIndeterminateClass: string;
+    isHeaderCell: boolean;
+    onExpand?: (...args: any) => any;
 }
 
 export interface MUIDataTablePopover {
@@ -597,6 +610,7 @@ export interface MUIDataTableViewCol {
 
 export const MUIDataTable: React.ComponentType<MUIDataTableProps>;
 
+export const ExpandButton: React.ComponentType<MUIDataTableExpandButton>;
 export const Popover: React.ComponentType<MUIDataTablePopover>;
 export const TableBody: React.ComponentType<MUIDataTableBody>;
 export const TableBodyCell: React.ComponentType<MUIDataTableBodyCell>;

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -1,8 +1,4 @@
-import MUIDataTable, {
-    MUIDataTableColumn,
-    MUIDataTableOptions,
-    MUIDataTableProps,
-} from 'mui-datatables';
+import MUIDataTable, { ExpandButton, MUIDataTableColumn, MUIDataTableOptions, MUIDataTableProps } from 'mui-datatables';
 import * as React from 'react';
 
 interface Props extends Omit<MUIDataTableProps, 'columns'> {
@@ -206,6 +202,7 @@ const todoOptions: MUIDataTableOptions = {
 <MuiCustomTable title="Todo Table" data={Todos} options={todoOptions} />;
 
 const customComponents: MUIDataTableProps['components'] = {
+    ExpandButton: ({ dataIndex }) => (dataIndex == 1 ? <>expand button</> : null),
     TableFooter: props => <>table footer</>,
 };
 

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -202,7 +202,7 @@ const todoOptions: MUIDataTableOptions = {
 <MuiCustomTable title="Todo Table" data={Todos} options={todoOptions} />;
 
 const customComponents: MUIDataTableProps['components'] = {
-    ExpandButton: ({ dataIndex }) => (dataIndex == 1 ? <>expand button</> : null),
+    ExpandButton: ({ dataIndex }) => (dataIndex === 1 ? <>expand button</> : null),
     TableFooter: props => <>table footer</>,
 };
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
[ExpandButton](https://github.com/gregnb/mui-datatables/blob/v3_4_0/src/components/ExpandButton.js) is present since v3.4.0 and documented in the [examples](https://github.com/gregnb/mui-datatables/blob/v3_4_0/examples/expandable-rows/index.js), but missing from the types.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
