### PR TITLE
[js-cookie] Change `export =` to `export default`

### DIFF
--- a/types/js-cookie/index.d.ts
+++ b/types/js-cookie/index.d.ts
@@ -112,5 +112,5 @@ declare namespace Cookies {
 
 declare const Cookies: Cookies.CookiesStatic;
 
-export = Cookies;
+export default Cookies;
 export as namespace Cookies;


### PR DESCRIPTION
got an error if using `export =` in ts4