### PR TITLE
[node] add undefined to global NodeModule.parent in v12

### DIFF
--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -231,7 +231,8 @@ interface NodeModule {
     id: string;
     filename: string;
     loaded: boolean;
-    parent: NodeModule | null;
+    /** @deprecated since 12.19.0 Please use `require.main` and `module.children` instead. */
+    parent: NodeModule | null | undefined;
     children: NodeModule[];
     /**
      * @since 11.14.0

--- a/types/node/v12/test/global.ts
+++ b/types/node/v12/test/global.ts
@@ -7,6 +7,7 @@ import { Readable, Writable } from 'stream';
     x.parent = require.main!;
     require.main = y;
     x.path; // $ExpectType string
+    y.parent; // $ExpectType NodeModule | null | undefined
 }
 
 {


### PR DESCRIPTION
This is a follow-up to #48570 that also updates the global `NodeModule` to reflect the deprecated `parent` property.

Fixes #49151

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#2020-10-06-version-12190-erbium-lts-codebytere
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
