### PR TITLE
Add types for findAndReplaceDOMText

### DIFF
--- a/types/findandreplacedomtext/findandreplacedomtext-tests.ts
+++ b/types/findandreplacedomtext/findandreplacedomtext-tests.ts
@@ -1,0 +1,176 @@
+import findAndReplaceDOMText from 'findandreplacedomtext';
+
+// Mock functions
+const forcedAContext = (el: HTMLElement) => {
+    return el.nodeName.toLowerCase() === 'a';
+};
+
+// Init some HTML node
+const d = document.createElement('div');
+d.innerHTML = 'This is a test';
+
+// Tests
+findAndReplaceDOMText(d, { find: /TEST/, wrap: 'x' });
+
+findAndReplaceDOMText(d, { find: '??test', wrap: 'x' });
+
+findAndReplaceDOMText(d, { find: /x+/, wrap: 'z' });
+
+findAndReplaceDOMText(d, { find: /(TEST)hello/, wrap: 'x', replace: '$1' });
+
+findAndReplaceDOMText(d, { find: /(TEST)hello/g, wrap: 'x', replace: '$1' });
+
+findAndReplaceDOMText(d, { find: /\s(TEST)(hello)/g, wrap: 'x', replace: '$2' });
+
+findAndReplaceDOMText(d, { find: /\bat\b/, wrap: 'x' });
+
+findAndReplaceDOMText(d, { find: /\bat\b/g, wrap: 'x' });
+
+findAndReplaceDOMText(d, {
+    find: /\bAAA\b/,
+    wrap: 'x',
+    forceContext: el => {
+        return el.nodeName.toLowerCase() === 'p';
+    },
+});
+
+findAndReplaceDOMText(d, { find: /FooBar/, wrap: 'x' });
+
+findAndReplaceDOMText(d, { find: /FooBar/, wrap: 'x', forceContext: true });
+
+findAndReplaceDOMText(d, { find: /FooBar/, wrap: 'x', forceContext: false });
+
+findAndReplaceDOMText(d, { find: /FooBar/, wrap: 'x', forceContext: forcedAContext });
+
+findAndReplaceDOMText(d, { find: /FooBar/, wrap: 'x', forceContext: forcedAContext });
+
+findAndReplaceDOMText(d, {
+    find: /test/gi,
+    replace: portion => {
+        const e = document.createElement('x');
+        e.className = 'f';
+        e.appendChild(document.createTextNode(portion.text));
+        return e;
+    },
+});
+
+findAndReplaceDOMText(d, {
+    find: /test/gi,
+    wrap: document.createElement('z'),
+});
+
+findAndReplaceDOMText(d, { find: /x/, wrap: 'em' });
+
+findAndReplaceDOMText(d, {
+    find: /a/g,
+    replace: portion => {
+        return document.createTextNode('b' + portion.text);
+    },
+});
+
+findAndReplaceDOMText(d, {
+    find: 'foo',
+    replace: 'bar',
+});
+
+findAndReplaceDOMText(d, {
+    find: /(\d+)/g,
+    replace: 'aaa$1',
+});
+
+findAndReplaceDOMText(d, {
+    find: /(a)(b)(c)/g,
+    replace: '$3$2$1',
+});
+
+findAndReplaceDOMText(d, {
+    find: /[a-z]{2}/g,
+    replace: '_$0_$&_',
+});
+
+findAndReplaceDOMText(d, {
+    find: /\ba\b/,
+    replace: '[$`]',
+});
+
+findAndReplaceDOMText(d, {
+    find: /\ba\b/,
+    replace: "[$']",
+});
+
+findAndReplaceDOMText(d, {
+    find: /(1+)(\s+)?(3+)/g,
+    replace: '$3$2$1',
+});
+
+findAndReplaceDOMText(d, {
+    find: /foo/g,
+    wrap: 'span',
+    filterElements: el => {
+        return !/^(?:script|style)$/i.test(el.nodeName);
+    },
+});
+
+findAndReplaceDOMText(d, {
+    find: /foo/g,
+    wrap: 'span',
+    filterElements: el => {
+        return 'script' !== el.nodeName.toLowerCase();
+    },
+});
+
+findAndReplaceDOMText(d, {
+    find: /\w{2}/g,
+    replace: '$`',
+}).revert();
+
+findAndReplaceDOMText(d, {
+    find: /\ba\b/,
+    replace: 'something',
+}).revert();
+
+findAndReplaceDOMText(d, {
+    find: /\d{5}/g,
+    wrap: 'span',
+}).revert();
+
+findAndReplaceDOMText(d, { find: /FooBar/, wrapClass: 'my-class' });
+
+findAndReplaceDOMText(d, {
+    find: /hello/i,
+    wrap: 'span',
+    portionMode: 'first',
+});
+
+findAndReplaceDOMText(d, {
+    find: /hello/i,
+    wrap: 'span',
+    portionMode: 'retain',
+});
+
+findAndReplaceDOMText(d, {
+    find: /123/g,
+    replace: '999',
+    preset: 'prose',
+});
+
+findAndReplaceDOMText(d, {
+    find: /A+/g,
+    replace: portion => {
+        return portion.indexInMatch;
+    },
+});
+
+findAndReplaceDOMText(d, {
+    find: /A+/g,
+    replace: portion => {
+        return portion.indexInMatch;
+    },
+});
+
+findAndReplaceDOMText(d, {
+    find: /A+/g,
+    replace: portion => {
+        return portion.indexInMatch;
+    },
+});

