### PR TITLE
fix: add missing prop render header in react-native-calendars

### DIFF
--- a/types/react-native-calendars/index.d.ts
+++ b/types/react-native-calendars/index.d.ts
@@ -53,16 +53,16 @@ export interface CalendarTheme {
     indicatorColor?: string;
 
     // Theme ID's to style for
-    "stylesheet.calendar.header"?: CalendarThemeIdStyle;
-    "stylesheet.calendar.main"?: CalendarThemeIdStyle;
-    "stylesheet.calendar-list.main"?: CalendarThemeIdStyle;
-    "stylesheet.agenda.main"?: CalendarThemeIdStyle;
-    "stylesheet.agenda.list"?: CalendarThemeIdStyle;
-    "stylesheet.day.basic"?: CalendarThemeIdStyle;
-    "stylesheet.day.single"?: CalendarThemeIdStyle;
-    "stylesheet.day.multiDot"?: CalendarThemeIdStyle;
-    "stylesheet.day.period"?: CalendarThemeIdStyle;
-    "stylesheet.dot"?: CalendarThemeIdStyle;
+    'stylesheet.calendar.header'?: CalendarThemeIdStyle;
+    'stylesheet.calendar.main'?: CalendarThemeIdStyle;
+    'stylesheet.calendar-list.main'?: CalendarThemeIdStyle;
+    'stylesheet.agenda.main'?: CalendarThemeIdStyle;
+    'stylesheet.agenda.list'?: CalendarThemeIdStyle;
+    'stylesheet.day.basic'?: CalendarThemeIdStyle;
+    'stylesheet.day.single'?: CalendarThemeIdStyle;
+    'stylesheet.day.multiDot'?: CalendarThemeIdStyle;
+    'stylesheet.day.period'?: CalendarThemeIdStyle;
+    'stylesheet.dot'?: CalendarThemeIdStyle;
 }
 
 export type DateCallbackHandler = (date: DateObject) => void;
@@ -118,10 +118,7 @@ export interface PeriodMarking {
     disabled?: boolean;
 }
 
