### PR TITLE
feat(bson): add toString() and valueOf() to ObjectId

### DIFF
--- a/types/bson/bson-tests.ts
+++ b/types/bson/bson-tests.ts
@@ -57,3 +57,9 @@ o = EJSON.serialize(doc2);
 let o2 = EJSON.deserialize (o);
 console.log(o);
 console.log(o2);
+
+
+const id = new ObjectId("5f935f8a8f3bdf089aa0a36f")
+
+console.log('ObjectId("5f935f8a8f3bdf089aa0a36f")' === id.toString())
+console.log("5f935f8a8f3bdf089aa0a36f" === id.valueOf())

--- a/types/bson/index.d.ts
+++ b/types/bson/index.d.ts
@@ -405,6 +405,16 @@ export class ObjectId {
      * @return {string} return the 24 byte hex string representation.
      */
     toHexString(): string;
+    /**
+     * Returns the string representation of the ObjectId().
+     * @return {string} the string representation.
+     */
+    toString(): string;
+    /**
+     * Returns the value of the ObjectId() as a lowercase hexadecimal string. This value is the str attribute of the ObjectId() object.
+     * @return {string} the str representation.
+     */
+    valueOf(): string;
 }
 
 /**


### PR DESCRIPTION
Add toString() and valueOf() methods to ObjectId class, as of https://docs.mongodb.com/manual/reference/method/ObjectId/#methods-and-attributes.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.mongodb.com/manual/reference/method/ObjectId/#methods-and-attributes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing) (no test needed)
