### PR TITLE
Create a new package '@adeira/graphql-resolve-wrapper'

### DIFF
--- a/types/adeira__graphql-resolve-wrapper/adeira__graphql-resolve-wrapper-tests.ts
+++ b/types/adeira__graphql-resolve-wrapper/adeira__graphql-resolve-wrapper-tests.ts
@@ -1,0 +1,9 @@
+import { GraphQLSchema } from 'graphql';
+import { wrapResolvers } from '@adeira/graphql-resolve-wrapper';
+
+const Schema = new GraphQLSchema({});
+
+wrapResolvers(Schema, resolveFn => async (...args) => {
+    const value = await resolveFn(...args);
+    return typeof value === 'string' ? value.toUpperCase() : value;
+});

--- a/types/adeira__graphql-resolve-wrapper/index.d.ts
+++ b/types/adeira__graphql-resolve-wrapper/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for @adeira/graphql-resolve-wrapper 0.2
+// Project: https://github.com/adeira/universe/tree/master/src/graphql-resolve-wrapper
+// Definitions by: Martin Zlámal <https://github.com/mrtnzlml>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.4
+
+import { GraphQLSchema, GraphQLFieldResolver } from 'graphql';
+
+export function wrapResolvers<TContext>(
+    schema: GraphQLSchema,
+    resolveFn: (
+        resolveFn: GraphQLFieldResolver<unknown, TContext>,
+    ) => (
+        ...args: Parameters<GraphQLFieldResolver<unknown, TContext>>
+    ) => Promise<GraphQLFieldResolver<unknown, TContext>>,
+): void;
+
+export {};

--- a/types/adeira__graphql-resolve-wrapper/package.json
+++ b/types/adeira__graphql-resolve-wrapper/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "graphql": "^15.1.0"
+    }
+}

--- a/types/adeira__graphql-resolve-wrapper/tsconfig.json
+++ b/types/adeira__graphql-resolve-wrapper/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es2018"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@adeira/*": ["adeira__*"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "adeira__graphql-resolve-wrapper-tests.ts"
+    ]
+}

--- a/types/adeira__graphql-resolve-wrapper/tslint.json
+++ b/types/adeira__graphql-resolve-wrapper/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
See: https://github.com/adeira/universe/tree/master/src/graphql-resolve-wrapper

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.