### PR TITLE
[mongoose] add missing option "overwrite" to interface QueryFindOneAndUpdateOptions

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -87,7 +87,7 @@ declare module "mongoose" {
   type NonFunctionPropertyNames<T> = {
     [K in keyof T]: T[K] extends Function ? never : K;
   }[keyof T];
-  
+
   type NonFunctionProperties<T> = Pick<T, NonFunctionPropertyNames<T>>;
 
   type IfEquals<X, Y, A, B> =
@@ -102,10 +102,10 @@ declare module "mongoose" {
 
   type MongooseBuiltIns = mongodb.ObjectID | mongodb.Decimal128 | Date | number | boolean;
 
-  type ImplicitMongooseConversions<T> = 
-    T extends MongooseBuiltIns 
+  type ImplicitMongooseConversions<T> =
+    T extends MongooseBuiltIns
       ? T extends (boolean | mongodb.Decimal128 | Date) ? T | string | number // accept numbers for these
-      : T | string 
+      : T | string
     : T;
 
   type DeepCreateObjectTransformer<T> =
@@ -120,15 +120,15 @@ declare module "mongoose" {
 
   // removes functions from schema from all levels
   type DeepCreateTransformer<T> =
-    T extends Map<infer KM, infer KV> 
+    T extends Map<infer KM, infer KV>
       // handle map values
       // Maps are not scrubbed, replace below line with this once minimum TS version is 3.7:
       // ? Map<KM, DeepNonFunctionProperties<KV>>
       ? { [key: string]: DeepCreateTransformer<KV> } | [KM, KV][] | Map<KM, KV>
-      : 
+      :
     T extends Array<infer U>
       ? Array<DeepCreateObjectTransformer<U>>
-      : 
+      :
     DeepCreateObjectTransformer<T>;
 
   // mongoose allows Map<K, V> to be specified either as a Map or a Record<K, V>
@@ -193,9 +193,9 @@ declare module "mongoose" {
 
   // ensure that if an empty document type is passed, we allow any properties
   // for backwards compatibility
-  export type CreateQuery<D> = HasJustId<CreateDocumentDefinition<D>> extends true 
-    ? { _id?: any } & Record<string, any> 
-    : D extends { _id: infer TId } 
+  export type CreateQuery<D> = HasJustId<CreateDocumentDefinition<D>> extends true
+    ? { _id?: any } & Record<string, any>
+    : D extends { _id: infer TId }
       ? mongodb.OptionalId<CreateDocumentDefinition<D> & { _id: TId }>
       : CreateDocumentDefinition<D>
 
@@ -2605,6 +2605,11 @@ declare module "mongoose" {
      * True by default. Set to false to make findOneAndUpdate() and findOneAndRemove() use native findOneAndUpdate() rather than findAndModify().
      */
     useFindAndModify?:boolean;
+    /**
+     * False by default. Setting this to true allows the update to overwrite the existing document if no update
+     * operators are included in the update. When set to false, mongoose will wrap the update in a $set.
+     */
+    overwrite?: boolean;
   }
 
   interface QueryUpdateOptions extends ModelUpdateOptions {

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Mongoose 5.7.13
+// Type definitions for Mongoose 5.10.9
 // Project: http://mongoosejs.com/
 // Definitions by: horiuchi <https://github.com/horiuchi>
 //                 lukasz-zak <https://github.com/lukasz-zak>

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -158,6 +158,7 @@ MongoModel.findOneAndUpdate({}, {}, {});
 MongoModel.findOneAndUpdate({}, {}, { upsert: true, new: true });
 MongoModel.findOneAndUpdate({}, {}, { upsert: true, new: true, arrayFilters: [{ 'elem._id': 123 }] });
 MongoModel.findOneAndUpdate({}, {}, { upsert: true, new: true, timestamps: true });
+MongoModel.findOneAndUpdate({}, {}, { overwrite: true });
 MongoModel.findOneAndUpdate({}, {}, cb);
 MongoModel.findOneAndUpdate({}, {});
 MongoModel.findOneAndUpdate();
@@ -646,8 +647,8 @@ interface ModelWithFunction extends mongoose.Document {
     selfRefArray2?: ModelWithFunction[] | mongodb.ObjectID[];
 
     parent?: {
-        ref: { 
-            _id: mongodb.ObjectId; 
+        ref: {
+            _id: mongodb.ObjectId;
             child: ModelWithFunction
         } | mongodb.ObjectID;
     }
@@ -664,40 +665,40 @@ interface ModelWithFunction extends mongoose.Document {
         tuple?: [number, number];
         array?: number[];
 
-        deepArray?: Array<{ 
-            title: string, 
+        deepArray?: Array<{
+            title: string,
             func: () => {}, // should be excluded in CreateQuery<T>
             tuple?: [number, number]
             objectId?: mongoose.Types.ObjectId;
 
-            mapWithFuncs?: Map<string, { 
-                title: string, 
+            mapWithFuncs?: Map<string, {
+                title: string,
                 func: () => {}, // should be excluded in CreateQuery<T>
                 innerMap: Map<string, {
-                    title: string, 
+                    title: string,
                     func: () => {} // should be excluded in CreateQuery<T>
                     readonly readonly: unknown; // should be excluded in CreateQuery<T>
                     objectId?: mongoose.Types.ObjectId;
-                }> 
+                }>
             }>;
         }>
     }
-    
+
     map?: Map<string, boolean>
 
-    mapWithFuncs?: Map<string, { 
-        title: string, 
+    mapWithFuncs?: Map<string, {
+        title: string,
         func: () => {}, // should be excluded in CreateQuery<T>
         innerMap: Map<string, {
-            title: string, 
+            title: string,
             func: () => {} // should be excluded in CreateQuery<T>
             readonly readonly: unknown; // should be excluded in CreateQuery<T>
-        }> 
+        }>
     }>;
 
 
-    jobs: Array<{ 
-        title: string, 
+    jobs: Array<{
+        title: string,
         readonly readonly: unknown // should be excluded in CreateQuery<T>
     }>;
 
@@ -711,34 +712,34 @@ var ModelWithFunctionInSchema = mongoose.model<ModelWithFunction>("ModelWithFunc
 
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], deeperFuncTest: { test: "test", array: [1, 2, 3], tuple: [1, 2] } });
 
-ModelWithFunctionInSchema.create({ 
-    name: "test", 
-    jobs: [], 
-    deeperFuncTest: { 
-        test: "hello", 
-        deepArray: [{ 
-            title: "test", 
-            tuple: [1, 2], 
+ModelWithFunctionInSchema.create({
+    name: "test",
+    jobs: [],
+    deeperFuncTest: {
+        test: "hello",
+        deepArray: [{
+            title: "test",
+            tuple: [1, 2],
             objectId: "valid-object-id-source",
-            mapWithFuncs: { 
-                test: { 
-                    title: "test", 
-                    innerMap: { 
-                        test: { 
+            mapWithFuncs: {
+                test: {
+                    title: "test",
+                    innerMap: {
+                        test: {
                             title: "hello",
                             objectId: "valid-object-id-source"
                         },
                     }
                 }
-            } 
-        }] 
-    } 
+            }
+        }]
+    }
 });
 
 
 // ------------------------------------------------------------------------------------
 // TESTS DISABLED: note that these tests does not properly pass $ExpectError on TS 3.3
-// they can be re-enabled once minimum TS version is bumped 
+// they can be re-enabled once minimum TS version is bumped
 
 //! $ExpectError
 //ModelWithFunctionInSchema.create({ name: "test", jobs: [], deeperFuncTest: { deepArray: [{ title1: "test" }] } });
@@ -786,16 +787,16 @@ ModelWithFunctionInSchema.create({ name: "test", jobs: [] }).then(ref => {
 });
 
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], objectId: "valid-object-id-source" });
-ModelWithFunctionInSchema.create({ 
-    name: "test", 
-    jobs: [], 
-    objectId: new mongodb.ObjectID("valid-object-id-source") 
+ModelWithFunctionInSchema.create({
+    name: "test",
+    jobs: [],
+    objectId: new mongodb.ObjectID("valid-object-id-source")
 });
 
-ModelWithFunctionInSchema.create({ 
-    name: "test", 
-    jobs: [], 
-    date: new Date() 
+ModelWithFunctionInSchema.create({
+    name: "test",
+    jobs: [],
+    date: new Date()
 });
 ModelWithFunctionInSchema.create({ name: "test", jobs: [], date: "2020-01-01" });
 


### PR DESCRIPTION
[Model.findOneAndUpdate](https://mongoosejs.com/docs/api.html#model_Model.findOneAndUpdate) supports the `overwrite` option which is not declared in the `QueryFindOneAndUpdateOptions` interface.  This option was added to [mongoose version 5.9.12 on 2020-05-04](https://github.com/Automattic/mongoose/blob/master/History.md#5912--2020-05-04).  Updated to the latest version of the library, 5.10.9, in the header.

Also removes trailing spaces in `index.d.ts` and `test/model.ts`.

--
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [here](https://mongoosejs.com/docs/api.html#model_Model.findOneAndUpdate)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
