### PR TITLE
Fix the types of `md5` package for when `asBytes` option is provided

### DIFF
--- a/types/md5/index.d.ts
+++ b/types/md5/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Bill Sourour <https://github.com/arcdev1>
 //                 Cameron Crothers <https://github.com/jprogrammer>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+//                 Ruslan Arkhipau <https://github.com/DethAriel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -14,7 +15,9 @@
  * @param options
  * @returns the resultant MD5 hash of the given message
  */
-declare function md5(message: string | Buffer | number[], options?: md5.Options): string;
+declare function md5(message: string | Buffer | number[], options: md5.Options & { asBytes: true }): number[];
+declare function md5(message: string | Buffer | number[], options?: Pick<md5.Options, 'asString' | 'encoding'>): string;
+declare function md5(message: string | Buffer | number[], options?: md5.Options): string | number[];
 
 declare namespace md5 {
     interface Options {

--- a/types/md5/md5-tests.ts
+++ b/types/md5/md5-tests.ts
@@ -1,13 +1,25 @@
 import md5 = require('md5');
 
 const message = 'message';
-console.log(md5(message)); // should print 78e731027d8fd50ed642340b7c9a63b3
+
+// $ExpectType string
+md5(message);
 
 const array = new Array<number>(message.length);
 for (let i = 0; i < message.length; ++i) array[i] = message.charCodeAt(i);
-const buffer = new Buffer(array);
-console.log(md5(buffer)); // Should be same result as above.
+const buffer = Buffer.from(array);
 
-const hash1 = md5('abc', { asString: true });
-const hash2 = md5(hash1 + 'a', { asString: true, encoding: 'binary' });
-const hash3 = md5(hash1 + 'a', { encoding: 'binary' });
+// $ExpectType string
+md5(buffer);
+
+// $ExpectType string
+md5('message', { asString: true });
+
+// $ExpectType string
+md5('message', { asString: true, encoding: 'binary' });
+
+// $ExpectType string
+md5('message', { encoding: 'binary' });
+
+// $ExpectType number[]
+md5('message', { asBytes: true });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see below
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

#### Explanation of changes

`{ asBytes: true }` option results in the function returning `number[]`, as seen on [these lines of md5 package](https://github.com/pvorb/node-md5/blob/v2.2.1/md5.js#L154-L155), and [these lines of `crypt` package](https://github.com/pvorb/node-crypt/blob/v0.0.2/crypt.js#L44-L48)