### PR TITLE
[jscodeshift] Make collection type a generic

### DIFF
--- a/types/jscodeshift/src/core.d.ts
+++ b/types/jscodeshift/src/core.d.ts
@@ -76,7 +76,7 @@ declare namespace core {
     }
 
     type JSCodeshift = Core & recast.NamedTypes & recast.Builders;
-    type Collection =  Collection.Collection<any>;
+    type Collection<T = any> = Collection.Collection<T>;
 
     interface API {
         j: JSCodeshift;

--- a/types/jscodeshift/test/jscodeshift-tests.ts
+++ b/types/jscodeshift/test/jscodeshift-tests.ts
@@ -82,6 +82,11 @@ const transformWithRecastParseOptions: Transform = (file, { j }) => {
     }
 }
 
+// Can define a collection
+function getFileDefaultImport(file: FileInfo, j: JSCodeshift): Collection<ImportDeclaration> {
+    return j(file.source).find(j.ImportDeclaration);
+}
+
 // Can define a test
 testUtils.defineTest(
     "directory",

--- a/types/jscodeshift/test/jscodeshift-tests.ts
+++ b/types/jscodeshift/test/jscodeshift-tests.ts
@@ -1,4 +1,4 @@
-import { ASTNode, FileInfo, API, Transform, Parser } from "jscodeshift";
+import { ASTNode, FileInfo, API, Transform, Parser, JSCodeshift, Collection, ImportDeclaration } from "jscodeshift";
 import * as testUtils from "jscodeshift/src/testUtils";
 
 // Can define transform with `function`.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

Changing an existing definition:
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