-export type Marking =
-    CustomMarking | DotMarking |
-    MultiDotMarking | MultiPeriodMarking |
-    PeriodMarking;
+export type Marking = CustomMarking | DotMarking | MultiDotMarking | MultiPeriodMarking | PeriodMarking;
 
 export interface CustomMarkingProps {
     markingType: 'custom';
@@ -151,7 +148,7 @@ export interface MultiDotMarkingProps {
 export interface MultiPeriodMarkingProps {
     markingType: 'multi-period';
     markedDates: {
-        [date: string]: MultiPeriodMarking
+        [date: string]: MultiPeriodMarking;
     };
 }
 
@@ -163,12 +160,12 @@ export interface PeriodMarkingProps {
 }
 
 export type CalendarMarkingProps =
-    MultiDotMarkingProps |
-    DotMarkingProps |
-    PeriodMarkingProps |
-    MultiPeriodMarkingProps |
-    CustomMarkingProps |
-    {};
+    | MultiDotMarkingProps
+    | DotMarkingProps
+    | PeriodMarkingProps
+    | MultiPeriodMarkingProps
+    | CustomMarkingProps
+    | {};
 
 export interface DayComponentProps {
     date: DateObject;
@@ -310,6 +307,10 @@ export interface CalendarBaseProps {
      *  Provide aria-level for calendar heading for proper accessibility when used with web (react-native-web)
      */
     webAriaLevel?: number;
+    /*
+     *  Replace default month and year title with custom one. the function receive a date as parameter.
+     */
+    renderHeader?: (date: Date) => React.ReactNode;
 }
 
 export type CalendarProps = CalendarMarkingProps &
@@ -374,7 +375,7 @@ export interface CalendarListBaseProps extends CalendarBaseProps {
     selected?: string;
 }
 
-export class CalendarList extends React.Component<CalendarMarkingProps & CalendarListBaseProps> { }
+export class CalendarList extends React.Component<CalendarMarkingProps & CalendarListBaseProps> {}
 
 export interface AgendaThemeStyle extends CalendarTheme {
     agendaDayNumColor?: string;
@@ -517,4 +518,4 @@ export interface AgendaProps<TItem> {
      */
     theme?: AgendaThemeStyle;
 }
-export class Agenda<TItem> extends React.Component<AgendaProps<TItem> & CalendarMarkingProps> { }
+export class Agenda<TItem> extends React.Component<AgendaProps<TItem> & CalendarMarkingProps> {}

--- a/types/react-native-calendars/react-native-calendars-tests.tsx
+++ b/types/react-native-calendars/react-native-calendars-tests.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
-import { Text, View } from "react-native";
-import { Calendar, CalendarList, Agenda } from "react-native-calendars";
+import * as React from 'react';
+import { Text, View } from 'react-native';
+import { Calendar, CalendarList, Agenda } from 'react-native-calendars';
 
 declare const Arrow: React.SFC<unknown>;
 
@@ -16,17 +16,23 @@ declare const Arrow: React.SFC<unknown>;
     // Maximum date that can be selected, dates after maxDate will be grayed out. Default = undefined
     maxDate={'2012-05-30'}
     // Handler which gets executed on day press. Default = undefined
-    onDayPress={(day) => { console.log('selected day', day); }}
+    onDayPress={day => {
+        console.log('selected day', day);
+    }}
     // Handler which gets executed on day long press. Default = undefined
-    onDayLongPress={(day) => { console.log('selected day', day); }}
+    onDayLongPress={day => {
+        console.log('selected day', day);
+    }}
     // Month format in calendar title. Formatting values: http://arshaw.com/xdate/#Formatting
     monthFormat={'yyyy MM'}
     // Handler which gets executed when visible month changes in calendar. Default = undefined
-    onMonthChange={(month) => { console.log('month changed', month); }}
+    onMonthChange={month => {
+        console.log('month changed', month);
+    }}
     // Hide month navigation arrows. Default = false
     hideArrows={true}
     // Replace default arrows with custom ones (direction can be 'left' or 'right')
-    renderArrow={(direction) => (<Arrow/>)}
+    renderArrow={direction => <Arrow />}
     // Do not show days of other months in month page. Default = false
     hideExtraDays={true}
     // If hideArrows=false and hideExtraDays=false do not switch month when tapping on greyed out
@@ -50,24 +56,24 @@ declare const Arrow: React.SFC<unknown>;
 
 <Calendar
     // Initially visible month. Default = Date()
-    current={"2012-03-01"}
+    current={'2012-03-01'}
     // Minimum date that can be selected, dates before minDate will be grayed out. Default = undefined
-    minDate={"2012-05-10"}
+    minDate={'2012-05-10'}
     // Maximum date that can be selected, dates after maxDate will be grayed out. Default = undefined
-    maxDate={"2012-05-30"}
+    maxDate={'2012-05-30'}
     // Handler which gets executed on day press. Default = undefined
     onDayPress={date => {
-        console.log("selected day", date.day);
+        console.log('selected day', date.day);
     }}
     // Handler which gets executed on day long press. Default = undefined
     onDayLongPress={date => {
-        console.log("selected day", date.day);
+        console.log('selected day', date.day);
     }}
     // Month format in calendar title. Formatting values: http://arshaw.com/xdate/#Formatting
-    monthFormat={"yyyy MM"}
+    monthFormat={'yyyy MM'}
     // Handler which gets executed when visible month changes in calendar. Default = undefined
     onMonthChange={date => {
-        console.log("month changed", date.month);
+        console.log('month changed', date.month);
     }}
     // Hide month navigation arrows. Default = false
     hideArrows={true}
@@ -89,67 +95,67 @@ declare const Arrow: React.SFC<unknown>;
     // Handler which gets executed when press arrow icon left. It receive a callback can go next month
     onPressArrowRight={addMonth => console.log(addMonth)}
     markedDates={{
-        "2012-05-16": { selected: true, marked: true, selectedColor: "blue" },
-        "2012-05-17": { marked: true },
-        "2012-05-18": { marked: true, dotColor: "red", activeOpacity: 0 },
-        "2012-05-19": { disabled: true, disableTouchEvent: true }
+        '2012-05-16': { selected: true, marked: true, selectedColor: 'blue' },
+        '2012-05-17': { marked: true },
+        '2012-05-18': { marked: true, dotColor: 'red', activeOpacity: 0 },
+        '2012-05-19': { disabled: true, disableTouchEvent: true },
     }}
 />;
 
-const vacation = { key: "vacation", color: "red", selectedDotColor: "blue" };
-const massage = { key: "massage", color: "blue", selectedDotColor: "blue" };
-const workout = { key: "workout", color: "green" };
+const vacation = { key: 'vacation', color: 'red', selectedDotColor: 'blue' };
+const massage = { key: 'massage', color: 'blue', selectedDotColor: 'blue' };
+const workout = { key: 'workout', color: 'green' };
 
 <Calendar
     markedDates={{
-        "2017-10-25": {
+        '2017-10-25': {
             dots: [vacation, massage, workout],
             selected: true,
-            selectedColor: "red"
+            selectedColor: 'red',
         },
-        "2017-10-26": { dots: [massage, workout], disabled: true }
+        '2017-10-26': { dots: [massage, workout], disabled: true },
     }}
-    markingType={"multi-dot"}
+    markingType={'multi-dot'}
 />;
 
 <Calendar
     // Collection of dates that have to be colored in a special way. Default = {}
     markedDates={{
-        "2012-05-20": { textColor: "green" },
-        "2012-05-22": { startingDay: true, color: "green" },
-        "2012-05-23": {
+        '2012-05-20': { textColor: 'green' },
+        '2012-05-22': { startingDay: true, color: 'green' },
+        '2012-05-23': {
             selected: true,
             endingDay: true,
-            color: "green",
-            textColor: "gray"
+            color: 'green',
+            textColor: 'gray',
         },
-        "2012-05-04": {
+        '2012-05-04': {
             disabled: true,
             startingDay: true,
-            color: "green",
-            endingDay: true
-        }
+            color: 'green',
+            endingDay: true,
+        },
     }}
     // Date marking style [simple/period/multi-dot/custom]. Default = 'simple'
-    markingType={"period"}
+    markingType={'period'}
 />;
 
 <Calendar
     markedDates={{
-        "2017-12-14": {
+        '2017-12-14': {
             periods: [
-                { startingDay: false, endingDay: true, color: "#5f9ea0" },
-                { startingDay: false, endingDay: true, color: "#ffa500" },
-                { startingDay: true, endingDay: false, color: "#f0e68c" }
-            ]
+                { startingDay: false, endingDay: true, color: '#5f9ea0' },
+                { startingDay: false, endingDay: true, color: '#ffa500' },
+                { startingDay: true, endingDay: false, color: '#f0e68c' },
+            ],
         },
-        "2017-12-15": {
+        '2017-12-15': {
             periods: [
-                { startingDay: true, endingDay: false, color: "#ffa500" },
-                { color: "transparent" },
-                { startingDay: false, endingDay: false, color: "#f0e68c" }
-            ]
-        }
+                { startingDay: true, endingDay: false, color: '#ffa500' },
+                { color: 'transparent' },
+                { startingDay: false, endingDay: false, color: '#f0e68c' },
+            ],
+        },
     }}
     // Date marking style [simple/period/multi-dot/custom]. Default = 'simple'
     markingType="multi-period"
@@ -159,28 +165,28 @@ const workout = { key: "workout", color: "green" };
     // Date marking style [simple/period/multi-dot/single]. Default = 'simple'
     markingType="custom"
     markedDates={{
-        "2018-03-28": {
+        '2018-03-28': {
             customStyles: {
                 container: {
-                    backgroundColor: "green"
+                    backgroundColor: 'green',
                 },
                 text: {
-                    color: "black",
-                    fontWeight: "bold"
-                }
-            }
+                    color: 'black',
+                    fontWeight: 'bold',
+                },
+            },
         },
-        "2018-03-29": {
+        '2018-03-29': {
             customStyles: {
                 container: {
-                    backgroundColor: "white",
-                    elevation: 2
+                    backgroundColor: 'white',
+                    elevation: 2,
                 },
                 text: {
-                    color: "blue"
-                }
-            }
-        }
+                    color: 'blue',
+                },
+            },
+        },
     }}
 />;
 
@@ -188,30 +194,30 @@ const workout = { key: "workout", color: "green" };
     // Specify style for calendar container element. Default = {}
     style={{
         borderWidth: 1,
-        borderColor: "gray",
-        height: 350
+        borderColor: 'gray',
+        height: 350,
     }}
     // Specify theme properties to override specific styles for calendar parts. Default = {}
     theme={{
-        backgroundColor: "#ffffff",
-        calendarBackground: "#ffffff",
-        textSectionTitleColor: "#b6c1cd",
-        selectedDayBackgroundColor: "#00adf5",
-        selectedDayTextColor: "#ffffff",
-        todayTextColor: "#00adf5",
-        dayTextColor: "#2d4150",
-        textDisabledColor: "#d9e1e8",
-        dotColor: "#00adf5",
-        selectedDotColor: "#ffffff",
-        arrowColor: "orange",
-        monthTextColor: "blue",
-        textDayFontFamily: "monospace",
-        textMonthFontFamily: "monospace",
-        textDayHeaderFontFamily: "monospace",
-        textMonthFontWeight: "bold",
+        backgroundColor: '#ffffff',
+        calendarBackground: '#ffffff',
+        textSectionTitleColor: '#b6c1cd',
+        selectedDayBackgroundColor: '#00adf5',
+        selectedDayTextColor: '#ffffff',
+        todayTextColor: '#00adf5',
+        dayTextColor: '#2d4150',
+        textDisabledColor: '#d9e1e8',
+        dotColor: '#00adf5',
+        selectedDotColor: '#ffffff',
+        arrowColor: 'orange',
+        monthTextColor: 'blue',
+        textDayFontFamily: 'monospace',
+        textMonthFontFamily: 'monospace',
+        textDayHeaderFontFamily: 'monospace',
+        textMonthFontWeight: 'bold',
         textDayFontSize: 16,
         textMonthFontSize: 16,
-        textDayHeaderFontSize: 16
+        textDayHeaderFontSize: 16,
     }}
 />;
 
@@ -222,8 +228,8 @@ const workout = { key: "workout", color: "green" };
             <View style={{ flex: 1 }}>
                 <Text
                     style={{
-                        textAlign: "center",
-                        color: state === "disabled" ? "gray" : "black"
+                        textAlign: 'center',
+                        color: state === 'disabled' ? 'gray' : 'black',
                     }}
                 >
                     {date.day}
@@ -236,7 +242,7 @@ const workout = { key: "workout", color: "green" };
 <CalendarList
     // Callback which gets executed when visible months change in scroll view. Default = undefined
     onVisibleMonthsChange={months => {
-        console.log("now these months are visible", months);
+        console.log('now these months are visible', months);
     }}
     // Max amount of months allowed to scroll to the past. Default = 50
     pastScrollRange={50}
@@ -249,24 +255,24 @@ const workout = { key: "workout", color: "green" };
     // Enable or disable vertical scroll indicator. Default = false
     showScrollIndicator={true}
     // Initially visible month. Default = Date()
-    current={"2012-03-01"}
+    current={'2012-03-01'}
     // Minimum date that can be selected, dates before minDate will be grayed out. Default = undefined
-    minDate={"2012-05-10"}
+    minDate={'2012-05-10'}
     // Maximum date that can be selected, dates after maxDate will be grayed out. Default = undefined
-    maxDate={"2012-05-30"}
+    maxDate={'2012-05-30'}
     // Handler which gets executed on day press. Default = undefined
     onDayPress={day => {
-        console.log("selected day", day);
+        console.log('selected day', day);
     }}
     // Handler which gets executed on day long press. Default = undefined
     onDayLongPress={day => {
-        console.log("selected day", day);
+        console.log('selected day', day);
     }}
     // Month format in calendar title. Formatting values: http://arshaw.com/xdate/#Formatting
-    monthFormat={"yyyy MM"}
+    monthFormat={'yyyy MM'}
     // Handler which gets executed when visible month changes in calendar. Default = undefined
     onMonthChange={month => {
-        console.log("month changed", month);
+        console.log('month changed', month);
     }}
     // Hide month navigation arrows. Default = false
     hideArrows={true}
@@ -301,8 +307,8 @@ const workout = { key: "workout", color: "green" };
             <View style={{ flex: 1 }}>
                 <Text
                     style={{
-                        textAlign: "center",
-                        color: state === "disabled" ? "gray" : "black"
+                        textAlign: 'center',
+                        color: state === 'disabled' ? 'gray' : 'black',
                     }}
                 >
                     {date.day}
@@ -317,17 +323,14 @@ const workout = { key: "workout", color: "green" };
     // the value of date key kas to be an empty array []. If there exists no value for date key it is
     // considered that the date in question is not yet loaded
     items={{
-        "2012-05-22": [{ text: "item 1 - any js object" }],
-        "2012-05-23": [{ text: "item 2 - any js object" }],
-        "2012-05-24": [],
-        "2012-05-25": [
-            { text: "item 3 - any js object" },
-            { text: "any js object" }
-        ]
+        '2012-05-22': [{ text: 'item 1 - any js object' }],
+        '2012-05-23': [{ text: 'item 2 - any js object' }],
+        '2012-05-24': [],
+        '2012-05-25': [{ text: 'item 3 - any js object' }, { text: 'any js object' }],
     }}
     // callback that gets called when items for a certain month should be loaded (month became visible)
     loadItemsForMonth={month => {
-        console.log("trigger items loading");
+        console.log('trigger items loading');
     }}
     // callback that fires when the calendar is opened or closed
     onCalendarToggled={calendarOpened => {
@@ -335,18 +338,18 @@ const workout = { key: "workout", color: "green" };
     }}
     // callback that gets called on day press
     onDayPress={day => {
-        console.log("day pressed");
+        console.log('day pressed');
     }}
     // callback that gets called when day changes while scrolling agenda list
     onDayChange={day => {
-        console.log("day changed");
+        console.log('day changed');
     }}
     // initially selected day
-    selected={"2012-05-16"}
+    selected={'2012-05-16'}
     // Minimum date that can be selected, dates before minDate will be grayed out. Default = undefined
-    minDate={"2012-05-10"}
+    minDate={'2012-05-10'}
     // Maximum date that can be selected, dates after maxDate will be grayed out. Default = undefined
-    maxDate={"2012-05-30"}
+    maxDate={'2012-05-30'}
     // Max amount of months allowed to scroll to the past. Default = 50
     pastScrollRange={50}
     // Max amount of months allowed to scroll to the future. Default = 50
@@ -379,22 +382,22 @@ const workout = { key: "workout", color: "green" };
     hideKnob={true}
     // By default, agenda dates are marked if they have at least one item, but you can override this if needed
     markedDates={{
-        "2012-05-16": { selected: true, marked: true },
-        "2012-05-17": { marked: true },
-        "2012-05-18": { disabled: true }
+        '2012-05-16': { selected: true, marked: true },
+        '2012-05-17': { marked: true },
+        '2012-05-18': { disabled: true },
     }}
     // If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality. Make sure to also set the refreshing prop correctly.
-    onRefresh={() => console.log("refreshing...")}
+    onRefresh={() => console.log('refreshing...')}
     // Set this true while waiting for new data from a refresh
     refreshing={false}
     // Add a custom RefreshControl component, used to provide pull-to-refresh functionality for the ScrollView.
     refreshControl={null}
     // agenda theme
     theme={{
-        agendaDayTextColor: "yellow",
-        agendaDayNumColor: "green",
-        agendaTodayColor: "red",
-        agendaKnobColor: "blue"
+        agendaDayTextColor: 'yellow',
+        agendaDayNumColor: 'green',
+        agendaTodayColor: 'red',
+        agendaKnobColor: 'blue',
     }}
     // agenda container style
     style={{}}
@@ -403,5 +406,13 @@ const workout = { key: "workout", color: "green" };
     // If firstDay=1 week starts from Monday. Note that dayNames and dayNamesShort should still start from Sunday.
     firstDay={1}
     // Month format in calendar title. Formatting values: http://arshaw.com/xdate/#Formatting
-    monthFormat={"yyyy MM"}
+    monthFormat={'yyyy MM'}
+/>;
+
+<Calendar
+    renderHeader={date => (
+        <View>
+            <Text>{date.toISOString()}</Text>
+        </View>
+    )}
 />;


### PR DESCRIPTION
The goal is to add renderHeader prop defined in [js lib](https://github.com/wix/react-native-calendars#basic-parameters)  but missing in type 

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X ] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present) - fails on another package ```Error: Errors in typescript@4.1 for external dependencies:
../react/index.d.ts(38,22): error TS2307: Cannot find module 'csstype' or its corresponding type declarations.```

Select one of these and delete the others:



If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [see renderHeader prop](https://github.com/wix/react-native-calendars#basic-parameters)
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)



