### PR TITLE
[jsforce] add httpProxy to ConnectionOptions and userInfo to Connection

### DIFF
--- a/types/jsforce/connection.d.ts
+++ b/types/jsforce/connection.d.ts
@@ -52,6 +52,7 @@ export interface ConnectionOptions extends PartialOAuth2Options {
     maxRequest?: number;
     oauth2?: Partial<PartialOAuth2Options>;
     proxyUrl?: string;
+    httpProxy?: string;
     redirectUri?: string;
     refreshToken?: string;
     refreshFn?: (conn: Connection, callback: Callback<UserInfo>) => Promise<UserInfo>;
@@ -236,6 +237,7 @@ export class Connection extends BaseConnection {
     version: string;
     accessToken: string;
     refreshToken?: string;
+    userInfo?: UserInfo;
     initialize(options?: ConnectionOptions): void;
     queryAll<T>(soql: string, options?: object, callback?: (err: Error, result: QueryResult<T>) => void): Query<QueryResult<T>>;
     authorize(code: string, callback?: (err: Error, res: UserInfo) => void): Promise<UserInfo>;

--- a/types/jsforce/jsforce-tests.ts
+++ b/types/jsforce/jsforce-tests.ts
@@ -21,6 +21,19 @@ const salesforceConnection: sf.Connection = new sf.Connection({
     },
 });
 
+async function testProxyOptions() {
+    // send valid proxy values
+    // $ExpectType Connection
+    new sf.Connection({
+        proxyUrl: "http://127.0.0.1:8080/",
+        httpProxy: "127.0.0.1:8080",
+    });
+
+    // send invalid proxy values
+    // $ExpectError
+    new sf.Connection({ httpProxy: { host: "127.0.0.1:8080"} });
+}
+
 async function testIdentity(connection: sf.Connection) {
     // Callback style.
     connection.identity((err: Error | null, identityInfo: sf.IdentityInfo) => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jsforce/jsforce/blob/master/lib/connection.js#L57 and https://github.com/jsforce/jsforce/blob/master/lib/connection.js#L235
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.