### PR TITLE
Add types for Meteor HTTP's asyncCallback

### DIFF
--- a/types/meteor/globals/http.d.ts
+++ b/types/meteor/globals/http.d.ts
@@ -23,15 +23,17 @@ declare module HTTP {
         data?: any;
     }
 
-    function call(method: string, url: string, options?: HTTP.HTTPRequest, asyncCallback?: Function): HTTP.HTTPResponse;
+    type AsyncCallback = (error: Meteor.Error | null, result?: HTTPResponse) => void;
 
-    function del(url: string, callOptions?: HTTP.HTTPRequest, asyncCallback?: Function): HTTP.HTTPResponse;
+    function call(method: string, url: string, options?: HTTP.HTTPRequest, asyncCallback?: AsyncCallback): HTTP.HTTPResponse;
 
-    function get(url: string, callOptions?: HTTP.HTTPRequest, asyncCallback?: Function): HTTP.HTTPResponse;
+    function del(url: string, callOptions?: HTTP.HTTPRequest, asyncCallback?: AsyncCallback): HTTP.HTTPResponse;
 
-    function post(url: string, callOptions?: HTTP.HTTPRequest, asyncCallback?: Function): HTTP.HTTPResponse;
+    function get(url: string, callOptions?: HTTP.HTTPRequest, asyncCallback?: AsyncCallback): HTTP.HTTPResponse;
 
-    function put(url: string, callOptions?: HTTP.HTTPRequest, asyncCallback?: Function): HTTP.HTTPResponse;
+    function post(url: string, callOptions?: HTTP.HTTPRequest, asyncCallback?: AsyncCallback): HTTP.HTTPResponse;
+
+    function put(url: string, callOptions?: HTTP.HTTPRequest, asyncCallback?: AsyncCallback): HTTP.HTTPResponse;
 
     function call(method: string, url: string, options?: {
         content?: string;
@@ -44,5 +46,5 @@ declare module HTTP {
         followRedirects?: boolean;
         npmRequestOptions?: Object;
         beforeSend?: Function;
-    }, asyncCallback?: Function): HTTP.HTTPResponse;
+    }, asyncCallback?: AsyncCallback): HTTP.HTTPResponse;
 }

--- a/types/meteor/http.d.ts
+++ b/types/meteor/http.d.ts
@@ -24,15 +24,17 @@ declare module "meteor/http" {
             data?: any;
         }
 
-        function call(method: string, url: string, options?: HTTP.HTTPRequest, asyncCallback?: Function): HTTP.HTTPResponse;
+        type AsyncCallback = (error: Meteor.Error | null, result?: HTTPResponse) => void;
 
-        function del(url: string, callOptions?: HTTP.HTTPRequest, asyncCallback?: Function): HTTP.HTTPResponse;
+        function call(method: string, url: string, options?: HTTP.HTTPRequest, asyncCallback?: AsyncCallback): HTTP.HTTPResponse;
 
-        function get(url: string, callOptions?: HTTP.HTTPRequest, asyncCallback?: Function): HTTP.HTTPResponse;
+        function del(url: string, callOptions?: HTTP.HTTPRequest, asyncCallback?: AsyncCallback): HTTP.HTTPResponse;
 
-        function post(url: string, callOptions?: HTTP.HTTPRequest, asyncCallback?: Function): HTTP.HTTPResponse;
+        function get(url: string, callOptions?: HTTP.HTTPRequest, asyncCallback?: AsyncCallback): HTTP.HTTPResponse;
 
