### PR TITLE
feat: Add Gantt chart to @types/google.visualization. Closes #43921

### DIFF
--- a/types/google.visualization/google.visualization-tests.ts
+++ b/types/google.visualization/google.visualization-tests.ts
@@ -789,3 +789,87 @@ function test_GaugeChart() {
         });
     }
 }
+
+function test_GanttChart() {
+    var data = new google.visualization.DataTable();
+    data.addColumn('string', 'Task ID');
+    data.addColumn('string', 'Task Name');
+    data.addColumn('date', 'Start Date');
+    data.addColumn('date', 'End Date');
+    data.addColumn('number', 'Duration');
+    data.addColumn('number', 'Percent Complete');
+    data.addColumn('string', 'Dependencies');
+
+    function daysToMilliseconds(days: number): number {
+        return days * 24 * 60 * 60 * 1000;
+    }
+
+    data.addRows([
+        ['Research', 'Find sources',
+            new Date(2015, 0, 1), new Date(2015, 0, 5), null, 100, null],
+        ['Write', 'Write paper',
+            null, new Date(2015, 0, 9), daysToMilliseconds(3), 25, 'Research,Outline'],
+        ['Cite', 'Create bibliography',
+            null, new Date(2015, 0, 7), daysToMilliseconds(1), 20, 'Research'],
+        ['Complete', 'Hand in paper',
+            null, new Date(2015, 0, 10), daysToMilliseconds(1), 0, 'Cite,Write'],
+        ['Outline', 'Outline paper',
+            null, new Date(2015, 0, 6), daysToMilliseconds(1), 100, 'Research']
+    ]);
+
+    var container = document.getElementById('chart_div');
+    if (container) {
+        var chart = new google.visualization.Gantt(container);
+
+        chart.draw(data, {
+            height: 300,
+            backgroundColor: {
+                fill: 'white'
+            },
+            gantt: {
+                arrow: {
+                    angle: 45,
+                    color: 'blue',
+                    length: 8,
+                    radius: 30,
+                    spaceAfter: 8,
+                    width: 1.4
+                },
+                barCornerRadius: 5,
+                barHeight: 20,
+                criticalPathEnabled: true,
+                criticalPathStyle: {
+                    stroke: '#fe4444',
+                    strokeWidth: 1.4
+                },
+                defaultStartDate: new Date(2015, 0, 1),
+                innerGridHorizLine: {
+                    stroke: '#888',
+                    strokeWidth: 1
+                },
+                innerGridTrack: {
+                    fill: '#fefefe'
+                },
+                innerGridDarkTrack: {
+                    fill: '#efefef'
+                },
+                labelMaxWidth: 300,
+                labelStyle: {
+                    fontName: 'sans-serif',
+                    fontSize: 14,
+                    color: '#222'
+                },
+                percentEnabled: true,
+                percentStyle: {
+                    fill: '#fecccc'
+                },
+                shadowEnabled: true,
+                shadowStyle: {
+                    fill: '#666'
+                },
+                shadowOffset: 1,
+                trackHeight: 30
+            }
+        });
+    }
+}

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -437,9 +437,15 @@ declare namespace google {
             zoomDelta?: number;
         }
 
-        export interface ChartStrokeFill {
+        export interface ChartStrokeFill extends ChartStroke, ChartFill {
+        }
+
+        export interface ChartStroke {
             stroke?: string;
             strokeWidth?: number;
+        }
+
+        export interface ChartFill {
             fill?: string;
         }
 
@@ -1177,7 +1183,7 @@ declare namespace google {
         export interface LabelStyle {
             color: string;
             fontName: string;
-            fontSize: string;
+            fontSize: number;
         }
 
         //#endregion
@@ -1616,6 +1622,53 @@ declare namespace google {
              */
             size?: string;
         }
+
+        //#endregion
+        //#region Gantt
+
+        // https://developers.google.com/chart/interactive/docs/gallery/ganttchart
+        export class Gantt extends ChartBaseClearable {
+            draw(data: DataTable | DataView, options: GanttChartOptions): void;
+        }
+
+        // https://developers.google.com/chart/interactive/docs/gallery/ganttchart#configuration-options
+        export interface GanttChartOptions {
+            backgroundColor?: ChartFill;
+            gantt?: GanttOptions;
+            width?: number;
+            height?: number;
+        }
+
+        export interface GanttOptions {
+            arrow?: GanttArrow;
+            barCornerRadius?: number;
+            barHeight?: number;
+            criticalPathEnabled?: boolean;
+            criticalPathStyle?: ChartStroke;
+            defaultStartDate?: Date | number;
+            innerGridHorizLine?: ChartStroke;
+            innerGridTrack?: ChartFill;
+            innerGridDarkTrack?: ChartFill;
+            labelMaxWidth?: number;
+            labelStyle?: LabelStyle;
+            percentEnabled?: boolean;
+            percentStyle?: ChartFill;
+            shadowEnabled?: boolean;
+            shadowStyle?: ChartFill;
+            shadowOffset?: number;
+            sortTasks?: boolean;
+            trackHeight?: number;
+        }
+
+        export interface GanttArrow {
+            angle?: number;
+            color?: string;
+            length?: number;
+            radius?: number;
+            spaceAfter?: number;
+            width?: number;
+        }
+
 
         //#endregion
         //#region Gauge


### PR DESCRIPTION
Closes #43921

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ x Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/chart/interactive/docs/gallery/ganttchart
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

------
Notes: 

I also updated `LabelStyle.fontSize`, which should be `number` not `string`. The docs are misleading, in one place they say it's string, in another that it's number, and in the example it's number: https://developers.google.com/chart/interactive/docs/gallery/timeline#changing-the-fonts `rowLabelStyle: {fontName: 'Helvetica', fontSize: 24, color: '#603913'}`


Gantt docs are also wrong regarding  `shadowColor` and inconsistent with the actual impl, where `shadowStyle.fill` is used instead.
See [actual impl](https://www.gstatic.com/charts/49/js/jsapi_compiled_gantt_module.js ) (sorry for the minified version, but I don't know where to find the unminified source code...)
```js
// defaults
gvjs_.Mf = function() {
    return {
        backgroundColor: {
            fill: gvjs_ea
        },
        gantt: {
            arrow: {
                angle: 45,
                color: gvjs_gX[gvjs_8r],
                length: 8,
                radius: 30,
                spaceAfter: 8,
                width: 1.4
            },
            barCornerRadius: 5,
            barHeight: null,
            criticalPathEnabled: !0,
            criticalPathStyle: {
                stroke: gvjs_7D[gvjs_5r],
                strokeWidth: 1.4
            },
            defaultStartDate: null,
            innerGridHorizLine: {
                stroke: null,
                strokeWidth: 1
            },
            innerGridTrack: {
                fill: null
            },
            innerGridDarkTrack: {
                fill: null
            },
            labelMaxWidth: 300,
            labelStyle: {
                fontName: gvjs_ws,
                fontSize: 14, // number !
                color: gvjs_gX[gvjs_6r]
            },
            percentEnabled: !0,
            percentStyle: {
                fill: gvjs_ca
            },
            shadowEnabled: !0,
            shadowStyle: { // no shadowColor !
                fill: gvjs_gX[gvjs_8r]
            },
            shadowOffset: 1,
            trackHeight: null
        }
    }
}
```
