### PR TITLE
fix(benchmark): update benchmark types to match release 2.1.4

### DIFF
--- a/types/benchmark/benchmark-tests.ts
+++ b/types/benchmark/benchmark-tests.ts
@@ -4,23 +4,23 @@ var suite = new Benchmark.Suite;
 
 // add tests
 suite.add('RegExp#test', function() {
-  /o/.test('Hello World!');
+    /o/.test('Hello World!');
 })
-.add('String#indexOf', function() {
-  'Hello World!'.indexOf('o') > -1;
-})
-.add('String#match', function() {
-  !!'Hello World!'.match(/o/);
-})
-// add listeners
-.on('cycle', function(event: {target: any}) {
-  console.log(String(event.target));
-})
-.on('complete', function() {
-  console.log('Fastest is ' + this.filter('fastest').pluck('name'));
-})
-// run async
-.run({ 'async': true });
+    .add('String#indexOf', function() {
+        'Hello World!'.indexOf('o') > -1;
+    })
+    .add('String#match', function() {
+        !!'Hello World!'.match(/o/);
+    })
+    // add listeners
+    .on('cycle', function(event: Benchmark.Event) {
+        console.log(String(event.target));
+    })
+    .on('complete', function(this: Benchmark.Suite) {
+        console.log('Fastest is ' + this.filter('fastest').map('name'));
+    })
+    // run async
+    .run({ 'async': true });
 
 var fn: Function;
 var onStart: Function;
