### PR TITLE
[har-format] PostData has mutually exclusive text and params props

### DIFF
--- a/types/har-format/har-format-tests.ts
+++ b/types/har-format/har-format-tests.ts
@@ -48,6 +48,34 @@ const testCookie: harFormat.Cookie = {
     secure: true
 };
 
+const textPostData: harFormat.PostData = {
+    mimeType: "text/plain",
+    text: "some-text"
+};
+
+const paramsPostData: harFormat.PostData = {
+    mimeType: "multipart/form-data",
+    params: [{
+        name: "some-param",
+        value: "val"
+    }]
+};
+
+// $ExpectError
+const missingPostData: harFormat.PostData = {
+    mimeType: "text/plain"
+};
+
+// $ExpectError
+const tooMuchPostData: harFormat.PostData = {
+    mimeType: "multipart/form-data",
+    params: [{
+        name: "some-param",
+        value: "val"
+    }],
+    text: "asd"
+};
+
 const testContent: harFormat.Content = {
     size: 26915,
     mimeType: "text/html",
@@ -96,12 +124,12 @@ const testCacheNoInformation: harFormat.Cache = {
 };
 
 const testNoCacheAfter: harFormat.Cache = {
-  afterRequest: null
+    afterRequest: null
 };
 
 const testCacheNotCached: harFormat.Cache = {
-  beforeRequest: null,
-  afterRequest: null
+    beforeRequest: null,
+    afterRequest: null
 };
 
 const testLog: harFormat.Log = {

--- a/types/har-format/index.d.ts
+++ b/types/har-format/index.d.ts
@@ -11,7 +11,7 @@
  */
 export interface Har {
     /** This object represents the root of exported data. */
-    "log": Log;
+    log: Log;
 }
 /**
  * This object (`log`) represents the root of exported data.
@@ -233,7 +233,7 @@ export interface Page {
     /** _non-standard_  */
     _score_gzip?: number | null;
     /** _non-standard_  */
-    "_score_keep-alive"?: number | null;
+    '_score_keep-alive'?: number | null;
     /** _non-standard_  */
     _score_minify?: number | null;
     /** _non-standard_  */
@@ -466,7 +466,7 @@ export interface Entry {
     /** _non-standard_  */
     _score_gzip?: number | string | null;
     /** _non-standard_  */
-    "_score_keep-alive"?: number | string | null;
+    '_score_keep-alive'?: number | string | null;
     /** _non-standard_  */
     _score_minify?: number | string | null;
     /** _non-standard_  */
@@ -650,7 +650,7 @@ export interface PostDataCommon {
 /**
  * Post data with `params` specified.
  */
-interface PostDataParams {
+export interface PostDataParams {
     /**
      * List of posted parameters (in case of URL encoded parameters).
      */
@@ -665,7 +665,7 @@ interface PostDataParams {
 /**
  * Post data with `text` specified.
  */
-interface PostDataText {
+export interface PostDataText {
     /**
      * Plain text posted data
      */

--- a/types/har-format/index.d.ts
+++ b/types/har-format/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for non-npm package HAR 1.2
 // Project: https://w3c.github.io/web-performance/specs/HAR/Overview.html
 // Definitions by: Michael Mrowetz <https://github.com/micmro>
+//                 Marcell Toth <https://github.com/marcelltoth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**
@@ -634,24 +635,48 @@ export interface QueryString {
  *
  * http://www.softwareishard.com/blog/har-12-spec/#postData
  */
-export interface PostData {
+export type PostData = PostDataCommon & (PostDataParams | PostDataText);
+
+/**
+ * The common properties of PostData
+ */
+export interface PostDataCommon {
     /** Mime type of posted data. */
     mimeType: string;
-    /**
-     * List of posted parameters (in case of URL encoded parameters).
-     *
-     * _`text` and `params` fields are mutually exclusive._
-     */
-    params: Param[];
-    /**
-     * Plain text posted data
-     *
-     * _`params` and `text` fields are mutually exclusive._
-     */
-    text: string;
     /**  A comment provided by the user or the application */
     comment?: string;
 }
+
+/**
+ * Post data with `params` specified.
+ */
+interface PostDataParams {
+    /**
+     * List of posted parameters (in case of URL encoded parameters).
+     */
+    params: Param[];
+
+    /**
+     * _`params` and `text` fields are mutually exclusive._
+     */
+    text?: never;
+}
+
+/**
+ * Post data with `text` specified.
+ */
+interface PostDataText {
+    /**
+     * Plain text posted data
+     */
+    text: string;
+
+    /**
+     * _`params` and `text` fields are mutually exclusive._
+     */
+    params?: never;
+}
+
 /**
  * List of posted parameters, if any (embedded in `postData` object).
  *
@@ -669,6 +694,7 @@ export interface Param {
     /**  A comment provided by the user or the application */
     comment?: string;
 }
+
 /**
  * This object describes details about response content
  * (embedded in `response` object).


### PR DESCRIPTION
## Summary

Right now there is a bug in the HAR typings: a `PostData` object requires both `text` and `params` props to be set, even though the standard explicitly says:
> Note that text and params fields are mutually exclusive.

This PR implements a mutually exclusive `text` and `params` field on a `PostData` object. 
Tests are added.

## Template

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://www.softwareishard.com/blog/har-12-spec/#postData & https://w3c.github.io/web-performance/specs/HAR/Overview.html#sec-object-types-postData
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

