### PR TITLE
[@types/carbon-components-react] Update types to match 7.23.x

### DIFF
--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
     AccordionItem,
+    AspectRatio,
     Button,
     CodeSnippet,
     CodeSnippetType,
@@ -60,6 +61,22 @@ const accordionItemTwo = (
     <AccordionItem title={accordionTitle} className="extra-class">
         Lorem ipsum.
     </AccordionItem>
+);
+
+//
+// AspectRatio
+//
+
+const AspectRatioCustomComp1: React.FC<{ someRandomProp: number, optionalProp?: string }> = () => <div/>;
+
+const aspectRatioT1 = (
+    <AspectRatio>Default</AspectRatio>
+);
+const aspectRatioT2 = (
+    <AspectRatio as="section" onClick={(e) => {}}>IntrinsicElement</AspectRatio>
+);
+const aspectRatioT3 = (
+    <AspectRatio as={AspectRatioCustomComp1} someRandomProp={3}>Component</AspectRatio>
 );
 
 //

--- a/types/carbon-components-react/index.d.ts
+++ b/types/carbon-components-react/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for carbon-components-react 7.22
+// Type definitions for carbon-components-react 7.23
 // Project: https://github.com/carbon-design-system/carbon/tree/master/packages/react
 // Definitions by: Kyle Albert <https://github.com/kalbert312>
 //                 Sebastien Gregoire <https://github.com/sgregoire>

--- a/types/carbon-components-react/index.d.ts
+++ b/types/carbon-components-react/index.d.ts
@@ -96,6 +96,7 @@ export * from "./lib/components/UnorderedList";
 
 export { default as Accordion } from "./lib/components/Accordion";
 export { default as AccordionItem } from "./lib/components/AccordionItem";
+export { AspectRatio } from "./lib/components/AspectRatio";
 export { Breadcrumb, BreadcrumbItem } from "./lib/components/Breadcrumb";
 export { default as Button } from "./lib/components/Button";
 export { default as ButtonSet } from "./lib/components/ButtonSet";

--- a/types/carbon-components-react/index.d.ts
+++ b/types/carbon-components-react/index.d.ts
@@ -11,6 +11,7 @@ export as namespace CarbonReact;
 // This group is primarily for type exports but will cover non-default exports as well.
 export * from "./lib/components/Accordion";
 export * from "./lib/components/AccordionItem";
+export * from "./lib/components/AspectRatio";
 export * from "./lib/components/Breadcrumb";
 export * from "./lib/components/BreadcrumbItem";
 export * from "./lib/components/Button";

--- a/types/carbon-components-react/lib/components/AspectRatio/AspectRatio.d.ts
+++ b/types/carbon-components-react/lib/components/AspectRatio/AspectRatio.d.ts
@@ -1,5 +1,5 @@
-import * as React from '../../../../react/index';
-import { ReactAttr, ReactDivAttr, JSXIntrinsicElementProps, FCReturn } from '../../../typings/shared';
+import * as React from 'react';
+import { ReactDivAttr, JSXIntrinsicElementProps, FCReturn } from '../../../typings/shared';
 
 export type AspectRatio = '16x9' | '9x16' | '2x1' | '1x2' | '4x3' | '3x4' | '1x1';
 

--- a/types/carbon-components-react/lib/components/AspectRatio/AspectRatio.d.ts
+++ b/types/carbon-components-react/lib/components/AspectRatio/AspectRatio.d.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { ReactDivAttr, JSXIntrinsicElementProps, FCReturn } from '../../../typings/shared';
 
-export type AspectRatio = '16x9' | '9x16' | '2x1' | '1x2' | '4x3' | '3x4' | '1x1';
+export type AspectRatioValue = '16x9' | '9x16' | '2x1' | '1x2' | '4x3' | '3x4' | '1x1';
 
 interface AspectRatioBaseIsolatedProps {
-    ratio?: AspectRatio;
+    ratio?: AspectRatioValue;
 }
 
 type SafeProps<P> = Omit<P, 'as' | keyof AspectRatioBaseIsolatedProps>;

