### PR TITLE
[ember-qunit] Provide `this` type for module `NestedHooks`

### DIFF
--- a/types/ember-qunit/ember-qunit-tests.ts
+++ b/types/ember-qunit/ember-qunit-tests.ts
@@ -16,16 +16,16 @@ import {
 } from 'ember-qunit';
 
 moduleForComponent('x-foo', {
-    integration: true
+    integration: true,
 });
 
 moduleForComponent('x-foo', {
     unit: true,
-    needs: ['helper:pluralize-string']
+    needs: ['helper:pluralize-string'],
 });
 
 moduleForModel('user', {
-    needs: ['model:child']
+    needs: ['model:child'],
 });
 
 moduleFor('controller:home');
@@ -33,8 +33,7 @@ moduleFor('controller:home');
 moduleFor('component:x-foo', 'Some description');
 
 moduleFor('component:x-foo', 'TestModule callbacks', {
-    beforeSetup() {
-    },
+    beforeSetup() {},
 
     beforeEach(assert) {
         this.registry.register('helper:i18n', {});
@@ -51,18 +50,18 @@ moduleFor('component:x-foo', 'TestModule callbacks', {
 
     afterTeardown(assert) {
         assert.ok(true);
-    }
+    },
 });
 
 // if you don't have a custom resolver, do it like this:
 setResolver(Ember.DefaultResolver.create());
 
-test('it renders', function(assert) {
+test('it renders', function (assert) {
     assert.expect(2);
 
     // setup the outer context
     this.set('value', 'cat');
-    this.on('action', function(result) {
+    this.on('action', function (result) {
         assert.equal(result, 'bar', 'The correct result was returned');
         assert.equal(this.get('value'), 'cat');
     });
@@ -72,29 +71,27 @@ test('it renders', function(assert) {
         {{ x-foo value=value action="result" }}
     `);
     this.render('{{ x-foo value=value action="result" }}');
-    this.render([
-        '{{ x-foo value=value action="result" }}'
-    ]);
+    this.render(['{{ x-foo value=value action="result" }}']);
 
     assert.equal(this.$('div>.value').text(), 'cat', 'The component shows the correct value');
 
     this.$('button').click();
 });
 
-test('it renders', function(assert) {
+test('it renders', function (assert) {
     assert.expect(1);
 
     // creates the component instance
     const subject = this.subject();
 
     const subject2 = this.subject({
-        item: 42
+        item: 42,
     });
 
     const { inputFormat } = this.setProperties({
         inputFormat: 'M/D/YY',
         outputFormat: 'MMMM D, YYYY',
-        date: '5/3/10'
+        date: '5/3/10',
     });
 
     const { inputFormat: if2, outputFormat } = this.getProperties('inputFormat', 'outputFormat');
@@ -106,7 +103,7 @@ test('it renders', function(assert) {
     assert.equal(this.$('.foo').text(), 'bar');
 });
 
-test('It can calculate the result', function(assert) {
+test('It can calculate the result', function (assert) {
     assert.expect(1);
 
     const subject = this.subject();
@@ -118,7 +115,7 @@ test('It can calculate the result', function(assert) {
 // This test is intended to ensure the appropriate behavior for @typescript-eslint/no-misused-promises.
 // However, we don't actually use typescript-eslint in this project and tslint has no equivalent,
 // so we can't properly test it.
-test('it can be async', async function(assert) {
+test('it can be async', async function (assert) {
     assert.expect(1);
 
     await this.render();
@@ -128,12 +125,12 @@ test('it can be async', async function(assert) {
 
 skip('disabled test');
 
-skip('disabled test', function(assert) { });
+skip('disabled test', function (assert) {});
 
 // This test is intended to ensure the appropriate behavior for @typescript-eslint/no-misused-promises.
 // However, we don't actually use typescript-eslint in this project and tslint has no equivalent,
 // so we can't properly test it.
-skip('it can skip async', async function(assert) {
+skip('it can skip async', async function (assert) {
     assert.expect(1);
 
     await this.render();
@@ -144,7 +141,7 @@ skip('it can skip async', async function(assert) {
 // This test is intended to ensure the appropriate behavior for @typescript-eslint/no-misused-promises.
 // However, we don't actually use typescript-eslint in this project and tslint has no equivalent,
 // so we can't properly test it.
-only('it can only run async', async function(assert) {
+only('it can only run async', async function (assert) {
     assert.expect(1);
 
     await this.render();
@@ -155,7 +152,7 @@ only('it can only run async', async function(assert) {
 // This test is intended to ensure the appropriate behavior for @typescript-eslint/no-misused-promises.
 // However, we don't actually use typescript-eslint in this project and tslint has no equivalent,
 // so we can't properly test it.
-todo('it can have an async todo', async function(assert) {
+todo('it can have an async todo', async function (assert) {
     assert.expect(1);
 
     await this.render();
@@ -164,31 +161,31 @@ todo('it can have an async todo', async function(assert) {
 });
 
 // https://github.com/emberjs/rfcs/blob/master/text/0232-simplify-qunit-testing-api.md#qunit-nested-modules-api
-QUnit.module('some description', function(hooks) {
-  hooks.before(() => {});
-  hooks.beforeEach(() => {});
-  hooks.afterEach(() => {});
-  hooks.after(() => {});
+QUnit.module('some description', function (hooks) {
+    hooks.before(() => {});
+    hooks.beforeEach(() => {});
+    hooks.afterEach(() => {});
+    hooks.after(() => {});
 
-  QUnit.test('it blends', function(assert) {
-    assert.ok(true, 'of course!');
-  });
+    QUnit.test('it blends', function (assert) {
+        assert.ok(true, 'of course!');
+    });
 });
 
 // http://rwjblue.com/2017/10/23/ember-qunit-simplication/#setuprenderingtest
-module('x-foo', function(hooks) {
+module('x-foo', function (hooks) {
     setupRenderingTest(hooks);
 });
 
 // http://rwjblue.com/2017/10/23/ember-qunit-simplication/#setuptest
-module('foo service', function(hooks) {
+module('foo service', function (hooks) {
     setupTest(hooks);
 });
 
 // RFC-232 equivalent of https://github.com/ember-engines/ember-engines#unitintegration-testing-for-in-repo-engines
-module('engine foo component', function(hooks) {
+module('engine foo component', function (hooks) {
     setupTest(hooks, {
-        resolver: Ember.Resolver.create()
+        resolver: Ember.Resolver.create(),
     });
 });
 

--- a/types/ember-qunit/ember-qunit-tests.ts
+++ b/types/ember-qunit/ember-qunit-tests.ts
@@ -189,4 +189,44 @@ module('engine foo component', function (hooks) {
     });
 });
 
+module('all the hooks', function (hooks) {
+    setupTest(hooks);
+
+    hooks.after(function () {
+        this.owner.lookup('service:store');
+    });
+
+    hooks.afterEach(function () {
+        this.owner.lookup('service:store');
+    });
+
+    hooks.before(function () {
+        this.owner.lookup('service:store');
+    });
+
+    hooks.beforeEach(function () {
+        this.owner.lookup('service:store');
+    });
+});
+
+module.only('exclusive module with hooks', function (hooks) {
+    setupTest(hooks);
+
+    hooks.after(function () {
+        this.owner.lookup('service:store');
+    });
+
+    hooks.afterEach(function () {
+        this.owner.lookup('service:store');
+    });
+
+    hooks.before(function () {
+        this.owner.lookup('service:store');
+    });
+
+    hooks.beforeEach(function () {
+        this.owner.lookup('service:store');
+    });
+});
+
 start();

--- a/types/ember-qunit/index.d.ts
+++ b/types/ember-qunit/index.d.ts
@@ -152,6 +152,29 @@ interface QUnitStartOptions {
 export function start(options?: QUnitStartOptions): void;
 
 declare global {
+    interface NestedHooks {
+        /**
+         * Runs after the last test. If additional tests are defined after the
+         * module's queue has emptied, it will not run this hook again.
+         */
+        after(fn: (this: TestContext, assert: Assert) => void | Promise<void>): void;
+
+        /**
+         * Runs after each test.
+         */
+        afterEach(fn: (this: TestContext, assert: Assert) => void | Promise<void>): void;
+
+        /**
+         * Runs before the first test.
+         */
+        before(fn: (this: TestContext, assert: Assert) => void | Promise<void>): void;
+
+        /**
+         * Runs before each test.
+         */
+        beforeEach(fn: (this: TestContext, assert: Assert) => void | Promise<void>): void;
+    }
+
     interface QUnit {
         /**
          * Add a test to run.

--- a/types/ember-qunit/index.d.ts
+++ b/types/ember-qunit/index.d.ts
@@ -12,7 +12,7 @@
 /// <reference types="qunit" />
 
 import Ember from 'ember';
-import { ModuleCallbacks, TestContext } from "ember-test-helpers";
+import { ModuleCallbacks, TestContext } from 'ember-test-helpers';
 
 interface QUnitModuleCallbacks extends ModuleCallbacks, Hooks {
     beforeSetup?(assert: Assert): void;
@@ -105,7 +105,7 @@ export function setupRenderingTest(hooks: NestedHooks, options?: SetupTestOption
  */
 export function setupTest(hooks: NestedHooks, options?: SetupTestOptions): void;
 
-export class QUnitAdapter extends Ember.Test.Adapter { }
+export class QUnitAdapter extends Ember.Test.Adapter {}
 
 export { module, test, skip, only, todo } from 'qunit';
 

--- a/types/ember-qunit/tslint.json
+++ b/types/ember-qunit/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "only-arrow-functions": false
+        "only-arrow-functions": false,
+        "space-before-function-paren": false
     }
 }

--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -202,12 +202,7 @@ declare global {
          *
          * @param assertionResult The assertion result
          */
-        pushResult(assertResult: {
-            result: boolean;
-            actual: any;
-            expected: any;
-            message: string;
-        }): void;
+        pushResult(assertResult: { result: boolean; actual: any; expected: any; message: string }): void;
 
         /**
          * A strict type and value comparison.
@@ -263,11 +258,7 @@ declare global {
          * @param message A short description of the assertion
          */
         rejects(promise: Promise<any>, message?: string): Promise<void>;
-        rejects(
-            promise: Promise<any>,
-            expectedMatcher?: any,
-            message?: string,
-        ): Promise<void>;
+        rejects(promise: Promise<any>, expectedMatcher?: any, message?: string): Promise<void>;
 
         /**
          * A marker for progress in a given test.
@@ -294,7 +285,6 @@ declare global {
          * @param message A short description of the assertion
          */
         verifySteps(steps: string[], message?: string): void;
-
     }
 
     interface Config {
@@ -302,7 +292,7 @@ declare global {
         autostart: boolean;
         collapse: boolean;
         current: any;
-        filter: string | RegExp
+        filter: string | RegExp;
         fixture: string;
         hidepassed: boolean;
         maxDepth: number;
@@ -320,12 +310,11 @@ declare global {
             id?: string;
             label?: string;
             tooltip?: string;
-            value?: string | string[] | { [key: string]: string }
+            value?: string | string[] | { [key: string]: string };
         }[];
     }
 
     interface Hooks {
-
         /**
          * Runs after the last test. If additional tests are defined after the
          * module's queue has emptied, it will not run this hook again.
@@ -346,7 +335,6 @@ declare global {
          * Runs before each test.
          */
         beforeEach?: (assert: Assert) => void | Promise<void>;
-
     }
 
     interface NestedHooks {
@@ -370,18 +358,24 @@ declare global {
          * Runs before each test.
          */
         beforeEach: (fn: (assert: Assert) => void | Promise<void>) => void;
-
     }
 
     type moduleFunc1 = (name: string, hooks?: Hooks, nested?: (hooks: NestedHooks) => void) => void;
     type moduleFunc2 = (name: string, nested?: (hooks: NestedHooks) => void) => void;
-    type ModuleOnly = { only: moduleFunc1 & moduleFunc2 }
+    type ModuleOnly = { only: moduleFunc1 & moduleFunc2 };
 
     namespace QUnit {
-        interface BeginDetails { totalTests: number }
-        interface DoneDetails { failed: number, passed: number, total: number, runtime: number }
+        interface BeginDetails {
+            totalTests: number;
+        }
+        interface DoneDetails {
+            failed: number;
+            passed: number;
+            total: number;
+            runtime: number;
+        }
         interface LogDetails {
-            result: boolean,
+            result: boolean;
             actual: any;
             expected: any;
             message: string;
@@ -397,7 +391,9 @@ declare global {
             total: number;
             runtime: number;
         }
-        interface ModuleStartDetails { name: string }
+        interface ModuleStartDetails {
+            name: string;
+        }
         interface TestDoneDetails {
             name: string;
             module: string;
@@ -406,11 +402,13 @@ declare global {
             total: number;
             runtime: number;
         }
-        interface TestStartDetails { name: string; module: string; }
+        interface TestStartDetails {
+            name: string;
+            module: string;
+        }
     }
 
     interface QUnit {
-
         /**
          * Namespace for QUnit assertions
          *
@@ -437,7 +435,7 @@ declare global {
          * QUnit has a bunch of internal configuration defaults, some of which are
          * useful to override. Check the description for each option for details.
          */
-        config: Config
+        config: Config;
 
         /**
          * Register a callback to fire whenever the test suite ends.
@@ -463,7 +461,7 @@ declare global {
          */
         dump: {
             maxDepth: number;
-            parse(data: any): string
+            parse(data: any): string;
         };
 
         /**
@@ -644,14 +642,16 @@ declare global {
          *
          * @param callback Callback to execute
          */
-        testDone(callback: (details: {
-            name: string;
-            module: string;
-            failed: number;
-            passed: number;
-            total: number;
-            runtime: number;
-        }) => void | Promise<void>): void;
+        testDone(
+            callback: (details: {
+                name: string;
+                module: string;
+                failed: number;
+                passed: number;
+                total: number;
+                runtime: number;
+            }) => void | Promise<void>,
+        ): void;
 
         /**
          * Register a callback to fire whenever a test begins.
@@ -689,10 +689,9 @@ declare global {
         isLocal: boolean;
 
         /**
-        * QUnit version
-        */
+         * QUnit version
+         */
         version: string;
-
     }
 
     /* QUnit */

--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -342,22 +342,22 @@ declare global {
          * Runs after the last test. If additional tests are defined after the
          * module's queue has emptied, it will not run this hook again.
          */
-        after: (fn: (assert: Assert) => void | Promise<void>) => void;
+        after(fn: (assert: Assert) => void | Promise<void>): void;
 
         /**
          * Runs after each test.
          */
-        afterEach: (fn: (assert: Assert) => void | Promise<void>) => void;
+        afterEach(fn: (assert: Assert) => void | Promise<void>): void;
 
         /**
          * Runs before the first test.
          */
-        before: (fn: (assert: Assert) => void | Promise<void>) => void;
+        before(fn: (assert: Assert) => void | Promise<void>): void;
 
         /**
          * Runs before each test.
          */
-        beforeEach: (fn: (assert: Assert) => void | Promise<void>) => void;
+        beforeEach(fn: (assert: Assert) => void | Promise<void>): void;
     }
 
     type moduleFunc1 = (name: string, hooks?: Hooks, nested?: (hooks: NestedHooks) => void) => void;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emberjs/ember-qunit#setup-tests
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

This PR is a continuation of the work @gitKrystan did in #46278, now that @jamescdavis's refactorings to have `qunit` expose ES module declarations on its own have landed. Big thanks to both of them for making this easy to pull over the finish line!

Note: DT recently had a `prettierrc` added, and my editor was pretty insistent about applying formatting updates, so the first commit here is just me pre-applying that before actually changing anything. The latter two contain the actual content of this change.