### PR TITLE
Ssh2 - type declaration for `authHandler` field of ConnectConfig object.

### DIFF
--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -458,6 +458,8 @@ export interface ConnectConfig {
     compress?: boolean | 'force';
     /** A function that receives a single string argument to get detailed (local) debug information. */
     debug?: (information: string) => any;
+    /** Function with parameters (methodsLeft, partialSuccess, callback) where methodsLeft and partialSuccess are null on the first authentication attempt, otherwise are an array and boolean respectively. Return or call callback() with the name of the authentication method to try next (pass false to signal no more methods to try). Valid method names are: 'none', 'password', 'publickey', 'agent', 'keyboard-interactive', 'hostbased'. Default: function that follows a set method order: None -> Password -> Private Key -> Agent (-> keyboard-interactive if tryKeyboard is true) -> Hostbased. */
+    authHandler?: (methodsLeft: Array<string> | null, partialSuccess: boolean | null, callback: Function) => any;
 }
 
 export interface TcpConnectionDetails {

--- a/types/ssh2/ssh2-tests.ts
+++ b/types/ssh2/ssh2-tests.ts
@@ -300,7 +300,8 @@ const sshconfig: ssh2.ConnectConfig = {
     host: 'localhost',
     port: 22,
     username: 'ubuntu',
-    password: 'password'
+    password: 'password',
+    authHandler: (methodsLeft: any, partialSuccess: any, callback: any) => { if(!methodsLeft) callback('password') }
 };
 
 //


### PR DESCRIPTION
added type declaration for `authHandler` field of ConnectConfig object.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/mscdex/ssh2/blob/8a0fe5ec14388f4d0b5267d2dea3549999ebe4b2/lib/client.js#L78
https://www.npmjs.com/package/ssh2#client-methods
