### PR TITLE
[@types/carbon-components-react] Update types to match 7.22.x

### DIFF
--- a/types/carbon-components-react/index.d.ts
+++ b/types/carbon-components-react/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for carbon-components-react 7.21
+// Type definitions for carbon-components-react 7.22
 // Project: https://github.com/carbon-design-system/carbon/tree/master/packages/react
 // Definitions by: Kyle Albert <https://github.com/kalbert312>
 //                 Sebastien Gregoire <https://github.com/sgregoire>

--- a/types/carbon-components-react/index.d.ts
+++ b/types/carbon-components-react/index.d.ts
@@ -156,6 +156,7 @@ export { default as OrderedList } from "./lib/components/OrderedList";
 export { default as OverflowMenu } from "./lib/components/OverflowMenu";
 export { default as OverflowMenuItem } from "./lib/components/OverflowMenuItem";
 export { default as Pagination } from "./lib/components/Pagination";
+export { default as PaginationSkeleton } from "./lib/components/Pagination/Pagination.Skeleton";
 export { default as PaginationNav } from "./lib/components/PaginationNav";
 export { PageSelector as unstable_PageSelector } from "./lib/components/Pagination/experimental";
 export { Pagination as unstable_Pagination } from "./lib/components/Pagination/experimental";

--- a/types/carbon-components-react/lib/components/Accordion/Accordion.d.ts
+++ b/types/carbon-components-react/lib/components/Accordion/Accordion.d.ts
@@ -3,6 +3,8 @@ import { ReactAttr } from "../../../typings/shared";
 
 export interface AccordionProps extends ReactAttr<HTMLUListElement> {
     align?: "end" | "start";
+    disabled?: boolean;
+    size?: "sm" | "xl";
 }
 
 declare const Accordion: React.FC<AccordionProps>;

