### PR TITLE
Add 'addRule' method definition to HTMLHint typings

### DIFF
--- a/types/htmlhint/htmlhint-tests.ts
+++ b/types/htmlhint/htmlhint-tests.ts
@@ -1,4 +1,4 @@
-import { HTMLHint, RuleSet } from "htmlhint";
+import { HTMLHint, LintResult, Rule, RuleSet } from "htmlhint";
 
 const htmlHintRules: RuleSet = {
     "tagname-lowercase": true,
@@ -14,5 +14,12 @@ const htmlHintRules: RuleSet = {
     "space-tab-mixed-disabled": "tab"
 };
 
-const result = HTMLHint.verify('<span></span>', htmlHintRules);
-const formatted = HTMLHint.format(result, { indent: 2 });
+const rule: Rule = {
+    id: 'custom-rule',
+    description: 'Custom rule',
+    link: '../custom-rule'
+};
+HTMLHint.addRule(rule);
+
+const result: LintResult[] = HTMLHint.verify('<span></span>', htmlHintRules);
+const formatted: string[] = HTMLHint.format(result, { indent: 2 });

--- a/types/htmlhint/index.d.ts
+++ b/types/htmlhint/index.d.ts
@@ -27,6 +27,7 @@ export interface RuleSet {
 }
 
 export namespace HTMLHint {
+    function addRule(rule: Rule): void;
     function verify(fileContent: string, ruleSet?: RuleSet): LintResult[];
     function format(arrMessages: LintResult[], options?: FormatOptions): string[];
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/htmlhint/HTMLHint/blob/d6e5861bfe26ac8013549d093dc7bfdf45428955/src/core/core.ts#L26
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
