### PR TITLE
Add types for share-api-polyfill

### DIFF
--- a/types/share-api-polyfill/index.d.ts
+++ b/types/share-api-polyfill/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for share-api-polyfill 1.0
+// Project: https://github.com/on2-dev/share-api-polyfill#readme
+// Definitions by: Jan Vlnas <https://github.com/jnv>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.9
+
+export interface ShareAPIPolyfillData extends ShareData {
+    fbId?: string;
+    hashtags?: string;
+}
+
+export interface ShareAPIPolyfillOptions {
+    copy: boolean;
+    email: boolean;
+    print: boolean;
+    sms: boolean;
+    messenger: boolean;
+    facebook: boolean;
+    whatsapp: boolean;
+    twitter: boolean;
+    linkedin: boolean;
+    telegram: boolean;
+    skype: boolean;
+    language: string;
+}
+
+declare global {
+    interface Navigator {
+        share(data?: ShareAPIPolyfillData, configuration?: Partial<ShareAPIPolyfillOptions>): Promise<void>;
+    }
+}

--- a/types/share-api-polyfill/share-api-polyfill-tests.ts
+++ b/types/share-api-polyfill/share-api-polyfill-tests.ts
@@ -1,0 +1,3 @@
+navigator.share({ url: 'https://example.com' }); // $ExpectType Promise<void>
+navigator.share({ url: 'https://example.com', hashtags: 'example' }); // $ExpectType Promise<void>
+navigator.share({ title: 'Example' }, { sms: false, language: 'en' }); // $ExpectType Promise<void>

--- a/types/share-api-polyfill/tsconfig.json
+++ b/types/share-api-polyfill/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "DOM"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "share-api-polyfill-tests.ts"
+    ]
+}

--- a/types/share-api-polyfill/tslint.json
+++ b/types/share-api-polyfill/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
