### PR TITLE
[node] Add WebSocket HTTP headers in IncomingHttpHeaders

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -51,6 +51,11 @@ declare module "http" {
         'range'?: string;
         'referer'?: string;
         'retry-after'?: string;
+        'sec-websocket-accept'?: string;
+        'sec-websocket-extensions'?: string;
+        'sec-websocket-key'?: string;
+        'sec-websocket-protocol'?: string;
+        'sec-websocket-version'?: string;
         'set-cookie'?: string[];
         'strict-transport-security'?: string;
         'tk'?: string;


### PR DESCRIPTION
Add definitions for HTTP headers used for upgrading the connection to WebSocket protocol.

The HTTP headers related to the WebSocket protocol are described in [RFC 6455 section 11.3](https://tools.ietf.org/html/rfc6455#section-11.3)