### PR TITLE
fix(express): update `express.static` for recent `serve-static` change

### DIFF
--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -15,7 +15,13 @@ namespace express_tests {
     express.static.mime.define({
         'application/fx': ['fx']
     });
-    app.use('/static', express.static(__dirname + '/public'));
+    app.use('/static', express.static(__dirname + '/public', {
+        setHeaders: res => {
+            // $ExpectType Response<any>
+            res;
+            res.set("foo", "bar");
+        }
+    }));
 
     // simple logger
     app.use((req, res, next) => {

--- a/types/express/index.d.ts
+++ b/types/express/index.d.ts
@@ -18,7 +18,7 @@
 /// <reference types="serve-static" />
 
 import * as bodyParser from "body-parser";
-import serveStatic = require("serve-static");
+import * as serveStatic from "serve-static";
 import * as core from "express-serve-static-core";
 import * as qs from "qs";
 
@@ -56,7 +56,7 @@ declare namespace e {
     /**
      * This is a built-in middleware function in Express. It serves static files and is based on serve-static.
      */
-    var static: typeof serveStatic;
+    var static: serveStatic.RequestHandlerConstructor<Response>;
 
     /**
      * This is a built-in middleware function in Express. It parses incoming requests with urlencoded payloads and is based on body-parser.

--- a/types/serve-static/index.d.ts
+++ b/types/serve-static/index.d.ts
@@ -98,6 +98,11 @@ declare namespace serveStatic {
     interface RequestHandler<R extends http.OutgoingMessage> {
         (request: http.IncomingMessage, response: R, next: () => void): any;
     }
+
+    interface RequestHandlerConstructor<R extends http.OutgoingMessage> {
+        (root: string, options?: ServeStaticOptions<R>): RequestHandler<R>;
+        mime: typeof m;
+    }
 }
 
 export = serveStatic;


### PR DESCRIPTION
Static request handler created with `express.static` will be passed to `expressApp.use` so it's okay to mark the response as `express.Response` as that's what it will be received.

Funny enough there might be some builds breaking right now because of [#48591](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48591) and because the express test case that I just added in this PR was missing so we couldn't catch it. So this PR fixes the breaking change.

[#48591](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48591) also broke `@feathersjs/express` hence [#48956](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48956) but that was an indirect breaking this PR is the correct way to fix it.

cc @sandersn

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes:
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
