### PR TITLE
[css-tree] Add types for definitionSyntax exports

### DIFF
--- a/types/css-tree/css-tree-tests.ts
+++ b/types/css-tree/css-tree-tests.ts
@@ -1,4 +1,4 @@
-import * as csstree from "css-tree";
+import * as csstree from 'css-tree';
 
 const ast = csstree.parse('.a { color: red; }');
 ast; // $ExpectType CssNode
@@ -635,3 +635,71 @@ switch (toPlain.type) {
     default:
         toPlain; // $ExpectType never
 }
+
+csstree.definitionSyntax.syntaxError; // $ExpectType SyntaxError
+const syntax = csstree.definitionSyntax.parse('foo | bar'); // $ExpectType DSNodeGroup
+const node = syntax.terms[0]; // $ExpectType DSNode
+switch (node.type) {
+    case 'AtKeyword':
+        node; // $ExpectType DSNodeAtWord
+        node.name; // $ExpectType string
+        break;
+    case 'Comma':
+        node; // $ExpectType DSNodeComma
+        break;
+    case 'Function':
+        node; // $ExpectType DSNodeFunction
+        node.name; // $ExpectType string
+        break;
+    case 'Group':
+        node; // $ExpectType DSNodeGroup
+        node.terms; // $ExpectType DSNode[]
+        node.combinator; // $ExpectType DSNodeCombinator
+        node.disallowEmpty; // $ExpectType boolean
+        node.explicit; // $ExpectType boolean
+        break;
+    case 'Keyword':
+        node; // $ExpectType DSNodeKeyword
+        node.name; // $ExpectType string
+        break;
+    case 'Multiplier':
+        node; // $ExpectType DSNodeMultiplier
+        node.comma; // $ExpectType boolean
+        node.min; // $ExpectType number
+        node.max; // $ExpectType number
+        node.term; // $ExpectType DSNodeMultiplied
+        break;
+    case 'Property':
+        node; // $ExpectType DSNodeProperty
+        node.name; // $ExpectType string
+        break;
+    case 'String':
+        node; // $ExpectType DSNodeString
+        node.value; // $ExpectType string
+        break;
+    case 'Token':
+        node; // $ExpectType DSNodeToken
+        node.value; // $ExpectType string
+        break;
+    case 'Type':
+        node; // $ExpectType DSNodeType
+        node.name; // $ExpectType string
+        node.opts; // $ExpectType DSNodeTypeOpts | null
+        break;
+}
+
+csstree.definitionSyntax.generate(syntax); // $ExpectType string
+csstree.definitionSyntax.generate(syntax, { forceBraces: true }); // $ExpectType string
+csstree.definitionSyntax.generate(syntax, { compact: true }); // $ExpectType string
+csstree.definitionSyntax.generate(syntax, { decorate: (result: string, node) => {
+    result; // $ExpectType string
+    node; // $ExpectType DSNode
+    return result;
+}});
+
+csstree.definitionSyntax.walk(syntax, (node) => {
+    node; // $ExpectType DSNode
+});
+csstree.definitionSyntax.walk(syntax, (node) => {
+    node; // $ExpectType DSNode
+}, undefined);

--- a/types/css-tree/index.d.ts
+++ b/types/css-tree/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for css-tree 1.0
 // Project: https://github.com/csstree/csstree
 // Definitions by: Erik Källén <https://github.com/erik-kallen>
+//                 Jason Kratzer <https://github.com/pyoor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
@@ -618,3 +619,196 @@ export function clone(node: CssNode): CssNode;
 
 export function fromPlainObject(node: CssNodePlain): CssNode;
 export function toPlainObject(node: CssNode): CssNodePlain;
