### PR TITLE
fix(@babel/traverse): add missing denylist option

### DIFF
--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -285,6 +285,11 @@ const VisitorStateTest: Visitor<SomeVisitorState> = {
             this;
         },
     },
+    denylist: [
+        'TypeAnnotation',
+        // $ExpectError
+        'SomethingRandom',
+    ],
 };
 
 traverse(ast, VisitorStateTest, undefined, { someState: 'test' });

--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -285,11 +285,6 @@ const VisitorStateTest: Visitor<SomeVisitorState> = {
             this;
         },
     },
-    denylist: [
-        'TypeAnnotation',
-        // $ExpectError
-        'SomethingRandom',
-    ],
 };
 
 traverse(ast, VisitorStateTest, undefined, { someState: 'test' });
@@ -338,4 +333,13 @@ function testNullishPath(
     let actualType = optionalPath.type;
     const expectedType: t.Node['type'] | undefined = actualType;
     actualType = expectedType;
+}
+
+const visitorWithDenylist: Visitor = {
+    denylist: ['TypeAnnotation'],
+}
+
+const visitorWithInvalidDenylist: Visitor = {
+    // $ExpectError
+    denylist: ['SomeRandomType'],
 }

--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -337,9 +337,9 @@ function testNullishPath(
 
 const visitorWithDenylist: Visitor = {
     denylist: ['TypeAnnotation'],
-}
+};
 
 const visitorWithInvalidDenylist: Visitor = {
     // $ExpectError
     denylist: ['SomeRandomType'],
-}
+};

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -210,7 +210,7 @@ export interface VisitNodeObject<S, P extends Node> {
     enter?: VisitNodeFunction<S, P>;
     exit?: VisitNodeFunction<S, P>;
     denylist?: NodeType[];
-    /** 
+    /**
      * @deprecated will be removed in Babel 8
      */
     blacklist?: NodeType[];

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @babel/traverse 7.0
+// Type definitions for @babel/traverse 7.11
 // Project: https://github.com/babel/babel/tree/main/packages/babel-traverse, https://babeljs.io
 // Definitions by: Troy Gerwien <https://github.com/yortus>
 //                 Marvin Hagemeister <https://github.com/marvinhagemeister>
@@ -204,9 +204,16 @@ export type VisitNode<S, P extends Node> = VisitNodeFunction<S, P> | VisitNodeOb
 
 export type VisitNodeFunction<S, P extends Node> = (this: S, path: NodePath<P>, state: S) => void;
 
+type NodeType = Node['type'] | keyof t.Aliases;
+
 export interface VisitNodeObject<S, P extends Node> {
     enter?: VisitNodeFunction<S, P>;
     exit?: VisitNodeFunction<S, P>;
+    denylist?: NodeType[];
+    /** 
+     * @deprecated will be removed in Babel 8
+     */
+    blacklist?: NodeType[];
 }
 
 export type NodePaths<T extends Node | readonly Node[]> = T extends readonly Node[]


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/babel/babel/blob/b7754d3c82f6a8ab6b4a1b03007f098deed0a591/packages/babel-traverse/src/visitors.js#L269-L288
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.