### PR TITLE
Call os.cpus in update-codeowners

### DIFF
--- a/scripts/update-codeowners.js
+++ b/scripts/update-codeowners.js
@@ -13,7 +13,7 @@ async function main() {
 
     clean();
     const dt = await getDefinitelyTyped(options, log);
-    await parseDefinitions(dt, { nProcesses: os.cpus.length, definitelyTypedPath: "." }, log);
+    await parseDefinitions(dt, { nProcesses: os.cpus().length, definitelyTypedPath: "." }, log);
     const allPackages = await AllPackages.read(dt);
     const typings = allPackages.allTypings();
     const maxPathLen = Math.max(...typings.map(t => t.subDirectoryPath.length));


### PR DESCRIPTION
If you don't call it, you get the number of parameters of os.cpus, which is 0, which parseDefinition treats as a signal to return an empty result instead of parsing.