### PR TITLE
[share-api-polyfill] Make options interface partial

### DIFF
--- a/types/share-api-polyfill/index.d.ts
+++ b/types/share-api-polyfill/index.d.ts
@@ -10,22 +10,22 @@ export interface ShareAPIPolyfillData extends ShareData {
 }
 
 export interface ShareAPIPolyfillOptions {
-    copy: boolean;
-    email: boolean;
-    print: boolean;
-    sms: boolean;
-    messenger: boolean;
-    facebook: boolean;
-    whatsapp: boolean;
-    twitter: boolean;
-    linkedin: boolean;
-    telegram: boolean;
-    skype: boolean;
-    language: string;
+    copy?: boolean;
+    email?: boolean;
+    print?: boolean;
+    sms?: boolean;
+    messenger?: boolean;
+    facebook?: boolean;
+    whatsapp?: boolean;
+    twitter?: boolean;
+    linkedin?: boolean;
+    telegram?: boolean;
+    skype?: boolean;
+    language?: string;
 }
 
 declare global {
     interface Navigator {
-        share(data?: ShareAPIPolyfillData, configuration?: Partial<ShareAPIPolyfillOptions>): Promise<void>;
+        share(data?: ShareAPIPolyfillData, configuration?: ShareAPIPolyfillOptions): Promise<void>;
     }
 }

--- a/types/share-api-polyfill/share-api-polyfill-tests.ts
+++ b/types/share-api-polyfill/share-api-polyfill-tests.ts
@@ -1,3 +1,6 @@
+import { ShareAPIPolyfillOptions } from 'share-api-polyfill';
+
 navigator.share({ url: 'https://example.com' }); // $ExpectType Promise<void>
 navigator.share({ url: 'https://example.com', hashtags: 'example' }); // $ExpectType Promise<void>
 navigator.share({ title: 'Example' }, { sms: false, language: 'en' }); // $ExpectType Promise<void>
+const options: ShareAPIPolyfillOptions = { copy: false };


### PR DESCRIPTION
This is a follow-up to the recommendation in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49015#pullrequestreview-515994456 by @peterblazejewicz. All properties in the exported `ShareAPIPolyfillOptions` are optional for easier reuse.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49015#pullrequestreview-515994456
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.