### PR TITLE
Add `page` option to Pa11y types

### DIFF
--- a/types/pa11y/index.d.ts
+++ b/types/pa11y/index.d.ts
@@ -38,6 +38,7 @@ interface Results {
 interface Options {
     actions?: string[];
     browser?: Browser;
+    page?: Page;
     pages?: Page[];
     chromeLaunchConfig?: LaunchConfig;
     headers?: object;

--- a/types/pa11y/pa11y-tests.ts
+++ b/types/pa11y/pa11y-tests.ts
@@ -1,6 +1,21 @@
 import pa11y = require('pa11y');
+import puppeteer = require('puppeteer');
 
 pa11y('http://example.com/');
+
+(async () => {
+    const browser = await puppeteer.launch();
+    const page = await browser.newPage();
+    await page.goto('https://google.com');
+
+    pa11y('', {
+        browser,
+        ignoreUrl: true,
+        page,
+    });
+
+    await browser.close();
+})();
 
 pa11y('http://example.com/', {
     log: {


### PR DESCRIPTION
Pa11y has a `page` option that is buried in their code. See https://github.com/pa11y/pa11y/blob/master/lib/pa11y.js#L198.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pa11y/pa11y/blob/master/lib/pa11y.js#L198
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
