### PR TITLE
Property 'apply' is missing in type 'CompressionPlugin' but required in type 'WebpackPluginInstance'.

### DIFF
--- a/types/compression-webpack-plugin/index.d.ts
+++ b/types/compression-webpack-plugin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for compression-webpack-plugin 4.0
+// Type definitions for compression-webpack-plugin 6.0.3
 // Project: https://github.com/webpack-contrib/compression-webpack-plugin
 // Definitions by: Anton Kandybo <https://github.com/dublicator>
 //                 Rhys van der Waerden <https://github.com/rhys-vdw>

--- a/types/compression-webpack-plugin/index.d.ts
+++ b/types/compression-webpack-plugin/index.d.ts
@@ -5,7 +5,7 @@
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Plugin } from 'webpack';
+import { Plugin, Compiler } from 'webpack';
 import { ZlibOptions as ZlibCompressionOptions } from 'zlib';
 
 export = CompressionPlugin;
@@ -16,6 +16,8 @@ export = CompressionPlugin;
 declare class CompressionPlugin<O = any> extends Plugin {
     static isWebpack4(): boolean;
     constructor(options?: CompressionPlugin.Options<O>);
+
+    apply(compiler: Compiler): void;
 }
 
 declare namespace CompressionPlugin {

--- a/types/mini-css-extract-plugin/index.d.ts
+++ b/types/mini-css-extract-plugin/index.d.ts
@@ -6,7 +6,7 @@
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { ChunkData, Plugin } from 'webpack';
+import { ChunkData, Plugin, Compiler } from 'webpack';
 
 /**
  * Lightweight CSS extraction webpack plugin
@@ -18,6 +18,8 @@ declare class MiniCssExtractPlugin extends Plugin {
     static loader: string;
 
     constructor(options?: MiniCssExtractPlugin.PluginOptions);
+
+    apply(compiler: Compiler): void;
 }
 
 declare namespace MiniCssExtractPlugin {


### PR DESCRIPTION
This MR addes types for the `apply` function required by the `WebpackPluginInstance`. To test the bug you can clone [my repo](https://github.com/polaroidkidd/dle.dev/tree/feat/migrate-to-custom-webpack) (at that branch) and run `yarn build:prod`

The issue is fixed when I add the changes listed in this MR locally.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test my code: This MR fixes webpack build issues with the mentioned plugin in my [website repository](https://github.com/polaroidkidd/dle.dev/tree/feat/migrate-to-custom-webpack). I've added the changes in the local packages and it all seems to work from the onwards.
- [ ] Running Tests: I'm having trouble getting the linting to run. I keep on getting the following error

```
../webpack/index.d.ts(46,30): error TS7016: Could not find a declaration file for module 'source-map'. '/home/dle/DevWork/me/forks/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/source-map` if it exists or add a new declaration (.d.ts) file containing `declare module 'source-map';`
```
Installing the mentioned packages doesn't fix the issue.

- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request). (Hopefully, yes. This is my first MR to a large repo so this is very new ground to me).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present): As mentioned above, I can't get the linting to run.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/webpack-contrib/compression-webpack-plugin>> (I'm attempting to fix the typings in a similar fashion to this [MR](https://github.com/jantimon/html-webpack-plugin/pull/1245/files/c1bafc3bccd0dcb00ca96631c1f71dc0cda5869f)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~

