### PR TITLE
[masonry-layout] Added definitions for hiddenStyle and visibleStyle

### DIFF
--- a/types/masonry-layout/index.d.ts
+++ b/types/masonry-layout/index.d.ts
@@ -51,6 +51,8 @@ declare namespace Masonry {
         originLeft?: boolean;
         originTop?: boolean;
         horizontalOrder?: boolean;
+        hiddenStyle?: CSSStyleDeclaration;
+        visibleStyle?: CSSStyleDeclaration;
 
         // setup
         containerStyle?: {};

--- a/types/masonry-layout/index.d.ts
+++ b/types/masonry-layout/index.d.ts
@@ -40,8 +40,7 @@ declare class Masonry {
 }
 
 declare namespace Masonry {
-
-    type hiddenOrVisibleStyle = {
+    interface hiddenOrVisibleStyle {
         transform?: string;
         opacity?: number;
     }

--- a/types/masonry-layout/index.d.ts
+++ b/types/masonry-layout/index.d.ts
@@ -40,6 +40,12 @@ declare class Masonry {
 }
 
 declare namespace Masonry {
+
+    type hiddenOrVisibleStyle = {
+        transform?: string;
+        opacity?: number;
+    }
+
     interface Options {
         // layout
         itemSelector?: string;
@@ -51,8 +57,8 @@ declare namespace Masonry {
         originLeft?: boolean;
         originTop?: boolean;
         horizontalOrder?: boolean;
-        hiddenStyle?: CSSStyleDeclaration;
-        visibleStyle?: CSSStyleDeclaration;
+        hiddenStyle?: hiddenOrVisibleStyle;
+        visibleStyle?: hiddenOrVisibleStyle;
 
         // setup
         containerStyle?: {};

--- a/types/masonry-layout/index.d.ts
+++ b/types/masonry-layout/index.d.ts
@@ -55,6 +55,7 @@ declare namespace Masonry {
         // setup
         containerStyle?: {};
         transitionDuration?: any;
+        stagger?: string | number;
         resize?: boolean;
         initLayout?: boolean;
     }

--- a/types/masonry-layout/index.d.ts
+++ b/types/masonry-layout/index.d.ts
@@ -40,7 +40,7 @@ declare class Masonry {
 }
 
 declare namespace Masonry {
-    interface hiddenOrVisibleStyle {
+    interface hiddenOrVisibleStyleOption {
         transform?: string;
         opacity?: number;
     }
@@ -56,8 +56,8 @@ declare namespace Masonry {
         originLeft?: boolean;
         originTop?: boolean;
         horizontalOrder?: boolean;
-        hiddenStyle?: hiddenOrVisibleStyle;
-        visibleStyle?: hiddenOrVisibleStyle;
+        hiddenStyle?: hiddenOrVisibleStyleOption;
+        visibleStyle?: hiddenOrVisibleStyleOption;
 
         // setup
         containerStyle?: {};

--- a/types/masonry-layout/masonry-layout-tests.ts
+++ b/types/masonry-layout/masonry-layout-tests.ts
@@ -41,6 +41,7 @@ function testExtendedOptions() {
             position: 'relative'
         },
         transitionDuration: '0.4s',
+        stagger: 30,
         resize: true,
         initLayout: true,
         horizontalOrder: true

--- a/types/masonry-layout/masonry-layout-tests.ts
+++ b/types/masonry-layout/masonry-layout-tests.ts
@@ -40,6 +40,14 @@ function testExtendedOptions() {
         containerStyle: {
             position: 'relative'
         },
+        hiddenStyle: {
+            transform: 'translateY(100px)',
+            opacity: 0,
+        },
+        visibleStyle: {
+            transform: 'translateY(0px)',
+            opacity: 1
+        },
         transitionDuration: '0.4s',
         stagger: 30,
         resize: true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://codepen.io/desandro/pen/bqvLaZ/ shows how to use those two options. This example is linked in the [docs](https://masonry.desandro.com/extras.html). Additionally you can see usage in code when they set the defaults: https://github.com/desandro/masonry/blob/master/dist/masonry.pkgd.js#L1438-L1444
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
