### PR TITLE
[jquery.fancytree] Added icon to FancytreeNode

### DIFF
--- a/types/jquery.fancytree/index.d.ts
+++ b/types/jquery.fancytree/index.d.ts
@@ -232,6 +232,8 @@ declare namespace Fancytree {
         extraClasses: string;
         /** Folder nodes have different default icons and click behavior. Note: Also non-folders may have children. */
         folder: boolean;
+        /** Icon of the tree node. */
+        icon: string;
         /** null or type of temporarily generated system node like 'loading', or 'error'. */
         statusNodeType: string;
         /** True if this node is loaded on demand, i.e. on first expansion. */

--- a/types/jquery.fancytree/jquery.fancytree-tests.ts
+++ b/types/jquery.fancytree/jquery.fancytree-tests.ts
@@ -70,6 +70,9 @@ var activeNode: Fancytree.FancytreeNode = tree.getRootNode();
 // Sort children of active node:
 activeNode.sortChildren();
 
+// Set new icon for active node:
+activeNode.icon = "./icon.svg";
+
 // Expand all tree nodes
 tree.visit(function (node) {
     node.setExpanded(true);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: The official example at http://wwwendt.de/tech/fancytree/demo/sample-theming.html contains a *Set icons* button which accesses `node.icon` directly.
Additionaly, the following as said at https://github.com/mar10/fancytree/wiki/TutorialLoadData#pass-a-javascript-array:
> The following attributes are available as 'node.PROPERTY':
> [...] `icon` [...]
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
