### PR TITLE
roslib: Add getTopicsAndRawTypes() definition

### DIFF
--- a/types/roslib/index.d.ts
+++ b/types/roslib/index.d.ts
@@ -119,6 +119,21 @@ declare namespace ROSLIB {
         ): void;
 
         /**
+         * Retrieves list of topics and their associated type definitions.
+         *
+         * @param callback function with params:
+         *   * topics - Array of topic names
+         *   * types - Array of message type names
+         *   * typedefs_full_text - Array of full definitions of message types, similar to `gendeps --cat`
+         * @param failedCallback - the callback function when the service call failed (optional). Params:
+         *   * error - the error message reported by ROS
+         */
+        getTopicsAndRawTypes(
+            callback: (topics: { topics: string[]; types: string[]; typedefs_full_text: string[] }) => void,
+            failedCallback?: (error: any) => void,
+        ): void;
+        
+        /**
          * Retrieves Topics in ROS as an array as specific type
          *
          * @param topicType topic type to find:


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/RobotWebTools/roslibjs/blob/c1d27cecaf5c8dab308362e1c895f242128490b7/build/roslib.js#L2898
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (1.0.1)
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
