### PR TITLE
fix(history, react-router): Make Location state property optional

### DIFF
--- a/types/history/history-tests.ts
+++ b/types/history/history-tests.ts
@@ -18,7 +18,7 @@ let input = { value: '' };
 {
     let history = createBrowserHistory<{ some: 'state' }>();
 
-    history.location.state; // $ExpectType { some: "state"; }
+    history.location.state; // $ExpectType { some: "state"; } | undefined
 
     // Listen for changes to the current location. The listener is called once immediately.
     let unlisten = history.listen(function (location) {

--- a/types/history/index.d.ts
+++ b/types/history/index.d.ts
@@ -27,7 +27,7 @@ export interface History<HistoryLocationState = LocationState> {
 export interface Location<S = LocationState> {
     pathname: Pathname;
     search: Search;
-    state: S;
+    state?: S;
     hash: Hash;
     key?: LocationKey;
 }

--- a/types/react-router/test/WithRouter.tsx
+++ b/types/react-router/test/WithRouter.tsx
@@ -57,8 +57,8 @@ const WithRouterTestClass2 = () => <WithRouterComponentClass username="John" wra
     type SomethingToRead = (Book | Magazine) & RouteComponentProps<{}, StaticContext, State>;
 
     const Readable: React.SFC<SomethingToRead> = props => {
-        props.location.state; // $ExpectType State
-        props.history.location.state; // $ExpectType State
+        props.location.state; // $ExpectType State | undefined
+        props.history.location.state; // $ExpectType State | undefined
 
         if (props.kind === 'magazine') {
             return <div>magazine #{props.issue}</div>;

--- a/types/react-router/test/hooks.tsx
+++ b/types/react-router/test/hooks.tsx
@@ -36,8 +36,8 @@ const HooksTest: React.FC = () => {
     // $ExpectType match<Params>
     const match4 = useRouteMatch<Params>();
 
-    history.location.state.s;
-    location.state.s;
+    history.location.state && history.location.state.s;
+    location.state && location.state.s;
     id && id.replace;
     params.id.replace;
     optionalParams.id && optionalParams.id.replace;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/issues/49060>
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)


This PR makes the `state` property in the `Location` interface optional since it will be `undefined` unless a value is provided. A good example is the test I had to fix:
```
let history = createBrowserHistory<{ some: 'state' }>();
history.location.state; // $ExpectType { some: "state"; }
```
The types imply that `history.location.state.some` has the value `'state'` but instead it is `undefined` resulting in a runtime error.

This fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/49060.