-        function put(url: string, callOptions?: HTTP.HTTPRequest, asyncCallback?: Function): HTTP.HTTPResponse;
+        function post(url: string, callOptions?: HTTP.HTTPRequest, asyncCallback?: AsyncCallback): HTTP.HTTPResponse;
+
+        function put(url: string, callOptions?: HTTP.HTTPRequest, asyncCallback?: AsyncCallback): HTTP.HTTPResponse;
 
         function call(method: string, url: string, options?: {
             content?: string;
@@ -45,6 +47,6 @@ declare module "meteor/http" {
             followRedirects?: boolean;
             npmRequestOptions?: Object;
             beforeSend?: Function;
-        }, asyncCallback?: Function): HTTP.HTTPResponse;
+        }, asyncCallback?: AsyncCallback): HTTP.HTTPResponse;
     }
 }

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -744,15 +744,10 @@ Meteor.methods({
 HTTP.call("POST", "http://api.twitter.com/xyz",
     { data: { some: "json", stuff: 1 } },
     function (error, result) {
-        if (error) {
-            // $ExpectType Error
-            error;
-        } else {
-            // $ExpectType null
-            error;
-        }
+        error; // $ExpectType Error
+        result; // $ExpectType HTTPResponse
 
-        if (result && result.statusCode === 200) {
+        if (result.statusCode === 200) {
             Session.set("twizzled", true);
         }
     });
@@ -760,15 +755,10 @@ HTTP.call("POST", "http://api.twitter.com/xyz",
 HTTP.post("http://api.twitter.com/xyz",
     { data: { some: "json", stuff: 1 } },
     function (error, result) {
-        if (error) {
-            // $ExpectType Error
-            error;
-        } else {
-            // $ExpectType null
-            error;
-        }
+        error; // $ExpectType Error
+        result; // $ExpectType HTTPResponse
 
-        if (result && result.statusCode === 200) {
+        if (result.statusCode === 200) {
             Session.set("twizzled", true);
         }
     });

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -9,8 +9,6 @@
  * that was assumed to have been declared earlier)
  */
 
-import { HTTP } from "meteor/http";
-
 /*********************************** Begin setup for tests ******************************/
 
 declare namespace Meteor {

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -744,7 +744,7 @@ Meteor.methods({
 HTTP.call("POST", "http://api.twitter.com/xyz",
     { data: { some: "json", stuff: 1 } },
     function (error, result) {
-        // $ExpectType Meteor.Error | null
+        // $ExpectType Error | null
         error;
 
         if (result && result.statusCode === 200) {
@@ -755,7 +755,7 @@ HTTP.call("POST", "http://api.twitter.com/xyz",
 HTTP.post("http://api.twitter.com/xyz",
     { data: { some: "json", stuff: 1 } },
     function (error, result) {
-        // $ExpectType Meteor.Error | null
+        // $ExpectType Error | null
         error;
 
         if (result && result.statusCode === 200) {

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -744,8 +744,13 @@ Meteor.methods({
 HTTP.call("POST", "http://api.twitter.com/xyz",
     { data: { some: "json", stuff: 1 } },
     function (error, result) {
-        // $ExpectType Error | null
-        error;
+        if (error) {
+            // $ExpectType Error
+            error;
+        } else {
+            // $ExpectType null
+            error;
+        }
 
         if (result && result.statusCode === 200) {
             Session.set("twizzled", true);
@@ -755,8 +760,13 @@ HTTP.call("POST", "http://api.twitter.com/xyz",
 HTTP.post("http://api.twitter.com/xyz",
     { data: { some: "json", stuff: 1 } },
     function (error, result) {
-        // $ExpectType Error | null
-        error;
+        if (error) {
+            // $ExpectType Error
+            error;
+        } else {
+            // $ExpectType null
+            error;
+        }
 
         if (result && result.statusCode === 200) {
             Session.set("twizzled", true);

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -9,6 +9,8 @@
  * that was assumed to have been declared earlier)
  */
 
+import { HTTP } from "meteor/http";
+
 /*********************************** Begin setup for tests ******************************/
 
 declare namespace Meteor {
@@ -741,8 +743,22 @@ Meteor.methods({
 
 HTTP.call("POST", "http://api.twitter.com/xyz",
     { data: { some: "json", stuff: 1 } },
-    function (error: Meteor.Error, result: any) {
-        if (result.statusCode === 200) {
+    function (error, result) {
+        // $ExpectType Meteor.Error | null
+        error;
+
+        if (result && result.statusCode === 200) {
+            Session.set("twizzled", true);
+        }
+    });
+
+HTTP.post("http://api.twitter.com/xyz",
+    { data: { some: "json", stuff: 1 } },
+    function (error, result) {
+        // $ExpectType Meteor.Error | null
+        error;
+
+        if (result && result.statusCode === 200) {
             Session.set("twizzled", true);
         }
     });

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -768,8 +768,13 @@ Meteor.methods({
 HTTP.call("POST", "http://api.twitter.com/xyz",
     { data: { some: "json", stuff: 1 } },
     function (error, result) {
-        // $ExpectType Error | null
-        error;
+        if (error) {
+            // $ExpectType Error
+            error;
+        } else {
+            // $ExpectType null
+            error;
+        }
 
         if (result && result.statusCode === 200) {
             Session.set("twizzled", true);
@@ -779,8 +784,13 @@ HTTP.call("POST", "http://api.twitter.com/xyz",
 HTTP.post("http://api.twitter.com/xyz",
     { data: { some: "json", stuff: 1 } },
     function (error, result) {
-        // $ExpectType Error | null
-        error;
+        if (error) {
+            // $ExpectType Error
+            error;
+        } else {
+            // $ExpectType null
+            error;
+        }
 
         if (result && result.statusCode === 200) {
             Session.set("twizzled", true);

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -768,7 +768,7 @@ Meteor.methods({
 HTTP.call("POST", "http://api.twitter.com/xyz",
     { data: { some: "json", stuff: 1 } },
     function (error, result) {
-        // $ExpectType Meteor.Error | null
+        // $ExpectType Error | null
         error;
 
         if (result && result.statusCode === 200) {
@@ -779,7 +779,7 @@ HTTP.call("POST", "http://api.twitter.com/xyz",
 HTTP.post("http://api.twitter.com/xyz",
     { data: { some: "json", stuff: 1 } },
     function (error, result) {
-        // $ExpectType Meteor.Error | null
+        // $ExpectType Error | null
         error;
 
         if (result && result.statusCode === 200) {

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -767,8 +767,22 @@ Meteor.methods({
 
 HTTP.call("POST", "http://api.twitter.com/xyz",
     { data: { some: "json", stuff: 1 } },
-    function (error: Meteor.Error, result: any) {
-        if (result.statusCode === 200) {
+    function (error, result) {
+        // $ExpectType Meteor.Error | null
+        error;
+
+        if (result && result.statusCode === 200) {
+            Session.set("twizzled", true);
+        }
+    });
+
+HTTP.post("http://api.twitter.com/xyz",
+    { data: { some: "json", stuff: 1 } },
+    function (error, result) {
+        // $ExpectType Meteor.Error | null
+        error;
+
+        if (result && result.statusCode === 200) {
             Session.set("twizzled", true);
         }
     });

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -768,15 +768,10 @@ Meteor.methods({
 HTTP.call("POST", "http://api.twitter.com/xyz",
     { data: { some: "json", stuff: 1 } },
     function (error, result) {
-        if (error) {
-            // $ExpectType Error
-            error;
-        } else {
-            // $ExpectType null
-            error;
-        }
+        error; // $ExpectType Error
+        result; // $ExpectType HTTPResponse
 
-        if (result && result.statusCode === 200) {
+        if (result.statusCode === 200) {
             Session.set("twizzled", true);
         }
     });
@@ -784,15 +779,10 @@ HTTP.call("POST", "http://api.twitter.com/xyz",
 HTTP.post("http://api.twitter.com/xyz",
     { data: { some: "json", stuff: 1 } },
     function (error, result) {
-        if (error) {
-            // $ExpectType Error
-            error;
-        } else {
-            // $ExpectType null
-            error;
-        }
+        error; // $ExpectType Error
+        result; // $ExpectType HTTPResponse
 
-        if (result && result.statusCode === 200) {
+        if (result.statusCode === 200) {
             Session.set("twizzled", true);
         }
     });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/meteor/meteor/blob/master/packages/http/httpcall_client.js#L133-L190
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
