### PR TITLE
Add react-date-range v1 support(remove moment)

### DIFF
--- a/types/react-date-range/index.d.ts
+++ b/types/react-date-range/index.d.ts
@@ -4,7 +4,7 @@
 //                 John Demetriou <https://github.com/DevsAnon>
 //                 Minseok Choi <https://github.com/Curzy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.0
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-date-range/package.json
+++ b/types/react-date-range/package.json
@@ -1,6 +1,3 @@
 {
-    "private": true,
-    "dependencies": {
-        "moment": ">=2.14.0"
-    }
+    "private": true
 }

--- a/types/react-date-range/v0/index.d.ts
+++ b/types/react-date-range/v0/index.d.ts
@@ -1,15 +1,15 @@
-// Type definitions for react-date-range 1.0
+// Type definitions for react-date-range 0.95
 // Project: https://github.com/Adphorus/react-date-range/
 // Definitions by: Junbong Lee <https://github.com/Junbong>
 //                 John Demetriou <https://github.com/DevsAnon>
-//                 Minseok Choi <https://github.com/Curzy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.0
+// TypeScript Version: 2.8
 
 import * as React from "react";
+import * as moment from "moment";
 
-export type AnyDate = string | Date;
-export type DateFunc = (now: Date) => AnyDate;
+export type AnyDate = string | moment.Moment;
+export type DateFunc = (now: moment.Moment) => AnyDate;
 export type DateInputType = AnyDate | DateFunc;
 export type LanguageType =
     | "cn"
@@ -24,7 +24,7 @@ export type LanguageType =
 export type SizeType = number;
 
 export interface DateContainerType {
-    date: Date;
+    date: moment.Moment;
 }
 
 export interface CalendarTheme {
@@ -54,14 +54,15 @@ export interface CalendarTheme {
 
 export interface Range {
     /** default: today */
-    startDate?: Date;
+    startDate?: moment.Moment;
     /** default: today */
-    endDate?: Date;
+    endDate?: moment.Moment;
 }
 
 export interface CommonCalendarProps {
     /** default: DD/MM/YYY */
     format?: string;
+    /** default: moment.localeData().firstDayOfWeek() */
     firstDayOfWeek?: number;
     theme?: CalendarTheme;
     /** default: none */
@@ -156,8 +157,8 @@ export type DateRangeIndex =
     | "Last 30 Days";
 
 export interface DateRangeObject {
-    startDate: (now: Date) => Date;
-    endDate: (now: Date) => Date;
+    startDate: (now: moment.Moment) => moment.Moment;
+    endDate: (now: moment.Moment) => moment.Moment;
 }
 export const defaultRanges: {
     [measure: string]: DateRangeObject;

--- a/types/react-date-range/v0/package.json
+++ b/types/react-date-range/v0/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "moment": ">=2.14.0"
+    }
+}

--- a/types/react-date-range/v0/react-date-range-tests.tsx
+++ b/types/react-date-range/v0/react-date-range-tests.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+import {
+    defaultRanges,
+    DateRange,
+    DateRangePicker,
+    Range
+} from "react-date-range";
+
+class ReactDatePicker extends React.Component<any, any> {
+    constructor(props: {}) {
+        super(props);
+    }
+
+    handleChange(range: Range) {
+        console.log(range);
+    }
+
+    render() {
+        return (
+            <div>
+                <DateRange
+                    linkedCalendars={true}
+                    ranges={defaultRanges}
+                    onInit={this.handleChange}
+                    onChange={this.handleChange}
+                    theme={{
+                        Calendar: { width: 200 },
+                        PredefinedRanges: { marginLeft: 10, marginTop: 10 }
+                    }}
+                />
+            </div>
+        );
+    }
+}
+
+class ReactDateRangePicker extends React.Component<any, any> {
+    constructor(props: {}) {
+        super(props);
+    }
+
+    handleChange(range: Range) {
+        console.log(range);
+    }
+
+    render() {
+        return (
+            <div>
+                <DateRangePicker
+                    linkedCalendars={true}
+                    ranges={defaultRanges}
+                    scroll={{enabled: true}}
+                    onInit={this.handleChange}
+                    onChange={this.handleChange}
+                    showSelectionPreview={true}
+                    editableDateInputs={true}
+                    showMonthArrow={true}
+                    months={1}
+                    moveRangeOnFirstSelection={false}
+                    direction="horizontal"
+                    weekStartsOn={1}
+                    theme={{
+                        Calendar: { width: 200 },
+                        PredefinedRanges: { marginLeft: 10, marginTop: 10 }
+                    }}
+                />
+            </div>
+        );
+    }
+}

--- a/types/react-date-range/v0/tsconfig.json
+++ b/types/react-date-range/v0/tsconfig.json
@@ -1,0 +1,30 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "paths": {
+            "react-date-range": [
+                "react-date-range/v0"
+            ]
+        },
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react"
+    },
+    "files": [
+        "index.d.ts",
+        "react-date-range-tests.tsx"
+    ]
+}

--- a/types/react-date-range/v0/tslint.json
+++ b/types/react-date-range/v0/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
+}


### PR DESCRIPTION
Remove moment dependency & types by react-date-range v1
---
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/hypeserver/react-date-range/releases/tag/v1.0.0-alpha0>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.