### PR TITLE
update(color-convert): v2 update and fixes

### DIFF
--- a/types/color-convert/color-convert-tests.ts
+++ b/types/color-convert/color-convert-tests.ts
@@ -1,6 +1,171 @@
-import * as color from 'color-convert';
-import * as conv from 'color-convert/conversions';
+import convert = require('color-convert');
 
-const hsv: [number, number, number] = color.rgb.hsv([1, 2, 3]);
-const hsv_raw: [number, number, number] = color.rgb.hsv.raw([1, 2, 3]);
-const aaa: [number, number, number] = color.rgb.hsv([1, 2, 3]);
+convert.rgb.hsv([1, 2, 3]);
+convert.rgb.hsv(1, 2, 3);
+convert.rgb.hsv.raw([1, 2, 3]);
+convert.rgb.hsv.raw(1, 2, 3);
+convert.rgb.hsv([1, 2, 3]);
+convert.rgb.hsv(1, 2, 3);
+
+convert.rgb.hex(123, 45, 67);
+convert.rgb.hex([123, 45, 67]);
+
+convert.hex.lab('DEADBF');
+convert.hex.lab.raw('DEADBF');
+
+convert.rgb.cmyk(167, 255, 4);
+convert.rgb.cmyk.raw(167, 255, 4);
+
+convert.rgb.hsl([140, 200, 100]);
+convert.rgb.hsv([140, 200, 100]);
+convert.rgb.hwb([140, 200, 100]);
+convert.rgb.cmyk([140, 200, 100]);
+convert.rgb.keyword([255, 228, 196]);
+convert.rgb.xyz([92, 191, 84]);
+convert.rgb.lab([92, 191, 84]);
+convert.rgb.lch([92, 191, 84]);
+convert.rgb.ansi16([92, 191, 84]);
+convert.rgb.ansi256([92, 191, 84]);
+convert.rgb.hex([92, 191, 84]);
+convert.rgb.hcg([140, 200, 100]);
+convert.rgb.apple([255, 127, 0]);
+
+convert.hsl.rgb([96, 48, 59]);
+convert.hsl.hsv([96, 48, 59]);
+convert.hsl.hwb([96, 48, 59]);
+convert.hsl.cmyk([96, 48, 59]);
+convert.hsl.keyword([240, 100, 50]);
+convert.hsl.ansi16([240, 100, 50]);
+convert.hsl.ansi256([240, 100, 50]);
+convert.hsl.hex([240, 100, 50]);
+convert.hsl.hcg([96, 48, 59]);
+
+convert.hsv.rgb([96, 50, 78]);
+convert.hsv.hsl([96, 50, 78]);
+convert.hsv.hsl([0, 0, 0]);
+convert.hsv.hwb([96, 50, 78]);
+convert.hsv.cmyk([96, 50, 78]);
+convert.hsv.keyword([240, 100, 100]);
+convert.hsv.ansi16([240, 100, 100]);
+convert.hsv.ansi256([240, 100, 100]);
+convert.hsv.hex([251, 80, 42]);
+convert.hsv.hcg([96, 50, 78]);
+
+convert.cmyk.rgb([30, 0, 50, 22]);
+convert.cmyk.hsl([30, 0, 50, 22]);
+convert.cmyk.hsv([30, 0, 50, 22]);
+convert.cmyk.hwb([30, 0, 50, 22]);
+convert.cmyk.keyword([100, 100, 0, 0]);
+convert.cmyk.ansi16([30, 0, 50, 22]);
+convert.cmyk.ansi256([30, 0, 50, 22]);
+convert.cmyk.hex([30, 0, 50, 22]);
+
+convert.keyword.rgb('blue');
+convert.keyword.hsl('blue');
+convert.keyword.hsv('blue');
+convert.keyword.hwb('blue');
+convert.keyword.cmyk('blue');
+convert.keyword.lab('blue');
+convert.keyword.xyz('blue');
+convert.keyword.ansi16('purple');
+convert.keyword.ansi256('purple');
+convert.keyword.hex('blue');
+
+convert.xyz.rgb([25, 40, 15]);
+convert.xyz.rgb([50, 100, 100]);
+convert.xyz.lab([25, 40, 15]);
+convert.xyz.lch([25, 40, 15]);
+
+convert.lab.xyz([69, -48, 44]);
+convert.lab.rgb([75, 20, -30]);
+convert.lab.lch([69, -48, 44]);
+
+convert.lch.lab([69, 65, 137]);
+convert.lch.xyz([69, 65, 137]);
+convert.lch.rgb([69, 65, 137]);
+
+convert.ansi16.rgb(103);
+convert.ansi256.rgb(175);
+
+convert.hex.rgb('ABCDEF');
+convert.hex.rgb('AABBCC');
+convert.hex.rgb('ABC');
+
+convert.hcg.rgb([96, 39, 64]);
+convert.hcg.hsv([96, 39, 64]);
+convert.hcg.hsl([96, 39, 64]);
+convert.rgb.hcg.raw([250, 0, 255]);
+convert.hsl.rgb.raw([96, 48, 59]);
+convert.rgb.hsl.raw([140, 200, 100]);
+
+convert.hsv.rgb.raw([96, 50, 78]);
+convert.rgb.hsv.raw([140, 200, 100]);
+
+convert.hwb.rgb.raw([96, 39, 22]);
+convert.rgb.hwb.raw([140, 200, 100]);
+
+convert.cmyk.rgb.raw([30, 0, 50, 22]);
+convert.rgb.cmyk.raw([140, 200, 100]);
+
+convert.keyword.rgb.raw('blue');
+convert.rgb.keyword.raw([255, 228, 196]);
+
+convert.hsv.hsl.raw([96, 50, 78]);
+convert.hsv.hsl.raw([302, 32, 55]);
+convert.hsv.hsl.raw([267, 19, 89]);
+convert.hsv.hsl.raw([267, 91, 95]);
+convert.hsv.hsl.raw([267, 91, 12]);
+convert.hsv.hsl.raw([180, 50, 0]);
+
+convert.hsl.hsv.raw([96, 48, 59]);
+convert.hsl.hsv.raw([120, 54, 61]);
+convert.hsl.hsv.raw([27, 51, 43]);
+convert.hsl.hsv.raw([241, 17, 79]);
+convert.hsl.hsv.raw([120, 50, 0]);
+
+convert.xyz.rgb.raw([25, 40, 15]);
+convert.rgb.xyz.raw([92, 191, 84]);
+
+convert.rgb.lab.raw([92, 191, 84]);
+convert.hwb.rgb([0, 0, 0]);
+convert.hwb.rgb([0, 20, 40]);
+convert.hwb.rgb([0, 40, 40]);
+convert.hwb.rgb([0, 40, 20]);
+
+convert.hwb.rgb([120, 0, 0]);
+convert.hwb.rgb([120, 20, 40]);
+convert.hwb.rgb([120, 40, 40]);
+convert.hwb.rgb([120, 40, 20]);
+
+convert.hwb.rgb([240, 0, 0]);
+convert.hwb.rgb([240, 20, 40]);
+convert.hwb.rgb([240, 40, 40]);
+convert.hwb.rgb([240, 40, 20]);
+
+const val: [number, number, number] = [0, 0, 0];
+
+convert.hsl.hsv(val);
+convert.hsl.rgb(val);
+convert.hsl.hwb(val);
+convert.hsl.cmyk(val);
+convert.hsl.hex(val);
+
+convert.rgb.keyword(255, 255, 0);
+convert.rgb.keyword(255, 255, 1);
+convert.rgb.keyword(250, 254, 1);
+convert.gray.rgb([0]);
+convert.gray.rgb([50]);
+convert.gray.rgb([100]);
+convert.gray.hsl([50]);
+convert.gray.hsv([50]);
+convert.gray.hwb([50]);
+convert.gray.cmyk([50]);
+convert.gray.lab([50]);
+convert.gray.hex([50]);
+convert.gray.hex([100]);
+convert.gray.hex([0]);
+
+convert.rgb.gray([0, 0, 0]);
+convert.rgb.gray([128, 128, 128]);
+convert.rgb.gray([255, 255, 255]);
+convert.rgb.gray([0, 128, 255]);