--- a/types/findandreplacedomtext/index.d.ts
+++ b/types/findandreplacedomtext/index.d.ts
@@ -1,0 +1,33 @@
+// Type definitions for findandreplacedomtext 0.4
+// Project: https://github.com/padolsey/findAndReplaceDOMText
+// Definitions by: BART! <https://github.com/bartholomej>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface Options {
+    find: RegExp | string;
+    replace?: string | ((portion: Portion, match?: any) => string | number | HTMLElement | Text);
+    wrap?: string | HTMLElement;
+    wrapClass?: string;
+    filterElements?: (el: HTMLElement) => boolean;
+    portionMode?: 'retain' | 'first';
+    forceContext?: boolean | ((el: HTMLElement) => boolean);
+    preset?: 'prose' | string;
+}
+
+interface Portion {
+    node: HTMLElement;
+    index: number;
+    text: string;
+    indexInMatch: number;
+    indexInNode: number;
+    endIndexInNode: number;
+    isEnd: boolean;
+}
+
+interface Return {
+    revert: () => Return;
+}
+
+declare function findAndReplaceDOMText(node: HTMLElement, options: Options): Return;
+
+export = findAndReplaceDOMText;

--- a/types/findandreplacedomtext/index.d.ts
+++ b/types/findandreplacedomtext/index.d.ts
@@ -4,13 +4,54 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface Options {
+    /**
+     * Something to search for. A string will perform a global search by default (looking for all matches), but a RegExp will only do so if you include the global (/.../g) flag.
+     */
     find: RegExp | string;
+    /**
+     * A String of text to replace matches with, or a Function which should return replacement Node or String. If you use a string, it can contain various tokens:
+     *
+     *  $n to represent the nth captured group of a regular expression (i.e. $1, $2, ...)
+     *
+     * $0 or $& to represent the entire match
+     *
+     * $` to represent everything to the left of the match.
+     *
+     * $' to represent everything to the right of the match.
+     */
     replace?: string | ((portion: Portion, match?: any) => string | number | HTMLElement | Text);
+    /**
+     * A string representing the node-name of an element that will be wrapped around matches (e.g. span or em).
+     *
+     * Or a Node (i.e. a stencil node) that we will clone for each match portion.
+     */
     wrap?: string | HTMLElement;
+    /**
+     * A string representing the class name to be assigned to the wrapping element (e.g. <span class="myClass">found text</span>).
+     *
+     * If the wrap option is not specified, then this option is ignored.
+     */
     wrapClass?: string;
-    filterElements?: (el: HTMLElement) => boolean;
+    /**
+     * Indicates whether to re-use existing node boundaries when replacing a match with text (i.e. the default, "retain"),
+     * or whether to instead place the entire replacement in the first-found match portion's node.
+     *
+     * Most of the time you'll want the default.
+     */
     portionMode?: 'retain' | 'first';
+    /**
+     * A function to be called on every element encountered by findAndReplaceDOMText.
+     * If the function returns false the element will be altogether ignored.
+     */
+    filterElements?: (el: HTMLElement) => boolean;
+    /**
+     * A boolean or a boolean-returning function that'll be called on every element to determine if it should be considered as its own matching context.
+     * More info: https://github.com/padolsey/findAndReplaceDOMText#contexts
+     */
     forceContext?: boolean | ((el: HTMLElement) => boolean);
+    /**
+     * Currently there's only one preset: prose. https://github.com/padolsey/findAndReplaceDOMText#presetprose
+     */
     preset?: 'prose' | string;
 }
 
@@ -25,9 +66,15 @@ interface Portion {
 }
 
 interface Return {
+    /**
+     * Reversion occurs backwards so as to avoid nodes subsequently replaced during the matching phase.
+     */
     revert: () => Return;
 }
 
+/**
+ * findAndReplaceDOMText searches for regular expression matches in a given DOM node and replaces or wraps each match with a node or piece of text that you can specify.
+ */
 declare function findAndReplaceDOMText(node: HTMLElement, options: Options): Return;
 
 export = findAndReplaceDOMText;

--- a/types/findandreplacedomtext/tsconfig.json
+++ b/types/findandreplacedomtext/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "allowSyntheticDefaultImports": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "findandreplacedomtext-tests.ts"
+    ]
+}

--- a/types/findandreplacedomtext/tslint.json
+++ b/types/findandreplacedomtext/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.