### PR TITLE
[Summernote] Added missing properties to Options interface

### DIFF
--- a/types/summernote/index.d.ts
+++ b/types/summernote/index.d.ts
@@ -10,6 +10,8 @@
 
 declare global {
     namespace Summernote {
+        type fontSizeUnitOptions = 'px' | 'pt';
+
         interface Options {
             airMode?: boolean;
             tabDisable?: boolean;
@@ -28,6 +30,7 @@ declare global {
             fontNames?: string[];
             fontNamesIgnoreCheck?: string[];
             fontSizes?: string[];
+            fontSizeUnits?: fontSizeUnitOptions[];
             height?: number;
             hint?: HintOptions;
             icons?: IconsOptions;

--- a/types/summernote/index.d.ts
+++ b/types/summernote/index.d.ts
@@ -27,6 +27,7 @@ declare global {
             focus?: boolean;
             fontNames?: string[];
             fontNamesIgnoreCheck?: string[];
+            fontSizes?: string[];
             height?: number;
             hint?: HintOptions;
             icons?: IconsOptions;

--- a/types/summernote/summernote-tests.ts
+++ b/types/summernote/summernote-tests.ts
@@ -22,6 +22,7 @@ const config: Summernote.Options = {
     ],
     fontNames: ['Helvetica', 'Arial', 'Arial Black', 'Comic Sans MS', 'Courier New', 'Roboto', 'Times'],
     fontSizes: ['8', '9', '10', '11', '12', '14', '18', '24', '36', '48' , '64', '82', '150'],
+    fontSizeUnits: ['px', 'pt'],
 };
 
 $('#testElement').summernote('code', '<p> hello </p>');

--- a/types/summernote/summernote-tests.ts
+++ b/types/summernote/summernote-tests.ts
@@ -21,6 +21,7 @@ const config: Summernote.Options = {
         ['insert', ['picture', 'video']],
     ],
     fontNames: ['Helvetica', 'Arial', 'Arial Black', 'Comic Sans MS', 'Courier New', 'Roboto', 'Times'],
+    fontSizes: ['8', '9', '10', '11', '12', '14', '18', '24', '36', '48' , '64', '82', '150'],
 };
 
 $('#testElement').summernote('code', '<p> hello </p>');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    * `fontSizes`: from https://stackoverflow.com/a/36790696, property also can be found here: https://github.com/summernote/summernote/blob/develop/src/js/base/settings.js#L160
    * `fontSizeUnits`:  https://summernote.org/deep-dive/#custom-font-size-units
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
