### PR TITLE
[nodegit] Fix Revwalker's getCommitsUntil return type

### DIFF
--- a/types/nodegit/nodegit-tests.ts
+++ b/types/nodegit/nodegit-tests.ts
@@ -94,3 +94,9 @@ repo.getHeadCommit().then(async commit => {
 
 Git.version; // $ExpectType string
 Git.Promise; // $ExpectType PromiseConstructor
+
+const revwalk = Git.Revwalk.create(repo);
+revwalk.push(id);
+const commitList: Promise<Git.Commit[]> = revwalk.getCommitsUntil((commit: Git.Commit) => {
+    return true;
+});

--- a/types/nodegit/rev-walk.d.ts
+++ b/types/nodegit/rev-walk.d.ts
@@ -42,6 +42,6 @@ export class Revwalk {
     /**
      * Walk the history grabbing commits until the checkFn called with the current commit returns false.
      */
-    getCommitsUntil(checkFn: Function): Promise<any[]>;
+    getCommitsUntil(checkFn: Function): Promise<Commit[]>;
     getCommits(count: number): Promise<Commit[]>;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodegit/nodegit/blob/master/lib/revwalk.js#L68
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
