### PR TITLE
[faker] Fix `time.recent` overloads and return types

### DIFF
--- a/types/faker/faker-tests.ts
+++ b/types/faker/faker-tests.ts
@@ -289,8 +289,10 @@ resultStr = faker.system.directoryPath();
 resultStr = faker.system.filePath();
 resultStr = faker.system.semver();
 
-resultDate = faker.time.recent();
-resultDate = faker.time.recent('foo');
+resultNum = faker.time.recent();
+resultNum = faker.time.recent('unix');
+resultStr = faker.time.recent('abbr');
+resultStr = faker.time.recent('wide');
 
 resultStr = faker.vehicle.vehicle();
 resultStr = faker.vehicle.manufacturer();

--- a/types/faker/index.d.ts
+++ b/types/faker/index.d.ts
@@ -254,7 +254,9 @@ declare namespace Faker {
         };
 
         time: {
-            recent(outputType?: string): Date;
+            recent(): number;
+            recent(outputType: 'unix'): number;
+            recent(outputType: 'abbr' | 'wide'): string;
         };
 
         seed(value: number): void;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Marak/faker.js/blob/91dc8a3372426bc691be56153b33e81a16459f49/lib/time.js#L20-L30
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
