### PR TITLE
[summernote] Added fontsizeunit for toolbar button and fixed definitions for code method

### DIFF
--- a/types/summernote/index.d.ts
+++ b/types/summernote/index.d.ts
@@ -55,7 +55,7 @@ declare global {
         }
 
         type toolbarStyleGroupOptions = 'style' | 'bold' | 'italic' | 'underline' | 'clear';
-        type toolbarFontGroupOptions = 'fontname' | 'fontsize' | 'color' | 'forecolor' | 'backcolor' | 'bold' | 'italic' | 'underline' | 'strikethrough' | 'superscript' | 'subscript' | 'clear';
+        type toolbarFontGroupOptions = 'fontname' | 'fontsize' | 'fontsizeunit' | 'color' | 'forecolor' | 'backcolor' | 'bold' | 'italic' | 'underline' | 'strikethrough' | 'superscript' | 'subscript' | 'clear';
         type toolbarFontsizeGroupOptions = 'fontsize' | 'fontname' | 'color';
         type toolbarColorGroupOptions = 'color';
         type toolbarParaGroupOptions = 'ul' | 'ol' | 'paragraph' | 'style' | 'height';
@@ -219,7 +219,7 @@ declare global {
         summernote(command: 'formatH1'): JQuery;
         summernote(command: 'formatH2'): JQuery;
         summernote(command: 'formatH3'): JQuery;
-            summernote(command: 'formatH4'): JQuery;
+        summernote(command: 'formatH4'): JQuery;
         summernote(command: 'formatH5'): JQuery;
         summernote(command: 'formatH6'): JQuery;
         // Insertion API

--- a/types/summernote/index.d.ts
+++ b/types/summernote/index.d.ts
@@ -180,7 +180,8 @@ declare global {
         summernote(command: string, url: string, filename?: (string | Summernote.EditImageCallback)): JQuery;
 
         summernote(command: 'destroy'): JQuery;
-        summernote(command: 'code', markupStr?: string): JQuery;
+        summernote(command: 'code'): string;
+        summernote(command: 'code', markupStr: string): undefined;
         summernote(command: 'editor.pasteHTML' | 'pasteHTML', markup: string): JQuery;
 
         // Basic API

--- a/types/summernote/index.d.ts
+++ b/types/summernote/index.d.ts
@@ -55,7 +55,8 @@ declare global {
         }
 
         type toolbarStyleGroupOptions = 'style' | 'bold' | 'italic' | 'underline' | 'clear';
-        type toolbarFontGroupOptions = 'fontname' | 'fontsize' | 'fontsizeunit' | 'color' | 'forecolor' | 'backcolor' | 'bold' | 'italic' | 'underline' | 'strikethrough' | 'superscript' | 'subscript' | 'clear';
+        type toolbarFontGroupOptions = 'fontname' | 'fontsize' | 'fontsizeunit' | 'color' | 'forecolor' | 'backcolor' | 'bold' | 'italic' | 'underline' | 'strikethrough' | 'superscript' |
+            'subscript' | 'clear';
         type toolbarFontsizeGroupOptions = 'fontsize' | 'fontname' | 'color';
         type toolbarColorGroupOptions = 'color';
         type toolbarParaGroupOptions = 'ul' | 'ol' | 'paragraph' | 'style' | 'height';

--- a/types/summernote/summernote-tests.ts
+++ b/types/summernote/summernote-tests.ts
@@ -25,5 +25,6 @@ const config: Summernote.Options = {
     fontSizeUnits: ['px', 'pt'],
 };
 
-$('#testElement').summernote('code', '<p> hello </p>');
-$('#testElement').summernote('code');
+const code = '<p> hello </p>';
+$('#testElement').summernote('code', code);
+alert(code === $('#testElement').summernote('code'));

--- a/types/summernote/summernote-tests.ts
+++ b/types/summernote/summernote-tests.ts
@@ -16,7 +16,7 @@ const config: Summernote.Options = {
     toolbar: [
         ['misc', ['undo', 'redo']],
         ['style', ['bold', 'italic', 'underline', 'clear']],
-        ['font', ['fontname', 'fontsize', 'color']],
+        ['font', ['fontname', 'fontsize', 'fontsizeunit', 'color']],
         ['para', ['style', 'ul', 'ol', 'paragraph', 'height']],
         ['insert', ['picture', 'video']],
     ],


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
 * fontsizeunit: this is listed as an option here and shows a button to switch between `px` and `pt` https://summernote.org/deep-dive/#custom-toolbar-popover
 * `code`-method: https://summernote.org/deep-dive/#custom-toolbar-popover According to this, it returns the content as string, not a JQuery Element. Checking in the browser console, I get the same results:
![image](https://user-images.githubusercontent.com/8461282/97416660-012b1c00-1907-11eb-9f60-57fcc5bd8507.png)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
