### PR TITLE
Fix typo in @types/node for tls.connect options when using PSK

### DIFF
--- a/types/node/test/tls.ts
+++ b/types/node/test/tls.ts
@@ -30,7 +30,7 @@ import * as fs from "fs";
                 return null;
             }
             return {
-                identitty: 'henlo',
+                identity: 'henlo',
                 psk: Buffer.from('asd'),
             };
         },

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -436,7 +436,7 @@ declare module "tls" {
 
     interface PSKCallbackNegotation {
         psk: DataView | NodeJS.TypedArray;
-        identitty: string;
+        identity: string;
     }
 
     interface ConnectionOptions extends SecureContextOptions, CommonConnectionOptions {

--- a/types/node/v13/test/tls.ts
+++ b/types/node/v13/test/tls.ts
@@ -30,7 +30,7 @@ import * as fs from "fs";
                 return null;
             }
             return {
-                identitty: 'henlo',
+                identity: 'henlo',
                 psk: Buffer.from('asd'),
             };
         },

--- a/types/node/v13/tls.d.ts
+++ b/types/node/v13/tls.d.ts
@@ -436,7 +436,7 @@ declare module "tls" {
 
     interface PSKCallbackNegotation {
         psk: DataView | NodeJS.TypedArray;
-        identitty: string;
+        identity: string;
     }
 
     interface ConnectionOptions extends SecureContextOptions, CommonConnectionOptions {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/tls.html#tls_tls_connect_options_callback
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~
