### PR TITLE
Update autoprefixer to v10

### DIFF
--- a/types/autoprefixer/autoprefixer-tests.ts
+++ b/types/autoprefixer/autoprefixer-tests.ts
@@ -1,13 +1,13 @@
 import autoprefixer = require('autoprefixer');
 import Browsers = require('autoprefixer/lib/browsers');
 import Prefixes = require('autoprefixer/lib/prefixes');
-import { Transformer } from 'postcss';
+import { Plugin } from 'postcss';
 
 // No options
-const ap1: Transformer = autoprefixer();
+const ap1: Plugin = autoprefixer();
 
 // Default options
-const ap2: Transformer = autoprefixer({
+const ap2: Plugin = autoprefixer({
     overrideBrowserslist: [],
     env: 'test',
     cascade: true,
@@ -27,11 +27,11 @@ const deprecationTest = autoprefixer({
 });
 
 autoprefixer.info(); // $ExpectedType () => void
-autoprefixer.data; // $ExpectType any
+autoprefixer.data; // $ExpectType { browsers: any; prefixes: any; }
 autoprefixer.defaults; // $ExpectedType string
 
 // Using environment map in "overrideBrowserslist"
-const ap3: Transformer = autoprefixer({
+const ap3: Plugin = autoprefixer({
     overrideBrowserslist: {
         production: ['> 1%', 'ie 10'],
         modern: ['last 1 chrome version', 'last 1 firefox version'],

--- a/types/autoprefixer/autoprefixer-tests.ts
+++ b/types/autoprefixer/autoprefixer-tests.ts
@@ -27,7 +27,7 @@ const deprecationTest = autoprefixer({
 });
 
 autoprefixer.info(); // $ExpectedType () => void
-autoprefixer.data; // $ExpectType { browsers: any; prefixes: any; }
+autoprefixer.data; // $ExpectType any
 autoprefixer.defaults; // $ExpectedType string
 
 // Using environment map in "overrideBrowserslist"

--- a/types/autoprefixer/index.d.ts
+++ b/types/autoprefixer/index.d.ts
@@ -7,7 +7,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
-import { Plugin } from 'postcss';
+import { PluginCreator } from 'postcss';
 import { Stats } from 'browserslist';
 
 declare namespace autoprefixer {
@@ -62,7 +62,7 @@ declare namespace autoprefixer {
         info(): void;
     }
 
-    type Autoprefixer = Plugin<Options> & ExportedAPI;
+    type Autoprefixer = PluginCreator<Options> & ExportedAPI;
 }
 
 declare const autoprefixer: autoprefixer.Autoprefixer;

--- a/types/autoprefixer/index.d.ts
+++ b/types/autoprefixer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for autoprefixer 10.0.1
+// Type definitions for autoprefixer 10.0
 // Project: https://github.com/postcss/autoprefixer
 // Definitions by: Armando Meziat <https://github.com/odnamrataizem>
 //                 murt <https://github.com/murt>

--- a/types/autoprefixer/index.d.ts
+++ b/types/autoprefixer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for autoprefixer 9.7
+// Type definitions for autoprefixer 10.0.1
 // Project: https://github.com/postcss/autoprefixer
 // Definitions by: Armando Meziat <https://github.com/odnamrataizem>
 //                 murt <https://github.com/murt>

--- a/types/autoprefixer/package.json
+++ b/types/autoprefixer/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "postcss": "7.x.x"
+        "@tsconfig/recommended": "^1.0.1",
+        "postcss": "8.x.x"
     }
 }

--- a/types/autoprefixer/package.json
+++ b/types/autoprefixer/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "postcss": "8.x.x"
+        "postcss": "^8.1.0"
     }
 }

--- a/types/autoprefixer/package.json
+++ b/types/autoprefixer/package.json
@@ -1,7 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@tsconfig/recommended": "^1.0.1",
         "postcss": "8.x.x"
     }
 }

--- a/types/autoprefixer/tsconfig.json
+++ b/types/autoprefixer/tsconfig.json
@@ -1,11 +1,12 @@
 {
-    "extends": "@tsconfig/recommended/tsconfig.json",
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
             "es2015",
             "es2018.promise"
         ],
+        "target": "es2015",
+        "skipLibCheck": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
@@ -21,5 +22,6 @@
     "files": [
         "index.d.ts",
         "autoprefixer-tests.ts"
-    ]
+    ],
+    "$schema": "https://json.schemastore.org/tsconfig"
 }

--- a/types/autoprefixer/tsconfig.json
+++ b/types/autoprefixer/tsconfig.json
@@ -1,8 +1,10 @@
 {
+    "extends": "@tsconfig/recommended/tsconfig.json",
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es2015",
+            "es2018.promise"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/autoprefixer/tsconfig.json
+++ b/types/autoprefixer/tsconfig.json
@@ -6,7 +6,6 @@
             "es2018.promise"
         ],
         "target": "es2015",
-        "skipLibCheck": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
@@ -22,6 +21,5 @@
     "files": [
         "index.d.ts",
         "autoprefixer-tests.ts"
-    ],
-    "$schema": "https://json.schemastore.org/tsconfig"
+    ]
 }