--- a/types/carbon-components-react/lib/components/Accordion/AccordionItem.d.ts
+++ b/types/carbon-components-react/lib/components/Accordion/AccordionItem.d.ts
@@ -7,6 +7,7 @@ export interface HeadingClickData {
 }
 
 export interface AccordionItemProps extends Omit<ReactLIAttr, "title"> {
+    disabled?: boolean;
     /**
      * @deprecated
      */

--- a/types/carbon-components-react/lib/components/CodeSnippet/CodeSnippet.d.ts
+++ b/types/carbon-components-react/lib/components/CodeSnippet/CodeSnippet.d.ts
@@ -13,6 +13,7 @@ interface SharedProps {
     light?: boolean,
     showLessText?: string,
     showMoreText?: string,
+    wrapText?: boolean,
 }
 
 export interface CodeSnippetDivProps extends SharedProps, InheritedDivProps {

--- a/types/carbon-components-react/lib/components/ComboBox/ComboBox.d.ts
+++ b/types/carbon-components-react/lib/components/ComboBox/ComboBox.d.ts
@@ -18,7 +18,7 @@ export interface ComboBoxProps<ItemType = string, CustomElementProps = Extract<I
     id: string;
     initialSelectedItem?: ItemType;
     invalid?: boolean;
-    invalidText?: string;
+    invalidText?: React.ReactNode;
     items: readonly ItemType[],
     itemToElement?: CustomElementProps extends object ? React.ComponentType<CustomElementProps> : never,
     itemToString?(item: ItemType | null | undefined): string;

--- a/types/carbon-components-react/lib/components/ContentSwitcher/ContentSwitcher.d.ts
+++ b/types/carbon-components-react/lib/components/ContentSwitcher/ContentSwitcher.d.ts
@@ -5,6 +5,7 @@ export interface ContentSwitcherProps extends Omit<ReactDivAttr, "role"> {
     light?: boolean,
     selectedIndex?: number,
     selectionMode?: "automatic" | "manual";
+    size?: "sm" | "xl";
 }
 
 declare class ContentSwitcher extends React.Component<ContentSwitcherProps> {}

--- a/types/carbon-components-react/lib/components/DatePicker/DatePicker.d.ts
+++ b/types/carbon-components-react/lib/components/DatePicker/DatePicker.d.ts
@@ -4,6 +4,7 @@ import * as React from "react";
 import { ReactDivAttr } from "../../../typings/shared";
 
 export interface DatePickerProps extends Omit<ReactDivAttr, "onChange"> {
+    allowInput?: boolean,
     appendTo?: string | HTMLElement,
     dateFormat?: string,
     datePickerType?: "range" | "single" | "simple",

--- a/types/carbon-components-react/lib/components/DatePickerInput/DatePickerInput.d.ts
+++ b/types/carbon-components-react/lib/components/DatePickerInput/DatePickerInput.d.ts
@@ -11,7 +11,7 @@ export interface DatePickerInputProps extends Omit<ReactInputAttr, ExcludedAttri
     id: string,
     iconDescription?: string,
     invalid?: boolean,
-    invalidText?: string,
+    invalidText?: React.ReactNode,
     labelText: NonNullable<React.ReactNode>,
     openCalendar?: React.MouseEventHandler,
     pattern?: string,

--- a/types/carbon-components-react/lib/components/Dropdown/Dropdown.d.ts
+++ b/types/carbon-components-react/lib/components/Dropdown/Dropdown.d.ts
@@ -34,6 +34,8 @@ export interface DropdownProps<ItemType = string> extends
     size?: ListBoxProps["size"],
     titleText: NonNullable<React.ReactNode>,
     type?: ListBoxProps["type"],
+    warn?: boolean,
+    warnText?: string,
 }
 
 declare function Dropdown<ItemType = string>(props: ForwardRefProps<HTMLButtonElement, DropdownProps<ItemType>>): FCReturn;

--- a/types/carbon-components-react/lib/components/Dropdown/Dropdown.d.ts
+++ b/types/carbon-components-react/lib/components/Dropdown/Dropdown.d.ts
@@ -35,7 +35,7 @@ export interface DropdownProps<ItemType = string> extends
     titleText: NonNullable<React.ReactNode>,
     type?: ListBoxProps["type"],
     warn?: boolean,
-    warnText?: string,
+    warnText?: React.ReactNode,
 }
 
 declare function Dropdown<ItemType = string>(props: ForwardRefProps<HTMLButtonElement, DropdownProps<ItemType>>): FCReturn;

--- a/types/carbon-components-react/lib/components/Dropdown/Dropdown.d.ts
+++ b/types/carbon-components-react/lib/components/Dropdown/Dropdown.d.ts
@@ -22,7 +22,7 @@ export interface DropdownProps<ItemType = string> extends
      */
     inline?: boolean,
     invalid?: boolean;
-    invalidText?: string;
+    invalidText?: React.ReactNode;
     helperText?: React.ReactNode,
     items: readonly ItemType[],
     itemToElement?: ItemType extends object ? React.ComponentType<ItemType> : never,

--- a/types/carbon-components-react/lib/components/ListBox/ListBox.d.ts
+++ b/types/carbon-components-react/lib/components/ListBox/ListBox.d.ts
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { ReactDivAttr, ForwardRefReturn } from "../../../typings/shared";
 import { ListBoxFieldComponent } from "./ListBoxField";
 import { ListBoxMenuComponent } from "./ListBoxMenu";
@@ -16,6 +17,8 @@ export interface ListBoxProps extends Omit<ReactDivAttr, ExcludedAttributes> {
     light?: boolean,
     size?: ListBoxSize,
     type?: ListBoxType, // required but has default value
+    warn?: boolean,
+    warnText?: React.ReactNode,
 }
 
 export interface ListBoxComponent extends ForwardRefReturn<HTMLDivElement, ListBoxProps> {

--- a/types/carbon-components-react/lib/components/ListBox/ListBox.d.ts
+++ b/types/carbon-components-react/lib/components/ListBox/ListBox.d.ts
@@ -12,7 +12,7 @@ type ExcludedAttributes = "onKeyDown" | "onKeyPress" | "ref";
 export interface ListBoxProps extends Omit<ReactDivAttr, ExcludedAttributes> {
     disabled?: boolean, // required but has default value
     invalid?: boolean,
-    invalidText?: string,
+    invalidText?: React.ReactNode,
     isOpen?: boolean,
     light?: boolean,
     size?: ListBoxSize,

--- a/types/carbon-components-react/lib/components/MultiSelect/MultiSelect.d.ts
+++ b/types/carbon-components-react/lib/components/MultiSelect/MultiSelect.d.ts
@@ -26,7 +26,7 @@ export interface MultiSelectProps<T extends ListBoxBaseItemType = string> extend
     itemToString?(item: T | null | undefined): string;
     inline?: boolean,
     invalid?: boolean,
-    invalidText?: string,
+    invalidText?: React.ReactNode,
     label?: React.ReactNode,
     light?: boolean,
     locale?: string,

--- a/types/carbon-components-react/lib/components/MultiSelect/MultiSelect.d.ts
+++ b/types/carbon-components-react/lib/components/MultiSelect/MultiSelect.d.ts
@@ -37,6 +37,8 @@ export interface MultiSelectProps<T extends ListBoxBaseItemType = string> extend
     titleText?: string,
     type?: ListBoxProps["type"],
     useTitleInItem?: boolean,
+    warn?: boolean,
+    warnText?: React.ReactNode,
 }
 
 interface MultiSelect<T extends ListBoxBaseItemType = string> {

--- a/types/carbon-components-react/lib/components/Select/Select.d.ts
+++ b/types/carbon-components-react/lib/components/Select/Select.d.ts
@@ -14,7 +14,7 @@ export interface SelectProps extends Omit<React.SelectHTMLAttributes<HTMLSelectE
     id: string,
     inline?: boolean,
     invalid?: boolean,
-    invalidText?: string,
+    invalidText?: React.ReactNode,
     labelText?: React.ReactNode,
     light?: boolean,
     noLabel?: boolean,

--- a/types/carbon-components-react/lib/components/TextArea/TextArea.d.ts
+++ b/types/carbon-components-react/lib/components/TextArea/TextArea.d.ts
@@ -8,7 +8,7 @@ export interface TextAreaProps extends Omit<React.TextareaHTMLAttributes<HTMLTex
     helperText?: React.ReactNode,
     hideLabel?: boolean,
     invalid?: boolean,
-    invalidText?: string,
+    invalidText?: React.ReactNode,
     labelText: React.ReactNode,
     light?: boolean,
     value?: string | number,

--- a/types/carbon-components-react/lib/components/TextInput/props.d.ts
+++ b/types/carbon-components-react/lib/components/TextInput/props.d.ts
@@ -9,7 +9,7 @@ export interface TextInputSharedProps extends Omit<ReactInputAttr, ExcludedAttri
     hideLabel?: boolean,
     id: string,
     invalid?: boolean,
-    invalidText?: string,
+    invalidText?: React.ReactNode,
     labelText: NonNullable<React.ReactNode>,
     light?: boolean,
     value?: string | number,

--- a/types/carbon-components-react/lib/components/TimePicker/TimePicker.d.ts
+++ b/types/carbon-components-react/lib/components/TimePicker/TimePicker.d.ts
@@ -5,7 +5,7 @@ export interface TimePickerProps extends Omit<ReactInputAttr, "id"> {
     hideLabel?: boolean,
     id: string,
     invalid?: boolean,
-    invalidText?: string,
+    invalidText?: React.ReactNode,
     labelText?: React.ReactNode,
     light?: boolean,
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/carbon-design-system/carbon/tree/v10.22.0/packages/react
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
