### PR TITLE
[d3-array] Update types to v2.5

### DIFF
--- a/types/d3-array/d3-array-tests.ts
+++ b/types/d3-array/d3-array-tests.ts
@@ -354,6 +354,27 @@ numOrUndefined = d3Array.variance(mixedObjectArray, accessorMixedObjectToNum);
 numOrUndefined = d3Array.variance(mixedObjectOrUndefinedArray, accessorMixedObjectToNumOrUndefined);
 numOrUndefined = d3Array.variance(readonlyMixedObjectOrUndefinedArray, accessorReadOnlyMixedObjectToNumOrUndefined);
 
+// fsum() ----------------------------------------------------------------------
+
+numOrUndefined = d3Array.fsum(numbersArray);
+numOrUndefined = d3Array.fsum(numericArray);
+numOrUndefined = d3Array.fsum(numbersOrUndefinedArray);
+
+numOrUndefined = d3Array.fsum(typedArray);
+numOrUndefined = d3Array.fsum(readonlyNumbersArray);
+numOrUndefined = d3Array.fsum(readonlyNumericArray);
+numOrUndefined = d3Array.fsum(readonlyNumbersOrUndefinedArray);
+
+numOrUndefined = d3Array.fsum(mixedObjectArray, accessorMixedObjectToNum);
+numOrUndefined = d3Array.fsum(mixedObjectOrUndefinedArray, accessorMixedObjectToNumOrUndefined);
+numOrUndefined = d3Array.fsum(readonlyMixedObjectOrUndefinedArray, accessorReadOnlyMixedObjectToNumOrUndefined);
+
+// Adder() ---------------------------------------------------------------------
+
+const adder = new d3Array.Adder();
+for (let i = 0; i < 10; i++) adder.add(.1);
+const value: number = adder.valueOf();
+
 // -----------------------------------------------------------------------------
 // Test Searching Arrays
 // -----------------------------------------------------------------------------

--- a/types/d3-array/index.d.ts
+++ b/types/d3-array/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-array module 2.4
+// Type definitions for D3JS d3-array module 2.5
 // Project: https://github.com/d3/d3-array, https://d3js.org/d3-array
 // Definitions by: Alex Ford <https://github.com/gustavderdrache>
 //                 Boris Yankov <https://github.com/borisyankov>
@@ -9,7 +9,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-// Last module patch version validated against: 2.4.0
+// Last module patch version validated against: 2.5.1
 
 // --------------------------------------------------------------------------
 // Shared Types and Interfaces
@@ -248,6 +248,38 @@ export function deviation<T>(
     iterable: Iterable<T>,
     accessor: (datum: T, index: number, array: Iterable<T>) => number | undefined | null
 ): number | undefined;
+
+/**
+ * Returns a full precision summation of the given values.
+ * Although slower, d3.fsum can replace d3.sum wherever greater precision is needed. Uses d3.Adder.
+ */
+export function fsum<T extends Numeric>(values: Iterable<T | undefined | null>): number;
+/**
+ * Returns a full precision summation of the given values.
+ * Although slower, d3.fsum can replace d3.sum wherever greater precision is needed. Uses d3.Adder.
+ */
+export function fsum<T>(
+    values: Iterable<T>,
+    accessor: (datum: T, index: number, array: Iterable<T>) => number | undefined | null
+): number;
+
+export class Adder {
+    /**
+     * Creates a full precision adder for IEEE 754 floating point numbers, setting its initial value to 0.
+     */
+    constructor();
+
+    /**
+     * Adds the specified number to the adder’s current value and returns the adder.
+     */
+    add(number: number): Adder;
+
+    /**
+     * Returns the IEEE 754 double precision representation of the adder’s current value.
+     * Most useful as the short-hand notation +adder.
+     */
+    valueOf(): number;
+}
 
 // --------------------------------------------------------------------------------------
 // Searching Arrays


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-array/releases/tag/v2.5.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Related: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/38939.
