### PR TITLE
fix(conventional-commits-parser): allow booleans for `warn` in options

### DIFF
--- a/types/conventional-commits-parser/conventional-commits-parser-tests.ts
+++ b/types/conventional-commits-parser/conventional-commits-parser-tests.ts
@@ -68,3 +68,10 @@ namespace Module.Commit.Revert {
     revert.hash; // $ExpectType string | null | undefined
     revert.header; // $ExpectType string | null | undefined
 }
+
+namespace Module.Options {
+    let options: conventionalCommitsParser.Options;
+    options = {};
+    options = {warn: console.warn.bind(console)};
+    options = {warn: true};
+}

--- a/types/conventional-commits-parser/index.d.ts
+++ b/types/conventional-commits-parser/index.d.ts
@@ -284,7 +284,7 @@ declare namespace conventionalCommitsParser {
          * @default
          * function () {}
          */
-        warn?: (message?: any) => void | boolean;
+        warn?: ((message?: any) => void) | boolean;
     }
 
     namespace Options {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/conventional-changelog/conventional-changelog/tree/be1246c68f5dc4e6f28996129951a75bbf1cf307/packages/conventional-commits-parser#warn
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.