### PR TITLE
Fix webpack-dev-server types to work with Webpack 5

### DIFF
--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -292,7 +292,7 @@ declare namespace WebpackDevServer {
          * displayed.  This can be a nice middle ground if you want some bundle
          * information, but not all of it.
          */
-        stats?: webpack.Options.Stats;
+        stats?: webpack.Configuration['stats'];
         /**
          * transportMode is an experimental option, meaning its usage could
          * potentially change without warning.
@@ -337,7 +337,7 @@ declare namespace WebpackDevServer {
          */
         watchContentBase?: boolean;
         /** Control options related to watching the files. */
-        watchOptions?: webpack.WatchOptions;
+        watchOptions?: webpack.Configuration['watchOptions'];
         /** Tells devServer to write generated assets to the disk. */
         writeToDisk?: boolean | ((filePath: string) => boolean);
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [link](https://webpack.js.org/configuration/dev-server/)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.