### PR TITLE
Updates type definitions from sharp 0.26.0 to support animated GIF and WEBP formats.

### DIFF
--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -516,7 +516,7 @@ declare namespace sharp {
          */
         toFormat(
             format: string | AvailableFormatInfo,
-            options?: OutputOptions | JpegOptions | PngOptions | WebpOptions | TiffOptions,
+            options?: OutputOptions | JpegOptions | PngOptions | WebpOptions | GifOptions | TiffOptions,
         ): Sharp;
 
         /**
@@ -808,6 +808,11 @@ declare namespace sharp {
         reductionEffort?: number;
     }
 
+    /** 
+     * Requires libvips compiled with support for ImageMagick or GraphicsMagick.
+     * The prebuilt binaries do not include this - see
+     * {@link https://sharp.pixelplumbing.com/install#custom-libvips installing a custom libvips}. 
+     */
     interface GifOptions extends OutputOptions, AnimationOptions {}
 
     interface TiffOptions extends OutputOptions {

--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -634,6 +634,10 @@ declare namespace sharp {
         pages?: number;
         /** Page number to start extracting from for multi-page input (GIF, TIFF, PDF), zero based. (optional, default 0) */
         page?: number;
+        /** Level to extract from a multi-level input (OpenSlide), zero based. (optional, default 0) */
+        level?: number;
+        /** Set to `true` to read all frames/pages of an animated image (equivalent of setting `pages` to `-1`). (optional, default false) */
+        animated?: boolean;
         /** Describes raw pixel input image data. See raw() for pixel ordering. */
         raw?: Raw;
         /** Describes a new image to be created. */
@@ -791,7 +795,7 @@ declare namespace sharp {
         quantizationTable?: number;
     }
 
-    interface WebpOptions extends OutputOptions {
+    interface WebpOptions extends OutputOptions, AnimationOptions {
         /** Quality of alpha layer, number from 0-100 (optional, default 100) */
         alphaQuality?: number;
         /** Use lossless compression mode (optional, default false) */
@@ -803,6 +807,8 @@ declare namespace sharp {
         /** Level of CPU effort to reduce file size, integer 0-6 (optional, default 4) */
         reductionEffort?: number;
     }
+
+    interface GifOptions extends OutputOptions, AnimationOptions {}
 
     interface TiffOptions extends OutputOptions {
         /** Compression options: lzw, deflate, jpeg, ccittfax4 (optional, default 'jpeg') */
@@ -965,6 +971,15 @@ declare namespace sharp {
         container?: string;
         /** Filesystem layout, possible values are dz, iiif, zoomify or google. (optional, default 'dz') */
         layout?: TileLayout;
+    }
+
+    interface AnimationOptions {
+        /** Page height for animated output, a value greater than 0. (optional) */
+        pageHeight?: number;
+        /** Number of animation iterations, a value between 0 and 65535. Use 0 for infinite animation. (optional, default 0) */
+        loop?: number;
+        /** List of delays between animation frames (in milliseconds), each value between 0 and 65535. (optional) */
+        delay?: number[];
     }
 
     interface OutputInfo {

--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -808,10 +808,10 @@ declare namespace sharp {
         reductionEffort?: number;
     }
 
-    /** 
+    /**
      * Requires libvips compiled with support for ImageMagick or GraphicsMagick.
      * The prebuilt binaries do not include this - see
-     * {@link https://sharp.pixelplumbing.com/install#custom-libvips installing a custom libvips}. 
+     * {@link https://sharp.pixelplumbing.com/install#custom-libvips installing a custom libvips}.
      */
     interface GifOptions extends OutputOptions, AnimationOptions {}
 

--- a/types/sharp/sharp-tests.ts
+++ b/types/sharp/sharp-tests.ts
@@ -275,3 +275,7 @@ sharp('input.jpg')
 // From https://sharp.pixelplumbing.com/api-output#examples-9
 // Extract alpha channel as raw pixel data from PNG input
 sharp('input.png').ensureAlpha().extractChannel(3).toColourspace('b-w').raw().toBuffer();
+
+// From https://sharp.pixelplumbing.com/api-constructor#examples-4
+// Convert an animated GIF to an animated WebP
+sharp('in.gif', { animated: true }).toFile('out.webp');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/lovell/sharp/tree/master/lib>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
