### PR TITLE
amqplib exchange types should include all strings

### DIFF
--- a/types/amqplib/index.d.ts
+++ b/types/amqplib/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Michael Nahkies <https://github.com/mnahkies>,
 //                 Ab Reitsma <https://github.com/abreits>,
 //                 Nicolás Fantone <https://github.com/nfantone>,
-//                 Nick Zelei <https://github.com/zelein>,
+//                 Nick Zelei <https://github.com/nickzelei>,
 //                 Vincenzo Chianese <https://github.com/XVincentX>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.2

--- a/types/amqplib/index.d.ts
+++ b/types/amqplib/index.d.ts
@@ -34,7 +34,7 @@ export interface Channel extends events.EventEmitter {
     bindQueue(queue: string, source: string, pattern: string, args?: any): Promise<Replies.Empty>;
     unbindQueue(queue: string, source: string, pattern: string, args?: any): Promise<Replies.Empty>;
 
-    assertExchange(exchange: string, type: '' | 'direct' | 'topic' | 'headers' | 'fanout' | 'match', options?: Options.AssertExchange): Promise<Replies.AssertExchange>;
+    assertExchange(exchange: string, type: 'direct' | 'topic' | 'headers' | 'fanout' | 'match' | string, options?: Options.AssertExchange): Promise<Replies.AssertExchange>;
     checkExchange(exchange: string): Promise<Replies.Empty>;
 
     deleteExchange(exchange: string, options?: Options.DeleteExchange): Promise<Replies.Empty>;


### PR DESCRIPTION
Fix for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/47047  which assumed that '' | 'direct' | 'topic' | 'fanout' | 'headers' | 'match' exchange type was exchaustive, but delayed message plugin adds x-delayed-exchange exchange type for instance. 

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
