### PR TITLE
[terraformer__arcgis] accept all GeoJSON types for geojsonToArcGIS

### DIFF
--- a/types/terraformer__arcgis/index.d.ts
+++ b/types/terraformer__arcgis/index.d.ts
@@ -8,4 +8,4 @@ import * as GeoJSON from 'geojson';
 import * as ArcGIS from 'arcgis-rest-api';
 
 export function arcgisToGeoJSON(arcgis: ArcGIS.Geometry, idAttribute?: string): GeoJSON.GeometryObject;
-export function geojsonToArcGIS(geojson: GeoJSON.GeometryObject, idAttribute?: string): ArcGIS.Geometry;
+export function geojsonToArcGIS(geojson: GeoJSON.GeoJSON, idAttribute?: string): ArcGIS.Geometry;

--- a/types/terraformer__arcgis/terraformer__arcgis-tests.ts
+++ b/types/terraformer__arcgis/terraformer__arcgis-tests.ts
@@ -13,8 +13,22 @@ const geojsonPoint: GeoJSON.Point = {
     coordinates: [45.5165, -122.6764],
 };
 
+const geojsonFeatureCollection: GeoJSON.FeatureCollection = {
+    type: 'FeatureCollection',
+    features: [
+        {
+            type: 'Feature',
+            geometry: geojsonPoint,
+            properties: {},
+        },
+    ],
+};
+
 // parse ArcGIS JSON, convert it to GeoJSON
 Terraformer.arcgisToGeoJSON(arcgisPoint);
 
-// take GeoJSON and convert it to ArcGIS JSON
+// take a GeoJSON Point and convert it to ArcGIS JSON
 Terraformer.geojsonToArcGIS(geojsonPoint);
+
+// take a GeoJSON FeatureCollection and convert it to ArcGIS JSON
+Terraformer.geojsonToArcGIS(geojsonFeatureCollection);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: README here https://github.com/terraformer-js/terraformer/blob/master/packages/arcgis/README.md and in code here https://github.com/terraformer-js/terraformer/blob/master/packages/arcgis/src/geojson.js#L58-L105
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
