### PR TITLE
[ember] Apply prettier to Ember-ecosystem packages

### DIFF
--- a/types/ember-data/test/adapter.ts
+++ b/types/ember-data/test/adapter.ts
@@ -3,7 +3,9 @@ import DS from 'ember-data';
 
 class Session extends Ember.Service {}
 declare module '@ember/service' {
-    interface Registry { 'session': Session; }
+    interface Registry {
+        session: Session;
+    }
 }
 
 const JsonApi = DS.JSONAPIAdapter.extend({
@@ -14,19 +16,19 @@ const Customized = DS.JSONAPIAdapter.extend({
     host: 'https://api.example.com',
     namespace: 'api/v1',
     headers: {
-        'API_KEY': 'secret key',
-        'ANOTHER_HEADER': 'Some header value'
-    }
+        API_KEY: 'secret key',
+        ANOTHER_HEADER: 'Some header value',
+    },
 });
 
 const AuthTokenHeader = DS.JSONAPIAdapter.extend({
     session: Ember.inject.service('session'),
-    headers: Ember.computed('session.authToken', function() {
+    headers: Ember.computed('session.authToken', function () {
         return {
-            'API_KEY': this.get('session.authToken'),
-            'ANOTHER_HEADER': 'Some header value'
+            API_KEY: this.get('session.authToken'),
+            ANOTHER_HEADER: 'Some header value',
         };
-    })
+    }),
 });
 
 // Ensure that we are allowed to overwrite properties with a getter
@@ -42,7 +44,7 @@ class GetterTest extends DS.JSONAPIAdapter {
     }
     get headers() {
         return {
-            'CUSTOM_HEADER': 'Some header value'
+            CUSTOM_HEADER: 'Some header value',
         };
     }
 }
@@ -51,21 +53,21 @@ const UseAjax = DS.JSONAPIAdapter.extend({
     query(store: DS.Store, type: string, query: object) {
         const url = 'https://api.example.com/my-api';
         return this.ajax(url, 'POST', {
-            param: 'foo'
+            param: 'foo',
         });
-    }
+    },
 });
 
 const UseAjaxOptions = DS.JSONAPIAdapter.extend({
     query(store: DS.Store, type: string, query: object) {
         const url = 'https://api.example.com/my-api';
         const options = this.ajaxOptions(url, 'DELETE', {
-            foo: 'bar'
+            foo: 'bar',
         });
         return Ember.$.ajax(url, {
-            ...options
+            ...options,
         });
-    }
+    },
 });
 
 const UseAjaxOptionsWithOptionalThirdParams = DS.JSONAPIAdapter.extend({
@@ -73,14 +75,14 @@ const UseAjaxOptionsWithOptionalThirdParams = DS.JSONAPIAdapter.extend({
         const url = 'https://api.example.com/my-api';
         const options = this.ajaxOptions(url, 'DELETE');
         return Ember.$.ajax(url, {
-            ...options
+            ...options,
         });
-    }
+    },
 });
 
 declare module 'ember-data/types/registries/model' {
     export default interface ModelRegistry {
-        'rootModel': any;
+        rootModel: any;
         'super-user': any;
     }
 }
@@ -134,5 +136,5 @@ const BuildURLAdapter = DS.RESTAdapter.extend({
     worksWithUnknownRequestType() {
         this.buildURL('super-user', 1, null, 'unknown');
         this.buildURL('super-user', null, null, 'unknown');
-    }
+    },
 });

--- a/types/ember-data/test/has-many.ts
+++ b/types/ember-data/test/has-many.ts
@@ -47,7 +47,7 @@ blogPost.get('commentsAsync').then(comments => {
 
 blogPost.set('commentsAsync', blogPost.get('commentsAsync'));
 blogPost.set('commentsAsync', Ember.A());
-blogPost.set('commentsAsync', Ember.A([ comment! ]));
+blogPost.set('commentsAsync', Ember.A([comment!]));
 
 class PaymentMethod extends DS.Model {}
 declare module 'ember-data/types/registries/model' {

--- a/types/ember-data/test/injections.ts
+++ b/types/ember-data/test/injections.ts
@@ -13,7 +13,7 @@ declare module 'ember-data/types/registries/model' {
 Ember.Route.extend({
     model(): any {
         return this.store.findAll('my-model');
-    }
+    },
 });
 
 Controller.extend({
@@ -21,12 +21,12 @@ Controller.extend({
         create(): any {
             this.queryParams;
             return this.store.createRecord('my-model');
-        }
-    }
+        },
+    },
 });
 
 Ember.DataAdapter.extend({
     test() {
         this.store.findRecord('my-model', 123);
-    }
+    },
 });

--- a/types/ember-data/test/model.ts
+++ b/types/ember-data/test/model.ts
@@ -1,17 +1,17 @@
 import Ember from 'ember';
 import DS, { ChangedAttributes } from 'ember-data';
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 import RSVP from 'rsvp';
 
 const Person = DS.Model.extend({
     firstName: DS.attr(),
     lastName: DS.attr(),
-    title: DS.attr({ defaultValue: "The default" }),
-    title2: DS.attr({ defaultValue: () => "The default" }),
+    title: DS.attr({ defaultValue: 'The default' }),
+    title2: DS.attr({ defaultValue: () => 'The default' }),
 
-    fullName: Ember.computed('firstName', 'lastName', function() {
+    fullName: Ember.computed('firstName', 'lastName', function () {
         return `${this.get('firstName')} ${this.get('lastName')}`;
-    })
+    }),
 });
 
 const User = DS.Model.extend({
@@ -20,8 +20,10 @@ const User = DS.Model.extend({
     verified: DS.attr('boolean', { defaultValue: false }),
     canBeNull: DS.attr('boolean', { allowNull: true }),
     createdAt: DS.attr('date', {
-        defaultValue() { return new Date(); }
-    })
+        defaultValue() {
+            return new Date();
+        },
+    }),
 });
 
 const user = User.create({ username: 'dwickern' });
@@ -42,8 +44,8 @@ user.rollbackAttributes(); // $ExpectType void
 let destroyResult: RSVP.Promise<typeof user>;
 destroyResult = user.destroyRecord();
 destroyResult = user.destroyRecord({});
-destroyResult = user.destroyRecord({ adapterOptions: {}});
-destroyResult = user.destroyRecord({ adapterOptions: { waffles: 'are yummy' }});
+destroyResult = user.destroyRecord({ adapterOptions: {} });
+destroyResult = user.destroyRecord({ adapterOptions: { waffles: 'are yummy' } });
 
 user.deleteRecord(); // $ExpectType void
 

--- a/types/ember-data/test/module-api.ts
+++ b/types/ember-data/test/module-api.ts
@@ -33,7 +33,7 @@ import Store from 'ember-data/store';
 // Errors
 import * as EDErrors from 'ember-data/adapters/errors';
 
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 // ADAPTERS
 // - identity

--- a/types/ember-data/test/promises.ts
+++ b/types/ember-data/test/promises.ts
@@ -1,5 +1,5 @@
 import DS from 'ember-data';
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 declare const store: DS.Store;
 
@@ -13,8 +13,8 @@ declare module 'ember-data/types/registries/model' {
     }
 }
 
-const promiseFind = store.findRecord("person", 1);
+const promiseFind = store.findRecord('person', 1);
 
 promiseFind.content; // $ExpectType Person | undefined
 
-promiseFind.get("firstName");
+promiseFind.get('firstName');

--- a/types/ember-data/test/record-reference.ts
+++ b/types/ember-data/test/record-reference.ts
@@ -1,5 +1,5 @@
 import DS from 'ember-data';
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 declare const store: DS.Store;
 
@@ -38,7 +38,7 @@ userRef.reload().then(user => {
 });
 
 // provide data for reference
-userRef.push({ id: 1, username: '@user' }).then(function(user) {
+userRef.push({ id: 1, username: '@user' }).then(function (user) {
     assertType<User>(user);
     userRef.value() === user;
 });

--- a/types/ember-data/test/relationships.ts
+++ b/types/ember-data/test/relationships.ts
@@ -7,7 +7,7 @@ declare const store: DS.Store;
 
 const Person = DS.Model.extend({
     children: DS.hasMany('folder', { inverse: 'parent' }),
-    parent: DS.belongsTo('folder', { inverse: 'children' })
+    parent: DS.belongsTo('folder', { inverse: 'children' }),
 });
 
 // $ExpectType void
@@ -37,7 +37,7 @@ Person.eachTransformedAttribute((name, type) => {
 });
 
 const Polymorphic = DS.Model.extend({
-    paymentMethods: DS.hasMany('payment-method', { polymorphic: true })
+    paymentMethods: DS.hasMany('payment-method', { polymorphic: true }),
 });
 
 // $ExpectType void
@@ -65,7 +65,7 @@ Polymorphic.eachRelatedType(() => '');
 // $ExpectType void
 Polymorphic.eachRelatedType(() => '', {});
 // $ExpectType void
-Polymorphic.eachRelatedType((name) => {
+Polymorphic.eachRelatedType(name => {
     let s: string = name;
 });
 
@@ -94,7 +94,7 @@ declare module 'ember-data/types/registries/model' {
 }
 
 let blogPost = store.peekRecord('relational-post', 1);
-blogPost!.get('comments').then((comments) => {
+blogPost!.get('comments').then(comments => {
     // now we can work with the comments
     let author: string = comments.get('firstObject')!.get('author');
 });

--- a/types/ember-data/test/serializer.ts
+++ b/types/ember-data/test/serializer.ts
@@ -14,32 +14,38 @@ const Customized = DS.JSONAPISerializer.extend({
 
         json.data.attributes.cost = {
             amount: json.data.attributes.amount,
-            currency: json.data.attributes.currency
+            currency: json.data.attributes.currency,
         };
 
         return json;
     },
-    normalizeResponse(store: DS.Store, primaryModelClass: DS.Model, payload: any, id: string|number, requestType: string) {
+    normalizeResponse(
+        store: DS.Store,
+        primaryModelClass: DS.Model,
+        payload: any,
+        id: string | number,
+        requestType: string,
+    ) {
         payload.data.attributes.amount = payload.data.attributes.cost.amount;
         payload.data.attributes.currency = payload.data.attributes.cost.currency;
 
         delete payload.data.attributes.cost;
 
         return this._super(...Array.from(arguments));
-    }
+    },
 });
 
 const EmbeddedRecordMixin = DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
         author: {
             serialize: false,
-            deserialize: 'records'
+            deserialize: 'records',
         },
         comments: {
             deserialize: 'records',
-            serialize: 'ids'
-        }
-    }
+            serialize: 'ids',
+        },
+    },
 });
 
 class Message extends DS.Model.extend({
@@ -47,7 +53,7 @@ class Message extends DS.Model.extend({
     body: DS.attr(),
 
     author: DS.belongsTo('user'),
-    comments: DS.belongsTo('comment')
+    comments: DS.belongsTo('comment'),
 }) {}
 
 declare module 'ember-data/types/registries/model' {
@@ -65,7 +71,7 @@ const SerializerUsingSnapshots = DS.RESTSerializer.extend({
         let json: any = {
             POST_TTL: snapshot.attr('title'),
             POST_BDY: snapshot.attr('body'),
-            POST_CMS: snapshot.hasMany('comments', { ids: true })
+            POST_CMS: snapshot.hasMany('comments', { ids: true }),
         };
 
         if (options.includeId) {
@@ -73,13 +79,13 @@ const SerializerUsingSnapshots = DS.RESTSerializer.extend({
         }
 
         return json;
-    }
+    },
 });
 
 DS.Serializer.extend({
     serialize(snapshot: DS.Snapshot<'message-for-serializer'>, options: {}) {
         let json: Dict<any> = {
-            id: snapshot.id
+            id: snapshot.id,
         };
 
         // $ExpectType void

--- a/types/ember-data/test/store.ts
+++ b/types/ember-data/test/store.ts
@@ -29,7 +29,7 @@ post.save().then(saved => {
     assertType<Post>(saved);
 });
 
-store.findRecord('post', 1).then(function(post) {
+store.findRecord('post', 1).then(function (post) {
     post.get('title'); // => "Rails is Omakase"
     post.set('title', 'A new post');
     post.save(); // => PATCH to '/posts/1'
@@ -43,18 +43,18 @@ class Author extends User {}
 
 declare module 'ember-data/types/registries/model' {
     export default interface ModelRegistry {
-        'user': User;
-        'author': Author;
+        user: User;
+        author: Author;
     }
 }
 
-store.queryRecord('user', {}).then(function(user) {
+store.queryRecord('user', {}).then(function (user) {
     let username = user.get('username');
     console.log(`Currently logged in as ${username}`);
 });
 
 store.findAll('post'); // => GET /posts
-store.findAll('author', { reload: true }).then(function(authors) {
+store.findAll('author', { reload: true }).then(function (authors) {
     authors.getEach('id'); // ['first', 'second']
 });
 store.findAll('post', {
@@ -82,14 +82,14 @@ declare module 'ember-data/types/registries/model' {
 }
 
 const messages = store.peekAll('message');
-messages.forEach(function(message) {
+messages.forEach(function (message) {
     message.set('hasBeenSeen', true);
 });
 messages.save();
 
 const people = store.peekAll('user');
 people.get('isUpdating'); // false
-people.update().then(function() {
+people.update().then(function () {
     people.get('isUpdating'); // false
 });
 people.get('isUpdating'); // true
@@ -147,16 +147,16 @@ const tom = store
             email: 'tomster@example.com',
         },
     })
-    .then(function(users) {
+    .then(function (users) {
         return users.get('firstObject');
     });
 
 // GET /users?isAdmin=true
 const admins = store.query('user', { isAdmin: true });
-admins.then(function() {
+admins.then(function () {
     console.log(admins.get('length')); // 42
 });
-admins.update().then(function() {
+admins.update().then(function () {
     admins.get('isUpdating'); // false
     console.log(admins.get('length')); // 123
 });

--- a/types/ember-data/test/transform.ts
+++ b/types/ember-data/test/transform.ts
@@ -10,7 +10,7 @@ const PointTransform = DS.Transform.extend({
     serialize(value: Point): number[] {
         return [value.get('x'), value.get('y')];
     },
-    deserialize(value: [ number, number ]): Point {
+    deserialize(value: [number, number]): Point {
         return Point.create({ x: value[0], y: value[1] });
-    }
+    },
 });

--- a/types/ember-data/tslint.json
+++ b/types/ember-data/tslint.json
@@ -10,6 +10,7 @@
         "object-literal-key-quotes": false,
         "only-arrow-functions": false,
         "prefer-const": false,
+        "space-before-function-paren": false,
         "npm-naming": [true, { "mode": "code", "errors": [["NoDefaultExport", false]] }]
     }
 }

--- a/types/ember-data/v2/adapter.d.ts
+++ b/types/ember-data/v2/adapter.d.ts
@@ -1,4 +1,4 @@
-import { DS } from "ember-data";
+import { DS } from 'ember-data';
 
 export default DS.Adapter;
 export { AdapterRegistry } from 'ember-data';

--- a/types/ember-data/v2/index.d.ts
+++ b/types/ember-data/v2/index.d.ts
@@ -13,10 +13,10 @@ export interface ModelRegistry {}
 export interface AdapterRegistry {}
 export interface SerializerRegistry {}
 export interface TransformRegistry {
-    'string': string;
-    'boolean': boolean;
-    'number': number;
-    'date': Date;
+    string: string;
+    boolean: boolean;
+    number: number;
+    date: Date;
 }
 
 type AttributesFor<Model> = keyof Model; // TODO: filter to attr properties only (TS 2.8)
@@ -58,8 +58,12 @@ export namespace DS {
         polymorphic?: boolean;
     }
 
-    interface Sync { async: false; }
-    interface Async { async?: true; }
+    interface Sync {
+        async: false;
+    }
+    interface Async {
+        async?: true;
+    }
 
     /**
      * `DS.belongsTo` is used to define One-To-One and One-To-Many
@@ -67,11 +71,11 @@ export namespace DS {
      */
     function belongsTo<K extends keyof ModelRegistry>(
         modelName: K,
-        options: RelationshipOptions<ModelRegistry[K]> & Sync
+        options: RelationshipOptions<ModelRegistry[K]> & Sync,
     ): Ember.ComputedProperty<ModelRegistry[K]>;
     function belongsTo<K extends keyof ModelRegistry>(
         modelName: K,
-        options?: RelationshipOptions<ModelRegistry[K]> & Async
+        options?: RelationshipOptions<ModelRegistry[K]> & Async,
     ): Ember.ComputedProperty<ModelRegistry[K] & PromiseObject<ModelRegistry[K]>, ModelRegistry[K]>;
     /**
      * `DS.hasMany` is used to define One-To-Many and Many-To-Many
@@ -79,11 +83,11 @@ export namespace DS {
      */
     function hasMany<K extends keyof ModelRegistry>(
         type: K,
-        options: RelationshipOptions<ModelRegistry[K]> & Sync
+        options: RelationshipOptions<ModelRegistry[K]> & Sync,
     ): Ember.ComputedProperty<ManyArray<ModelRegistry[K]>>;
     function hasMany<K extends keyof ModelRegistry>(
         type: K,
-        options?: RelationshipOptions<ModelRegistry[K]> & Async
+        options?: RelationshipOptions<ModelRegistry[K]> & Async,
     ): Ember.ComputedProperty<PromiseManyArray<ModelRegistry[K]>, Ember.Array<ModelRegistry[K]>>;
     /**
      * This method normalizes a modelName into the format Ember Data uses
@@ -107,7 +111,7 @@ export namespace DS {
      */
     function attr<K extends keyof TransformRegistry>(
         type: K,
-        options?: AttrOptions<TransformRegistry[K]>
+        options?: AttrOptions<TransformRegistry[K]>,
     ): Ember.ComputedProperty<TransformRegistry[K]>;
     function attr(options?: AttrOptions): Ember.ComputedProperty<any>;
     /**
@@ -136,23 +140,16 @@ export namespace DS {
             id?: string | any[] | {} | null,
             snapshot?: Snapshot<K> | any[] | null,
             requestType?: string,
-            query?: {}
+            query?: {},
         ): string;
         /**
          * Builds a URL for a `store.findRecord(type, id)` call.
          */
-        urlForFindRecord<K extends keyof ModelRegistry>(
-            id: string,
-            modelName: K,
-            snapshot: Snapshot<K>
-        ): string;
+        urlForFindRecord<K extends keyof ModelRegistry>(id: string, modelName: K, snapshot: Snapshot<K>): string;
         /**
          * Builds a URL for a `store.findAll(type)` call.
          */
-        urlForFindAll<K extends keyof ModelRegistry>(
-            modelName: K,
-            snapshot: SnapshotRecordArray<K>
-        ): string;
+        urlForFindAll<K extends keyof ModelRegistry>(modelName: K, snapshot: SnapshotRecordArray<K>): string;
         /**
          * Builds a URL for a `store.query(type, query)` call.
          */
@@ -166,29 +163,17 @@ export namespace DS {
          * records into 1 request when the adapter's `coalesceFindRequests`
          * property is true.
          */
-        urlForFindMany<K extends keyof ModelRegistry>(
-            ids: any[],
-            modelName: K,
-            snapshots: any[]
-        ): string;
+        urlForFindMany<K extends keyof ModelRegistry>(ids: any[], modelName: K, snapshots: any[]): string;
         /**
          * Builds a URL for fetching a async hasMany relationship when a url
          * is not provided by the server.
          */
-        urlForFindHasMany<K extends keyof ModelRegistry>(
-            id: string,
-            modelName: K,
-            snapshot: Snapshot<K>
-        ): string;
+        urlForFindHasMany<K extends keyof ModelRegistry>(id: string, modelName: K, snapshot: Snapshot<K>): string;
         /**
          * Builds a URL for fetching a async belongsTo relationship when a url
          * is not provided by the server.
          */
-        urlForFindBelongsTo<K extends keyof ModelRegistry>(
-            id: string,
-            modelName: K,
-            snapshot: Snapshot<K>
-        ): string;
+        urlForFindBelongsTo<K extends keyof ModelRegistry>(id: string, modelName: K, snapshot: Snapshot<K>): string;
         /**
          * Builds a URL for a `record.save()` call when the record was created
          * locally using `store.createRecord()`.
@@ -197,19 +182,11 @@ export namespace DS {
         /**
          * Builds a URL for a `record.save()` call when the record has been update locally.
          */
-        urlForUpdateRecord<K extends keyof ModelRegistry>(
-            id: string,
-            modelName: K,
-            snapshot: Snapshot<K>
-        ): string;
+        urlForUpdateRecord<K extends keyof ModelRegistry>(id: string, modelName: K, snapshot: Snapshot<K>): string;
         /**
          * Builds a URL for a `record.save()` call when the record has been deleted locally.
          */
-        urlForDeleteRecord<K extends keyof ModelRegistry>(
-            id: string,
-            modelName: K,
-            snapshot: Snapshot<K>
-        ): string;
+        urlForDeleteRecord<K extends keyof ModelRegistry>(id: string, modelName: K, snapshot: Snapshot<K>): string;
         /**
          * Determines the pathname for a given type.
          */
@@ -291,11 +268,7 @@ export namespace DS {
          * DEPRECATED:
          * Register with target handler
          */
-        registerHandlers(
-            target: {},
-            becameInvalid: Function,
-            becameValid: Function
-        ): any;
+        registerHandlers(target: {}, becameInvalid: Function, becameValid: Function): any;
         /**
          * Returns errors for a given attribute
          */
@@ -525,7 +498,11 @@ export namespace DS {
          * invoking the callback with the name of each relationship and its relationship
          * descriptor.
          */
-        eachRelationship<T extends Model>(this: T, callback: (name: string, details: RelationshipMeta<T>) => void, binding?: any): any;
+        eachRelationship<T extends Model>(
+            this: T,
+            callback: (name: string, details: RelationshipMeta<T>) => void,
+            binding?: any,
+        ): any;
         /**
          * Represents the model's class name as a string. This can be used to look up the model's class name through
          * `DS.Store`'s modelFor method.
@@ -557,9 +534,7 @@ export namespace DS {
          * included once, regardless of the number of relationships it has with
          * the model.
          */
-        static relatedTypes: Ember.ComputedProperty<
-            Ember.NativeArray<string>
-        >;
+        static relatedTypes: Ember.ComputedProperty<Ember.NativeArray<string>>;
         /**
          * A map whose keys are the relationships of a model and whose values are
          * relationship descriptors.
@@ -576,7 +551,10 @@ export namespace DS {
          * invoking the callback with the name of each relationship and its relationship
          * descriptor.
          */
-        static eachRelationship<M extends Model = Model>(callback: (name: string, details: RelationshipMeta<M>) => void, binding?: any): any;
+        static eachRelationship<M extends Model = Model>(
+            callback: (name: string, details: RelationshipMeta<M>) => void,
+            binding?: any,
+        ): any;
         /**
          * Given a callback, iterates over each of the types related to a model,
          * invoking the callback with the related type's class. Each type will be
@@ -607,10 +585,7 @@ export namespace DS {
          * the passed function on each attribute. Note the callback will not be
          * called for any attributes that do not have an transformation type.
          */
-        static eachTransformedAttribute(
-            callback: Function,
-            binding: {}
-        ): any;
+        static eachTransformedAttribute(callback: Function, binding: {}): any;
         /**
          * Discards any unsaved changes to the given attribute. This feature is not enabled by default. You must enable `ds-rollback-attribute` and be running a canary build.
          */
@@ -619,11 +594,7 @@ export namespace DS {
          * This Ember.js hook allows an object to be notified when a property
          * is defined.
          */
-        didDefineProperty(
-            proto: {},
-            key: string,
-            value: Ember.ComputedProperty<any>
-        ): any;
+        didDefineProperty(proto: {}, key: string, value: Ember.ComputedProperty<any>): any;
     }
     /**
      * ### State
@@ -830,10 +801,7 @@ export namespace DS {
      * relationship.
      */
     interface ManyArray<T> extends Ember.MutableArray<T> {}
-    class ManyArray<T> extends Ember.Object.extend(
-        Ember.MutableArray as {},
-        Ember.Evented
-    ) {
+    class ManyArray<T> extends Ember.Object.extend(Ember.MutableArray as {}, Ember.Evented) {
         /**
          * The loading state of this array
          */
@@ -865,9 +833,7 @@ export namespace DS {
      * it easy to create data bindings with the `PromiseArray` that will be
      * updated when the promise resolves.
      */
-    interface PromiseArray<T>
-        extends Ember.ArrayProxy<T>,
-            Ember.PromiseProxyMixin<Ember.ArrayProxy<T>> {}
+    interface PromiseArray<T> extends Ember.ArrayProxy<T>, Ember.PromiseProxyMixin<Ember.ArrayProxy<T>> {}
     class PromiseArray<T> {}
     /**
      * A `PromiseObject` is an object that acts like both an `Ember.Object`
@@ -876,9 +842,7 @@ export namespace DS {
      * it easy to create data bindings with the `PromiseObject` that will
      * be updated when the promise resolves.
      */
-    interface PromiseObject<T>
-        extends Ember.ObjectProxy,
-            Ember.PromiseProxyMixin<T & Ember.ObjectProxy> {}
+    interface PromiseObject<T> extends Ember.ObjectProxy, Ember.PromiseProxyMixin<T & Ember.ObjectProxy> {}
     class PromiseObject<T> {}
     /**
      * A PromiseManyArray is a PromiseArray that also proxies certain method calls
@@ -963,29 +927,32 @@ export namespace DS {
          */
         belongsTo<L extends RelationshipsFor<ModelRegistry[K]>>(
             keyName: L,
-            options?: {}
+            options?: {},
         ): Snapshot<K>['record'][L] | string | null | undefined;
         /**
          * Returns the current value of a hasMany relationship.
          */
         hasMany<L extends RelationshipsFor<ModelRegistry[K]>>(
             keyName: L,
-            options?: { ids: false }
+            options?: { ids: false },
         ): Array<Snapshot<K>['record'][L]> | undefined;
-        hasMany<L extends RelationshipsFor<ModelRegistry[K]>>(
-            keyName: L,
-            options: { ids: true }
-        ): string[] | undefined;
+        hasMany<L extends RelationshipsFor<ModelRegistry[K]>>(keyName: L, options: { ids: true }): string[] | undefined;
         /**
          * Iterates through all the attributes of the model, calling the passed
          * function on each attribute.
          */
-        eachAttribute<M extends ModelRegistry[K]>(callback: (key: keyof M, meta: AttributeMeta<M>) => void, binding?: {}): any;
+        eachAttribute<M extends ModelRegistry[K]>(
+            callback: (key: keyof M, meta: AttributeMeta<M>) => void,
+            binding?: {},
+        ): any;
         /**
          * Iterates through all the relationships of the model, calling the passed
          * function on each relationship.
          */
-        eachRelationship<M extends ModelRegistry[K]>(callback: (key: keyof M, meta: RelationshipMeta<M>) => void, binding?: {}): any;
+        eachRelationship<M extends ModelRegistry[K]>(
+            callback: (key: keyof M, meta: RelationshipMeta<M>) => void,
+            binding?: {},
+        ): any;
         /**
          * Serializes the snapshot using the serializer for the model.
          */
@@ -1009,10 +976,7 @@ export namespace DS {
          * Create a new record in the current store. The properties passed
          * to this method are set on the newly created record.
          */
-        createRecord<K extends keyof ModelRegistry>(
-            modelName: K,
-            inputProperties?: {}
-        ): ModelRegistry[K];
+        createRecord<K extends keyof ModelRegistry>(modelName: K, inputProperties?: {}): ModelRegistry[K];
         /**
          * For symmetry, a record can be deleted via the store.
          */
@@ -1028,48 +992,39 @@ export namespace DS {
         findRecord<K extends keyof ModelRegistry>(
             modelName: K,
             id: string | number,
-            options?: {}
+            options?: {},
         ): PromiseObject<ModelRegistry[K]> & ModelRegistry[K];
         /**
          * Get the reference for the specified record.
          */
         getReference<K extends keyof ModelRegistry>(
             modelName: K,
-            id: string | number
+            id: string | number,
         ): RecordReference<ModelRegistry[K]>;
         /**
          * Get a record by a given type and ID without triggering a fetch.
          */
-        peekRecord<K extends keyof ModelRegistry>(
-            modelName: K,
-            id: string | number
-        ): ModelRegistry[K] | null;
+        peekRecord<K extends keyof ModelRegistry>(modelName: K, id: string | number): ModelRegistry[K] | null;
         /**
          * This method returns true if a record for a given modelName and id is already
          * loaded in the store. Use this function to know beforehand if a findRecord()
          * will result in a request or that it will be a cache hit.
          */
-        hasRecordForId<K extends keyof ModelRegistry>(
-            modelName: K,
-            id: string | number
-        ): boolean;
+        hasRecordForId<K extends keyof ModelRegistry>(modelName: K, id: string | number): boolean;
         /**
          * This method delegates a query to the adapter. This is the one place where
          * adapter-level semantics are exposed to the application.
          */
         query<K extends keyof ModelRegistry>(
             modelName: K,
-            query: any
+            query: any,
         ): AdapterPopulatedRecordArray<ModelRegistry[K]> & PromiseArray<ModelRegistry[K]>;
         /**
          * This method makes a request for one record, where the `id` is not known
          * beforehand (if the `id` is known, use [`findRecord`](#method_findRecord)
          * instead).
          */
-        queryRecord<K extends keyof ModelRegistry>(
-            modelName: K,
-            query: any
-        ): RSVP.Promise<ModelRegistry[K]>;
+        queryRecord<K extends keyof ModelRegistry>(modelName: K, query: any): RSVP.Promise<ModelRegistry[K]>;
         /**
          * `findAll` asks the adapter's `findAll` method to find the records for the
          * given type, and returns a promise which will resolve with all records of
@@ -1083,7 +1038,7 @@ export namespace DS {
                 backgroundReload?: boolean;
                 include?: string;
                 adapterOptions?: any;
-            }
+            },
         ): PromiseArray<ModelRegistry[K]>;
         /**
          * This method returns a filtered array that contains all of the
@@ -1156,11 +1111,7 @@ export namespace DS {
         /**
          * Takes a URL, an HTTP method and a hash of data, and makes an HTTP request.
          */
-        ajax(
-            url: string,
-            type: string,
-            options?: object
-        ): RSVP.Promise<any>;
+        ajax(url: string, type: string, options?: object): RSVP.Promise<any>;
         /**
          * Generate ajax options
          */
@@ -1202,7 +1153,7 @@ export namespace DS {
             store: Store,
             type: ModelRegistry[K],
             id: string,
-            snapshot: Snapshot<K>
+            snapshot: Snapshot<K>,
         ): RSVP.Promise<any>;
         /**
          * Called by the store in order to fetch a JSON array for all
@@ -1212,7 +1163,7 @@ export namespace DS {
             store: Store,
             type: ModelRegistry[K],
             sinceToken: string,
-            snapshotRecordArray: SnapshotRecordArray<K>
+            snapshotRecordArray: SnapshotRecordArray<K>,
         ): RSVP.Promise<any>;
         /**
          * Called by the store in order to fetch a JSON array for
@@ -1223,11 +1174,7 @@ export namespace DS {
          * Called by the store in order to fetch a JSON object for
          * the record that matches a particular query.
          */
-        queryRecord<K extends keyof ModelRegistry>(
-            store: Store,
-            type: ModelRegistry[K],
-            query: {}
-        ): RSVP.Promise<any>;
+        queryRecord<K extends keyof ModelRegistry>(store: Store, type: ModelRegistry[K], query: {}): RSVP.Promise<any>;
         /**
          * Called by the store in order to fetch several records together if `coalesceFindRequests` is true
          */
@@ -1235,7 +1182,7 @@ export namespace DS {
             store: Store,
             type: ModelRegistry[K],
             ids: any[],
-            snapshots: any[]
+            snapshots: any[],
         ): RSVP.Promise<any>;
         /**
          * Called by the store in order to fetch a JSON array for
@@ -1246,7 +1193,7 @@ export namespace DS {
             store: Store,
             snapshot: Snapshot<K>,
             url: string,
-            relationship: {}
+            relationship: {},
         ): RSVP.Promise<any>;
         /**
          * Called by the store in order to fetch the JSON for the unloaded record in a
@@ -1256,7 +1203,7 @@ export namespace DS {
         findBelongsTo<K extends keyof ModelRegistry>(
             store: Store,
             snapshot: Snapshot<K>,
-            url: string
+            url: string,
         ): RSVP.Promise<any>;
         /**
          * Called by the store when a newly created record is
@@ -1265,7 +1212,7 @@ export namespace DS {
         createRecord<K extends keyof ModelRegistry>(
             store: Store,
             type: ModelRegistry[K],
-            snapshot: Snapshot<K>
+            snapshot: Snapshot<K>,
         ): RSVP.Promise<any>;
         /**
          * Called by the store when an existing record is saved
@@ -1274,7 +1221,7 @@ export namespace DS {
         updateRecord<K extends keyof ModelRegistry>(
             store: Store,
             type: ModelRegistry[K],
-            snapshot: Snapshot<K>
+            snapshot: Snapshot<K>,
         ): RSVP.Promise<any>;
         /**
          * Called by the store when a record is deleted.
@@ -1282,7 +1229,7 @@ export namespace DS {
         deleteRecord<K extends keyof ModelRegistry>(
             store: Store,
             type: ModelRegistry[K],
-            snapshot: Snapshot<K>
+            snapshot: Snapshot<K>,
         ): RSVP.Promise<any>;
         /**
          * Organize records into groups, each of which is to be passed to separate
@@ -1292,12 +1239,7 @@ export namespace DS {
         /**
          * Takes an ajax response, and returns the json payload or an error.
          */
-        handleResponse(
-            status: number,
-            headers: {},
-            payload: {},
-            requestData: {}
-        ): {};
+        handleResponse(status: number, headers: {}, payload: {}, requestData: {}): {};
         /**
          * Default `handleResponse` implementation uses this hook to decide if the
          * response is a success.
@@ -1332,23 +1274,16 @@ export namespace DS {
             id?: string | any[] | {} | null,
             snapshot?: Snapshot<K> | any[] | null,
             requestType?: string,
-            query?: {}
+            query?: {},
         ): string;
         /**
          * Builds a URL for a `store.findRecord(type, id)` call.
          */
-        urlForFindRecord<K extends keyof ModelRegistry>(
-            id: string,
-            modelName: K,
-            snapshot: Snapshot<K>
-        ): string;
+        urlForFindRecord<K extends keyof ModelRegistry>(id: string, modelName: K, snapshot: Snapshot<K>): string;
         /**
          * Builds a URL for a `store.findAll(type)` call.
          */
-        urlForFindAll<K extends keyof ModelRegistry>(
-            modelName: K,
-            snapshot: SnapshotRecordArray<K>
-        ): string;
+        urlForFindAll<K extends keyof ModelRegistry>(modelName: K, snapshot: SnapshotRecordArray<K>): string;
         /**
          * Builds a URL for a `store.query(type, query)` call.
          */
@@ -1362,29 +1297,17 @@ export namespace DS {
          * records into 1 request when the adapter's `coalesceFindRequests`
          * property is true.
          */
-        urlForFindMany<K extends keyof ModelRegistry>(
-            ids: any[],
-            modelName: K,
-            snapshots: any[]
-        ): string;
+        urlForFindMany<K extends keyof ModelRegistry>(ids: any[], modelName: K, snapshots: any[]): string;
         /**
          * Builds a URL for fetching a async hasMany relationship when a url
          * is not provided by the server.
          */
-        urlForFindHasMany<K extends keyof ModelRegistry>(
-            id: string,
-            modelName: K,
-            snapshot: Snapshot<K>
-        ): string;
+        urlForFindHasMany<K extends keyof ModelRegistry>(id: string, modelName: K, snapshot: Snapshot<K>): string;
         /**
          * Builds a URL for fetching a async belongsTo relationship when a url
          * is not provided by the server.
          */
-        urlForFindBelongsTo<K extends keyof ModelRegistry>(
-            id: string,
-            modelName: K,
-            snapshot: Snapshot<K>
-        ): string;
+        urlForFindBelongsTo<K extends keyof ModelRegistry>(id: string, modelName: K, snapshot: Snapshot<K>): string;
         /**
          * Builds a URL for a `record.save()` call when the record was created
          * locally using `store.createRecord()`.
@@ -1393,19 +1316,11 @@ export namespace DS {
         /**
          * Builds a URL for a `record.save()` call when the record has been update locally.
          */
-        urlForUpdateRecord<K extends keyof ModelRegistry>(
-            id: string,
-            modelName: K,
-            snapshot: Snapshot<K>
-        ): string;
+        urlForUpdateRecord<K extends keyof ModelRegistry>(id: string, modelName: K, snapshot: Snapshot<K>): string;
         /**
          * Builds a URL for a `record.save()` call when the record has been deleted locally.
          */
-        urlForDeleteRecord<K extends keyof ModelRegistry>(
-            id: string,
-            modelName: K,
-            snapshot: Snapshot<K>
-        ): string;
+        urlForDeleteRecord<K extends keyof ModelRegistry>(id: string, modelName: K, snapshot: Snapshot<K>): string;
         /**
          * Determines the pathname for a given type.
          */
@@ -1423,19 +1338,11 @@ export namespace DS {
         /**
          * Serialize `belongsTo` relationship when it is configured as an embedded object.
          */
-        serializeBelongsTo<K extends keyof ModelRegistry>(
-            snapshot: Snapshot<K>,
-            json: {},
-            relationship: {}
-        ): any;
+        serializeBelongsTo<K extends keyof ModelRegistry>(snapshot: Snapshot<K>, json: {}, relationship: {}): any;
         /**
          * Serializes `hasMany` relationships when it is configured as embedded objects.
          */
-        serializeHasMany<K extends keyof ModelRegistry>(
-            snapshot: Snapshot<K>,
-            json: {},
-            relationship: {}
-        ): any;
+        serializeHasMany<K extends keyof ModelRegistry>(snapshot: Snapshot<K>, json: {}, relationship: {}): any;
         /**
          * When serializing an embedded record, modify the property (in the json payload)
          * that refers to the parent record (foreign key for relationship).
@@ -1444,7 +1351,7 @@ export namespace DS {
             snapshot: Snapshot<K>,
             embeddedSnapshot: Snapshot<K>,
             relationship: {},
-            json: {}
+            json: {},
         ): any;
     }
     /**
@@ -1476,11 +1383,7 @@ export namespace DS {
          * http://jsonapi.org/format and uses dashes as word separators in
          * relationship properties.
          */
-        keyForRelationship(
-            key: string,
-            typeClass: string,
-            method: string
-        ): string;
+        keyForRelationship(key: string, typeClass: string, method: string): string;
         /**
          * `modelNameFromPayloadType` can be used to change the mapping for a DS model
          * name, taken from the value in the payload.
@@ -1522,98 +1425,98 @@ export namespace DS {
             primaryModelClass: Model,
             payload: {},
             id: string | number,
-            requestType: string
+            requestType: string,
         ): {};
         normalizeFindRecordResponse(
             store: Store,
             primaryModelClass: Model,
             payload: {},
             id: string | number,
-            requestType: string
+            requestType: string,
         ): {};
         normalizeQueryRecordResponse(
             store: Store,
             primaryModelClass: Model,
             payload: {},
             id: string | number,
-            requestType: string
+            requestType: string,
         ): {};
         normalizeFindAllResponse(
             store: Store,
             primaryModelClass: Model,
             payload: {},
             id: string | number,
-            requestType: string
+            requestType: string,
         ): {};
         normalizeFindBelongsToResponse(
             store: Store,
             primaryModelClass: Model,
             payload: {},
             id: string | number,
-            requestType: string
+            requestType: string,
         ): {};
         normalizeFindHasManyResponse(
             store: Store,
             primaryModelClass: Model,
             payload: {},
             id: string | number,
-            requestType: string
+            requestType: string,
         ): {};
         normalizeFindManyResponse(
             store: Store,
             primaryModelClass: Model,
             payload: {},
             id: string | number,
-            requestType: string
+            requestType: string,
         ): {};
         normalizeQueryResponse(
             store: Store,
             primaryModelClass: Model,
             payload: {},
             id: string | number,
-            requestType: string
+            requestType: string,
         ): {};
         normalizeCreateRecordResponse(
             store: Store,
             primaryModelClass: Model,
             payload: {},
             id: string | number,
-            requestType: string
+            requestType: string,
         ): {};
         normalizeDeleteRecordResponse(
             store: Store,
             primaryModelClass: Model,
             payload: {},
             id: string | number,
-            requestType: string
+            requestType: string,
         ): {};
         normalizeUpdateRecordResponse(
             store: Store,
             primaryModelClass: Model,
             payload: {},
             id: string | number,
-            requestType: string
+            requestType: string,
         ): {};
         normalizeSaveResponse(
             store: Store,
             primaryModelClass: Model,
             payload: {},
             id: string | number,
-            requestType: string
+            requestType: string,
         ): {};
         normalizeSingleResponse(
             store: Store,
             primaryModelClass: Model,
             payload: {},
             id: string | number,
-            requestType: string
+            requestType: string,
         ): {};
         normalizeArrayResponse(
             store: Store,
             primaryModelClass: Model,
             payload: {},
             id: string | number,
-            requestType: string
+            requestType: string,
         ): {};
         /**
          * Normalizes a part of the JSON payload returned by
@@ -1632,18 +1535,11 @@ export namespace DS {
         /**
          * Returns a relationship formatted as a JSON-API "relationship object".
          */
-        extractRelationship(
-            relationshipModelName: {},
-            relationshipHash: {}
-        ): {};
+        extractRelationship(relationshipModelName: {}, relationshipHash: {}): {};
         /**
          * Returns a polymorphic relationship formatted as a JSON-API "relationship object".
          */
-        extractPolymorphicRelationship(
-            relationshipModelName: {},
-            relationshipHash: {},
-            relationshipOptions: {}
-        ): {};
+        extractPolymorphicRelationship(relationshipModelName: {}, relationshipHash: {}, relationshipOptions: {}): {};
         /**
          * Returns the resource's relationships formatted as a JSON-API "relationships object".
          */
@@ -1655,7 +1551,7 @@ export namespace DS {
         shouldSerializeHasMany<K extends keyof ModelRegistry>(
             snapshot: Snapshot<K>,
             key: string,
-            relationshipType: string
+            relationshipType: string,
         ): boolean;
         /**
          * Called when a record is saved in order to convert the
@@ -1674,7 +1570,7 @@ export namespace DS {
             hash: {},
             typeClass: ModelRegistry[K],
             snapshot: Snapshot<K>,
-            options?: {}
+            options?: {},
         ): any;
         /**
          * `serializeAttribute` can be used to customize how `DS.attr`
@@ -1684,37 +1580,25 @@ export namespace DS {
             snapshot: Snapshot<K>,
             json: {},
             key: string,
-            attribute: {}
+            attribute: {},
         ): any;
         /**
          * `serializeBelongsTo` can be used to customize how `DS.belongsTo`
          * properties are serialized.
          */
-        serializeBelongsTo<K extends keyof ModelRegistry>(
-            snapshot: Snapshot<K>,
-            json: {},
-            relationship: {}
-        ): any;
+        serializeBelongsTo<K extends keyof ModelRegistry>(snapshot: Snapshot<K>, json: {}, relationship: {}): any;
         /**
          * `serializeHasMany` can be used to customize how `DS.hasMany`
          * properties are serialized.
          */
-        serializeHasMany<K extends keyof ModelRegistry>(
-            snapshot: Snapshot<K>,
-            json: {},
-            relationship: {}
-        ): any;
+        serializeHasMany<K extends keyof ModelRegistry>(snapshot: Snapshot<K>, json: {}, relationship: {}): any;
         /**
          * You can use this method to customize how polymorphic objects are
          * serialized. Objects are considered to be polymorphic if
          * `{ polymorphic: true }` is pass as the second argument to the
          * `DS.belongsTo` function.
          */
-        serializePolymorphicType<K extends keyof ModelRegistry>(
-            snapshot: Snapshot<K>,
-            json: {},
-            relationship: {}
-        ): any;
+        serializePolymorphicType<K extends keyof ModelRegistry>(snapshot: Snapshot<K>, json: {}, relationship: {}): any;
         /**
          * `extractMeta` is used to deserialize any meta information in the
          * adapter payload. By default Ember Data expects meta information to
@@ -1727,12 +1611,7 @@ export namespace DS {
          * Ember Data expects error information to be located on the `errors`
          * property of the payload object.
          */
-        extractErrors(
-            store: Store,
-            typeClass: Model,
-            payload: {},
-            id: string | number
-        ): {};
+        extractErrors(store: Store, typeClass: Model, payload: {}, id: string | number): {};
         /**
          * `keyForAttribute` can be used to define rules for how to convert an
          * attribute name in your model to a key in your JSON.
@@ -1743,11 +1622,7 @@ export namespace DS {
          * serializing and deserializing relationship properties. By default
          * `JSONSerializer` does not provide an implementation of this method.
          */
-        keyForRelationship(
-            key: string,
-            typeClass: string,
-            method: string
-        ): string;
+        keyForRelationship(key: string, typeClass: string, method: string): string;
         /**
          * `keyForLink` can be used to define a custom key when deserializing link
          * properties.
@@ -1770,11 +1645,7 @@ export namespace DS {
          * serializing and deserializing a polymorphic type. By default, the
          * returned key is `${key}Type`.
          */
-        keyForPolymorphicType(
-            key: string,
-            typeClass: string,
-            method: string
-        ): string;
+        keyForPolymorphicType(key: string, typeClass: string, method: string): string;
         /**
          * Normalizes a part of the JSON payload returned by
          * the server. You should override this method, munge the hash
@@ -1807,7 +1678,7 @@ export namespace DS {
             hash: {},
             typeClass: Model,
             snapshot: Snapshot<K>,
-            options?: {}
+            options?: {},
         ): any;
         /**
          * You can use `payloadKeyFromModelName` to override the root key for an outgoing
@@ -1820,20 +1691,12 @@ export namespace DS {
          * By default the REST Serializer creates the key by appending `Type` to
          * the attribute and value from the model's camelcased model name.
          */
-        serializePolymorphicType<K extends keyof ModelRegistry>(
-            snapshot: Snapshot<K>,
-            json: {},
-            relationship: {}
-        ): any;
+        serializePolymorphicType<K extends keyof ModelRegistry>(snapshot: Snapshot<K>, json: {}, relationship: {}): any;
         /**
          * You can use this method to customize how a polymorphic relationship should
          * be extracted.
          */
-        extractPolymorphicRelationship(
-            relationshipType: {},
-            relationshipHash: {},
-            relationshipOptions: {}
-        ): {};
+        extractPolymorphicRelationship(relationshipType: {}, relationshipHash: {}, relationshipOptions: {}): {};
         /**
          * `modelNameFromPayloadType` can be used to change the mapping for a DS model
          * name, taken from the value in the payload.
@@ -1919,7 +1782,7 @@ export namespace DS {
             store: Store,
             type: ModelRegistry[K],
             id: string,
-            snapshot: Snapshot<K>
+            snapshot: Snapshot<K>,
         ): RSVP.Promise<any>;
         /**
          * The `findAll()` method is used to retrieve all records for a given type.
@@ -1928,7 +1791,7 @@ export namespace DS {
             store: Store,
             type: ModelRegistry[K],
             sinceToken: string,
-            snapshotRecordArray: SnapshotRecordArray<K>
+            snapshotRecordArray: SnapshotRecordArray<K>,
         ): RSVP.Promise<any>;
         /**
          * This method is called when you call `query` on the store.
@@ -1937,17 +1800,13 @@ export namespace DS {
             store: Store,
             type: ModelRegistry[K],
             query: {},
-            recordArray: AdapterPopulatedRecordArray<any>
+            recordArray: AdapterPopulatedRecordArray<any>,
         ): RSVP.Promise<any>;
         /**
          * The `queryRecord()` method is invoked when the store is asked for a single
          * record through a query object.
          */
-        queryRecord<K extends keyof ModelRegistry>(
-            store: Store,
-            type: ModelRegistry[K],
-            query: {}
-        ): RSVP.Promise<any>;
+        queryRecord<K extends keyof ModelRegistry>(store: Store, type: ModelRegistry[K], query: {}): RSVP.Promise<any>;
         /**
          * If the globally unique IDs for your records should be generated on the client,
          * implement the `generateIdForRecord()` method. This method will be invoked
@@ -1957,7 +1816,7 @@ export namespace DS {
         generateIdForRecord<K extends keyof ModelRegistry>(
             store: Store,
             type: ModelRegistry[K],
-            inputProperties: {}
+            inputProperties: {},
         ): string | number;
         /**
          * Proxies to the serializer's `serialize` method.
@@ -1970,7 +1829,7 @@ export namespace DS {
         createRecord<K extends keyof ModelRegistry>(
             store: Store,
             type: ModelRegistry[K],
-            snapshot: Snapshot<K>
+            snapshot: Snapshot<K>,
         ): RSVP.Promise<any>;
         /**
          * Implement this method in a subclass to handle the updating of
@@ -1979,7 +1838,7 @@ export namespace DS {
         updateRecord<K extends keyof ModelRegistry>(
             store: Store,
             type: ModelRegistry[K],
-            snapshot: Snapshot<K>
+            snapshot: Snapshot<K>,
         ): RSVP.Promise<any>;
         /**
          * Implement this method in a subclass to handle the deletion of
@@ -1988,7 +1847,7 @@ export namespace DS {
         deleteRecord<K extends keyof ModelRegistry>(
             store: Store,
             type: ModelRegistry[K],
-            snapshot: Snapshot<K>
+            snapshot: Snapshot<K>,
         ): RSVP.Promise<any>;
         /**
          * By default the store will try to coalesce all `fetchRecord` calls within the same runloop
@@ -2006,7 +1865,7 @@ export namespace DS {
             store: Store,
             type: ModelRegistry[K],
             ids: any[],
-            snapshots: any[]
+            snapshots: any[],
         ): RSVP.Promise<any>;
         /**
          * Organize records into groups, each of which is to be passed to separate
@@ -2026,17 +1885,14 @@ export namespace DS {
          */
         shouldReloadAll<K extends keyof ModelRegistry>(
             store: Store,
-            snapshotRecordArray: SnapshotRecordArray<K>
+            snapshotRecordArray: SnapshotRecordArray<K>,
         ): boolean;
         /**
          * This method is used by the store to determine if the store should
          * reload a record after the `store.findRecord` method resolves a
          * cached record.
          */
-        shouldBackgroundReloadRecord<K extends keyof ModelRegistry>(
-            store: Store,
-            snapshot: Snapshot<K>
-        ): boolean;
+        shouldBackgroundReloadRecord<K extends keyof ModelRegistry>(store: Store, snapshot: Snapshot<K>): boolean;
         /**
          * This method is used by the store to determine if the store should
          * reload a record array after the `store.findAll` method resolves
@@ -2044,7 +1900,7 @@ export namespace DS {
          */
         shouldBackgroundReloadAll<K extends keyof ModelRegistry>(
             store: Store,
-            snapshotRecordArray: SnapshotRecordArray<K>
+            snapshotRecordArray: SnapshotRecordArray<K>,
         ): boolean;
     }
     /**
@@ -2068,7 +1924,7 @@ export namespace DS {
             primaryModelClass: Model,
             payload: {},
             id: string | number,
-            requestType: string
+            requestType: string,
         ): {};
         /**
          * The `serialize` method is used when a record is saved in order to convert
@@ -2090,10 +1946,10 @@ export default DS;
 declare module 'ember' {
     namespace Ember {
         /*
-        * The store is automatically injected into these objects
-        *
-        * https://github.com/emberjs/data/blob/05e95280e11c411177f2fbcb65fd83488d6a9d89/addon/setup-container.js#L71-L78
-        */
+         * The store is automatically injected into these objects
+         *
+         * https://github.com/emberjs/data/blob/05e95280e11c411177f2fbcb65fd83488d6a9d89/addon/setup-container.js#L71-L78
+         */
         interface Route {
             store: DS.Store;
         }
@@ -2110,7 +1966,7 @@ declare module 'ember' {
 
 declare module '@ember/service' {
     interface Registry {
-        'store': DS.Store;
+        store: DS.Store;
     }
 }
 

--- a/types/ember-data/v2/test/adapter.ts
+++ b/types/ember-data/v2/test/adapter.ts
@@ -3,7 +3,9 @@ import DS from 'ember-data';
 
 class Session extends Ember.Service {}
 declare module '@ember/service' {
-    interface Registry { 'session': Session; }
+    interface Registry {
+        session: Session;
+    }
 }
 
 const JsonApi = DS.JSONAPIAdapter.extend({
@@ -14,40 +16,40 @@ const Customized = DS.JSONAPIAdapter.extend({
     host: 'https://api.example.com',
     namespace: 'api/v1',
     headers: {
-        'API_KEY': 'secret key',
-        'ANOTHER_HEADER': 'Some header value'
-    }
+        API_KEY: 'secret key',
+        ANOTHER_HEADER: 'Some header value',
+    },
 });
 
 const AuthTokenHeader = DS.JSONAPIAdapter.extend({
     session: Ember.inject.service('session'),
-    headers: Ember.computed('session.authToken', function() {
+    headers: Ember.computed('session.authToken', function () {
         return {
-            'API_KEY': this.get('session.authToken'),
-            'ANOTHER_HEADER': 'Some header value'
+            API_KEY: this.get('session.authToken'),
+            ANOTHER_HEADER: 'Some header value',
         };
-    })
+    }),
 });
 
 const UseAjax = DS.JSONAPIAdapter.extend({
     query(store: DS.Store, type: string, query: object) {
         const url = 'https://api.example.com/my-api';
         return this.ajax(url, 'POST', {
-            param: 'foo'
+            param: 'foo',
         });
-    }
+    },
 });
 
 const UseAjaxOptions = DS.JSONAPIAdapter.extend({
     query(store: DS.Store, type: string, query: object) {
         const url = 'https://api.example.com/my-api';
         const options = this.ajaxOptions(url, 'DELETE', {
-            foo: 'bar'
+            foo: 'bar',
         });
         return Ember.$.ajax(url, {
-            ...options
+            ...options,
         });
-    }
+    },
 });
 
 const UseAjaxOptionsWithOptionalThirdParams = DS.JSONAPIAdapter.extend({
@@ -55,14 +57,14 @@ const UseAjaxOptionsWithOptionalThirdParams = DS.JSONAPIAdapter.extend({
         const url = 'https://api.example.com/my-api';
         const options = this.ajaxOptions(url, 'DELETE');
         return Ember.$.ajax(url, {
-            ...options
+            ...options,
         });
-    }
+    },
 });
 
 declare module 'ember-data' {
     interface ModelRegistry {
-        'rootModel': any;
+        rootModel: any;
         'super-user': any;
     }
 }
@@ -116,5 +118,5 @@ const BuildURLAdapter = DS.RESTAdapter.extend({
     worksWithUnknownRequestType() {
         this.buildURL('super-user', 1, null, 'unknown');
         this.buildURL('super-user', null, null, 'unknown');
-    }
+    },
 });

--- a/types/ember-data/v2/test/has-many.ts
+++ b/types/ember-data/v2/test/has-many.ts
@@ -47,7 +47,7 @@ blogPost.get('commentsAsync').then(comments => {
 
 blogPost.set('commentsAsync', blogPost.get('commentsAsync'));
 blogPost.set('commentsAsync', Ember.A());
-blogPost.set('commentsAsync', Ember.A([ comment! ]));
+blogPost.set('commentsAsync', Ember.A([comment!]));
 
 class PaymentMethod extends DS.Model {}
 declare module 'ember-data' {

--- a/types/ember-data/v2/test/injections.ts
+++ b/types/ember-data/v2/test/injections.ts
@@ -12,19 +12,19 @@ declare module 'ember-data' {
 Ember.Route.extend({
     model(): any {
         return this.store.findAll('my-model');
-    }
+    },
 });
 
 Ember.Controller.extend({
     actions: {
         create(): any {
             return this.store.createRecord('my-model');
-        }
-    }
+        },
+    },
 });
 
 Ember.DataAdapter.extend({
     test() {
         this.store.findRecord('my-model', 123);
-    }
+    },
 });

--- a/types/ember-data/v2/test/model.ts
+++ b/types/ember-data/v2/test/model.ts
@@ -1,16 +1,16 @@
 import Ember from 'ember';
 import DS, { ChangedAttributes } from 'ember-data';
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 const Person = DS.Model.extend({
     firstName: DS.attr(),
     lastName: DS.attr(),
-    title: DS.attr({ defaultValue: "The default" }),
-    title2: DS.attr({ defaultValue: () => "The default" }),
+    title: DS.attr({ defaultValue: 'The default' }),
+    title2: DS.attr({ defaultValue: () => 'The default' }),
 
-    fullName: Ember.computed('firstName', 'lastName', function() {
+    fullName: Ember.computed('firstName', 'lastName', function () {
         return `${this.get('firstName')} ${this.get('lastName')}`;
-    })
+    }),
 });
 
 const User = DS.Model.extend({
@@ -19,8 +19,10 @@ const User = DS.Model.extend({
     verified: DS.attr('boolean', { defaultValue: false }),
     canBeNull: DS.attr('boolean', { allowNull: true }),
     createdAt: DS.attr('date', {
-        defaultValue() { return new Date(); }
-    })
+        defaultValue() {
+            return new Date();
+        },
+    }),
 });
 
 const user = User.create({ username: 'dwickern' });

--- a/types/ember-data/v2/test/module-api.ts
+++ b/types/ember-data/v2/test/module-api.ts
@@ -33,7 +33,7 @@ import Store from 'ember-data/store';
 // Errors
 import * as EDErrors from 'ember-data/adapters/errors';
 
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 // ADAPTERS
 // - identity

--- a/types/ember-data/v2/test/record-reference.ts
+++ b/types/ember-data/v2/test/record-reference.ts
@@ -1,5 +1,5 @@
 import DS from 'ember-data';
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 declare const store: DS.Store;
 
@@ -38,7 +38,7 @@ userRef.reload().then(user => {
 });
 
 // provide data for reference
-userRef.push({ id: 1, username: '@user' }).then(function(user) {
+userRef.push({ id: 1, username: '@user' }).then(function (user) {
     assertType<User>(user);
     userRef.value() === user;
 });

--- a/types/ember-data/v2/test/relationships.ts
+++ b/types/ember-data/v2/test/relationships.ts
@@ -5,11 +5,11 @@ declare const store: DS.Store;
 
 const Person = DS.Model.extend({
     children: DS.hasMany('folder', { inverse: 'parent' }),
-    parent: DS.belongsTo('folder', { inverse: 'children' })
+    parent: DS.belongsTo('folder', { inverse: 'children' }),
 });
 
 const Polymorphic = DS.Model.extend({
-    paymentMethods: DS.hasMany('payment-method', { polymorphic: true })
+    paymentMethods: DS.hasMany('payment-method', { polymorphic: true }),
 });
 
 Polymorphic.eachRelationship(() => '');
@@ -51,7 +51,7 @@ declare module 'ember-data' {
 }
 
 let blogPost = store.peekRecord('relational-post', 1);
-blogPost!.get('comments').then((comments) => {
+blogPost!.get('comments').then(comments => {
     // now we can work with the comments
     let author: string = comments.get('firstObject')!.get('author');
 });

--- a/types/ember-data/v2/test/serializer.ts
+++ b/types/ember-data/v2/test/serializer.ts
@@ -10,32 +10,38 @@ const Customized = DS.JSONAPISerializer.extend({
 
         json.data.attributes.cost = {
             amount: json.data.attributes.amount,
-            currency: json.data.attributes.currency
+            currency: json.data.attributes.currency,
         };
 
         return json;
     },
-    normalizeResponse(store: DS.Store, primaryModelClass: DS.Model, payload: any, id: string|number, requestType: string) {
+    normalizeResponse(
+        store: DS.Store,
+        primaryModelClass: DS.Model,
+        payload: any,
+        id: string | number,
+        requestType: string,
+    ) {
         payload.data.attributes.amount = payload.data.attributes.cost.amount;
         payload.data.attributes.currency = payload.data.attributes.cost.currency;
 
         delete payload.data.attributes.cost;
 
         return this._super(...Array.from(arguments));
-    }
+    },
 });
 
 const EmbeddedRecordMixin = DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
         author: {
             serialize: false,
-            deserialize: 'records'
+            deserialize: 'records',
         },
         comments: {
             deserialize: 'records',
-            serialize: 'ids'
-        }
-    }
+            serialize: 'ids',
+        },
+    },
 });
 
 class Message extends DS.Model.extend({
@@ -43,7 +49,7 @@ class Message extends DS.Model.extend({
     body: DS.attr(),
 
     author: DS.belongsTo('user'),
-    comments: DS.belongsTo('comment')
+    comments: DS.belongsTo('comment'),
 }) {}
 
 declare module 'ember-data' {
@@ -61,7 +67,7 @@ const SerializerUsingSnapshots = DS.RESTSerializer.extend({
         let json: any = {
             POST_TTL: snapshot.attr('title'),
             POST_BDY: snapshot.attr('body'),
-            POST_CMS: snapshot.hasMany('comments', { ids: true })
+            POST_CMS: snapshot.hasMany('comments', { ids: true }),
         };
 
         if (options.includeId) {
@@ -69,13 +75,13 @@ const SerializerUsingSnapshots = DS.RESTSerializer.extend({
         }
 
         return json;
-    }
+    },
 });
 
 DS.Serializer.extend({
     serialize(snapshot: DS.Snapshot<'message-for-serializer'>, options: {}) {
         let json: any = {
-            id: snapshot.id
+            id: snapshot.id,
         };
 
         snapshot.eachAttribute((key, attribute) => {

--- a/types/ember-data/v2/test/store.ts
+++ b/types/ember-data/v2/test/store.ts
@@ -13,7 +13,7 @@ class Post extends DS.Model {
 
 declare module 'ember-data' {
     interface ModelRegistry {
-        'post': Post;
+        post: Post;
         'post-comment': PostComment;
     }
 }
@@ -28,7 +28,7 @@ post.save().then(saved => {
     assertType<Post>(saved);
 });
 
-store.findRecord('post', 1).then(function(post) {
+store.findRecord('post', 1).then(function (post) {
     post.get('title'); // => "Rails is Omakase"
     post.set('title', 'A new post');
     post.save(); // => PATCH to '/posts/1'
@@ -42,18 +42,18 @@ class Author extends User {}
 
 declare module 'ember-data' {
     interface ModelRegistry {
-        'user': User;
-        'author': Author;
+        user: User;
+        author: Author;
     }
 }
 
-store.queryRecord('user', {}).then(function(user) {
+store.queryRecord('user', {}).then(function (user) {
     let username = user.get('username');
     console.log(`Currently logged in as ${username}`);
 });
 
 store.findAll('post'); // => GET /posts
-store.findAll('author', { reload: true }).then(function(authors) {
+store.findAll('author', { reload: true }).then(function (authors) {
     authors.getEach('id'); // ['first', 'second']
 });
 store.findAll('post', {
@@ -81,14 +81,14 @@ declare module 'ember-data' {
 }
 
 const messages = store.peekAll('message');
-messages.forEach(function(message) {
+messages.forEach(function (message) {
     message.set('hasBeenSeen', true);
 });
 messages.save();
 
 const people = store.peekAll('user');
 people.get('isUpdating'); // false
-people.update().then(function() {
+people.update().then(function () {
     people.get('isUpdating'); // false
 });
 people.get('isUpdating'); // true
@@ -108,7 +108,7 @@ const SomeComponent = Ember.Component.extend({
     lookUpUsers() {
         assertType<User>(this.get('store').findRecord('user', 123));
         assertType<DS.PromiseArray<User>>(this.get('store').findAll('user'));
-    }
+    },
 });
 
 const MyRouteAsync = Ember.Route.extend({
@@ -123,7 +123,7 @@ const MyRouteAsync = Ember.Route.extend({
     async afterModel(): Promise<Ember.Array<Comment>> {
         const post = await this.get('store').findRecord('post', 1);
         return await post.get('comments');
-    }
+    },
 });
 
 class MyRouteAsyncES6 extends Ember.Route {
@@ -146,16 +146,16 @@ const tom = store
             email: 'tomster@example.com',
         },
     })
-    .then(function(users) {
+    .then(function (users) {
         return users.get('firstObject');
     });
 
 // GET /users?isAdmin=true
 const admins = store.query('user', { isAdmin: true });
-admins.then(function() {
+admins.then(function () {
     console.log(admins.get('length')); // 42
 });
-admins.update().then(function() {
+admins.update().then(function () {
     admins.get('isUpdating'); // false
     console.log(admins.get('length')); // 123
 });

--- a/types/ember-data/v2/test/transform.ts
+++ b/types/ember-data/v2/test/transform.ts
@@ -10,7 +10,7 @@ const PointTransform = DS.Transform.extend({
     serialize(value: Point): number[] {
         return [value.get('x'), value.get('y')];
     },
-    deserialize(value: [ number, number ]): Point {
+    deserialize(value: [number, number]): Point {
         return Point.create({ x: value[0], y: value[1] });
-    }
+    },
 });

--- a/types/ember-data/v2/tslint.json
+++ b/types/ember-data/v2/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "space-before-function-paren": false,
         "ban-types": false,
         "no-empty-interface": false,
         "no-return-await": false,

--- a/types/ember-data__adapter/test/json-api.ts
+++ b/types/ember-data__adapter/test/json-api.ts
@@ -19,7 +19,7 @@ const Customized = JSONAPIAdapter.extend({
 
 const AuthTokenHeader = JSONAPIAdapter.extend({
     session: service('session'),
-    headers: computed('session.authToken', function() {
+    headers: computed('session.authToken', function () {
         return {
             API_KEY: this.get('session.authToken'),
             ANOTHER_HEADER: 'Some header value',

--- a/types/ember-data__adapter/tslint.json
+++ b/types/ember-data__adapter/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "space-before-function-paren": false,
         "no-unnecessary-generics": false,
         "npm-naming": [
             true,

--- a/types/ember-data__model/test/model.ts
+++ b/types/ember-data__model/test/model.ts
@@ -17,7 +17,7 @@ class Person extends Model.extend({
     title: attr({ defaultValue: 'The default' }),
     title2: attr({ defaultValue: () => 'The default' }),
 
-    fullName: computed('firstName', 'lastName', function() {
+    fullName: computed('firstName', 'lastName', function () {
         return `${this.get('firstName')} ${this.get('lastName')}`;
     }),
 }) {}

--- a/types/ember-data__model/tslint.json
+++ b/types/ember-data__model/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "space-before-function-paren": false,
         "no-unnecessary-generics": false,
         "npm-naming": [
             true,

--- a/types/ember-data__serializer/tslint.json
+++ b/types/ember-data__serializer/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "space-before-function-paren": false,
         "npm-naming": [
             true,
             {

--- a/types/ember-data__store/tslint.json
+++ b/types/ember-data__store/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "space-before-function-paren": false,
         "npm-naming": [
             true,
             {

--- a/types/ember-feature-flags/tslint.json
+++ b/types/ember-feature-flags/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "space-before-function-paren": false
+    }
+}

--- a/types/ember-feature-flags/v3/ember-feature-flags-tests.ts
+++ b/types/ember-feature-flags/v3/ember-feature-flags-tests.ts
@@ -19,8 +19,8 @@ features.isEnabled('new-billing-plans'); // $ExpectType boolean
 features.enable('newHomepage'); // $ExpectType void
 features.disable('newHomepage'); // $ExpectType void
 const setup = {
-  'new-billing-plans': true,
-  'new-homepage': false
+    'new-billing-plans': true,
+    'new-homepage': false,
 };
 features.setup(setup); // $ExpectType void
 withFeature('new-homepage'); // $ExpectType void

--- a/types/ember-feature-flags/v3/tslint.json
+++ b/types/ember-feature-flags/v3/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "space-before-function-paren": false
+    }
+}

--- a/types/ember-mocha/tslint.json
+++ b/types/ember-mocha/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "space-before-function-paren": false,
         "no-declare-current-package": false,
         "no-empty-interface": false,
         "only-arrow-functions": false,

--- a/types/ember-modal-dialog/tslint.json
+++ b/types/ember-modal-dialog/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "space-before-function-paren": false,
         "no-declare-current-package": false,
         "no-single-declare-module": false
     }

--- a/types/ember-modal-dialog/v2/ember-modal-dialog-tests.ts
+++ b/types/ember-modal-dialog/v2/ember-modal-dialog-tests.ts
@@ -23,5 +23,5 @@ class MyDialog extends ModalDialog {
 class MyOtherDialog extends ModalDialog.extend({
     testProperties() {
         this.hasOverlay; // $ExpectType boolean
-    }
+    },
 }) {}

--- a/types/ember-modal-dialog/v2/tslint.json
+++ b/types/ember-modal-dialog/v2/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "space-before-function-paren": false,
         "no-single-declare-module": false
     }
 }

--- a/types/ember-qunit/v2/ember-qunit-tests.ts
+++ b/types/ember-qunit/v2/ember-qunit-tests.ts
@@ -3,16 +3,16 @@ import hbs from 'htmlbars-inline-precompile';
 import { test, skip, moduleFor, moduleForModel, moduleForComponent, setResolver } from 'ember-qunit';
 
 moduleForComponent('x-foo', {
-    integration: true
+    integration: true,
 });
 
 moduleForComponent('x-foo', {
     unit: true,
-    needs: ['helper:pluralize-string']
+    needs: ['helper:pluralize-string'],
 });
 
 moduleForModel('user', {
-    needs: ['model:child']
+    needs: ['model:child'],
 });
 
 moduleFor('controller:home');
@@ -20,8 +20,7 @@ moduleFor('controller:home');
 moduleFor('component:x-foo', 'Some description');
 
 moduleFor('component:x-foo', 'TestModule callbacks', {
-    beforeSetup() {
-    },
+    beforeSetup() {},
 
     beforeEach(assert) {
         this.registry.register('helper:i18n', {});
@@ -38,18 +37,18 @@ moduleFor('component:x-foo', 'TestModule callbacks', {
 
     afterTeardown(assert) {
         assert.ok(true);
-    }
+    },
 });
 
 // if you don't have a custom resolver, do it like this:
 setResolver(Ember.DefaultResolver.create());
 
-test('it renders', function(assert) {
+test('it renders', function (assert) {
     assert.expect(2);
 
     // setup the outer context
     this.set('value', 'cat');
-    this.on('action', function(result) {
+    this.on('action', function (result) {
         assert.equal(result, 'bar', 'The correct result was returned');
         assert.equal(this.get('value'), 'cat');
     });
@@ -59,29 +58,27 @@ test('it renders', function(assert) {
         {{ x-foo value=value action="result" }}
     `);
     this.render('{{ x-foo value=value action="result" }}');
-    this.render([
-        '{{ x-foo value=value action="result" }}'
-    ]);
+    this.render(['{{ x-foo value=value action="result" }}']);
 
     assert.equal(this.$('div>.value').text(), 'cat', 'The component shows the correct value');
 
     this.$('button').click();
 });
 
-test('it renders', function(assert) {
+test('it renders', function (assert) {
     assert.expect(1);
 
     // creates the component instance
     const subject = this.subject();
 
     const subject2 = this.subject({
-        item: 42
+        item: 42,
     });
 
     const { inputFormat } = this.setProperties({
         inputFormat: 'M/D/YY',
         outputFormat: 'MMMM D, YYYY',
-        date: '5/3/10'
+        date: '5/3/10',
     });
 
     const { inputFormat: if2, outputFormat } = this.getProperties('inputFormat', 'outputFormat');
@@ -93,7 +90,7 @@ test('it renders', function(assert) {
     assert.equal(this.$('.foo').text(), 'bar');
 });
 
-test('It can calculate the result', function(assert) {
+test('It can calculate the result', function (assert) {
     assert.expect(1);
 
     const subject = this.subject();
@@ -104,4 +101,4 @@ test('It can calculate the result', function(assert) {
 
 skip('disabled test');
 
-skip('disabled test', function(assert) { });
+skip('disabled test', function (assert) {});

--- a/types/ember-qunit/v2/index.d.ts
+++ b/types/ember-qunit/v2/index.d.ts
@@ -8,7 +8,7 @@
 /// <reference types="qunit" />
 
 import Ember from 'ember';
-import { ModuleCallbacks, TestContext } from "ember-test-helpers";
+import { ModuleCallbacks, TestContext } from 'ember-test-helpers';
 
 interface QUnitModuleCallbacks extends ModuleCallbacks, Hooks {
     beforeSetup?(assert: Assert): void;

--- a/types/ember-qunit/v2/tslint.json
+++ b/types/ember-qunit/v2/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "space-before-function-paren": false,
         "only-arrow-functions": false
     }
 }

--- a/types/ember-resolver/tslint.json
+++ b/types/ember-resolver/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "space-before-function-paren": false
+    }
+}

--- a/types/ember-resolver/v4/ember-resolver-tests.ts
+++ b/types/ember-resolver/v4/ember-resolver-tests.ts
@@ -3,10 +3,10 @@ import EmberResolver from 'ember-resolver';
 
 const MyResolver = EmberResolver.extend({
     pluralizedTypes: {
-        sheep: 'sheep'
-    }
+        sheep: 'sheep',
+    },
 });
 
 const App = Ember.Application.extend({
-    Resolver: MyResolver
+    Resolver: MyResolver,
 });

--- a/types/ember-resolver/v4/tslint.json
+++ b/types/ember-resolver/v4/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "space-before-function-paren": false
+    }
+}

--- a/types/ember-test-helpers/tslint.json
+++ b/types/ember-test-helpers/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "space-before-function-paren": false,
         "no-declare-current-package": false,
         "npm-naming": false
     }

--- a/types/ember-test-helpers/v0/ember-test-helpers-tests.ts
+++ b/types/ember-test-helpers/v0/ember-test-helpers-tests.ts
@@ -1,5 +1,5 @@
 /// <reference types="qunit" />
-import { ModuleCallbacks, TestContext, TestModule } from "ember-test-helpers";
+import { ModuleCallbacks, TestContext, TestModule } from 'ember-test-helpers';
 import wait from 'ember-test-helpers/wait';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
@@ -14,7 +14,7 @@ function moduleFor(name: string, description: string, callbacks: ModuleCallbacks
         },
         afterEach() {
             module.teardown();
-        }
+        },
     });
 }
 
@@ -27,17 +27,17 @@ if (hasEmberVersion(2, 10)) {
 }
 
 // https://github.com/emberjs/ember-test-helpers/blob/f07e86914f2a3823c4cb6787307f9ba2bf447e68/tests/unit/setup-context-test.js
-QUnit.test('it sets up this.owner', function(this: TestContext, assert: Assert) {
+QUnit.test('it sets up this.owner', function (this: TestContext, assert: Assert) {
     const { owner } = this;
     assert.ok(owner, 'owner was setup');
     assert.equal(typeof owner.lookup, 'function', 'has expected lookup interface');
 
     if (hasEmberVersion(2, 12)) {
-      assert.equal(typeof owner.factoryFor, 'function', 'has expected factory interface');
+        assert.equal(typeof owner.factoryFor, 'function', 'has expected factory interface');
     }
 });
 
-QUnit.test('can pauseTest to be resumed "later"', async function(this: TestContext, assert: Assert) {
+QUnit.test('can pauseTest to be resumed "later"', async function (this: TestContext, assert: Assert) {
     const promise = this.pauseTest();
 
     this.resumeTest();
@@ -46,7 +46,7 @@ QUnit.test('can pauseTest to be resumed "later"', async function(this: TestConte
 });
 
 // https://github.com/emberjs/ember-test-helpers/blob/fb4c8d4cd36b54728ce180227f865b1fa0162632/tests/unit/setup-rendering-context-test.js
-QUnit.test('render exposes an `.element` property', async function(this: TestContext, assert: Assert) {
+QUnit.test('render exposes an `.element` property', async function (this: TestContext, assert: Assert) {
     await this.render(hbs`<p>Hello!</p>`);
 
     assert.equal(this.element.textContent, 'Hello!');

--- a/types/ember-test-helpers/v0/index.d.ts
+++ b/types/ember-test-helpers/v0/index.d.ts
@@ -10,7 +10,7 @@
 declare module 'ember-test-helpers' {
     import Ember from 'ember';
     import { TemplateFactory } from 'htmlbars-inline-precompile';
-    import RSVP from "rsvp";
+    import RSVP from 'rsvp';
 
     interface ModuleCallbacks {
         integration?: boolean;
@@ -84,7 +84,7 @@ declare module 'ember-test-helpers' {
 }
 
 declare module 'ember-test-helpers/wait' {
-    import RSVP from "rsvp";
+    import RSVP from 'rsvp';
 
     interface WaitOptions {
         waitForTimers?: boolean;

--- a/types/ember-test-helpers/v0/tslint.json
+++ b/types/ember-test-helpers/v0/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "space-before-function-paren": false
+    }
+}

--- a/types/ember-testing-helpers/tslint.json
+++ b/types/ember-testing-helpers/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "space-before-function-paren": false,
         "ban-types": false,
         "dt-header": false,
         "no-unnecessary-generics": false,

--- a/types/ember/test/access-modifier.ts
+++ b/types/ember/test/access-modifier.ts
@@ -6,9 +6,15 @@ import Ember from 'ember';
 import { assertType } from './lib/assert';
 
 class Foo extends Ember.Object {
-    hello() { return 'world'; }
-    protected bar() { return 'bar'; }
-    private baz() { return 'baz'; }
+    hello() {
+        return 'world';
+    }
+    protected bar() {
+        return 'bar';
+    }
+    private baz() {
+        return 'baz';
+    }
 }
 const f = new Foo();
 assertType<string>(f.hello());
@@ -18,10 +24,17 @@ assertType<string>(f.bar()); // $ExpectError
 assertType<string>(f.baz()); // $ExpectError
 
 class Foo2 extends Ember.Object.extend({
-    bar: ''
+    bar: '',
 }) {
-    hello() { return 'world'; }
+    hello() {
+        return 'world';
+    }
     // Cannot override with a mis-matched property type
-    protected bar() { return 'bar'; } // $ExpectError
-    private baz() { return 'baz'; }
+    // $ExpectError
+    protected bar() {
+        return 'bar';
+    }
+    private baz() {
+        return 'baz';
+    }
 }

--- a/types/ember/test/application-instance.ts
+++ b/types/ember/test/application-instance.ts
@@ -5,11 +5,11 @@ const appInstance = ApplicationInstance.create();
 appInstance.register('some:injection', class Foo {});
 
 appInstance.register('some:injection', class Foo {}, {
-  singleton: true,
+    singleton: true,
 });
 
 appInstance.register('some:injection', class Foo {}, {
-  instantiate: false,
+    instantiate: false,
 });
 
 appInstance.register('templates:foo/bar', hbs`<h1>Hello World</h1>`);
@@ -25,5 +25,5 @@ appInstance.lookup('route:basic');
 appInstance.boot();
 
 (async () => {
-  await appInstance.boot();
+    await appInstance.boot();
 })();

--- a/types/ember/test/application.ts
+++ b/types/ember/test/application.ts
@@ -1,37 +1,37 @@
 import Ember from 'ember';
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 const BaseApp = Ember.Application.extend({
-    modulePrefix: 'my-app'
+    modulePrefix: 'my-app',
 });
 
 BaseApp.initializer({
     name: 'my-initializer',
     initialize(app) {
         app.register('foo:bar', Ember.Object.extend({ foo: 'bar' }));
-    }
+    },
 });
 
 BaseApp.instanceInitializer({
     name: 'my-instance-initializer',
     initialize(app) {
         app.lookup('foo:bar').get('foo');
-    }
+    },
 });
 
 const App1 = BaseApp.create({
     rootElement: '#app-one',
     customEvents: {
-        paste: 'paste'
-    }
+        paste: 'paste',
+    },
 });
 
 const App2 = BaseApp.create({
     rootElement: '#app-two',
     customEvents: {
         mouseenter: null,
-        mouseleave: null
-    }
+        mouseleave: null,
+    },
 });
 
 const App3 = BaseApp.create();

--- a/types/ember/test/array-proxy.ts
+++ b/types/ember/test/array-proxy.ts
@@ -12,7 +12,7 @@ const overridden = Ember.ArrayProxy.create({
     content: Ember.A(pets),
     objectAtContent(idx: number): string {
         return this.get('content').objectAt(idx)!.toUpperCase();
-    }
+    },
 });
 
 overridden.get('firstObject'); // 'DOG'

--- a/types/ember/test/array.ts
+++ b/types/ember/test/array.ts
@@ -4,7 +4,7 @@ import { assertType } from './lib/assert';
 type Person = typeof Person.prototype;
 const Person = Ember.Object.extend({
     name: '',
-    isHappy: false
+    isHappy: false,
 });
 
 const people = Ember.A([
@@ -18,7 +18,7 @@ assertType<boolean>(people.isAny('isHappy'));
 assertType<boolean>(people.isAny('isHappy', 'false'));
 assertType<Ember.Enumerable<Person>>(people.filterBy('isHappy'));
 assertType<Ember.Enumerable<Person>>(people.rejectBy('isHappy'));
-assertType<Ember.Enumerable<Person>>(people.filter((person) => person.get('name') === 'Yehuda'));
+assertType<Ember.Enumerable<Person>>(people.filter(person => person.get('name') === 'Yehuda'));
 assertType<typeof people>(people.get('[]'));
 assertType<Person>(people.get('[]').get('firstObject'));
 

--- a/types/ember/test/component.ts
+++ b/types/ember/test/component.ts
@@ -2,10 +2,10 @@ import Ember from 'ember';
 import Component from '@ember/component';
 import Object, { computed } from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 Component.extend({
-  layout: hbs`
+    layout: hbs`
         <div>
           {{yield}}
         </div>
@@ -13,112 +13,112 @@ Component.extend({
 });
 
 Component.extend({
-  layout: 'my-layout',
+    layout: 'my-layout',
 });
 
 const MyComponent = Component.extend();
 assertType<string | string[]>(Ember.get(MyComponent, 'positionalParams'));
 
 const component1 = Component.extend({
-  actions: {
-    hello(name: string) {
-      console.log('Hello', name);
+    actions: {
+        hello(name: string) {
+            console.log('Hello', name);
+        },
     },
-  },
 });
 
 Component.extend({
-  name: '',
-  hello(name: string) {
-    this.set('name', name);
-  },
+    name: '',
+    hello(name: string) {
+        this.set('name', name);
+    },
 });
 
 Component.extend({
-  tagName: 'em',
+    tagName: 'em',
 });
 
 Component.extend({
-  classNames: ['my-class', 'my-other-class'],
+    classNames: ['my-class', 'my-other-class'],
 });
 
 Component.extend({
-  classNameBindings: ['propertyA', 'propertyB'],
-  propertyA: 'from-a',
-  propertyB: computed(function() {
-    if (!this.get('propertyA')) {
-      return 'from-b';
-    }
-  }),
+    classNameBindings: ['propertyA', 'propertyB'],
+    propertyA: 'from-a',
+    propertyB: computed(function () {
+        if (!this.get('propertyA')) {
+            return 'from-b';
+        }
+    }),
 });
 
 Component.extend({
-  classNameBindings: ['hovered'],
-  hovered: true,
+    classNameBindings: ['hovered'],
+    hovered: true,
 });
 
 Component.extend({
-  classNameBindings: ['messages.empty'],
-  messages: Object.create({
-    empty: true,
-  }),
+    classNameBindings: ['messages.empty'],
+    messages: Object.create({
+        empty: true,
+    }),
 });
 
 Component.extend({
-  classNameBindings: ['isEnabled:enabled:disabled'],
-  isEnabled: true,
+    classNameBindings: ['isEnabled:enabled:disabled'],
+    isEnabled: true,
 });
 
 Component.extend({
-  classNameBindings: ['isEnabled::disabled'],
-  isEnabled: true,
+    classNameBindings: ['isEnabled::disabled'],
+    isEnabled: true,
 });
 
 Component.extend({
-  tagName: 'a',
-  attributeBindings: ['href'],
-  href: 'http://google.com',
+    tagName: 'a',
+    attributeBindings: ['href'],
+    href: 'http://google.com',
 });
 
 Component.extend({
-  tagName: 'a',
-  attributeBindings: ['url:href'],
-  url: 'http://google.com',
+    tagName: 'a',
+    attributeBindings: ['url:href'],
+    url: 'http://google.com',
 });
 
 Component.extend({
-  tagName: 'use',
-  attributeBindings: ['xlinkHref:xlink:href'],
-  xlinkHref: '#triangle',
+    tagName: 'use',
+    attributeBindings: ['xlinkHref:xlink:href'],
+    xlinkHref: '#triangle',
 });
 
 Component.extend({
-  tagName: 'input',
-  attributeBindings: ['disabled'],
-  disabled: false,
+    tagName: 'input',
+    attributeBindings: ['disabled'],
+    disabled: false,
 });
 
 Component.extend({
-  tagName: 'input',
-  attributeBindings: ['disabled'],
-  disabled: computed(() => {
-    if ('someLogic') {
-      return true;
-    } else {
-      return false;
-    }
-  }),
+    tagName: 'input',
+    attributeBindings: ['disabled'],
+    disabled: computed(() => {
+        if ('someLogic') {
+            return true;
+        } else {
+            return false;
+        }
+    }),
 });
 
 Component.extend({
-  tagName: 'form',
-  attributeBindings: ['novalidate'],
-  novalidate: null,
+    tagName: 'form',
+    attributeBindings: ['novalidate'],
+    novalidate: null,
 });
 
 Component.extend({
-  click(event: object) {
-    // will be called when an instance's
-    // rendered element is clicked
-  },
+    click(event: object) {
+        // will be called when an instance's
+        // rendered element is clicked
+    },
 });

--- a/types/ember/test/computed.ts
+++ b/types/ember/test/computed.ts
@@ -10,11 +10,11 @@ const Person = Ember.Object.extend({
 
     noArgs: Ember.computed<string>(() => 'test'),
 
-    fullName: Ember.computed<string>('firstName', 'lastName', function() {
+    fullName: Ember.computed<string>('firstName', 'lastName', function () {
         return `${this.get('firstName')} ${this.get('lastName')}`;
     }),
 
-    fullNameReadonly: Ember.computed<string>('fullName', function() {
+    fullNameReadonly: Ember.computed<string>('fullName', function () {
         return this.get('fullName');
     }).readOnly(),
 
@@ -27,13 +27,13 @@ const Person = Ember.Object.extend({
             this.set('firstName', first);
             this.set('lastName', last);
             return value;
-        }
+        },
     }),
 
     fullNameGetOnly: Ember.computed<string>('fullName', {
         get() {
             return this.get('fullName');
-        }
+        },
     }),
 
     fullNameSetOnly: Ember.computed<string>('firstName', 'lastName', {
@@ -42,15 +42,16 @@ const Person = Ember.Object.extend({
             this.set('firstName', first);
             this.set('lastName', last);
             return value;
-        }
+        },
     }),
 
-    combinators: Ember.computed<string>(function() {
+    combinators: Ember.computed<string>(function () {
         return this.get('firstName');
-    }).property('firstName')
-      .meta({ foo: 'bar' })
-      .volatile()
-      .readOnly(),
+    })
+        .property('firstName')
+        .meta({ foo: 'bar' })
+        .volatile()
+        .readOnly(),
 
     explicitlyDeclared: alias('fullName') as Computed<string>,
 });
@@ -83,10 +84,10 @@ assertType<string>(person.get('fullNameSetOnly'));
 assertType<string>(person.get('combinators'));
 assertType<string>(person.get('explicitlyDeclared'));
 
-assertType<{ firstName: string, fullName: string, age: number }>(person.getProperties('firstName', 'fullName', 'age'));
+assertType<{ firstName: string; fullName: string; age: number }>(person.getProperties('firstName', 'fullName', 'age'));
 
 const person2 = Person.create({
-    fullName: 'Fred Smith'
+    fullName: 'Fred Smith',
 });
 
 assertType<string>(person2.get('firstName'));
@@ -94,7 +95,7 @@ assertType<string>(person2.get('fullName'));
 
 const person3 = Person.extend({
     firstName: 'Fred',
-    fullName: 'Fred Smith'
+    fullName: 'Fred Smith',
 }).create();
 
 assertType<string>(person3.get('firstName'));
@@ -102,7 +103,7 @@ assertType<string>(person3.get('fullName'));
 
 const person4 = Person.extend({
     firstName: Ember.computed(() => 'Fred'),
-    fullName: Ember.computed(() => 'Fred Smith')
+    fullName: Ember.computed(() => 'Fred Smith'),
 }).create();
 
 assertType<string>(person4.get('firstName'));
@@ -116,13 +117,13 @@ const objectWithComputedProperties = Ember.Object.extend({
     collect: Ember.computed.collect('foo', 'bar', 'baz', 'qux'),
     deprecatingAlias: Ember.computed.deprecatingAlias('foo', {
         id: 'hamster.deprecate-banana',
-        until: '3.0.0'
+        until: '3.0.0',
     }),
     empty: Ember.computed.empty('foo'),
     equalNumber: Ember.computed.equal('foo', 1),
     equalString: Ember.computed.equal('foo', 'bar'),
     equalObject: Ember.computed.equal('foo', {}),
-    filter: Ember.computed.filter('foo', (item) => item === 'bar'),
+    filter: Ember.computed.filter('foo', item => item === 'bar'),
     filterBy1: Ember.computed.filterBy('foo', 'bar'),
     filterBy2: Ember.computed.filterBy('foo', 'bar', false),
     gt: Ember.computed.gt('foo', 3),
@@ -156,11 +157,11 @@ const objectWithComputedProperties = Ember.Object.extend({
     sum: Ember.computed.sum('foo'),
     union: Ember.computed.union('foo', 'bar', 'baz', 'qux'),
     uniq: Ember.computed.uniq('foo'),
-    uniqBy: Ember.computed.uniqBy('foo', 'bar')
+    uniqBy: Ember.computed.uniqBy('foo', 'bar'),
 });
 
 const component2 = Component.extend({
-    isAnimal: or('isDog', 'isCat')
+    isAnimal: or('isDog', 'isCat'),
 }).create();
 
 assertType<boolean>(component2.get('isAnimal'));

--- a/types/ember/test/controller.ts
+++ b/types/ember/test/controller.ts
@@ -1,11 +1,11 @@
 import Controller from '@ember/controller';
 
-Controller.extend ({
-  queryParams: ['category'],
-  category: null,
-  isExpanded: false,
+Controller.extend({
+    queryParams: ['category'],
+    category: null,
+    isExpanded: false,
 
-  toggleBody() {
-    this.toggleProperty('isExpanded');
-  }
+    toggleBody() {
+        this.toggleProperty('isExpanded');
+    },
 });

--- a/types/ember/test/core-object.ts
+++ b/types/ember/test/core-object.ts
@@ -32,7 +32,7 @@ const co4 = Ember.CoreObject.extend({
     bar: 456,
     baz(): [string, number] {
         return [this.foo, this.bar];
-    }
+    },
 }).create();
 
 co4.foo; // $ExpectType string
@@ -41,11 +41,11 @@ co4.baz; // $ExpectType () => [string, number]
 
 /** .extend with inconsistent arguments passed into .create()  */
 const class05 = Ember.CoreObject.extend({
-    foo: '123' as (string | boolean),
+    foo: '123' as string | boolean,
     bar: 456,
     baz() {
         return [this.foo, this.bar];
-    }
+    },
 });
 const c05 = class05.create({ foo: 99 }); // $ExpectError
 const c05b = class05.create({ foo: true });
@@ -54,33 +54,36 @@ assertType<string>(c05b.foo); // $ExpectError
 assertType<boolean>(c05c.foo); // $ExpectError
 
 /** two .extend arguments with a zero-argument .create() */
-const co6 = Ember.CoreObject.extend({
-    foo: '123',
-    bar: 456,
-    baz() {
-        return [this.foo, this.bar];
+const co6 = Ember.CoreObject.extend(
+    {
+        foo: '123',
+        bar: 456,
+        baz() {
+            return [this.foo, this.bar];
+        },
+        func1() {
+            // this includes stuff from CoreObject
+            this.init; // $ExpectType () => void
+            // this includes stuff from this extend-arg
+            this.foo; // $ExpectType string
+            // this does not include stuff from later extend args
+            this.bee; // $ExpectError
+        },
     },
-    func1() {
-        // this includes stuff from CoreObject
-        this.init; // $ExpectType () => void
-        // this includes stuff from this extend-arg
-        this.foo; // $ExpectType string
-        // this does not include stuff from later extend args
-        this.bee; // $ExpectError
-    }
-}, {
-    foo: 99,
-    bee: 'honey',
-    func2() {
-        // this includes stuff from CoreObject
-        this.init; // $ExpectType () => void
-        // this includes stuff from this extend-arg
-        // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
-        this.foo;
-        // this includes stuff from earlier extend-args
-        this.bar; // $ExpectType number
-    }
-}).create();
+    {
+        foo: 99,
+        bee: 'honey',
+        func2() {
+            // this includes stuff from CoreObject
+            this.init; // $ExpectType () => void
+            // this includes stuff from this extend-arg
+            // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
+            this.foo;
+            // this includes stuff from earlier extend-args
+            this.bar; // $ExpectType number
+        },
+    },
+).create();
 
 // TODO: enable in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
 // assertType<string>(co6.foo); // $ExpectError
@@ -88,45 +91,49 @@ assertType<number>(co6.bar); // $ExpectType number
 assertType<() => Array<string | number>>(co6.baz); // $ExpectType () => (string | number)[]
 
 /** three .extend arguments with a zero-argument .create() */
-const co7 = Ember.CoreObject.extend({
-    foo: '123',
-    bar: 456,
-    baz() {
-        return [this.foo, this.bar];
+const co7 = Ember.CoreObject.extend(
+    {
+        foo: '123',
+        bar: 456,
+        baz() {
+            return [this.foo, this.bar];
+        },
+        func1() {
+            // this includes stuff from CoreObject
+            this.init; // $ExpectType () => void
+            // this includes stuff from this extend-arg
+            this.foo; // $ExpectType string
+            // this does not include stuff from later extend args
+            this.bee; // $ExpectError
+        },
     },
-    func1() {
-        // this includes stuff from CoreObject
-        this.init; // $ExpectType () => void
-        // this includes stuff from this extend-arg
-        this.foo; // $ExpectType string
-        // this does not include stuff from later extend args
-        this.bee; // $ExpectError
-    }
-}, {
-    foo: 99,
-    bee: 'honey',
-    func2() {
-        // this includes stuff from CoreObject
-        this.init; // $ExpectType () => void
-        // this includes stuff from this extend-arg
-        // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
-        this.foo;
-        // this includes stuff from earlier extend-args
-        this.bar; // $ExpectType number
-    }
-}, {
-    foo: '99',
-    money: 'in the banana stand',
-    func3() {
-        // this includes stuff from CoreObject
-        this.init; // $ExpectType () => void
-        // this includes stuff from this extend-arg
-        this.money; // $ExpectType string
-        // this includes stuff from earlier extend-args
-        this.bee; // $ExpectType string
-        this.bar; // $ExpectType number
-    }
-}).create();
+    {
+        foo: 99,
+        bee: 'honey',
+        func2() {
+            // this includes stuff from CoreObject
+            this.init; // $ExpectType () => void
+            // this includes stuff from this extend-arg
+            // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
+            this.foo;
+            // this includes stuff from earlier extend-args
+            this.bar; // $ExpectType number
+        },
+    },
+    {
+        foo: '99',
+        money: 'in the banana stand',
+        func3() {
+            // this includes stuff from CoreObject
+            this.init; // $ExpectType () => void
+            // this includes stuff from this extend-arg
+            this.money; // $ExpectType string
+            // this includes stuff from earlier extend-args
+            this.bee; // $ExpectType string
+            this.bar; // $ExpectType number
+        },
+    },
+).create();
 // TODO: enable in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
 // assertType<number>(co7.foo); // $ExpectError
 assertType<number>(co7.bar); // $ExpectType number
@@ -134,62 +141,67 @@ assertType<string>(co7.money); // $ExpectType string
 assertType<() => Array<string | number>>(co7.baz); // $ExpectType () => (string | number)[]
 
 /** four .extend arguments with a zero-argument .create() */
-const co8 = Ember.CoreObject.extend({
-    foo: '123',
-    bar: 456,
-    baz() {
-        return [this.foo, this.bar];
+const co8 = Ember.CoreObject.extend(
+    {
+        foo: '123',
+        bar: 456,
+        baz() {
+            return [this.foo, this.bar];
+        },
+        func1() {
+            // this includes stuff from CoreObject
+            this.init; // $ExpectType () => void
+            // this includes stuff from this extend-arg
+            this.foo; // $ExpectType string
+            // this does not include stuff from later extend args
+            this.bee; // $ExpectError
+        },
     },
-    func1() {
-        // this includes stuff from CoreObject
-        this.init; // $ExpectType () => void
-        // this includes stuff from this extend-arg
-        this.foo; // $ExpectType string
-        // this does not include stuff from later extend args
-        this.bee; // $ExpectError
-    }
-}, {
-    foo: 99,
-    bee: 'honey',
-    func2() {
-        // this includes stuff from CoreObject
-        this.init; // $ExpectType () => void
-        // this includes stuff from this extend-arg
-        // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
-        this.foo;
-        // this includes stuff from earlier extend-args
-        this.bar; // $ExpectType number
-        // this does not include stuff from later extend args
-        this.money; // $ExpectError
-    }
-}, {
-    foo: '99',
-    money: 'in the banana stand',
-    func3() {
-        // this includes stuff from CoreObject
-        this.init; // $ExpectType () => void
-        // this includes stuff from this extend-arg
-        this.money; // $ExpectType string
-        // this includes stuff from earlier extend-args
-        this.bee; // $ExpectType string
-        this.bar; // $ExpectType number
-        // this does not include stuff from later extend args
-        this.neighborhood; // $ExpectError
-    }
-}, {
-    foo: '99',
-    neighborhood: 'sudden valley',
-    func4() {
-        // this includes stuff from CoreObject
-        this.init; // $ExpectType () => void
-        // this includes stuff from this extend-arg
-        this.neighborhood; // $ExpectType string
-        // this includes stuff from earlier extend-args
-        this.bee; // $ExpectType string
-        this.bar; // $ExpectType number
-        this.money; // $ExpectType string
-    }
-}).create();
+    {
+        foo: 99,
+        bee: 'honey',
+        func2() {
+            // this includes stuff from CoreObject
+            this.init; // $ExpectType () => void
+            // this includes stuff from this extend-arg
+            // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
+            this.foo;
+            // this includes stuff from earlier extend-args
+            this.bar; // $ExpectType number
+            // this does not include stuff from later extend args
+            this.money; // $ExpectError
+        },
+    },
+    {
+        foo: '99',
+        money: 'in the banana stand',
+        func3() {
+            // this includes stuff from CoreObject
+            this.init; // $ExpectType () => void
+            // this includes stuff from this extend-arg
+            this.money; // $ExpectType string
+            // this includes stuff from earlier extend-args
+            this.bee; // $ExpectType string
+            this.bar; // $ExpectType number
+            // this does not include stuff from later extend args
+            this.neighborhood; // $ExpectError
+        },
+    },
+    {
+        foo: '99',
+        neighborhood: 'sudden valley',
+        func4() {
+            // this includes stuff from CoreObject
+            this.init; // $ExpectType () => void
+            // this includes stuff from this extend-arg
+            this.neighborhood; // $ExpectType string
+            // this includes stuff from earlier extend-args
+            this.bee; // $ExpectType string
+            this.bar; // $ExpectType number
+            this.money; // $ExpectType string
+        },
+    },
+).create();
 
 // TODO: enable in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
 // assertType<number>(co8.foo); // $ExpectError

--- a/types/ember/test/create.ts
+++ b/types/ember/test/create.ts
@@ -15,7 +15,7 @@ assertType<(key: string) => any>(o.get); // from prototype
 /**
  * One-argument case
  */
-const o1 = Ember.Object.create({x: 9, y: 'hello', z: false});
+const o1 = Ember.Object.create({ x: 9, y: 'hello', z: false });
 assertType<number>(o1.x);
 assertType<string>(o1.y);
 o1.y; // $ExpectType string
@@ -27,9 +27,9 @@ assertType<number>(obj.a);
 assertType<number>(obj.c);
 
 export class Person extends Ember.Object.extend({
-    fullName: Ember.computed('firstName', 'lastName', function() {
+    fullName: Ember.computed('firstName', 'lastName', function () {
         return [this.firstName + this.lastName].join(' ');
-    })
+    }),
 }) {
     firstName: string;
     lastName: string;
@@ -46,7 +46,7 @@ const p2b = Person.create({}, { firstName: 'string' });
 const p2c = Person.create({}, {}, { firstName: 'string' });
 
 export class PersonWithNumberName extends Person.extend({
-  fullName: 6
+    fullName: 6,
 }) {}
 
 const p4 = new PersonWithNumberName();

--- a/types/ember/test/data-adapter.ts
+++ b/types/ember/test/data-adapter.ts
@@ -3,13 +3,14 @@ import Ember from 'ember';
 const da = Ember.DataAdapter.create();
 
 const filters = da.getFilters();
-filters.includes({ name: 'foo', desc: 'bar'}); // $ExpectType boolean
+filters.includes({ name: 'foo', desc: 'bar' }); // $ExpectType boolean
 filters.includes({}); // $ExpectError
 
 filters[0].name; // $ExpectType string
 filters[0].desc; // $ExpectType string
 
-da.watchModelTypes(// $ExpectType () => void
+// $ExpectType () => void
+da.watchModelTypes(
     function added(wrappedTypes) {
         wrappedTypes;
         wrappedTypes[0].release; // $ExpectType () => void
@@ -25,11 +26,13 @@ da.watchModelTypes(// $ExpectType () => void
         wrappedTypes[0].type.columns[0].name; // $ExpectType string
         wrappedTypes[0].type.count; // $ExpectType number
         wrappedTypes[0].type.name; // $ExpectType string
-    }
+    },
 );
-da.watchModelTypes(() => void); // $ExpectError
+da.watchModelTypes(() => {}); // $ExpectError
 
-da.watchRecords('house', // $ExpectType () => void
+// $ExpectType () => void
+da.watchRecords(
+    'house',
     function added(records) {
         records[0].object; // $ExpectType object
         records[0].columnValues; // $ExpectType object
@@ -39,11 +42,11 @@ da.watchRecords('house', // $ExpectType () => void
         records[0].columnValues; // $ExpectType object
     },
     function removed(idx, count) {
-        idx;    // $ExpectType number
-        count;  // $ExpectType number
-    }
+        idx; // $ExpectType number
+        count; // $ExpectType number
+    },
 );
-da.watchRecords(() => void); // $ExpectError
+da.watchRecords(() => {}); // $ExpectError
 
 da.acceptsModelName; // $ExpectType boolean
 da.containerDebugAdapter; // $ExpectType ContainerDebugAdapter

--- a/types/ember/test/debug.ts
+++ b/types/ember/test/debug.ts
@@ -4,7 +4,7 @@ const {
     runInDebug,
     warn,
     debug,
-    Debug: { registerDeprecationHandler, registerWarnHandler }
+    Debug: { registerDeprecationHandler, registerWarnHandler },
 } = Ember;
 
 // Workaround for https://github.com/microsoft/TypeScript/issues/36931.
@@ -20,8 +20,9 @@ runInDebug(() => console.log('Should not show up in prod')); // $ExpectType void
 const tomsterCount = 2;
 warn('Too many tomsters!'); // $ExpectType void
 warn('Too many tomsters!', tomsterCount <= 3); // $ExpectType void
-warn('Too many tomsters!', tomsterCount <= 3, { // $ExpectType void
-    id: 'ember-debug.too-many-tomsters'
+// $ExpectType void
+warn('Too many tomsters!', tomsterCount <= 3, {
+    id: 'ember-debug.too-many-tomsters',
 });
 
 debug(); // $ExpectError
@@ -31,26 +32,30 @@ debug('Too many tomsters!', 'foo'); // $ExpectError
 // next is not called, so no warnings get the default behavior
 registerWarnHandler(); // $ExpectError
 registerWarnHandler(() => {}); // $ExpectType void
-registerWarnHandler((message, { id }, next) => { // $ExpectType void
+// $ExpectType void
+registerWarnHandler((message, { id }, next) => {
     message; // $ExpectType string
     id; // $ExpectType string
     next; // $ExpectType (message?: string | undefined, options?: { id: string; } | undefined) => void
 });
-registerWarnHandler((message, { id }, next) => { // $ExpectType void
-  message; // $ExpectType string
-  id; // $ExpectType string
-  next(); // $ExpectType void
+// $ExpectType void
+registerWarnHandler((message, { id }, next) => {
+    message; // $ExpectType string
+    id; // $ExpectType string
+    next(); // $ExpectType void
 });
-registerWarnHandler((message, { id }, next) => { // $ExpectType void
-  message; // $ExpectType string
-  id; // $ExpectType string
-  next(message, { id }); // $ExpectType void
+// $ExpectType void
+registerWarnHandler((message, { id }, next) => {
+    message; // $ExpectType string
+    id; // $ExpectType string
+    next(message, { id }); // $ExpectType void
 });
 
 // next is not called, so no warnings get the default behavior
 registerDeprecationHandler(); // $ExpectError
 registerDeprecationHandler(() => {}); // $ExpectType void
-registerDeprecationHandler((message, { id, until }, next) => { // $ExpectType void
+// $ExpectType void
+registerDeprecationHandler((message, { id, until }, next) => {
     message; // $ExpectType string
     id; // $ExpectType string
     until; // $ExpectType string

--- a/types/ember/test/detect-instance.ts
+++ b/types/ember/test/detect-instance.ts
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { assertType } from './lib/assert';
 
 const ExtendClass = Ember.Object.extend({
-    foo: 'hello'
+    foo: 'hello',
 });
 
 class ES6Class extends Ember.Object {

--- a/types/ember/test/detect.ts
+++ b/types/ember/test/detect.ts
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { assertType } from './lib/assert';
 
 const ExtendClass = Ember.Object.extend({
-    foo: 'hello'
+    foo: 'hello',
 });
 
 class ES6Class extends Ember.Object {

--- a/types/ember/test/ember-module-tests.ts
+++ b/types/ember/test/ember-module-tests.ts
@@ -40,7 +40,7 @@ Ember.debug('some info for developers');
 // deprecate
 Ember.deprecate("you shouldn't use this anymore", 3 === 3, {
     id: 'no-longer-allowed',
-    until: '99.0.0'
+    until: '99.0.0',
 });
 // get
 Ember.get({ z: 23 }, 'z'); // $ExpectType number
@@ -87,13 +87,13 @@ const o2 = Ember.Object.extend({
     name: 'foo',
     age: 3,
     nameWatcher: Ember.observer('name', () => {}),
-    nameWatcher2: Ember.observer('name', 'fullName', () => {})
+    nameWatcher2: Ember.observer('name', 'fullName', () => {}),
 });
 // on
 const o3 = Ember.Object.extend({
     name: 'foo',
     nameWatcher: Ember.on('init', () => {}),
-    nameWatcher2: Ember.on('destroy', () => {})
+    nameWatcher2: Ember.on('destroy', () => {}),
 });
 // removeListener
 Ember.addListener(o2, 'create', () => {});
@@ -167,7 +167,7 @@ const cp: Ember.ComputedProperty<string, string> = Ember.computed('foo', {
     },
     set(_key: string, newVal: string): string {
         return '';
-    }
+    },
 });
 // Ember.ContainerDebugAdapter
 const cda = new Ember.ContainerDebugAdapter(); // $ExpectType ContainerDebugAdapter
@@ -196,7 +196,7 @@ new Ember.Error('Halp!');
 const oe1 = Ember.Object.extend(Ember.Evented).create();
 oe1.trigger('foo');
 oe1.on('bar', () => {});
-oe1.on('bar', { foo() {}}, () => {});
+oe1.on('bar', { foo() {} }, () => {});
 // Ember.HashLocation
 const hl = new Ember.HashLocation(); // $ExpectType HashLocation
 // Ember.Helper
@@ -204,7 +204,7 @@ const h1 = Ember.Helper.extend({
     compute() {
         this.recompute();
         return '';
-    }
+    },
 });
 // Ember.HistoryLocation
 const hil = new Ember.HistoryLocation(); // $ExpectType HistoryLocation
@@ -214,16 +214,10 @@ Ember.LinkComponent.create(); // $ExpectType LinkComponent
 Ember.Object.extend(Ember.Mixin.create({ foo: 'bar' }), {
     baz() {
         this.foo; // $ExpectType string
-    }
+    },
 });
 // Ember.MutableArray
-const ma1: Ember.MutableArray<string> = [
-    'money',
-    'in',
-    'the',
-    'bananna',
-    'stand'
-];
+const ma1: Ember.MutableArray<string> = ['money', 'in', 'the', 'bananna', 'stand'];
 ma1.addObject('!'); // $ExpectType string
 ma1.filterBy(''); // $ExpectType NativeArray<string>
 ma1.firstObject; // $ExpectType string | undefined
@@ -238,7 +232,7 @@ const na: Ember.NativeArray<number> = Ember.A([2, 3, 4]);
 na; // $ExpectType NativeArray<number>
 na.clear(); // $ExpectType NativeArray<number>
 // Ember.NoneLocation
-new Ember.NoneLocation();  // $ExpectType NoneLocation
+new Ember.NoneLocation(); // $ExpectType NoneLocation
 // Ember.Object
 new Ember.Object();
 // Ember.ObjectProxy
@@ -250,7 +244,7 @@ Ember.Object.extend(Ember.PromiseProxyMixin, {
     foo() {
         this.reason; // $ExpectType any
         this.isPending; // $ExpectType boolean
-    }
+    },
 });
 // Ember.Route
 new Ember.Route();
@@ -288,14 +282,14 @@ Ember.Test.checkWaiters(); // $ExpectType boolean
  * stay gone
  */
 
- Ember.bind; // $ExpectError
- Ember.deprecate('foo', 'bar'); // $ExpectError
- Ember.K; // $ExpectError
- Ember.Binding; // $ExpectError
- Ember.Transition; // $ExpectError
- Ember.create; // $ExpectError
- Ember.reset; // $ExpectError
- Ember.unsubscribe; // $ExpectError
- Ember.subscribe; // $ExpectError
- Ember.instrument; // $ExpectError
- Ember.Instrumentation; // $ExpectError
+Ember.bind; // $ExpectError
+Ember.deprecate('foo', 'bar'); // $ExpectError
+Ember.K; // $ExpectError
+Ember.Binding; // $ExpectError
+Ember.Transition; // $ExpectError
+Ember.create; // $ExpectError
+Ember.reset; // $ExpectError
+Ember.unsubscribe; // $ExpectError
+Ember.subscribe; // $ExpectError
+Ember.instrument; // $ExpectError
+Ember.Instrumentation; // $ExpectError

--- a/types/ember/test/ember-tests.ts
+++ b/types/ember/test/ember-tests.ts
@@ -13,7 +13,7 @@ App.country.get('presidentName');
 App.president = Ember.Object.create({
     firstName: 'Barack',
     lastName: 'Obama',
-    fullName: Ember.computed(function() {
+    fullName: Ember.computed(function () {
         return `${this.get('firstName')} ${this.get('lastName')}`;
     }),
 });
@@ -48,7 +48,7 @@ PersonReopened.create().get('isPerson');
 
 App.todosController = Ember.Object.create({
     todos: [Ember.Object.create({ isDone: false })],
-    remaining: Ember.computed('todos.@each.isDone', function() {
+    remaining: Ember.computed('todos.@each.isDone', function () {
         const todos = this.get('todos');
         return todos.filterProperty('isDone', false).get('length');
     }),
@@ -95,7 +95,7 @@ App.userController = Ember.Object.create({
 Ember.Handlebars.registerHelper(
     'highlight',
     (property: string, options: any) =>
-        new Ember.Handlebars.SafeString('<span class="highlight">' + 'some value' + '</span>')
+        new Ember.Handlebars.SafeString('<span class="highlight">' + 'some value' + '</span>'),
 );
 
 const coolView = App.CoolView.create();
@@ -150,7 +150,7 @@ promise.then(
     },
     (reason: any) => {
         // on rejection
-    }
+    },
 );
 
 // make sure Ember.RSVP.Promise can be reference as a type
@@ -170,4 +170,4 @@ const component1 = Ember.Component.extend(mix1, mix2, {
 });
 
 // make sure htmlSafe returns a SafeString
-Ember.String.htmlSafe("hello"); // $ExpectType SafeString
+Ember.String.htmlSafe('hello'); // $ExpectType SafeString

--- a/types/ember/test/engine-instance.ts
+++ b/types/ember/test/engine-instance.ts
@@ -5,11 +5,11 @@ const engineInstance = EngineInstance.create();
 engineInstance.register('some:injection', class Foo {});
 
 engineInstance.register('some:injection', class Foo {}, {
-  singleton: true,
+    singleton: true,
 });
 
 engineInstance.register('some:injection', class Foo {}, {
-  instantiate: false,
+    instantiate: false,
 });
 
 engineInstance.register('some:injection', class Foo {}, {
@@ -23,5 +23,5 @@ engineInstance.lookup('route:basic');
 engineInstance.boot();
 
 (async () => {
-  await engineInstance.boot();
+    await engineInstance.boot();
 })();

--- a/types/ember/test/engine.ts
+++ b/types/ember/test/engine.ts
@@ -1,37 +1,37 @@
 import Ember from 'ember';
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 const BaseEngine = Ember.Engine.extend({
-    modulePrefix: 'my-engine'
+    modulePrefix: 'my-engine',
 });
 
 BaseEngine.initializer({
     name: 'my-initializer',
     initialize(engine) {
         engine.register('foo:bar', Ember.Object.extend({ foo: 'bar' }));
-    }
+    },
 });
 
 BaseEngine.instanceInitializer({
     name: 'my-instance-initializer',
     initialize(engine) {
         engine.lookup('foo:bar').get('foo');
-    }
+    },
 });
 
 const Engine1 = BaseEngine.create({
     rootElement: '#engine-one',
     customEvents: {
-        paste: 'paste'
-    }
+        paste: 'paste',
+    },
 });
 
 const Engine2 = BaseEngine.create({
     rootElement: '#engine-two',
     customEvents: {
         mouseenter: null,
-        mouseleave: null
-    }
+        mouseleave: null,
+    },
 });
 
 const Engine3 = BaseEngine.create();

--- a/types/ember/test/error.ts
+++ b/types/ember/test/error.ts
@@ -1,5 +1,5 @@
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
-import Ember from "ember";
+import Ember from 'ember';
 
 assertType<typeof Ember.Error>(Ember.Error);

--- a/types/ember/test/event.ts
+++ b/types/ember/test/event.ts
@@ -4,7 +4,7 @@ function testOn() {
     const Job = Ember.Object.extend({
         logCompleted: Ember.on('completed', () => {
             console.log('Job completed!');
-        })
+        }),
     });
 
     const job = Job.create();
@@ -16,7 +16,7 @@ function testEvented() {
     const Person = Ember.Object.extend(Ember.Evented, {
         greet() {
             this.trigger('greet');
-        }
+        },
     });
 
     const person = Person.create();
@@ -25,11 +25,14 @@ function testEvented() {
         console.log('Our person has greeted');
     });
 
-    person.on('greet', () => {
-        console.log('Our person has greeted');
-    }).one('greet', () => {
-        console.log('Offer one-time special');
-    }).off('event', {}, () => {});
+    person
+        .on('greet', () => {
+            console.log('Our person has greeted');
+        })
+        .one('greet', () => {
+            console.log('Offer one-time special');
+        })
+        .off('event', {}, () => {});
 
     person.greet();
 }
@@ -38,7 +41,7 @@ function testObserver() {
     Ember.Object.extend({
         valueObserver: Ember.observer('value', () => {
             // Executes whenever the "value" property changes
-        })
+        }),
     });
 }
 
@@ -52,7 +55,6 @@ function testListener() {
             Ember.removeListener(this, 'willDestroyElement', this, 'willDestroyListener');
             Ember.removeListener(this, 'willDestroyElement', this, this.willDestroyListener);
         },
-        willDestroyListener() {
-        }
+        willDestroyListener() {},
     });
 }

--- a/types/ember/test/extend.ts
+++ b/types/ember/test/extend.ts
@@ -10,7 +10,7 @@ const Person = Ember.Object.extend({
     },
     getFullName2(): string {
         return `${this.get('firstName')} ${this.get('lastName')}`;
-    }
+    },
 });
 
 assertType<string>(Person.prototype.firstName);
@@ -19,7 +19,7 @@ assertType<() => string>(Person.prototype.getFullName);
 const person = Person.create({
     firstName: 'Joe',
     lastName: 'Blow',
-    extra: 42
+    extra: 42,
 });
 
 assertType<string>(person.getFullName());
@@ -43,7 +43,7 @@ assertType<string>(ES6Person.prototype.fullName);
 const es6Person = ES6Person.create({
     firstName: 'Joe',
     lastName: 'Blow',
-    extra: 42
+    extra: 42,
 });
 
 assertType<string>(es6Person.fullName);

--- a/types/ember/test/function-ext.ts
+++ b/types/ember/test/function-ext.ts
@@ -9,17 +9,17 @@ Ember.Object.extend({
     foo: '',
 
     // tslint:disable-next-line:only-arrow-functions
-    arr: function() {
+    arr: function () {
         return [];
     }.property(),
 
-    alias: function(this: any) {
+    alias: function (this: any) {
         return this.get('foo');
     }.property('foo', 'bar.@each.baz'),
 
     // tslint:disable-next-line:only-arrow-functions
-    observer: function() {}.observes('foo', 'bar'),
+    observer: function () {}.observes('foo', 'bar'),
 
     // tslint:disable-next-line:only-arrow-functions
-    on: function() {}.on('foo', 'bar'),
+    on: function () {}.on('foo', 'bar'),
 });

--- a/types/ember/test/helper.ts
+++ b/types/ember/test/helper.ts
@@ -22,26 +22,24 @@ declare module '@ember/service' {
 
 const CurrentUserEmailHelper = Ember.Helper.extend({
     session: Ember.inject.service('session'),
-    onNewUser: Ember.observer('session.currentUser', function(this: Ember.Helper) {
+    onNewUser: Ember.observer('session.currentUser', function (this: Ember.Helper) {
         this.recompute();
     }),
     compute(): string {
-        return this.get('session')
-            .get('currentUser')
-            .get('email');
+        return this.get('session').get('currentUser').get('email');
     },
 });
 
 import { helper } from '@ember/component/helper';
 
 function typedHelp(/*params, hash*/) {
-  return 'my type of help';
+    return 'my type of help';
 }
 
 export default helper(typedHelp);
 
 function arrayNumHelp(/*params, hash*/) {
-  return [1, 2, 3];
+    return [1, 2, 3];
 }
 
 helper(arrayNumHelp);

--- a/types/ember/test/inject.ts
+++ b/types/ember/test/inject.ts
@@ -12,13 +12,13 @@ class ApplicationController extends Ember.Controller {
 
 declare module '@ember/service' {
     interface Registry {
-        'auth': AuthService;
+        auth: AuthService;
     }
 }
 
 declare module '@ember/controller' {
     interface Registry {
-        'application': ApplicationController;
+        application: ApplicationController;
     }
 }
 

--- a/types/ember/test/mixin.ts
+++ b/types/ember/test/mixin.ts
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 interface EditableMixin {
     edit(): void;
@@ -12,7 +12,7 @@ const EditableMixin = Ember.Mixin.create<EditableMixin, Ember.Route>({
         console.log('starting to edit');
         this.set('isEditing', true);
     },
-    isEditing: false
+    isEditing: false,
 });
 
 const EditableComment = Ember.Route.extend(EditableMixin, {
@@ -26,11 +26,11 @@ const EditableComment = Ember.Route.extend(EditableMixin, {
         if (this.canEdit()) {
             this.edit();
         }
-    }
+    },
 });
 
 const comment = EditableComment.create({
-    postId: 42
+    postId: 42,
 });
 
 comment.edit();

--- a/types/ember/test/object.ts
+++ b/types/ember/test/object.ts
@@ -11,7 +11,7 @@ const LifetimeHooks = Ember.Object.extend({
     willDestroy() {
         delete this.resource;
         this._super();
-    }
+    },
 });
 
 class MyObject30 extends Ember.Object {
@@ -28,9 +28,13 @@ class MyObject31 extends Ember.Object {
 
 class Foo extends Ember.Object.extend({
     a: Ember.computed({
-        get() { return ''; },
-        set(key: string, newVal: string) { return ''; }
-    })
+        get() {
+            return '';
+        },
+        set(key: string, newVal: string) {
+            return '';
+        },
+    }),
 }) {
     b = 5;
     baz() {
@@ -45,31 +49,31 @@ class Foo extends Ember.Object.extend({
         // this.setProperties({ b: '11' }); // $ExpectError
         this.setProperties({
             a: 'def',
-            b: 11
+            b: 11,
         });
     }
 }
 
 export class Foo2 extends Ember.Object {
-  name!: string;
+    name!: string;
 
-  changeName(name: string) {
-    const a: string = this.set('name', name);
-    const b: number = this.set('name', name); // $ExpectError
-    const x: string = Ember.set(this, 'name', name);
-    const y: number = Ember.set(this, 'name', name); // $ExpectError
-    this.setProperties({
-        name
-    });
-    Ember.setProperties(this, {
-        name
-    });
-  }
+    changeName(name: string) {
+        const a: string = this.set('name', name);
+        const b: number = this.set('name', name); // $ExpectError
+        const x: string = Ember.set(this, 'name', name);
+        const y: number = Ember.set(this, 'name', name); // $ExpectError
+        this.setProperties({
+            name,
+        });
+        Ember.setProperties(this, {
+            name,
+        });
+    }
 
-  bar() {
-      Ember.notifyPropertyChange(this, 'name');
-      Ember.notifyPropertyChange(this); // $ExpectError
-      Ember.notifyPropertyChange('name'); // $ExpectError
-      Ember.notifyPropertyChange(this, 'name', 'bar'); // $ExpectError
-  }
+    bar() {
+        Ember.notifyPropertyChange(this, 'name');
+        Ember.notifyPropertyChange(this); // $ExpectError
+        Ember.notifyPropertyChange('name'); // $ExpectError
+        Ember.notifyPropertyChange(this, 'name', 'bar'); // $ExpectError
+    }
 }

--- a/types/ember/test/observable.ts
+++ b/types/ember/test/observable.ts
@@ -35,9 +35,9 @@ myComponent.set('foo', 'baz');
 const person = Ember.Object.create({
     name: 'Fred',
     age: 29,
-    capitalized: Ember.computed<string>(function() {
+    capitalized: Ember.computed<string>(function () {
         return this.get('name').toUpperCase();
-    })
+    }),
 });
 
 const pojo = { name: 'Fred', age: 29 };
@@ -54,14 +54,16 @@ function testGet() {
 
 function testGetProperties() {
     assertType<{ name: string }>(Ember.getProperties(person, 'name'));
-    assertType<{ name: string, age: number }>(Ember.getProperties(person, 'name', 'age'));
-    assertType<{ name: string, age: number }>(Ember.getProperties(person, [ 'name', 'age' ]));
-    assertType<{ name: string, age: number, capitalized: string }>(Ember.getProperties(person, 'name', 'age', 'capitalized'));
+    assertType<{ name: string; age: number }>(Ember.getProperties(person, 'name', 'age'));
+    assertType<{ name: string; age: number }>(Ember.getProperties(person, ['name', 'age']));
+    assertType<{ name: string; age: number; capitalized: string }>(
+        Ember.getProperties(person, 'name', 'age', 'capitalized'),
+    );
     assertType<{ name: string }>(person.getProperties('name'));
-    assertType<{ name: string, age: number }>(person.getProperties('name', 'age'));
-    assertType<{ name: string, age: number }>(person.getProperties([ 'name', 'age' ]));
-    assertType<{ name: string, age: number, capitalized: string }>(person.getProperties('name', 'age', 'capitalized'));
-    assertType<{ name: string, age: number }>(Ember.getProperties(pojo, 'name', 'age'));
+    assertType<{ name: string; age: number }>(person.getProperties('name', 'age'));
+    assertType<{ name: string; age: number }>(person.getProperties(['name', 'age']));
+    assertType<{ name: string; age: number; capitalized: string }>(person.getProperties('name', 'age', 'capitalized'));
+    assertType<{ name: string; age: number }>(Ember.getProperties(pojo, 'name', 'age'));
 }
 
 function testGetWithDefault() {
@@ -86,12 +88,12 @@ function testSet() {
 
 function testSetProperties() {
     assertType<{ name: string }>(Ember.setProperties(person, { name: 'Joe' }));
-    assertType<{ name: string, age: number }>(Ember.setProperties(person, { name: 'Joe', age: 35 }));
-    assertType<{ name: string, capitalized: string }>(Ember.setProperties(person, { name: 'Joe', capitalized: 'JOE' }));
+    assertType<{ name: string; age: number }>(Ember.setProperties(person, { name: 'Joe', age: 35 }));
+    assertType<{ name: string; capitalized: string }>(Ember.setProperties(person, { name: 'Joe', capitalized: 'JOE' }));
     assertType<{ name: string }>(person.setProperties({ name: 'Joe' }));
-    assertType<{ name: string, age: number }>(person.setProperties({ name: 'Joe', age: 35 }));
-    assertType<{ name: string, capitalized: string }>(person.setProperties({ name: 'Joe', capitalized: 'JOE' }));
-    assertType<{ name: string, age: number }>(Ember.setProperties(pojo, { name: 'Joe', age: 35 }));
+    assertType<{ name: string; age: number }>(person.setProperties({ name: 'Joe', age: 35 }));
+    assertType<{ name: string; capitalized: string }>(person.setProperties({ name: 'Joe', capitalized: 'JOE' }));
+    assertType<{ name: string; age: number }>(Ember.setProperties(pojo, { name: 'Joe', age: 35 }));
 }
 
 function testDynamic() {
@@ -103,11 +105,11 @@ function testDynamic() {
     assertType<string>(Ember.getWithDefault(obj, 'dummy', 'default'));
     assertType<string>(Ember.getWithDefault(obj, dynamicKey, 'default'));
     assertType<{ dummy: any }>(Ember.getProperties(obj, 'dummy'));
-    assertType<{ dummy: any }>(Ember.getProperties(obj, [ 'dummy' ]));
+    assertType<{ dummy: any }>(Ember.getProperties(obj, ['dummy']));
     assertType<object>(Ember.getProperties(obj, dynamicKey));
-    assertType<object>(Ember.getProperties(obj, [ dynamicKey ]));
+    assertType<object>(Ember.getProperties(obj, [dynamicKey]));
     assertType<string>(Ember.set(obj, 'dummy', 'value'));
     assertType<string>(Ember.set(obj, dynamicKey, 'value'));
-    assertType<{ dummy: string }>(Ember.setProperties(obj, { dummy: 'value '}));
+    assertType<{ dummy: string }>(Ember.setProperties(obj, { dummy: 'value ' }));
     assertType<object>(Ember.setProperties(obj, { [dynamicKey]: 'value' }));
 }

--- a/types/ember/test/private/computed-tests.ts
+++ b/types/ember/test/private/computed-tests.ts
@@ -3,21 +3,20 @@ import {
     UnwrapComputedPropertySetters,
     UnwrapComputedPropertyGetters,
     UnwrapComputedPropertySetter,
-    UnwrapComputedPropertyGetter
+    UnwrapComputedPropertyGetter,
 } from '@ember/object/-private/types';
 import { assertType } from '../lib/assert';
 
 class Example1 extends Ember.Object.extend({
     firstName: '',
     lastName: '',
-    allNames: Ember.computed('fullName', function() {
+    allNames: Ember.computed('fullName', function () {
         return [this.fullName];
     }) as Ember.ComputedProperty<string[]>,
-    fullName: Ember.computed('firstName', 'lastName', function() {
+    fullName: Ember.computed('firstName', 'lastName', function () {
         return `${this.firstName} ${this.lastName}`;
-    })
-}) {
-}
+    }),
+}) {}
 
 const unwrappedGetters1: UnwrapComputedPropertyGetters<Example1> = {} as any;
 unwrappedGetters1.firstName; // $ExpectType string
@@ -32,12 +31,12 @@ unwrappedSetters1.fullName; // $ExpectType string
 unwrappedSetters1.allNames; // $ExpectType string[]
 
 class Example2 extends Ember.Object.extend({
-    allNames: Ember.computed('fullName', function() {
+    allNames: Ember.computed('fullName', function () {
         return [this.fullName + ''];
     }),
-    fullName: Ember.computed('firstName', 'lastName', function() {
+    fullName: Ember.computed('firstName', 'lastName', function () {
         return `${this.firstName} ${this.lastName}`;
-    })
+    }),
 }) {
     firstName = '';
     lastName = '';
@@ -55,7 +54,9 @@ class Example2 extends Ember.Object.extend({
 }
 const ex2 = new Example2();
 
-const unwrappedGetters2: UnwrapComputedPropertyGetters<typeof ex2> = (ex2 as any) as UnwrapComputedPropertyGetters<typeof ex2>;
+const unwrappedGetters2: UnwrapComputedPropertyGetters<typeof ex2> = (ex2 as any) as UnwrapComputedPropertyGetters<
+    typeof ex2
+>;
 assertType<string>(unwrappedGetters2.firstName); // $ExpectType string
 assertType<string>(unwrappedGetters2.lastName); // $ExpectType string
 assertType<string>(unwrappedGetters2.fullName); // $ExpectType string
@@ -74,34 +75,18 @@ ex2.firstName; // $ExpectType string
 type UnwStringSet = UnwrapComputedPropertySetter<string>; // $ExpectType string
 type UnwStringGet = UnwrapComputedPropertyGetter<string>; // $ExpectType string
 // $ExpectType string
-type UnwCpStringSet1 = UnwrapComputedPropertySetter<
-    Ember.ComputedProperty<string>
->;
+type UnwCpStringSet1 = UnwrapComputedPropertySetter<Ember.ComputedProperty<string>>;
 // $ExpectType string
-type UnwCpStringGet1 = UnwrapComputedPropertyGetter<
-    Ember.ComputedProperty<string>
->;
+type UnwCpStringGet1 = UnwrapComputedPropertyGetter<Ember.ComputedProperty<string>>;
 // $ExpectType string
-type UnwCpStringSet2 = UnwrapComputedPropertySetter<
-    Ember.ComputedProperty<string, string>
->;
+type UnwCpStringSet2 = UnwrapComputedPropertySetter<Ember.ComputedProperty<string, string>>;
 // $ExpectType string
-type UnwCpStringGet2 = UnwrapComputedPropertyGetter<
-    Ember.ComputedProperty<string, string>
->;
+type UnwCpStringGet2 = UnwrapComputedPropertyGetter<Ember.ComputedProperty<string, string>>;
 // $ExpectType string
-type UnwCpStringSet3 = UnwrapComputedPropertySetter<
-    Ember.ComputedProperty<number, string>
->;
+type UnwCpStringSet3 = UnwrapComputedPropertySetter<Ember.ComputedProperty<number, string>>;
 // $ExpectType number
-type UnwCpStringGet3 = UnwrapComputedPropertyGetter<
-    Ember.ComputedProperty<number, string>
->;
+type UnwCpStringGet3 = UnwrapComputedPropertyGetter<Ember.ComputedProperty<number, string>>;
 // $ExpectType number
-type UnwCpStringSet4 = UnwrapComputedPropertySetter<
-    Ember.ComputedProperty<string, number>
->;
+type UnwCpStringSet4 = UnwrapComputedPropertySetter<Ember.ComputedProperty<string, number>>;
 // $ExpectType string
-type UnwCpStringGet4 = UnwrapComputedPropertyGetter<
-    Ember.ComputedProperty<string, number>
->;
+type UnwCpStringGet4 = UnwrapComputedPropertyGetter<Ember.ComputedProperty<string, number>>;

--- a/types/ember/test/private/observable-tests.ts
+++ b/types/ember/test/private/observable-tests.ts
@@ -1,13 +1,13 @@
 // tslint-disable-next-line
-import { assertType } from "../lib/assert";
-import Ember from "ember";
+import { assertType } from '../lib/assert';
+import Ember from 'ember';
 import {
     ExtractPropertyNamesOfType,
     UnwrapComputedPropertyGetter,
     UnwrapComputedPropertyGetters,
-    UnwrapComputedPropertySetters
+    UnwrapComputedPropertySetters,
 } from '@ember/object/-private/types';
-import Observable from "@ember/object/observable";
+import Observable from '@ember/object/observable';
 
 class OtherThing {
     observerOfDemo(target: DemoObservable, key: 'foo') {}
@@ -57,46 +57,63 @@ class DemoObservable implements Observable {
     fooDidChange(obj: this, propName: 'foo') {}
     protected fooDidChangeProtected(obj: this, propName: 'foo') {}
     get<K extends keyof this>(key: K): UnwrapComputedPropertyGetter<this[K]> {
-        throw new Error("Method not implemented.");
+        throw new Error('Method not implemented.');
     }
     getProperties<K extends keyof this>(list: K[]): Pick<UnwrapComputedPropertyGetters<this>, K>;
     getProperties<K extends keyof this>(...list: K[]): Pick<UnwrapComputedPropertyGetters<this>, K>;
     getProperties(...rest: any[]): any {
-        throw new Error("Method not implemented.");
+        throw new Error('Method not implemented.');
     }
     set<K extends keyof this>(key: K, value: this[K]): this[K] {
-        throw new Error("Method not implemented.");
+        throw new Error('Method not implemented.');
     }
-    setProperties<K extends keyof this>(hash: Pick<this, K>): Pick< UnwrapComputedPropertySetters<this>, K> {
-        throw new Error("Method not implemented.");
+    setProperties<K extends keyof this>(hash: Pick<this, K>): Pick<UnwrapComputedPropertySetters<this>, K> {
+        throw new Error('Method not implemented.');
     }
     notifyPropertyChange(keyName: string): this {
-        throw new Error("Method not implemented.");
+        throw new Error('Method not implemented.');
     }
-    addObserver<Target>(key: keyof this, target: Target, method: keyof Target | ((this: Target, sender: this, key: string, value: any, rev: number) => void)): any;
-    addObserver<K extends keyof this>(key: K, method: keyof this | ((this: this, sender: this, key: K, value: this[K], rev: number) => void)): any;
+    addObserver<Target>(
+        key: keyof this,
+        target: Target,
+        method: keyof Target | ((this: Target, sender: this, key: string, value: any, rev: number) => void),
+    ): any;
+    addObserver<K extends keyof this>(
+        key: K,
+        method: keyof this | ((this: this, sender: this, key: K, value: this[K], rev: number) => void),
+    ): any;
     addObserver(key: any, target: any, method?: any) {
-        throw new Error("Method not implemented.");
+        throw new Error('Method not implemented.');
     }
-    removeObserver<Target>(key: keyof this, target: Target, method: keyof Target | ((this: Target, sender: this, key: string, value: any, rev: number) => void)): any;
-    removeObserver(key: keyof this, method: keyof this | ((this: this, sender: this, key: string, value: any, rev: number) => void)): any;
+    removeObserver<Target>(
+        key: keyof this,
+        target: Target,
+        method: keyof Target | ((this: Target, sender: this, key: string, value: any, rev: number) => void),
+    ): any;
+    removeObserver(
+        key: keyof this,
+        method: keyof this | ((this: this, sender: this, key: string, value: any, rev: number) => void),
+    ): any;
     removeObserver(key: any, target: any, method?: any): void {
-        throw new Error("Method not implemented.");
+        throw new Error('Method not implemented.');
     }
-    getWithDefault<K extends keyof this>(key: K, defaultValue: UnwrapComputedPropertyGetter<this[K]>): UnwrapComputedPropertyGetter<this[K]> {
-        throw new Error("Method not implemented.");
+    getWithDefault<K extends keyof this>(
+        key: K,
+        defaultValue: UnwrapComputedPropertyGetter<this[K]>,
+    ): UnwrapComputedPropertyGetter<this[K]> {
+        throw new Error('Method not implemented.');
     }
     incrementProperty(keyName: ExtractPropertyNamesOfType<this, number | undefined>, increment?: number): number {
-        throw new Error("Method not implemented.");
+        throw new Error('Method not implemented.');
     }
     decrementProperty(keyName: ExtractPropertyNamesOfType<this, number | undefined>, decrement?: number): number {
-        throw new Error("Method not implemented.");
+        throw new Error('Method not implemented.');
     }
     toggleProperty(keyName: ExtractPropertyNamesOfType<this, boolean | undefined>): boolean {
-        throw new Error("Method not implemented.");
+        throw new Error('Method not implemented.');
     }
     cacheFor<K extends keyof this>(key: K): UnwrapComputedPropertyGetter<this[K]> | undefined {
-        throw new Error("Method not implemented.");
+        throw new Error('Method not implemented.');
     }
 }
 const o = new DemoObservable();
@@ -143,9 +160,9 @@ assertType<number | undefined>(o.getWithDefault()); // $ExpectError
  * getProperties
  */
 // ('foo', 'bar')
-assertType<{ foo: string, bar: [boolean, boolean] }>(o.getProperties('foo', 'bar')); // $ExpectType { foo: string; bar: [boolean, boolean]; }
+assertType<{ foo: string; bar: [boolean, boolean] }>(o.getProperties('foo', 'bar')); // $ExpectType { foo: string; bar: [boolean, boolean]; }
 // ['foo', 'bar']
-assertType<{ foo: string, bar: [boolean, boolean] }>(o.getProperties(['foo', 'bar'])); // $ExpectType { foo: string; bar: [boolean, boolean]; }
+assertType<{ foo: string; bar: [boolean, boolean] }>(o.getProperties(['foo', 'bar'])); // $ExpectType { foo: string; bar: [boolean, boolean]; }
 // empty cases
 assertType<{}>(o.getProperties()); // $ExpectType {}
 assertType<{}>(o.getProperties([])); // $ExpectType {}
@@ -166,7 +183,7 @@ assertType<any>(o.set('jeanShorts', 10)); // $ExpectError
 /**
  * setProperties
  */
-assertType<{ foo: string, bar: [boolean, boolean] }>(o.setProperties({ foo: 'abc', bar: [true, true] })); // $ExpectType { foo: string; bar: [boolean, boolean]; }
+assertType<{ foo: string; bar: [boolean, boolean] }>(o.setProperties({ foo: 'abc', bar: [true, true] })); // $ExpectType { foo: string; bar: [boolean, boolean]; }
 // empty case
 assertType<{}>(o.setProperties({})); // $ExpectType {}
 // property that doesn't exist

--- a/types/ember/test/reopen.ts
+++ b/types/ember/test/reopen.ts
@@ -1,12 +1,12 @@
 import Ember from 'ember';
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 type Person = typeof Person.prototype;
 const Person = Ember.Object.extend({
     name: '',
     sayHello() {
         alert(`Hello. My name is ${this.get('name')}`);
-    }
+    },
 });
 
 assertType<Person>(Person.reopen());
@@ -19,7 +19,7 @@ const Person2 = Person.reopenClass({
 
     createPerson(name: string): Person {
         return Person.create({ name });
-    }
+    },
 });
 
 assertType<string>(Person2.create().name);
@@ -27,7 +27,7 @@ Person2.create().sayHello(); // $ExpectType void
 assertType<string>(Person2.species);
 
 const tom = Person2.create({
-    name: 'Tom Dale'
+    name: 'Tom Dale',
 });
 
 const badTom = Person2.create({ name: 99 }); // $ExpectError
@@ -43,7 +43,7 @@ const Person3 = Person2.reopen({
 
     sayGoodbye() {
         alert(`${this.get('goodbyeMessage')}, ${this.get('name')}`);
-    }
+    },
 });
 
 const person3 = Person3.create();
@@ -52,11 +52,13 @@ person3.get('goodbyeMessage');
 person3.sayHello();
 person3.sayGoodbye();
 
-interface AutoResizeMixin { resizable: true; }
+interface AutoResizeMixin {
+    resizable: true;
+}
 const AutoResizeMixin = Ember.Mixin.create({ resizable: true });
 
 const ResizableTextArea = Ember.TextArea.reopen(AutoResizeMixin, {
-    scaling: 1.0
+    scaling: 1.0,
 });
 const text = ResizableTextArea.create();
 assertType<boolean>(text.resizable);

--- a/types/ember/test/route.ts
+++ b/types/ember/test/route.ts
@@ -102,9 +102,9 @@ class RouteUsingClass extends Route.extend({
         this.intermediateTransitionTo('some-route');
     }
     intermediateTransitionWithModel() {
-        this.intermediateTransitionTo('some.other.route', { });
+        this.intermediateTransitionTo('some.other.route', {});
     }
     intermediateTransitionWithMultiModel() {
-        this.intermediateTransitionTo('some.other.route', 1, 2, { });
+        this.intermediateTransitionTo('some.other.route', 1, 2, {});
     }
 }

--- a/types/ember/test/router.ts
+++ b/types/ember/test/router.ts
@@ -1,27 +1,26 @@
 import Ember from 'ember';
 import { assertType } from './lib/assert';
 
-const AppRouter = Ember.Router.extend({
-});
+const AppRouter = Ember.Router.extend({});
 
-AppRouter.map(function() {
+AppRouter.map(function () {
     this.route('index', { path: '/' });
     this.route('about');
     this.route('favorites', { path: '/favs' });
-    this.route('posts', function() {
+    this.route('posts', function () {
         this.route('index', { path: '/' });
         this.route('new');
         this.route('post', { path: '/post/:post_id', resetNamespace: true });
-        this.route('comments', { resetNamespace: true }, function() {
+        this.route('comments', { resetNamespace: true }, function () {
             this.route('new');
         });
     });
-    this.route('photo', { path: '/photo/:id' }, function() {
+    this.route('photo', { path: '/photo/:id' }, function () {
         this.route('comment', { path: '/comment/:id' });
     });
     this.route('not-found', { path: '/*path' });
     this.mount('my-engine');
-    this.mount('my-engine', { as: 'some-other-engine', path: '/some-other-engine'});
+    this.mount('my-engine', { as: 'some-other-engine', path: '/some-other-engine' });
 });
 
 const RouterServiceConsumer = Ember.Service.extend({
@@ -33,22 +32,18 @@ const RouterServiceConsumer = Ember.Service.extend({
         const x: string = Ember.get(this, 'router').currentURL;
     },
     transitionWithoutModel() {
-        Ember.get(this, 'router')
-        .transitionTo('some-route');
+        Ember.get(this, 'router').transitionTo('some-route');
     },
     transitionWithModel() {
         const model = Ember.Object.create();
-        Ember.get(this, 'router')
-        .transitionTo('some.other.route', model);
+        Ember.get(this, 'router').transitionTo('some.other.route', model);
     },
     transitionWithMultiModel() {
         const model = Ember.Object.create();
-        Ember.get(this, 'router')
-        .transitionTo('some.other.route', model, model);
+        Ember.get(this, 'router').transitionTo('some.other.route', model, model);
     },
     transitionWithModelAndOptions() {
         const model = Ember.Object.create();
-        Ember.get(this, 'router')
-        .transitionTo('index', model, { queryParams: { search: 'ember' }});
-    }
+        Ember.get(this, 'router').transitionTo('index', model, { queryParams: { search: 'ember' } });
+    },
 });

--- a/types/ember/test/run.ts
+++ b/types/ember/test/run.ts
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import RSVP from 'rsvp';
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 assertType<string[]>(Ember.run.queues);
 
@@ -13,7 +13,7 @@ function testRun() {
 
     function destroyApp(application: Ember.Application) {
         Ember.run(application, 'destroy');
-        Ember.run(application, function() {
+        Ember.run(application, function () {
             this.destroy();
         });
     }
@@ -30,7 +30,7 @@ function testBind() {
 
         setupEditor(editor: string) {
             this.set('editor', editor);
-        }
+        },
     });
 }
 
@@ -43,9 +43,13 @@ function testCancel() {
 
     Ember.run.cancel(runNext);
 
-    const runLater = Ember.run.later(myContext, () => {
-        // will not be executed
-    }, 500);
+    const runLater = Ember.run.later(
+        myContext,
+        () => {
+            // will not be executed
+        },
+        500,
+    );
 
     Ember.run.cancel(runLater);
 
@@ -61,29 +65,42 @@ function testCancel() {
 
     Ember.run.cancel(runOnce);
 
-    const throttle = Ember.run.throttle(myContext, () => {
-        // will not be executed
-    }, 1, false);
+    const throttle = Ember.run.throttle(
+        myContext,
+        () => {
+            // will not be executed
+        },
+        1,
+        false,
+    );
 
     Ember.run.cancel(throttle);
 
-    const debounce = Ember.run.debounce(myContext, () => {
-        // will not be executed
-    }, 1);
+    const debounce = Ember.run.debounce(
+        myContext,
+        () => {
+            // will not be executed
+        },
+        1,
+    );
 
     Ember.run.cancel(debounce);
 
-    const debounceImmediate = Ember.run.debounce(myContext, () => {
-        // will be executed since we passed in true (immediate)
-    }, 100, true);
+    const debounceImmediate = Ember.run.debounce(
+        myContext,
+        () => {
+            // will be executed since we passed in true (immediate)
+        },
+        100,
+        true,
+    );
 
     // the 100ms delay until this method can be called again will be canceled
     Ember.run.cancel(debounceImmediate);
 }
 
 function testDebounce() {
-    function runIt() {
-    }
+    function runIt() {}
 
     const myContext = { name: 'debounce' };
 
@@ -99,8 +116,8 @@ function testDebounce() {
             handleTyping() {
                 // the fetchResults function is passed into the component from its parent
                 Ember.run.debounce(this, this.get('fetchResults'), this.get('searchValue'), 250);
-            }
-        }
+            },
+        },
     });
 }
 
@@ -123,7 +140,7 @@ function testJoin() {
         });
     });
 
-    new RSVP.Promise((resolve) => {
+    new RSVP.Promise(resolve => {
         Ember.run.later(() => {
             resolve({ msg: 'Hold Your Horses' });
         }, 3000);
@@ -132,9 +149,13 @@ function testJoin() {
 
 function testLater() {
     const myContext = {};
-    Ember.run.later(myContext, () => {
-        // code here will execute within a RunLoop in about 500ms with this == myContext
-    }, 500);
+    Ember.run.later(
+        myContext,
+        () => {
+            // code here will execute within a RunLoop in about 500ms with this == myContext
+        },
+        500,
+    );
 }
 
 function testNext() {
@@ -151,8 +172,7 @@ function testOnce() {
             Ember.run.once(this, 'processFullName');
         },
 
-        processFullName() {
-        }
+        processFullName() {},
     });
 }
 
@@ -168,7 +188,7 @@ function testSchedule() {
                 // this will be executed in the 'actions' queue, after bindings have synced.
                 console.log('scheduled on actions queue');
             });
-        }
+        },
     });
 
     Ember.run.schedule('actions', () => {
@@ -193,8 +213,7 @@ function testScheduleOnce() {
 }
 
 function testThrottle() {
-    function runIt() {
-    }
+    function runIt() {}
 
     const myContext = { name: 'throttle' };
 

--- a/types/ember/test/string-ext.ts
+++ b/types/ember/test/string-ext.ts
@@ -26,4 +26,4 @@ declare global {
 ''.capitalize('blue man group'); // $ExpectError
 
 ''.loc(); // $ExpectType string
-''.loc("_Hello World");  // $ExpectError
+''.loc('_Hello World'); // $ExpectError

--- a/types/ember/test/string.ts
+++ b/types/ember/test/string.ts
@@ -32,9 +32,9 @@ capitalize('blue man group'); // $ExpectType string
 capitalize('', ''); // $ExpectError
 
 loc(); // $ExpectError
-loc("_Hello World");  // $ExpectType string
+loc('_Hello World'); // $ExpectType string
 // TODO - fix this case upstream in @types/ember https://github.com/typed-ember/ember-cli-typescript/issues/281
-loc("_Hello %@ %@", ["John", "Smith"]);  // $ExpectType string
+loc('_Hello %@ %@', ['John', 'Smith']); // $ExpectType string
 
 const handlebarsSafeString: SafeString = Ember.String.htmlSafe('lorem ipsum...');
 Ember.String.htmlSafe('lorem ipsum...'); // $ExpectType SafeString

--- a/types/ember/test/test.ts
+++ b/types/ember/test/test.ts
@@ -8,20 +8,20 @@ declare const MyDb: {
 };
 Ember.Test.registerWaiter(MyDb, MyDb.hasPendingTransactions);
 
-Ember.Test.promise((resolve) => {
+Ember.Test.promise(resolve => {
     window.setTimeout(resolve, 500);
 });
 
-Ember.Test.registerHelper('boot', (app) => {
+Ember.Test.registerHelper('boot', app => {
     Ember.run(app, app.advanceReadiness);
 });
 
-Ember.Test.registerAsyncHelper('boot', (app) => {
+Ember.Test.registerAsyncHelper('boot', app => {
     Ember.run(app, app.advanceReadiness);
 });
 
 Ember.Test.registerAsyncHelper('waitForPromise', (app, promise) => {
-    return new Ember.Test.Promise((resolve) => {
+    return new Ember.Test.Promise(resolve => {
         Ember.Test.adapter.asyncStart();
 
         promise.then(() => {

--- a/types/ember/test/transition.ts
+++ b/types/ember/test/transition.ts
@@ -7,7 +7,7 @@ Ember.Route.extend({
             alert('Sorry, you need a time machine to enter this route.');
             transition.abort();
         }
-    }
+    },
 });
 
 Ember.Controller.extend({
@@ -24,6 +24,6 @@ Ember.Controller.extend({
                 // Default back to homepage
                 this.transitionToRoute('index');
             }
-        }
-    }
+        },
+    },
 });

--- a/types/ember/test/utils.ts
+++ b/types/ember/test/utils.ts
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 function testTypeOf() {
     Ember.typeOf(); // $ExpectType "undefined"
@@ -41,22 +41,20 @@ function testIsNone() {
 }
 
 function testMerge() {
-    assertType<{ first: string, last: string }>(
-        Ember.merge({ first: 'Tom' }, { last: 'Dale' })
-    );
+    assertType<{ first: string; last: string }>(Ember.merge({ first: 'Tom' }, { last: 'Dale' }));
 }
 
 function testAssign() {
-    assertType<{ first: string, middle: string, last: string }>(
-        Ember.assign({ first: 'Tom' }, { middle: 'M' }, { last: 'Dale' })
+    assertType<{ first: string; middle: string; last: string }>(
+        Ember.assign({ first: 'Tom' }, { middle: 'M' }, { last: 'Dale' }),
     );
 }
 
 function testOnError() {
-    Ember.onerror = (error) => {
+    Ember.onerror = error => {
         Ember.$.post('/report-error', {
             stack: error.stack,
-            otherInformation: 'whatever app state you want to provide'
+            otherInformation: 'whatever app state you want to provide',
         });
     };
 }
@@ -66,7 +64,11 @@ function testDeprecateFunc() {
         return '';
     }
 
-    const oldMethod = Ember.deprecateFunc('Please use the new method', { id: 'deprecated.id', until: '6.0' }, newMethod);
+    const oldMethod = Ember.deprecateFunc(
+        'Please use the new method',
+        { id: 'deprecated.id', until: '6.0' },
+        newMethod,
+    );
     assertType<string>(newMethod('first', 123));
     assertType<string>(oldMethod('first', 123));
 }
@@ -79,23 +81,33 @@ function testDefineProperty() {
         writable: true,
         configurable: false,
         enumerable: true,
-        value: 'Charles'
+        value: 'Charles',
     });
 
     // define a simple property
     Ember.defineProperty(contact, 'lastName', undefined, 'Jolley');
 
     // define a computed property
-    Ember.defineProperty(contact, 'fullName', Ember.computed('firstName', 'lastName', function() {
-        return `${this.firstName} ${this.lastName}`;
-    }));
+    Ember.defineProperty(
+        contact,
+        'fullName',
+        Ember.computed('firstName', 'lastName', function () {
+            return `${this.firstName} ${this.lastName}`;
+        }),
+    );
 }
 
 function testTryInvoke() {
     class Foo {
-        hello() { return ['world']; }
-        add(x: number, y: string) { return x + parseInt(y, 10); }
-        apples(n: number) { return `${n} apples`; }
+        hello() {
+            return ['world'];
+        }
+        add(x: number, y: string) {
+            return x + parseInt(y, 10);
+        }
+        apples(n: number) {
+            return `${n} apples`;
+        }
     }
     // zero-argument function
     Ember.tryInvoke(new Foo(), 'hello'); // $ExpectType string[]
@@ -121,33 +133,34 @@ function testTryInvoke() {
 
 (() => {
     /** typeOf */
-    Ember.typeOf();                       // $ExpectType "undefined"
-    Ember.typeOf(null);                   // $ExpectType "null"
-    Ember.typeOf(undefined);              // $ExpectType "undefined"
-    Ember.typeOf('michael');              // $ExpectType "string"
+    Ember.typeOf(); // $ExpectType "undefined"
+    Ember.typeOf(null); // $ExpectType "null"
+    Ember.typeOf(undefined); // $ExpectType "undefined"
+    Ember.typeOf('michael'); // $ExpectType "string"
     // tslint:disable-next-line:no-construct
-    Ember.typeOf(new String('michael'));  // $ExpectType "string"
-    Ember.typeOf(101);                    // $ExpectType "number"
+    Ember.typeOf(new String('michael')); // $ExpectType "string"
+    Ember.typeOf(101); // $ExpectType "number"
     // tslint:disable-next-line:no-construct
-    Ember.typeOf(new Number(101));        // $ExpectType "number"
-    Ember.typeOf(true);                   // $ExpectType "boolean"
+    Ember.typeOf(new Number(101)); // $ExpectType "number"
+    Ember.typeOf(true); // $ExpectType "boolean"
     // tslint:disable-next-line:no-construct
-    Ember.typeOf(new Boolean(true));      // $ExpectType "boolean"
-    Ember.typeOf(() => 4);                // $ExpectType "function"
-    Ember.typeOf([1, 2, 90]);             // $ExpectType "array"
-    Ember.typeOf(/abc/);                  // $ExpectType "regexp"
-    Ember.typeOf(new Date());             // $ExpectType "date"
-    Ember.typeOf(({} as any) as FileList);  // $ExpectType "filelist"
-    Ember.typeOf(Ember.Object.extend());   // $ExpectType "class"
-    Ember.typeOf(Ember.Object.create());   // $ExpectType "instance"
-    Ember.typeOf(new Error('teamocil'));  // $ExpectType "error"
-    Ember.typeOf((new Date()) as RegExp | Date); // "regexp" | "date"
+    Ember.typeOf(new Boolean(true)); // $ExpectType "boolean"
+    Ember.typeOf(() => 4); // $ExpectType "function"
+    Ember.typeOf([1, 2, 90]); // $ExpectType "array"
+    Ember.typeOf(/abc/); // $ExpectType "regexp"
+    Ember.typeOf(new Date()); // $ExpectType "date"
+    Ember.typeOf(({} as any) as FileList); // $ExpectType "filelist"
+    Ember.typeOf(Ember.Object.extend()); // $ExpectType "class"
+    Ember.typeOf(Ember.Object.create()); // $ExpectType "instance"
+    Ember.typeOf(new Error('teamocil')); // $ExpectType "error"
+    Ember.typeOf(new Date() as RegExp | Date); // "regexp" | "date"
 })();
 
-(() => { /* assign */
-    Ember.assign({}, { a: 'b'});
-    Ember.assign({}, { a: 'b'}).a; // $ExpectType string
-    Ember.assign({ a: 6 }, { a: 'b'}).a; // $ExpectType string
+(() => {
+    /* assign */
+    Ember.assign({}, { a: 'b' });
+    Ember.assign({}, { a: 'b' }).a; // $ExpectType string
+    Ember.assign({ a: 6 }, { a: 'b' }).a; // $ExpectType string
     Ember.assign({ a: 6 }, {}).a; // $ExpectType number
     Ember.assign({ b: 6 }, {}).a; // $ExpectError
     Ember.assign({}, { b: 6 }, {}).b; // $ExpectType number
@@ -157,10 +170,11 @@ function testTryInvoke() {
     Ember.assign({ d: ['gobias industries'] }, { a: 'hello' }, { b: 6 }, { a: true }).d; // $ExpectType string[]
 })();
 
-(() => { /* merge */
-    Ember.merge({}, { a: 'b'});
-    Ember.merge({}, { a: 'b'}).a; // $ExpectType string
-    Ember.merge({ a: 6 }, { a: 'b'}).a; // $ExpectType string
+(() => {
+    /* merge */
+    Ember.merge({}, { a: 'b' });
+    Ember.merge({}, { a: 'b' }).a; // $ExpectType string
+    Ember.merge({ a: 6 }, { a: 'b' }).a; // $ExpectType string
     Ember.merge({ a: 6 }, {}).a; // $ExpectType number
     Ember.merge({ b: 6 }, {}).a; // $ExpectError
 })();

--- a/types/ember/test/view-utils.ts
+++ b/types/ember/test/view-utils.ts
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 import { assertType } from './lib/assert';
 
-const { ViewUtils: { isSimpleClick } } = Ember;
+const {
+    ViewUtils: { isSimpleClick },
+} = Ember;
 assertType<boolean>(isSimpleClick(new Event('wat')));

--- a/types/ember/tslint.json
+++ b/types/ember/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "space-before-function-paren": false,
         "npm-naming": false
     }
 }

--- a/types/ember/v1/ember-tests.ts
+++ b/types/ember/v1/ember-tests.ts
@@ -1,12 +1,12 @@
-var App : any;
+var App: any;
 
 App = Em.Application.create<Em.Application>();
 
 App.president = Em.Object.create({
-    name: 'Barack Obama'
+    name: 'Barack Obama',
 });
 App.country = Em.Object.create({
-    presidentNameBinding: 'MyApp.president.name'
+    presidentNameBinding: 'MyApp.president.name',
 });
 App.country.get('presidentName');
 App.president = Em.Object.create({
@@ -14,7 +14,7 @@ App.president = Em.Object.create({
     lastName: 'Obama',
     fullName: function () {
         return this.get('firstName') + ' ' + this.get('lastName');
-    }.property()
+    }.property(),
 });
 App.president.get('fullName');
 
@@ -25,7 +25,7 @@ declare class MyPerson extends Em.Object {
 var Person1 = Em.Object.extend<typeof MyPerson>({
     say: (thing: string) => {
         alert(thing);
-    }
+    },
 });
 
 declare class MyPerson2 extends Em.Object {
@@ -33,9 +33,9 @@ declare class MyPerson2 extends Em.Object {
 }
 var tom = Person1.create<MyPerson2>({
     name: 'Tom Dale',
-    helloWorld: function() {
+    helloWorld: function () {
         this.say('Hi my name is ' + this.get('name'));
-    }
+    },
 });
 tom.helloWorld();
 
@@ -45,7 +45,7 @@ Person1.create<Em.Object>().get('isPerson');
 Person1.reopenClass({
     createMan: () => {
         return Person1.create({ isMan: true });
-    }
+    },
 });
 // ReSharper disable once DuplicatingLocalDeclaration
 declare var Person1: typeof MyPerson;
@@ -53,19 +53,17 @@ Person1.createMan().get('isMan');
 
 var person = Person1.create<Em.Object>({
     firstName: 'Yehuda',
-    lastName: 'Katz'
+    lastName: 'Katz',
 });
-person.addObserver('fullName', null, () => { });
+person.addObserver('fullName', null, () => {});
 person.set('firstName', 'Brohuda');
 
 App.todosController = Em.Object.create({
-    todos: [
-        Em.Object.create({ isDone: false })
-    ],
-    remaining: (function() {
+    todos: [Em.Object.create({ isDone: false })],
+    remaining: function () {
         var todos = this.get('todos');
         return todos.filterProperty('isDone', false).get('length');
-    }).property('todos.@each.isDone')
+    }.property('todos.@each.isDone'),
 });
 
 var todos = App.todosController.get('todos');
@@ -77,32 +75,32 @@ todos.pushObject(todo);
 App.todosController.get('remaining');
 
 App.wife = Em.Object.create({
-    householdIncome: 80000
+    householdIncome: 80000,
 });
 App.husband = Em.Object.create({
-    householdIncomeBinding: 'App.wife.householdIncome'
+    householdIncomeBinding: 'App.wife.householdIncome',
 });
 App.husband.get('householdIncome');
 App.husband.set('householdIncome', 90000);
 App.wife.get('householdIncome');
 
 App.user = Em.Object.create({
-    fullName: 'Kara Gates'
+    fullName: 'Kara Gates',
 });
 App.userView = Em.View.create({
-    userNameBinding: Em.Binding.oneWay('App.user.fullName')
+    userNameBinding: Em.Binding.oneWay('App.user.fullName'),
 });
 App.user.set('fullName', 'Krang Gates');
 App.userView.set('userName', 'Truckasaurus Gates');
 App.user.get('fullName');
 
 App = Em.Application.create({
-    rootElement: '#sidebar'
+    rootElement: '#sidebar',
 });
 
 var view = Em.View.create<Em.View>({
     templateName: 'say-hello',
-    name: 'Bob'
+    name: 'Bob',
 });
 view.appendTo('#container');
 view.append();
@@ -110,14 +108,14 @@ view.remove();
 
 App.AlertView = Em.View.extend({
     priority: 'p4',
-    isUrgent: true
+    isUrgent: true,
 });
 
 App.ListingView = Em.View.extend({
     templateName: 'listing',
     edit: (event: any) => {
         event.view.set('isEditing', true);
-    }
+    },
 });
 
 App.userController = Em.Object.create({
@@ -125,30 +123,30 @@ App.userController = Em.Object.create({
         firstName: 'Albert',
         lastName: 'Hofmann',
         posts: 25,
-        hobbies: 'Riding bicycles'
-    })
+        hobbies: 'Riding bicycles',
+    }),
 });
 
-Handlebars.registerHelper('highlight', function(property: string, options: any) {
+Handlebars.registerHelper('highlight', function (property: string, options: any) {
     var value = Em.Handlebars.get(this, property, options);
     return new Handlebars.SafeString('<span class="highlight">' + value + '</span>');
 });
 
 App.MyText = Em.TextField.extend({
     formBlurredBinding: 'App.adminController.formBlurred',
-    change: function() {
+    change: function () {
         this.set('formBlurred', true);
-    }
+    },
 });
 
 var textArea = Em.TextArea.create({
-    valueBinding: 'TestObject.value'
+    valueBinding: 'TestObject.value',
 });
 
 App.ClickableView = Em.View.extend({
     click: () => {
         alert('ClickableView was clicked!');
-    }
+    },
 });
 
 var container = Em.ContainerView.create<Em.ContainerView>();
@@ -158,15 +156,11 @@ var coolView = App.CoolView.create(),
 childViews.pushObject(coolView);
 
 var Person2 = Em.Object.extend<typeof Em.Object>({
-    sayHello: function() {
+    sayHello: function () {
         console.log('Hello from ' + this.get('name'));
-    }
+    },
 });
-var people = [
-    Person2.create({ name: 'Juan' }),
-    Person2.create({ name: 'Charles' }),
-    Person2.create({ name: 'Majd' })
-];
+var people = [Person2.create({ name: 'Juan' }), Person2.create({ name: 'Charles' }), Person2.create({ name: 'Majd' })];
 people.invoke('sayHello');
 
 var arr = [Em.Object.create(), Em.Object.create()];
@@ -175,12 +169,9 @@ arr.getEach('name');
 
 var Person3 = Em.Object.extend<typeof Em.Object>({
     name: null,
-    isHappy: false
+    isHappy: false,
 });
-var people2 = [
-    Person3.create({ name: 'Yehuda', isHappy: true }),
-    Person3.create({ name: 'Majd', isHappy: false })
-];
+var people2 = [Person3.create({ name: 'Yehuda', isHappy: true }), Person3.create({ name: 'Majd', isHappy: false })];
 people2.every((person: Em.Object) => {
     return !!person.get('isHappy');
 });
@@ -191,16 +182,19 @@ people2.everyProperty('isHappy', true);
 people2.someProperty('isHappy', true);
 
 // Examples taken from http://emberjs.com/api/classes/Ember.RSVP.Promise.html
-var promise = new Ember.RSVP.Promise(function(resolve: Function, reject: Function) {
-  // on success
-  resolve('ok!');
+var promise = new Ember.RSVP.Promise(function (resolve: Function, reject: Function) {
+    // on success
+    resolve('ok!');
 
-  // on failure
-  reject('no-k!');
+    // on failure
+    reject('no-k!');
 });
 
-promise.then(function(value: any) {
-  // on fulfillment
-}, function(reason: any) {
-  // on rejection
-});
+promise.then(
+    function (value: any) {
+        // on fulfillment
+    },
+    function (reason: any) {
+        // on rejection
+    },
+);

--- a/types/ember/v1/index.d.ts
+++ b/types/ember/v1/index.d.ts
@@ -8,19 +8,18 @@
 /// <reference types="handlebars"/>
 
 declare namespace EmberStates {
-
     interface Transition {
         targetName: string;
         urlMethod: string;
         intent: any;
-        params: {}|any;
+        params: {} | any;
         pivotHandler: any;
         resolveIndex: number;
         handlerInfos: any;
-        resolvedModels: {}|any;
+        resolvedModels: {} | any;
         isActive: boolean;
         state: any;
-        queryParams: {}|any;
+        queryParams: {} | any;
         queryParamsOnly: boolean;
 
         isTransition: boolean;
@@ -128,7 +127,7 @@ declare namespace EmberStates {
           @arg {Boolean} [ignoreFailure=false] a boolean specifying whether unhandled events throw an error
           @arg {String} name the name of the event to fire
          */
-        trigger(ignoreFailure:boolean, eventName: string): void;
+        trigger(ignoreFailure: boolean, eventName: string): void;
         /**
           Fires an event on the current list of resolved/resolving
           handlers within this transition. Useful for firing events
@@ -152,23 +151,18 @@ declare namespace EmberStates {
          */
         followRedirects(): Ember.RSVP.Promise;
     }
-
 }
 
 declare namespace EmberTesting {
-
     namespace Test {
-
         class Adapter {
             asyncEnd(): void;
             asyncStart(): void;
             exception(error: string): void;
         }
 
-        class QUnitAdapter extends Adapter { }
-
+        class QUnitAdapter extends Adapter {}
     }
-
 }
 
 interface Function {
@@ -221,7 +215,7 @@ interface Array<T> {
     filter(callback: Function, target?: any): any[];
     filterBy(key: string, value?: string): any[];
 
- /**
+    /**
     Returns the first item in the array for which the callback returns true.
     This method works similar to the `filter()` method defined in JavaScript 1.6
     except that it will stop working on the array once a match is found.
@@ -352,8 +346,8 @@ interface CoreObjectArguments {
 }
 
 interface EnumerableConfigurationOptions {
-    willChange?: boolean ;
-    didChange?: boolean ;
+    willChange?: boolean;
+    didChange?: boolean;
 }
 
 interface ItemIndexEnumerableCallbackTarget {
@@ -583,9 +577,9 @@ declare namespace Ember {
         toArray(): any[];
         uniq(): Enumerable;
         without(value: any): Enumerable;
-    '@each': EachProxy;
+        '@each': EachProxy;
         Boolean: boolean;
-    '[]': any[];
+        '[]': any[];
         firstObject: any;
         hasEnumerableObservers: boolean;
         lastObject: any;
@@ -625,7 +619,6 @@ declare namespace Ember {
         queryParams: any;
         send(name: string, ...args: any[]): void;
         actions: {};
-
     }
     /**
     Array polyfills to support ES5 features in older browsers.
@@ -718,8 +711,8 @@ declare namespace Ember {
         unshiftObject(object: any): any;
         unshiftObjects(objects: any[]): any[];
         without(value: any): Enumerable;
-    '[]': any[];
-    '@each': EachProxy;
+        '[]': any[];
+        '@each': EachProxy;
         Boolean: boolean;
         firstObject: any;
         hasEnumerableObservers: boolean;
@@ -917,7 +910,7 @@ declare namespace Ember {
         replaceRoute(name: string, ...args: any[]): void;
         transitionToRoute(name: string, ...args: any[]): void;
         controllers: {};
-        model : any;
+        model: any;
         needs: string[];
         queryParams: any;
         target: any;
@@ -1014,7 +1007,7 @@ declare namespace Ember {
         @param {Object} [args] - Object containing values to use within the new class
         Non-static method because Ember classes aren't currently 'real' TypeScript classes.
         **/
-        extend<T>(args ?: CoreObjectArguments): T;
+        extend<T>(args?: CoreObjectArguments): T;
         /**
         Creates a new subclass.
         @method extend
@@ -1022,7 +1015,7 @@ declare namespace Ember {
         @param {Object} [args] - Object containing values to use within the new class
         Non-static method because Ember classes aren't currently 'real' TypeScript classes.
         **/
-        extend<T>(mixins ? : Mixin, args ?: CoreObjectArguments): T;
+        extend<T>(mixins?: Mixin, args?: CoreObjectArguments): T;
 
         /**
         Equivalent to doing extend(arguments).create(). If possible use the normal create method instead.
@@ -1137,7 +1130,7 @@ declare namespace Ember {
     The default implementation handles simple properties.
     You generally won't need to create or subclass this directly.
     **/
-    class Descriptor { }
+    class Descriptor {}
     var EMPTY_META: {}; // TODO: define interface
     var ENV: {};
     var EXTEND_PROTOTYPES: boolean;
@@ -1210,7 +1203,7 @@ declare namespace Ember {
         toArray(): any[];
         uniq(): Enumerable;
         without(value: any): Enumerable;
-    '[]': any[];
+        '[]': any[];
         firstObject: any;
         hasEnumerableObservers: boolean;
         lastObject: any;
@@ -1291,8 +1284,8 @@ declare namespace Ember {
         }
         function precompile(string: string): void;
         function registerBoundHelper(name: string, func: Function, dependentKeys?: string): void;
-        class Compiler { }
-        class JavaScriptCompiler { }
+        class Compiler {}
+        class JavaScriptCompiler {}
         function registerHelper(name: string, fn: Function, inverse?: boolean): void;
         function registerPartial(name: string, str: any): void;
         function K(): any;
@@ -1543,7 +1536,7 @@ declare namespace Ember {
         toArray(): any[];
         uniq(): Enumerable;
         without(value: any): Enumerable;
-    '[]': any[];
+        '[]': any[];
         firstObject: any;
         hasEnumerableObservers: boolean;
         lastObject: any;
@@ -1794,7 +1787,6 @@ declare namespace Ember {
         }
 
         class Promise {
-
             /**
               Promise objects represent the eventual result of an asynchronous operation. The
               primary way of interacting with a promise is through its `then` method, which
@@ -1871,7 +1863,6 @@ declare namespace Ember {
       the [routing guide](http://emberjs.com/guides/routing/) for documentation.
     */
     class Route extends Object implements ActionHandlerMixin, Evented {
-
         static isClass: boolean;
         static isMethod: boolean;
 
@@ -1996,7 +1987,7 @@ declare namespace Ember {
         @method disconnectOutlet
         @param {Object|String} options the options hash or outlet name
         */
-        disconnectOutlet(options: DisconnectOutletOptions|string): void;
+        disconnectOutlet(options: DisconnectOutletOptions | string): void;
 
         /**
         @method findModel
@@ -2044,7 +2035,7 @@ declare namespace Ember {
             the promise resolves, and the resolved value of the promise
             will be used as the model for this route.
         */
-        model(params: {}, transition: EmberStates.Transition): any|RSVP.Promise;
+        model(params: {}, transition: EmberStates.Transition): any | RSVP.Promise;
 
         /**
         Returns the model of a parent (or any ancestor) route
@@ -2067,7 +2058,7 @@ declare namespace Ember {
         @method paramsFor
         @param {String} name
         */
-        paramsFor(name: string) : any;
+        paramsFor(name: string): any;
 
         /**
         Configuration hash for this route's queryParams.
@@ -2096,7 +2087,6 @@ declare namespace Ember {
         @since 1.4.0
         */
         redirect(): EmberStates.Transition;
-
 
         /**
         Refresh the model on this route and any child routes, firing the
@@ -2378,7 +2368,7 @@ declare namespace Ember {
         @param {Function} method The function of the subscription
         @return this
         */
-        off(name: string, target:any , method: Function): Evented;
+        off(name: string, target: any, method: Function): Evented;
 
         /**
         Checks to see if object has any subscriptions for named event.
@@ -3009,111 +2999,111 @@ declare namespace Em {
     **/
     var $: typeof Ember.$;
     var A: typeof Ember.A;
-    class ActionHandlerMixin extends Ember.ActionHandlerMixin { }
-    class Application extends Ember.Application { }
-    class Array extends Ember.Array { }
-    class ArrayController extends Ember.ArrayController { }
+    class ActionHandlerMixin extends Ember.ActionHandlerMixin {}
+    class Application extends Ember.Application {}
+    class Array extends Ember.Array {}
+    class ArrayController extends Ember.ArrayController {}
     var ArrayPolyfills: typeof Ember.ArrayPolyfills;
-    class ArrayProxy extends Ember.ArrayProxy { }
+    class ArrayProxy extends Ember.ArrayProxy {}
     var BOOTED: typeof Ember.BOOTED;
-    class Binding extends Ember.Binding { }
-    class Button extends Ember.Button { }
-    class Checkbox extends Ember.Checkbox { }
-    class CollectionView extends Ember.CollectionView { }
-    class Comparable extends Ember.Comparable { }
-    class Component extends Ember.Component { }
-    class ComputedProperty extends Ember.ComputedProperty { }
-    class Container extends Ember.Container { }
-    class ContainerView extends Ember.ContainerView { }
-    class Controller extends Ember.Controller { }
-    class ControllerMixin extends Ember.ControllerMixin { }
-    class Copyable extends Ember.Copyable { }
-    class CoreObject extends Ember.CoreObject { }
-    class CoreView extends Ember.CoreView { }
-    class DAG extends Ember.DAG { }
+    class Binding extends Ember.Binding {}
+    class Button extends Ember.Button {}
+    class Checkbox extends Ember.Checkbox {}
+    class CollectionView extends Ember.CollectionView {}
+    class Comparable extends Ember.Comparable {}
+    class Component extends Ember.Component {}
+    class ComputedProperty extends Ember.ComputedProperty {}
+    class Container extends Ember.Container {}
+    class ContainerView extends Ember.ContainerView {}
+    class Controller extends Ember.Controller {}
+    class ControllerMixin extends Ember.ControllerMixin {}
+    class Copyable extends Ember.Copyable {}
+    class CoreObject extends Ember.CoreObject {}
+    class CoreView extends Ember.CoreView {}
+    class DAG extends Ember.DAG {}
     var DEFAULT_GETTER_FUNCTION: typeof Ember.DEFAULT_GETTER_FUNCTION;
-    class DefaultResolver extends Ember.DefaultResolver { }
-    class Deffered extends Ember.Deferred { }
-    class DeferredMixin extends Ember.DeferredMixin { }
-    class Descriptor extends Ember.Descriptor { }
+    class DefaultResolver extends Ember.DefaultResolver {}
+    class Deffered extends Ember.Deferred {}
+    class DeferredMixin extends Ember.DeferredMixin {}
+    class Descriptor extends Ember.Descriptor {}
     var EMPTY_META: typeof Ember.EMPTY_META;
     var ENV: typeof Ember.ENV;
     var EXTEND_PROTOTYPES: typeof Ember.EXTEND_PROTOTYPES;
-    class EachProxy extends Ember.EachProxy { }
-    class Enumerable extends Ember.Enumerable { }
+    class EachProxy extends Ember.EachProxy {}
+    class Enumerable extends Ember.Enumerable {}
     var EnumerableUtils: typeof Ember.EnumerableUtils;
     var Error: typeof Ember.Error;
-    class EventDispatcher extends Ember.EventDispatcher { }
-    class Evented extends Ember.Evented { }
+    class EventDispatcher extends Ember.EventDispatcher {}
+    class Evented extends Ember.Evented {}
     var FROZEN_ERROR: typeof Ember.FROZEN_ERROR;
-    class Freezable extends Ember.Freezable { }
+    class Freezable extends Ember.Freezable {}
     var GUID_KEY: typeof Ember.GUID_KEY;
     namespace Handlebars {
         var compile: typeof Ember.Handlebars.compile;
         var get: typeof Ember.Handlebars.get;
         var helper: typeof Ember.Handlebars.helper;
-        class helpers extends Ember.Handlebars.helpers { }
+        class helpers extends Ember.Handlebars.helpers {}
         var precompile: typeof Ember.Handlebars.precompile;
         var registerBoundHelper: typeof Ember.Handlebars.registerBoundHelper;
-        class Compiler extends Ember.Handlebars.Compiler { }
-        class JavaScriptCompiler extends Ember.Handlebars.JavaScriptCompiler { }
+        class Compiler extends Ember.Handlebars.Compiler {}
+        class JavaScriptCompiler extends Ember.Handlebars.JavaScriptCompiler {}
         var registerHelper: typeof Ember.Handlebars.registerHelper;
         var registerPartial: typeof Ember.Handlebars.registerPartial;
         var K: typeof Ember.Handlebars.K;
         var createFrame: typeof Ember.Handlebars.createFrame;
         var Exception: typeof Ember.Handlebars.Exception;
-        class SafeString extends Ember.Handlebars.SafeString { }
+        class SafeString extends Ember.Handlebars.SafeString {}
         var parse: typeof Ember.Handlebars.parse;
         var print: typeof Ember.Handlebars.print;
         var logger: typeof Ember.Handlebars.logger;
         var log: typeof Ember.Handlebars.log;
     }
-    class HashLocation extends Ember.HashLocation { }
-    class HistoryLocation extends Ember.HistoryLocation { }
+    class HashLocation extends Ember.HashLocation {}
+    class HistoryLocation extends Ember.HistoryLocation {}
     var IS_BINDING: typeof Ember.IS_BINDING;
-    class Instrumentation extends Ember.Instrumentation { }
+    class Instrumentation extends Ember.Instrumentation {}
     var K: typeof Ember.K;
     var LOG_BINDINGS: typeof Ember.LOG_BINDINGS;
     var LOG_STACKTRACE_ON_DEPRECATION: typeof Ember.LOG_STACKTRACE_ON_DEPRECATION;
     var LOG_VERSION: typeof Ember.LOG_VERSION;
-    class LinkView extends Ember.LinkView { }
-    class Location extends Ember.Location { }
+    class LinkView extends Ember.LinkView {}
+    class Location extends Ember.Location {}
     var Logger: typeof Ember.Logger;
     var MANDATORY_SETTER_FUNCTION: typeof Ember.MANDATORY_SETTER_FUNCTION;
     var META_KEY: typeof Ember.META_KEY;
-    class Map extends Ember.Map { }
-    class MapWithDefault extends Ember.MapWithDefault { }
-    class Mixin extends Ember.Mixin { }
-    class MutableArray extends Ember.MutableArray { }
-    class MutableEnumerable extends Ember.MutableEnumerable { }
+    class Map extends Ember.Map {}
+    class MapWithDefault extends Ember.MapWithDefault {}
+    class Mixin extends Ember.Mixin {}
+    class MutableArray extends Ember.MutableArray {}
+    class MutableEnumerable extends Ember.MutableEnumerable {}
     var NAME_KEY: typeof Ember.NAME_KEY;
-    class Namespace extends Ember.Namespace { }
-    class NativeArray extends Ember.NativeArray { }
-    class NoneLocation extends Ember.NoneLocation { }
+    class Namespace extends Ember.Namespace {}
+    class NativeArray extends Ember.NativeArray {}
+    class NoneLocation extends Ember.NoneLocation {}
     var ORDER_DEFINITION: typeof Ember.ORDER_DEFINITION;
-    class Object extends Ember.Object { }
-    class ObjectController extends Ember.ObjectController { }
-    class ObjectProxy extends Ember.ObjectProxy { }
-    class Observable extends Ember.Observable { }
-    class OrderedSet extends Ember.OrderedSet { }
+    class Object extends Ember.Object {}
+    class ObjectController extends Ember.ObjectController {}
+    class ObjectProxy extends Ember.ObjectProxy {}
+    class Observable extends Ember.Observable {}
+    class OrderedSet extends Ember.OrderedSet {}
     namespace RSVP {
-        interface PromiseResolve extends Ember.RSVP.PromiseResolve { }
-        interface PromiseReject extends Ember.RSVP.PromiseReject { }
-        interface PromiseResolverFunction extends Ember.RSVP.PromiseResolverFunction { }
-        class Promise extends Ember.RSVP.Promise { }
+        interface PromiseResolve extends Ember.RSVP.PromiseResolve {}
+        interface PromiseReject extends Ember.RSVP.PromiseReject {}
+        interface PromiseResolverFunction extends Ember.RSVP.PromiseResolverFunction {}
+        class Promise extends Ember.RSVP.Promise {}
     }
-    class RenderBuffer extends Ember.RenderBuffer { }
-    class Route extends Ember.Route { }
-    class Router extends Ember.Router { }
-    class RouterDSL extends Ember.RouterDSL { }
+    class RenderBuffer extends Ember.RenderBuffer {}
+    class Route extends Ember.Route {}
+    class Router extends Ember.Router {}
+    class RouterDSL extends Ember.RouterDSL {}
     var SHIM_ES5: typeof Ember.SHIM_ES5;
     var STRINGS: typeof Ember.STRINGS;
-    class Select extends Ember.Select { }
-    class SelectOption extends Ember.SelectOption { }
-    class Set extends Ember.Set { }
-    class SortableMixin extends Ember.SortableMixin { }
-    class State extends Ember.State { }
-    class StateManager extends Ember.StateManager { }
+    class Select extends Ember.Select {}
+    class SelectOption extends Ember.SelectOption {}
+    class Set extends Ember.Set {}
+    class SortableMixin extends Ember.SortableMixin {}
+    class State extends Ember.State {}
+    class StateManager extends Ember.StateManager {}
     namespace String {
         var camelize: typeof Ember.String.camelize;
         var capitalize: typeof Ember.String.capitalize;
@@ -3127,14 +3117,14 @@ declare namespace Em {
         var w: typeof Ember.String.w;
     }
     var TEMPLATES: typeof Ember.TEMPLATES;
-    class TargetActionSupport extends Ember.TargetActionSupport { }
-    class Test extends Ember.Test { }
-    class TextArea extends Ember.TextArea { }
-    class TextField extends Ember.TextField { }
-    class TextSupport extends Ember.TextSupport { }
+    class TargetActionSupport extends Ember.TargetActionSupport {}
+    class Test extends Ember.Test {}
+    class TextArea extends Ember.TextArea {}
+    class TextField extends Ember.TextField {}
+    class TextSupport extends Ember.TextSupport {}
     var VERSION: typeof Ember.VERSION;
-    class View extends Ember.View { }
-    class ViewTargetActionSupport extends Ember.ViewTargetActionSupport { }
+    class View extends Ember.View {}
+    class ViewTargetActionSupport extends Ember.ViewTargetActionSupport {}
     var ViewUtils: typeof Ember.ViewUtils;
     var addBeforeObserver: typeof Ember.addBeforeObserver;
     var addListener: typeof Ember.addListener;
@@ -3249,115 +3239,114 @@ declare namespace Em {
  * External ambient module - to allow "import Ember = require('Ember');" to work correctly
  */
 
-declare module "Ember" {
-
+declare module 'Ember' {
     var $: typeof Ember.$;
     var A: typeof Ember.A;
-    class ActionHandlerMixin extends Ember.ActionHandlerMixin { }
-    class Application extends Ember.Application { }
-    class Array extends Ember.Array { }
-    class ArrayController extends Ember.ArrayController { }
+    class ActionHandlerMixin extends Ember.ActionHandlerMixin {}
+    class Application extends Ember.Application {}
+    class Array extends Ember.Array {}
+    class ArrayController extends Ember.ArrayController {}
     var ArrayPolyfills: typeof Ember.ArrayPolyfills;
-    class ArrayProxy extends Ember.ArrayProxy { }
+    class ArrayProxy extends Ember.ArrayProxy {}
     var BOOTED: typeof Ember.BOOTED;
-    class Binding extends Ember.Binding { }
-    class Button extends Ember.Button { }
-    class Checkbox extends Ember.Checkbox { }
-    class CollectionView extends Ember.CollectionView { }
-    class Comparable extends Ember.Comparable { }
-    class Component extends Ember.Component { }
-    class ComputedProperty extends Ember.ComputedProperty { }
-    class Container extends Ember.Container { }
-    class ContainerView extends Ember.ContainerView { }
-    class Controller extends Ember.Controller { }
-    class ControllerMixin extends Ember.ControllerMixin { }
-    class Copyable extends Ember.Copyable { }
-    class CoreObject extends Ember.CoreObject { }
-    class CoreView extends Ember.CoreView { }
-    class DAG extends Ember.DAG { }
+    class Binding extends Ember.Binding {}
+    class Button extends Ember.Button {}
+    class Checkbox extends Ember.Checkbox {}
+    class CollectionView extends Ember.CollectionView {}
+    class Comparable extends Ember.Comparable {}
+    class Component extends Ember.Component {}
+    class ComputedProperty extends Ember.ComputedProperty {}
+    class Container extends Ember.Container {}
+    class ContainerView extends Ember.ContainerView {}
+    class Controller extends Ember.Controller {}
+    class ControllerMixin extends Ember.ControllerMixin {}
+    class Copyable extends Ember.Copyable {}
+    class CoreObject extends Ember.CoreObject {}
+    class CoreView extends Ember.CoreView {}
+    class DAG extends Ember.DAG {}
     var DEFAULT_GETTER_FUNCTION: typeof Ember.DEFAULT_GETTER_FUNCTION;
-    class DefaultResolver extends Ember.DefaultResolver { }
-    class Deffered extends Ember.Deferred { }
-    class DeferredMixin extends Ember.DeferredMixin { }
-    class Descriptor extends Ember.Descriptor { }
+    class DefaultResolver extends Ember.DefaultResolver {}
+    class Deffered extends Ember.Deferred {}
+    class DeferredMixin extends Ember.DeferredMixin {}
+    class Descriptor extends Ember.Descriptor {}
     var EMPTY_META: typeof Ember.EMPTY_META;
     var ENV: typeof Ember.ENV;
     var EXTEND_PROTOTYPES: typeof Ember.EXTEND_PROTOTYPES;
-    class EachProxy extends Ember.EachProxy { }
-    class Enumerable extends Ember.Enumerable { }
+    class EachProxy extends Ember.EachProxy {}
+    class Enumerable extends Ember.Enumerable {}
     var EnumerableUtils: typeof Ember.EnumerableUtils;
     var Error: typeof Ember.Error;
-    class EventDispatcher extends Ember.EventDispatcher { }
-    class Evented extends Ember.Evented { }
+    class EventDispatcher extends Ember.EventDispatcher {}
+    class Evented extends Ember.Evented {}
     var FROZEN_ERROR: typeof Ember.FROZEN_ERROR;
-    class Freezable extends Ember.Freezable { }
+    class Freezable extends Ember.Freezable {}
     var GUID_KEY: typeof Ember.GUID_KEY;
     namespace Handlebars {
         var compile: typeof Ember.Handlebars.compile;
         var get: typeof Ember.Handlebars.get;
         var helper: typeof Ember.Handlebars.helper;
-        class helpers extends Ember.Handlebars.helpers { }
+        class helpers extends Ember.Handlebars.helpers {}
         var precompile: typeof Ember.Handlebars.precompile;
         var registerBoundHelper: typeof Ember.Handlebars.registerBoundHelper;
-        class Compiler extends Ember.Handlebars.Compiler { }
-        class JavaScriptCompiler extends Ember.Handlebars.JavaScriptCompiler { }
+        class Compiler extends Ember.Handlebars.Compiler {}
+        class JavaScriptCompiler extends Ember.Handlebars.JavaScriptCompiler {}
         var registerHelper: typeof Ember.Handlebars.registerHelper;
         var registerPartial: typeof Ember.Handlebars.registerPartial;
         var K: typeof Ember.Handlebars.K;
         var createFrame: typeof Ember.Handlebars.createFrame;
         var Exception: typeof Ember.Handlebars.Exception;
-        class SafeString extends Ember.Handlebars.SafeString { }
+        class SafeString extends Ember.Handlebars.SafeString {}
         var parse: typeof Ember.Handlebars.parse;
         var print: typeof Ember.Handlebars.print;
         var logger: typeof Ember.Handlebars.logger;
         var log: typeof Ember.Handlebars.log;
     }
-    class HashLocation extends Ember.HashLocation { }
-    class HistoryLocation extends Ember.HistoryLocation { }
+    class HashLocation extends Ember.HashLocation {}
+    class HistoryLocation extends Ember.HistoryLocation {}
     var IS_BINDING: typeof Ember.IS_BINDING;
-    class Instrumentation extends Ember.Instrumentation { }
+    class Instrumentation extends Ember.Instrumentation {}
     var K: typeof Ember.K;
     var LOG_BINDINGS: typeof Ember.LOG_BINDINGS;
     var LOG_STACKTRACE_ON_DEPRECATION: typeof Ember.LOG_STACKTRACE_ON_DEPRECATION;
     var LOG_VERSION: typeof Ember.LOG_VERSION;
-    class LinkView extends Ember.LinkView { }
-    class Location extends Ember.Location { }
+    class LinkView extends Ember.LinkView {}
+    class Location extends Ember.Location {}
     var Logger: typeof Ember.Logger;
     var MANDATORY_SETTER_FUNCTION: typeof Ember.MANDATORY_SETTER_FUNCTION;
     var META_KEY: typeof Ember.META_KEY;
-    class Map extends Ember.Map { }
-    class MapWithDefault extends Ember.MapWithDefault { }
-    class Mixin extends Ember.Mixin { }
-    class MutableArray extends Ember.MutableArray { }
-    class MutableEnumerable extends Ember.MutableEnumerable { }
+    class Map extends Ember.Map {}
+    class MapWithDefault extends Ember.MapWithDefault {}
+    class Mixin extends Ember.Mixin {}
+    class MutableArray extends Ember.MutableArray {}
+    class MutableEnumerable extends Ember.MutableEnumerable {}
     var NAME_KEY: typeof Ember.NAME_KEY;
-    class Namespace extends Ember.Namespace { }
-    class NativeArray extends Ember.NativeArray { }
-    class NoneLocation extends Ember.NoneLocation { }
+    class Namespace extends Ember.Namespace {}
+    class NativeArray extends Ember.NativeArray {}
+    class NoneLocation extends Ember.NoneLocation {}
     var ORDER_DEFINITION: typeof Ember.ORDER_DEFINITION;
-    class Object extends Ember.Object { }
-    class ObjectController extends Ember.ObjectController { }
-    class ObjectProxy extends Ember.ObjectProxy { }
-    class Observable extends Ember.Observable { }
-    class OrderedSet extends Ember.OrderedSet { }
+    class Object extends Ember.Object {}
+    class ObjectController extends Ember.ObjectController {}
+    class ObjectProxy extends Ember.ObjectProxy {}
+    class Observable extends Ember.Observable {}
+    class OrderedSet extends Ember.OrderedSet {}
     namespace RSVP {
-        interface PromiseResolve extends Ember.RSVP.PromiseResolve { }
-        interface PromiseReject extends Ember.RSVP.PromiseReject { }
-        interface PromiseResolverFunction extends Ember.RSVP.PromiseResolverFunction { }
-        class Promise extends Ember.RSVP.Promise { }
+        interface PromiseResolve extends Ember.RSVP.PromiseResolve {}
+        interface PromiseReject extends Ember.RSVP.PromiseReject {}
+        interface PromiseResolverFunction extends Ember.RSVP.PromiseResolverFunction {}
+        class Promise extends Ember.RSVP.Promise {}
     }
-    class RenderBuffer extends Ember.RenderBuffer { }
-    class Route extends Ember.Route { }
-    class Router extends Ember.Router { }
-    class RouterDSL extends Ember.RouterDSL { }
+    class RenderBuffer extends Ember.RenderBuffer {}
+    class Route extends Ember.Route {}
+    class Router extends Ember.Router {}
+    class RouterDSL extends Ember.RouterDSL {}
     var SHIM_ES5: typeof Ember.SHIM_ES5;
     var STRINGS: typeof Ember.STRINGS;
-    class Select extends Ember.Select { }
-    class SelectOption extends Ember.SelectOption { }
-    class Set extends Ember.Set { }
-    class SortableMixin extends Ember.SortableMixin { }
-    class State extends Ember.State { }
-    class StateManager extends Ember.StateManager { }
+    class Select extends Ember.Select {}
+    class SelectOption extends Ember.SelectOption {}
+    class Set extends Ember.Set {}
+    class SortableMixin extends Ember.SortableMixin {}
+    class State extends Ember.State {}
+    class StateManager extends Ember.StateManager {}
     namespace String {
         var camelize: typeof Ember.String.camelize;
         var capitalize: typeof Ember.String.capitalize;
@@ -3371,14 +3360,14 @@ declare module "Ember" {
         var w: typeof Ember.String.w;
     }
     var TEMPLATES: typeof Ember.TEMPLATES;
-    class TargetActionSupport extends Ember.TargetActionSupport { }
-    class Test extends Ember.Test { }
-    class TextArea extends Ember.TextArea { }
-    class TextField extends Ember.TextField { }
-    class TextSupport extends Ember.TextSupport { }
+    class TargetActionSupport extends Ember.TargetActionSupport {}
+    class Test extends Ember.Test {}
+    class TextArea extends Ember.TextArea {}
+    class TextField extends Ember.TextField {}
+    class TextSupport extends Ember.TextSupport {}
     var VERSION: typeof Ember.VERSION;
-    class View extends Ember.View { }
-    class ViewTargetActionSupport extends Ember.ViewTargetActionSupport { }
+    class View extends Ember.View {}
+    class ViewTargetActionSupport extends Ember.ViewTargetActionSupport {}
     var ViewUtils: typeof Ember.ViewUtils;
     var addBeforeObserver: typeof Ember.addBeforeObserver;
     var addListener: typeof Ember.addListener;

--- a/types/ember/v2/index.d.ts
+++ b/types/ember/v2/index.d.ts
@@ -29,8 +29,12 @@ declare module 'ember' {
     /**
      * Deconstructs computed properties into the types which would be returned by `.get()`.
      */
-    type ComputedPropertyGetters<T> = { [K in keyof T]: Ember.ComputedProperty<T[K], any> | ModuleComputed<T[K], any> | T[K] };
-    type ComputedPropertySetters<T> = { [K in keyof T]: Ember.ComputedProperty<any, T[K]> | ModuleComputed<any, T[K]> | T[K] };
+    type ComputedPropertyGetters<T> = {
+        [K in keyof T]: Ember.ComputedProperty<T[K], any> | ModuleComputed<T[K], any> | T[K];
+    };
+    type ComputedPropertySetters<T> = {
+        [K in keyof T]: Ember.ComputedProperty<any, T[K]> | ModuleComputed<any, T[K]> | T[K];
+    };
 
     /**
      * Check that any arguments to `create()` match the type's properties.
@@ -104,18 +108,12 @@ declare module 'ember' {
     }
 
     type RunMethod<Target, Ret = any> = ((this: Target, ...args: any[]) => Ret) | keyof Target;
-    type EmberRunQueues =
-        | 'sync'
-        | 'actions'
-        | 'routerTransitions'
-        | 'render'
-        | 'afterRender'
-        | 'destroy';
+    type EmberRunQueues = 'sync' | 'actions' | 'routerTransitions' | 'render' | 'afterRender' | 'destroy';
     type QueryParamTypes = 'boolean' | 'number' | 'array' | 'string';
     type QueryParamScopeTypes = 'controller' | 'model';
 
     type ObserverMethod<Target, Sender> =
-        | (keyof Target)
+        | keyof Target
         | ((this: Target, sender: Sender, key: keyof Sender, value: any, rev: number) => void);
 
     interface RenderOptions {
@@ -337,7 +335,7 @@ declare module 'ember' {
              * `inject`) or for service lookup. Each factory is registered with
              * a full name including two parts: `type:name`.
              */
-            register(fullName: string, factory: any, options?: { singleton?: boolean, instantiate?: boolean }): any;
+            register(fullName: string, factory: any, options?: { singleton?: boolean; instantiate?: boolean }): any;
             /**
              * Unregister a factory.
              */
@@ -755,11 +753,16 @@ declare module 'ember' {
             replaceRoute(name: string, ...args: any[]): void;
             transitionToRoute(name: string, ...args: any[]): void;
             model: any;
-            queryParams: string | string[] | Array<{ [key: string]: {
-                type?: QueryParamTypes,
-                scope?: QueryParamScopeTypes,
-                as?: string
-            }}>;
+            queryParams:
+                | string
+                | string[]
+                | Array<{
+                      [key: string]: {
+                          type?: QueryParamTypes;
+                          scope?: QueryParamScopeTypes;
+                          as?: string;
+                      };
+                  }>;
             target: Object;
         }
         const ControllerMixin: Ember.Mixin<ControllerMixin>;
@@ -842,7 +845,7 @@ declare module 'ember' {
 
             static create<Instance, Args, T1 extends EmberInstanceArguments<Args>>(
                 this: EmberClassConstructor<Instance & ComputedPropertyGetters<Args>>,
-                arg1: T1 & ThisType<Fix<T1 & Instance>>
+                arg1: T1 & ThisType<Fix<T1 & Instance>>,
             ): Fix<Instance & T1>;
 
             static create<
@@ -853,7 +856,7 @@ declare module 'ember' {
             >(
                 this: EmberClassConstructor<Instance & ComputedPropertyGetters<Args>>,
                 arg1: T1 & ThisType<Fix<Instance & T1>>,
-                arg2: T2 & ThisType<Fix<Instance & T1 & T2>>
+                arg2: T2 & ThisType<Fix<Instance & T1 & T2>>,
             ): Fix<Instance & T1 & T2>;
 
             static create<
@@ -866,16 +869,16 @@ declare module 'ember' {
                 this: EmberClassConstructor<Instance & ComputedPropertyGetters<Args>>,
                 arg1: T1 & ThisType<Fix<Instance & T1>>,
                 arg2: T2 & ThisType<Fix<Instance & T1 & T2>>,
-                arg3: T3 & ThisType<Fix<Instance & T1 & T2 & T3>>
+                arg3: T3 & ThisType<Fix<Instance & T1 & T2 & T3>>,
             ): Fix<Instance & T1 & T2 & T3>;
 
             static extend<Statics, Instance>(
-                this: Statics & EmberClassConstructor<Instance>
+                this: Statics & EmberClassConstructor<Instance>,
             ): Objectify<Statics> & EmberClassConstructor<Instance>;
 
             static extend<Statics, Instance extends B1, T1 extends EmberClassArguments, B1>(
                 this: Statics & EmberClassConstructor<Instance>,
-                arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>
+                arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>,
             ): Objectify<Statics> & EmberClassConstructor<T1 & Instance>;
 
             static extend<
@@ -888,7 +891,7 @@ declare module 'ember' {
             >(
                 this: Statics & EmberClassConstructor<Instance>,
                 arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>,
-                arg2: MixinOrLiteral<T2, B2> & ThisType<Fix<Instance & T1 & T2>>
+                arg2: MixinOrLiteral<T2, B2> & ThisType<Fix<Instance & T1 & T2>>,
             ): Objectify<Statics> & EmberClassConstructor<T1 & T2 & Instance>;
 
             static extend<
@@ -904,7 +907,7 @@ declare module 'ember' {
                 this: Statics & EmberClassConstructor<Instance>,
                 arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>,
                 arg2: MixinOrLiteral<T2, B2> & ThisType<Fix<Instance & T1 & T2>>,
-                arg3: MixinOrLiteral<T3, B3> & ThisType<Fix<Instance & T1 & T2 & T3>>
+                arg3: MixinOrLiteral<T3, B3> & ThisType<Fix<Instance & T1 & T2 & T3>>,
             ): Objectify<Statics> & EmberClassConstructor<T1 & T2 & T3 & Instance>;
 
             static extend<
@@ -923,16 +926,16 @@ declare module 'ember' {
                 arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>,
                 arg2: MixinOrLiteral<T2, B2> & ThisType<Fix<Instance & T1 & T2>>,
                 arg3: MixinOrLiteral<T3, B3> & ThisType<Fix<Instance & T1 & T2 & T3>>,
-                arg4: MixinOrLiteral<T4, B4> & ThisType<Fix<Instance & T1 & T2 & T3 & T4>>
+                arg4: MixinOrLiteral<T4, B4> & ThisType<Fix<Instance & T1 & T2 & T3 & T4>>,
             ): Objectify<Statics> & EmberClassConstructor<T1 & T2 & T3 & T4 & Instance>;
 
             static reopen<Statics, Instance>(
-                this: Statics & EmberClassConstructor<Instance>
+                this: Statics & EmberClassConstructor<Instance>,
             ): Objectify<Statics> & EmberClassConstructor<Instance>;
 
             static reopen<Statics, Instance extends B1, T1 extends EmberClassArguments, B1>(
                 this: Statics & EmberClassConstructor<Instance>,
-                arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>
+                arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>,
             ): Objectify<Statics> & EmberClassConstructor<Instance & T1>;
 
             static reopen<
@@ -945,7 +948,7 @@ declare module 'ember' {
             >(
                 this: Statics & EmberClassConstructor<Instance>,
                 arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>,
-                arg2: MixinOrLiteral<T2, B2> & ThisType<Fix<Instance & T1 & T2>>
+                arg2: MixinOrLiteral<T2, B2> & ThisType<Fix<Instance & T1 & T2>>,
             ): Objectify<Statics> & EmberClassConstructor<Instance & T1 & T2>;
 
             static reopen<
@@ -961,21 +964,18 @@ declare module 'ember' {
                 this: Statics & EmberClassConstructor<Instance>,
                 arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>,
                 arg2: MixinOrLiteral<T2, B2> & ThisType<Fix<Instance & T1 & T2>>,
-                arg3: MixinOrLiteral<T3, B3> & ThisType<Fix<Instance & T1 & T2 & T3>>
+                arg3: MixinOrLiteral<T3, B3> & ThisType<Fix<Instance & T1 & T2 & T3>>,
             ): Objectify<Statics> & EmberClassConstructor<Instance & T1 & T2 & T3>;
 
             static reopenClass<Statics>(this: Statics): Statics;
 
-            static reopenClass<Statics, T1 extends EmberClassArguments>(
-                this: Statics,
-                arg1: T1
-            ): Statics & T1;
+            static reopenClass<Statics, T1 extends EmberClassArguments>(this: Statics, arg1: T1): Statics & T1;
 
-            static reopenClass<
-                Statics,
-                T1 extends EmberClassArguments,
-                T2 extends EmberClassArguments
-            >(this: Statics, arg1: T1, arg2: T2): Statics & T1 & T2;
+            static reopenClass<Statics, T1 extends EmberClassArguments, T2 extends EmberClassArguments>(
+                this: Statics,
+                arg1: T1,
+                arg2: T2,
+            ): Statics & T1 & T2;
 
             static reopenClass<
                 Statics,
@@ -986,13 +986,10 @@ declare module 'ember' {
 
             static detect<Statics, Instance>(
                 this: Statics & EmberClassConstructor<Instance>,
-                obj: any
+                obj: any,
             ): obj is Objectify<Statics> & EmberClassConstructor<Instance>;
 
-            static detectInstance<Instance>(
-                this: EmberClassConstructor<Instance>,
-                obj: any
-            ): obj is Instance;
+            static detectInstance<Instance>(this: EmberClassConstructor<Instance>, obj: any): obj is Instance;
 
             /**
              Iterate over each computed property for the class, passing its name and any
@@ -1040,7 +1037,7 @@ declare module 'ember' {
                 modelName: string,
                 recordsAdded: Function,
                 recordsUpdated: Function,
-                recordsRemoved: Function
+                recordsRemoved: Function,
             ): Function;
         }
         const Debug: {
@@ -1113,10 +1110,7 @@ declare module 'ember' {
          * The `EngineInstance` encapsulates all of the stateful aspects of a
          * running `Engine`.
          */
-        class EngineInstance extends Ember.Object.extend(
-            _RegistryProxyMixin,
-            _ContainerProxyMixin
-        ) {
+        class EngineInstance extends Ember.Object.extend(_RegistryProxyMixin, _ContainerProxyMixin) {
             /**
              * Unregister a factory.
              */
@@ -1314,22 +1308,14 @@ declare module 'ember' {
             /**
              * Subscribes to a named event with given function.
              */
-            on<Target>(
-                name: string,
-                target: Target,
-                method: (this: Target, ...args: any[]) => void
-            ): this;
+            on<Target>(name: string, target: Target, method: (this: Target, ...args: any[]) => void): this;
             on(name: string, method: (...args: any[]) => void): this;
             /**
              * Subscribes a function to a named event and then cancels the subscription
              * after the first time the event is triggered. It is good to use ``one`` when
              * you only care about the first time an event has taken place.
              */
-            one<Target>(
-                name: string,
-                target: Target,
-                method: (this: Target, ...args: any[]) => void
-            ): this;
+            one<Target>(name: string, target: Target, method: (this: Target, ...args: any[]) => void): this;
             one(name: string, method: (...args: any[]) => void): this;
             /**
              * Triggers a named event for the object. Any additional arguments
@@ -1340,11 +1326,7 @@ declare module 'ember' {
             /**
              * Cancels subscription for given name, target, and method.
              */
-            off<Target>(
-                name: string,
-                target: Target,
-                method: (this: Target, ...args: any[]) => void
-            ): this;
+            off<Target>(name: string, target: Target, method: (this: Target, ...args: any[]) => void): this;
             off(name: string, method: (...args: any[]) => void): this;
             /**
              * Checks to see if object has any subscriptions for named event.
@@ -1519,25 +1501,25 @@ declare module 'ember' {
             __ember_mixin__: never;
 
             static create<T, Base = Ember.Object>(
-              args?: MixinOrLiteral<T, Base> & ThisType<Fix<T & Base>>
+                args?: MixinOrLiteral<T, Base> & ThisType<Fix<T & Base>>,
             ): Mixin<T, Base>;
 
             static create<T1, T2, Base = Ember.Object>(
-              arg1: MixinOrLiteral<T1, Base> & ThisType<Fix<T1 & Base>>,
-              arg2: MixinOrLiteral<T2, Base> & ThisType<Fix<T2 & Base>>
+                arg1: MixinOrLiteral<T1, Base> & ThisType<Fix<T1 & Base>>,
+                arg2: MixinOrLiteral<T2, Base> & ThisType<Fix<T2 & Base>>,
             ): Mixin<T1 & T2, Base>;
 
             static create<T1, T2, T3, Base = Ember.Object>(
-              arg1: MixinOrLiteral<T1, Base> & ThisType<Fix<T1 & Base>>,
-              arg2: MixinOrLiteral<T2, Base> & ThisType<Fix<T2 & Base>>,
-              arg3: MixinOrLiteral<T3, Base> & ThisType<Fix<T3 & Base>>
+                arg1: MixinOrLiteral<T1, Base> & ThisType<Fix<T1 & Base>>,
+                arg2: MixinOrLiteral<T2, Base> & ThisType<Fix<T2 & Base>>,
+                arg3: MixinOrLiteral<T3, Base> & ThisType<Fix<T3 & Base>>,
             ): Mixin<T1 & T2 & T3, Base>;
 
             static create<T1, T2, T3, T4, Base = Ember.Object>(
-              arg1: MixinOrLiteral<T1, Base> & ThisType<Fix<T1 & Base>>,
-              arg2: MixinOrLiteral<T2, Base> & ThisType<Fix<T2 & Base>>,
-              arg3: MixinOrLiteral<T3, Base> & ThisType<Fix<T3 & Base>>,
-              arg4: MixinOrLiteral<T4, Base> & ThisType<Fix<T4 & Base>>
+                arg1: MixinOrLiteral<T1, Base> & ThisType<Fix<T1 & Base>>,
+                arg2: MixinOrLiteral<T2, Base> & ThisType<Fix<T2 & Base>>,
+                arg3: MixinOrLiteral<T3, Base> & ThisType<Fix<T3 & Base>>,
+                arg4: MixinOrLiteral<T4, Base> & ThisType<Fix<T4 & Base>>,
             ): Mixin<T1 & T2 & T3 & T4, Base>;
         }
         /**
@@ -1688,10 +1670,7 @@ declare module 'ember' {
              * with a list of strings or an array:
              */
             getProperties<T, K extends keyof T>(this: ComputedPropertyGetters<T>, list: K[]): Pick<T, K>;
-            getProperties<T, K extends keyof T>(
-                this: ComputedPropertyGetters<T>,
-                ...list: K[]
-            ): Pick<T, K>;
+            getProperties<T, K extends keyof T>(this: ComputedPropertyGetters<T>, ...list: K[]): Pick<T, K>;
             /**
              * Sets the provided key or path to the value.
              */
@@ -1701,10 +1680,7 @@ declare module 'ember' {
              * a single `beginPropertyChanges` and `endPropertyChanges` batch, so
              * observers will be buffered.
              */
-            setProperties<T, K extends keyof T>(
-                this: ComputedPropertySetters<T>,
-                hash: Pick<T, K>
-            ): Pick<T, K>;
+            setProperties<T, K extends keyof T>(this: ComputedPropertySetters<T>, hash: Pick<T, K>): Pick<T, K>;
             /**
              * Convenience method to call `propertyWillChange` and `propertyDidChange` in
              * succession.
@@ -1713,38 +1689,20 @@ declare module 'ember' {
             /**
              * Adds an observer on a property.
              */
-            addObserver<Target>(
-                key: keyof this,
-                target: Target,
-                method: ObserverMethod<Target, this>
-            ): void;
-            addObserver(
-                key: keyof this,
-                method: ObserverMethod<this, this>
-            ): void;
+            addObserver<Target>(key: keyof this, target: Target, method: ObserverMethod<Target, this>): void;
+            addObserver(key: keyof this, method: ObserverMethod<this, this>): void;
             /**
              * Remove an observer you have previously registered on this object. Pass
              * the same key, target, and method you passed to `addObserver()` and your
              * target will no longer receive notifications.
              */
-            removeObserver<Target>(
-                key: keyof this,
-                target: Target,
-                method: ObserverMethod<Target, this>
-            ): any;
-            removeObserver(
-                key: keyof this,
-                method: ObserverMethod<this, this>
-            ): any;
+            removeObserver<Target>(key: keyof this, target: Target, method: ObserverMethod<Target, this>): any;
+            removeObserver(key: keyof this, method: ObserverMethod<this, this>): any;
             /**
              * Retrieves the value of a property, or a default value in the case that the
              * property returns `undefined`.
              */
-            getWithDefault<T, K extends keyof T>(
-                this: ComputedPropertyGetters<T>,
-                key: K,
-                defaultValue: T[K]
-            ): T[K];
+            getWithDefault<T, K extends keyof T>(this: ComputedPropertyGetters<T>, key: K, defaultValue: T[K]): T[K];
             /**
              * Set the value of a property to the current value plus some amount.
              */
@@ -1819,11 +1777,7 @@ declare module 'ember' {
          * by type.
          */
         class Registry {
-            register(
-                fullName: string,
-                factory: EmberClassConstructor<any>,
-                options?: { singleton?: boolean }
-            ): void;
+            register(fullName: string, factory: EmberClassConstructor<any>, options?: { singleton?: boolean }): void;
         }
         class Resolver extends Ember.Object {}
         /**
@@ -2156,16 +2110,16 @@ declare module 'ember' {
             route(
                 name: string,
                 options?: { path?: string; resetNamespace?: boolean },
-                callback?: (this: RouterDSL) => void
+                callback?: (this: RouterDSL) => void,
             ): void;
             mount(
                 name: string,
                 options?: {
-                    as?: string,
-                    path?: string,
-                    resetNamespace?: boolean,
-                    engineInfo?: any
-                }
+                    as?: string;
+                    path?: string;
+                    resetNamespace?: boolean;
+                    engineInfo?: any;
+                },
             ): void;
         }
         class Service extends Object {}
@@ -2264,16 +2218,13 @@ declare module 'ember' {
             function registerHelper(
                 name: string,
                 helperMethod: (app: Application, ...args: any[]) => any,
-                options?: object
+                options?: object,
             ): any;
             /**
              * `registerAsyncHelper` is used to register an async test helper that will be injected
              * when `App.injectTestHelpers` is called.
              */
-            function registerAsyncHelper(
-                name: string,
-                helperMethod: (app: Application, ...args: any[]) => any
-            ): void;
+            function registerAsyncHelper(name: string, helperMethod: (app: Application, ...args: any[]) => any): void;
             /**
              * Remove a previously added helper method.
              */
@@ -2289,11 +2240,8 @@ declare module 'ember' {
              * callback in the last chained then.
              */
             function promise<T>(
-                resolver: (
-                    resolve: (value?: T | PromiseLike<T>) => void,
-                    reject: (reason?: any) => void
-                ) => void,
-                label?: string
+                resolver: (resolve: (value?: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void,
+                label?: string,
             ): Ember.Test.Promise<T>;
             /**
              * Replacement for `Ember.RSVP.resolve`
@@ -2310,19 +2258,13 @@ declare module 'ember' {
              * is executed and the process repeats.
              */
             function registerWaiter(callback: () => boolean): any;
-            function registerWaiter<Context>(
-                context: Context,
-                callback: (this: Context) => boolean
-            ): any;
+            function registerWaiter<Context>(context: Context, callback: (this: Context) => boolean): any;
             /**
              * `unregisterWaiter` is used to unregister a callback that was
              * registered with `registerWaiter`.
              */
             function unregisterWaiter(callback: () => boolean): any;
-            function unregisterWaiter<Context>(
-                context: Context,
-                callback: (this: Context) => boolean
-            ): any;
+            function unregisterWaiter<Context>(context: Context, callback: (this: Context) => boolean): any;
             /**
              * Iterates through each registered test waiter, and invokes
              * its callback. If any waiter returns false, this method will return
@@ -2361,10 +2303,7 @@ declare module 'ember' {
             class QUnitAdapter extends Adapter {}
             class Promise<T> extends Rsvp.Promise<T> {
                 constructor(
-                    executor: (
-                        resolve: (value?: T | PromiseLike<T>) => void,
-                        reject: (reason?: any) => void
-                    ) => void
+                    executor: (resolve: (value?: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void,
                 );
             }
         }
@@ -2377,17 +2316,13 @@ declare module 'ember' {
              * Can only be used when defining another controller.
              */
             function controller(): ComputedProperty<Ember.Controller>;
-            function controller<K extends keyof ControllerRegistry>(
-                name: K
-            ): ComputedProperty<ControllerRegistry[K]>;
+            function controller<K extends keyof ControllerRegistry>(name: K): ComputedProperty<ControllerRegistry[K]>;
             /**
              * Creates a property that lazily looks up a service in the container. There
              * are no restrictions as to what objects a service can be injected into.
              */
             function service(): ComputedProperty<Ember.Service>;
-            function service<K extends keyof ServiceRegistry>(
-                name: K
-            ): ComputedProperty<ServiceRegistry[K]>;
+            function service<K extends keyof ServiceRegistry>(name: K): ComputedProperty<ServiceRegistry[K]>;
         }
         namespace ENV {
             const EXTEND_PROTOTYPES: typeof Ember.EXTEND_PROTOTYPES;
@@ -2439,26 +2374,15 @@ declare module 'ember' {
             <T>(cb: ComputedPropertyCallback<T>): ComputedProperty<T>;
             <T>(k1: string, cb: ComputedPropertyCallback<T>): ComputedProperty<T>;
             <T>(k1: string, k2: string, cb: ComputedPropertyCallback<T>): ComputedProperty<T>;
-            <T>(
-                k1: string,
-                k2: string,
-                k3: string,
-                cb: ComputedPropertyCallback<T>
-            ): ComputedProperty<T>;
-            <T>(
-                k1: string,
-                k2: string,
-                k3: string,
-                k4: string,
-                cb: ComputedPropertyCallback<T>
-            ): ComputedProperty<T>;
+            <T>(k1: string, k2: string, k3: string, cb: ComputedPropertyCallback<T>): ComputedProperty<T>;
+            <T>(k1: string, k2: string, k3: string, k4: string, cb: ComputedPropertyCallback<T>): ComputedProperty<T>;
             <T>(
                 k1: string,
                 k2: string,
                 k3: string,
                 k4: string,
                 k5: string,
-                cb: ComputedPropertyCallback<T>
+                cb: ComputedPropertyCallback<T>,
             ): ComputedProperty<T>;
             <T>(
                 k1: string,
@@ -2467,7 +2391,7 @@ declare module 'ember' {
                 k4: string,
                 k5: string,
                 k6: string,
-                cb: ComputedPropertyCallback<T>
+                cb: ComputedPropertyCallback<T>,
             ): ComputedProperty<T>;
             (
                 k1: string,
@@ -2578,17 +2502,11 @@ declare module 'ember' {
              * though they were called on the original property, but also
              * print a deprecation warning.
              */
-            deprecatingAlias(
-                dependentKey: string,
-                options: DeprecationOptions
-            ): ComputedProperty<any>;
+            deprecatingAlias(dependentKey: string, options: DeprecationOptions): ComputedProperty<any>;
             /**
              * @deprecated Missing deprecation options: https://emberjs.com/deprecations/v2.x/#toc_ember-debug-function-options
              */
-            deprecatingAlias(
-                dependentKey: string,
-                options?: Partial<DeprecationOptions>
-            ): ComputedProperty<any>;
+            deprecatingAlias(dependentKey: string, options?: Partial<DeprecationOptions>): ComputedProperty<any>;
             /**
              * A computed property that returns the sum of the values
              * in the dependent array.
@@ -2611,7 +2529,7 @@ declare module 'ember' {
              */
             map<U>(
                 dependentKey: string,
-                callback: (value: any, index: number, array: any[]) => U
+                callback: (value: any, index: number, array: any[]) => U,
             ): ComputedProperty<U[]>;
             /**
              * Returns an array mapped to the specified key.
@@ -2622,16 +2540,12 @@ declare module 'ember' {
              */
             filter(
                 dependentKey: string,
-                callback: (value: any, index: number, array: any[]) => boolean
+                callback: (value: any, index: number, array: any[]) => boolean,
             ): ComputedProperty<any[]>;
             /**
              * Filters the array by the property and value
              */
-            filterBy(
-                dependentKey: string,
-                propertyKey: string,
-                value?: any
-            ): ComputedProperty<any[]>;
+            filterBy(dependentKey: string, propertyKey: string, value?: any): ComputedProperty<any[]>;
             /**
              * A computed property which returns a new array with all the unique
              * elements from one or more dependent arrays.
@@ -2670,7 +2584,7 @@ declare module 'ember' {
              */
             sort(
                 itemsKey: string,
-                sortDefinition: string | ((itemA: any, itemB: any) => number)
+                sortDefinition: string | ((itemA: any, itemB: any) => number),
             ): ComputedProperty<any[]>;
         };
         const run: {
@@ -2687,22 +2601,14 @@ declare module 'ember' {
              * queue.
              */
             join<Ret>(method: (...args: any[]) => Ret, ...args: any[]): Ret | undefined;
-            join<Target, Ret>(
-                target: Target,
-                method: RunMethod<Target, Ret>,
-                ...args: any[]
-            ): Ret | undefined;
+            join<Target, Ret>(target: Target, method: RunMethod<Target, Ret>, ...args: any[]): Ret | undefined;
             /**
              * Allows you to specify which context to call the specified function in while
              * adding the execution of that function to the Ember run loop. This ability
              * makes this method a great way to asynchronously integrate third-party libraries
              * into your Ember application.
              */
-            bind<Target, Ret>(
-                target: Target,
-                method: RunMethod<Target, Ret>,
-                ...args: any[]
-            ): (...args: any[]) => Ret;
+            bind<Target, Ret>(target: Target, method: RunMethod<Target, Ret>, ...args: any[]): (...args: any[]) => Ret;
             /**
              * Begins a new RunLoop. Any deferred actions invoked after the begin will
              * be buffered until you invoke a matching call to `run.end()`. This is
@@ -2727,11 +2633,7 @@ declare module 'ember' {
                 method: RunMethod<Target>,
                 ...args: any[]
             ): EmberRunTimer;
-            schedule(
-                queue: EmberRunQueues,
-                method: (args: any[]) => any,
-                ...args: any[]
-            ): EmberRunTimer;
+            schedule(queue: EmberRunQueues, method: (args: any[]) => any, ...args: any[]): EmberRunTimer;
             /**
              * Invokes the passed target/method and optional arguments after a specified
              * period of time. The last parameter of this method must always be a number
@@ -2739,26 +2641,15 @@ declare module 'ember' {
              */
             later(method: (...args: any[]) => any, wait: number): EmberRunTimer;
             later<Target>(target: Target, method: RunMethod<Target>, wait: number): EmberRunTimer;
-            later<Target>(
-                target: Target,
-                method: RunMethod<Target>,
-                arg0: any,
-                wait: number
-            ): EmberRunTimer;
-            later<Target>(
-                target: Target,
-                method: RunMethod<Target>,
-                arg0: any,
-                arg1: any,
-                wait: number
-            ): EmberRunTimer;
+            later<Target>(target: Target, method: RunMethod<Target>, arg0: any, wait: number): EmberRunTimer;
+            later<Target>(target: Target, method: RunMethod<Target>, arg0: any, arg1: any, wait: number): EmberRunTimer;
             later<Target>(
                 target: Target,
                 method: RunMethod<Target>,
                 arg0: any,
                 arg1: any,
                 arg2: any,
-                wait: number
+                wait: number,
             ): EmberRunTimer;
             later<Target>(
                 target: Target,
@@ -2767,7 +2658,7 @@ declare module 'ember' {
                 arg1: any,
                 arg2: any,
                 arg3: any,
-                wait: number
+                wait: number,
             ): EmberRunTimer;
             later<Target>(
                 target: Target,
@@ -2777,7 +2668,7 @@ declare module 'ember' {
                 arg2: any,
                 arg3: any,
                 arg4: any,
-                wait: number
+                wait: number,
             ): EmberRunTimer;
             later<Target>(
                 target: Target,
@@ -2788,7 +2679,7 @@ declare module 'ember' {
                 arg3: any,
                 arg4: any,
                 arg5: any,
-                wait: number
+                wait: number,
             ): EmberRunTimer;
             /**
              * Schedule a function to run one time during the current RunLoop. This is equivalent
@@ -2824,23 +2715,19 @@ declare module 'ember' {
              * the specified time has elapsed, the timer is reset and the entire period
              * must pass again before the target method is called.
              */
-            debounce(
-                method: (...args: any[]) => any,
-                wait: number,
-                immediate?: boolean
-            ): EmberRunTimer;
+            debounce(method: (...args: any[]) => any, wait: number, immediate?: boolean): EmberRunTimer;
             debounce<Target>(
                 target: Target,
                 method: RunMethod<Target>,
                 wait: number,
-                immediate?: boolean
+                immediate?: boolean,
             ): EmberRunTimer;
             debounce<Target>(
                 target: Target,
                 method: RunMethod<Target>,
                 arg0: any,
                 wait: number,
-                immediate?: boolean
+                immediate?: boolean,
             ): EmberRunTimer;
             debounce<Target>(
                 target: Target,
@@ -2848,7 +2735,7 @@ declare module 'ember' {
                 arg0: any,
                 arg1: any,
                 wait: number,
-                immediate?: boolean
+                immediate?: boolean,
             ): EmberRunTimer;
             debounce<Target>(
                 target: Target,
@@ -2857,7 +2744,7 @@ declare module 'ember' {
                 arg1: any,
                 arg2: any,
                 wait: number,
-                immediate?: boolean
+                immediate?: boolean,
             ): EmberRunTimer;
             debounce<Target>(
                 target: Target,
@@ -2867,7 +2754,7 @@ declare module 'ember' {
                 arg2: any,
                 arg3: any,
                 wait: number,
-                immediate?: boolean
+                immediate?: boolean,
             ): EmberRunTimer;
             debounce<Target>(
                 target: Target,
@@ -2878,7 +2765,7 @@ declare module 'ember' {
                 arg3: any,
                 arg4: any,
                 wait: number,
-                immediate?: boolean
+                immediate?: boolean,
             ): EmberRunTimer;
             debounce<Target>(
                 target: Target,
@@ -2890,29 +2777,25 @@ declare module 'ember' {
                 arg4: any,
                 arg5: any,
                 wait: number,
-                immediate?: boolean
+                immediate?: boolean,
             ): EmberRunTimer;
             /**
              * Ensure that the target method is never called more frequently than
              * the specified spacing period. The target method is called immediately.
              */
-            throttle(
-                method: (...args: any[]) => any,
-                spacing: number,
-                immediate?: boolean
-            ): EmberRunTimer;
+            throttle(method: (...args: any[]) => any, spacing: number, immediate?: boolean): EmberRunTimer;
             throttle<Target>(
                 target: Target,
                 method: RunMethod<Target>,
                 spacing: number,
-                immediate?: boolean
+                immediate?: boolean,
             ): EmberRunTimer;
             throttle<Target>(
                 target: Target,
                 method: RunMethod<Target>,
                 arg0: any,
                 spacing: number,
-                immediate?: boolean
+                immediate?: boolean,
             ): EmberRunTimer;
             throttle<Target>(
                 target: Target,
@@ -2920,7 +2803,7 @@ declare module 'ember' {
                 arg0: any,
                 arg1: any,
                 spacing: number,
-                immediate?: boolean
+                immediate?: boolean,
             ): EmberRunTimer;
             throttle<Target>(
                 target: Target,
@@ -2929,7 +2812,7 @@ declare module 'ember' {
                 arg1: any,
                 arg2: any,
                 spacing: number,
-                immediate?: boolean
+                immediate?: boolean,
             ): EmberRunTimer;
             throttle<Target>(
                 target: Target,
@@ -2939,7 +2822,7 @@ declare module 'ember' {
                 arg2: any,
                 arg3: any,
                 spacing: number,
-                immediate?: boolean
+                immediate?: boolean,
             ): EmberRunTimer;
             throttle<Target>(
                 target: Target,
@@ -2950,7 +2833,7 @@ declare module 'ember' {
                 arg3: any,
                 arg4: any,
                 spacing: number,
-                immediate?: boolean
+                immediate?: boolean,
             ): EmberRunTimer;
             throttle<Target>(
                 target: Target,
@@ -2962,7 +2845,7 @@ declare module 'ember' {
                 arg4: any,
                 arg5: any,
                 spacing: number,
-                immediate?: boolean
+                immediate?: boolean,
             ): EmberRunTimer;
 
             queues: EmberRunQueues[];
@@ -2980,19 +2863,11 @@ declare module 'ember' {
          * Display a deprecation warning with the provided message and a stack trace
          * (Chrome and Firefox only).
          */
-        function deprecate(
-            message: string,
-            test: boolean,
-            options: DeprecationOptions
-        ): any;
+        function deprecate(message: string, test: boolean, options: DeprecationOptions): any;
         /**
          * @deprecated Missing deprecation options: https://emberjs.com/deprecations/v2.x/#toc_ember-debug-function-options
          */
-        function deprecate(
-            message: string,
-            test: boolean,
-            options?: Partial<DeprecationOptions>
-        ): any;
+        function deprecate(message: string, test: boolean, options?: Partial<DeprecationOptions>): any;
         /**
          * Define an assertion that will throw an exception if the condition is not met.
          */
@@ -3011,23 +2886,20 @@ declare module 'ember' {
             keyName: string,
             desc?: PropertyDescriptor | ComputedProperty<any>,
             data?: any,
-            meta?: any
+            meta?: any,
         ): void;
         /**
          * Alias an old, deprecated method with its new counterpart.
          */
-        function deprecateFunc<Func extends ((...args: any[]) => any)>(
+        function deprecateFunc<Func extends (...args: any[]) => any>(
             message: string,
             options: DeprecationOptions,
-            func: Func
+            func: Func,
         ): Func;
         /**
          * @deprecated Missing deprecation options: https://emberjs.com/deprecations/v2.x/#toc_ember-debug-function-options
          */
-        function deprecateFunc<Func extends ((...args: any[]) => any)>(
-            message: string,
-            func: Func
-        ): Func;
+        function deprecateFunc<Func extends (...args: any[]) => any>(message: string, func: Func): Func;
         /**
          * Run a function meant for debugging.
          */
@@ -3057,10 +2929,7 @@ declare module 'ember' {
          * property that is generated lazily, without accidentally causing
          * it to be created.
          */
-        function cacheFor<T, K extends keyof T>(
-            obj: ComputedPropertyGetters<T>,
-            key: K
-        ): T[K] | undefined;
+        function cacheFor<T, K extends keyof T>(obj: ComputedPropertyGetters<T>, key: K): T[K] | undefined;
         /**
          * Add an event listener
          */
@@ -3069,13 +2938,9 @@ declare module 'ember' {
             key: keyof Context,
             target: Target,
             method: ObserverMethod<Target, Context>,
-            once?: boolean
+            once?: boolean,
         ): void;
-        function addListener<Context>(
-            obj: Context,
-            key: keyof Context,
-            method: ObserverMethod<Context, Context>
-        ): void;
+        function addListener<Context>(obj: Context, key: keyof Context, method: ObserverMethod<Context, Context>): void;
         /**
          * Remove an event listener
          */
@@ -3083,12 +2948,12 @@ declare module 'ember' {
             obj: Context,
             key: keyof Context,
             target: Target,
-            method: ObserverMethod<Target, Context>
+            method: ObserverMethod<Target, Context>,
         ): any;
         function removeListener<Context>(
             obj: Context,
             key: keyof Context,
-            method: ObserverMethod<Context, Context>
+            method: ObserverMethod<Context, Context>,
         ): any;
         /**
          * Send an event. The execution of suspended listeners
@@ -3106,15 +2971,9 @@ declare module 'ember' {
          * To get multiple properties at once, call `Ember.getProperties`
          * with an object followed by a list of strings or an array:
          */
-        function getProperties<T, K extends keyof T>(
-            obj: ComputedPropertyGetters<T>,
-            list: K[]
-        ): Pick<T, K>;
+        function getProperties<T, K extends keyof T>(obj: ComputedPropertyGetters<T>, list: K[]): Pick<T, K>;
         function getProperties<T, K extends keyof T>(obj: T, list: K[]): Pick<T, K>; // for dynamic K
-        function getProperties<T, K extends keyof T>(
-            obj: ComputedPropertyGetters<T>,
-            ...list: K[]
-        ): Pick<T, K>;
+        function getProperties<T, K extends keyof T>(obj: ComputedPropertyGetters<T>, ...list: K[]): Pick<T, K>;
         function getProperties<T, K extends keyof T>(obj: T, ...list: K[]): Pick<T, K>; // for dynamic K
         /**
          * A value is blank if it is empty or a whitespace string.
@@ -3148,23 +3007,14 @@ declare module 'ember' {
          * Specify a method that observes property changes.
          */
         function observer(key1: string, func: (target: any, key: string) => void): void;
-        function observer(
-            key1: string,
-            key2: string,
-            func: (target: any, key: string) => void
-        ): void;
-        function observer(
-            key1: string,
-            key2: string,
-            key3: string,
-            func: (target: any, key: string) => void
-        ): void;
+        function observer(key1: string, key2: string, func: (target: any, key: string) => void): void;
+        function observer(key1: string, key2: string, key3: string, func: (target: any, key: string) => void): void;
         function observer(
             key1: string,
             key2: string,
             key3: string,
             key4: string,
-            func: (target: any, key: string) => void
+            func: (target: any, key: string) => void,
         ): void;
         function observer(
             key1: string,
@@ -3172,7 +3022,7 @@ declare module 'ember' {
             key3: string,
             key4: string,
             key5: string,
-            func: (target: any, key: string) => void
+            func: (target: any, key: string) => void,
         ): void;
         /**
          * Adds an observer on a property.
@@ -3181,13 +3031,9 @@ declare module 'ember' {
             obj: Context,
             key: keyof Context,
             target: Target,
-            method: ObserverMethod<Target, Context>
+            method: ObserverMethod<Target, Context>,
         ): void;
-        function addObserver<Context>(
-            obj: Context,
-            key: keyof Context,
-            method: ObserverMethod<Context, Context>
-        ): void;
+        function addObserver<Context>(obj: Context, key: keyof Context, method: ObserverMethod<Context, Context>): void;
         /**
          * Remove an observer you have previously registered on this object. Pass
          * the same key, target, and method you passed to `addObserver()` and your
@@ -3197,12 +3043,12 @@ declare module 'ember' {
             obj: Context,
             key: keyof Context,
             target: Target,
-            method: ObserverMethod<Target, Context>
+            method: ObserverMethod<Target, Context>,
         ): any;
         function removeObserver<Context>(
             obj: Context,
             key: keyof Context,
-            method: ObserverMethod<Context, Context>
+            method: ObserverMethod<Context, Context>,
         ): any;
         /**
          * Gets the value of a property on an object. If the property is computed,
@@ -3218,7 +3064,7 @@ declare module 'ember' {
         function getWithDefault<T, K extends keyof T>(
             obj: ComputedPropertyGetters<T>,
             key: K,
-            defaultValue: T[K]
+            defaultValue: T[K],
         ): T[K];
         function getWithDefault<T, K extends keyof T>(obj: T, key: K, defaultValue: T[K]): T[K]; // for dynamic K
         /**
@@ -3227,11 +3073,7 @@ declare module 'ember' {
          * property is not defined but the object implements the `setUnknownProperty`
          * method then that will be invoked as well.
          */
-        function set<T, K extends keyof T, V extends T[K]>(
-            obj: ComputedPropertySetters<T>,
-            key: K,
-            value: V
-        ): V;
+        function set<T, K extends keyof T, V extends T[K]>(obj: ComputedPropertySetters<T>, key: K, value: V): V;
         function set<T, K extends keyof T, V extends T[K]>(obj: T, key: K, value: V): V; // for dynamic K
         /**
          * Error-tolerant form of `Ember.set`. Will not blow up if any part of the
@@ -3243,10 +3085,7 @@ declare module 'ember' {
          * a single `beginPropertyChanges` and `endPropertyChanges` batch, so
          * observers will be buffered.
          */
-        function setProperties<T, K extends keyof T>(
-            obj: ComputedPropertySetters<T>,
-            hash: Pick<T, K>
-        ): Pick<T, K>;
+        function setProperties<T, K extends keyof T>(obj: ComputedPropertySetters<T>, hash: Pick<T, K>): Pick<T, K>;
         function setProperties<T, K extends keyof T>(obj: T, hash: Pick<T, K>): Pick<T, K>; // for dynamic K
         /**
          * Detects when a specific package of Ember (e.g. 'Ember.Application')
@@ -3437,9 +3276,27 @@ declare module 'ember' {
          */
         isActive(routeName: string, options?: { queryParams: object }): boolean;
         isActive(routeName: string, models: RouteModel, options?: { queryParams: object }): boolean;
-        isActive(routeName: string, modelsA: RouteModel, modelsB: RouteModel, options?: { queryParams: object }): boolean;
-        isActive(routeName: string, modelsA: RouteModel, modelsB: RouteModel, modelsC: RouteModel, options?: { queryParams: object }): boolean;
-        isActive(routeName: string, modelsA: RouteModel, modelsB: RouteModel, modelsC: RouteModel, modelsD: RouteModel, options?: { queryParams: object }): boolean;
+        isActive(
+            routeName: string,
+            modelsA: RouteModel,
+            modelsB: RouteModel,
+            options?: { queryParams: object },
+        ): boolean;
+        isActive(
+            routeName: string,
+            modelsA: RouteModel,
+            modelsB: RouteModel,
+            modelsC: RouteModel,
+            options?: { queryParams: object },
+        ): boolean;
+        isActive(
+            routeName: string,
+            modelsA: RouteModel,
+            modelsB: RouteModel,
+            modelsC: RouteModel,
+            modelsD: RouteModel,
+            options?: { queryParams: object },
+        ): boolean;
 
         // https://emberjs.com/api/ember/2.18/classes/RouterService/methods/isActive?anchor=replaceWith
         /**
@@ -3455,9 +3312,27 @@ declare module 'ember' {
          */
         replaceWith(routeNameOrUrl: string, options?: { queryParams: object }): Ember.Transition;
         replaceWith(routeNameOrUrl: string, models: RouteModel, options?: { queryParams: object }): Ember.Transition;
-        replaceWith(routeNameOrUrl: string, modelsA: RouteModel, modelsB: RouteModel, options?: { queryParams: object }): Ember.Transition;
-        replaceWith(routeNameOrUrl: string, modelsA: RouteModel, modelsB: RouteModel, modelsC: RouteModel, options?: { queryParams: object }): Ember.Transition;
-        replaceWith(routeNameOrUrl: string, modelsA: RouteModel, modelsB: RouteModel, modelsC: RouteModel, modelsD: RouteModel, options?: { queryParams: object }): Ember.Transition;
+        replaceWith(
+            routeNameOrUrl: string,
+            modelsA: RouteModel,
+            modelsB: RouteModel,
+            options?: { queryParams: object },
+        ): Ember.Transition;
+        replaceWith(
+            routeNameOrUrl: string,
+            modelsA: RouteModel,
+            modelsB: RouteModel,
+            modelsC: RouteModel,
+            options?: { queryParams: object },
+        ): Ember.Transition;
+        replaceWith(
+            routeNameOrUrl: string,
+            modelsA: RouteModel,
+            modelsB: RouteModel,
+            modelsC: RouteModel,
+            modelsD: RouteModel,
+            options?: { queryParams: object },
+        ): Ember.Transition;
 
         // https://emberjs.com/api/ember/2.18/classes/RouterService/methods/isActive?anchor=transitionTo
         /**
@@ -3473,9 +3348,27 @@ declare module 'ember' {
          */
         transitionTo(routeNameOrUrl: string, options?: { queryParam: object }): Ember.Transition;
         transitionTo(routeNameOrUrl: string, models: RouteModel, options?: { queryParams: object }): Ember.Transition;
-        transitionTo(routeNameOrUrl: string, modelsA: RouteModel, modelsB: RouteModel, options?: { queryParams: object }): Ember.Transition;
-        transitionTo(routeNameOrUrl: string, modelsA: RouteModel, modelsB: RouteModel, modelsC: RouteModel, options?: { queryParams: object }): Ember.Transition;
-        transitionTo(routeNameOrUrl: string, modelsA: RouteModel, modelsB: RouteModel, modelsC: RouteModel, modelsD: RouteModel, options?: { queryParams: object }): Ember.Transition;
+        transitionTo(
+            routeNameOrUrl: string,
+            modelsA: RouteModel,
+            modelsB: RouteModel,
+            options?: { queryParams: object },
+        ): Ember.Transition;
+        transitionTo(
+            routeNameOrUrl: string,
+            modelsA: RouteModel,
+            modelsB: RouteModel,
+            modelsC: RouteModel,
+            options?: { queryParams: object },
+        ): Ember.Transition;
+        transitionTo(
+            routeNameOrUrl: string,
+            modelsA: RouteModel,
+            modelsB: RouteModel,
+            modelsC: RouteModel,
+            modelsD: RouteModel,
+            options?: { queryParams: object },
+        ): Ember.Transition;
 
         // https://emberjs.com/api/ember/2.18/classes/RouterService/methods/isActive?anchor=urlFor
         /**
@@ -3491,13 +3384,26 @@ declare module 'ember' {
         urlFor(routeName: string, options?: { queryParams: object }): string;
         urlFor(routeName: string, models: RouteModel, options?: { queryParams: object }): string;
         urlFor(routeName: string, modelsA: RouteModel, modelsB: RouteModel, options?: { queryParams: object }): string;
-        urlFor(routeName: string, modelsA: RouteModel, modelsB: RouteModel, modelsC: RouteModel, options?: { queryParams: object }): string;
-        urlFor(routeName: string, modelsA: RouteModel, modelsB: RouteModel, modelsC: RouteModel, modelsD: RouteModel, options?: { queryParams: object }): string;
+        urlFor(
+            routeName: string,
+            modelsA: RouteModel,
+            modelsB: RouteModel,
+            modelsC: RouteModel,
+            options?: { queryParams: object },
+        ): string;
+        urlFor(
+            routeName: string,
+            modelsA: RouteModel,
+            modelsB: RouteModel,
+            modelsC: RouteModel,
+            modelsD: RouteModel,
+            options?: { queryParams: object },
+        ): string;
     }
 
     module '@ember/service' {
         interface Registry {
-            'router': RouterService;
+            router: RouterService;
         }
     }
 
@@ -3506,7 +3412,7 @@ declare module 'ember' {
 
 declare module '@ember/application' {
     import Ember from 'ember';
-    export default class Application extends Ember.Application { }
+    export default class Application extends Ember.Application {}
     export const getOwner: typeof Ember.getOwner;
     export const onLoad: typeof Ember.onLoad;
     export const runLoadHooks: typeof Ember.runLoadHooks;
@@ -3521,17 +3427,17 @@ declare module '@ember/application/deprecations' {
 
 declare module '@ember/application/globals-resolver' {
     import Ember from 'ember';
-    export default class GlobalsResolver extends Ember.DefaultResolver { }
+    export default class GlobalsResolver extends Ember.DefaultResolver {}
 }
 
 declare module '@ember/application/instance' {
     import Ember from 'ember';
-    export default class ApplicationInstance extends Ember.ApplicationInstance { }
+    export default class ApplicationInstance extends Ember.ApplicationInstance {}
 }
 
 declare module '@ember/application/resolver' {
     import Ember from 'ember';
-    export default class Resolver extends Ember.Resolver { }
+    export default class Resolver extends Ember.Resolver {}
 }
 
 declare module '@ember/array' {
@@ -3553,22 +3459,22 @@ declare module '@ember/array/mutable' {
 
 declare module '@ember/array/proxy' {
     import Ember from 'ember';
-    export default class ArrayProxy<T> extends Ember.ArrayProxy<T> { }
+    export default class ArrayProxy<T> extends Ember.ArrayProxy<T> {}
 }
 
 declare module '@ember/component' {
     import Ember from 'ember';
-    export default class Component extends Ember.Component { }
+    export default class Component extends Ember.Component {}
 }
 
 declare module '@ember/component/checkbox' {
     import Ember from 'ember';
-    export default class Checkbox extends Ember.Checkbox { }
+    export default class Checkbox extends Ember.Checkbox {}
 }
 
 declare module '@ember/component/helper' {
     import Ember from 'ember';
-    export default class Helper extends Ember.Helper { }
+    export default class Helper extends Ember.Helper {}
     /**
      * In many cases, the ceremony of a full `Helper` class is not required.
      * The `helper` method create pure-function helpers without instances. For
@@ -3587,17 +3493,17 @@ declare module '@ember/component/helper' {
 
 declare module '@ember/component/text-area' {
     import Ember from 'ember';
-    export default class TextArea extends Ember.TextArea { }
+    export default class TextArea extends Ember.TextArea {}
 }
 
 declare module '@ember/component/text-field' {
     import Ember from 'ember';
-    export default class TextField extends Ember.TextField { }
+    export default class TextField extends Ember.TextField {}
 }
 
 declare module '@ember/controller' {
     import Ember from 'ember';
-    export default class Controller extends Ember.Controller { }
+    export default class Controller extends Ember.Controller {}
     export const inject: typeof Ember.inject.controller;
 
     // A type registry for Ember `Controller`s. Meant to be declaration-merged
@@ -3618,23 +3524,23 @@ declare module '@ember/debug' {
 
 declare module '@ember/debug/container-debug-adapter' {
     import Ember from 'ember';
-    export default class ContainerDebugAdapter extends Ember.ContainerDebugAdapter { }
+    export default class ContainerDebugAdapter extends Ember.ContainerDebugAdapter {}
 }
 
 declare module '@ember/debug/data-adapter' {
     import Ember from 'ember';
-    export default class DataAdapter extends Ember.DataAdapter { }
+    export default class DataAdapter extends Ember.DataAdapter {}
 }
 
 declare module '@ember/engine' {
     import Ember from 'ember';
-    export default class Engine extends Ember.Engine { }
+    export default class Engine extends Ember.Engine {}
     export const getEngineParent: typeof Ember.getEngineParent;
 }
 
 declare module '@ember/engine/instance' {
     import Ember from 'ember';
-    export default class EngineInstance extends Ember.EngineInstance { }
+    export default class EngineInstance extends Ember.EngineInstance {}
 }
 
 declare module '@ember/enumerable' {
@@ -3660,17 +3566,17 @@ declare module '@ember/instrumentation' {
 
 declare module '@ember/map' {
     import Ember from 'ember';
-    export default class EmberMap extends Ember.Map { }
+    export default class EmberMap extends Ember.Map {}
 }
 
 declare module '@ember/map/with-default' {
     import Ember from 'ember';
-    export default class MapWithDefault extends Ember.MapWithDefault { }
+    export default class MapWithDefault extends Ember.MapWithDefault {}
 }
 
 declare module '@ember/object' {
     import Ember from 'ember';
-    export default class EmberObject extends Ember.Object { }
+    export default class EmberObject extends Ember.Object {}
     export const aliasMethod: typeof Ember.aliasMethod;
     export const computed: typeof Ember.computed;
     export const defineProperty: typeof Ember.defineProperty;
@@ -3685,7 +3591,7 @@ declare module '@ember/object' {
 
 declare module '@ember/object/computed' {
     import Ember from 'ember';
-    export default class ComputedProperty<Get, Set = Get> extends Ember.ComputedProperty<Get, Set> { }
+    export default class ComputedProperty<Get, Set = Get> extends Ember.ComputedProperty<Get, Set> {}
     export const alias: typeof Ember.computed.alias;
     export const and: typeof Ember.computed.and;
     export const bool: typeof Ember.computed.bool;
@@ -3723,7 +3629,7 @@ declare module '@ember/object/computed' {
 
 declare module '@ember/object/core' {
     import Ember from 'ember';
-    export default class CoreObject extends Ember.CoreObject { }
+    export default class CoreObject extends Ember.CoreObject {}
 }
 
 declare module '@ember/object/evented' {
@@ -3775,7 +3681,7 @@ declare module '@ember/object/promise-proxy-mixin' {
 
 declare module '@ember/object/proxy' {
     import Ember from 'ember';
-    export default class ObjectProxy extends Ember.ObjectProxy { }
+    export default class ObjectProxy extends Ember.ObjectProxy {}
 }
 
 declare module '@ember/polyfills' {
@@ -3789,22 +3695,22 @@ declare module '@ember/polyfills' {
 
 declare module '@ember/routing/auto-location' {
     import Ember from 'ember';
-    export default class AutoLocation extends Ember.AutoLocation { }
+    export default class AutoLocation extends Ember.AutoLocation {}
 }
 
 declare module '@ember/routing/hash-location' {
     import Ember from 'ember';
-    export default class HashLocation extends Ember.HashLocation { }
+    export default class HashLocation extends Ember.HashLocation {}
 }
 
 declare module '@ember/routing/history-location' {
     import Ember from 'ember';
-    export default class HistoryLocation extends Ember.HistoryLocation { }
+    export default class HistoryLocation extends Ember.HistoryLocation {}
 }
 
 declare module '@ember/routing/link-component' {
     import Ember from 'ember';
-    export default class LinkComponent extends Ember.LinkComponent { }
+    export default class LinkComponent extends Ember.LinkComponent {}
 }
 
 declare module '@ember/routing/location' {
@@ -3815,22 +3721,22 @@ declare module '@ember/routing/location' {
 
 declare module '@ember/routing/none-location' {
     import Ember from 'ember';
-    export default class NoneLocation extends Ember.NoneLocation { }
+    export default class NoneLocation extends Ember.NoneLocation {}
 }
 
 declare module '@ember/routing/route' {
     import Ember from 'ember';
-    export default class Route extends Ember.Route { }
+    export default class Route extends Ember.Route {}
 }
 
 declare module '@ember/routing/router' {
     import Ember from 'ember';
-    export default class EmberRouter extends Ember.Router { }
+    export default class EmberRouter extends Ember.Router {}
 }
 
 declare module '@ember/routing/router-service' {
     import { RouterService } from 'ember';
-    export default class extends RouterService { }
+    export default class extends RouterService {}
 }
 
 declare module '@ember/runloop' {
@@ -3852,7 +3758,7 @@ declare module '@ember/runloop' {
 
 declare module '@ember/service' {
     import Ember from 'ember';
-    export default class Service extends Ember.Service { }
+    export default class Service extends Ember.Service {}
     export const inject: typeof Ember.inject.service;
 
     // A type registry for Ember `Service`s. Meant to be declaration-merged so
@@ -3886,7 +3792,7 @@ declare module '@ember/test' {
 
 declare module '@ember/test/adapter' {
     import Ember from 'ember';
-    export default class TestAdapter extends Ember.Test.Adapter { }
+    export default class TestAdapter extends Ember.Test.Adapter {}
 }
 
 declare module '@ember/utils' {

--- a/types/ember/v2/test/application-instance.ts
+++ b/types/ember/v2/test/application-instance.ts
@@ -5,11 +5,11 @@ const appInstance = ApplicationInstance.create();
 appInstance.register('some:injection', class Foo {});
 
 appInstance.register('some:injection', class Foo {}, {
-  singleton: true,
+    singleton: true,
 });
 
 appInstance.register('some:injection', class Foo {}, {
-  instantiate: false,
+    instantiate: false,
 });
 
 appInstance.register('templates:foo/bar', hbs`<h1>Hello World</h1>`);
@@ -24,6 +24,6 @@ appInstance.lookup('route:basic');
 
 appInstance.boot();
 
-(async function() {
-  await appInstance.boot();
-}());
+(async function () {
+    await appInstance.boot();
+})();

--- a/types/ember/v2/test/application.ts
+++ b/types/ember/v2/test/application.ts
@@ -1,35 +1,35 @@
 import Ember from 'ember';
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 let BaseApp = Ember.Application.extend({
-    modulePrefix: 'my-app'
+    modulePrefix: 'my-app',
 });
 
 BaseApp.initializer({
     name: 'my-initializer',
     initialize(app) {
         app.register('foo:bar', Ember.Object.extend({ foo: 'bar' }));
-    }
+    },
 });
 
 BaseApp.instanceInitializer({
     name: 'my-instance-initializer',
     initialize(app) {
         app.lookup('foo:bar').get('foo');
-    }
+    },
 });
 
 let App1 = BaseApp.create({
     rootElement: '#app-one',
     customEvents: {
-        paste: 'paste'
-    }
+        paste: 'paste',
+    },
 });
 
 let App2 = BaseApp.create({
     rootElement: '#app-two',
     customEvents: {
         mouseenter: null,
-        mouseleave: null
-    }
+        mouseleave: null,
+    },
 });

--- a/types/ember/v2/test/array-proxy.ts
+++ b/types/ember/v2/test/array-proxy.ts
@@ -12,7 +12,7 @@ const overridden = Ember.ArrayProxy.create({
     content: Ember.A(pets),
     objectAtContent(idx: number): string {
         return this.get('content').objectAt(idx)!.toUpperCase();
-    }
+    },
 });
 
 overridden.get('firstObject'); // 'DOG'

--- a/types/ember/v2/test/array.ts
+++ b/types/ember/v2/test/array.ts
@@ -4,7 +4,7 @@ import { assertType } from './lib/assert';
 type Person = typeof Person.prototype;
 const Person = Ember.Object.extend({
     name: '',
-    isHappy: false
+    isHappy: false,
 });
 
 const people = Ember.A([
@@ -18,7 +18,7 @@ assertType<boolean>(people.isAny('isHappy'));
 assertType<boolean>(people.isAny('isHappy', 'false'));
 assertType<Ember.Enumerable<Person>>(people.filterBy('isHappy'));
 assertType<Ember.Enumerable<Person>>(people.rejectBy('isHappy'));
-assertType<Ember.Enumerable<Person>>(people.filter((person) => person.get('name') === 'Yehuda'));
+assertType<Ember.Enumerable<Person>>(people.filter(person => person.get('name') === 'Yehuda'));
 assertType<typeof people>(people.get('[]'));
 assertType<Person>(people.get('[]').get('firstObject'));
 

--- a/types/ember/v2/test/component.ts
+++ b/types/ember/v2/test/component.ts
@@ -2,10 +2,10 @@ import Ember from 'ember';
 import Component from '@ember/component';
 import Object, { computed } from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 Component.extend({
-  layout: hbs`
+    layout: hbs`
         <div>
           {{yield}}
         </div>
@@ -13,112 +13,112 @@ Component.extend({
 });
 
 Component.extend({
-  layout: 'my-layout',
+    layout: 'my-layout',
 });
 
 const MyComponent = Component.extend();
 assertType<string | string[]>(Ember.get(MyComponent, 'positionalParams'));
 
 const component1 = Component.extend({
-  actions: {
-    hello(name: string) {
-      console.log('Hello', name);
+    actions: {
+        hello(name: string) {
+            console.log('Hello', name);
+        },
     },
-  },
 });
 
 Component.extend({
-  name: '',
-  hello(name: string) {
-    this.set('name', name);
-  },
+    name: '',
+    hello(name: string) {
+        this.set('name', name);
+    },
 });
 
 Component.extend({
-  tagName: 'em',
+    tagName: 'em',
 });
 
 Component.extend({
-  classNames: ['my-class', 'my-other-class'],
+    classNames: ['my-class', 'my-other-class'],
 });
 
 Component.extend({
-  classNameBindings: ['propertyA', 'propertyB'],
-  propertyA: 'from-a',
-  propertyB: computed(function() {
-    if (!this.get('propertyA')) {
-      return 'from-b';
-    }
-  }),
+    classNameBindings: ['propertyA', 'propertyB'],
+    propertyA: 'from-a',
+    propertyB: computed(function () {
+        if (!this.get('propertyA')) {
+            return 'from-b';
+        }
+    }),
 });
 
 Component.extend({
-  classNameBindings: ['hovered'],
-  hovered: true,
+    classNameBindings: ['hovered'],
+    hovered: true,
 });
 
 Component.extend({
-  classNameBindings: ['messages.empty'],
-  messages: Object.create({
-    empty: true,
-  }),
+    classNameBindings: ['messages.empty'],
+    messages: Object.create({
+        empty: true,
+    }),
 });
 
 Component.extend({
-  classNameBindings: ['isEnabled:enabled:disabled'],
-  isEnabled: true,
+    classNameBindings: ['isEnabled:enabled:disabled'],
+    isEnabled: true,
 });
 
 Component.extend({
-  classNameBindings: ['isEnabled::disabled'],
-  isEnabled: true,
+    classNameBindings: ['isEnabled::disabled'],
+    isEnabled: true,
 });
 
 Component.extend({
-  tagName: 'a',
-  attributeBindings: ['href'],
-  href: 'http://google.com',
+    tagName: 'a',
+    attributeBindings: ['href'],
+    href: 'http://google.com',
 });
 
 Component.extend({
-  tagName: 'a',
-  attributeBindings: ['url:href'],
-  url: 'http://google.com',
+    tagName: 'a',
+    attributeBindings: ['url:href'],
+    url: 'http://google.com',
 });
 
 Component.extend({
-  tagName: 'use',
-  attributeBindings: ['xlinkHref:xlink:href'],
-  xlinkHref: '#triangle',
+    tagName: 'use',
+    attributeBindings: ['xlinkHref:xlink:href'],
+    xlinkHref: '#triangle',
 });
 
 Component.extend({
-  tagName: 'input',
-  attributeBindings: ['disabled'],
-  disabled: false,
+    tagName: 'input',
+    attributeBindings: ['disabled'],
+    disabled: false,
 });
 
 Component.extend({
-  tagName: 'input',
-  attributeBindings: ['disabled'],
-  disabled: computed(() => {
-    if ('someLogic') {
-      return true;
-    } else {
-      return false;
-    }
-  }),
+    tagName: 'input',
+    attributeBindings: ['disabled'],
+    disabled: computed(() => {
+        if ('someLogic') {
+            return true;
+        } else {
+            return false;
+        }
+    }),
 });
 
 Component.extend({
-  tagName: 'form',
-  attributeBindings: ['novalidate'],
-  novalidate: null,
+    tagName: 'form',
+    attributeBindings: ['novalidate'],
+    novalidate: null,
 });
 
 Component.extend({
-  click(event: object) {
-    // will be called when an instance's
-    // rendered element is clicked
-  },
+    click(event: object) {
+        // will be called when an instance's
+        // rendered element is clicked
+    },
 });

--- a/types/ember/v2/test/computed.ts
+++ b/types/ember/v2/test/computed.ts
@@ -10,11 +10,11 @@ const Person = Ember.Object.extend({
 
     noArgs: Ember.computed<string>(() => 'test'),
 
-    fullName: Ember.computed<string>('firstName', 'lastName', function() {
+    fullName: Ember.computed<string>('firstName', 'lastName', function () {
         return `${this.get('firstName')} ${this.get('lastName')}`;
     }),
 
-    fullNameReadonly: Ember.computed<string>('fullName', function() {
+    fullNameReadonly: Ember.computed<string>('fullName', function () {
         return this.get('fullName');
     }).readOnly(),
 
@@ -27,13 +27,13 @@ const Person = Ember.Object.extend({
             this.set('firstName', first);
             this.set('lastName', last);
             return value;
-        }
+        },
     }),
 
     fullNameGetOnly: Ember.computed<string>('fullName', {
         get() {
             return this.get('fullName');
-        }
+        },
     }),
 
     fullNameSetOnly: Ember.computed<string>('firstName', 'lastName', {
@@ -42,15 +42,16 @@ const Person = Ember.Object.extend({
             this.set('firstName', first);
             this.set('lastName', last);
             return value;
-        }
+        },
     }),
 
-    combinators: Ember.computed<string>(function() {
+    combinators: Ember.computed<string>(function () {
         return this.get('firstName');
-    }).property('firstName')
-      .meta({ foo: 'bar' })
-      .volatile()
-      .readOnly(),
+    })
+        .property('firstName')
+        .meta({ foo: 'bar' })
+        .volatile()
+        .readOnly(),
 
     explicitlyDeclared: alias('fullName') as Computed<string>,
 });
@@ -83,10 +84,10 @@ assertType<string>(person.get('fullNameSetOnly'));
 assertType<string>(person.get('combinators'));
 assertType<string>(person.get('explicitlyDeclared'));
 
-assertType<{ firstName: string, fullName: string, age: number }>(person.getProperties('firstName', 'fullName', 'age'));
+assertType<{ firstName: string; fullName: string; age: number }>(person.getProperties('firstName', 'fullName', 'age'));
 
 const person2 = Person.create({
-    fullName: 'Fred Smith'
+    fullName: 'Fred Smith',
 });
 
 assertType<string>(person2.get('firstName'));
@@ -94,7 +95,7 @@ assertType<string>(person2.get('fullName'));
 
 const person3 = Person.extend({
     firstName: 'Fred',
-    fullName: 'Fred Smith'
+    fullName: 'Fred Smith',
 }).create();
 
 assertType<string>(person3.get('firstName'));
@@ -102,7 +103,7 @@ assertType<string>(person3.get('fullName'));
 
 const person4 = Person.extend({
     firstName: Ember.computed(() => 'Fred'),
-    fullName: Ember.computed(() => 'Fred Smith')
+    fullName: Ember.computed(() => 'Fred Smith'),
 }).create();
 
 assertType<string>(person4.get('firstName'));
@@ -116,13 +117,13 @@ const objectWithComputedProperties = Ember.Object.extend({
     collect: Ember.computed.collect('foo', 'bar', 'baz', 'qux'),
     deprecatingAlias: Ember.computed.deprecatingAlias('foo', {
         id: 'hamster.deprecate-banana',
-        until: '3.0.0'
+        until: '3.0.0',
     }),
     empty: Ember.computed.empty('foo'),
     equalNumber: Ember.computed.equal('foo', 1),
     equalString: Ember.computed.equal('foo', 'bar'),
     equalObject: Ember.computed.equal('foo', {}),
-    filter: Ember.computed.filter('foo', (item) => item === 'bar'),
+    filter: Ember.computed.filter('foo', item => item === 'bar'),
     filterBy1: Ember.computed.filterBy('foo', 'bar'),
     filterBy2: Ember.computed.filterBy('foo', 'bar', false),
     gt: Ember.computed.gt('foo', 3),
@@ -156,11 +157,11 @@ const objectWithComputedProperties = Ember.Object.extend({
     sum: Ember.computed.sum('foo'),
     union: Ember.computed.union('foo', 'bar', 'baz', 'qux'),
     uniq: Ember.computed.uniq('foo'),
-    uniqBy: Ember.computed.uniqBy('foo', 'bar')
+    uniqBy: Ember.computed.uniqBy('foo', 'bar'),
 });
 
 const component2 = Component.extend({
-    isAnimal: or('isDog', 'isCat')
+    isAnimal: or('isDog', 'isCat'),
 }).create();
 
 assertType<boolean>(component2.get('isAnimal'));

--- a/types/ember/v2/test/controller.ts
+++ b/types/ember/v2/test/controller.ts
@@ -1,11 +1,11 @@
 import Controller from '@ember/controller';
 
-Controller.extend ({
-  queryParams: ['category'],
-  category: null,
-  isExpanded: false,
+Controller.extend({
+    queryParams: ['category'],
+    category: null,
+    isExpanded: false,
 
-  toggleBody() {
-    this.toggleProperty('isExpanded');
-  }
+    toggleBody() {
+        this.toggleProperty('isExpanded');
+    },
 });

--- a/types/ember/v2/test/create.ts
+++ b/types/ember/v2/test/create.ts
@@ -4,7 +4,7 @@ import { assertType } from './lib/assert';
 const o = Ember.Object.create();
 assertType<object>(o);
 
-const o1 = Ember.Object.create({x: 9});
+const o1 = Ember.Object.create({ x: 9 });
 assertType<number>(o1.x);
 
 const obj = Ember.Object.create({ a: 1 }, { b: 2 }, { c: 3 });
@@ -13,9 +13,9 @@ assertType<number>(obj.a);
 assertType<number>(obj.c);
 
 export class Person extends Ember.Object.extend({
-    fullName: Ember.computed('firstName', 'lastName', function() {
+    fullName: Ember.computed('firstName', 'lastName', function () {
         return [this.firstName + this.lastName].join(' ');
-    })
+    }),
 }) {
     firstName: string;
     lastName: string;
@@ -31,7 +31,7 @@ const p2b = Person.create({}, { firstName: 'string' });
 const p2c = Person.create({}, {}, { firstName: 'string' });
 
 export class PersonWithNumberName extends Person.extend({
-  fullName: 6
+    fullName: 6,
 }) {}
 
 const p4 = new PersonWithNumberName();

--- a/types/ember/v2/test/detect-instance.ts
+++ b/types/ember/v2/test/detect-instance.ts
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { assertType } from './lib/assert';
 
 const ExtendClass = Ember.Object.extend({
-    foo: 'hello'
+    foo: 'hello',
 });
 
 class ES6Class extends Ember.Object {

--- a/types/ember/v2/test/detect.ts
+++ b/types/ember/v2/test/detect.ts
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { assertType } from './lib/assert';
 
 const ExtendClass = Ember.Object.extend({
-    foo: 'hello'
+    foo: 'hello',
 });
 
 class ES6Class extends Ember.Object {

--- a/types/ember/v2/test/ember-tests.ts
+++ b/types/ember/v2/test/ember-tests.ts
@@ -13,7 +13,7 @@ App.country.get('presidentName');
 App.president = Ember.Object.create({
     firstName: 'Barack',
     lastName: 'Obama',
-    fullName: Ember.computed(function() {
+    fullName: Ember.computed(function () {
         return `${this.get('firstName')} ${this.get('lastName')}`;
     }),
 });
@@ -48,7 +48,7 @@ PersonReopened.create().get('isPerson');
 
 App.todosController = Ember.Object.create({
     todos: [Ember.Object.create({ isDone: false })],
-    remaining: Ember.computed('todos.@each.isDone', function() {
+    remaining: Ember.computed('todos.@each.isDone', function () {
         const todos = this.get('todos');
         return todos.filterProperty('isDone', false).get('length');
     }),
@@ -95,7 +95,7 @@ App.userController = Ember.Object.create({
 Ember.Handlebars.registerHelper(
     'highlight',
     (property: string, options: any) =>
-        new Ember.Handlebars.SafeString('<span class="highlight">' + 'some value' + '</span>')
+        new Ember.Handlebars.SafeString('<span class="highlight">' + 'some value' + '</span>'),
 );
 
 const coolView = App.CoolView.create();
@@ -150,7 +150,7 @@ promise.then(
     },
     (reason: any) => {
         // on rejection
-    }
+    },
 );
 
 // make sure Ember.RSVP.Promise can be reference as a type

--- a/types/ember/v2/test/engine-instance.ts
+++ b/types/ember/v2/test/engine-instance.ts
@@ -4,11 +4,11 @@ const engineInstance = EngineInstance.create();
 engineInstance.register('some:injection', class Foo {});
 
 engineInstance.register('some:injection', class Foo {}, {
-  singleton: true,
+    singleton: true,
 });
 
 engineInstance.register('some:injection', class Foo {}, {
-  instantiate: false,
+    instantiate: false,
 });
 
 engineInstance.register('some:injection', class Foo {}, {
@@ -21,6 +21,6 @@ engineInstance.lookup('route:basic');
 
 engineInstance.boot();
 
-(async function() {
-  await engineInstance.boot();
-}());
+(async function () {
+    await engineInstance.boot();
+})();

--- a/types/ember/v2/test/error.ts
+++ b/types/ember/v2/test/error.ts
@@ -1,6 +1,6 @@
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
-import Ember from "ember";
-import EmberError from "@ember/error";
+import Ember from 'ember';
+import EmberError from '@ember/error';
 
 assertType<typeof Ember.Error>(EmberError);

--- a/types/ember/v2/test/event.ts
+++ b/types/ember/v2/test/event.ts
@@ -2,9 +2,9 @@ import Ember from 'ember';
 
 function testOn() {
     let Job = Ember.Object.extend({
-        logCompleted: Ember.on('completed', function() {
+        logCompleted: Ember.on('completed', function () {
             console.log('Job completed!');
-        })
+        }),
     });
 
     let job = Job.create();
@@ -16,29 +16,32 @@ function testEvented() {
     let Person = Ember.Object.extend(Ember.Evented, {
         greet() {
             this.trigger('greet');
-        }
+        },
     });
 
     let person = Person.create();
 
-    person.on('greet', function() {
+    person.on('greet', function () {
         console.log('Our person has greeted');
     });
 
-    person.on('greet', function() {
-        console.log('Our person has greeted');
-    }).one('greet', function() {
-        console.log('Offer one-time special');
-    }).off('event', {}, function() {});
+    person
+        .on('greet', function () {
+            console.log('Our person has greeted');
+        })
+        .one('greet', function () {
+            console.log('Offer one-time special');
+        })
+        .off('event', {}, function () {});
 
     person.greet();
 }
 
 function testObserver() {
     Ember.Object.extend({
-        valueObserver: Ember.observer('value', function() {
+        valueObserver: Ember.observer('value', function () {
             // Executes whenever the "value" property changes
-        })
+        }),
     });
 }
 
@@ -52,7 +55,6 @@ function testListener() {
             Ember.removeListener(this, 'willDestroyElement', this, 'willDestroyListener');
             Ember.removeListener(this, 'willDestroyElement', this, this.willDestroyListener);
         },
-        willDestroyListener() {
-        }
+        willDestroyListener() {},
     });
 }

--- a/types/ember/v2/test/extend.ts
+++ b/types/ember/v2/test/extend.ts
@@ -10,7 +10,7 @@ const Person = Ember.Object.extend({
     },
     getFullName2(): string {
         return `${this.get('firstName')} ${this.get('lastName')}`;
-    }
+    },
 });
 
 assertType<string>(Person.prototype.firstName);
@@ -19,7 +19,7 @@ assertType<() => string>(Person.prototype.getFullName);
 const person = Person.create({
     firstName: 'Joe',
     lastName: 'Blow',
-    extra: 42
+    extra: 42,
 });
 
 assertType<string>(person.getFullName());
@@ -43,7 +43,7 @@ assertType<string>(ES6Person.prototype.fullName);
 const es6Person = ES6Person.create({
     firstName: 'Joe',
     lastName: 'Blow',
-    extra: 42
+    extra: 42,
 });
 
 assertType<string>(es6Person.fullName);

--- a/types/ember/v2/test/function-ext.ts
+++ b/types/ember/v2/test/function-ext.ts
@@ -7,15 +7,15 @@ declare global {
 Ember.Object.extend({
     foo: '',
 
-    arr: function() {
+    arr: function () {
         return [];
     }.property(),
 
-    alias: function(this: any) {
+    alias: function (this: any) {
         return this.get('foo');
     }.property('foo', 'bar.@each.baz'),
 
-    observer: function() {}.observes('foo', 'bar'),
+    observer: function () {}.observes('foo', 'bar'),
 
-    on: function() {}.on('foo', 'bar'),
+    on: function () {}.on('foo', 'bar'),
 });

--- a/types/ember/v2/test/helper.ts
+++ b/types/ember/v2/test/helper.ts
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const FormatCurrencyHelper = Ember.Helper.helper(function(params, hash: { currency: string }) {
+const FormatCurrencyHelper = Ember.Helper.helper(function (params, hash: { currency: string }) {
     let cents = params[0];
     let currency = hash.currency;
     return `${currency}${cents * 0.01}`;
@@ -16,26 +16,24 @@ class SessionService extends Ember.Service {
 
 const CurrentUserEmailHelper = Ember.Helper.extend({
     session: Ember.inject.service() as Ember.ComputedProperty<SessionService>,
-    onNewUser: Ember.observer('session.currentUser', function(this: Ember.Helper) {
+    onNewUser: Ember.observer('session.currentUser', function (this: Ember.Helper) {
         this.recompute();
     }),
     compute(): string {
-        return this.get('session')
-            .get('currentUser')
-            .get('email');
+        return this.get('session').get('currentUser').get('email');
     },
 });
 
 import { helper } from '@ember/component/helper';
 
 function typedHelp(/*params, hash*/) {
-  return 'my type of help';
+    return 'my type of help';
 }
 
 export default helper(typedHelp);
 
 function arrayNumHelp(/*params, hash*/) {
-  return [1, 2, 3];
+    return [1, 2, 3];
 }
 
 helper(arrayNumHelp);

--- a/types/ember/v2/test/inject.ts
+++ b/types/ember/v2/test/inject.ts
@@ -12,13 +12,13 @@ class ApplicationController extends Ember.Controller {
 
 declare module '@ember/service' {
     interface Registry {
-        'auth': AuthService;
+        auth: AuthService;
     }
 }
 
 declare module '@ember/controller' {
     interface Registry {
-        'application': ApplicationController;
+        application: ApplicationController;
     }
 }
 

--- a/types/ember/v2/test/mixin.ts
+++ b/types/ember/v2/test/mixin.ts
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 interface EditableMixin {
     edit(): void;
@@ -12,7 +12,7 @@ const EditableMixin = Ember.Mixin.create<EditableMixin, Ember.Route>({
         console.log('starting to edit');
         this.set('isEditing', true);
     },
-    isEditing: false
+    isEditing: false,
 });
 
 const EditableComment = Ember.Route.extend(EditableMixin, {
@@ -26,11 +26,11 @@ const EditableComment = Ember.Route.extend(EditableMixin, {
         if (this.canEdit()) {
             this.edit();
         }
-    }
+    },
 });
 
 const comment = EditableComment.create({
-    postId: 42
+    postId: 42,
 });
 
 comment.edit();

--- a/types/ember/v2/test/object.ts
+++ b/types/ember/v2/test/object.ts
@@ -11,7 +11,7 @@ const LifetimeHooks = Ember.Object.extend({
     willDestroy() {
         delete this.resource;
         this._super();
-    }
+    },
 });
 
 class MyObject30 extends Ember.Object {

--- a/types/ember/v2/test/observable.ts
+++ b/types/ember/v2/test/observable.ts
@@ -35,9 +35,9 @@ myComponent.set('foo', 'baz');
 const person = Ember.Object.create({
     name: 'Fred',
     age: 29,
-    capitalized: Ember.computed<string>(function() {
+    capitalized: Ember.computed<string>(function () {
         return this.get('name').toUpperCase();
-    })
+    }),
 });
 
 const pojo = { name: 'Fred', age: 29 };
@@ -54,14 +54,16 @@ function testGet() {
 
 function testGetProperties() {
     assertType<{ name: string }>(Ember.getProperties(person, 'name'));
-    assertType<{ name: string, age: number }>(Ember.getProperties(person, 'name', 'age'));
-    assertType<{ name: string, age: number }>(Ember.getProperties(person, [ 'name', 'age' ]));
-    assertType<{ name: string, age: number, capitalized: string }>(Ember.getProperties(person, 'name', 'age', 'capitalized'));
+    assertType<{ name: string; age: number }>(Ember.getProperties(person, 'name', 'age'));
+    assertType<{ name: string; age: number }>(Ember.getProperties(person, ['name', 'age']));
+    assertType<{ name: string; age: number; capitalized: string }>(
+        Ember.getProperties(person, 'name', 'age', 'capitalized'),
+    );
     assertType<{ name: string }>(person.getProperties('name'));
-    assertType<{ name: string, age: number }>(person.getProperties('name', 'age'));
-    assertType<{ name: string, age: number }>(person.getProperties([ 'name', 'age' ]));
-    assertType<{ name: string, age: number, capitalized: string }>(person.getProperties('name', 'age', 'capitalized'));
-    assertType<{ name: string, age: number }>(Ember.getProperties(pojo, 'name', 'age'));
+    assertType<{ name: string; age: number }>(person.getProperties('name', 'age'));
+    assertType<{ name: string; age: number }>(person.getProperties(['name', 'age']));
+    assertType<{ name: string; age: number; capitalized: string }>(person.getProperties('name', 'age', 'capitalized'));
+    assertType<{ name: string; age: number }>(Ember.getProperties(pojo, 'name', 'age'));
 }
 
 function testGetWithDefault() {
@@ -86,12 +88,12 @@ function testSet() {
 
 function testSetProperties() {
     assertType<{ name: string }>(Ember.setProperties(person, { name: 'Joe' }));
-    assertType<{ name: string, age: number }>(Ember.setProperties(person, { name: 'Joe', age: 35 }));
-    assertType<{ name: string, capitalized: string }>(Ember.setProperties(person, { name: 'Joe', capitalized: 'JOE' }));
+    assertType<{ name: string; age: number }>(Ember.setProperties(person, { name: 'Joe', age: 35 }));
+    assertType<{ name: string; capitalized: string }>(Ember.setProperties(person, { name: 'Joe', capitalized: 'JOE' }));
     assertType<{ name: string }>(person.setProperties({ name: 'Joe' }));
-    assertType<{ name: string, age: number }>(person.setProperties({ name: 'Joe', age: 35 }));
-    assertType<{ name: string, capitalized: string }>(person.setProperties({ name: 'Joe', capitalized: 'JOE' }));
-    assertType<{ name: string, age: number }>(Ember.setProperties(pojo, { name: 'Joe', age: 35 }));
+    assertType<{ name: string; age: number }>(person.setProperties({ name: 'Joe', age: 35 }));
+    assertType<{ name: string; capitalized: string }>(person.setProperties({ name: 'Joe', capitalized: 'JOE' }));
+    assertType<{ name: string; age: number }>(Ember.setProperties(pojo, { name: 'Joe', age: 35 }));
 }
 
 function testDynamic() {
@@ -103,11 +105,11 @@ function testDynamic() {
     assertType<string>(Ember.getWithDefault(obj, 'dummy', 'default'));
     assertType<string>(Ember.getWithDefault(obj, dynamicKey, 'default'));
     assertType<{ dummy: any }>(Ember.getProperties(obj, 'dummy'));
-    assertType<{ dummy: any }>(Ember.getProperties(obj, [ 'dummy' ]));
+    assertType<{ dummy: any }>(Ember.getProperties(obj, ['dummy']));
     assertType<object>(Ember.getProperties(obj, dynamicKey));
-    assertType<object>(Ember.getProperties(obj, [ dynamicKey ]));
+    assertType<object>(Ember.getProperties(obj, [dynamicKey]));
     assertType<string>(Ember.set(obj, 'dummy', 'value'));
     assertType<string>(Ember.set(obj, dynamicKey, 'value'));
-    assertType<{ dummy: string }>(Ember.setProperties(obj, { dummy: 'value '}));
+    assertType<{ dummy: string }>(Ember.setProperties(obj, { dummy: 'value ' }));
     assertType<object>(Ember.setProperties(obj, { [dynamicKey]: 'value' }));
 }

--- a/types/ember/v2/test/reopen.ts
+++ b/types/ember/v2/test/reopen.ts
@@ -1,12 +1,12 @@
 import Ember from 'ember';
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 type Person = typeof Person.prototype;
 const Person = Ember.Object.extend({
     name: '',
     sayHello() {
         alert(`Hello. My name is ${this.get('name')}`);
-    }
+    },
 });
 
 assertType<Person>(Person.reopen());
@@ -19,7 +19,7 @@ const Person2 = Person.reopenClass({
 
     createPerson(name: string): Person {
         return Person.create({ name });
-    }
+    },
 });
 
 assertType<string>(Person2.create().name);
@@ -27,7 +27,7 @@ assertType<void>(Person2.create().sayHello());
 assertType<string>(Person2.species);
 
 let tom = Person2.create({
-    name: 'Tom Dale'
+    name: 'Tom Dale',
 });
 let yehuda = Person2.createPerson('Yehuda Katz');
 
@@ -40,7 +40,7 @@ const Person3 = Person2.reopen({
 
     sayGoodbye() {
         alert(`${this.get('goodbyeMessage')}, ${this.get('name')}`);
-    }
+    },
 });
 
 const person3 = Person3.create();
@@ -49,11 +49,13 @@ person3.get('goodbyeMessage');
 person3.sayHello();
 person3.sayGoodbye();
 
-interface AutoResizeMixin { resizable: true; }
+interface AutoResizeMixin {
+    resizable: true;
+}
 declare const AutoResizeMixin: Ember.Mixin<AutoResizeMixin>;
 
 const ResizableTextArea = Ember.TextArea.reopen(AutoResizeMixin, {
-    scaling: 1.0
+    scaling: 1.0,
 });
 const text = ResizableTextArea.create();
 assertType<boolean>(text.resizable);

--- a/types/ember/v2/test/route.ts
+++ b/types/ember/v2/test/route.ts
@@ -104,9 +104,9 @@ class RouteUsingClass extends Route.extend({
         this.intermediateTransitionTo('some-route');
     }
     intermediateTransitionWithModel() {
-        this.intermediateTransitionTo('some.other.route', { });
+        this.intermediateTransitionTo('some.other.route', {});
     }
     intermediateTransitionWithMultiModel() {
-        this.intermediateTransitionTo('some.other.route', 1, 2, { });
+        this.intermediateTransitionTo('some.other.route', 1, 2, {});
     }
 }

--- a/types/ember/v2/test/router.ts
+++ b/types/ember/v2/test/router.ts
@@ -1,27 +1,26 @@
 import Ember from 'ember';
 import { assertType } from './lib/assert';
 
-const AppRouter = Ember.Router.extend({
-});
+const AppRouter = Ember.Router.extend({});
 
-AppRouter.map(function() {
+AppRouter.map(function () {
     this.route('index', { path: '/' });
     this.route('about');
     this.route('favorites', { path: '/favs' });
-    this.route('posts', function() {
+    this.route('posts', function () {
         this.route('index', { path: '/' });
         this.route('new');
         this.route('post', { path: '/post/:post_id', resetNamespace: true });
-        this.route('comments', { resetNamespace: true }, function() {
+        this.route('comments', { resetNamespace: true }, function () {
             this.route('new');
         });
     });
-    this.route('photo', { path: '/photo/:id' }, function() {
+    this.route('photo', { path: '/photo/:id' }, function () {
         this.route('comment', { path: '/comment/:id' });
     });
     this.route('not-found', { path: '/*path' });
     this.mount('my-engine');
-    this.mount('my-engine', { as: 'some-other-engine', path: '/some-other-engine'});
+    this.mount('my-engine', { as: 'some-other-engine', path: '/some-other-engine' });
 });
 
 const RouterServiceConsumer = Ember.Service.extend({
@@ -33,22 +32,18 @@ const RouterServiceConsumer = Ember.Service.extend({
         const x: string = Ember.get(this, 'router').currentURL;
     },
     transitionWithoutModel() {
-        Ember.get(this, 'router')
-        .transitionTo('some-route');
+        Ember.get(this, 'router').transitionTo('some-route');
     },
     transitionWithModel() {
         const model = Ember.Object.create();
-        Ember.get(this, 'router')
-        .transitionTo('some.other.route', model);
+        Ember.get(this, 'router').transitionTo('some.other.route', model);
     },
     transitionWithMultiModel() {
         const model = Ember.Object.create();
-        Ember.get(this, 'router')
-        .transitionTo('some.other.route', model, model);
+        Ember.get(this, 'router').transitionTo('some.other.route', model, model);
     },
     transitionWithModelAndOptions() {
         const model = Ember.Object.create();
-        Ember.get(this, 'router')
-        .transitionTo('index', model, { queryParams: { search: 'ember' }});
-    }
+        Ember.get(this, 'router').transitionTo('index', model, { queryParams: { search: 'ember' } });
+    },
 });

--- a/types/ember/v2/test/run.ts
+++ b/types/ember/v2/test/run.ts
@@ -1,12 +1,12 @@
 import Ember from 'ember';
 import RSVP from 'rsvp';
 import { run } from '@ember/runloop';
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 assertType<string[]>(Ember.run.queues);
 
 function testRun() {
-    let r = run(function() {
+    let r = run(function () {
         // code to be executed within a RunLoop
         return 123;
     });
@@ -14,7 +14,7 @@ function testRun() {
 
     function destroyApp(application: Ember.Application) {
         Ember.run(application, 'destroy');
-        run(application, function() {
+        run(application, function () {
             this.destroy();
         });
     }
@@ -31,60 +31,77 @@ function testBind() {
 
         setupEditor(editor: string) {
             this.set('editor', editor);
-        }
+        },
     });
 }
 
 function testCancel() {
     const myContext = {};
 
-    let runNext = run.next(myContext, function() {
+    let runNext = run.next(myContext, function () {
         // will not be executed
     });
 
     run.cancel(runNext);
 
-    let runLater = run.later(myContext, function() {
-        // will not be executed
-    }, 500);
+    let runLater = run.later(
+        myContext,
+        function () {
+            // will not be executed
+        },
+        500,
+    );
 
     run.cancel(runLater);
 
-    let runScheduleOnce = run.scheduleOnce('afterRender', myContext, function() {
+    let runScheduleOnce = run.scheduleOnce('afterRender', myContext, function () {
         // will not be executed
     });
 
     run.cancel(runScheduleOnce);
 
-    let runOnce = run.once(myContext, function() {
+    let runOnce = run.once(myContext, function () {
         // will not be executed
     });
 
     run.cancel(runOnce);
 
-    let throttle = run.throttle(myContext, function() {
-        // will not be executed
-    }, 1, false);
+    let throttle = run.throttle(
+        myContext,
+        function () {
+            // will not be executed
+        },
+        1,
+        false,
+    );
 
     run.cancel(throttle);
 
-    let debounce = run.debounce(myContext, function() {
-        // will not be executed
-    }, 1);
+    let debounce = run.debounce(
+        myContext,
+        function () {
+            // will not be executed
+        },
+        1,
+    );
 
     run.cancel(debounce);
 
-    let debounceImmediate = run.debounce(myContext, function() {
-        // will be executed since we passed in true (immediate)
-    }, 100, true);
+    let debounceImmediate = run.debounce(
+        myContext,
+        function () {
+            // will be executed since we passed in true (immediate)
+        },
+        100,
+        true,
+    );
 
     // the 100ms delay until this method can be called again will be canceled
     run.cancel(debounceImmediate);
 }
 
 function testDebounce() {
-    function runIt() {
-    }
+    function runIt() {}
 
     let myContext = { name: 'debounce' };
 
@@ -100,8 +117,8 @@ function testDebounce() {
             handleTyping() {
                 // the fetchResults function is passed into the component from its parent
                 Ember.run.debounce(this, this.get('fetchResults'), this.get('searchValue'), 250);
-            }
-        }
+            },
+        },
     });
 }
 
@@ -112,20 +129,20 @@ function testBegin() {
 }
 
 function testJoin() {
-    run.join(function() {
+    run.join(function () {
         // creates a new run-loop
     });
 
-    run(function() {
+    run(function () {
         // creates a new run-loop
-        run.join(function() {
+        run.join(function () {
             // joins with the existing run-loop, and queues for invocation on
             // the existing run-loops action queue.
         });
     });
 
-    new RSVP.Promise(function(resolve) {
-        Ember.run.later(function() {
+    new RSVP.Promise(function (resolve) {
+        Ember.run.later(function () {
             resolve({ msg: 'Hold Your Horses' });
         }, 3000);
     });
@@ -133,14 +150,18 @@ function testJoin() {
 
 function testLater() {
     const myContext = {};
-    run.later(myContext, function() {
-        // code here will execute within a RunLoop in about 500ms with this == myContext
-    }, 500);
+    run.later(
+        myContext,
+        function () {
+            // code here will execute within a RunLoop in about 500ms with this == myContext
+        },
+        500,
+    );
 }
 
 function testNext() {
     const myContext = {};
-    run.next(myContext, function() {
+    run.next(myContext, function () {
         // code to be executed in the next run loop,
         // which will be scheduled after the current one
     });
@@ -152,24 +173,23 @@ function testOnce() {
             Ember.run.once(this, 'processFullName');
         },
 
-        processFullName() {
-        }
+        processFullName() {},
     });
 }
 
 function testSchedule() {
     Ember.Component.extend({
         init() {
-            run.schedule('sync', this, function() {
+            run.schedule('sync', this, function () {
                 // this will be executed in the first RunLoop queue, when bindings are synced
                 console.log('scheduled on sync queue');
             });
 
-            run.schedule('actions', this, function() {
+            run.schedule('actions', this, function () {
                 // this will be executed in the 'actions' queue, after bindings have synced.
                 console.log('scheduled on actions queue');
             });
-        }
+        },
     });
 
     Ember.run.schedule('actions', () => {
@@ -183,19 +203,18 @@ function testScheduleOnce() {
     }
 
     const myContext = {};
-    run(function() {
+    run(function () {
         run.scheduleOnce('afterRender', myContext, sayHi);
         run.scheduleOnce('afterRender', myContext, sayHi);
         // sayHi will only be executed once, in the afterRender queue of the RunLoop
     });
-    run.scheduleOnce('actions', myContext, function() {
+    run.scheduleOnce('actions', myContext, function () {
         console.log('Closure');
     });
 }
 
 function testThrottle() {
-    function runIt() {
-    }
+    function runIt() {}
 
     let myContext = { name: 'throttle' };
 

--- a/types/ember/v2/test/test.ts
+++ b/types/ember/v2/test/test.ts
@@ -8,20 +8,20 @@ declare const MyDb: {
 };
 Ember.Test.registerWaiter(MyDb, MyDb.hasPendingTransactions);
 
-Ember.Test.promise(function(resolve) {
+Ember.Test.promise(function (resolve) {
     window.setTimeout(resolve, 500);
 });
 
-Ember.Test.registerHelper('boot', function(app) {
+Ember.Test.registerHelper('boot', function (app) {
     Ember.run(app, app.advanceReadiness);
 });
 
-Ember.Test.registerAsyncHelper('boot', function(app) {
+Ember.Test.registerAsyncHelper('boot', function (app) {
     Ember.run(app, app.advanceReadiness);
 });
 
 Ember.Test.registerAsyncHelper('waitForPromise', (app, promise) => {
-    return new Ember.Test.Promise((resolve) => {
+    return new Ember.Test.Promise(resolve => {
         Ember.Test.adapter.asyncStart();
 
         promise.then(() => {

--- a/types/ember/v2/test/transition.ts
+++ b/types/ember/v2/test/transition.ts
@@ -6,7 +6,7 @@ Ember.Route.extend({
             alert('Sorry, you need a time machine to enter this route.');
             transition.abort();
         }
-    }
+    },
 });
 
 Ember.Controller.extend({
@@ -23,6 +23,6 @@ Ember.Controller.extend({
                 // Default back to homepage
                 this.transitionToRoute('index');
             }
-        }
-    }
+        },
+    },
 });

--- a/types/ember/v2/test/utils.ts
+++ b/types/ember/v2/test/utils.ts
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import * as utils from '@ember/utils';
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 function testIsNoneType() {
     const maybeUndefined: string | undefined = 'not actually undefined';
@@ -12,22 +12,20 @@ function testIsNoneType() {
 }
 
 function testMerge() {
-    assertType<{ first: string, last: string }>(
-        Ember.merge({ first: 'Tom' }, { last: 'Dale' })
-    );
+    assertType<{ first: string; last: string }>(Ember.merge({ first: 'Tom' }, { last: 'Dale' }));
 }
 
 function testAssign() {
-    assertType<{ first: string, middle: string, last: string }>(
-        Ember.assign({ first: 'Tom' }, { middle: 'M' }, { last: 'Dale' })
+    assertType<{ first: string; middle: string; last: string }>(
+        Ember.assign({ first: 'Tom' }, { middle: 'M' }, { last: 'Dale' }),
     );
 }
 
 function testOnError() {
-    Ember.onerror = function(error) {
+    Ember.onerror = function (error) {
         Ember.$.post('/report-error', {
             stack: error.stack,
-            otherInformation: 'whatever app state you want to provide'
+            otherInformation: 'whatever app state you want to provide',
         });
     };
 }
@@ -51,11 +49,11 @@ function testDeprecateFunc() {
 }
 
 function testDeprecate() {
-  Ember.deprecate('This has been deprecated', false, {
-    id: 'some.id',
-    until: '1.0.0',
-    url: 'http://www.emberjs.com'
-  });
+    Ember.deprecate('This has been deprecated', false, {
+        id: 'some.id',
+        until: '1.0.0',
+        url: 'http://www.emberjs.com',
+    });
 }
 
 function testDefineProperty() {
@@ -66,14 +64,18 @@ function testDefineProperty() {
         writable: true,
         configurable: false,
         enumerable: true,
-        value: 'Charles'
+        value: 'Charles',
     });
 
     // define a simple property
     Ember.defineProperty(contact, 'lastName', undefined, 'Jolley');
 
     // define a computed property
-    Ember.defineProperty(contact, 'fullName', Ember.computed('firstName', 'lastName', function() {
-        return `${this.firstName} ${this.lastName}`;
-    }));
+    Ember.defineProperty(
+        contact,
+        'fullName',
+        Ember.computed('firstName', 'lastName', function () {
+            return `${this.firstName} ${this.lastName}`;
+        }),
+    );
 }

--- a/types/ember/v2/test/view-utils.ts
+++ b/types/ember/v2/test/view-utils.ts
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 import { assertType } from './lib/assert';
 
-const { ViewUtils: { isSimpleClick } } = Ember;
+const {
+    ViewUtils: { isSimpleClick },
+} = Ember;
 assertType<boolean>(isSimpleClick(new Event('wat')));

--- a/types/ember/v2/tslint.json
+++ b/types/ember/v2/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "space-before-function-paren": false,
         "ban-types": false,
         "jsdoc-format": false,
         "no-empty-interface": false,

--- a/types/ember__application/-private/default-resolver.d.ts
+++ b/types/ember__application/-private/default-resolver.d.ts
@@ -1,5 +1,5 @@
-import Resolver from "@ember/engine/-private/resolver";
-import Application from "@ember/application";
+import Resolver from '@ember/engine/-private/resolver';
+import Application from '@ember/application';
 
 /**
  * The DefaultResolver defines the default lookup rules to resolve

--- a/types/ember__application/-private/event-dispatcher.d.ts
+++ b/types/ember__application/-private/event-dispatcher.d.ts
@@ -1,4 +1,4 @@
-import { EventDispatcherEvents } from "@ember/application/types";
+import { EventDispatcherEvents } from '@ember/application/types';
 
 /**
  * `Ember.EventDispatcher` handles delegating browser events to their

--- a/types/ember__application/-private/registry.d.ts
+++ b/types/ember__application/-private/registry.d.ts
@@ -1,13 +1,9 @@
-import { EmberClassConstructor } from "@ember/object/-private/types";
+import { EmberClassConstructor } from '@ember/object/-private/types';
 
 /**
  * A registry used to store factory and option information keyed
  * by type.
  */
 export default class Registry {
-    register(
-        fullName: string,
-        factory: EmberClassConstructor<any>,
-        options?: { singleton?: boolean }
-    ): void;
+    register(fullName: string, factory: EmberClassConstructor<any>, options?: { singleton?: boolean }): void;
 }

--- a/types/ember__application/test/application-instance.ts
+++ b/types/ember__application/test/application-instance.ts
@@ -5,23 +5,23 @@ const appInstance = ApplicationInstance.create();
 appInstance.register('some:injection', class Foo {});
 
 appInstance.register('some:injection', class Foo {}, {
-  singleton: true,
+    singleton: true,
 });
 
 appInstance.register('some:injection', class Foo {}, {
-  instantiate: false,
+    instantiate: false,
 });
 
 appInstance.register('templates:foo/bar', hbs`<h1>Hello World</h1>`);
 appInstance.register('templates:foo/bar', hbs`<h1>Hello World</h1>`, {
-    singleton: true
+    singleton: true,
 });
 appInstance.register('templates:foo/bar', hbs`<h1>Hello World</h1>`, {
-    instantiate: true
+    instantiate: true,
 });
 appInstance.register('templates:foo/bar', hbs`<h1>Hello World</h1>`, {
     singleton: true,
-    instantiate: true
+    instantiate: true,
 });
 // $ExpectError
 appInstance.register('templates:foo/bar', hbs`<h1>Hello World</h1>`, { singleton: 'true', instantiate: true });
@@ -37,5 +37,5 @@ appInstance.lookup('route:basic');
 appInstance.boot();
 
 (async () => {
-  await appInstance.boot();
+    await appInstance.boot();
 })();

--- a/types/ember__application/test/application.ts
+++ b/types/ember__application/test/application.ts
@@ -1,37 +1,37 @@
-import Application from "@ember/application";
-import EmberObject from "@ember/object";
+import Application from '@ember/application';
+import EmberObject from '@ember/object';
 
 const BaseApp = Application.extend({
-    modulePrefix: 'my-app'
+    modulePrefix: 'my-app',
 });
 
 BaseApp.initializer({
     name: 'my-initializer',
     initialize(app) {
         app.register('foo:bar', EmberObject.extend({ foo: 'bar' }));
-    }
+    },
 });
 
 BaseApp.instanceInitializer({
     name: 'my-instance-initializer',
     initialize(app) {
         app.lookup('foo:bar').get('foo');
-    }
+    },
 });
 
 const App1 = BaseApp.create({
     rootElement: '#app-one',
     customEvents: {
-        paste: 'paste'
-    }
+        paste: 'paste',
+    },
 });
 
 const App2 = BaseApp.create({
     rootElement: '#app-two',
     customEvents: {
         mouseenter: null,
-        mouseleave: null
-    }
+        mouseleave: null,
+    },
 });
 
 const App3 = BaseApp.create();

--- a/types/ember__application/test/deprecations.ts
+++ b/types/ember__application/test/deprecations.ts
@@ -1,19 +1,15 @@
 import { deprecate, deprecateFunc } from '@ember/application/deprecations';
 
 deprecate('this is no longer advised', false, {
-  id: 'no-longer-advised',
-  until: 'v4.0'
+    id: 'no-longer-advised',
+    until: 'v4.0',
 });
 deprecate('this is no longer advised', false, {
     id: 'no-longer-advised',
     until: 'v4.0',
-    url: 'https://emberjs.com'
+    url: 'https://emberjs.com',
 });
 deprecate('this is no longer advised', false); // $ExpectError
 
 deprecateFunc('this is no longer advised', () => {}); // $ExpectError
-deprecateFunc(
-    'this is no longer advised',
-    { id: 'no-longer-do-this', until: 'v4.0' },
-    () => {}
-);
+deprecateFunc('this is no longer advised', { id: 'no-longer-do-this', until: 'v4.0' }, () => {});

--- a/types/ember__application/test/globals-resolver.ts
+++ b/types/ember__application/test/globals-resolver.ts
@@ -1,4 +1,4 @@
-import GlobalsResolver from "@ember/application/globals-resolver";
+import GlobalsResolver from '@ember/application/globals-resolver';
 
 const gr = GlobalsResolver.create();
 

--- a/types/ember__application/test/resolver.ts
+++ b/types/ember__application/test/resolver.ts
@@ -1,3 +1,3 @@
-import Resolver from "@ember/application/resolver";
+import Resolver from '@ember/application/resolver';
 
 const res = Resolver.create();

--- a/types/ember__application/tslint.json
+++ b/types/ember__application/tslint.json
@@ -1,4 +1,6 @@
 {
     "extends": "dtslint/dt.json",
-    "rules": {}
+    "rules": {
+        "space-before-function-paren": false
+    }
 }

--- a/types/ember__array/-private/enumerable.d.ts
+++ b/types/ember__array/-private/enumerable.d.ts
@@ -1,6 +1,6 @@
-import ComputedProperty from "@ember/object/computed";
-import Mixin from "@ember/object/mixin";
-import NativeArray from "@ember/array/-private/native-array";
+import ComputedProperty from '@ember/object/computed';
+import Mixin from '@ember/object/mixin';
+import NativeArray from '@ember/array/-private/native-array';
 import EmberArray from '@ember/array';
 /**
  * This mixin defines the common interface implemented by enumerable objects
@@ -62,10 +62,7 @@ interface Enumerable<T> {
      * Returns an array with all of the items in the enumeration where the passed
      * function returns false. This method is the inverse of filter().
      */
-    reject(
-        callbackfn: (value: T, index: number, array: T[]) => any,
-        thisArg?: any
-    ): NativeArray<T>;
+    reject(callbackfn: (value: T, index: number, array: T[]) => any, thisArg?: any): NativeArray<T>;
     /**
      * Returns an array with just the items with the matched property. You
      * can pass an optional second argument with the target value. Otherwise
@@ -105,10 +102,7 @@ interface Enumerable<T> {
      * Returns `true` if the passed function returns true for any item in the
      * enumeration.
      */
-    any(
-        callback: (value: T, index: number, array: T[]) => boolean,
-        target?: {}
-    ): boolean;
+    any(callback: (value: T, index: number, array: T[]) => boolean, target?: {}): boolean;
     /**
      * Returns `true` if the passed property resolves to the value of the second
      * argument for any item in the enumerable. This method is often simpler/faster

--- a/types/ember__array/-private/mutable-enumerable.d.ts
+++ b/types/ember__array/-private/mutable-enumerable.d.ts
@@ -1,5 +1,5 @@
-import Mixin from "@ember/object/mixin";
-import Enumerable from "@ember/array/-private/enumerable";
+import Mixin from '@ember/object/mixin';
+import Enumerable from '@ember/array/-private/enumerable';
 
 /**
  * This mixin defines the API for modifying generic enumerables. These methods

--- a/types/ember__array/-private/native-array.d.ts
+++ b/types/ember__array/-private/native-array.d.ts
@@ -1,7 +1,7 @@
-import MutableArray from "@ember/array/mutable";
-import Observable from "@ember/object/observable";
-import Mixin from "@ember/object/mixin";
-import Copyable from "@ember/object/-private/copyable";
+import MutableArray from '@ember/array/mutable';
+import Observable from '@ember/object/observable';
+import Mixin from '@ember/object/mixin';
+import Copyable from '@ember/object/-private/copyable';
 
 // Get an alias to the global Array type to use in inner scope below.
 type GlobalArray<T> = T[];
@@ -13,11 +13,7 @@ type GlobalArray<T> = T[];
  * false, this will be applied automatically. Otherwise you can apply the mixin
  * at anytime by calling `Ember.NativeArray.apply(Array.prototype)`.
  */
-interface NativeArray<T>
-    extends GlobalArray<T>,
-        MutableArray<T>,
-        Observable,
-        Copyable {
+interface NativeArray<T> extends GlobalArray<T>, MutableArray<T>, Observable, Copyable {
     /**
      * __Required.__ You must implement this method to apply this mixin.
      */

--- a/types/ember__array/test/array-proxy.ts
+++ b/types/ember__array/test/array-proxy.ts
@@ -13,7 +13,7 @@ const overridden = ArrayProxy.create({
     content: A(pets),
     objectAtContent(idx: number): string {
         return this.get('content').objectAt(idx)!.toUpperCase();
-    }
+    },
 });
 
 overridden.get('firstObject'); // 'DOG'

--- a/types/ember__array/test/array.ts
+++ b/types/ember__array/test/array.ts
@@ -6,13 +6,10 @@ import MutableArray from '@ember/array/mutable';
 type Person = typeof Person.prototype;
 const Person = EmberObject.extend({
     name: '',
-    isHappy: false
+    isHappy: false,
 });
 
-const people = A([
-    Person.create({ name: 'Yehuda', isHappy: true }),
-    Person.create({ name: 'Majd', isHappy: false }),
-]);
+const people = A([Person.create({ name: 'Yehuda', isHappy: true }), Person.create({ name: 'Majd', isHappy: false })]);
 
 assertType<number>(people.get('length'));
 assertType<Person>(people.get('lastObject'));
@@ -24,8 +21,8 @@ const persons1: Person[] = people.filterBy('isHappy');
 const persons2: MutableArray<Person> = people.filterBy('isHappy');
 const persons3: Person[] = people.rejectBy('isHappy');
 const persons4: MutableArray<Person> = people.rejectBy('isHappy');
-const persons5: Person[] = people.filter((person) => person.get('name') === 'Yehuda');
-const persons6: MutableArray<Person> = people.filter((person) => person.get('name') === 'Yehuda');
+const persons5: Person[] = people.filter(person => person.get('name') === 'Yehuda');
+const persons6: MutableArray<Person> = people.filter(person => person.get('name') === 'Yehuda');
 
 assertType<typeof people>(people.get('[]'));
 assertType<Person>(people.get('[]').get('firstObject')); // $ExpectType any
@@ -33,7 +30,7 @@ assertType<Person>(people.get('[]').get('firstObject')); // $ExpectType any
 assertType<boolean[]>(people.mapBy('isHappy')); // $ExpectType boolean[]
 assertType<any[]>(people.mapBy('name.length'));
 
-const last = people.get('lastObject');  // $ExpectType ({ name: string; isHappy: boolean; } & EmberObject & { name: string; isHappy: boolean; }) | undefined
+const last = people.get('lastObject'); // $ExpectType ({ name: string; isHappy: boolean; } & EmberObject & { name: string; isHappy: boolean; }) | undefined
 if (last) {
     assertType<string>(last.get('name'));
 }
@@ -55,5 +52,9 @@ const filters = A(value.split(','));
 filters.push('4');
 filters.sort();
 
-const multiSortArr = A([{ k: 'a', v: 'z' }, { k: 'a', v: 'y' }, { k: 'b', v: 'c' }]);
+const multiSortArr = A([
+    { k: 'a', v: 'z' },
+    { k: 'a', v: 'y' },
+    { k: 'b', v: 'c' },
+]);
 multiSortArr.sortBy('k', 'v');

--- a/types/ember__array/tslint.json
+++ b/types/ember__array/tslint.json
@@ -1,4 +1,6 @@
 {
     "extends": "dtslint/dt.json",
-    "rules": {}
+    "rules": {
+        "space-before-function-paren": false
+    }
 }

--- a/types/ember__component/-private/action-support.d.ts
+++ b/types/ember__component/-private/action-support.d.ts
@@ -1,4 +1,4 @@
-import Mixin from "@ember/object/mixin";
+import Mixin from '@ember/object/mixin';
 
 interface ActionSupport {
     sendAction(action: string, ...params: any[]): void;

--- a/types/ember__component/-private/class-names-support.d.ts
+++ b/types/ember__component/-private/class-names-support.d.ts
@@ -1,4 +1,4 @@
-import Mixin from "@ember/object/mixin";
+import Mixin from '@ember/object/mixin';
 
 interface ClassNamesSupport {
     /**

--- a/types/ember__component/-private/core-view.d.ts
+++ b/types/ember__component/-private/core-view.d.ts
@@ -1,6 +1,6 @@
-import EmberObject from "@ember/object";
-import Evented from "@ember/object/evented";
-import ActionHandler from "@ember/object/-private/action-handler";
+import EmberObject from '@ember/object';
+import Evented from '@ember/object/evented';
+import ActionHandler from '@ember/object/-private/action-handler';
 
 /**
  * Ember.CoreView is an abstract class that exists to give view-like behavior to both Ember's main

--- a/types/ember__component/-private/target-action-support.d.ts
+++ b/types/ember__component/-private/target-action-support.d.ts
@@ -1,4 +1,4 @@
-import EmberObject from "@ember/object";
+import EmberObject from '@ember/object';
 
 // tslint:disable-next-line:strict-export-declare-modifiers
 interface TriggerActionOptions {

--- a/types/ember__component/-private/text-support.d.ts
+++ b/types/ember__component/-private/text-support.d.ts
@@ -1,5 +1,5 @@
-import TargetActionSupport from "@ember/component/-private/target-action-support";
-import Mixin from "@ember/object/mixin";
+import TargetActionSupport from '@ember/component/-private/target-action-support';
+import Mixin from '@ember/object/mixin';
 
 /**
  * `TextSupport` is a shared mixin used by both `Ember.TextField` and

--- a/types/ember__component/-private/view-mixin.d.ts
+++ b/types/ember__component/-private/view-mixin.d.ts
@@ -1,4 +1,4 @@
-import Mixin from "@ember/object/mixin";
+import Mixin from '@ember/object/mixin';
 
 interface ViewMixin {
     /**

--- a/types/ember__component/test/component.ts
+++ b/types/ember__component/test/component.ts
@@ -1,10 +1,10 @@
 import Component from '@ember/component';
 import Object, { computed, get } from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
-import { assertType } from "./lib/assert";
+import { assertType } from './lib/assert';
 
 Component.extend({
-  layout: hbs`
+    layout: hbs`
         <div>
           {{yield}}
         </div>
@@ -12,112 +12,112 @@ Component.extend({
 });
 
 Component.extend({
-  layout: 'my-layout',
+    layout: 'my-layout',
 });
 
 const MyComponent = Component.extend();
 assertType<string | string[]>(get(MyComponent, 'positionalParams'));
 
 const component1 = Component.extend({
-  actions: {
-    hello(name: string) {
-      console.log('Hello', name);
+    actions: {
+        hello(name: string) {
+            console.log('Hello', name);
+        },
     },
-  },
 });
 
 Component.extend({
-  name: '',
-  hello(name: string) {
-    this.set('name', name);
-  },
+    name: '',
+    hello(name: string) {
+        this.set('name', name);
+    },
 });
 
 Component.extend({
-  tagName: 'em',
+    tagName: 'em',
 });
 
 Component.extend({
-  classNames: ['my-class', 'my-other-class'],
+    classNames: ['my-class', 'my-other-class'],
 });
 
 Component.extend({
-  classNameBindings: ['propertyA', 'propertyB'],
-  propertyA: 'from-a',
-  propertyB: computed(function() {
-    if (!this.get('propertyA')) {
-      return 'from-b';
-    }
-  }),
+    classNameBindings: ['propertyA', 'propertyB'],
+    propertyA: 'from-a',
+    propertyB: computed(function () {
+        if (!this.get('propertyA')) {
+            return 'from-b';
+        }
+    }),
 });
 
 Component.extend({
-  classNameBindings: ['hovered'],
-  hovered: true,
+    classNameBindings: ['hovered'],
+    hovered: true,
 });
 
 Component.extend({
-  classNameBindings: ['messages.empty'],
-  messages: Object.create({
-    empty: true,
-  }),
+    classNameBindings: ['messages.empty'],
+    messages: Object.create({
+        empty: true,
+    }),
 });
 
 Component.extend({
-  classNameBindings: ['isEnabled:enabled:disabled'],
-  isEnabled: true,
+    classNameBindings: ['isEnabled:enabled:disabled'],
+    isEnabled: true,
 });
 
 Component.extend({
-  classNameBindings: ['isEnabled::disabled'],
-  isEnabled: true,
+    classNameBindings: ['isEnabled::disabled'],
+    isEnabled: true,
 });
 
 Component.extend({
-  tagName: 'a',
-  attributeBindings: ['href'],
-  href: 'http://google.com',
+    tagName: 'a',
+    attributeBindings: ['href'],
+    href: 'http://google.com',
 });
 
 Component.extend({
-  tagName: 'a',
-  attributeBindings: ['url:href'],
-  url: 'http://google.com',
+    tagName: 'a',
+    attributeBindings: ['url:href'],
+    url: 'http://google.com',
 });
 
 Component.extend({
-  tagName: 'use',
-  attributeBindings: ['xlinkHref:xlink:href'],
-  xlinkHref: '#triangle',
+    tagName: 'use',
+    attributeBindings: ['xlinkHref:xlink:href'],
+    xlinkHref: '#triangle',
 });
 
 Component.extend({
-  tagName: 'input',
-  attributeBindings: ['disabled'],
-  disabled: false,
+    tagName: 'input',
+    attributeBindings: ['disabled'],
+    disabled: false,
 });
 
 Component.extend({
-  tagName: 'input',
-  attributeBindings: ['disabled'],
-  disabled: computed(() => {
-    if ('someLogic') {
-      return true;
-    } else {
-      return false;
-    }
-  }),
+    tagName: 'input',
+    attributeBindings: ['disabled'],
+    disabled: computed(() => {
+        if ('someLogic') {
+            return true;
+        } else {
+            return false;
+        }
+    }),
 });
 
 Component.extend({
-  tagName: 'form',
-  attributeBindings: ['novalidate'],
-  novalidate: null,
+    tagName: 'form',
+    attributeBindings: ['novalidate'],
+    novalidate: null,
 });
 
 Component.extend({
-  click(event: object) {
-    // will be called when an instance's
-    // rendered element is clicked
-  },
+    click(event: object) {
+        // will be called when an instance's
+        // rendered element is clicked
+    },
 });

--- a/types/ember__component/test/helper.ts
+++ b/types/ember__component/test/helper.ts
@@ -20,6 +20,6 @@ const addHelper = helper(function add([a, b]: number[]) {
     return a + b;
 });
 
-const dasherizeHelper = helper(function dasherize([str]: string[], { delim = '-'}) {
+const dasherizeHelper = helper(function dasherize([str]: string[], { delim = '-' }) {
     return str.split(/[\s\n\_\.]+/g).join(delim);
 });

--- a/types/ember__component/tslint.json
+++ b/types/ember__component/tslint.json
@@ -1,4 +1,6 @@
 {
     "extends": "dtslint/dt.json",
-    "rules": {}
+    "rules": {
+        "space-before-function-paren": false
+    }
 }

--- a/types/ember__controller/test/main.ts
+++ b/types/ember__controller/test/main.ts
@@ -1,7 +1,7 @@
-import Controller, { inject } from "@ember/controller";
+import Controller, { inject } from '@ember/controller';
 
 Controller.extend({
-    queryParams: ["category"],
+    queryParams: ['category'],
     category: null,
     isExpanded: false,
 
@@ -9,6 +9,6 @@ Controller.extend({
     second: inject('second'),
 
     toggleBody() {
-        this.toggleProperty("isExpanded");
-    }
+        this.toggleProperty('isExpanded');
+    },
 });

--- a/types/ember__controller/test/octane.ts
+++ b/types/ember__controller/test/octane.ts
@@ -1,33 +1,33 @@
-import Controller, { inject } from "@ember/controller";
+import Controller, { inject } from '@ember/controller';
 
 class FirstController extends Controller {
-    foo = "bar";
+    foo = 'bar';
     @inject second: InstanceType<typeof SecondController>;
     @inject() otherSecond: InstanceType<typeof SecondController>;
-    @inject("second") moreSecond: InstanceType<typeof SecondController>;
+    @inject('second') moreSecond: InstanceType<typeof SecondController>;
 
     queryParams = [
         'category',
         {
             searchTerm: {
-                as: 'search'
-            }
-        }
+                as: 'search',
+            },
+        },
     ];
 
     first() {
-        return "";
+        return '';
     }
 }
 const SecondController = Controller.extend({
-    foo: "bar",
+    foo: 'bar',
 
     second() {
-        return "";
-    }
+        return '';
+    },
 });
 
-declare module "@ember/controller" {
+declare module '@ember/controller' {
     interface Registry {
         first: FirstController;
         second: InstanceType<typeof SecondController>;

--- a/types/ember__controller/tslint.json
+++ b/types/ember__controller/tslint.json
@@ -1,4 +1,6 @@
 {
     "extends": "dtslint/dt.json",
-    "rules": {}
+    "rules": {
+        "space-before-function-paren": false
+    }
 }

--- a/types/ember__debug/tslint.json
+++ b/types/ember__debug/tslint.json
@@ -1,4 +1,6 @@
 {
     "extends": "dtslint/dt.json",
-    "rules": { }
+    "rules": {
+        "space-before-function-paren": false
+    }
 }

--- a/types/ember__engine/-private/container-proxy-mixin.d.ts
+++ b/types/ember__engine/-private/container-proxy-mixin.d.ts
@@ -1,4 +1,4 @@
-import Mixin from "@ember/object/mixin";
+import Mixin from '@ember/object/mixin';
 
 /**
  * Given a fullName return a factory manager.

--- a/types/ember__engine/-private/registry-proxy-mixin.d.ts
+++ b/types/ember__engine/-private/registry-proxy-mixin.d.ts
@@ -14,11 +14,7 @@ interface RegistryProxyMixin {
      * `inject`) or for service lookup. Each factory is registered with
      * a full name including two parts: `type:name`.
      */
-    register(
-        fullName: string,
-        factory: any,
-        options?: { singleton?: boolean; instantiate?: boolean }
-    ): any;
+    register(fullName: string, factory: any, options?: { singleton?: boolean; instantiate?: boolean }): any;
     /**
      * Unregister a factory.
      */
@@ -55,11 +51,7 @@ interface RegistryProxyMixin {
      * Define a dependency injection onto a specific factory or all factories
      * of a type.
      */
-    inject(
-        factoryNameOrType: string,
-        property: string,
-        injectionName: string
-    ): any;
+    inject(factoryNameOrType: string, property: string, injectionName: string): any;
 }
 declare const RegistryProxyMixin: Mixin<RegistryProxyMixin>;
 export default RegistryProxyMixin;

--- a/types/ember__engine/-private/resolver.d.ts
+++ b/types/ember__engine/-private/resolver.d.ts
@@ -1,3 +1,3 @@
-import EmberObject from "@ember/object";
+import EmberObject from '@ember/object';
 
 export default class Resolver extends EmberObject {}

--- a/types/ember__engine/test/engine-instance.ts
+++ b/types/ember__engine/test/engine-instance.ts
@@ -4,11 +4,11 @@ const engineInstance = EngineInstance.create();
 engineInstance.register('some:injection', class Foo {});
 
 engineInstance.register('some:injection', class Foo {}, {
-  singleton: true,
+    singleton: true,
 });
 
 engineInstance.register('some:injection', class Foo {}, {
-  instantiate: false,
+    instantiate: false,
 });
 
 engineInstance.register('some:injection', class Foo {}, {
@@ -22,5 +22,5 @@ engineInstance.lookup('route:basic');
 engineInstance.boot();
 
 (async () => {
-  await engineInstance.boot();
+    await engineInstance.boot();
 })();

--- a/types/ember__engine/test/engine.ts
+++ b/types/ember__engine/test/engine.ts
@@ -1,37 +1,37 @@
-import Engine from "@ember/engine";
-import EmberObject from "@ember/object";
+import Engine from '@ember/engine';
+import EmberObject from '@ember/object';
 
 const BaseEngine = Engine.extend({
-    modulePrefix: 'my-engine'
+    modulePrefix: 'my-engine',
 });
 
 BaseEngine.initializer({
     name: 'my-initializer',
     initialize(engine) {
         engine.register('foo:bar', EmberObject.extend({ foo: 'bar' }));
-    }
+    },
 });
 
 BaseEngine.instanceInitializer({
     name: 'my-instance-initializer',
     initialize(engine) {
         engine.lookup('foo:bar').get('foo');
-    }
+    },
 });
 
 const Engine1 = BaseEngine.create({
     rootElement: '#engine-one',
     customEvents: {
-        paste: 'paste'
-    }
+        paste: 'paste',
+    },
 });
 
 const Engine2 = BaseEngine.create({
     rootElement: '#engine-two',
     customEvents: {
         mouseenter: null,
-        mouseleave: null
-    }
+        mouseleave: null,
+    },
 });
 
 const Engine3 = BaseEngine.create();

--- a/types/ember__engine/tslint.json
+++ b/types/ember__engine/tslint.json
@@ -1,4 +1,6 @@
 {
     "extends": "dtslint/dt.json",
-    "rules": {}
+    "rules": {
+        "space-before-function-paren": false
+    }
 }

--- a/types/ember__error/tslint.json
+++ b/types/ember__error/tslint.json
@@ -1,5 +1,6 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "space-before-function-paren": false
     }
 }

--- a/types/ember__object/-private/action-handler.d.ts
+++ b/types/ember__object/-private/action-handler.d.ts
@@ -1,4 +1,4 @@
-import Mixin from "@ember/object/mixin";
+import Mixin from '@ember/object/mixin';
 
 interface ActionsHash {
     [index: string]: (...params: any[]) => any;

--- a/types/ember__object/-private/copyable.d.ts
+++ b/types/ember__object/-private/copyable.d.ts
@@ -1,4 +1,4 @@
-import Mixin from "@ember/object/mixin";
+import Mixin from '@ember/object/mixin';
 
 /**
  * Implements some standard methods for copying an object. Add this mixin to

--- a/types/ember__object/-private/types.d.ts
+++ b/types/ember__object/-private/types.d.ts
@@ -13,7 +13,7 @@ import ComputedProperty from '@ember/object/computed';
 export type Objectify<T> = Readonly<T>;
 
 export type ExtractPropertyNamesOfType<T, S> = {
-    [K in keyof T]: T[K] extends S ? K : never
+    [K in keyof T]: T[K] extends S ? K : never;
 }[keyof T];
 
 export type Fix<T> = { [K in keyof T]: T[K] };
@@ -46,8 +46,7 @@ export class ComputedPropertyMarker<Get, Set = Get> {
  * Implementation is carefully chosen for the reasons described in
  * https://github.com/typed-ember/ember-typings/pull/29
  */
-export type EmberClassConstructor<T> = (new (properties?: object) => T) &
-    (new (...args: any[]) => T);
+export type EmberClassConstructor<T> = (new (properties?: object) => T) & (new (...args: any[]) => T);
 
 /**
  * Check that any arguments to `create()` match the type's properties.
@@ -73,33 +72,18 @@ export type MixinOrLiteral<T, Base> = Mixin<T, Base> | T;
 /**
  * Deconstructs computed properties into the types which would be returned by `.get()`.
  */
-export type UnwrapComputedPropertyGetter<T> = T extends ComputedPropertyMarker<
-    infer U,
-    any
->
-    ? U
-    : T;
+export type UnwrapComputedPropertyGetter<T> = T extends ComputedPropertyMarker<infer U, any> ? U : T;
 export type UnwrapComputedPropertyGetters<T> = {
-    [P in keyof T]: UnwrapComputedPropertyGetter<T[P]>
+    [P in keyof T]: UnwrapComputedPropertyGetter<T[P]>;
 };
 
-export type UnwrapComputedPropertySetter<T> = T extends ComputedPropertyMarker<
-    any,
-    infer V
->
-    ? V
-    : T;
+export type UnwrapComputedPropertySetter<T> = T extends ComputedPropertyMarker<any, infer V> ? V : T;
 export type UnwrapComputedPropertySetters<T> = {
-    [P in keyof T]: UnwrapComputedPropertySetter<T[P]>
+    [P in keyof T]: UnwrapComputedPropertySetter<T[P]>;
 };
 
 export type ComputedPropertyGetterFunction<T> = (this: any, key: string) => T;
-export type ComputedPropertySetterFunction<T> = (
-    this: any,
-    key: string,
-    newVal: T,
-    oldVal: T
-) => T;
+export type ComputedPropertySetterFunction<T> = (this: any, key: string, newVal: T, oldVal: T) => T;
 
 export interface ComputedPropertyGetterObj<T> {
     get(this: any, key: string): T;
@@ -113,23 +97,11 @@ export type ComputedPropertyObj<T> =
     | ComputedPropertySetterObj<T>
     | (ComputedPropertyGetterObj<T> & ComputedPropertySetterObj<T>);
 
-export type ComputedPropertyGetter<T> =
-    | ComputedPropertyGetterFunction<T>
-    | ComputedPropertyGetterObj<T>;
-export type ComputedPropertySetter<T> =
-    | ComputedPropertySetterFunction<T>
-    | ComputedPropertySetterObj<T>;
+export type ComputedPropertyGetter<T> = ComputedPropertyGetterFunction<T> | ComputedPropertyGetterObj<T>;
+export type ComputedPropertySetter<T> = ComputedPropertySetterFunction<T> | ComputedPropertySetterObj<T>;
 
-export type ComputedPropertyCallback<T> =
-    | ComputedPropertyGetterFunction<T>
-    | ComputedPropertyObj<T>;
+export type ComputedPropertyCallback<T> = ComputedPropertyGetterFunction<T> | ComputedPropertyObj<T>;
 
 export type ObserverMethod<Target, Sender> =
-    | (keyof Target)
-    | ((
-          this: Target,
-          sender: Sender,
-          key: string,
-          value: any,
-          rev: number
-      ) => void);
+    | keyof Target
+    | ((this: Target, sender: Sender, key: string, value: any, rev: number) => void);

--- a/types/ember__object/test/access-modifier.ts
+++ b/types/ember__object/test/access-modifier.ts
@@ -2,9 +2,15 @@ import { assertType } from './lib/assert';
 import EmberObject from '@ember/object';
 
 class Foo extends EmberObject {
-    hello() { return 'world'; }
-    protected bar() { return 'bar'; }
-    private baz() { return 'baz'; }
+    hello() {
+        return 'world';
+    }
+    protected bar() {
+        return 'bar';
+    }
+    private baz() {
+        return 'baz';
+    }
 }
 const f = new Foo();
 assertType<string>(f.hello());

--- a/types/ember__object/test/computed.ts
+++ b/types/ember__object/test/computed.ts
@@ -31,7 +31,7 @@ import ComputedProperty, {
     uniq,
     deprecatingAlias,
     bool,
-    collect
+    collect,
 } from '@ember/object/computed';
 import { assertType } from './lib/assert';
 
@@ -42,11 +42,11 @@ const Person = EmberObject.extend({
 
     noArgs: computed<string>(() => 'test'),
 
-    fullName: computed<string>('firstName', 'lastName', function() {
+    fullName: computed<string>('firstName', 'lastName', function () {
         return `${this.get('firstName')} ${this.get('lastName')}`;
     }),
 
-    fullNameReadonly: computed<string>('fullName', function() {
+    fullNameReadonly: computed<string>('fullName', function () {
         return this.get('fullName');
     }).readOnly(),
 
@@ -59,13 +59,13 @@ const Person = EmberObject.extend({
             this.set('firstName', first);
             this.set('lastName', last);
             return value;
-        }
+        },
     }),
 
     fullNameGetOnly: computed<string>('fullName', {
         get() {
             return this.get('fullName');
-        }
+        },
     }),
 
     fullNameSetOnly: computed<string>('firstName', 'lastName', {
@@ -74,15 +74,16 @@ const Person = EmberObject.extend({
             this.set('firstName', first);
             this.set('lastName', last);
             return value;
-        }
+        },
     }),
 
-    combinators: computed<string>(function() {
+    combinators: computed<string>(function () {
         return this.get('firstName');
-    }).property('firstName')
-      .meta({ foo: 'bar' })
-      .volatile()
-      .readOnly(),
+    })
+        .property('firstName')
+        .meta({ foo: 'bar' })
+        .volatile()
+        .readOnly(),
 
     explicitlyDeclared: alias('fullName') as ComputedProperty<string>,
 });
@@ -115,10 +116,10 @@ assertType<string>(person.get('fullNameSetOnly'));
 assertType<string>(person.get('combinators'));
 assertType<string>(person.get('explicitlyDeclared'));
 
-assertType<{ firstName: string, fullName: string, age: number }>(person.getProperties('firstName', 'fullName', 'age'));
+assertType<{ firstName: string; fullName: string; age: number }>(person.getProperties('firstName', 'fullName', 'age'));
 
 const person2 = Person.create({
-    fullName: 'Fred Smith'
+    fullName: 'Fred Smith',
 });
 
 assertType<string>(person2.get('firstName'));
@@ -126,7 +127,7 @@ assertType<string>(person2.get('fullName'));
 
 const person3 = Person.extend({
     firstName: 'Fred',
-    fullName: 'Fred Smith'
+    fullName: 'Fred Smith',
 }).create();
 
 assertType<string>(person3.get('firstName'));
@@ -134,7 +135,7 @@ assertType<string>(person3.get('fullName'));
 
 const person4 = Person.extend({
     firstName: computed(() => 'Fred'),
-    fullName: computed(() => 'Fred Smith')
+    fullName: computed(() => 'Fred Smith'),
 }).create();
 
 assertType<string>(person4.get('firstName'));
@@ -148,14 +149,14 @@ const objectWithComputedProperties = EmberObject.extend({
     collect: collect('foo', 'bar', 'baz', 'qux'),
     deprecatingAlias: deprecatingAlias('foo', {
         id: 'hamster.deprecate-banana',
-        until: '3.0.0'
+        until: '3.0.0',
     }),
     empty: empty('foo'),
     equalNumber: equal('foo', 1),
     equalString: equal('foo', 'bar'),
     equalObject: equal('foo', {}),
-    filter1: filter('foo', (item) => item === 'bar'),
-    filter2: filter('foo', ['bar', 'baz'], (item) => item === 'bar'),
+    filter1: filter('foo', item => item === 'bar'),
+    filter2: filter('foo', ['bar', 'baz'], item => item === 'bar'),
     filterBy1: filterBy('foo', 'bar'),
     filterBy2: filterBy('foo', 'bar', false),
     gt: gt('foo', 3),
@@ -199,11 +200,11 @@ const objectWithComputedProperties = EmberObject.extend({
     sum: sum('foo'),
     union: union('foo', 'bar', 'baz', 'qux'),
     uniq: uniq('foo'),
-    uniqBy: uniqBy('foo', 'bar')
+    uniqBy: uniqBy('foo', 'bar'),
 });
 
 const component2 = EmberObject.extend({
-    isAnimal: or('isDog', 'isCat')
+    isAnimal: or('isDog', 'isCat'),
 }).create();
 
 assertType<boolean>(component2.get('isAnimal'));

--- a/types/ember__object/test/core.ts
+++ b/types/ember__object/test/core.ts
@@ -32,7 +32,7 @@ const co4 = CoreObject.extend({
     bar: 456,
     baz(): [string, number] {
         return [this.foo, this.bar];
-    }
+    },
 }).create();
 
 co4.foo; // $ExpectType string
@@ -45,7 +45,7 @@ const class05 = CoreObject.extend({
     bar: 456,
     baz() {
         return [this.foo, this.bar];
-    }
+    },
 });
 const c05 = class05.create({ foo: 99 }); // $ExpectError
 const c05b = class05.create({ foo: true });
@@ -68,7 +68,7 @@ const co6 = CoreObject.extend(
             this.foo; // $ExpectType string
             // this does not include stuff from later extend args
             this.bee; // $ExpectError
-        }
+        },
     },
     {
         foo: 99,
@@ -81,8 +81,8 @@ const co6 = CoreObject.extend(
             this.foo;
             // this includes stuff from earlier extend-args
             this.bar; // $ExpectType number
-        }
-    }
+        },
+    },
 ).create();
 
 // TODO: enable in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
@@ -105,7 +105,7 @@ const co7 = CoreObject.extend(
             this.foo; // $ExpectType string
             // this does not include stuff from later extend args
             this.bee; // $ExpectError
-        }
+        },
     },
     {
         foo: 99,
@@ -118,7 +118,7 @@ const co7 = CoreObject.extend(
             this.foo;
             // this includes stuff from earlier extend-args
             this.bar; // $ExpectType number
-        }
+        },
     },
     {
         foo: '99',
@@ -131,8 +131,8 @@ const co7 = CoreObject.extend(
             // this includes stuff from earlier extend-args
             this.bee; // $ExpectType string
             this.bar; // $ExpectType number
-        }
-    }
+        },
+    },
 ).create();
 // TODO: enable in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
 // assertType<number>(co7.foo); // $ExpectError
@@ -155,7 +155,7 @@ const co8 = CoreObject.extend(
             this.foo; // $ExpectType string
             // this does not include stuff from later extend args
             this.bee; // $ExpectError
-        }
+        },
     },
     {
         foo: 99,
@@ -170,7 +170,7 @@ const co8 = CoreObject.extend(
             this.bar; // $ExpectType number
             // this does not include stuff from later extend args
             this.money; // $ExpectError
-        }
+        },
     },
     {
         foo: '99',
@@ -185,7 +185,7 @@ const co8 = CoreObject.extend(
             this.bar; // $ExpectType number
             // this does not include stuff from later extend args
             this.neighborhood; // $ExpectError
-        }
+        },
     },
     {
         foo: '99',
@@ -199,8 +199,8 @@ const co8 = CoreObject.extend(
             this.bee; // $ExpectType string
             this.bar; // $ExpectType number
             this.money; // $ExpectType string
-        }
-    }
+        },
+    },
 ).create();
 
 // TODO: enable in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291

--- a/types/ember__object/test/create.ts
+++ b/types/ember__object/test/create.ts
@@ -16,7 +16,7 @@ assertType<(key: keyof EmberObject) => any>(o.get); // from prototype
 /**
  * One-argument case
  */
-const o1 = EmberObject.create({x: 9, y: 'hello', z: false});
+const o1 = EmberObject.create({ x: 9, y: 'hello', z: false });
 assertType<number>(o1.x);
 assertType<string>(o1.y);
 o1.y; // $ExpectType string
@@ -28,7 +28,7 @@ assertType<number>(obj.a);
 assertType<number>(obj.c);
 
 export class Person extends EmberObject {
-    fullName = computed('firstName', 'lastName', function() {
+    fullName = computed('firstName', 'lastName', function () {
         return [this.firstName + this.lastName].join(' ');
     });
     firstName: string;
@@ -46,7 +46,7 @@ const p2b = Person.create({}, { firstName: 'string' });
 const p2c = Person.create({}, {}, { firstName: 'string' });
 
 export class PersonWithNumberName extends Person.extend({
-  fullName: 6
+    fullName: 6,
 }) {}
 
 const p4 = new PersonWithNumberName();

--- a/types/ember__object/test/detect-instance.ts
+++ b/types/ember__object/test/detect-instance.ts
@@ -2,7 +2,7 @@ import { assertType } from './lib/assert';
 import EmberObject from '@ember/object';
 
 const ExtendClass = EmberObject.extend({
-    foo: 'hello'
+    foo: 'hello',
 });
 
 class ES6Class extends EmberObject {

--- a/types/ember__object/test/detect.ts
+++ b/types/ember__object/test/detect.ts
@@ -2,7 +2,7 @@ import { assertType } from './lib/assert';
 import EmberObject from '@ember/object';
 
 const ExtendClass = EmberObject.extend({
-    foo: 'hello'
+    foo: 'hello',
 });
 
 class ES6Class extends EmberObject {

--- a/types/ember__object/test/event.ts
+++ b/types/ember__object/test/event.ts
@@ -9,7 +9,7 @@ function testOn() {
         }),
         logCompleted: on('completed', () => {
             console.log('Job completed!');
-        })
+        }),
     });
 
     const job = Job.create();
@@ -23,7 +23,7 @@ function testEvented() {
     const Person = EmberObject.extend(Evented, {
         greet() {
             this.trigger('greet');
-        }
+        },
     });
 
     const person = Person.create();
@@ -31,26 +31,25 @@ function testEvented() {
     const target = {
         hi() {
             console.log('Hello!');
-        }
+        },
     };
 
     person.on('greet', () => {
         console.log('Our person has greeted');
     });
 
-    person.on('greet', () => {
-        console.log('Our person has greeted');
-    }).one('greet', () => {
-        console.log('Offer one-time special');
-    }).off('event', {}, () => {});
+    person
+        .on('greet', () => {
+            console.log('Our person has greeted');
+        })
+        .one('greet', () => {
+            console.log('Offer one-time special');
+        })
+        .off('event', {}, () => {});
 
-    person.on('greet', target, 'hi')
-        .one('greet', target, 'hi')
-        .off('event', target, 'hi');
+    person.on('greet', target, 'hi').one('greet', target, 'hi').off('event', target, 'hi');
 
-    person.on('greet', target, target.hi)
-        .one('greet', target, target.hi)
-        .off('event', target, target.hi);
+    person.on('greet', target, target.hi).one('greet', target, target.hi).off('event', target, target.hi);
 
     person.greet();
 }
@@ -74,7 +73,6 @@ function testListener() {
             removeListener(this, 'willDestroy', this, 'willDestroyListener');
             removeListener(this, 'willDestroy', this, this.willDestroyListener);
         },
-        willDestroyListener() {
-        }
+        willDestroyListener() {},
     });
 }

--- a/types/ember__object/test/extend.ts
+++ b/types/ember__object/test/extend.ts
@@ -10,7 +10,7 @@ const Person = EmberObject.extend({
     },
     getFullName2(): string {
         return `${this.get('firstName')} ${this.get('lastName')}`;
-    }
+    },
 });
 
 assertType<string>(Person.prototype.firstName);
@@ -19,7 +19,7 @@ assertType<() => string>(Person.prototype.getFullName);
 const person = Person.create({
     firstName: 'Joe',
     lastName: 'Blow',
-    extra: 42
+    extra: 42,
 });
 
 assertType<string>(person.getFullName());
@@ -43,7 +43,7 @@ assertType<string>(ES6Person.prototype.fullName);
 const es6Person = ES6Person.create({
     firstName: 'Joe',
     lastName: 'Blow',
-    extra: 42
+    extra: 42,
 });
 
 assertType<string>(es6Person.fullName);

--- a/types/ember__object/test/object.ts
+++ b/types/ember__object/test/object.ts
@@ -1,4 +1,4 @@
-import EmberObject, { computed, notifyPropertyChange } from "@ember/object";
+import EmberObject, { computed, notifyPropertyChange } from '@ember/object';
 
 const LifetimeHooks = EmberObject.extend({
     resource: undefined as {} | undefined,
@@ -11,7 +11,7 @@ const LifetimeHooks = EmberObject.extend({
     willDestroy() {
         delete this.resource;
         this._super();
-    }
+    },
 });
 
 class MyObject30 extends EmberObject {
@@ -28,8 +28,12 @@ class MyObject31 extends EmberObject {
 
 class Foo extends EmberObject {
     a = computed({
-        get() { return ''; },
-        set(key: string, newVal: string) { return ''; }
+        get() {
+            return '';
+        },
+        set(key: string, newVal: string) {
+            return '';
+        },
     });
     b = 5;
     baz() {
@@ -44,7 +48,7 @@ class Foo extends EmberObject {
         // this.setProperties({ b: '11' }); // $ExpectError
         this.setProperties({
             a: 'def',
-            b: 11
+            b: 11,
         });
     }
     bar() {

--- a/types/ember__object/test/observable.ts
+++ b/types/ember__object/test/observable.ts
@@ -36,9 +36,9 @@ myComponent.set('foo', 'baz');
 const person = EmberObject.create({
     name: 'Fred',
     age: 29,
-    capitalized: computed<string>(function() {
+    capitalized: computed<string>(function () {
         return this.get('name').toUpperCase();
-    })
+    }),
 });
 
 const pojo = { name: 'Fred', age: 29 };
@@ -55,14 +55,14 @@ function testGet() {
 
 function testGetProperties() {
     assertType<{ name: string }>(getProperties(person, 'name'));
-    assertType<{ name: string, age: number }>(getProperties(person, 'name', 'age'));
-    assertType<{ name: string, age: number }>(getProperties(person, [ 'name', 'age' ]));
-    assertType<{ name: string, age: number, capitalized: string }>(getProperties(person, 'name', 'age', 'capitalized'));
+    assertType<{ name: string; age: number }>(getProperties(person, 'name', 'age'));
+    assertType<{ name: string; age: number }>(getProperties(person, ['name', 'age']));
+    assertType<{ name: string; age: number; capitalized: string }>(getProperties(person, 'name', 'age', 'capitalized'));
     assertType<{ name: string }>(person.getProperties('name'));
-    assertType<{ name: string, age: number }>(person.getProperties('name', 'age'));
-    assertType<{ name: string, age: number }>(person.getProperties([ 'name', 'age' ]));
-    assertType<{ name: string, age: number, capitalized: string }>(person.getProperties('name', 'age', 'capitalized'));
-    assertType<{ name: string, age: number }>(getProperties(pojo, 'name', 'age'));
+    assertType<{ name: string; age: number }>(person.getProperties('name', 'age'));
+    assertType<{ name: string; age: number }>(person.getProperties(['name', 'age']));
+    assertType<{ name: string; age: number; capitalized: string }>(person.getProperties('name', 'age', 'capitalized'));
+    assertType<{ name: string; age: number }>(getProperties(pojo, 'name', 'age'));
 }
 
 function testGetWithDefault() {
@@ -87,12 +87,12 @@ function testSet() {
 
 function testSetProperties() {
     assertType<{ name: string }>(setProperties(person, { name: 'Joe' }));
-    assertType<{ name: string, age: number }>(setProperties(person, { name: 'Joe', age: 35 }));
-    assertType<{ name: string, capitalized: string }>(setProperties(person, { name: 'Joe', capitalized: 'JOE' }));
+    assertType<{ name: string; age: number }>(setProperties(person, { name: 'Joe', age: 35 }));
+    assertType<{ name: string; capitalized: string }>(setProperties(person, { name: 'Joe', capitalized: 'JOE' }));
     assertType<{ name: string }>(person.setProperties({ name: 'Joe' }));
-    assertType<{ name: string, age: number }>(person.setProperties({ name: 'Joe', age: 35 }));
-    assertType<{ name: string, capitalized: string }>(person.setProperties({ name: 'Joe', capitalized: 'JOE' }));
-    assertType<{ name: string, age: number }>(setProperties(pojo, { name: 'Joe', age: 35 }));
+    assertType<{ name: string; age: number }>(person.setProperties({ name: 'Joe', age: 35 }));
+    assertType<{ name: string; capitalized: string }>(person.setProperties({ name: 'Joe', capitalized: 'JOE' }));
+    assertType<{ name: string; age: number }>(setProperties(pojo, { name: 'Joe', age: 35 }));
 }
 
 function testDynamic() {
@@ -104,11 +104,11 @@ function testDynamic() {
     assertType<string>(getWithDefault(obj, 'dummy', 'default'));
     assertType<string>(getWithDefault(obj, dynamicKey, 'default'));
     assertType<{ dummy: any }>(getProperties(obj, 'dummy'));
-    assertType<{ dummy: any }>(getProperties(obj, [ 'dummy' ]));
+    assertType<{ dummy: any }>(getProperties(obj, ['dummy']));
     assertType<object>(getProperties(obj, dynamicKey));
-    assertType<object>(getProperties(obj, [ dynamicKey ]));
+    assertType<object>(getProperties(obj, [dynamicKey]));
     assertType<string>(set(obj, 'dummy', 'value'));
     assertType<string>(set(obj, dynamicKey, 'value'));
-    assertType<{ dummy: string }>(setProperties(obj, { dummy: 'value '}));
+    assertType<{ dummy: string }>(setProperties(obj, { dummy: 'value ' }));
     assertType<object>(setProperties(obj, { [dynamicKey]: 'value' }));
 }

--- a/types/ember__object/test/octane.ts
+++ b/types/ember__object/test/octane.ts
@@ -1,4 +1,4 @@
-import { action, computed, default as EmberObject } from "@ember/object";
+import { action, computed, default as EmberObject } from '@ember/object';
 import {
     alias,
     and,
@@ -31,8 +31,8 @@ import {
     sum,
     union,
     uniq,
-    uniqBy
-} from "@ember/object/computed";
+    uniqBy,
+} from '@ember/object/computed';
 
 function customMacro(message: string) {
     return computed(() => {
@@ -48,15 +48,15 @@ class Foo extends EmberObject {
     @action // $ExpectError
     bar: string;
 
-    @computed("firstName", "lastName")
+    @computed('firstName', 'lastName')
     get fullName() {
         return `${this.firstName} ${this.lastName}`;
     }
 
-    @computed("firstName", "lastName") // $ExpectError
+    @computed('firstName', 'lastName') // $ExpectError
     badFullName: string;
 
-    @computed("fullName", function(this: Foo) {
+    @computed('fullName', function (this: Foo) {
         return this.fullName.toUpperCase();
     })
     bigFullName: string;
@@ -78,162 +78,162 @@ class Bar extends EmberObject {
 
     @alias aliasTest0: string; // $ExpectError
     @alias() aliasTest1: string; // $ExpectError
-    @alias("firstName") aliasTest2: string;
+    @alias('firstName') aliasTest2: string;
 
     @and andTest0: boolean; // $ExpectError
     @and() andTest1: boolean;
-    @and("firstName") andTest2: boolean;
-    @and("firstName", "lastName") andTest3: boolean;
+    @and('firstName') andTest2: boolean;
+    @and('firstName', 'lastName') andTest3: boolean;
 
     @bool boolTest0: boolean; // $ExpectError
     @bool() boolTest1: boolean; // $ExpectError
-    @bool("firstName") boolTest2: boolean;
+    @bool('firstName') boolTest2: boolean;
 
     @collect collectTest0: any; // $ExpectError
     @collect() collectTest1: any;
-    @collect("firstName") collectTest2: any;
+    @collect('firstName') collectTest2: any;
 
     @deprecatingAlias deprecatingAliasTest0: string; // $ExpectError
     @deprecatingAlias() deprecatingAliasTest1: string; // $ExpectError
-    @deprecatingAlias("firstName") deprecatingAliasTest2: string;
+    @deprecatingAlias('firstName') deprecatingAliasTest2: string;
 
     @empty emptyTest0: boolean; // $ExpectError
     @empty() emptyTest1: boolean; // $ExpectError
-    @empty("firstName") emptyTest2: boolean;
+    @empty('firstName') emptyTest2: boolean;
 
     @equal equalTest0: boolean; // $ExpectError
     @equal() equalTest1: boolean; // $ExpectError
-    @equal("firstName") equalTest2: boolean; // $ExpectError
-    @equal("firstName", "lastName") equalTest3: boolean;
+    @equal('firstName') equalTest2: boolean; // $ExpectError
+    @equal('firstName', 'lastName') equalTest3: boolean;
 
     @filter filterTest1: string[]; // $ExpectError
     @filter() filterTest2: string[]; // $ExpectError
-    @filter("firstName") filterTest3: string[]; // $ExpectError
-    @filter("firstName", x => x) filterTest4: string[];
-    @filter("firstName", "secondName", x => x) filterTest5: string[]; // $ExpectError
-    @filter("firstName", ["secondName"], x => x) filterTest6: string[];
+    @filter('firstName') filterTest3: string[]; // $ExpectError
+    @filter('firstName', x => x) filterTest4: string[];
+    @filter('firstName', 'secondName', x => x) filterTest5: string[]; // $ExpectError
+    @filter('firstName', ['secondName'], x => x) filterTest6: string[];
 
     @filterBy filterByTest1: any[]; // $ExpectError
     @filterBy() filterByTest2: any[]; // $ExpectError
-    @filterBy("firstName") filterByTest3: any[]; // $ExpectError
-    @filterBy("firstName", "id") filterByTest4: any[];
+    @filterBy('firstName') filterByTest3: any[]; // $ExpectError
+    @filterBy('firstName', 'id') filterByTest4: any[];
 
     @gt gtTest1: boolean; // $ExpectError
     @gt() gtTest2: boolean; // $ExpectError
-    @gt("firstName") gtTest3: boolean; // $ExpectError
-    @gt("firstName", 3) gtTest4: boolean;
+    @gt('firstName') gtTest3: boolean; // $ExpectError
+    @gt('firstName', 3) gtTest4: boolean;
 
     @gte gteTest1: boolean; // $ExpectError
     @gte() gteTest2: boolean; // $ExpectError
-    @gte("firstName") gteTest3: boolean; // $ExpectError
-    @gte("firstName", 3) gteTest4: boolean;
+    @gte('firstName') gteTest3: boolean; // $ExpectError
+    @gte('firstName', 3) gteTest4: boolean;
 
     @intersect intersectTest1: any; // $ExpectError
     @intersect() intersectTest2: any;
-    @intersect("firstName") intersectTest3: any;
-    @intersect("firstName", "lastName") intersectTest4: any;
+    @intersect('firstName') intersectTest3: any;
+    @intersect('firstName', 'lastName') intersectTest4: any;
 
     @lt ltTest1: boolean; // $ExpectError
     @lt() ltTest2: boolean; // $ExpectError
-    @lt("firstName") ltTest3: boolean; // $ExpectError
-    @lt("firstName", 3) ltTest4: boolean;
+    @lt('firstName') ltTest3: boolean; // $ExpectError
+    @lt('firstName', 3) ltTest4: boolean;
 
     @lte lteTest1: boolean; // $ExpectError
     @lte() lteTest2: boolean; // $ExpectError
-    @lte("firstName") lteTest3: boolean; // $ExpectError
-    @lte("firstName", 3) lteTest4: boolean;
+    @lte('firstName') lteTest3: boolean; // $ExpectError
+    @lte('firstName', 3) lteTest4: boolean;
 
     @map mapTest1: string[]; // $ExpectError
     @map() mapTest2: string[]; // $ExpectError
-    @map("firstName") mapTest3: string[]; // $ExpectError
-    @map("firstName", x => x) mapTest4: string[];
+    @map('firstName') mapTest3: string[]; // $ExpectError
+    @map('firstName', x => x) mapTest4: string[];
 
     @mapBy mapByTest1: any[]; // $ExpectError
     @mapBy() mapByTest2: any[]; // $ExpectError
-    @mapBy("firstName") mapByTest3: any[]; // $ExpectError
-    @mapBy("firstName", "id") mapByTest4: any[];
+    @mapBy('firstName') mapByTest3: any[]; // $ExpectError
+    @mapBy('firstName', 'id') mapByTest4: any[];
 
     @match matchTest1: boolean; // $ExpectError
     @match() matchTest2: boolean; // $ExpectError
-    @match("firstName") matchTest3: boolean; // $ExpectError
-    @match("firstName", "abc") matchTest4: boolean; // $ExpectError
-    @match("firstName", /\s+/) matchTest5: boolean;
+    @match('firstName') matchTest3: boolean; // $ExpectError
+    @match('firstName', 'abc') matchTest4: boolean; // $ExpectError
+    @match('firstName', /\s+/) matchTest5: boolean;
 
     @max maxTest1: number; // $ExpectError
     @max() maxTest2: number; // $ExpectError
-    @max("values") maxTest3: number;
-    @max("values", "a") maxTest4: number; // $ExpectError
+    @max('values') maxTest3: number;
+    @max('values', 'a') maxTest4: number; // $ExpectError
 
     @min minTest1: number; // $ExpectError
     @min() minTest2: number; // $ExpectError
-    @min("values") minTest3: number;
-    @min("values", "a") minTest4: number; // $ExpectError
+    @min('values') minTest3: number;
+    @min('values', 'a') minTest4: number; // $ExpectError
 
     @none noneTest1: number; // $ExpectError
     @none() noneTest2: number; // $ExpectError
-    @none("values") noneTest3: number;
-    @none("values", "a") noneTest4: number; // $ExpectError
+    @none('values') noneTest3: number;
+    @none('values', 'a') noneTest4: number; // $ExpectError
 
     @not notTest1: number; // $ExpectError
     @not() notTest2: number; // $ExpectError
-    @not("values") notTest3: number;
-    @not("values", "a") notTest4: number; // $ExpectError
+    @not('values') notTest3: number;
+    @not('values', 'a') notTest4: number; // $ExpectError
 
     @notEmpty notEmptyTest1: boolean; // $ExpectError
     @notEmpty() notEmptyTest2: boolean; // $ExpectError
-    @notEmpty("firstName") notEmptyTest3: boolean;
-    @notEmpty("firstName", "a") notEmptyTest4: boolean; // $ExpectError
+    @notEmpty('firstName') notEmptyTest3: boolean;
+    @notEmpty('firstName', 'a') notEmptyTest4: boolean; // $ExpectError
 
     @oneWay oneWayTest1: boolean; // $ExpectError
     @oneWay() oneWayTest2: boolean; // $ExpectError
-    @oneWay("firstName") oneWayTest3: boolean;
-    @oneWay("firstName", "b") oneWayTest4: boolean; // $ExpectError
+    @oneWay('firstName') oneWayTest3: boolean;
+    @oneWay('firstName', 'b') oneWayTest4: boolean; // $ExpectError
 
     @or orTest1: boolean; // $ExpectError
     @or() orTest2: boolean;
-    @or("firstName") orTest3: boolean;
-    @or("firstName", "lastName") orTest4: boolean;
+    @or('firstName') orTest3: boolean;
+    @or('firstName', 'lastName') orTest4: boolean;
 
     @readOnly readOnlyTest1: boolean; // $ExpectError
     @readOnly() readOnlyTest2: boolean; // $ExpectError
-    @readOnly("firstName") readOnlyTest3: boolean;
+    @readOnly('firstName') readOnlyTest3: boolean;
 
     @reads readsTest1: boolean; // $ExpectError
     @reads() readsTest2: boolean; // $ExpectError
-    @reads("firstName") readsTest3: boolean;
-    @reads("firstName", "a") readsTest4: boolean; // $ExpectError
+    @reads('firstName') readsTest3: boolean;
+    @reads('firstName', 'a') readsTest4: boolean; // $ExpectError
 
     @setDiff setDiffTest1: number; // $ExpectError
     @setDiff() setDiffTest2: number; // $ExpectError
-    @setDiff("values") setDiffTest3: number; // $ExpectError
-    @setDiff("values", "otherThing") setDiffTest4: number;
-    @setDiff("values", "otherThing", "a") setDiffTest5: number; // $ExpectError
+    @setDiff('values') setDiffTest3: number; // $ExpectError
+    @setDiff('values', 'otherThing') setDiffTest4: number;
+    @setDiff('values', 'otherThing', 'a') setDiffTest5: number; // $ExpectError
 
     @sort sortTest1: number; // $ExpectError
     @sort() sortTest2: number; // $ExpectError
-    @sort("values") sortTest3: number; // $ExpectError
-    @sort("values", "id") sortTest4: number;
-    @sort("values", "id", "a") sortTest5: number; // $ExpectError
-    @sort("values", (a, b) => a - b) sortTest6: number;
-    @sort("values", ["id"], (a, b) => a - b) sortTest7: number;
-    @sort("values", "id", (a, b) => a - b) sortTest8: number; // $ExpectError
-    @sort(["id"], (a, b) => a - b) sortTest9: number; // $ExpectError
+    @sort('values') sortTest3: number; // $ExpectError
+    @sort('values', 'id') sortTest4: number;
+    @sort('values', 'id', 'a') sortTest5: number; // $ExpectError
+    @sort('values', (a, b) => a - b) sortTest6: number;
+    @sort('values', ['id'], (a, b) => a - b) sortTest7: number;
+    @sort('values', 'id', (a, b) => a - b) sortTest8: number; // $ExpectError
+    @sort(['id'], (a, b) => a - b) sortTest9: number; // $ExpectError
 
     @sum sumTest1: number; // $ExpectError
     @sum() sumTest2: number; // $ExpectError
-    @sum("values") sumTest3: number;
+    @sum('values') sumTest3: number;
 
     @union unionTest1: any; // $ExpectError
     @union() unionTest2: any;
-    @union("firstName") unionTest3: any;
-    @union("firstName", "lastName") unionTest4: any;
+    @union('firstName') unionTest3: any;
+    @union('firstName', 'lastName') unionTest4: any;
 
     @uniq uniqTest1: number; // $ExpectError
     @uniq() uniqTest2: number; // $ExpectError
-    @uniq("values") uniqTest3: number;
+    @uniq('values') uniqTest3: number;
 
     @uniqBy uniqByTest1: number; // $ExpectError
     @uniqBy() uniqByTest2: number; // $ExpectError
-    @uniqBy("values") uniqByTest3: number; // $ExpectError
-    @uniqBy("values", "id") uniqByTest4: number;
+    @uniqBy('values') uniqByTest3: number; // $ExpectError
+    @uniqBy('values', 'id') uniqByTest4: number;
 }

--- a/types/ember__object/test/proxy.ts
+++ b/types/ember__object/test/proxy.ts
@@ -1,38 +1,38 @@
-import ObjectProxy from "@ember/object/proxy";
+import ObjectProxy from '@ember/object/proxy';
 
 interface Book {
-  title: string;
-  subtitle: string;
-  chapters: Array<{ title: string }>;
+    title: string;
+    subtitle: string;
+    chapters: Array<{ title: string }>;
 }
 
 class DefaultProxy extends ObjectProxy {}
 DefaultProxy.create().content; // $ExpectType object | undefined
 
 class BookProxy extends ObjectProxy<Book> {
-  private readonly baz = 'baz';
+    private readonly baz = 'baz';
 
-  getTitle() {
-    return this.get('title');
-  }
+    getTitle() {
+        return this.get('title');
+    }
 
-  getPropertiesTitleSubtitle() {
-    return this.getProperties('title', 'subtitle');
-  }
+    getPropertiesTitleSubtitle() {
+        return this.getProperties('title', 'subtitle');
+    }
 }
 
 const book = BookProxy.create();
 book.content; // $ExpectType Book | undefined
 
-book.get("unknownProperty"); // $ExpectError
-book.get("title"); // $ExpectType string | undefined
+book.get('unknownProperty'); // $ExpectError
+book.get('title'); // $ExpectType string | undefined
 book.getTitle(); // $ExpectType string | undefined
 
-book.getProperties("title", "unknownProperty"); // $ExpectError
-book.getProperties("title", "subtitle"); // $ExpectType Pick<Partial<UnwrapComputedPropertyGetters<Book>>, "title" | "subtitle">
+book.getProperties('title', 'unknownProperty'); // $ExpectError
+book.getProperties('title', 'subtitle'); // $ExpectType Pick<Partial<UnwrapComputedPropertyGetters<Book>>, "title" | "subtitle">
 book.getPropertiesTitleSubtitle(); // $ExpectType Pick<Partial<UnwrapComputedPropertyGetters<Book>>, "title" | "subtitle">
 
-book.getProperties(["subtitle", "chapters"]); // $ExpectType Pick<Partial<UnwrapComputedPropertyGetters<Book>>, "subtitle" | "chapters">
-book.getProperties(["title", "unknownProperty"]); // $ExpectError
+book.getProperties(['subtitle', 'chapters']); // $ExpectType Pick<Partial<UnwrapComputedPropertyGetters<Book>>, "subtitle" | "chapters">
+book.getProperties(['title', 'unknownProperty']); // $ExpectError
 
-book.get("baz"); // $ExpectError
+book.get('baz'); // $ExpectError

--- a/types/ember__object/test/reopen.ts
+++ b/types/ember__object/test/reopen.ts
@@ -1,13 +1,13 @@
-import { assertType } from "./lib/assert";
-import EmberObject from "@ember/object";
-import Mixin from "@ember/object/mixin";
+import { assertType } from './lib/assert';
+import EmberObject from '@ember/object';
+import Mixin from '@ember/object/mixin';
 
 type Person = typeof Person.prototype;
 const Person = EmberObject.extend({
     name: '',
     sayHello() {
         alert(`Hello. My name is ${this.get('name')}`);
-    }
+    },
 });
 
 assertType<Person>(Person.reopen());
@@ -21,7 +21,7 @@ const Person2 = Person.reopenClass({
 
     createPerson(name: string): Person {
         return Person.create({ name });
-    }
+    },
 });
 
 assertType<string>(Person2.create().name);
@@ -30,7 +30,7 @@ assertType<void>(Person2.create().sayHello());
 assertType<string>(Person2.species);
 
 const tom = Person2.create({
-    name: 'Tom Dale'
+    name: 'Tom Dale',
 });
 
 const badTom = Person2.create({ name: 99 }); // $ExpectError
@@ -46,7 +46,7 @@ const Person3 = Person2.reopen({
 
     sayGoodbye() {
         alert(`${this.get('goodbyeMessage')}, ${this.get('name')}`);
-    }
+    },
 });
 
 const person3 = Person3.create();
@@ -55,11 +55,13 @@ person3.get('goodbyeMessage');
 person3.sayHello();
 person3.sayGoodbye();
 
-interface AutoResizeMixin { resizable: true; }
+interface AutoResizeMixin {
+    resizable: true;
+}
 declare const AutoResizeMixin: Mixin<AutoResizeMixin>;
 
 const ResizableTextArea = EmberObject.reopen(AutoResizeMixin, {
-    scaling: 1.0
+    scaling: 1.0,
 });
 const text = ResizableTextArea.create();
 // TODO fix upstream

--- a/types/ember__object/tslint.json
+++ b/types/ember__object/tslint.json
@@ -1,4 +1,6 @@
 {
     "extends": "dtslint/dt.json",
-    "rules": { }
+    "rules": {
+        "space-before-function-paren": false
+    }
 }

--- a/types/ember__ordered-set/test/ember__ordered-set-tests.ts
+++ b/types/ember__ordered-set/test/ember__ordered-set-tests.ts
@@ -54,7 +54,7 @@ const sansContext = OrderedSet.create<string>();
 
 sansContext.add('foo');
 
-sansContext.forEach(function(entry) {
+sansContext.forEach(function (entry) {
     assertType<string>(entry);
     assertType<void>(this);
 });
@@ -62,7 +62,7 @@ sansContext.forEach(function(entry) {
 // forEach() context can be set as second argument
 const withContext = OrderedSet.create<string>();
 const context = { bar: 'baz' };
-withContext.forEach(function(entry) {
+withContext.forEach(function (entry) {
     assertType<string>(entry);
     assertType<Dict<string>>(this);
 }, context);

--- a/types/ember__ordered-set/tslint.json
+++ b/types/ember__ordered-set/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "space-before-function-paren": false,
         "npm-naming": [
             true,
             {

--- a/types/ember__polyfills/tslint.json
+++ b/types/ember__polyfills/tslint.json
@@ -1,4 +1,6 @@
 {
     "extends": "dtslint/dt.json",
-    "rules": {}
+    "rules": {
+        "space-before-function-paren": false
+    }
 }

--- a/types/ember__routing/-private/router-dsl.d.ts
+++ b/types/ember__routing/-private/router-dsl.d.ts
@@ -4,15 +4,15 @@ export default class RouterDSL {
     route(
         name: string,
         options?: { path?: string; resetNamespace?: boolean },
-        callback?: (this: RouterDSL) => void
+        callback?: (this: RouterDSL) => void,
     ): void;
     mount(
         name: string,
         options?: {
-            as?: string,
-            path?: string,
-            resetNamespace?: boolean,
-            engineInfo?: any
-        }
+            as?: string;
+            path?: string;
+            resetNamespace?: boolean;
+            engineInfo?: any;
+        },
     ): void;
 }

--- a/types/ember__routing/-private/transition.d.ts
+++ b/types/ember__routing/-private/transition.d.ts
@@ -39,7 +39,7 @@ export default interface Transition<T = any> extends Partial<Promise<T>> {
      * @param label optional string for labeling the promise. Useful for tooling.
      */
     catch<TResult = never>(
-        onRejected?: ((reason: any) => TResult | PromiseLike<TResult>),
+        onRejected?: (reason: any) => TResult | PromiseLike<TResult>,
         label?: string,
     ): Promise<TResult>;
     /**
@@ -49,7 +49,7 @@ export default interface Transition<T = any> extends Partial<Promise<T>> {
      * @param onFinally
      * @param label optional string for labeling the promise. Useful for tooling.
      */
-    finally(onFinally?: (() => void), label?: string): Promise<T>;
+    finally(onFinally?: () => void, label?: string): Promise<T>;
     /**
      * Transitions are aborted and their promises rejected when redirects occur;
      * this method returns a promise that will follow any redirects that occur and
@@ -88,8 +88,8 @@ export default interface Transition<T = any> extends Partial<Promise<T>> {
      * @param  label label optional string for labeling the promise. Useful for tooling.
      */
     then<TResult1 = T, TResult2 = never>(
-        onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>),
-        onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>),
+        onfulfilled?: (value: T) => TResult1 | PromiseLike<TResult1>,
+        onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>,
         label?: string,
     ): Promise<TResult1 | TResult2>;
     /**

--- a/types/ember__routing/test/route.ts
+++ b/types/ember__routing/test/route.ts
@@ -98,7 +98,8 @@ class RedirectRoute extends Route {
 }
 
 class InvalidRedirect extends Route {
-    redirect(model: {}, a: Transition, anOddArg: any) { // $ExpectError
+    // $ExpectError
+    redirect(model: {}, a: Transition, anOddArg: any) {
         if (!model) {
             this.transitionTo('there');
         }
@@ -176,9 +177,9 @@ class RouteUsingClass extends Route.extend({
         this.intermediateTransitionTo('some-route');
     }
     intermediateTransitionWithModel() {
-        this.intermediateTransitionTo('some.other.route', { });
+        this.intermediateTransitionTo('some.other.route', {});
     }
     intermediateTransitionWithMultiModel() {
-        this.intermediateTransitionTo('some.other.route', 1, 2, { });
+        this.intermediateTransitionTo('some.other.route', 1, 2, {});
     }
 }

--- a/types/ember__routing/test/router.ts
+++ b/types/ember__routing/test/router.ts
@@ -2,27 +2,26 @@ import Router from '@ember/routing/router';
 import Service, { inject as service } from '@ember/service';
 import EmberObject, { get } from '@ember/object';
 
-const AppRouter = Router.extend({
-});
+const AppRouter = Router.extend({});
 
-AppRouter.map(function() {
+AppRouter.map(function () {
     this.route('index', { path: '/' });
     this.route('about');
     this.route('favorites', { path: '/favs' });
-    this.route('posts', function() {
+    this.route('posts', function () {
         this.route('index', { path: '/' });
         this.route('new');
         this.route('post', { path: '/post/:post_id', resetNamespace: true });
-        this.route('comments', { resetNamespace: true }, function() {
+        this.route('comments', { resetNamespace: true }, function () {
             this.route('new');
         });
     });
-    this.route('photo', { path: '/photo/:id' }, function() {
+    this.route('photo', { path: '/photo/:id' }, function () {
         this.route('comment', { path: '/comment/:id' });
     });
     this.route('not-found', { path: '/*path' });
     this.mount('my-engine');
-    this.mount('my-engine', { as: 'some-other-engine', path: '/some-other-engine'});
+    this.mount('my-engine', { as: 'some-other-engine', path: '/some-other-engine' });
 });
 
 const RouterServiceConsumer = Service.extend({
@@ -34,23 +33,19 @@ const RouterServiceConsumer = Service.extend({
         const x: string = get(this, 'router').currentURL;
     },
     transitionWithoutModel() {
-        get(this, 'router')
-        .transitionTo('some-route');
+        get(this, 'router').transitionTo('some-route');
     },
     transitionWithModel() {
         const model = EmberObject.create();
-        get(this, 'router')
-        .transitionTo('some.other.route', model);
+        get(this, 'router').transitionTo('some.other.route', model);
     },
     transitionWithMultiModel() {
         const model = EmberObject.create();
-        get(this, 'router')
-        .transitionTo('some.other.route', model, model);
+        get(this, 'router').transitionTo('some.other.route', model, model);
     },
     transitionWithModelAndOptions() {
         const model = EmberObject.create();
-        get(this, 'router')
-        .transitionTo('index', model, { queryParams: { search: 'ember' }});
+        get(this, 'router').transitionTo('index', model, { queryParams: { search: 'ember' } });
     },
     onAndRouteInfo() {
         const router = get(this, 'router');

--- a/types/ember__routing/tslint.json
+++ b/types/ember__routing/tslint.json
@@ -1,4 +1,6 @@
 {
     "extends": "dtslint/dt.json",
-    "rules": {}
+    "rules": {
+        "space-before-function-paren": false
+    }
 }

--- a/types/ember__runloop/-private/backburner.d.ts
+++ b/types/ember__runloop/-private/backburner.d.ts
@@ -1,37 +1,30 @@
 export interface QueueItem {
-  method: string;
-  target: object;
-  args: object[];
-  stack: string | undefined;
+    method: string;
+    target: object;
+    args: object[];
+    stack: string | undefined;
 }
 
 export interface DeferredActionQueues {
-  [index: string]: any;
-  queues: object;
-  schedule(
-    queueName: string,
-    target: any,
-    method: any,
-    args: any,
-    onceFlag: boolean,
-    stack: any
-  ): any;
-  flush(fromAutorun: boolean): any;
+    [index: string]: any;
+    queues: object;
+    schedule(queueName: string, target: any, method: any, args: any, onceFlag: boolean, stack: any): any;
+    flush(fromAutorun: boolean): any;
 }
 
 export interface DebugInfo {
-  autorun: Error | undefined | null;
-  counters: object;
-  timers: QueueItem[];
-  instanceStack: DeferredActionQueues[];
+    autorun: Error | undefined | null;
+    counters: object;
+    timers: QueueItem[];
+    instanceStack: DeferredActionQueues[];
 }
 
 export interface Backburner {
-  join(...args: any[]): void;
-  on(...args: any[]): void;
-  scheduleOnce(...args: any[]): void;
-  schedule(queueName: string, target: object | null, method: () => void | string): void;
-  ensureInstance(): void;
-  DEBUG: boolean;
-  getDebugInfo(): DebugInfo;
+    join(...args: any[]): void;
+    on(...args: any[]): void;
+    scheduleOnce(...args: any[]): void;
+    schedule(queueName: string, target: object | null, method: () => void | string): void;
+    ensureInstance(): void;
+    DEBUG: boolean;
+    getDebugInfo(): DebugInfo;
 }

--- a/types/ember__runloop/-private/types.d.ts
+++ b/types/ember__runloop/-private/types.d.ts
@@ -1,8 +1,2 @@
 export type RunMethod<Target, Ret = any> = ((this: Target, ...args: any[]) => Ret) | keyof Target;
-export type EmberRunQueues =
-    | 'sync'
-    | 'actions'
-    | 'routerTransitions'
-    | 'render'
-    | 'afterRender'
-    | 'destroy';
+export type EmberRunQueues = 'sync' | 'actions' | 'routerTransitions' | 'render' | 'afterRender' | 'destroy';

--- a/types/ember__runloop/tslint.json
+++ b/types/ember__runloop/tslint.json
@@ -1,4 +1,6 @@
 {
     "extends": "dtslint/dt.json",
-    "rules": { }
+    "rules": {
+        "space-before-function-paren": false
+    }
 }

--- a/types/ember__service/test/main.ts
+++ b/types/ember__service/test/main.ts
@@ -1,27 +1,27 @@
-import Service, { inject } from "@ember/service";
-import EmberObject from "@ember/object";
+import Service, { inject } from '@ember/service';
+import EmberObject from '@ember/object';
 
 class FirstSvc extends Service {
-    foo = "bar";
+    foo = 'bar';
     first() {
-        return "";
+        return '';
     }
 }
 const SecondSvc = Service.extend({
-    foo: "bar",
+    foo: 'bar',
     second() {
-        return "";
-    }
+        return '';
+    },
 });
 
 class ThirdSvc extends Service.extend({
-    foo: "bar",
+    foo: 'bar',
     third() {
-        return "";
-    }
+        return '';
+    },
 }) {}
 
-declare module "@ember/service" {
+declare module '@ember/service' {
     interface Registry {
         first: FirstSvc;
         second: InstanceType<typeof SecondSvc>;
@@ -30,15 +30,15 @@ declare module "@ember/service" {
 }
 
 const ServiceTriplet = EmberObject.extend({
-    sFirst: inject("first"),
-    sSecond: inject("second"),
-    sThird: inject("third"),
-    unknownService: inject()
+    sFirst: inject('first'),
+    sSecond: inject('second'),
+    sThird: inject('third'),
+    unknownService: inject(),
 });
 
 const obj = ServiceTriplet.create();
 
-obj.get("sFirst"); // $ExpectType FirstSvc
-obj.get("sSecond").second(); // $ExpectType ""
-obj.get("sThird"); // $ExpectType ThirdSvc
-obj.get("unknownService"); // $ExpectType Service
+obj.get('sFirst'); // $ExpectType FirstSvc
+obj.get('sSecond').second(); // $ExpectType ""
+obj.get('sThird'); // $ExpectType ThirdSvc
+obj.get('unknownService'); // $ExpectType Service

--- a/types/ember__service/test/octane.ts
+++ b/types/ember__service/test/octane.ts
@@ -1,20 +1,20 @@
-import Service, { inject } from "@ember/service";
-import EmberObject from "@ember/object";
+import Service, { inject } from '@ember/service';
+import EmberObject from '@ember/object';
 
 class FirstSvc extends Service {
-    foo = "bar";
+    foo = 'bar';
     first() {
-        return "";
+        return '';
     }
 }
 const SecondSvc = Service.extend({
-    foo: "bar",
+    foo: 'bar',
     second() {
-        return "";
-    }
+        return '';
+    },
 });
 
-declare module "@ember/service" {
+declare module '@ember/service' {
     interface Registry {
         first: FirstSvc;
         second: InstanceType<typeof SecondSvc>;
@@ -23,6 +23,6 @@ declare module "@ember/service" {
 
 class Foo extends EmberObject {
     @inject foo: FirstSvc;
-    @inject("first") baz: FirstSvc;
+    @inject('first') baz: FirstSvc;
     @inject() bar: FirstSvc;
 }

--- a/types/ember__service/tslint.json
+++ b/types/ember__service/tslint.json
@@ -1,4 +1,6 @@
 {
     "extends": "dtslint/dt.json",
-    "rules": {}
+    "rules": {
+        "space-before-function-paren": false
+    }
 }

--- a/types/ember__string/tslint.json
+++ b/types/ember__string/tslint.json
@@ -1,4 +1,6 @@
 {
     "extends": "dtslint/dt.json",
-    "rules": {}
+    "rules": {
+        "space-before-function-paren": false
+    }
 }

--- a/types/ember__template/tslint.json
+++ b/types/ember__template/tslint.json
@@ -1,4 +1,6 @@
 {
     "extends": "dtslint/dt.json",
-    "rules": {}
+    "rules": {
+        "space-before-function-paren": false
+    }
 }

--- a/types/ember__test-helpers/tslint.json
+++ b/types/ember__test-helpers/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "space-before-function-paren": false,
         "strict-export-declare-modifiers": false
     }
 }

--- a/types/ember__test/tslint.json
+++ b/types/ember__test/tslint.json
@@ -1,4 +1,6 @@
 {
     "extends": "dtslint/dt.json",
-    "rules": { }
+    "rules": {
+        "space-before-function-paren": false
+    }
 }

--- a/types/ember__utils/-private/types.d.ts
+++ b/types/ember__utils/-private/types.d.ts
@@ -1,6 +1,9 @@
-export type KeysOfType<Base, Condition> = keyof Pick<Base, {
-    [Key in keyof Base]: Base[Key] extends Condition ? Key : never
-}[keyof Base]>;
+export type KeysOfType<Base, Condition> = keyof Pick<
+    Base,
+    {
+        [Key in keyof Base]: Base[Key] extends Condition ? Key : never;
+    }[keyof Base]
+>;
 
 // Since `TypeLookup` resolves all *other* types, including `null` and
 // `undefined`, we can assume that if the type does *not* resolve from
@@ -25,15 +28,14 @@ export interface TypeLookup {
 
 // TODO: TypeScript 3.0
 // type FunctionArgs<F extends (...args: any[]) => any> = F extends (...args: infer ARGS) => any ? ARGS : never;
-export type FunctionArgs<F> =
-    F extends (a: infer A) => any
-        ? [A]
-        : F extends (a: infer A, b: infer B) => any
-            ? [A, B]
-            : F extends (a: infer A, b: infer B, c: infer C) => any
-                ? [A, B, C]
-                : F extends (a: infer A, b: infer B, c: infer C, d: infer D) => any
-                    ? [A, B, C, D]
-                    : F extends (a: infer A, b: infer B, c: infer C, d: infer D, e: infer E) => any
-                        ? [A, B, C, D, E]
-                        : never;
+export type FunctionArgs<F> = F extends (a: infer A) => any
+    ? [A]
+    : F extends (a: infer A, b: infer B) => any
+    ? [A, B]
+    : F extends (a: infer A, b: infer B, c: infer C) => any
+    ? [A, B, C]
+    : F extends (a: infer A, b: infer B, c: infer C, d: infer D) => any
+    ? [A, B, C, D]
+    : F extends (a: infer A, b: infer B, c: infer C, d: infer D, e: infer E) => any
+    ? [A, B, C, D, E]
+    : never;

--- a/types/ember__utils/tslint.json
+++ b/types/ember__utils/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "space-before-function-paren": false,
         "only-arrow-functions": false,
         "prefer-const": false
     }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- ~Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

In order to make it easier for folks to contribute without introducing extra diff noise, this PR applies `prettier --write` to declaration packages in the Ember ecosystem.

<details>
<summary>Package list</summary>

 - `@types/ember`
 - `@types/ember__application`
 - `@types/ember__array`
 - `@types/ember__component`
 - `@types/ember__controller`
 - `@types/ember__debug`
 - `@types/ember__engine`
 - `@types/ember__error`
 - `@types/ember__object`
 - `@types/ember__ordered-set`
 - `@types/ember__polyfills`
 - `@types/ember__routing`
 - `@types/ember__runloop`
 - `@types/ember__service`
 - `@types/ember__string`
 - `@types/ember__template`
 - `@types/ember__test-helpers`
 - `@types/ember__test`
 - `@types/ember__utils`
 - `@types/ember-data`
 - `@types/ember-data__adapter`
 - `@types/ember-data__model`
 - `@types/ember-data__serializer`
 - `@types/ember-data__store`
 - `@types/ember-feature-flags`
 - `@types/ember-mocha`
 - `@types/ember-modal-dialog`
 - `@types/ember-resolver`
 - `@types/ember-test-helpers`
 - `@types/ember-testing-helpers`

</details>

After consulting with a couple others who are listed as owners on most or all of these packages, we decided it would be easier to do this in a single pass rather than splitting it across multiple PRs and dealing with the flurry of notifications for everyone involved.

No semantic changes were made to the types or tests here. This diff was produced by running `prettier --write types/ember*/**/*.ts` and then moving a handful of `$Expect` comments to the line above their target rather than the line below where Prettier had moved them.