### PR TITLE
update(dotenv-webpack): version 5 update

### DIFF
--- a/types/dotenv-webpack/dotenv-webpack-tests.ts
+++ b/types/dotenv-webpack/dotenv-webpack-tests.ts
@@ -1,6 +1,7 @@
-import * as webpack from 'webpack';
+import webpack = require('webpack');
 import Dotenv = require('dotenv-webpack');
 import { Options } from 'dotenv-webpack';
+import { Configuration } from 'webpack';
 
 new Dotenv(); // $ExpectType DotenvWebpackPlugin
 
@@ -13,19 +14,14 @@ const optionsFull: Options = {
     systemvars: true,
     silent: true,
     expand: true,
-    defaults: true
+    defaults: true,
 };
 
 const optionsStrings: Options = {
     safe: './some.other.env.example',
-    defaults: './some.other.env.defaults'
+    defaults: './some.other.env.defaults',
 };
 
-const config: webpack.Configuration = {
-    plugins: [
-        new Dotenv(),
-        new Dotenv(optionsEmpty),
-        new Dotenv(optionsFull),
-        new Dotenv(optionsStrings)
-    ]
+const config: Configuration = {
+    plugins: [new Dotenv(), new Dotenv(optionsEmpty), new Dotenv(optionsFull), new Dotenv(optionsStrings)],
 };

--- a/types/dotenv-webpack/index.d.ts
+++ b/types/dotenv-webpack/index.d.ts
@@ -1,66 +1,67 @@
-// Type definitions for dotenv-webpack 3.0
+// Type definitions for dotenv-webpack 5.0
 // Project: https://github.com/mrsteele/dotenv-webpack
 // Definitions by: Karol Majewski <https://github.com/karol-majewski>
 //                 Dave Cardwell <https://github.com/davecardwell>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import * as webpack from 'webpack';
+import { Compiler, WebpackPluginInstance } from 'webpack';
 
 /**
  * A secure webpack plugin that supports dotenv and other environment variables
  * and only exposes what you choose and use.
  */
-declare class DotenvWebpackPlugin extends webpack.Plugin {
-  constructor(options?: DotenvWebpackPlugin.Options);
+declare class DotenvWebpackPlugin implements WebpackPluginInstance {
+    constructor(options?: DotenvWebpackPlugin.Options);
+    apply(compiler: Compiler): void;
 }
 
 declare namespace DotenvWebpackPlugin {
-  interface Options {
-    /**
-     * The path to your environment variables.
-     * @default './.env'.
-     */
-    path?: string;
+    interface Options {
+        /**
+         * The path to your environment variables.
+         * @default './.env'.
+         */
+        path?: string;
 
-    /**
-     * If `false` ignore safe-mode, if `true` load `'./.env.example'`, if a `string` load that file as the sample.
-     * @default false
-     */
-    safe?: boolean | string;
+        /**
+         * If `false` ignore safe-mode, if `true` load `'./.env.example'`, if a `string` load that file as the sample.
+         * @default false
+         */
+        safe?: boolean | string;
 
-    /**
-     * Whether to allow empty strings in safe mode.
-     * If false, will throw an error if any env variables are empty (but only if safe mode is enabled).
-     * @default false
-     */
-    allowEmptyValues?: boolean;
+        /**
+         * Whether to allow empty strings in safe mode.
+         * If false, will throw an error if any env variables are empty (but only if safe mode is enabled).
+         * @default false
+         */
+        allowEmptyValues?: boolean;
 
-    /**
-     * Set to `true` if you would rather load all system variables as well (useful for CI purposes).
-     * @default false
-     */
-    systemvars?: boolean;
+        /**
+         * Set to `true` if you would rather load all system variables as well (useful for CI purposes).
+         * @default false
+         */
+        systemvars?: boolean;
 
-    /**
-     * If `true`, all warnings will be surpressed.
-     * @default false
-     */
-    silent?: boolean;
+        /**
+         * If `true`, all warnings will be surpressed.
+         * @default false
+         */
+        silent?: boolean;
 
-    /**
-     * Allows your variables to be "expanded" for reusability within your .env file.
-     * @default false
-     */
-    expand?: boolean;
+        /**
+         * Allows your variables to be "expanded" for reusability within your .env file.
+         * @default false
+         */
+        expand?: boolean;
 
-    /**
-     * Adds support for dotenv-defaults. If set to `true`, uses `./.env.defaults`. If a `string`, uses that location for a defaults file.
-     * Read more at {@link https://www.npmjs.com/package/dotenv-defaults}.
-     * @default false
-     */
-    defaults?: boolean | string;
-  }
+        /**
+         * Adds support for dotenv-defaults. If set to `true`, uses `./.env.defaults`. If a `string`, uses that location for a defaults file.
+         * Read more at {@link https://www.npmjs.com/package/dotenv-defaults}.
+         * @default false
+         */
+        defaults?: boolean | string;
+    }
 }
 
 export = DotenvWebpackPlugin;


### PR DESCRIPTION
- the package itself external api shap is not changed under the v5, but
  behavior of details is breaking:
https://github.com/mrsteele/dotenv-webpack/compare/v4.0.0...v5.0.0
- take opportunity to update package definition to align with latest
  webpack changes and its own DT types
- DT default formatting applied

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.