+
+/**
+ * Definition syntax AtWord node
+ */
+export interface DSNodeAtWord {
+    type: 'AtKeyword';
+    name: string;
+}
+
+/**
+ * Definition syntax Comma node
+ */
+export interface DSNodeComma {
+    type: 'Comma';
+}
+
+/**
+ * Definition syntax Function node
+ */
+export interface DSNodeFunction {
+    type: 'Function';
+    name: string;
+}
+
+export type DSNodeCombinator = '|' | '||' | '&&' | ' ';
+
+/**
+ * Definition syntax Group node
+ */
+export interface DSNodeGroup {
+    type: 'Group';
+    terms: DSNode[];
+    combinator: DSNodeCombinator;
+    disallowEmpty: boolean;
+    explicit: boolean;
+}
+
+/**
+ * Definition syntax Keyword node
+ */
+export interface DSNodeKeyword {
+    type: 'Keyword';
+    name: string;
+}
+
+/**
+ * Definition syntax Multiplier node
+ */
+export interface DSNodeMultiplier {
+    type: 'Multiplier';
+    comma: boolean;
+    min: number;
+    max: number;
+    term: DSNodeMultiplied;
+}
+
+/**
+ * Definition syntax Property node
+ */
+export interface DSNodeProperty {
+    type: 'Property';
+    name: string;
+}
+
+/**
+ * Definition syntax String node
+ */
+export interface DSNodeString {
+    type: 'String';
+    value: string;
+}
+
+/**
+ * Definition syntax Token node
+ */
+export interface DSNodeToken {
+    type: 'Token';
+    value: string;
+}
+
+/**
+ * Definition syntax Type node options
+ */
+export interface DSNodeTypeOpts {
+    type: 'Range';
+    min: number | null;
+    max: number | null;
+}
+
+/**
+ * Definition syntax Type node
+ */
+export interface DSNodeType {
+    type: 'Type';
+    name: string;
+    opts: DSNodeTypeOpts | null;
+}
+
+/**
+ * Definition syntax node
+ */
+export type DSNode =
+    DSNodeAtWord
+    | DSNodeComma
+    | DSNodeFunction
+    | DSNodeGroup
+    | DSNodeKeyword
+    | DSNodeMultiplier
+    | DSNodeProperty
+    | DSNodeString
+    | DSNodeToken
+    | DSNodeType;
+
+/**
+ * Definition syntax node compatible with a multiplier
+ */
+export type DSNodeMultiplied =
+    DSNodeFunction
+    | DSNodeGroup
+    | DSNodeKeyword
+    | DSNodeProperty
+    | DSNodeString
+    | DSNodeType;
+
+/**
+ * Definition syntax generate options
+ */
+export interface DSGenerateOptions {
+    forceBraces?: boolean;
+    compact?: boolean;
+    decorate?: (result: string, node: DSNode) => void;
+}
+
+/**
+ * Definition syntax walk options
+ */
+export interface DSWalkOptions {
+    enter?: DSWalkEnterOrLeaveFn;
+    leave?: DSWalkEnterOrLeaveFn;
+}
+
+/**
+ * Definition syntax walk callback
+ */
+export type DSWalkEnterOrLeaveFn = (node: DSNode) => void;
+
+/**
+ * DefinitionSyntax
+ */
+export interface DefinitionSyntax {
+    /**
+     * Generates CSS value definition syntax from an AST
+     *
+     * @param node - The AST
+     * @param options - Options that affect generation
+     *
+     * @example
+     *  generate({type: 'Keyword', name: 'foo'}) => 'foo'
+     */
+    generate(node: DSNode, options?: DSGenerateOptions): string;
+
+    /**
+     * Generates an AST from a CSS value syntax
+     *
+     * @param source - The CSS value syntax to parse
+     *
+     * @example
+     *  parse('foo | bar') =>
+     *    {
+     *      type: 'Group',
+     *      terms: [
+     *        { type: 'Keyword', name: 'foo' },
+     *        { type: 'Keyword', name: 'bar' }
+     *      ],
+     *      combinator: '|',
+     *      disallowEmpty: false,
+     *      explicit: false
+     *    }
+     */
+    parse(source: string): DSNodeGroup;
+
+    /**
+     * Walks definition syntax AST
+     */
+    walk(node: DSNode, options: DSWalkEnterOrLeaveFn | DSWalkOptions, context?: any): void;
+
+    /**
+     * Wrapper for syntax errors
+     */
+    syntaxError: SyntaxError;
+}
+
+export const definitionSyntax: DefinitionSyntax;


### PR DESCRIPTION
The existing @types/css-tree definitions do not include the required types for the `definitionSyntax` export and related types.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/csstree/csstree/blob/master/lib/definition-syntax/index.js>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
