### PR TITLE
Upgrade `temp` package to 0.9 (Add Promise return types for async functions)

### DIFF
--- a/types/temp/index.d.ts
+++ b/types/temp/index.d.ts
@@ -1,48 +1,51 @@
-// Type definitions for temp 0.8
+// Type definitions for temp 0.9
 // Project: https://github.com/bruce/node-temp
 // Definitions by: Daniel Rosenwasser <https://github.com/DanielRosenwasser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
 
-import * as fs from "fs";
+import * as fs from 'fs';
 
 declare namespace temp {
-  interface OpenFile {
-    path: string;
-    fd: number;
-  }
+    interface OpenFile {
+        path: string;
+        fd: number;
+    }
 
-  interface Stats {
-    files: number;
-    dirs: number;
-  }
+    interface Stats {
+        files: number;
+        dirs: number;
+    }
 
-  interface AffixOptions {
-    prefix?: string;
-    suffix?: string;
-    dir?: string;
-  }
+    interface AffixOptions {
+        prefix?: string;
+        suffix?: string;
+        dir?: string;
+    }
 
-  let dir: string;
+    let dir: string;
 
-  function track(value?: boolean): typeof temp;
+    function track(value?: boolean): typeof temp;
 
-  function mkdir(affixes?: string | AffixOptions, callback?: (err: any, dirPath: string) => void): void;
+    function mkdir(affixes?: string | AffixOptions): Promise<string>;
+    function mkdir(affixes?: string | AffixOptions, callback?: (err: any, dirPath: string) => void): void;
 
-  function mkdirSync(affixes?: string | AffixOptions): string;
+    function mkdirSync(affixes?: string | AffixOptions): string;
 
-  function open(affixes?: string | AffixOptions, callback?: (err: any, result: OpenFile) => void): void;
+    function open(affixes?: string | AffixOptions): Promise<OpenFile>;
+    function open(affixes?: string | AffixOptions, callback?: (err: any, result: OpenFile) => void): void;
 
-  function openSync(affixes?: string | AffixOptions): OpenFile;
+    function openSync(affixes?: string | AffixOptions): OpenFile;
 
-  function path(affixes?: string | AffixOptions, defaultPrefix?: string): string;
+    function path(affixes?: string | AffixOptions, defaultPrefix?: string): string;
 
-  function cleanup(callback?: (err: any, result: Stats) => void): void;
+    function cleanup(): Promise<void>;
+    function cleanup(callback?: (err: any, result: Stats) => void): void;
 
-  function cleanupSync(): boolean | Stats;
+    function cleanupSync(): boolean | Stats;
 
-  function createWriteStream(affixes?: string | AffixOptions): fs.WriteStream;
+    function createWriteStream(affixes?: string | AffixOptions): fs.WriteStream;
 }
 
 export = temp;

--- a/types/temp/temp-tests.ts
+++ b/types/temp/temp-tests.ts
@@ -1,10 +1,11 @@
 // Author: Daniel Rosenwasser <https://github.com/DanielRosenwasser>
 
-import * as temp from "temp";
+import * as temp from 'temp';
 
-function testCleanup() {
+async function testCleanup() {
+    await temp.cleanup();
     temp.cleanup(result => {
-        if (typeof result === "boolean") {
+        if (typeof result === 'boolean') {
             const x = result;
         } else {
             const { files, dirs } = result;
@@ -16,7 +17,7 @@ function testCleanup() {
 
 function testCleanupSync() {
     const cleanupResult: boolean | temp.Stats = temp.cleanupSync();
-    if (typeof cleanupResult === "boolean") {
+    if (typeof cleanupResult === 'boolean') {
         const x = cleanupResult;
     } else {
         const { dirs, files } = cleanupResult;
@@ -25,14 +26,15 @@ function testCleanupSync() {
     }
 }
 
-function testOpen() {
-    temp.open({ dir: "tempDir", prefix: "pref", suffix: "suff" }, (err, result) => {
+async function testOpen() {
+    await temp.open({ dir: 'tempDir', prefix: 'pref', suffix: 'suff' });
+    temp.open({ dir: 'tempDir', prefix: 'pref', suffix: 'suff' }, (err, result) => {
         const { path, fd } = result;
         path.length;
         fd.toPrecision(5);
     });
 
-    temp.open("strPrefix", (err, result) => {
+    temp.open('strPrefix', (err, result) => {
         const { path, fd } = result;
         path.length;
         fd.toPrecision(5);
@@ -40,32 +42,33 @@ function testOpen() {
 }
 
 function testOpenSync() {
-    const f1: temp.OpenFile = temp.openSync({ dir: "tempDir", prefix: "pref", suffix: "suff" });
-    const f2: temp.OpenFile = temp.openSync("str");
+    const f1: temp.OpenFile = temp.openSync({ dir: 'tempDir', prefix: 'pref', suffix: 'suff' });
+    const f2: temp.OpenFile = temp.openSync('str');
 }
 
 function testCreateWriteStream() {
-    const stream = temp.createWriteStream("HelloStreamAffix");
-    stream.write("data");
+    const stream = temp.createWriteStream('HelloStreamAffix');
+    stream.write('data');
     const stream2 = temp.createWriteStream();
 }
 
-function testMkdir() {
-    temp.mkdir("prefix", (err, dirPath) => {
+async function testMkdir() {
+    await temp.mkdir('prefix');
+    temp.mkdir('prefix', (err, dirPath) => {
         dirPath.length;
     });
 }
 
 function testMkdirSync() {
-    const result = temp.mkdirSync("prefix");
+    const result = temp.mkdirSync('prefix');
     result.length;
 }
 
 function testPath() {
-    const p = temp.path({ suffix: "justSuffix" }, "defaultPrefix");
+    const p = temp.path({ suffix: 'justSuffix' }, 'defaultPrefix');
     p.length;
-    const p2: string = temp.path("prefix");
-    const p3: string = temp.path({ prefix: "prefix" });
+    const p2: string = temp.path('prefix');
+    const p3: string = temp.path({ prefix: 'prefix' });
 }
 
 function testTrack() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/bruce/node-temp/commit/e649841409ec2d0421cdb39f564f79849518f99e>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.