### PR TITLE
react(-dom): Update experimental typings

### DIFF
--- a/types/react-dom/experimental.d.ts
+++ b/types/react-dom/experimental.d.ts
@@ -76,21 +76,6 @@ declare module '.' {
      */
     function unstable_createRoot(container: Element | Document | DocumentFragment | Comment, options?: RootOptions): Root;
 
-    function unstable_discreteUpdates<R>(callback: () => R): R;
-
-    function unstable_discreteUpdates<R, A1>(callback: (a1: A1) => R, a1: A1): R;
-
-    function unstable_discreteUpdates<R, A1, A2>(callback: (a1: A1, a2: A2) => R, a1: A1, a2: A2): R;
-
-    function unstable_discreteUpdates<R, A1, A2, A3>(
-        callback: (a1: A1, a2: A2, a3: A3) => R,
-        a1: A1,
-        a2: A2,
-        a3: A3,
-    ): R;
-
-    function unstable_flushDiscreteUpdates(): void;
-
     function unstable_flushControlled(callback: () => void): void;
 
     // enableSelectiveHydration feature

--- a/types/react-dom/test/experimental-tests.tsx
+++ b/types/react-dom/test/experimental-tests.tsx
@@ -25,14 +25,5 @@ function createBlockingRoot() {
 }
 
 function updates() {
-    // $ExpectType 0
-    ReactDOM.unstable_discreteUpdates((): 0 => 0);
-    // $ExpectType number
-    ReactDOM.unstable_discreteUpdates((foo: number) => foo, 1);
-    // $ExpectError
-    ReactDOM.unstable_discreteUpdates((foo: number) => foo);
-
-    ReactDOM.unstable_flushDiscreteUpdates();
-
     ReactDOM.unstable_flushControlled(() => {});
 }

--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -173,4 +173,11 @@ declare module '.' {
     };
 
     export function unstable_useOpaqueIdentifier(): OpaqueIdentifier;
+
+    /**
+     * Similar to `useTransition` but allows uses where hooks are not available.
+     *
+     * @param callback A _synchronous_ function which causes state updates that can be deferred.
+     */
+    export function unstable_startTransition(scope: TransitionFunction): void;
 }

--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -39,6 +39,15 @@ import React = require('.');
 export {};
 
 declare module '.' {
+    export interface SuspenseProps {
+        /**
+         * The presence of this prop indicates that the content is computationally expensive to render.
+         * In other words, the tree is CPU bound and not I/O bound (e.g. due to fetching data).
+         * @see {@link https://github.com/facebook/react/pull/19936}
+         */
+        unstable_expectedLoadTime?: number;
+    }
+
     export type SuspenseListRevealOrder = 'forwards' | 'backwards' | 'together';
     export type SuspenseListTailMode = 'collapsed' | 'hidden';
 

--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -94,7 +94,7 @@ declare module '.' {
      */
     export const unstable_SuspenseList: ExoticComponent<SuspenseListProps>;
 
-    export interface SuspenseConfig extends TimeoutConfig {
+    export interface SuspenseConfig {
         busyDelayMs?: number;
         busyMinDurationMs?: number;
     }
@@ -104,17 +104,6 @@ declare module '.' {
         scope: () => void | undefined,
         config: SuspenseConfig | null | undefined,
     ): void;
-
-    export interface TimeoutConfig {
-        /**
-         * This timeout (in milliseconds) tells React how long to wait before showing the next state.
-         *
-         * React will always try to use a shorter lag when network and device allows it.
-         *
-         * **NOTE: We recommend that you share Suspense Config between different modules.**
-         */
-        timeoutMs: number;
-    }
 
     // must be synchronous
     export type TransitionFunction = () => void | undefined;
@@ -139,11 +128,10 @@ declare module '.' {
      * A good example of this is a text input.
      *
      * @param value The value that is going to be deferred
-     * @param config An optional object with `timeoutMs`
      *
      * @see https://reactjs.org/docs/concurrent-mode-reference.html#usedeferredvalue
      */
-    export function unstable_useDeferredValue<T>(value: T, config?: TimeoutConfig | null): T;
+    export function unstable_useDeferredValue<T>(value: T): T;
 
     /**
      * Allows components to avoid undesirable loading states by waiting for content to load

--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -152,9 +152,6 @@ declare module '.' {
      */
     export function unstable_useTransition(config?: SuspenseConfig | null): [TransitionStartFunction, boolean];
 
-    /**
-     * @private
-     */
     const opaqueIdentifierBranding: unique symbol;
     /**
      * WARNING: Don't use this as a `string`.

--- a/types/react/test/experimental.tsx
+++ b/types/react/test/experimental.tsx
@@ -79,3 +79,17 @@ function startTransitionTest() {
     // $ExpectError
     React.unstable_startTransition(async () => {});
 }
+
+function suspenseTest() {
+    function DisplayData() {
+        return null;
+    }
+
+    function FlameChart() {
+        return (
+            <React.Suspense fallback="computing..." unstable_expectedLoadTime={2000}>
+                <DisplayData />
+            </React.Suspense>
+        );
+    }
+}

--- a/types/react/test/experimental.tsx
+++ b/types/react/test/experimental.tsx
@@ -68,3 +68,14 @@ function InvalidOpaqueIdentifierUsage() {
 
     return null;
 }
+
+function startTransitionTest() {
+    function transitionToPage(page: string) {}
+
+    React.unstable_startTransition(() => {
+        transitionToPage('/');
+    });
+
+    // $ExpectError
+    React.unstable_startTransition(async () => {});
+}

--- a/types/react/test/experimental.tsx
+++ b/types/react/test/experimental.tsx
@@ -8,13 +8,12 @@ function useExperimentalHooks() {
     const [startTransition, done] = React.unstable_useTransition({
         busyMinDurationMs: 100,
         busyDelayMs: 200,
-        timeoutMs: 300,
     });
     // $ExpectType boolean
     done;
 
     // $ExpectType boolean
-    const deferredToggle = React.unstable_useDeferredValue(toggle, { timeoutMs: 500 });
+    const deferredToggle = React.unstable_useDeferredValue(toggle);
 
     const [func] = React.useState(() => () => 0);
 


### PR DESCRIPTION
useOpaqueIdentifier was already added in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46692

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [React 17 release changelog](https://github.com/facebook/react/releases/tag/v17.0.0)
  - [unstable_expectedLoadTime PR](https://github.com/facebook/react/pull/19936)
  - [startTransition PR](https://github.com/facebook/react/pull/19696)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