--- a/types/color-convert/conversions.d.ts
+++ b/types/color-convert/conversions.d.ts
@@ -1,4 +1,4 @@
-import * as cssKeywords from 'color-name';
+import colors = require('color-name');
 
 export type RGB = [number, number, number];
 export type HSL = [number, number, number];
@@ -9,7 +9,7 @@ export type XYZ = [number, number, number];
 export type LAB = [number, number, number];
 export type LCH = [number, number, number];
 export type HEX = string;
-export type KEYWORD = keyof typeof cssKeywords;
+export type KEYWORD = keyof typeof colors;
 export type ANSI16 = number;
 export type ANSI256 = number;
 export type HCG = [number, number, number];
@@ -20,18 +20,31 @@ export namespace rgb {
     const channels: 3;
     const labels: 'rgb';
     function hsl(rgb: RGB): HSL;
+    function hsl(...rgb: RGB): HSL;
     function hsv(rgb: RGB): HSV;
+    function hsv(...rgb: RGB): HSV;
     function hwb(rgb: RGB): HWB;
+    function hwb(...rgb: RGB): HWB;
     function cmyk(rgb: RGB): CMYK;
+    function cmyk(...rgb: RGB): CMYK;
     function keyword(rgb: RGB): KEYWORD;
+    function keyword(...rgb: RGB): KEYWORD;
     function xyz(rgb: RGB): XYZ;
+    function xyz(...rgb: RGB): XYZ;
     function lab(rgb: RGB): LAB;
+    function lab(...rgb: RGB): LAB;
     function ansi16(rgb: RGB): ANSI16;
+    function ansi16(...rgb: RGB): ANSI16;
     function ansi256(rgb: RGB): ANSI256;
+    function ansi256(...rgb: RGB): ANSI256;
     function hex(rgb: RGB): HEX;
+    function hex(...rgb: RGB): HEX;
     function hcg(rgb: RGB): HCG;
+    function hcg(...rgb: RGB): HCG;
     function apple(rgb: RGB): APPLE;
+    function apple(...rgb: RGB): APPLE;
     function gray(rgb: RGB): GRAY;
+    function gray(...rgb: RGB): GRAY;
 }
 
 export namespace hsl {

--- a/types/color-convert/index.d.ts
+++ b/types/color-convert/index.d.ts
@@ -1,98 +1,128 @@
-// Type definitions for color-convert 1.9
+// Type definitions for color-convert 2.0
 // Project: https://github.com/qix-/color-convert#readme
 // Definitions by: Junyoung Clare Jang <https://github.com/Airlun>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 import conversions = require('./conversions');
 import route = require('./route');
 
-export const rgb: typeof conversions.rgb & route.rgb & {
-    [F in keyof route.rgb]: {
-        raw: route.rgb[F]
-    }
-};
+export const rgb: typeof conversions.rgb &
+    route.rgb &
+    {
+        [F in keyof route.rgb]: {
+            raw: route.rgb[F];
+        };
+    };
 
-export const hsl: typeof conversions.hsl & route.hsl & {
-    [F in keyof route.hsl]: {
-        raw: route.hsl[F]
-    }
-};
+export const hsl: typeof conversions.hsl &
+    route.hsl &
+    {
+        [F in keyof route.hsl]: {
+            raw: route.hsl[F];
+        };
+    };
 
-export const hsv: typeof conversions.hsv & route.hsv & {
-    [F in keyof route.hsv]: {
-        raw: route.hsv[F]
-    }
-};
+export const hsv: typeof conversions.hsv &
+    route.hsv &
+    {
+        [F in keyof route.hsv]: {
+            raw: route.hsv[F];
+        };
+    };
 
-export const hwb: typeof conversions.hwb & route.hwb & {
-    [F in keyof route.hwb]: {
-        raw: route.hwb[F]
-    }
-};
+export const hwb: typeof conversions.hwb &
+    route.hwb &
+    {
+        [F in keyof route.hwb]: {
+            raw: route.hwb[F];
+        };
+    };
 
-export const cmyk: typeof conversions.cmyk & route.cmyk & {
-    [F in keyof route.cmyk]: {
-        raw: route.cmyk[F]
-    }
-};
+export const cmyk: typeof conversions.cmyk &
+    route.cmyk &
+    {
+        [F in keyof route.cmyk]: {
+            raw: route.cmyk[F];
+        };
+    };
 
-export const xyz: typeof conversions.xyz & route.xyz & {
-    [F in keyof route.xyz]: {
-        raw: route.xyz[F]
-    }
-};
+export const xyz: typeof conversions.xyz &
+    route.xyz &
+    {
+        [F in keyof route.xyz]: {
+            raw: route.xyz[F];
+        };
+    };
 
-export const lab: typeof conversions.lab & route.lab & {
-    [F in keyof route.lab]: {
-        raw: route.lab[F]
-    }
-};
+export const lab: typeof conversions.lab &
+    route.lab &
+    {
+        [F in keyof route.lab]: {
+            raw: route.lab[F];
+        };
+    };
 
-export const lch: typeof conversions.lch & route.lch & {
-    [F in keyof route.lch]: {
-        raw: route.lch[F]
-    }
-};
+export const lch: typeof conversions.lch &
+    route.lch &
+    {
+        [F in keyof route.lch]: {
+            raw: route.lch[F];
+        };
+    };
 
-export const hex: typeof conversions.hex & route.hex & {
-    [F in keyof route.hex]: {
-        raw: route.hex[F]
-    }
-};
+export const hex: typeof conversions.hex &
+    route.hex &
+    {
+        [F in keyof route.hex]: {
+            raw: route.hex[F];
+        };
+    };
 
-export const keyword: typeof conversions.keyword & route.keyword & {
-    [F in keyof route.keyword]: {
-        raw: route.keyword[F]
-    }
-};
+export const keyword: typeof conversions.keyword &
+    route.keyword &
+    {
+        [F in keyof route.keyword]: {
+            raw: route.keyword[F];
+        };
+    };
 
-export const ansi16: typeof conversions.ansi16 & route.ansi16 & {
-    [F in keyof route.ansi16]: {
-        raw: route.ansi16[F]
-    }
-};
+export const ansi16: typeof conversions.ansi16 &
+    route.ansi16 &
+    {
+        [F in keyof route.ansi16]: {
+            raw: route.ansi16[F];
+        };
+    };
 
-export const ansi256: typeof conversions.ansi256 & route.ansi256 & {
-    [F in keyof route.ansi256]: {
-        raw: route.ansi256[F]
-    }
-};
+export const ansi256: typeof conversions.ansi256 &
+    route.ansi256 &
+    {
+        [F in keyof route.ansi256]: {
+            raw: route.ansi256[F];
+        };
+    };
 
-export const hcg: typeof conversions.hcg & route.hcg & {
-    [F in keyof route.hcg]: {
-        raw: route.hcg[F]
-    }
-};
+export const hcg: typeof conversions.hcg &
+    route.hcg &
+    {
+        [F in keyof route.hcg]: {
+            raw: route.hcg[F];
+        };
+    };
 
-export const apple: typeof conversions.apple & route.apple & {
-    [F in keyof route.apple]: {
-        raw: route.apple[F]
-    }
-};
+export const apple: typeof conversions.apple &
+    route.apple &
+    {
+        [F in keyof route.apple]: {
+            raw: route.apple[F];
+        };
+    };
 
-export const gray: typeof conversions.gray & route.gray & {
-    [F in keyof route.gray]: {
-        raw: route.gray[F]
-    }
-};
+export const gray: typeof conversions.gray &
+    route.gray &
+    {
+        [F in keyof route.gray]: {
+            raw: route.gray[F];
+        };
+    };

--- a/types/color-convert/route.d.ts
+++ b/types/color-convert/route.d.ts
@@ -1,245 +1,277 @@
-import conversions = require('./conversions');
+import {
+    ANSI16,
+    ANSI256,
+    APPLE,
+    CMYK,
+    GRAY,
+    HCG,
+    HEX,
+    HSL,
+    HSV,
+    HWB,
+    KEYWORD,
+    LAB,
+    LCH,
+    RGB,
+    XYZ,
+} from './conversions';
 
 declare namespace route {
     interface rgb {
-        hsl(from: conversions.RGB): conversions.HSL;
-        hsv(from: conversions.RGB): conversions.HSV;
-        hwb(from: conversions.RGB): conversions.HWB;
-        cmyk(from: conversions.RGB): conversions.CMYK;
-        xyz(from: conversions.RGB): conversions.XYZ;
-        lab(from: conversions.RGB): conversions.LAB;
-        lch(from: conversions.RGB): conversions.LCH;
-        hex(from: conversions.RGB): conversions.HEX;
-        keyword(from: conversions.RGB): conversions.KEYWORD;
-        ansi16(from: conversions.RGB): conversions.ANSI16;
-        ansi256(from: conversions.RGB): conversions.ANSI256;
-        hcg(from: conversions.RGB): conversions.HCG;
-        apple(from: conversions.RGB): conversions.APPLE;
-        gray(from: conversions.RGB): conversions.GRAY;
+        hsl(from: RGB): HSL;
+        hsl(...from: RGB): HSL;
+        hsl(from: RGB): HSL;
+        hsl(...from: RGB): HSL;
+        hsv(from: RGB): HSV;
+        hsv(...from: RGB): HSV;
+        hwb(from: RGB): HWB;
+        hwb(...from: RGB): HWB;
+        cmyk(from: RGB): CMYK;
+        cmyk(...from: RGB): CMYK;
+        xyz(from: RGB): XYZ;
+        xyz(...from: RGB): XYZ;
+        lab(from: RGB): LAB;
+        lab(...from: RGB): LAB;
+        lch(from: RGB): LCH;
+        lch(...from: RGB): LCH;
+        hex(from: RGB): HEX;
+        hex(...from: RGB): HEX;
+        keyword(from: RGB): KEYWORD;
+        keyword(...from: RGB): KEYWORD;
+        ansi16(from: RGB): ANSI16;
+        ansi16(...from: RGB): ANSI16;
+        ansi256(from: RGB): ANSI256;
+        ansi256(...from: RGB): ANSI256;
+        hcg(from: RGB): HCG;
+        hcg(...from: RGB): HCG;
+        apple(from: RGB): APPLE;
+        apple(...from: RGB): APPLE;
+        gray(from: RGB): GRAY;
+        gray(...from: RGB): GRAY;
     }
     interface hsl {
-        rgb(from: conversions.HSL): conversions.RGB;
-        hsv(from: conversions.HSL): conversions.HSV;
-        hwb(from: conversions.HSL): conversions.HWB;
-        cmyk(from: conversions.HSL): conversions.CMYK;
-        xyz(from: conversions.HSL): conversions.XYZ;
-        lab(from: conversions.HSL): conversions.LAB;
-        lch(from: conversions.HSL): conversions.LCH;
-        hex(from: conversions.HSL): conversions.HEX;
-        keyword(from: conversions.HSL): conversions.KEYWORD;
-        ansi16(from: conversions.HSL): conversions.ANSI16;
-        ansi256(from: conversions.HSL): conversions.ANSI256;
-        hcg(from: conversions.HSL): conversions.HCG;
-        apple(from: conversions.HSL): conversions.APPLE;
-        gray(from: conversions.HSL): conversions.GRAY;
+        rgb(from: HSL): RGB;
+        hsv(from: HSL): HSV;
+        hwb(from: HSL): HWB;
+        cmyk(from: HSL): CMYK;
+        xyz(from: HSL): XYZ;
+        lab(from: HSL): LAB;
+        lch(from: HSL): LCH;
+        hex(from: HSL): HEX;
+        keyword(from: HSL): KEYWORD;
+        ansi16(from: HSL): ANSI16;
+        ansi256(from: HSL): ANSI256;
+        hcg(from: HSL): HCG;
+        apple(from: HSL): APPLE;
+        gray(from: HSL): GRAY;
     }
     interface hsv {
-        rgb(from: conversions.HSV): conversions.RGB;
-        hsl(from: conversions.HSV): conversions.HSL;
-        hwb(from: conversions.HSV): conversions.HWB;
-        cmyk(from: conversions.HSV): conversions.CMYK;
-        xyz(from: conversions.HSV): conversions.XYZ;
-        lab(from: conversions.HSV): conversions.LAB;
-        lch(from: conversions.HSV): conversions.LCH;
-        hex(from: conversions.HSV): conversions.HEX;
-        keyword(from: conversions.HSV): conversions.KEYWORD;
-        ansi16(from: conversions.HSV): conversions.ANSI16;
-        ansi256(from: conversions.HSV): conversions.ANSI256;
-        hcg(from: conversions.HSV): conversions.HCG;
-        apple(from: conversions.HSV): conversions.APPLE;
-        gray(from: conversions.HSV): conversions.GRAY;
+        rgb(from: HSV): RGB;
+        hsl(from: HSV): HSL;
+        hwb(from: HSV): HWB;
+        cmyk(from: HSV): CMYK;
+        xyz(from: HSV): XYZ;
+        lab(from: HSV): LAB;
+        lch(from: HSV): LCH;
+        hex(from: HSV): HEX;
+        keyword(from: HSV): KEYWORD;
+        ansi16(from: HSV): ANSI16;
+        ansi256(from: HSV): ANSI256;
+        hcg(from: HSV): HCG;
+        apple(from: HSV): APPLE;
+        gray(from: HSV): GRAY;
     }
     interface hwb {
-        rgb(from: conversions.HWB): conversions.RGB;
-        hsl(from: conversions.HWB): conversions.HSL;
-        hsv(from: conversions.HWB): conversions.HSV;
-        cmyk(from: conversions.HWB): conversions.CMYK;
-        xyz(from: conversions.HWB): conversions.XYZ;
-        lab(from: conversions.HWB): conversions.LAB;
-        lch(from: conversions.HWB): conversions.LCH;
-        hex(from: conversions.HWB): conversions.HEX;
-        keyword(from: conversions.HWB): conversions.KEYWORD;
-        ansi16(from: conversions.HWB): conversions.ANSI16;
-        ansi256(from: conversions.HWB): conversions.ANSI256;
-        hcg(from: conversions.HWB): conversions.HCG;
-        apple(from: conversions.HWB): conversions.APPLE;
-        gray(from: conversions.HWB): conversions.GRAY;
+        rgb(from: HWB): RGB;
+        hsl(from: HWB): HSL;
+        hsv(from: HWB): HSV;
+        cmyk(from: HWB): CMYK;
+        xyz(from: HWB): XYZ;
+        lab(from: HWB): LAB;
+        lch(from: HWB): LCH;
+        hex(from: HWB): HEX;
+        keyword(from: HWB): KEYWORD;
+        ansi16(from: HWB): ANSI16;
+        ansi256(from: HWB): ANSI256;
+        hcg(from: HWB): HCG;
+        apple(from: HWB): APPLE;
+        gray(from: HWB): GRAY;
     }
     interface cmyk {
-        rgb(from: conversions.CMYK): conversions.RGB;
-        hsl(from: conversions.CMYK): conversions.HSL;
-        hsv(from: conversions.CMYK): conversions.HSV;
-        hwb(from: conversions.CMYK): conversions.HWB;
-        xyz(from: conversions.CMYK): conversions.XYZ;
-        lab(from: conversions.CMYK): conversions.LAB;
-        lch(from: conversions.CMYK): conversions.LCH;
-        hex(from: conversions.CMYK): conversions.HEX;
-        keyword(from: conversions.CMYK): conversions.KEYWORD;
-        ansi16(from: conversions.CMYK): conversions.ANSI16;
-        ansi256(from: conversions.CMYK): conversions.ANSI256;
-        hcg(from: conversions.CMYK): conversions.HCG;
-        apple(from: conversions.CMYK): conversions.APPLE;
-        gray(from: conversions.CMYK): conversions.GRAY;
+        rgb(from: CMYK): RGB;
+        hsl(from: CMYK): HSL;
+        hsv(from: CMYK): HSV;
+        hwb(from: CMYK): HWB;
+        xyz(from: CMYK): XYZ;
+        lab(from: CMYK): LAB;
+        lch(from: CMYK): LCH;
+        hex(from: CMYK): HEX;
+        keyword(from: CMYK): KEYWORD;
+        ansi16(from: CMYK): ANSI16;
+        ansi256(from: CMYK): ANSI256;
+        hcg(from: CMYK): HCG;
+        apple(from: CMYK): APPLE;
+        gray(from: CMYK): GRAY;
     }
     interface xyz {
-        rgb(from: conversions.XYZ): conversions.RGB;
-        hsl(from: conversions.XYZ): conversions.HSL;
-        hsv(from: conversions.XYZ): conversions.HSV;
-        hwb(from: conversions.XYZ): conversions.HWB;
-        cmyk(from: conversions.XYZ): conversions.CMYK;
-        lab(from: conversions.XYZ): conversions.LAB;
-        lch(from: conversions.XYZ): conversions.LCH;
-        hex(from: conversions.XYZ): conversions.HEX;
-        keyword(from: conversions.XYZ): conversions.KEYWORD;
-        ansi16(from: conversions.XYZ): conversions.ANSI16;
-        ansi256(from: conversions.XYZ): conversions.ANSI256;
-        hcg(from: conversions.XYZ): conversions.HCG;
-        apple(from: conversions.XYZ): conversions.APPLE;
-        gray(from: conversions.XYZ): conversions.GRAY;
+        rgb(from: XYZ): RGB;
+        hsl(from: XYZ): HSL;
+        hsv(from: XYZ): HSV;
+        hwb(from: XYZ): HWB;
+        cmyk(from: XYZ): CMYK;
+        lab(from: XYZ): LAB;
+        lch(from: XYZ): LCH;
+        hex(from: XYZ): HEX;
+        keyword(from: XYZ): KEYWORD;
+        ansi16(from: XYZ): ANSI16;
+        ansi256(from: XYZ): ANSI256;
+        hcg(from: XYZ): HCG;
+        apple(from: XYZ): APPLE;
+        gray(from: XYZ): GRAY;
     }
     interface lab {
-        rgb(from: conversions.LAB): conversions.RGB;
-        hsl(from: conversions.LAB): conversions.HSL;
-        hsv(from: conversions.LAB): conversions.HSV;
-        hwb(from: conversions.LAB): conversions.HWB;
-        cmyk(from: conversions.LAB): conversions.CMYK;
-        xyz(from: conversions.LAB): conversions.XYZ;
-        lch(from: conversions.LAB): conversions.LCH;
-        hex(from: conversions.LAB): conversions.HEX;
-        keyword(from: conversions.LAB): conversions.KEYWORD;
-        ansi16(from: conversions.LAB): conversions.ANSI16;
-        ansi256(from: conversions.LAB): conversions.ANSI256;
-        hcg(from: conversions.LAB): conversions.HCG;
-        apple(from: conversions.LAB): conversions.APPLE;
-        gray(from: conversions.LAB): conversions.GRAY;
+        rgb(from: LAB): RGB;
+        hsl(from: LAB): HSL;
+        hsv(from: LAB): HSV;
+        hwb(from: LAB): HWB;
+        cmyk(from: LAB): CMYK;
+        xyz(from: LAB): XYZ;
+        lch(from: LAB): LCH;
+        hex(from: LAB): HEX;
+        keyword(from: LAB): KEYWORD;
+        ansi16(from: LAB): ANSI16;
+        ansi256(from: LAB): ANSI256;
+        hcg(from: LAB): HCG;
+        apple(from: LAB): APPLE;
+        gray(from: LAB): GRAY;
     }
     interface lch {
-        rgb(from: conversions.LCH): conversions.RGB;
-        hsl(from: conversions.LCH): conversions.HSL;
-        hsv(from: conversions.LCH): conversions.HSV;
-        hwb(from: conversions.LCH): conversions.HWB;
-        cmyk(from: conversions.LCH): conversions.CMYK;
-        xyz(from: conversions.LCH): conversions.XYZ;
-        lab(from: conversions.LCH): conversions.LAB;
-        hex(from: conversions.LCH): conversions.HEX;
-        keyword(from: conversions.LCH): conversions.KEYWORD;
-        ansi16(from: conversions.LCH): conversions.ANSI16;
-        ansi256(from: conversions.LCH): conversions.ANSI256;
-        hcg(from: conversions.LCH): conversions.HCG;
-        apple(from: conversions.LCH): conversions.APPLE;
-        gray(from: conversions.LCH): conversions.GRAY;
+        rgb(from: LCH): RGB;
+        hsl(from: LCH): HSL;
+        hsv(from: LCH): HSV;
+        hwb(from: LCH): HWB;
+        cmyk(from: LCH): CMYK;
+        xyz(from: LCH): XYZ;
+        lab(from: LCH): LAB;
+        hex(from: LCH): HEX;
+        keyword(from: LCH): KEYWORD;
+        ansi16(from: LCH): ANSI16;
+        ansi256(from: LCH): ANSI256;
+        hcg(from: LCH): HCG;
+        apple(from: LCH): APPLE;
+        gray(from: LCH): GRAY;
     }
     interface hex {
-        rgb(from: conversions.HEX): conversions.RGB;
-        hsl(from: conversions.HEX): conversions.HSL;
-        hsv(from: conversions.HEX): conversions.HSV;
-        hwb(from: conversions.HEX): conversions.HWB;
-        cmyk(from: conversions.HEX): conversions.CMYK;
-        xyz(from: conversions.HEX): conversions.XYZ;
-        lab(from: conversions.HEX): conversions.LAB;
-        lch(from: conversions.HEX): conversions.LCH;
-        keyword(from: conversions.HEX): conversions.KEYWORD;
-        ansi16(from: conversions.HEX): conversions.ANSI16;
-        ansi256(from: conversions.HEX): conversions.ANSI256;
-        hcg(from: conversions.HEX): conversions.HCG;
-        apple(from: conversions.HEX): conversions.APPLE;
-        gray(from: conversions.HEX): conversions.GRAY;
+        rgb(from: HEX): RGB;
+        hsl(from: HEX): HSL;
+        hsv(from: HEX): HSV;
+        hwb(from: HEX): HWB;
+        cmyk(from: HEX): CMYK;
+        xyz(from: HEX): XYZ;
+        lab(from: HEX): LAB;
+        lch(from: HEX): LCH;
+        keyword(from: HEX): KEYWORD;
+        ansi16(from: HEX): ANSI16;
+        ansi256(from: HEX): ANSI256;
+        hcg(from: HEX): HCG;
+        apple(from: HEX): APPLE;
+        gray(from: HEX): GRAY;
     }
     interface keyword {
-        rgb(from: conversions.KEYWORD): conversions.RGB;
-        hsl(from: conversions.KEYWORD): conversions.HSL;
-        hsv(from: conversions.KEYWORD): conversions.HSV;
-        hwb(from: conversions.KEYWORD): conversions.HWB;
-        cmyk(from: conversions.KEYWORD): conversions.CMYK;
-        xyz(from: conversions.KEYWORD): conversions.XYZ;
-        lab(from: conversions.KEYWORD): conversions.LAB;
-        lch(from: conversions.KEYWORD): conversions.LCH;
-        hex(from: conversions.KEYWORD): conversions.HEX;
-        ansi16(from: conversions.KEYWORD): conversions.ANSI16;
-        ansi256(from: conversions.KEYWORD): conversions.ANSI256;
-        hcg(from: conversions.KEYWORD): conversions.HCG;
-        apple(from: conversions.KEYWORD): conversions.APPLE;
-        gray(from: conversions.KEYWORD): conversions.GRAY;
+        rgb(from: KEYWORD): RGB;
+        hsl(from: KEYWORD): HSL;
+        hsv(from: KEYWORD): HSV;
+        hwb(from: KEYWORD): HWB;
+        cmyk(from: KEYWORD): CMYK;
+        xyz(from: KEYWORD): XYZ;
+        lab(from: KEYWORD): LAB;
+        lch(from: KEYWORD): LCH;
+        hex(from: KEYWORD): HEX;
+        ansi16(from: KEYWORD): ANSI16;
+        ansi256(from: KEYWORD): ANSI256;
+        hcg(from: KEYWORD): HCG;
+        apple(from: KEYWORD): APPLE;
+        gray(from: KEYWORD): GRAY;
     }
     interface ansi16 {
-        rgb(from: conversions.ANSI16): conversions.RGB;
-        hsl(from: conversions.ANSI16): conversions.HSL;
-        hsv(from: conversions.ANSI16): conversions.HSV;
-        hwb(from: conversions.ANSI16): conversions.HWB;
-        cmyk(from: conversions.ANSI16): conversions.CMYK;
-        xyz(from: conversions.ANSI16): conversions.XYZ;
-        lab(from: conversions.ANSI16): conversions.LAB;
-        lch(from: conversions.ANSI16): conversions.LCH;
-        hex(from: conversions.ANSI16): conversions.HEX;
-        keyword(from: conversions.ANSI16): conversions.KEYWORD;
-        ansi256(from: conversions.ANSI16): conversions.ANSI256;
-        hcg(from: conversions.ANSI16): conversions.HCG;
-        apple(from: conversions.ANSI16): conversions.APPLE;
-        gray(from: conversions.ANSI16): conversions.GRAY;
+        rgb(from: ANSI16): RGB;
+        hsl(from: ANSI16): HSL;
+        hsv(from: ANSI16): HSV;
+        hwb(from: ANSI16): HWB;
+        cmyk(from: ANSI16): CMYK;
+        xyz(from: ANSI16): XYZ;
+        lab(from: ANSI16): LAB;
+        lch(from: ANSI16): LCH;
+        hex(from: ANSI16): HEX;
+        keyword(from: ANSI16): KEYWORD;
+        ansi256(from: ANSI16): ANSI256;
+        hcg(from: ANSI16): HCG;
+        apple(from: ANSI16): APPLE;
+        gray(from: ANSI16): GRAY;
     }
     interface ansi256 {
-        rgb(from: conversions.ANSI256): conversions.RGB;
-        hsl(from: conversions.ANSI256): conversions.HSL;
-        hsv(from: conversions.ANSI256): conversions.HSV;
-        hwb(from: conversions.ANSI256): conversions.HWB;
-        cmyk(from: conversions.ANSI256): conversions.CMYK;
-        xyz(from: conversions.ANSI256): conversions.XYZ;
-        lab(from: conversions.ANSI256): conversions.LAB;
-        lch(from: conversions.ANSI256): conversions.LCH;
-        hex(from: conversions.ANSI256): conversions.HEX;
-        keyword(from: conversions.ANSI256): conversions.KEYWORD;
-        ansi16(from: conversions.ANSI256): conversions.ANSI16;
-        hcg(from: conversions.ANSI256): conversions.HCG;
-        apple(from: conversions.ANSI256): conversions.APPLE;
-        gray(from: conversions.ANSI256): conversions.GRAY;
+        rgb(from: ANSI256): RGB;
+        hsl(from: ANSI256): HSL;
+        hsv(from: ANSI256): HSV;
+        hwb(from: ANSI256): HWB;
+        cmyk(from: ANSI256): CMYK;
+        xyz(from: ANSI256): XYZ;
+        lab(from: ANSI256): LAB;
+        lch(from: ANSI256): LCH;
+        hex(from: ANSI256): HEX;
+        keyword(from: ANSI256): KEYWORD;
+        ansi16(from: ANSI256): ANSI16;
+        hcg(from: ANSI256): HCG;
+        apple(from: ANSI256): APPLE;
+        gray(from: ANSI256): GRAY;
     }
     interface hcg {
-        rgb(from: conversions.HCG): conversions.RGB;
-        hsl(from: conversions.HCG): conversions.HSL;
-        hsv(from: conversions.HCG): conversions.HSV;
-        hwb(from: conversions.HCG): conversions.HWB;
-        cmyk(from: conversions.HCG): conversions.CMYK;
-        xyz(from: conversions.HCG): conversions.XYZ;
-        lab(from: conversions.HCG): conversions.LAB;
-        lch(from: conversions.HCG): conversions.LCH;
-        hex(from: conversions.HCG): conversions.HEX;
-        keyword(from: conversions.HCG): conversions.KEYWORD;
-        ansi16(from: conversions.HCG): conversions.ANSI16;
-        ansi256(from: conversions.HCG): conversions.ANSI256;
-        apple(from: conversions.HCG): conversions.APPLE;
-        gray(from: conversions.HCG): conversions.GRAY;
+        rgb(from: HCG): RGB;
+        hsl(from: HCG): HSL;
+        hsv(from: HCG): HSV;
+        hwb(from: HCG): HWB;
+        cmyk(from: HCG): CMYK;
+        xyz(from: HCG): XYZ;
+        lab(from: HCG): LAB;
+        lch(from: HCG): LCH;
+        hex(from: HCG): HEX;
+        keyword(from: HCG): KEYWORD;
+        ansi16(from: HCG): ANSI16;
+        ansi256(from: HCG): ANSI256;
+        apple(from: HCG): APPLE;
+        gray(from: HCG): GRAY;
     }
     interface apple {
-        rgb(from: conversions.APPLE): conversions.RGB;
-        hsl(from: conversions.APPLE): conversions.HSL;
-        hsv(from: conversions.APPLE): conversions.HSV;
-        hwb(from: conversions.APPLE): conversions.HWB;
-        cmyk(from: conversions.APPLE): conversions.CMYK;
-        xyz(from: conversions.APPLE): conversions.XYZ;
-        lab(from: conversions.APPLE): conversions.LAB;
-        lch(from: conversions.APPLE): conversions.LCH;
-        hex(from: conversions.APPLE): conversions.HEX;
-        keyword(from: conversions.APPLE): conversions.KEYWORD;
-        ansi16(from: conversions.APPLE): conversions.ANSI16;
-        ansi256(from: conversions.APPLE): conversions.ANSI256;
-        hcg(from: conversions.APPLE): conversions.HCG;
-        gray(from: conversions.APPLE): conversions.GRAY;
+        rgb(from: APPLE): RGB;
+        hsl(from: APPLE): HSL;
+        hsv(from: APPLE): HSV;
+        hwb(from: APPLE): HWB;
+        cmyk(from: APPLE): CMYK;
+        xyz(from: APPLE): XYZ;
+        lab(from: APPLE): LAB;
+        lch(from: APPLE): LCH;
+        hex(from: APPLE): HEX;
+        keyword(from: APPLE): KEYWORD;
+        ansi16(from: APPLE): ANSI16;
+        ansi256(from: APPLE): ANSI256;
+        hcg(from: APPLE): HCG;
+        gray(from: APPLE): GRAY;
     }
     interface gray {
-        rgb(from: conversions.GRAY): conversions.RGB;
-        hsl(from: conversions.GRAY): conversions.HSL;
-        hsv(from: conversions.GRAY): conversions.HSV;
-        hwb(from: conversions.GRAY): conversions.HWB;
-        cmyk(from: conversions.GRAY): conversions.CMYK;
-        xyz(from: conversions.GRAY): conversions.XYZ;
-        lab(from: conversions.GRAY): conversions.LAB;
-        lch(from: conversions.GRAY): conversions.LCH;
-        hex(from: conversions.GRAY): conversions.HEX;
-        keyword(from: conversions.GRAY): conversions.KEYWORD;
-        ansi16(from: conversions.GRAY): conversions.ANSI16;
-        ansi256(from: conversions.GRAY): conversions.ANSI256;
-        hcg(from: conversions.GRAY): conversions.HCG;
-        apple(from: conversions.GRAY): conversions.APPLE;
+        rgb(from: GRAY): RGB;
+        hsl(from: GRAY): HSL;
+        hsv(from: GRAY): HSV;
+        hwb(from: GRAY): HWB;
+        cmyk(from: GRAY): CMYK;
+        xyz(from: GRAY): XYZ;
+        lab(from: GRAY): LAB;
+        lch(from: GRAY): LCH;
+        hex(from: GRAY): HEX;
+        keyword(from: GRAY): KEYWORD;
+        ansi16(from: GRAY): ANSI16;
+        ansi256(from: GRAY): ANSI256;
+        hcg(from: GRAY): HCG;
+        apple(from: GRAY): APPLE;
     }
 }
 


### PR DESCRIPTION
- RGB accepting methods converted to accept both typed tuple (array of
  numbers) and rgb parameters derived from type, as method explicitely
  accepts both:
  https://github.com/Qix-/color-convert#arrays
- version bump
- minor styling changes (types imports, DT defaults)
- maintainer added

https://github.com/Qix-/color-convert/compare/1.9.3...2.0.1

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)