### PR TITLE
feat(blueimp-load-image): Add promise style usage

### DIFF
--- a/types/blueimp-load-image/blueimp-load-image-tests.ts
+++ b/types/blueimp-load-image/blueimp-load-image-tests.ts
@@ -22,6 +22,7 @@ const b64DataJPEG =
   '2uLj5OXm5+jp6vLz9PX29/j5+v/aAAwDAQACEQMRAD8A/v4ooooA/9k=';
 const imageUrlJPEG = 'data:image/jpeg;base64,' + b64DataJPEG;
 
+// Callback style
 loadImage(imageUrlJPEG, (image: Event | HTMLCanvasElement | HTMLImageElement, data?: loadImage.MetaData): void => {
   const canvas = image as HTMLCanvasElement;
   console.log(data);
@@ -29,4 +30,14 @@ loadImage(imageUrlJPEG, (image: Event | HTMLCanvasElement | HTMLImageElement, da
     const url = canvas.toDataURL("image/png");
     console.log(url);
   });
-}, {canvas: true, orientation: true, maxWidth: 100, maxHeight: 100, crop: true});
+}, { canvas: true, orientation: true, maxWidth: 100, maxHeight: 100, crop: true });
+
+// Promise style
+loadImage(imageUrlJPEG, { canvas: true, orientation: true, maxWidth: 100, maxHeight: 100, crop: true }).then((data) => {
+  const canvas = (<any> data.image) as HTMLCanvasElement;
+  console.log(data);
+  canvas.toBlob((blob: Blob | null): void => {
+    const url = canvas.toDataURL("image/png");
+    console.log(url);
+  });
+});

--- a/types/blueimp-load-image/index.d.ts
+++ b/types/blueimp-load-image/index.d.ts
@@ -1,12 +1,16 @@
-// Type definitions for blueimp-load-image 2.23
+// Type definitions for blueimp-load-image 5.14
 // Project: https://github.com/blueimp/JavaScript-Load-Image
 // Definitions by: Evan Kesten <https://github.com/ebk46>
 //                 Konstantin Lukaschenko <https://github.com/KonstantinLukaschenko>
 //                 Saeid Rezaei <https://github.com/moeinio>
+//                 Zak Barbuto <https://github.com/zbarbuto>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace loadImage {
     type LoadImageCallback = (eventOrImage: Event | HTMLCanvasElement | HTMLImageElement, data?: MetaData) => void;
+    type LoadImageResult = MetaData & {
+        image: HTMLImageElement | FileReader | false;
+    };
 
     type ParseMetaDataCallback = (data: ImageHead) => void;
 
@@ -99,11 +103,12 @@ declare namespace loadImage {
 }
 
 // loadImage is implemented as a callable object.
-interface LoadImage  {
+interface LoadImage {
     (file: File | Blob | string, callback: loadImage.LoadImageCallback, options: loadImage.LoadImageOptions):
         | HTMLImageElement
         | FileReader
         | false;
+    (file: File | Blob | string, options: loadImage.LoadImageOptions): Promise<loadImage.LoadImageResult>;
 
     // Parses image meta data and calls the callback with the image head
     parseMetaData: (


### PR DESCRIPTION
As per [the latest docs](https://www.npmjs.com/package/blueimp-load-image#promise)

>If the loadImage() function is called without a callback function as second argument and the Promise API is available, it returns a Promise object

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/blueimp-load-image#promise
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

