### PR TITLE
Fix WordPress modal component icon prop type

### DIFF
--- a/types/wordpress__components/modal/index.d.ts
+++ b/types/wordpress__components/modal/index.d.ts
@@ -41,7 +41,7 @@ declare namespace Modal {
         /**
          * Icon component to render before the title.
          */
-        icon?: ComponentType;
+        icon?: ReactNode;
         /**
          * If this property is set to false, the modal will not display a close
          * icon and cannot be dismissed.


### PR DESCRIPTION
As shown [here](https://github.com/WordPress/gutenberg/blob/master/packages/components/src/modal/header.js#L30), `icon` is expected to be a `ReactNode`, not a `ComponentType`. In other words, `icon` should be an instance, not a class. Or in case of function components, a return value, not the function component itself.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [here](https://github.com/WordPress/gutenberg/blob/master/packages/components/src/modal/header.js#L30)

cc: @sirreal 