--- a/types/carbon-components-react/lib/components/AspectRatio/AspectRatio.d.ts
+++ b/types/carbon-components-react/lib/components/AspectRatio/AspectRatio.d.ts
@@ -1,0 +1,42 @@
+import * as React from '../../../../react/index';
+import { ReactAttr, ReactDivAttr, JSXIntrinsicElementProps, FCReturn } from '../../../typings/shared';
+
+export type AspectRatio = '16x9' | '9x16' | '2x1' | '1x2' | '4x3' | '3x4' | '1x1';
+
+interface AspectRatioBaseIsolatedProps {
+    ratio?: AspectRatio;
+}
+
+type SafeProps<P> = Omit<P, 'as' | keyof AspectRatioBaseIsolatedProps>;
+
+interface AspectRatioBaseProps extends AspectRatioBaseIsolatedProps {
+    children?: React.ReactNode;
+    className?: string;
+}
+
+export type AspectRatioDefaultProps = AspectRatioBaseProps &
+    ReactDivAttr & {
+        as?: undefined;
+    };
+
+export type AspectRatioIntrinsicProps<K extends keyof JSX.IntrinsicElements> = AspectRatioBaseProps &
+    SafeProps<JSXIntrinsicElementProps<K>> & {
+        as: K;
+    };
+
+export type AspectRatioCustomComponentProps<
+    C extends React.JSXElementConstructor<any>
+> = C extends React.JSXElementConstructor<infer P>
+    ? AspectRatioBaseProps &
+          SafeProps<P> & {
+              as: C;
+          }
+    : never;
+
+declare function AspectRatio(props: AspectRatioDefaultProps): FCReturn;
+declare function AspectRatio<T extends keyof JSX.IntrinsicElements>(props: AspectRatioIntrinsicProps<T>): FCReturn;
+declare function AspectRatio<T extends React.JSXElementConstructor<any>>(
+    props: AspectRatioCustomComponentProps<T>,
+): FCReturn;
+
+export default AspectRatio;

--- a/types/carbon-components-react/lib/components/AspectRatio/index.d.ts
+++ b/types/carbon-components-react/lib/components/AspectRatio/index.d.ts
@@ -1,0 +1,2 @@
+export * from "./AspectRatio";
+export { default as AspectRatio } from "./AspectRatio";

--- a/types/carbon-components-react/lib/components/Button/Button.d.ts
+++ b/types/carbon-components-react/lib/components/Button/Button.d.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../typings/shared";
 
 export type ButtonKind = "danger" | "danger--primary" | "ghost" | "primary" | "secondary" | "tertiary";
-export type ButtonSize = "default" | "field" | "small";
+export type ButtonSize = "default" | "field" | "lg" | "sm" | "small" | "xl";
 
 export interface ButtonRenderIconRenderProps {
     "aria-hidden"?: boolean;

--- a/types/carbon-components-react/lib/components/Link/Link.d.ts
+++ b/types/carbon-components-react/lib/components/Link/Link.d.ts
@@ -4,6 +4,7 @@ import { ReactAnchorAttr } from "../../../typings/shared";
 export interface LinkProps extends ReactAnchorAttr { // this is a <p> element when disabled but accounting for it is useless
     disabled?: boolean,
     inline?: boolean,
+    size?: "sm" | "lg",
     visited?: boolean,
 }
 

--- a/types/carbon-components-react/lib/components/OrderedList/OrderedList.d.ts
+++ b/types/carbon-components-react/lib/components/OrderedList/OrderedList.d.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 export interface OrderedListProps extends React.OlHTMLAttributes<HTMLOListElement> {
+    native?: boolean,
     nested?: boolean,
 }
 

--- a/types/carbon-components-react/lib/components/OverflowMenu/OverflowMenu.d.ts
+++ b/types/carbon-components-react/lib/components/OverflowMenu/OverflowMenu.d.ts
@@ -28,6 +28,7 @@ export interface OverflowMenuProps extends Omit<ReactButtonAttr, ExcludedAttribu
     open?: boolean,
     renderIcon?: any,
     selectorPrimaryFocus?: string,
+    size?: "sm" | "xl",
 }
 
 declare const OverflowMenu: ForwardRefReturn<HTMLButtonElement, OverflowMenuProps>;

--- a/types/carbon-components-react/lib/components/Pagination/Pagination.d.ts
+++ b/types/carbon-components-react/lib/components/Pagination/Pagination.d.ts
@@ -3,6 +3,11 @@ import { ReactDivAttr } from "../../../typings/shared";
 
 type ExcludedAttributes = "id" | "onChange";
 
