### PR TITLE
[fabric] Updated return type of toCanvasElement

### DIFF
--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -3336,9 +3336,9 @@ export class Object {
      * @param {Boolean} [options.enableRetinaScaling] Enable retina scaling for clone image. Introduce in 1.6.4
      * @param {Boolean} [options.withoutTransform] Remove current object transform ( no scale , no angle, no flip, no skew ). Introduced in 2.3.4
      * @param {Boolean} [options.withoutShadow] Remove current object shadow. Introduced in 2.4.2
-     * @return {String} Returns a data: URL containing a representation of the object in the format specified by options.format
+     * @return {HTMLCanvasElement} Returns a new HTMLCanvasElement painted with the current canvas object
      */
-    toCanvasElement(options?: IDataURLOptions): string;
+    toCanvasElement(options?: IDataURLOptions): HTMLCanvasElement;
 
     /**
      * Converts an object into a data-url-like string

--- a/types/fabric/test/index.ts
+++ b/types/fabric/test/index.ts
@@ -1053,3 +1053,8 @@ function sample12() {
   const x = position.left;
   const y = position.top;
 }
+
+function sample13() {
+  const rectangle = new fabric.Rect({top: 0, left: 0, width: 10, height: 10});
+  const rectangleAsHtmlCanvas: HTMLCanvasElement = rectangle.toCanvasElement();
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
Tried running `npm test fabric` but got plagued by the error below
```
The 'no-redundant-jsdoc-2' rule threw an error in '/home/driek/develop/work/DefinitelyTyped/types/fabric/fabric-impl.d.ts'
Error: Unexpected tag kind: JSDocPrivateTag
```
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). 
Same problem as above

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://fabricjs.com/docs/fabric.Object.html#toCanvasElement
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
Suggestions are welcome on contents of test to add. Did not noticed any assertions in the test file.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
