### PR TITLE
[google-apps-script]Drive v2 API's Permisson.role change to string literal.

### DIFF
--- a/types/google-apps-script/apis/drive_v2.d.ts
+++ b/types/google-apps-script/apis/drive_v2.d.ts
@@ -721,7 +721,7 @@ declare namespace GoogleAppsScript {
         name?: string;
         permissionDetails?: Drive.Schema.PermissionPermissionDetails[];
         photoLink?: string;
-        role?: string;
+        role?: "owner" | "organizer" | "fileOrganizer" | "writer" | "reader";
         selfLink?: string;
         teamDrivePermissionDetails?: Drive.Schema.PermissionTeamDrivePermissionDetails[];
         type?: string;
@@ -744,7 +744,7 @@ declare namespace GoogleAppsScript {
         inherited?: boolean;
         inheritedFrom?: string;
         permissionType?: string;
-        role?: string;
+        role?: "organizer" | "fileOrganizer" | "writer" | "reader";
       }
       interface PermissionTeamDrivePermissionDetails {
         additionalRoles?: string[];


### PR DESCRIPTION
The range of role and PermissionDetail.role are determined.
ref: https://developers.google.com/drive/api/v2/reference/permissions

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developers.google.com/drive/api/v2/reference/permissions>>