### PR TITLE
[plotly.js] Update to include sunburst specific properties and sunburstclick event

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -204,6 +204,30 @@ export interface SliderEndEvent {
     step: SliderStep;
 }
 
+export interface SunburstClickEvent {
+    event: MouseEvent;
+    nextLevel: string;
+    points: SunburstPlotDatum[];
+}
+
+export interface SunburstPlotDatum {
+    color: number;
+    curveNumber: number;
+    data: Data;
+    entry: string;
+    fullData: Data;
+    hovertext: string;
+    id: string;
+    label: string;
+    parent: string;
+    percentEntry: number;
+    percentParent: number;
+    percentRoot: number;
+    pointNumber: number;
+    root: string;
+    value: number;
+}
+
 export interface BeforePlotEvent {
     data: Data[];
     layout: Partial<Layout>;
@@ -221,6 +245,7 @@ export interface PlotlyHTMLElement extends HTMLElement {
     on(event: 'plotly_sliderchange', callback: (event: SliderChangeEvent) => void): void;
     on(event: 'plotly_sliderend', callback: (event: SliderEndEvent) => void): void;
     on(event: 'plotly_sliderstart', callback: (event: SliderStartEvent) => void): void;
+    on(event: 'plotly_sunburstclick', callback: (event: SunburstClickEvent) => void): void;
     on(event: 'plotly_event', callback: (data: any) => void): void;
     on(event: 'plotly_beforeplot', callback: (event: BeforePlotEvent) => boolean): void;
     on(
@@ -1219,6 +1244,8 @@ export interface PlotData {
     }>;
     title: Partial<DataTitle>;
     branchvalues: 'total' | 'remainder';
+    ids: string[];
+    level: string;
 }
 
 /**

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -713,3 +713,31 @@ function rand() {
 
     myPlot.removeAllListeners('plotly_restyle');
 })();
+//////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////////////////
+// Sunburst specific properties and events
+(async () => {
+    const sunburst = await newPlot(graphDiv, [
+        {
+            type: "sunburst",
+            ids: ["root", "child1", "child2"],
+            branchvalues: "total",
+            level: "child1",
+            parents: ["", "root", "root"],
+        },
+    ]);
+
+    sunburst.on('plotly_sunburstclick', (event) => {
+        console.log(`Clicked button ${event.event.button} to navigate to ${event.nextLevel}`);
+
+        const point = event.points[0];
+        console.log(`Clicked id ${point.id} with label ${point.label} and parent label ${point.parent}`);
+        console.log(`Point is number ${point.pointNumber} on trace ${point.curveNumber}`);
+        console.log(`Click happened while at level *labelled* ${point.entry}, and root *labelled* ${point.root}`);
+        console.log(`Point has value ${point.value}`);
+        console.log(`Point takes up proportions of (previous level, parent, root): (${point.percentEntry}, ${point.percentParent}, ${point.percentRoot})`);
+        console.log(`Colored ${point.color} and hover ${point.hovertext}`);
+        console.log(`Can access trace data ${point.data.name} and full data ${point.fullData.name}`);
+    });
+})();


### PR DESCRIPTION
The documentation on sunburst point data seems to be non-existent, and it seems to have very different properties to the existing `PlotDatum` definition (the docs say that it [depends on trace type](https://plotly.com/javascript/plotlyjs-events/#event-data)) so I made a new `SunburstPlotDatum` definition with all the properties I could sensibly figure out! Descriptions are in the test. Hope this is suitable!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    https://github.com/plotly/plotly.js/pull/4454
    https://plotly.com/javascript/plotlyjs-events/#event-data
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
