### PR TITLE
elasticsearch: add more 'includeTypeName' parameters

### DIFF
--- a/types/elasticsearch/elasticsearch-tests.ts
+++ b/types/elasticsearch/elasticsearch-tests.ts
@@ -52,6 +52,22 @@ client.search({
 }, (error) => {
 });
 
+client.indices.create({
+  index: 'test_index',
+  includeTypeName: true,
+  ignore: [400, 404]
+}).then((body) => {
+}, (error) => {
+});
+
+client.indices.get({
+  index: 'test_index',
+  includeTypeName: false,
+  ignore: 404
+}).then((body) => {
+}, (error) => {
+});
+
 client.indices.delete({
   index: 'test_index',
   ignore: [404]

--- a/types/elasticsearch/index.d.ts
+++ b/types/elasticsearch/index.d.ts
@@ -11,6 +11,7 @@
 //                 Budi Irawan <https://github.com/deerawan>
 //                 Yonatan Kiron <https://github.com/YonatanKiron>
 //                 Jani Šumak <https://github.com/dasdachs>
+//                 Chris Midgley <https://github.com/midgleyc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -1128,6 +1129,7 @@ export interface IndicesCreateParams extends GenericParams {
     timeout?: TimeSpan;
     masterTimeout?: TimeSpan;
     updateAllTypes?: boolean;
+    includeTypeName?: boolean;
     index: string;
 }
 
@@ -1211,6 +1213,7 @@ export interface IndicesGetParams extends GenericParams {
     includeDefaults?: boolean;
     index?: NameList;
     feature?: NameList;
+    includeTypeName?: boolean;
 }
 
 export interface IndicesGetAliasParams extends GenericParams {
@@ -1231,6 +1234,7 @@ export interface IndicesGetFieldMappingParams extends GenericParams {
     index?: NameList;
     type?: NameList;
     fields?: NameList;
+    includeTypeName?: boolean;
 }
 
 export interface IndicesGetMappingParams extends GenericParams {
@@ -1240,6 +1244,7 @@ export interface IndicesGetMappingParams extends GenericParams {
     local?: boolean;
     index?: NameList;
     type?: NameList;
+    includeTypeName?: boolean;
 }
 
 export interface IndicesGetSettingsParams extends GenericParams {
@@ -1259,6 +1264,7 @@ export interface IndicesGetTemplateParams extends GenericParams {
     masterTimeout?: TimeSpan;
     local?: boolean;
     name?: NameList;
+    includeTypeName?: boolean;
 }
 
 export interface IndicesGetUpgradeParams extends GenericParams {
@@ -1317,6 +1323,7 @@ export interface IndicesPutTemplateParams extends GenericParams {
     flatSettings?: boolean;
     name: string;
     body: any;
+    includeTypeName?: boolean;
 }
 
 export interface IndicesRecoveryParams extends GenericParams {
@@ -1341,6 +1348,7 @@ export interface IndicesRolloverParams extends GenericParams {
     waitForActiveShards?: number | string;
     alias?: string;
     newIndex?: string;
+    includeTypeName?: boolean;
 }
 
 export interface IndicesRolloverResponse {


### PR DESCRIPTION
#40055 added includeTypeName to indices.putMapping, but there are more indices.<something> methods that need this field.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html
