### PR TITLE
update(which): correct version and minor fixes

### DIFF
--- a/types/which/index.d.ts
+++ b/types/which/index.d.ts
@@ -1,35 +1,37 @@
-// Type definitions for which 1.3.0
+// Type definitions for which 2.0
 // Project: https://github.com/isaacs/node-which
 // Definitions by: vvakame <https://github.com/vvakame>
 //                 cspotcode <https://github.com/cspotcode>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
 /** Finds all instances of a specified executable in the PATH environment variable */
-declare function which(cmd: string, options: which.AsyncOptions & which.OptionsAll, cb: (err: Error | null, paths: Array<string> | undefined) => void): void;
-/** Finds the first instance of a specified executable in the PATH environment variable */
-declare function which(cmd: string, options: which.AsyncOptions & which.OptionsFirst, cb: (err: Error | null, path: string | undefined) => void): void;
-/** Finds the first instance of a specified executable in the PATH environment variable */
-declare function which(cmd: string, options: which.AsyncOptions, cb: (err: Error | null, path: string | Array<string> | undefined) => void): void;
-/** Finds the first instance of a specified executable in the PATH environment variable */
+declare function which(
+    cmd: string,
+    options: which.AsyncOptions & which.OptionsAll,
+    cb: (err: Error | null, paths: ReadonlyArray<string> | undefined) => void,
+): void;
+declare function which(
+    cmd: string,
+    options: which.AsyncOptions & which.OptionsFirst,
+    cb: (err: Error | null, path: string | undefined) => void,
+): void;
+declare function which(
+    cmd: string,
+    options: which.AsyncOptions,
+    cb: (err: Error | null, path: string | ReadonlyArray<string> | undefined) => void,
+): void;
 declare function which(cmd: string, cb: (err: Error | null, path: string | undefined) => void): void;
-/** Finds the first instance of a specified executable in the PATH environment variable */
 declare function which(cmd: string, options: which.AsyncOptions & which.OptionsAll): Promise<string[]>;
-/** Finds the first instance of a specified executable in the PATH environment variable */
 declare function which(cmd: string, options?: which.AsyncOptions & which.OptionsFirst): Promise<string>;
