### PR TITLE
update(serialize-javascript): update to v5 and minor fixes

### DIFF
--- a/types/serialize-javascript/index.d.ts
+++ b/types/serialize-javascript/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for serialize-javascript 4.0
+// Type definitions for serialize-javascript 5.0
 // Project: https://github.com/yahoo/serialize-javascript
 // Definitions by: François Nguyen <https://github.com/lith-light-g>
 //                 Pochodaydayup <https://github.com/Pochodaydayup>
-//                 Undefined <https://github.com/masnn>
+//                 undefined-moe <https://github.com/undefined-moe>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace serializeJavascript {
@@ -23,7 +24,7 @@ declare namespace serializeJavascript {
          * This options needs to be explicitly set to true. HTML characters and JavaScript line terminators will not be escaped.
          * You will have to roll your own.
          */
-        unsafe?: boolean;
+        unsafe?: true;
         /**
          * This option is to signal serialize() that we do not want serialize JavaScript function.
          * Just treat function like JSON.stringify do, but other features will work as expected.
@@ -38,5 +39,9 @@ declare namespace serializeJavascript {
  * @param options optional object
  * @returns serialized data
  */
-declare function serializeJavascript(input: any, options?: serializeJavascript.SerializeJSOptions): string;
+declare function serializeJavascript(
+    input: any,
+    options?: serializeJavascript.SerializeJSOptions | number | string,
+): string;
+
 export = serializeJavascript;

--- a/types/serialize-javascript/serialize-javascript-tests.ts
+++ b/types/serialize-javascript/serialize-javascript-tests.ts
@@ -18,3 +18,6 @@ serialize(obj, { space: 2 });
 serialize(obj, { space: "\t" });
 serialize(obj, { isJSON: true });
 serialize(obj, { ignoreFunction: true });
+serialize(obj, 2);
+serialize(obj, "\t");
+serialize(obj, { unsafe: true });


### PR DESCRIPTION
- `unsafe` can be only explicit `true`
- `space` as `number | string` can be used as second argument to
  `serialize`
- version 5 bump
- maintainer GitHub handle corrected (how it was really merged in the
  first place)
- maintainer added

https://github.com/yahoo/serialize-javascript/compare/v4.0.0...v5.0.1
https://github.com/yahoo/serialize-javascript/blob/main/index.js#L62
https://github.com/yahoo/serialize-javascript#optionsunsafe

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, updat the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)