--- a/types/autoprefixer/v9/autoprefixer-tests.ts
+++ b/types/autoprefixer/v9/autoprefixer-tests.ts
@@ -1,0 +1,68 @@
+import autoprefixer = require('autoprefixer');
+import Browsers = require('autoprefixer/lib/browsers');
+import Prefixes = require('autoprefixer/lib/prefixes');
+import { Transformer } from 'postcss';
+
+// No options
+const ap1: Transformer = autoprefixer();
+
+// Default options
+const ap2: Transformer = autoprefixer({
+    overrideBrowserslist: [],
+    env: 'test',
+    cascade: true,
+    add: true,
+    remove: true,
+    supports: true,
+    flexbox: true,
+    grid: false,
+    stats: {},
+    ignoreUnknownVersions: false,
+});
+
+const deprecationTest = autoprefixer({
+    browser: 'defaults',
+    browsers: 'defaults',
+    browserslist: 'defaults',
+});
+
+autoprefixer.info(); // $ExpectedType () => void
+autoprefixer.data; // $ExpectType { browsers: any; prefixes: any; }
+autoprefixer.defaults; // $ExpectedType string
+
+// Using environment map in "overrideBrowserslist"
+const ap3: Transformer = autoprefixer({
+    overrideBrowserslist: {
+        production: ['> 1%', 'ie 10'],
+        modern: ['last 1 chrome version', 'last 1 firefox version'],
+        ssr: ['node 12'],
+    },
+});
+
+const prefixes = new Prefixes(autoprefixer.data.prefixes, new Browsers(autoprefixer.data.browsers, []));
+const autoprefixerApiTest = {
+    atRuleName(identifier: string) {
+        return Boolean(prefixes.remove[`@${identifier.toLowerCase()}`]);
+    },
+    selector(identifier: string) {
+        return prefixes.remove.selectors.some((selectorObj: { prefixed: string }) => {
+            return identifier.toLowerCase() === selectorObj.prefixed;
+        });
+    },
+    mediaFeatureName(identifier: string) {
+        return identifier.toLowerCase().includes('device-pixel-ratio');
+    },
+    property(identifier: string) {
+        return Boolean(autoprefixer.data.prefixes[prefixes.unprefixed(identifier.toLowerCase())]);
+    },
+    propertyValue(prop: string, value: string) {
+        const possiblePrefixableValues =
+            (prefixes.remove[prop.toLowerCase()] && prefixes.remove[prop.toLowerCase()].values) || false;
+        return (
+            possiblePrefixableValues &&
+            possiblePrefixableValues.some((valueObj: { prefixed: string }) => {
+                return value.toLowerCase() === valueObj.prefixed;
+            })
+        );
+    },
+};

