### PR TITLE
Add type definitions for pretty-data

### DIFF
--- a/types/pretty-data/index.d.ts
+++ b/types/pretty-data/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Zeeshan Ahmad <https://github.com/ziishaned>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare const pd: {
+export const pd: {
     xml: (data: string) => string,
     json: (data: string) => string,
     css: (data: string, preserveComments?: boolean) => string,
@@ -13,5 +13,3 @@ declare const pd: {
     cssmin: (data: string) => string,
     sqlmin: (data: string) => string,
 };
-
-export = pd;

--- a/types/pretty-data/index.d.ts
+++ b/types/pretty-data/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for pretty-data 0.40
-// Project: https://github.com/sidorares/json-bigint#readme
+// Project: https://github.com/vkiryukhin/pretty-data#readme
 // Definitions by: Zeeshan Ahmad <https://github.com/ziishaned>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/pretty-data/index.d.ts
+++ b/types/pretty-data/index.d.ts
@@ -14,4 +14,4 @@ declare const pd: {
     sqlmin: (data: string) => string,
 };
 
-export  = pd;
+export = pd;

--- a/types/pretty-data/index.d.ts
+++ b/types/pretty-data/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pretty-data 0.40.0
+// Type definitions for pretty-data 0.40
 // Project: https://github.com/sidorares/json-bigint#readme
 // Definitions by: Zeeshan Ahmad <https://github.com/ziishaned>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/pretty-data/index.d.ts
+++ b/types/pretty-data/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for pretty-data 0.40.0
+// Project: https://github.com/sidorares/json-bigint#readme
+// Definitions by: Zeeshan Ahmad <https://github.com/ziishaned>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare const pd: {
+    xml: (data: string) => string,
+    json: (data: string) => string,
+    css: (data: string, preserveComments?: boolean) => string,
+    sql: (data: string) => string,
+    xmlmin: (data: string, preserveComments?: boolean) => string,
+    jsonmin: (data: string) => string,
+    cssmin: (data: string) => string,
+    sqlmin: (data: string) => string,
+};
+
+export  = pd;

--- a/types/pretty-data/pretty-data-tests.ts
+++ b/types/pretty-data/pretty-data-tests.ts
@@ -1,4 +1,4 @@
-import { pd } = require('pretty-data');
+import { pd } from 'pretty-data';
 
 pd.css('');
 pd.cssmin('');

--- a/types/pretty-data/pretty-data-tests.ts
+++ b/types/pretty-data/pretty-data-tests.ts
@@ -1,4 +1,4 @@
-import pd = require('pretty-data');
+import { pd } = require('pretty-data');
 
 pd.css('');
 pd.cssmin('');

--- a/types/pretty-data/pretty-data-tests.ts
+++ b/types/pretty-data/pretty-data-tests.ts
@@ -1,13 +1,13 @@
-import chalk = require('pretty-data');
+import pd = require('pretty-data');
 
-chalk.css('');
-chalk.cssmin('');
+pd.css('');
+pd.cssmin('');
 
-chalk.json('');
-chalk.jsonmin('');
+pd.json('');
+pd.jsonmin('');
 
-chalk.xml('');
-chalk.xmlmin('');
+pd.xml('');
+pd.xmlmin('');
 
-chalk.sql('');
-chalk.sqlmin('');
+pd.sql('');
+pd.sqlmin('');

--- a/types/pretty-data/pretty-data-tests.ts
+++ b/types/pretty-data/pretty-data-tests.ts
@@ -1,0 +1,13 @@
+import chalk = require('pretty-data');
+
+chalk.css('');
+chalk.cssmin('');
+
+chalk.json('');
+chalk.jsonmin('');
+
+chalk.xml('');
+chalk.xmlmin('');
+
+chalk.sql('');
+chalk.sqlmin('');

--- a/types/pretty-data/tsconfig.json
+++ b/types/pretty-data/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "pretty-data-tests.ts"
+    ]
+}

--- a/types/pretty-data/tslint.json
+++ b/types/pretty-data/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
