### PR TITLE
Deprecate the right package

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -428,7 +428,7 @@
         },
         {
             "libraryName": "bugsnag-js",
-            "typingsPackageName": "bugsnag-js",
+            "typingsPackageName": "bugsnag",
             "sourceRepoURL": "https://github.com/bugsnag/bugsnag-js",
             "asOfVersion": "3.1.0"
         },


### PR DESCRIPTION
#15621 removed `types/bugsnag` but deprecated (previously non-existent) [@types/bugsnag-js](https://www.npmjs.com/package/@types/bugsnag-js). This PR will correctly mark [@types/bugsnag](https://www.npmjs.com/package/@types/bugsnag) as deprecated.

`bugsnag-js` [is the package](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/15621#issuecomment-291937772) that shipped types to replace `@types/bugsnag`. It wasn't possible to deprecate an `@types` package with a differently-named replacement before microsoft/DefinitelyTyped-tools#122 because the publisher used to use `typingsPackageName` for the deprecated package and the replacement.