### PR TITLE
Ink gradient corrections

### DIFF
--- a/types/ink-gradient/index.d.ts
+++ b/types/ink-gradient/index.d.ts
@@ -6,35 +6,35 @@
 import * as React from 'react';
 
 // This needs to be updated when TypeScript enhances their support for mutual
-// exclusivity in properties. While I am defining the props as being either one with
-// name OR one with colors, and the type reflects this on hover, it doesnt throw any lint errors
-// when I disobey this type contstraint.
-type PropsColor =
-    | {
-          name:
-              | 'cristal'
-              | 'teen'
-              | 'mind'
-              | 'morning'
-              | 'vice'
-              | 'passion'
-              | 'fruit'
-              | 'instagram'
-              | 'atlas'
-              | 'retro'
-              | 'summer'
-              | 'pastel'
-              | 'rainbow';
-      }
-    | {
-          colors: string[] | object[];
-      };
+// exclusivity in properties. This edit I made will now throw errors when
+// a user gives both of the mutually exclusive props.
+
+type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
+type XOR<T, U> = T | U extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U;
+
+type PropsName = {
+    name:
+        | 'cristal'
+        | 'teen'
+        | 'mind'
+        | 'morning'
+        | 'vice'
+        | 'passion'
+        | 'fruit'
+        | 'instagram'
+        | 'atlas'
+        | 'retro'
+        | 'summer'
+        | 'pastel'
+        | 'rainbow';
+};
 
 // note, object[] in this case refers to objects interpretable by tinycolor2
+type PropsColor = {
+    colors: string[] | object[];
+};
 
-type GradientProps = {
-    children: React.ReactNode;
-} & PropsColor;
+type GradientProps = XOR<PropsName, PropsColor> & { children: React.ReactNode };
 
 declare const Gradient: React.FC<GradientProps>;
 export = Gradient;

--- a/types/ink-gradient/index.d.ts
+++ b/types/ink-gradient/index.d.ts
@@ -12,7 +12,7 @@ import * as React from 'react';
 type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
 type XOR<T, U> = T | U extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U;
 
-type PropsName = {
+interface PropsName {
     name:
         | 'cristal'
         | 'teen'
@@ -27,12 +27,12 @@ type PropsName = {
         | 'summer'
         | 'pastel'
         | 'rainbow';
-};
+}
 
 // note, object[] in this case refers to objects interpretable by tinycolor2
-type PropsColor = {
+interface PropsColor {
     colors: string[] | object[];
-};
+}
 
 type GradientProps = XOR<PropsName, PropsColor> & { children: React.ReactNode };
 

--- a/types/ink-gradient/ink-gradient-tests.tsx
+++ b/types/ink-gradient/ink-gradient-tests.tsx
@@ -12,13 +12,13 @@ function test() {
     );
 }
 
-function exclusivity() {
-    return (
-        // @ts-expect-error: colors + name cannot be used together
-        <Gradient name="rainbow" colors={[{ r: 100, g: 100, b: 100 }]}>
-            <Box borderStyle="round" borderColor="cyan" float="center" padding={1}>
-                I'm mutually exclusive!
-            </Box>
-        </Gradient>
-    );
-}
+// function exclusivity() {
+//     return (
+//         // @ts-expect-error: colors + name cannot be used together
+//         <Gradient name="rainbow" colors={[{ r: 100, g: 100, b: 100 }]}>
+//             <Box borderStyle="round" borderColor="cyan" float="center" padding={1}>
+//                 I'm mutually exclusive!
+//             </Box>
+//         </Gradient>
+//     );
+// }

--- a/types/ink-gradient/ink-gradient-tests.tsx
+++ b/types/ink-gradient/ink-gradient-tests.tsx
@@ -11,3 +11,14 @@ function test() {
         </Gradient>
     );
 }
+
+function exclusivity() {
+    return (
+        // @ts-expect-error: colors + name cannot be used together
+        <Gradient name="rainbow" colors={[{ r: 100, g: 100, b: 100 }]}>
+            <Box borderStyle="round" borderColor="cyan" float="center" padding={1}>
+                I'm mutually exclusive!
+            </Box>
+        </Gradient>
+    );
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/sindresorhus/ink-gradient/blob/master/index.js>>

A line 9 of the source code an error gets thrown if both `name` and `colors` props are passed to the component. These new changes to the type definition reflect this. 

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.