### PR TITLE
Add remark-abbr types

### DIFF
--- a/types/remark-abbr/index.d.ts
+++ b/types/remark-abbr/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for remark-abbr 1.4
+// Project: https://github.com/zestedesavoir/zmarkdown, https://zestedesavoir.github.io/zmarkdown/
+// Definitions by: Luke Carrier <https://github.com/LukeCarrier>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 4.0
+
+import { Plugin } from 'unified';
+
+declare namespace remarkAbbr {
+    type Abbr = Plugin<[Options?]>;
+
+    interface Options {
+        expandFirst?: boolean;
+    }
+}
+
+declare const remarkAbbr: remarkAbbr.Abbr;
+export = remarkAbbr;

--- a/types/remark-abbr/package.json
+++ b/types/remark-abbr/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "dependencies": {
+        "remark": "^12.0.0",
+        "unified": "^9.2.0"
+    }
+}

--- a/types/remark-abbr/remark-abbr-tests.ts
+++ b/types/remark-abbr/remark-abbr-tests.ts
@@ -1,0 +1,8 @@
+import remark = require('remark');
+import remarkAbbr = require('remark-abbr');
+
+remark().use(remarkAbbr);
+
+const options: remarkAbbr.Options = {};
+options.expandFirst = true;
+remark().use(remarkAbbr, options);

--- a/types/remark-abbr/tsconfig.json
+++ b/types/remark-abbr/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "remark-abbr-tests.ts"
+    ]
+}

--- a/types/remark-abbr/tslint.json
+++ b/types/remark-abbr/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Added type definitions for `remark-abbr`. Note that this package depends on type definitions present in `remark` and `unified` which are not currently whitelisted for inclusion in `package.json`; I've raised microsoft/DefinitelyTyped-tools#132 for this.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
