### PR TITLE
[gulp-rename] Fix the type definitions to reflect the implementation

### DIFF
--- a/types/gulp-rename/gulp-rename-tests.ts
+++ b/types/gulp-rename/gulp-rename-tests.ts
@@ -40,3 +40,12 @@ gulp.src("./src/main/text/hello.txt", { base: process.cwd() })
         extname: ".md"
     }))
     .pipe(gulp.dest("./dist")); // ./dist/main/text/ciao/bonjour-aloha-hola.md
+
+// rename with multi-ext
+gulp.src("./src/main/text/hello.min.js", { base: process.cwd() })
+    .pipe(rename({
+        suffix: "-v2"
+    }, {
+        multiExt: true
+    }))
+    .pipe(gulp.dest("./dist")); // ./dist/main/text/hello-v2.min.js

--- a/types/gulp-rename/gulp-rename-tests.ts
+++ b/types/gulp-rename/gulp-rename-tests.ts
@@ -14,9 +14,21 @@ gulp.src("./src/**/hello.txt")
     .pipe(rename((path) => {
         path.dirname += "/ciao";
         path.basename += "-goodbye";
-        path.extname = ".md"
+        path.extname = ".md";
     }))
     .pipe(gulp.dest("./dist")); // ./dist/main/text/ciao/hello-goodbye.md
+
+// rename via a map function
+gulp.src("./src/**/hello.txt")
+  .pipe(rename((path) => {
+    // Returns a completely new object, make sure you return all keys needed!
+    return {
+      dirname: path.dirname + "/ciao",
+      basename: path.basename + "-goodbye",
+      extname: ".md"
+    };
+  }))
+  .pipe(gulp.dest("./dist")); // ./dist/main/text/ciao/hello-goodbye.md
 
 // rename via hash
 gulp.src("./src/main/text/hello.txt", { base: process.cwd() })

--- a/types/gulp-rename/index.d.ts
+++ b/types/gulp-rename/index.d.ts
@@ -1,24 +1,28 @@
-// Type definitions for gulp-rename
+// Type definitions for gulp-rename 2.0
 // Project: https://github.com/hparra/gulp-rename
 // Definitions by: Asana <https://asana.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node"/>
+import * as File from 'vinyl';
 
 declare namespace rename {
     interface ParsedPath {
+        dirname: string;
+        basename: string;
+        extname: string;
+    }
+
+    interface Options {
         dirname?: string;
         basename?: string;
         extname?: string;
-    }
-
-    interface Options extends ParsedPath {
         prefix?: string;
         suffix?: string;
     }
 }
 
 declare function rename(name: string): NodeJS.ReadWriteStream;
-declare function rename(callback: (path: rename.ParsedPath) => any): NodeJS.ReadWriteStream;
+declare function rename(callback: (path: rename.ParsedPath, file: File) => rename.ParsedPath|void): NodeJS.ReadWriteStream;
 declare function rename(opts: rename.Options): NodeJS.ReadWriteStream;
 export = rename;

--- a/types/gulp-rename/index.d.ts
+++ b/types/gulp-rename/index.d.ts
@@ -22,7 +22,5 @@ declare namespace rename {
     }
 }
 
-declare function rename(name: string): NodeJS.ReadWriteStream;
-declare function rename(callback: (path: rename.ParsedPath, file: File) => rename.ParsedPath|void): NodeJS.ReadWriteStream;
-declare function rename(opts: rename.Options): NodeJS.ReadWriteStream;
+declare function rename(obj: string|rename.Options|((path: rename.ParsedPath, file: File) => rename.ParsedPath|void)): NodeJS.ReadWriteStream;
 export = rename;

--- a/types/gulp-rename/index.d.ts
+++ b/types/gulp-rename/index.d.ts
@@ -20,7 +20,11 @@ declare namespace rename {
         prefix?: string;
         suffix?: string;
     }
+
+    interface PluginOptions {
+        multiExt?: boolean;
+    }
 }
 
-declare function rename(obj: string|rename.Options|((path: rename.ParsedPath, file: File) => rename.ParsedPath|void)): NodeJS.ReadWriteStream;
+declare function rename(obj: string|rename.Options|((path: rename.ParsedPath, file: File) => rename.ParsedPath|void), options?: rename.PluginOptions): NodeJS.ReadWriteStream;
 export = rename;

--- a/types/gulp-rename/tslint.json
+++ b/types/gulp-rename/tslint.json
@@ -1,8 +1,6 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "dt-header": false,
-        "semicolon": false,
-        "unified-signatures": false
+        "dt-header": false
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see below
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Context for changes:
- The `multiExt` option was added in https://github.com/hparra/gulp-rename/pull/81.
- The `file` parameter for the callback was the subject of #46398 which was abandoned. The argument is documented in the readme: https://github.com/hparra/gulp-rename#notes It was implemented in https://github.com/hparra/gulp-rename/pull/82.
- The support for the return value in the callback was implemented in 2.0 by https://github.com/hparra/gulp-rename/pull/88. Note that previous types were describing the return type as `any` but the proper return type for 1.x should have been `void` instead.