+export interface PaginationPageSize {
+    text: string,
+    value: string,
+}
+
 export interface PaginationProps extends Omit<ReactDivAttr, ExcludedAttributes> {
     backwardText?: string,
     forwardText?: string,
@@ -20,7 +25,7 @@ export interface PaginationProps extends Omit<ReactDivAttr, ExcludedAttributes> 
     pageNumberText?: string,
     pageRangeText?(current: number, total: number): string,
     pageSize?: number,
-    pageSizes: readonly number[],
+    pageSizes: readonly number[] | readonly PaginationPageSize[],
     pageText?(page: number): string,
     pagesUnknown?: boolean,
     totalItems?: number,

--- a/types/carbon-components-react/lib/components/Tab/Tab.d.ts
+++ b/types/carbon-components-react/lib/components/Tab/Tab.d.ts
@@ -3,7 +3,10 @@ import { ReactLIAttr } from "../../../typings/shared";
 
 type ExcludedAttributes = "aria-controls" | "aria-selected" | "aria-disabled" | "role" | "tabIndex";
 
-export interface TabCustomAnchorProvidedProps {
+export interface TabCustomButtonProvidedProps {
+    "aria-controls": string,
+    "aria-disabled": boolean | undefined,
+    "aria-selected": boolean,
     className: string,
     href: string | undefined,
     id: string | undefined
@@ -11,14 +14,25 @@ export interface TabCustomAnchorProvidedProps {
     tabIndex: number,
 }
 
+/**
+ * @deprecated use TabCustomButtonProvidedProps
+ */
+export interface TabCustomAnchorProviderProps extends TabCustomButtonProvidedProps { }
+
 export interface TabStandaloneProps extends Omit<ReactLIAttr, ExcludedAttributes> {
     disabled?: boolean;
     handleTabClick(index: TabStandaloneProps["index"], event: React.MouseEvent<HTMLLIElement>): void,
     handleTabKeyDown(index: TabStandaloneProps["index"], event: React.KeyboardEvent<HTMLLIElement>): void,
+    /**
+     * @deprecated
+     */
     href?: string,
     index?: number,
     label?: React.ReactNode,
-    renderAnchor?: React.FC<TabCustomAnchorProvidedProps>,
+    /**
+     * @deprecated
+     */
+    renderAnchor?: React.FC<TabCustomButtonProvidedProps>,
     role?: string, // marked as required, but render code overwrites it currently, also has default
     selected: boolean,
 }
@@ -37,6 +51,7 @@ type TabsProvidedPropKeys = "index" | "handleTabClick" | "handleTabKeyDown" | "r
 export interface TabProps extends Omit<TabStandaloneProps, TabsProvidedPropKeys> {
     // only props that are used only by the parent "Tabs" component should go here
     // otherwise they should go in TabStandaloneProps interface
+    // 7.23: doesn't look like this is used anymore
     renderContent?: React.ComponentType<TabCustomContentProvidedProps>;
 }
 

--- a/types/carbon-components-react/lib/components/TabContent/TabContent.d.ts
+++ b/types/carbon-components-react/lib/components/TabContent/TabContent.d.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ReactDivAttr } from "../../../typings/shared";
 
-export interface TabContentProps extends Omit<ReactDivAttr, "aria-live" | "hidden"> {
+export interface TabContentProps extends Omit<ReactDivAttr, "hidden"> {
     selected?: boolean,
 }
 

--- a/types/carbon-components-react/lib/components/TimePicker/TimePicker.d.ts
+++ b/types/carbon-components-react/lib/components/TimePicker/TimePicker.d.ts
@@ -1,13 +1,14 @@
 import * as React from "react";
 import { ReactInputAttr } from "../../../typings/shared";
 
-export interface TimePickerProps extends Omit<ReactInputAttr, "id"> {
+export interface TimePickerProps extends Omit<ReactInputAttr, "id" | "size"> {
     hideLabel?: boolean,
     id: string,
     invalid?: boolean,
     invalidText?: React.ReactNode,
     labelText?: React.ReactNode,
     light?: boolean,
+    size?: "sm" | "xl",
 }
 
 declare class TimePicker extends React.Component<TimePickerProps> { }


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/carbon-design-system/carbon/tree/v10.23.0/packages/react
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