--- a/types/autoprefixer/v9/index.d.ts
+++ b/types/autoprefixer/v9/index.d.ts
@@ -1,0 +1,69 @@
+// Type definitions for autoprefixer 9.7
+// Project: https://github.com/postcss/autoprefixer
+// Definitions by: Armando Meziat <https://github.com/odnamrataizem>
+//                 murt <https://github.com/murt>
+//                 Slava Fomin II <https://github.com/slavafomin>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+import { Plugin } from 'postcss';
+import { Stats } from 'browserslist';
+
+declare namespace autoprefixer {
+    type BrowserslistTarget = string | string[] | { [key: string]: string[] };
+
+    interface Options {
+        /** environment for `Browserslist` */
+        env?: string;
+        /** should Autoprefixer use Visual Cascade, if CSS is uncompressed */
+        cascade?: boolean;
+        /** should Autoprefixer add prefixes. */
+        add?: boolean;
+        /** should Autoprefixer [remove outdated] prefixes */
+        remove?: boolean;
+        /** should Autoprefixer add prefixes for @supports parameters. */
+        supports?: boolean;
+        /** should Autoprefixer add prefixes for flexbox properties */
+        flexbox?: boolean | 'no-2009';
+        /** should Autoprefixer add IE 10-11 prefixes for Grid Layout properties */
+        grid?: false | 'autoplace' | 'no-autoplace';
+        /** custom usage statistics for > 10% in my stats browsers query */
+        stats?: Stats;
+        /** @deprecated 'Change `browser` option to `overrideBrowserslist` in Autoprefixer */
+        browser?: string;
+        /**
+         * @deprecated Replace Autoprefixer `browsers` option to Browserslist config.
+         * Use `browserslist` key in `package.json` or `.browserslistrc` file.
+         */
+        browsers?: string[] | string;
+        /** @deprecated Change `browserslist` option to `overrideBrowserslist` in Autoprefixer */
+        browserslist?: string[] | string;
+        /**
+         * list of queries for target browsers.
+         * Try to not use it.
+         * The best practice is to use `.browserslistrc` config or `browserslist` key in `package.json`
+         * to share target browsers with Babel, ESLint and Stylelint
+         */
+        overrideBrowserslist?: BrowserslistTarget;
+        /** do not raise error on unknown browser version in `Browserslist` config. */
+        ignoreUnknownVersions?: boolean;
+    }
+
+    interface ExportedAPI {
+        /** Autoprefixer data */
+        data: {
+            browsers: any;
+            prefixes: any;
+        };
+        /** Autoprefixer default browsers */
+        defaults: any;
+        /** Inspect with default Autoprefixer */
+        info(): void;
+    }
+
+    type Autoprefixer = Plugin<Options> & ExportedAPI;
+}
+
+declare const autoprefixer: autoprefixer.Autoprefixer;
+export = autoprefixer;

--- a/types/autoprefixer/v9/lib/browsers.d.ts
+++ b/types/autoprefixer/v9/lib/browsers.d.ts
@@ -1,0 +1,25 @@
+import browserslist = require('browserslist');
+
+type Queries = string | ReadonlyArray<string>;
+
+interface Browsers {
+    parse(queries: Queries): string[];
+    prefix(browser: string): string;
+    isSelected(browser: string): boolean;
+}
+
+declare class BrowsersImpl implements Browsers {
+    constructor(data: { [k: string]: any }, options?: any, browserslistOpts?: browserslist.Options);
+
+    isSelected(browser: string): boolean;
+
+    parse(queries: string | ReadonlyArray<string>): string[];
+
+    prefix(browser: string): string;
+
+    prefixes(): string[];
+
+    withPrefix(value: string): boolean;
+}
+
+export = BrowsersImpl;

--- a/types/autoprefixer/v9/lib/prefixes.d.ts
+++ b/types/autoprefixer/v9/lib/prefixes.d.ts
@@ -1,0 +1,17 @@
+import Browsers = require('./browsers');
+
+interface Prefixes {
+    remove: { [k: string]: any };
+
+    unprefixed(value: string): string;
+}
+
+declare class PrefixesImpl implements Prefixes {
+    constructor(data: string[], browsers: Browsers, options?: any);
+
+    remove: { [p: string]: any };
+
+    unprefixed(value: string): string;
+}
+
+export = PrefixesImpl;

--- a/types/autoprefixer/v9/package.json
+++ b/types/autoprefixer/v9/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "7.x.x"
+    }
+}

--- a/types/autoprefixer/v9/tsconfig.json
+++ b/types/autoprefixer/v9/tsconfig.json
@@ -14,7 +14,7 @@
         ],
         "paths": {
             "autoprefixer": [
-                "autoprefixer/v9"
+                "autoprefixer/v9/*"
             ]
         },
         "types": [],

--- a/types/autoprefixer/v9/tsconfig.json
+++ b/types/autoprefixer/v9/tsconfig.json
@@ -14,6 +14,9 @@
         ],
         "paths": {
             "autoprefixer": [
+                "autoprefixer/v9"
+            ],
+            "autoprefixer/*": [
                 "autoprefixer/v9/*"
             ]
         },

--- a/types/autoprefixer/v9/tsconfig.json
+++ b/types/autoprefixer/v9/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "paths": {
+            "autoprefixer": [
+                "autoprefixer/v9"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "autoprefixer-tests.ts"
+    ]
+}

--- a/types/autoprefixer/v9/tslint.json
+++ b/types/autoprefixer/v9/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/postcss/autoprefixer/releases/tag/10.0.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
