### PR TITLE
fix types for lucene: add missing properties to LeftOnlyAST and BinaryAst interfaces: field, parenthesized

### DIFF
--- a/types/lucene/index.d.ts
+++ b/types/lucene/index.d.ts
@@ -44,12 +44,17 @@ export type Node =
 
 export type Operator = '<implicit>' | 'NOT' | 'OR' | 'AND' | 'AND NOT' | 'OR NOT';
 
-export interface LeftOnlyAST {
+export interface ASTField {
+    field?: string;
+    parenthesized?: boolean;
+}
+
+export interface LeftOnlyAST extends ASTField {
     left: Node;
     start?: Operator;
 }
 
-export interface BinaryAST {
+export interface BinaryAST extends ASTField {
     left: AST | Node;
     operator: Operator;
     right: AST | Node;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: lucene interfaces are defined [here](https://github.com/bripkens/lucene/blob/v2.1.1/lib/lucene.grammar#L25)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
