### PR TITLE
fix - Fix webpack-plugin-serve types

### DIFF
--- a/types/webpack-plugin-serve/index.d.ts
+++ b/types/webpack-plugin-serve/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/shellscape/webpack-plugin-serve
 // Definitions by: Matheus Gonçalves da Silva <https://github.com/PlayMa256>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// Minimum TypeScript Version: 3.8
 /// <reference types="node" />
 
 import { Config as HttpProxyMiddlewareConfig, Proxy } from 'http-proxy-middleware';
@@ -12,7 +12,7 @@ import { ServerOptions as HttpsServerOptions } from 'https';
 import { Options as HistoryApiFallbackOptions } from 'connect-history-api-fallback';
 import { CompressOptions } from 'koa-compress';
 import { Options as KoaStaticOptions } from 'koa-static';
-import { GlobbyOptions } from 'globby';
+import type { GlobbyOptions } from 'globby';
 
 export interface Builtins {
     proxy: (args: HttpProxyMiddlewareConfig) => Proxy;

--- a/types/webpack-plugin-serve/index.d.ts
+++ b/types/webpack-plugin-serve/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for webpack-plugin-serve 1.2.0
+// Type definitions for webpack-plugin-serve 1.2
 // Project: https://github.com/shellscape/webpack-plugin-serve
 // Definitions by: Matheus Gonçalves da Silva <https://github.com/PlayMa256>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/webpack-plugin-serve/index.d.ts
+++ b/types/webpack-plugin-serve/index.d.ts
@@ -5,20 +5,14 @@
 // TypeScript Version: 2.3
 /// <reference types="node" />
 
-import { Url } from 'url';
 import { Config as HttpProxyMiddlewareConfig, Proxy } from 'http-proxy-middleware';
 import * as Koa from 'koa';
-import {
-    ServerOptions as Http2ServerOptions,
-    SecureServerOptions as Http2SecureServerOptions,
-} from 'http2';
+import { ServerOptions as Http2ServerOptions, SecureServerOptions as Http2SecureServerOptions } from 'http2';
 import { ServerOptions as HttpsServerOptions } from 'https';
-import { ZlibOptions } from 'zlib';
-import { Compiler } from 'webpack';
 import { Options as HistoryApiFallbackOptions } from 'connect-history-api-fallback';
 import { CompressOptions } from 'koa-compress';
 import { Options as KoaStaticOptions } from 'koa-static';
-import { Options as FastGlobOptions } from 'fast-glob';
+import { GlobbyOptions } from 'globby';
 
 export interface Builtins {
     proxy: (args: HttpProxyMiddlewareConfig) => Proxy;
@@ -31,7 +25,7 @@ export interface Builtins {
 
 export interface StaticObject {
     glob?: string | string[];
-    options?: FastGlobOptions;
+    options?: GlobbyOptions;
 }
 
 export interface WebpackPluginServeOptions {
@@ -42,7 +36,7 @@ export interface WebpackPluginServeOptions {
     };
     compress?: boolean;
     historyFallback?: boolean | HistoryApiFallbackOptions;
-    hmr?: boolean;
+    hmr?: boolean | 'refresh-on-failure';
     host?: string | Promise<string>;
     http2?: boolean | Http2ServerOptions | Http2SecureServerOptions;
     https?: HttpsServerOptions;
@@ -53,11 +47,11 @@ export interface WebpackPluginServeOptions {
     };
     middleware?: (app: Koa, builtins: Builtins) => void;
     open?:
-    | boolean
-    | {
-        wait?: boolean;
-        app?: string | ReadonlyArray<string>;
-    };
+        | boolean
+        | {
+              wait?: boolean;
+              app?: string | ReadonlyArray<string>;
+          };
     port?: number | Promise<number>;
     progress?: boolean | 'minimal';
     static?: string | string[] | StaticObject;
@@ -65,7 +59,7 @@ export interface WebpackPluginServeOptions {
     waitForBuild?: boolean;
 }
 
-export class WebpackPluginServe {
+export class WebpackPluginServe<Compiler> {
     constructor(opts?: WebpackPluginServeOptions);
     attach(): {
         apply(compiler: Compiler): void;

--- a/types/webpack-plugin-serve/index.d.ts
+++ b/types/webpack-plugin-serve/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for webpack-plugin-serve 0.10
+// Type definitions for webpack-plugin-serve 1.2.0
 // Project: https://github.com/shellscape/webpack-plugin-serve
 // Definitions by: Matheus Gonçalves da Silva <https://github.com/PlayMa256>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/webpack-plugin-serve/package.json
+++ b/types/webpack-plugin-serve/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "fast-glob": "^2.2.6"
+        "globby": "^11.0.1"
     }
 }

--- a/types/webpack-plugin-serve/webpack-plugin-serve-tests.ts
+++ b/types/webpack-plugin-serve/webpack-plugin-serve-tests.ts
@@ -1,46 +1,54 @@
 import { WebpackPluginServe } from 'webpack-plugin-serve';
-import { Configuration } from 'webpack';
+
+interface Configuration {
+    entry: string[];
+    watch?: boolean;
+    plugins?: object[];
+    output?: {
+        publicPath?: string;
+    };
+}
 
 const usage = (config: Configuration) => {
-  (config.entry as string[]).push('webpack-plugin-serve/client');
+    config.entry.push('webpack-plugin-serve/client');
 
-  config.watch = true;
+    config.watch = true;
 
-  config.plugins!.push(
-    new WebpackPluginServe({
-      compress: true,
-      historyFallback: true,
-      host: '0.0.0.0',
-      port: 3808,
-      liveReload: true,
-      middleware: (app: any, builtins: any) =>
-        app.use(async (ctx: any, next: any) => {
-          await next();
-          ctx.set('Access-Control-Allow-Headers', '*');
-          ctx.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-          ctx.set('Access-Control-Allow-Origin', '*');
+    config.plugins!.push(
+        new WebpackPluginServe({
+            compress: true,
+            historyFallback: true,
+            host: '0.0.0.0',
+            port: 3808,
+            liveReload: true,
+            middleware: (app: any, builtins: any) =>
+                app.use(async (ctx: any, next: any) => {
+                    await next();
+                    ctx.set('Access-Control-Allow-Headers', '*');
+                    ctx.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+                    ctx.set('Access-Control-Allow-Origin', '*');
+                }),
+            static: '/',
+
+            status: true,
+            progress: true,
         }),
-      static: '/',
+    );
 
-      status: true,
-      progress: true,
-    }),
-  );
+    config.output!.publicPath = '/';
 
-  config.output!.publicPath = '/';
-
-  return config;
+    return config;
 };
 
-const baseConfig = {
-    entry: 'index.js'
+const baseConfig: Configuration = {
+    entry: ['index.js'],
 };
 
 const configWithServer = usage(baseConfig);
 
 const newConfigWithGlobby = new WebpackPluginServe({
-  static: {
-    glob: ['dist/**/public'],
-    options: { onlyDirectories: true }
-  }
+    static: {
+        glob: ['dist/**/public'],
+        options: { onlyDirectories: true },
+    },
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://www.npmjs.com/package/webpack-plugin-serve>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The biggest change is that now webpack isn't an explicit dependency. Instead, you should pass `Compiler` as a generic to the plugin constructor. The change was necessary to fix the type definition tests.