### PR TITLE
[zip-webpack-plugin] solve Plugin not exist in webpack built-in typing

### DIFF
--- a/types/zip-webpack-plugin/index.d.ts
+++ b/types/zip-webpack-plugin/index.d.ts
@@ -1,10 +1,11 @@
 // Type definitions for zip-webpack-plugin 3.0
 // Project: https://github.com/erikdesjardins/zip-webpack-plugin
 // Definitions by: Blaise Kal <https://github.com/blaise-io>
+//                 Chuah Chee Shian <https://github.com/shian15810>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as webpack from 'webpack';
+import { Compiler } from 'webpack';
 
 export = ZipPlugin;
 
@@ -12,11 +13,12 @@ export = ZipPlugin;
  * Webpack plugin to zip emitted files. Compresses all assets into a zip file.
  * See https://www.npmjs.com/package/zip-webpack-plugin#usage
  */
-declare class ZipPlugin extends webpack.Plugin {
+declare class ZipPlugin {
     /**
      * @param options Options for ZipPlugin.
      */
     constructor(options?: ZipPlugin.Options);
+    apply(compiler: Compiler): void;
 }
 
 declare namespace ZipPlugin {

--- a/types/zip-webpack-plugin/zip-webpack-plugin-tests.ts
+++ b/types/zip-webpack-plugin/zip-webpack-plugin-tests.ts
@@ -2,6 +2,8 @@ import * as ZipPlugin from "zip-webpack-plugin";
 
 new ZipPlugin();
 
+new ZipPlugin({});
+
 const options: ZipPlugin.Options = {
     include: "include.string",
     exclude: "exclude.string",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/webpack/blob/dfae6f0ac70e1f4ec6d25a853838d4aa58e10e1f/types.d.ts#L110
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
