### PR TITLE
[relay]: Cleansup authors

### DIFF
--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for react-relay 7.0
 // Project: https://github.com/facebook/relay, https://facebook.github.io/relay
 // Definitions by: Eloy Durán <https://github.com/alloy>
-//                 Matt Krick <https://github.com/mattkrick>
 //                 Marais Rossouw <https://github.com/maraisr>
 //                 Edvin Erikson <https://github.com/edvinerikson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -1,16 +1,7 @@
 // Type definitions for react-relay 7.0
 // Project: https://github.com/facebook/relay, https://facebook.github.io/relay
-// Definitions by: Johannes Schickling <https://github.com/graphcool>
-//                 Matt Martin <https://github.com/voxmatt>
-//                 Eloy Durán <https://github.com/alloy>
-//                 Nicolas Pirotte <https://github.com/npirotte>
-//                 Cameron Knight <https://github.com/ckknight>
-//                 Kaare Hoff Skovgaard <https://github.com/kastermester>
+// Definitions by: Eloy Durán <https://github.com/alloy>
 //                 Matt Krick <https://github.com/mattkrick>
-//                 Jared Kass <https://github.com/jdk243>
-//                 Renan Machado <https://github.com/renanmav>
-//                 Janic Duplessis <https://github.com/janicduplessis>
-//                 Christian Ivicevic <https://github.com/ChristianIvicevic>
 //                 Marais Rossouw <https://github.com/maraisr>
 //                 Edvin Erikson <https://github.com/edvinerikson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for relay-runtime 10.0
 // Project: https://github.com/facebook/relay, https://facebook.github.io/relay
 // Definitions by: Eloy Durán <https://github.com/alloy>
+//                 Stephen Pittman <https://github.com/Stephen2>
 //                 Marais Rossouw <https://github.com/maraisr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -1,12 +1,6 @@
 // Type definitions for relay-runtime 10.0
 // Project: https://github.com/facebook/relay, https://facebook.github.io/relay
-// Definitions by: Matt Martin <https://github.com/voxmatt>
-//                 Eloy Durán <https://github.com/alloy>
-//                 Cameron Knight <https://github.com/ckknight>
-//                 Renan Machado <https://github.com/renanmav>
-//                 Stephen Pittman <https://github.com/Stephen2>
-//                 Christian Ivicevic <https://github.com/ChristianIvicevic>
-//                 Lorenzo Di Giacomo <https://github.com/morrys>
+// Definitions by: Eloy Durán <https://github.com/alloy>
 //                 Marais Rossouw <https://github.com/maraisr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0


### PR DESCRIPTION
This PR aims to clear out tagging people in PR's that haven't touched the types since 2019. We need to foster a healthy small, but solid group of maintainers for this package—it'll helper iterate quick as we need to iterate almost as fast as the Facebook folk.

cc @alloy Maybe I don't understand DT, but happy to leave this here from a "people who's done some work on it", but afaik the bot tags all those people, and nobody responds. 