### PR TITLE
[relay-runtime]: Adds in the `requiredFieldLogger` prop to env

### DIFF
--- a/types/relay-runtime/lib/store/RelayModernEnvironment.d.ts
+++ b/types/relay-runtime/lib/store/RelayModernEnvironment.d.ts
@@ -14,6 +14,7 @@ import {
     Snapshot,
     OptimisticResponseConfig,
     Environment,
+    RequiredFieldLogger,
 } from './RelayStoreTypes';
 import { Network, PayloadData, GraphQLResponse, UploadableMap } from '../network/RelayNetworkTypes';
 import { TaskScheduler } from './RelayModernQueryExecutor';
@@ -34,6 +35,7 @@ export interface EnvironmentConfig {
     readonly operationTracker?: OperationTracker | null;
     readonly options?: unknown;
     readonly isServer?: boolean;
+    readonly requiredFieldLogger?: RequiredFieldLogger | null;
 }
 
 export default class RelayModernEnvironment implements Environment {

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -824,7 +824,7 @@ export type RequiredFieldLogger = (
           owner: string,
           fieldPath: string,
         }>
-  ) => void;  
+  ) => void;
 
 /**
  * The results of normalizing a query.

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -809,6 +809,24 @@ export type MissingFieldHandler =
       };
 
 /**
+ * A handler for events related to @required fields. Currently reports missing
+ * fields with either `action: LOG` or `action: THROW`.
+ */
+export type RequiredFieldLogger = (
+    arg:
+      | Readonly<{
+          kind: "missing_field.log",
+          owner: string,
+          fieldPath: string,
+        }>
+      | Readonly<{
+          kind: "missing_field.throw",
+          owner: string,
+          fieldPath: string,
+        }>
+  ) => void;  
+
+/**
  * The results of normalizing a query.
  */
 export interface RelayResponsePayload {

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -124,7 +124,7 @@ const environment = new Environment({
         if (arg.kind === 'missing_field.log') {
             console.log(arg.fieldPath, arg.owner);
         } else {
-            arg.kind; // $ExpectType missing_field.throw
+            arg.kind; // $ExpectType "missing_field.throw"
             console.log(arg.fieldPath, arg.owner);
         }
     }

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -120,6 +120,14 @@ const environment = new Environment({
                 break;
         }
     },
+    requiredFieldLogger: (arg) => {
+        if (arg.kind === 'missing_field.log') {
+            console.log(arg.fieldPath, arg.owner);
+        } else {
+            arg.kind; // $ExpectType missing_field.throw
+            console.log(arg.fieldPath, arg.owner);
+        }
+    }
 });
 
 // ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Adds in the new `@required` field logger property to the environment. 

https://github.com/facebook/relay/blob/9e051d09f00247a1e64f5a823aa37babfe715291/packages/relay-runtime/store/RelayModernEnvironment.js#L89

Will raise a separate PR that adds in the rest of the peripheral types, and kinds from an AST perspective. But will do that in one sweep again, as there are many other new ast types. 