### PR TITLE
mssql: Add MSSQLError class + update subclasses

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -208,6 +208,13 @@ export interface config {
     beforeConnect?: (conn: tds.Connection) => void
 }
 
+export declare class MSSQLError extends Error {
+    constructor(message: Error | string, code?: string);
+    public code: string;
+    public name: string;
+    public originalError?: Error;
+}
+
 export declare class ConnectionPool extends events.EventEmitter {
     public connected: boolean;
     public connecting: boolean;
@@ -232,12 +239,7 @@ export declare class ConnectionPool extends events.EventEmitter {
     public transaction(): Transaction;
 }
 
-export declare class ConnectionError implements Error {
-    constructor(message: string, code?: any)
-    public name: string;
-    public message: string;
-    public code: string;
-}
+export declare class ConnectionError extends MSSQLError {}
 
 export interface IColumnOptions {
     nullable?: boolean;
@@ -340,15 +342,11 @@ export declare class Request extends events.EventEmitter {
     public resume(): boolean;
 }
 
-export declare class RequestError implements Error {
-    constructor(message: string, code?: any)
-    public name: string;
-    public message: string;
-    public code: string;
+export declare class RequestError extends MSSQLError {
     public number?: number;
+    public lineNumber?: number;
     public state?: number;
     public class?: number;
-    public lineNumber?: number;
     public serverName?: string;
     public procName?: string;
 }
@@ -370,12 +368,7 @@ export declare class Transaction extends events.EventEmitter {
     public request(): Request;
 }
 
-export declare class TransactionError implements Error {
-    constructor(message: string, code?: any)
-    public name: string;
-    public message: string;
-    public code: string;
-}
+export declare class TransactionError extends MSSQLError {}
 
 export declare class PreparedStatement extends events.EventEmitter {
     public transaction: Transaction;
@@ -397,9 +390,4 @@ export declare class PreparedStatement extends events.EventEmitter {
     public unprepare(callback: (err?: Error) => void): PreparedStatement;
 }
 
-export declare class PreparedStatementError implements Error {
-    constructor(message: string, code?: any)
-    public name: string;
-    public message: string;
-    public code: string;
-}
+export declare class PreparedStatementError extends MSSQLError {}

--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -345,8 +345,8 @@ export declare class Request extends events.EventEmitter {
 export declare class RequestError extends MSSQLError {
     public number?: number;
     public lineNumber?: number;
-    public state?: number;
-    public class?: number;
+    public state?: string;
+    public class?: string;
     public serverName?: string;
     public procName?: string;
 }

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -256,6 +256,7 @@ function test_rows_and_columnns() {
 function test_mssql_errors() {
     // Test constructors
     const sqlDriverError = new Error('mock error');
+    const mssqlStringError = new sql.MSSQLError('Something went wrong');
     const baseMSSQLError = new sql.MSSQLError(sqlDriverError, 'EREQUEST');
     const connectionError = new sql.ConnectionError(sqlDriverError, 'ELOGIN');
     const requestError = new sql.RequestError(sqlDriverError, 'EREQUEST');
@@ -264,18 +265,18 @@ function test_mssql_errors() {
 
     // Test inheritance
     if (
-        baseMSSQLError instanceof Error &&
-        connectionError instanceof sql.MSSQLError &&
-        requestError instanceof sql.MSSQLError &&
-        preparedStatementError instanceof sql.MSSQLError &&
-        transactionError instanceof sql.MSSQLError
+        'name' in baseMSSQLError &&
+        'name' in connectionError &&
+        'name' in requestError &&
+        'name' in preparedStatementError &&
+        'name' in transactionError
     ) {
-        const { code, message, name, originalError, stack } = baseMSSQLError;
-        requestError.message;
-        requestError.lineNumber;
-        requestError.originalError;
-        connectionError.originalError;
-        preparedStatementError.originalError;
-        transactionError.originalError;
+        let name: string = baseMSSQLError.name;
+        let msg: string = requestError.message;
+        let lineNo: number = requestError.lineNumber;
+        let err: Error = requestError.originalError;
+        err = connectionError.originalError;
+        err = preparedStatementError.originalError;
+        err = transactionError.originalError;
     }
 }

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -252,3 +252,30 @@ function test_rows_and_columnns() {
     var table = new sql.Table('#temp_table3');
     table.columns.forEach(col => col.name)
 }
+
+function test_mssql_errors() {
+    // Test constructors
+    const sqlDriverError = new Error('mock error');
+    const baseMSSQLError = new sql.MSSQLError(sqlDriverError, 'EREQUEST');
+    const connectionError = new sql.ConnectionError(sqlDriverError, 'ELOGIN');
+    const requestError = new sql.RequestError(sqlDriverError, 'EREQUEST');
+    const preparedStatementError = new sql.PreparedStatementError(sqlDriverError, 'EINJECT');
+    const transactionError = new sql.TransactionError(sqlDriverError, 'EABORT');
+
+    // Test inheritance
+    if (
+        baseMSSQLError instanceof Error &&
+        connectionError instanceof sql.MSSQLError &&
+        requestError instanceof sql.MSSQLError &&
+        preparedStatementError instanceof sql.MSSQLError &&
+        transactionError instanceof sql.MSSQLError
+    ) {
+        const { code, message, name, originalError, stack } = baseMSSQLError;
+        requestError.message;
+        requestError.lineNumber;
+        requestError.originalError;
+        connectionError.originalError;
+        preparedStatementError.originalError;
+        transactionError.originalError;
+    }
+}


### PR DESCRIPTION
See: https://github.com/tediousjs/node-mssql/blob/master/lib/error/mssql-error.js

All 4 errors extend the base class MSSQLError.
This will allow you to catch only mssql errors.

// Changes:

1. Export a new MSSQLError class.

2. Update constructor:
* `message` is actually the error from the sql driver. string is also supported.
* code: changed to string

3. Add the `originalError` property, defined by the base class with value received from driver.

4. Subclass error variants from this (new) base class.
You can now remove repeated base class signatures from subclasses, leaving them all empty except RequestError.

PS: included tests mainly proving inheritance and correct property access.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tediousjs/node-mssql/blob/master/lib/error/mssql-error.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.