### PR TITLE
Exclude types that never belonged to DefinitelyTyped

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -3985,12 +3985,6 @@
             "asOfVersion": "2.0.0"
         },
         {
-            "libraryName": "prando",
-            "typingsPackageName": "prando",
-            "sourceRepoURL": "https://github.com/zeh/prando",
-            "asOfVersion": "1.0.0"
-        },
-        {
             "libraryName": "pretty-bytes",
             "typingsPackageName": "pretty-bytes",
             "sourceRepoURL": "https://github.com/sindresorhus/pretty-bytes",
@@ -4925,12 +4919,6 @@
             "typingsPackageName": "simonwep__selection-js",
             "sourceRepoURL": "https://github.com/Simonwep/selection.git",
             "asOfVersion": "1.7.0"
-        },
-        {
-            "libraryName": "simplesignal",
-            "typingsPackageName": "simplesignal",
-            "sourceRepoURL": "https://github.com/zeh/simplesignal",
-            "asOfVersion": "1.0.0"
         },
         {
             "libraryName": "@sindresorhus/class-names",

--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -4915,12 +4915,6 @@
             "asOfVersion": "3.0.0"
         },
         {
-            "libraryName": "shopify-prime",
-            "typingsPackageName": "shopify-prime",
-            "sourceRepoURL": "https://github.com/nozzlegear/shopify-prime",
-            "asOfVersion": "2.0.0"
-        },
-        {
             "libraryName": "should",
             "typingsPackageName": "should",
             "sourceRepoURL": "https://github.com/shouldjs/should.js",


### PR DESCRIPTION
This PR reverts #12813 and #12866.

These packages only every shipped their own types and never belonged to DefinitelyTyped (never belonged to the Git repo and were never published on npm except for a [single](https://unpkg.com/browse/@types/shopify-prime@2.0.0/), [types-less](https://unpkg.com/browse/@types/prando@1.0.0/) [version](https://unpkg.com/browse/@types/simplesignal@1.0.0/): the deprecated stub) so they don't need to be in `notNeededPackages.json`.