### PR TITLE
@types/beanstalkd : Updating index.d.ts due to wrongly typed methods parameters

### DIFF
--- a/types/beanstalkd/index.d.ts
+++ b/types/beanstalkd/index.d.ts
@@ -185,7 +185,7 @@ export default class BeanstalkdClient {
      *
      * @param tube The Tube name to watch.
      */
-    watch(tube: number): Promise<number>;
+    watch(tube: string): Promise<number>;
 
     /**
      * Ignore the named tube.
@@ -193,7 +193,7 @@ export default class BeanstalkdClient {
      *
      * @param tube The Tube name to ignore.
      */
-    ignore(tube: number): Promise<number>;
+    ignore(tube: string): Promise<number>;
 
     /**
      * Responds with an array containing the names of the tubes currently watched by the client.


### PR DESCRIPTION
Methods watch() and ignore() should accepts a string, not a number. This was preventing from entering the desired tube name.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
```
// We should be able to watch any string, not any number. Same goes for ignore. When we had a number as a type, what
// would happen is that we would have watched the tube '3' for example, without any possibility to watch for
// the tube 'helloImATube' for example.

beanstalkd
  .connect()
  .then(function(beanstalkd) {

    beanstalkd.watch('myTube').then(totalTubes => {
      console.log('watching', totalTubes, 'tube(s)');
      beanstalkd.reserve().then(job => {
        console.log('reserving job id', job[0]);
      });
    });
  })
  .catch(err => {
    console.log(err);
  });
```
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.