### PR TITLE
Update @feathersjs/express types

### DIFF
--- a/types/feathersjs__express/feathersjs__express-tests.ts
+++ b/types/feathersjs__express/feathersjs__express-tests.ts
@@ -1,4 +1,4 @@
-import feathers, { Application } from '@feathersjs/feathers';
+import feathers from '@feathersjs/feathers';
 import feathersExpress, * as express from '@feathersjs/express';
 
 const app = feathersExpress(feathers());

--- a/types/feathersjs__express/index.d.ts
+++ b/types/feathersjs__express/index.d.ts
@@ -8,9 +8,11 @@
 import { Application as FeathersApplication, ServiceMethods, SetupMethod } from '@feathersjs/feathers';
 import * as express from 'express';
 import * as self from '@feathersjs/express';
-import { IRouterHandler, PathParams, RequestHandler, RequestHandlerParams } from 'express-serve-static-core';
+import { RequestHandler as StaticRequestHandler } from 'serve-static';
+import { PathParams, RequestHandler, RequestHandlerParams } from 'express-serve-static-core';
+import { OutgoingMessage } from 'http';
 
-declare const feathersExpress: (<T>(app: FeathersApplication<T>) => Application<T>) & typeof self;
+declare const feathersExpress: (<T extends OutgoingMessage>(app: FeathersApplication<T>) => Application<T>) & typeof self;
 export default feathersExpress;
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
@@ -19,13 +21,13 @@ type ExpressAndFeathersApplicationWithoutUse<T> = Omit<express.Application, 'use
 // Give the "any" type for the feathers options object a more precise name.
 export type FeathersServiceOptions = any;
 
-export interface FeathersRouterMatcher<T> {
-    (path: PathParams, ...handlers: Array<(RequestHandler | RequestHandlerParams | Partial<ServiceMethods<any> & SetupMethod> | Application)>): T;
+export interface FeathersRouterMatcher<T extends OutgoingMessage> {
+    (path: PathParams, ...handlers: Array<(RequestHandler | StaticRequestHandler<OutgoingMessage> | RequestHandlerParams | Partial<ServiceMethods<any> & SetupMethod> | Application)>): T;
 }
 
-type FeathersApplicationRequestHandler<T> = express.IRouterHandler<T> & FeathersRouterMatcher<T> & ((...handlers: RequestHandlerParams[]) => T);
+type FeathersApplicationRequestHandler<T extends OutgoingMessage> = express.IRouterHandler<T> & FeathersRouterMatcher<T> & ((...handlers: RequestHandlerParams[]) => T);
 
-export interface Application<T = any> extends ExpressAndFeathersApplicationWithoutUse<T> {
+export interface Application<T extends OutgoingMessage = OutgoingMessage> extends ExpressAndFeathersApplicationWithoutUse<T> {
     use: FeathersApplicationRequestHandler<T>;
 }
 

--- a/types/feathersjs__express/index.d.ts
+++ b/types/feathersjs__express/index.d.ts
@@ -22,7 +22,7 @@ type ExpressAndFeathersApplicationWithoutUse<T> = Omit<express.Application, 'use
 export type FeathersServiceOptions = any;
 
 export interface FeathersRouterMatcher<T extends OutgoingMessage> {
-    (path: PathParams, ...handlers: Array<(RequestHandler | StaticRequestHandler<OutgoingMessage> | RequestHandlerParams | Partial<ServiceMethods<any> & SetupMethod> | Application)>): T;
+    (path: PathParams, ...handlers: Array<(RequestHandler | StaticRequestHandler<T> | RequestHandlerParams | Partial<ServiceMethods<any> & SetupMethod> | Application)>): T;
 }
 
 type FeathersApplicationRequestHandler<T extends OutgoingMessage> = express.IRouterHandler<T> & FeathersRouterMatcher<T> & ((...handlers: RequestHandlerParams[]) => T);


### PR DESCRIPTION
`express.static` now returns a generic type `serveStatic.RequestHandler<T extends http.OutgoingMessage>`

That means FeathersRouterMatcher needs to support this type. Unfortunately, this means that all its generic types need to extend http.OutgoingMessage too.

I know nothing about express or feathersjs types -- if there is a better way to update this package, please let me know.