@@ -44,7 +44,7 @@ var bench = new Benchmark('foo', fn);
 // or with options
 var bench = new Benchmark('foo', fn, {
 
-  // displayed by Benchmark#toString if `name` is not available
+  // displayed by `Benchmark#toString` if `name` is not available
   'id': 'xyz',
 
   // called when the benchmark starts running
@@ -79,8 +79,8 @@ var bench = new Benchmark('foo', {
   'defer': true,
 
   // benchmark test function
-  'fn': function(deferred: {resolve(): void}) {
-    // call resolve() when the deferred test is finished
+  'fn': function(deferred: Benchmark.Deferred) {
+    // call `Deferred#resolve` when the deferred test is finished
     deferred.resolve();
   }
 });
@@ -97,7 +97,7 @@ var bench = new Benchmark({
 
 // a test’s `this` binding is set to the benchmark instance
 var bench = new Benchmark('foo', function() {
-  'My name is '.concat(this.name); // My name is foo
+  'My name is '.concat(this.name); // "My name is foo"
 });
 
 // get odd numbers

--- a/types/benchmark/index.d.ts
+++ b/types/benchmark/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Benchmark v1.0.0
+// Type definitions for Benchmark v2.1.4
 // Project: https://benchmarkjs.com
 // Definitions by: Asana <https://asana.com>
 //                 Charlie Fish <https://github.com/fishcharlie>
@@ -7,21 +7,19 @@
 
 
 declare class Benchmark {
-    static deepClone<T>(value: T): T;
-    static each(obj: Object | any[], callback: Function, thisArg?: any): void;
-    static extend(destination: Object, ...sources: Object[]): Object;
     static filter<T>(arr: T[], callback: (value: T) => any, thisArg?: any): T[];
     static filter<T>(arr: T[], filter: string, thisArg?: any): T[];
-    static forEach<T>(arr: T[], callback: (value: T) => any, thisArg?: any): void;
     static formatNumber(num: number): string;
-    static forOwn(obj: Object, callback: Function, thisArg?: any): void;
-    static hasKey(obj: Object, key: string): boolean;
-    static indexOf<T>(arr: T[], value: T, fromIndex?: number): number;
-    static interpolate(template: string, values: Object): string;
-    static invoke(benches: Benchmark[], name: string | Object, ...args: any[]): any[];
     static join(obj: Object, separator1?: string, separator2?: string): string;
+    static invoke(benches: Benchmark[], name: string | Object, ...args: any[]): any[];
+    static runInContext(context: Object): Function;
+
+    static each(obj: Object | any[], callback: Function, thisArg?: any): void;
+    static forEach<T>(arr: T[], callback: (value: T) => any, thisArg?: any): void;
+    static forOwn(obj: Object, callback: Function, thisArg?: any): void;
+    static has(obj: Object, path: any[] | string): boolean;
+    static indexOf<T>(arr: T[], value: T, fromIndex?: number): number;
     static map<T, K>(arr: T[], callback: (value: T) => K, thisArg?: any): K[];
-    static pluck<T, K>(arr: T[], key: string): K[];
     static reduce<T, K>(arr: T[], callback: (accumulator: K, value: T) => K, thisArg?: any): K;
 
     static options: Benchmark.Options;
@@ -34,13 +32,15 @@ declare class Benchmark {
     constructor(name: string, options?: Benchmark.Options);
     constructor(options: Benchmark.Options);
 
-    aborted: boolean;
-    compiled: Function | string;
+    id: number;
+    name: string;
     count: number;
     cycles: number;
+    hz: number;
+    compiled: Function | string;
     error: Error;
     fn: Function | string;
-    hz: number;
+    aborted: boolean;
     running: boolean;
     setup: Function | string;
     teardown: Function | string;
@@ -88,37 +88,28 @@ declare namespace Benchmark {
     export interface Platform {
         description: string;
         layout: string;
-        manufacturer: string;
+        product: string;
         name: string;
+        manufacturer: string;
         os: string;
         prerelease: string;
-        product: string;
         version: string;
         toString(): string;
     }
 
     export interface Support {
-        air: boolean;
-        argumentsClass: boolean;
         browser: boolean;
-        charByIndex: boolean;
-        charByOwnIndex: boolean;
-        decompilation: boolean;
-        descriptors: boolean;
-        getAllKeys: boolean;
-        iteratesOwnFirst: boolean;
-        java: boolean;
-        nodeClass: boolean;
         timeout: boolean;
+        decompilation: boolean;
     }
 
     export interface Stats {
-        deviation: number;
-        mean: number;
         moe: number;
         rme: number;
-        sample: any[];
         sem: number;
+        deviation: number;
+        mean: number;
+        sample: any[];
         variance: number;
     }
 
@@ -136,6 +127,8 @@ declare namespace Benchmark {
         cycles: number;
         elapsed: number;
         timeStamp: number;
+
+        resolve(): void;
     }
 
     export interface Target {
@@ -176,9 +169,10 @@ declare namespace Benchmark {
 
         constructor(name?: string, options?: Options);
 
-        aborted: boolean;
         length: number;
+        aborted: boolean;
         running: boolean;
+
         abort(): Suite;
         add(name: string, fn: Function | string, options?: Options): Suite;
         add(fn: Function | string, options?: Options): Suite;
@@ -187,27 +181,30 @@ declare namespace Benchmark {
         clone(options: Options): Suite;
         emit(type: string | Object): any;
         filter(callback: Function | string): Suite;
-        forEach(callback: Function): Suite;
-        indexOf(value: any): number;
-        invoke(name: string, ...args: any[]): any[];
         join(separator?: string): string;
         listeners(type: string): Function[];
-        map(callback: Function): any[];
         off(type?: string, callback?: Function): Suite;
         off(types: string[]): Suite;
         on(type?: string, callback?: Function): Suite;
         on(types: string[]): Suite;
-        pluck(property: string): any[];
-        pop(): Function;
         push(benchmark: Benchmark): number;
-        reduce<T>(callback: Function, accumulator: T): T;
         reset(): Suite;
-        reverse(): any[];
         run(options?: Options): Suite;
+        reverse(): any[];
+        sort(compareFn: (a: any, b: any) => number): any[];
+        splice(start: number, deleteCount?: number): any[];
+        unshift(benchmark: Benchmark): number;
+
+        each(callback: Function): Suite;
+        forEach(callback: Function): Suite;
+        indexOf(value: any): number;
+        map(callback: Function | string): any[];
+        reduce<T>(callback: Function, accumulator: T): T;
+
+        pop(): Function;
         shift(): Benchmark;
         slice(start: number, end: number): any[];
         slice(start: number, deleteCount: number, ...values: any[]): any[];
-        unshift(benchmark: Benchmark): number;
     }
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

The current types where for benchmark@1.0.0 which was [released in January 2016](https://github.com/bestiejs/benchmark.js/releases/tag/1.0.0). I've updated them to match the latest benchmark release 2.1.4 which was [released in March 2017](https://github.com/bestiejs/benchmark.js/releases/tag/2.1.4).

There were various changes between the versions which resulted in breaking changes, e.g. [removal of `pluck`](https://github.com/bestiejs/benchmark.js/commit/37dc7b083a363bd4b96c1431600caea145e4377a).
I wasn't able to find atomic commits for each change so I mostly relied on [comparing 1.0.0 with 2.1.4](https://github.com/bestiejs/benchmark.js/compare/1.0.0...2.1.4).

Here are the current field and methods:
* [Benchmark.Options fields](https://github.com/bestiejs/benchmark.js/blob/master/benchmark.js#L2133-L2298) (including Benchmark.Platform fields
* [Benchmark static methods](https://github.com/bestiejs/benchmark.js/blob/master/benchmark.js#L2300-L2307)
* [Benchmark static methods copied from lodash](https://github.com/bestiejs/benchmark.js/blob/master/benchmark.js#L2310-L2312)
* [Benchmark instance fields](https://github.com/bestiejs/benchmark.js/blob/master/benchmark.js#L2316-L2558)
* [Benchmark instance methods](https://github.com/bestiejs/benchmark.js/blob/master/benchmark.js#L2560-L2571)
* [Deferred instance fields and methods](https://github.com/bestiejs/benchmark.js/blob/master/benchmark.js#L2575-L2612)
* [Event instance fields](https://github.com/bestiejs/benchmark.js/blob/master/benchmark.js#L2616-L2673)
* [Suite instance fields and methods](https://github.com/bestiejs/benchmark.js/blob/master/benchmark.js#L2697-L2744)
* [Support fields](https://github.com/bestiejs/benchmark.js/blob/master/benchmark.js#L195-L235)

Note: I reordered some fields and methods because it was easier to make sure that nothing is missing from the source if it's in the same order.

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

