### PR TITLE
perf: remove cors dependency on express

### DIFF
--- a/types/cors/index.d.ts
+++ b/types/cors/index.d.ts
@@ -5,14 +5,15 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import express = require('express');
+import { IncomingHttpHeaders } from 'http';
 
-type CustomOrigin = (
-    requestOrigin: string | undefined,
-    callback: (err: Error | null, allow?: boolean) => void
-) => void;
+type CustomOrigin = (requestOrigin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => void;
 
 declare namespace e {
+    interface CorsRequest {
+        method?: string;
+        headers: IncomingHttpHeaders;
+    }
     interface CorsOptions {
         /**
          * @default '*''
@@ -35,13 +36,21 @@ declare namespace e {
          */
         optionsSuccessStatus?: number;
     }
-    type CorsOptionsDelegate = (
-        req: express.Request,
-        callback: (err: Error | null, options?: CorsOptions) => void
+    type CorsOptionsDelegate<T extends CorsRequest = CorsRequest> = (
+        req: T,
+        callback: (err: Error | null, options?: CorsOptions) => void,
     ) => void;
 }
 
-declare function e(
-    options?: e.CorsOptions | e.CorsOptionsDelegate
-): express.RequestHandler;
+declare function e<T extends e.CorsRequest = e.CorsRequest>(
+    options?: e.CorsOptions | e.CorsOptionsDelegate<T>,
+): (
+    req: T,
+    res: {
+        statusCode?: number;
+        setHeader(key: string, value: string): any;
+        end(): any;
+    },
+    next: (err?: any) => any,
+) => void;
 export = e;


### PR DESCRIPTION
There are many libraries (e.g. much of Apollo) that depend on `cors` but not necessarily on express. Importing `express` is overkill when we only care about a tiny part of the overall express API

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

I believe the existing tests sufficiently cover this change.