### PR TITLE
Exclude non-npm packages

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -6055,12 +6055,6 @@
             "asOfVersion": "3.0.0"
         },
         {
-            "libraryName": "yfiles",
-            "typingsPackageName": "yfiles",
-            "sourceRepoURL": "none",
-            "asOfVersion": "2.1.0"
-        },
-        {
             "libraryName": "yn",
             "typingsPackageName": "yn",
             "sourceRepoURL": "https://github.com/sindresorhus/yn",


### PR DESCRIPTION
Follow up #49005: Remove the only outstanding non-npm `libraryName` from `notNeededPackages.json`.

`yfiles` [is proprietary](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/23310) and was never distributed on npm so it doesn't need to be in `notNeededPackages.json`: The deprecated [@types/yfiles replacement](https://www.npmjs.com/package/@types/yfiles?activeTab=dependencies) is [non-existent](https://www.npmjs.com/package/yfiles).