+
 declare namespace which {
     /** Finds all instances of a specified executable in the PATH environment variable */
-    function sync(cmd: string, options: which.Options & which.OptionsAll & which.OptionsNoThrow): Array<string> | null;
-    /** Finds the first instance of a specified executable in the PATH environment variable */
-    function sync(cmd: string, options: which.Options & which.OptionsFirst & which.OptionsNoThrow): string | null;
-    /** Finds all instances of a specified executable in the PATH environment variable */
-    function sync(cmd: string, options: which.Options & which.OptionsAll & which.OptionsThrow): Array<string>;
-    /** Finds the first instance of a specified executable in the PATH environment variable */
-    function sync(cmd: string, options: which.Options & which.OptionsFirst & which.OptionsThrow): string;
-    /** Finds the first instance of a specified executable in the PATH environment variable */
-    function sync(cmd: string, options: which.Options): string | Array<string> | null;
-    /** Finds the first instance of a specified executable in the PATH environment variable */
-    function sync(cmd: string): string;
+    function sync(cmd: string, options: Options & OptionsAll & OptionsNoThrow): ReadonlyArray<string> | null;
+    function sync(cmd: string, options: Options & OptionsFirst & OptionsNoThrow): string | null;
+    function sync(cmd: string, options: Options & OptionsAll & OptionsThrow): ReadonlyArray<string>;
+    function sync(cmd: string, options?: Options & OptionsFirst & OptionsThrow): string;
+    function sync(cmd: string, options: Options): string | ReadonlyArray<string> | null;
 
     /** Options that ask for all matches. */
     interface OptionsAll extends AsyncOptions {
@@ -38,7 +40,7 @@ declare namespace which {
 
     /** Options that ask for the first match (the default behavior) */
     interface OptionsFirst extends AsyncOptions {
-        all?: false | undefined;
+        all?: false;
     }
 
     /** Options that ask to receive null instead of a thrown error */
@@ -48,7 +50,7 @@ declare namespace which {
 
     /** Options that ask for a thrown error if executable is not found (the default behavior) */
     interface OptionsThrow extends Options {
-        nothrow?: false | undefined;
+        nothrow?: false;
     }
 
     /** Options for which() async API */
@@ -60,7 +62,7 @@ declare namespace which {
         /** Use instead of the PATHEXT environment variable. */
         pathExt?: string;
     }
-    
+
     /** Options for which() sync and async APIs */
     interface Options extends AsyncOptions {
         /** If true, returns null when not found */

--- a/types/which/tsconfig.json
+++ b/types/which/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/which/tslint.json
+++ b/types/which/tslint.json
@@ -1,16 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "array-type": false,
-        "dt-header": false,
-        "no-consecutive-blank-lines": false,
-        "no-redundant-undefined": false,
-        "no-trailing-whitespace": false,
-        "no-unnecessary-qualifier": false,
-        "no-var-keyword": false,
-        "prefer-const": false,
-        "trim-file": false,
-        "unified-signatures": false,
-        "whitespace": false
-    }
+    "extends": "dtslint/dt.json"
 }

--- a/types/which/which-tests.ts
+++ b/types/which/which-tests.ts
@@ -1,39 +1,48 @@
+import which = require('which');
 
-import which = require("which");
-
-which("cat", (err, path) => {
-  console.log(path);
+which('cat', (err, path) => {
+    path; // $ExpectType string | undefined
 });
 
-var path = which.sync("cat");
-console.log(path);
+const path = which.sync('cat'); // $ExpectType string
 
-which("cat", {all: true}, (err, paths) => {
-  if(err) return;
-  if(paths) {
-    for(let path of paths) {
-      console.log(path);
+which('cat', { all: true }, (err, paths) => {
+    if (err) return;
+    if (paths) {
+        for (const path of paths) {
+            path; // $ExpectType string
+        }
     }
-  }
 });
 
-var promise: Promise<string> = which("cat");
-var promise1: Promise<string> = which("cat", { all: false });
-var promise2: Promise<string[]> = which("cat", { all: true });
+const promise: Promise<string> = which('cat');
+const promise1: Promise<string> = which('cat', { all: false });
+const promise2: Promise<string[]> = which('cat', { all: true });
 
-var paths = which.sync("cat", {all: true});
-for(let path of paths) {
-  console.log(path);
+which('node')
+    .then(resolvedPath => {
+        resolvedPath; // $ExpectType string
+    })
+    .catch(er => {});
+
+async () => {
+    const path = await which('cat');
+};
+
+const paths = which.sync('cat', { all: true });
+for (const path of paths) {
+    path; // $ExpectType string
 }
 
-var paths2 = which.sync("cat", {all: true, nothrow: true});
-if(paths2 !== null) {
-  for(let path of paths2) {
-    console.log(path);
-  }
+const paths2 = which.sync('cat', { all: true, nothrow: true });
+if (paths2 !== null) {
+    for (const path of paths2) {
+        path; // $ExpectType string
+    }
 }
 
-var path2 = which.sync("cat", {path: 'replacement path', pathExt: 'replacement pathext'});
-which("cat", {path: 'replacement path', pathExt: 'replacement pathext'}, (err, path) => {
-  const a: string = path!;
+const path2 = which.sync('cat', { path: 'replacement path', pathExt: 'replacement pathext' });
+which('cat', { path: 'replacement path', pathExt: 'replacement pathext' }, (err, path) => {
+    const a: string = path!;
 });
+which.sync('cat'); // $ExpectType string


### PR DESCRIPTION
- correct header version: should be 2.0
https://github.com/npm/node-which/commit/3982ac06736fadbba273bfb77fbaa631af3a1dd8#comments
- cleanup code removing duplicate comments, etc
- cleanup DT linting
- amend tests
- add mantainer

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.