### PR TITLE
Improve type definitions for async.queue and friends

### DIFF
--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -41,6 +41,7 @@ export interface AsyncAutoTaskFunction<R1, R extends Dictionary<any>, E = Error>
 
 export interface DataContainer<T> {
     data: T;
+    priority: number;
 }
 
 export interface CallbackContainer {
@@ -51,73 +52,180 @@ export interface PriorityContainer {
     priority: number;
 }
 
-export interface AsyncQueue<T> {
+export interface QueueObject<T> {
+    /**
+     * Returns the number of items waiting to be processed.
+     */
     length(): number;
+
+    /**
+     * Indicates whether or not any items have been pushed and processed by the queue.
+     */
     started: boolean;
+
+    /**
+     * Returns the number of items currently being processed.
+     */
     running(): number;
-    idle(): boolean;
-    concurrency: number;
-    push<R, E = Error>(task: T | T[], callback?: AsyncResultCallback<R, E>): void;
-    unshift<E = Error>(task: T | T[], callback?: ErrorCallback<E>): void;
-    remove(filter: (node: DataContainer<T>) => boolean): void;
 
-    saturated(): Promise<void>;
-    saturated(handler: () => void): void;
-    empty(): Promise<void>;
-    empty(handler: () => void): void;
-    drain(): Promise<void>;
-    drain(handler: () => void): void;
-
-    paused: boolean;
-    pause(): void;
-    resume(): void;
-    kill(): void;
+    /**
+     * Returns an array of items currently being processed.
+     */
     workersList<TWorker extends DataContainer<T>, CallbackContainer>(): TWorker[];
 
-    error(): Promise<void>;
-    error(handler: (error: Error, task: T) => void): void;
-
-    unsaturated(): void;
-    buffer: number;
-}
-
-export interface AsyncPriorityQueue<T> {
-    length(): number;
-    concurrency: number;
-    started: boolean;
-    paused: boolean;
-    push<R, E = Error>(task: T | T[], priority: number, callback?: AsyncResultArrayCallback<R, E>): void;
-    saturated: () => any;
-    empty: () => any;
-    drain: () => any;
-    running(): number;
-    idle(): boolean;
-    pause(): void;
-    resume(): void;
-    kill(): void;
-    workersList<TWorker extends DataContainer<T>, CallbackContainer, PriorityContainer>(): TWorker[];
-    error(error: Error, data: any): void;
-    unsaturated(): void;
-    buffer: number;
-}
-
-export interface AsyncCargo {
-    length(): number;
-    payload?: number;
-    push(task: any, callback?: Function): void;
-    saturated(): void;
-    empty(): void;
     /**
-     * a function that sets a callback that is called when the last item from the queue has returned from the worker.
-     * If the callback is omitted, q.drain() returns a promise for the next occurrence.
+     * Returns false if there are items waiting or being processed, or true if not.
+     */
+    idle(): boolean;
+
+    /**
+     * An integer for determining how many worker functions should be run in parallel.
+     * This property can be changed after a queue is created to alter the concurrency on-the-fly.
+     */
+    concurrency: number;
+
+    /**
+     * An integer that specifies how many items are passed to the worker function at a time.
+     * Only applies if this is a cargo object
+     */
+    payload: number;
+
+    /**
+     * Add a new task to the queue. Calls `callback` once the worker has finished
+     * processing the task.
+     *
+     * Instead of a single task, a tasks array can be submitted.
+     * The respective callback is used for every task in the list.
+     */
+    push<R>(task: T | T[]): Promise<R>;
+    push<R, E = Error>(task: T | T[], callback: AsyncResultCallback<R, E>): void;
+
+    /**
+     * Add a new task to the front of the queue
+     */
+    unshift<R>(task: T | T[]): Promise<R>;
+    unshift<R, E = Error>(task: T | T[], callback: AsyncResultCallback<R, E>): void;
+
+    /**
+     * The same as `q.push`, except this returns a promise that rejects if an error occurs.
+     * The `callback` arg is ignored
+     */
+    pushAsync<R>(task: T | T[]): Promise<R>;
+
+    /**
+     * The same as `q.unshift`, except this returns a promise that rejects if an error occurs.
+     * The `callback` arg is ignored
+     */
+    unshiftAsync<R>(task: T | T[]): Promise<R>;
+
+    /**
+     * Remove items from the queue that match a test function.
+     * The test function will be passed an object with a `data` property,
+     * and a `priority` property, if this is a `priorityQueue` object.
+     */
+    remove(filter: (node: DataContainer<T>) => boolean): void;
+
+    /**
+     * A function that sets a callback that is called when the number of
+     * running workers hits the `concurrency` limit, and further tasks will be
+     * queued.
+     *
+     * If the callback is omitted, `q.saturated()` returns a promise
+     * for the next occurrence.
+     */
+    saturated(): Promise<void>;
+    saturated(handler: () => void): void;
+
+    /**
+     * A function that sets a callback that is called when the number
+     * of running workers is less than the `concurrency` & `buffer` limits,
+     * and further tasks will not be queued
+     *
+     * If the callback is omitted, `q.unsaturated()` returns a promise
+     * for the next occurrence.
+     */
+    unsaturated(): Promise<void>;
+    unsaturated(handler: () => void): void;
+
+    /**
+     * A minimum threshold buffer in order to say that the `queue` is `unsaturated`.
+     */
+    buffer: number;
+
+    /**
+     * A function that sets a callback that is called when the last item from the `queue`
+     * is given to a `worker`.
+     *
+     * If the callback is omitted, `q.empty()` returns a promise for the next occurrence.
+     */
+    empty(): Promise<void>;
+    empty(handler: () => void): void;
+
+    /**
+     * A function that sets a callback that is called when the last item from
+     * the `queue` has returned from the `worker`.
+     *
+     * If the callback is omitted, `q.drain()` returns a promise for the next occurrence.
      */
     drain(): Promise<void>;
     drain(handler: () => void): void;
-    idle(): boolean;
+
+    /**
+     * A function that sets a callback that is called when a task errors.
+     *
+     * If the callback is omitted, `q.error()` returns a promise that rejects on the next error.
+     */
+    error(): Promise<never>;
+    error(handler: (error: Error, task: T) => void): void;
+
+    /**
+     * A boolean for determining whether the queue is in a paused state.
+     */
+    paused: boolean;
+
+    /**
+     * A function that pauses the processing of tasks until `q.resume()` is called.
+     */
     pause(): void;
+
+    /**
+     * A function that resumes the processing of queued tasks when the queue
+     * is paused.
+     */
     resume(): void;
+
+    /**
+     * A function that removes the drain callback and empties remaining tasks
+     * from the queue forcing it to go idle. No more tasks should be pushed to
+     * the queue after calling this function.
+     */
     kill(): void;
 }
+
+/**
+ * A priorityQueue object to manage the tasks.
+ *
+ * There are two differences between queue and priorityQueue objects:
+ * - `push(task, priority, [callback])` — priority should be a number. If an array of tasks is given, all tasks will be assigned the same priority.
+ * - The `unshift` method was removed.
+ */
+// FIXME: can not use Omit due to ts version restriction. Replace Pick with Omit, when ts 3.5+ will be allowed
+export interface AsyncPriorityQueue<T> extends Pick<QueueObject<T>, Exclude<keyof QueueObject<T>, 'push' | 'unshift'>> {
+    push<R>(task: T | T[], priority?: number): Promise<R>;
+    push<R, E = Error>(task: T | T[], priority: number, callback: AsyncResultCallback<R, E>): void;
+}
+
+/**
+ * @deprecated this is a type that left here for backward compatibility.
+ * Please use QueueObject instead
+ */
+export type AsyncQueue<T> = QueueObject<T>;
+
+/**
+ * @deprecated this is a type that left here for backward compatibility.
+ * Please use QueueObject instead
+ */
+export type AsyncCargoQueue<T = any> = QueueObject<T>;
 
 // Collections
 export function each<T, E = Error>(arr: IterableCollection<T>, iterator: AsyncIterator<T, E>, callback: ErrorCallback<E>): void;
@@ -223,10 +331,15 @@ export function compose(...fns: Function[]): Function;
 export function seq(...fns: Function[]): Function;
 export function applyEach(fns: Function[], ...argsAndCallback: any[]): void;           // applyEach(fns, args..., callback). TS does not support ... for a middle argument. Callback is optional.
 export function applyEachSeries(fns: Function[], ...argsAndCallback: any[]): void;     // applyEachSeries(fns, args..., callback). TS does not support ... for a middle argument. Callback is optional.
-export function queue<T, E = Error>(worker: AsyncWorker<T, E>, concurrency?: number): AsyncQueue<T>;
-export function queue<T, R, E = Error>(worker: AsyncResultIterator<T, R, E>, concurrency?: number): AsyncQueue<T>;
-export function priorityQueue<T, E = Error>(worker: AsyncWorker<T, E>, concurrency: number): AsyncPriorityQueue<T>;
-export function cargo<E = Error>(worker: (tasks: any[], callback: ErrorCallback<E>) => void, payload?: number): AsyncCargo;
+export function queue<T, E = Error>(worker: AsyncWorker<T, E>, concurrency?: number): QueueObject<T>;
+export function queue<T, R, E = Error>(worker: AsyncResultIterator<T, R, E>, concurrency?: number): QueueObject<T>;
+export function priorityQueue<T, E = Error>(worker: AsyncWorker<T, E>, concurrency?: number): AsyncPriorityQueue<T>;
+export function cargo<T, E = Error>(worker: AsyncWorker<T[], E>, payload?: number): QueueObject<T>;
+export function cargoQueue<T, E = Error>(
+    worker: AsyncWorker<T[], E>,
+    concurrency?: number,
+    payload?: number,
+): QueueObject<T>;
 export function auto<R extends Dictionary<any>, E = Error>(tasks: AsyncAutoTasks<R, E>, concurrency?: number, callback?: AsyncResultCallback<R, E>): void;
 export function auto<R extends Dictionary<any>, E = Error>(tasks: AsyncAutoTasks<R, E>, callback?: AsyncResultCallback<R, E>): void;
 export function autoInject<E = Error>(tasks: any, callback?: AsyncResultCallback<any, E>): void;

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -179,15 +179,25 @@ const q = async.queue<any>((task: any, callback: (err?: Error, msg?: string) => 
     callback(undefined, 'a message.');
 }, 2);
 
-q.drain(() => { console.log('all items have been processed'); });
-
-q.push({ name: 'foo' });
-q.push({ name: 'bar' }, err => { console.log('finished processing bar'); });
+// $ExpectType Promise<string>
+q.push<string>({ name: 'foo' });
+// $ExpectType Promise<string[]>
+q.pushAsync<string[]>({ name: 'foo' });
+// $ExpectType void
+q.push<number, SyntaxError>({ name: 'bar' }, (err: SyntaxError | null, result?: number) => {
+    console.log('finished processing bar');
+});
 q.push([{ name: 'baz' }, { name: 'bay' }, { name: 'bax' }], err => { console.log('finished processing bar'); });
 q.push<string>({name: 'foo'}, (err, msg) => { console.log(`foo finished with a message "${msg!}"`); });
 
-q.unshift({ name: 'foo' });
-q.unshift({ name: 'bar' }, err => { console.log('finished processing bar'); });
+// $ExpectType Promise<string>
+q.unshift<string>({ name: 'foo' });
+// $ExpectType Promise<string>
+q.unshiftAsync<string>({ name: 'foo' });
+// $ExpectType void
+q.unshift<number, SyntaxError>({ name: 'bar' }, (err: SyntaxError | null, result?: number) => {
+    console.log('finished processing bar');
+});
 q.unshift([{ name: 'baz' }, { name: 'bay' }, { name: 'bax' }], err => { console.log('finished processing bar'); });
 
 const qLength: number = q.length();
@@ -196,11 +206,25 @@ const qPaused: boolean = q.paused;
 const qProcessingCount: number = q.running();
 const qIsIdle: boolean = q.idle();
 
+// $ExpectType void
 q.saturated(() => { console.log('queue is saturated.'); });
+// $ExpectType Promise<void>
+q.saturated();
 
+// $ExpectType void
+q.unsaturated(() => { console.log('queue is unsaturated.'); });
+// $ExpectType Promise<void>
+q.unsaturated();
+
+// $ExpectType void
 q.empty(() => { console.log('queue is empty.'); });
+// $ExpectType Promise<void>
+q.empty();
 
+// $ExpectType void
 q.drain(() => { console.log('queue was drained.'); });
+// $ExpectType Promise<void>
+q.drain();
 
 q.pause();
 q.resume();
@@ -242,15 +266,19 @@ const q3 = async.queue<string>((task: string, callback: ErrorCallback) => {
     callback(new Error(task));
 }, 1);
 
-q3.error((error, task) => {
+// $ExpectType void
+q3.error((error: Error, task: string) => {
     console.log('task: ' +  task);
     console.log('error: ' + error);
 });
 
+// $ExpectType Promise<never>
+q3.error();
+
 q3.push(["task1", "task2", "task3"]);
 
 // create a cargo object with payload 2
-const cargo = async.cargo((tasks, callback) => {
+const cargo = async.cargo<{ name: string }>((tasks, callback) => {
     for (const task of tasks) {
         console.log('hello ' + task.name);
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://caolan.github.io/async/v3/docs.html#QueueObject, https://github.com/caolan/async/blob/master/lib/internal/queue.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
