### PR TITLE
plotly.js - allow for nested arrays of customdata

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1209,7 +1209,7 @@ export interface PlotData {
     rotation: number;
     theta: Datum[];
     r: Datum[];
-    customdata: Datum[];
+    customdata: Datum[] | Datum[][];
     selectedpoints: Datum[];
     domain: Partial<{
         rows: number;

--- a/types/plotly.js/test/core-tests.ts
+++ b/types/plotly.js/test/core-tests.ts
@@ -9,11 +9,13 @@ const graphDiv = '#test';
     const trace1 = {
         x: [1999, 2000, 2001, 2002],
         y: [10, 15, 13, 17],
+        customdata: [1, 2, 3],
         type: 'scatter',
     } as ScatterData;
     const trace2 = {
         x: [1999, 2000, 2001, 2002],
         y: [16, 5, 11, 9],
+        customdata: [[1, 'a'], [2, 'b'], [3, 'c']],
         type: 'scatter',
     } as ScatterData;
     const data = [trace1, trace2];


### PR DESCRIPTION
It's not very clear from the linked documentation, but the individual customdata for each data point can be an array itself, so customdata overall can be a nested array of arrays. You can then reference these different data points in the hovertemplate using `customdata[0]<br/>customdata[1]` etc.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://plotly.com/javascript/reference/scatter/#scatter-customdata
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
