### PR TITLE
fix(react-select): filterOption param to use generic OptionType

### DIFF
--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -7,7 +7,7 @@
 //                 Daniel Del Core <https://github.com/danieldelcore>
 //                 Joonas Rouhiainen <https://github.com/rjoonas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.4
+// TypeScript Version: 2.9
 
 import { StateManager } from './src/stateManager';
 

--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -7,7 +7,7 @@
 //                 Daniel Del Core <https://github.com/danieldelcore>
 //                 Joonas Rouhiainen <https://github.com/rjoonas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// Minimum TypeScript Version: 3.4
 
 import { StateManager } from './src/stateManager';
 

--- a/types/react-select/src/Select.d.ts
+++ b/types/react-select/src/Select.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import { Option } from './filters';
 import {
   InstructionsContext,
   ValueEventContext,
@@ -103,7 +102,7 @@ export interface NamedProps<OptionType extends OptionTypeBase = { label: string;
   escapeClearsValue?: boolean;
   /* Custom method to filter whether an option should be displayed in the menu */
   filterOption?: ((
-    option: Option,
+    option: OptionType,
     rawInput: string
   ) => boolean) | null;
   /* Formats group labels in the menu as React components */

--- a/types/react-select/src/filters.d.ts
+++ b/types/react-select/src/filters.d.ts
@@ -10,6 +10,7 @@ import { stripDiacritics } from './diacritics';
 
 export interface Option { label: string; value: string; data: any; }
 
+/* tslint:disable-next-line:no-unnecessary-generics */
 export function createFilter<T extends { value: any; label: any } = Option>(config: Config | null): (
   option: T,
   rawInput: string

--- a/types/react-select/src/filters.d.ts
+++ b/types/react-select/src/filters.d.ts
@@ -10,7 +10,7 @@ import { stripDiacritics } from './diacritics';
 
 export interface Option { label: string; value: string; data: any; }
 
-export function createFilter(config: Config | null): (
-  option: Option,
+export function createFilter<T = Option>(config: Config | null): (
+  option: T,
   rawInput: string
 ) => boolean;

--- a/types/react-select/src/filters.d.ts
+++ b/types/react-select/src/filters.d.ts
@@ -10,7 +10,7 @@ import { stripDiacritics } from './diacritics';
 
 export interface Option { label: string; value: string; data: any; }
 
-export function createFilter<T = Option>(config: Config | null): (
+export function createFilter<T extends { value: any; label: any } = Option>(config: Config | null): (
   option: T,
   rawInput: string
 ) => boolean;

--- a/types/react-select/src/filters.d.ts
+++ b/types/react-select/src/filters.d.ts
@@ -10,7 +10,7 @@ import { stripDiacritics } from './diacritics';
 
 export interface Option { label: string; value: string; data: any; }
 
-/* tslint:disable-next-line:no-unnecessary-generics */
+/* tslint:disable:no-unnecessary-generics */
 export function createFilter<T extends { value: any; label: any } = Option>(config: Config | null): (
   option: T,
   rawInput: string

--- a/types/react-select/src/filters.d.ts
+++ b/types/react-select/src/filters.d.ts
@@ -11,7 +11,7 @@ import { stripDiacritics } from './diacritics';
 export interface Option { label: string; value: string; data: any; }
 
 /* tslint:disable:no-unnecessary-generics */
-export function createFilter<T extends { value: any; label: any } = Option>(config: Config | null): (
+export function createFilter<T extends { label: any; value: string; data?: any; }>(config: Config | null): (
   option: T,
   rawInput: string
 ) => boolean;

--- a/types/react-select/test/examples/CustomFilterOption.tsx
+++ b/types/react-select/test/examples/CustomFilterOption.tsx
@@ -4,18 +4,19 @@ import Select from 'react-select';
 
 interface GroupOption {
   label: string;
-  value: {
+  value: string;
+  data: {
     email: string
     name: string
   };
 }
 
 function filterOption(option: GroupOption, rawInput: string): boolean {
-  return (option.value.email + option.value.name).includes(rawInput);
+  return (option.data.email + option.data.name).includes(rawInput);
 }
 
 const values: GroupOption[] = [
-    { label: "", value: { email: "", name: "" }}
+    { label: "", value: "", data: { email: "", name: "" }}
 ];
 
 export default () => (

--- a/types/react-select/test/examples/CustomFilterOption.tsx
+++ b/types/react-select/test/examples/CustomFilterOption.tsx
@@ -1,16 +1,27 @@
 import * as React from 'react';
 
 import Select from 'react-select';
-import { ColourOption, colourOptions } from '../data';
 
-function filterOption(arg: ColourOption, rawInput: string): boolean {
-    return true;
+interface GroupOption {
+  label: string;
+  value: {
+    email: string
+    name: string
+  };
 }
 
+function filterOption(option: GroupOption, rawInput: string): boolean {
+  return (option.value.email + option.value.name).includes(rawInput);
+}
+
+const values: GroupOption[] = [
+    { label: "", value: { email: "", name: "" }}
+];
+
 export default () => (
-  <Select<ColourOption>
-    defaultValue={colourOptions[1]}
-    options={colourOptions}
+  <Select<GroupOption>
+    defaultValue={values[0]}
+    options={values}
     filterOption={filterOption}
   />
 );

--- a/types/react-select/test/examples/CustomFilterOption.tsx
+++ b/types/react-select/test/examples/CustomFilterOption.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+import Select from 'react-select';
+import { ColourOption, colourOptions } from '../data';
+
+function filterOption(arg: ColourOption, rawInput: string): boolean {
+    return true;
+}
+
+export default () => (
+  <Select<ColourOption>
+    defaultValue={colourOptions[1]}
+    options={colourOptions}
+    filterOption={filterOption}
+  />
+);

--- a/types/react-select/tsconfig.json
+++ b/types/react-select/tsconfig.json
@@ -42,6 +42,7 @@
         "test/examples/CreatableMulti.tsx",
         "test/examples/CreatableSingle.tsx",
         "test/examples/CreateFilter.tsx",
+        "test/examples/CustomFilterOption.tsx",
         "test/examples/CustomClearIndicator.tsx",
         "test/examples/CustomControl.tsx",
         "test/examples/CustomDropdownIndicator.tsx",


### PR DESCRIPTION
Previously filterOption used Option:

```typescript
interface Option { label: string; value: string; data: any; }
```
Which isn't accurate as the type depends on the type param `OptionType`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JedWatson/react-select/blob/397e95337f54074cf0705cb5b06ce8951be72f2a/packages/react-select/src/Select.js#L884-L891

There are some flow types in the repo itself, but they aren't particularly strict: https://github.com/JedWatson/react-select/blob/397e95337f54074cf0705cb5b06ce8951be72f2a/packages/react-select/src/Select.js#L130-L132

