### PR TITLE
styled-components: Update forwardedAs to vary from as

### DIFF
--- a/types/styled-components/cssprop.d.ts
+++ b/types/styled-components/cssprop.d.ts
@@ -1,19 +1,19 @@
-import {} from "react";
-import { CSSProp } from ".";
+import {} from 'react';
+import { CSSProp } from '.';
 
-declare module "react" {
-  interface Attributes {
-      // NOTE: unlike the plain javascript version, it is not possible to get access
-      // to the element's own attributes inside function interpolations.
-      // Only theme will be accessible, and only with the DefaultTheme due to the global
-      // nature of this declaration.
-      // If you are writing this inline you already have access to all the attributes anyway,
-      // no need for the extra indirection.
-      /**
-       * If present, this React element will be converted by
-       * `babel-plugin-styled-components` into a styled component
-       * with the given css as its styles.
-       */
-      css?: CSSProp;
-  }
+declare module 'react' {
+    interface Attributes {
+        // NOTE: unlike the plain javascript version, it is not possible to get access
+        // to the element's own attributes inside function interpolations.
+        // Only theme will be accessible, and only with the DefaultTheme due to the global
+        // nature of this declaration.
+        // If you are writing this inline you already have access to all the attributes anyway,
+        // no need for the extra indirection.
+        /**
+         * If present, this React element will be converted by
+         * `babel-plugin-styled-components` into a styled component
+         * with the given css as its styles.
+         */
+        css?: CSSProp;
+    }
 }

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -88,10 +88,11 @@ type WithChildrenIfReactComponentClass<
 
 type StyledComponentPropsWithAs<
     C extends string | React.ComponentType<any>,
+    F extends string | React.ComponentType<any>,
     T extends object,
     O extends object,
     A extends keyof any
-> = StyledComponentProps<C, T, O, A> & { as?: C, forwardedAs?: C };
+> = StyledComponentProps<C, T, O, A> & { as?: C, forwardedAs?: F };
 
 export type FalseyValue = undefined | null | false;
 export type Interpolation<P> =
@@ -176,9 +177,9 @@ export interface StyledComponentBase<
     (
         props: StyledComponentProps<C, T, O, A> & { as?: never, forwardedAs?: never }
       ): React.ReactElement<StyledComponentProps<C, T, O, A>>;
-    <AsC extends string | React.ComponentType<any> = C>(
-      props: StyledComponentPropsWithAs<AsC, T, O, A>
-    ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A>>;
+    <AsC extends string | React.ComponentType<any> = C, FAsC extends string | React.ComponentType<any> = AsC>(
+      props: StyledComponentPropsWithAs<AsC, FAsC, T, O, A>
+    ): React.ReactElement<StyledComponentPropsWithAs<AsC, FAsC, T, O, A>>;
 
     withComponent<WithC extends AnyStyledComponent>(
         component: WithC

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -21,8 +21,8 @@ declare global {
     }
 }
 
-import * as CSS from "csstype";
-import * as React from "react";
+import * as CSS from 'csstype';
+import * as React from 'react';
 import * as hoistNonReactStatics from 'hoist-non-react-statics';
 
 export type CSSProperties = CSS.Properties<string | number>;
@@ -48,15 +48,14 @@ export type IntrinsicElementsKeys = keyof JSX.IntrinsicElements;
 // If declared props have indexed properties, ignore default props entirely as keyof gets widened
 // Wrap in an outer-level conditional type to allow distribution over props that are unions
 type Defaultize<P, D> = P extends any
-    ? string extends keyof P ? P :
-        & Pick<P, Exclude<keyof P, keyof D>>
-        & Partial<Pick<P, Extract<keyof P, keyof D>>>
-        & Partial<Pick<D, Exclude<keyof D, keyof P>>>
+    ? string extends keyof P
+        ? P
+        : Pick<P, Exclude<keyof P, keyof D>> &
+              Partial<Pick<P, Extract<keyof P, keyof D>>> &
+              Partial<Pick<D, Exclude<keyof D, keyof P>>>
     : never;
 
-type ReactDefaultizedProps<C, P> = C extends { defaultProps: infer D; }
-    ? Defaultize<P, D>
-    : P;
+type ReactDefaultizedProps<C, P> = C extends { defaultProps: infer D } ? Defaultize<P, D> : P;
 
 export type StyledComponentProps<
     // The Component from whose props are derived
@@ -70,21 +69,40 @@ export type StyledComponentProps<
 > =
     // Distribute O if O is a union type
     O extends object
-    ? WithOptionalTheme<
-        Omit<ReactDefaultizedProps<C, React.ComponentPropsWithRef<C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never>> & O, A> &
-            Partial<Pick<React.ComponentPropsWithRef<C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never> & O, A>>,
-T
-      > &
-          WithChildrenIfReactComponentClass<C>
-    : never;
+        ? WithOptionalTheme<
+              Omit<
+                  ReactDefaultizedProps<
+                      C,
+                      React.ComponentPropsWithRef<
+                          C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
+                      >
+                  > &
+                      O,
+                  A
+              > &
+                  Partial<
+                      Pick<
+                          React.ComponentPropsWithRef<
+                              C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
+                          > &
+                              O,
+                          A
+                      >
+                  >,
+              T
+          > &
+              WithChildrenIfReactComponentClass<C>
+        : never;
 
 // Because of React typing quirks, when getting props from a React.ComponentClass,
 // we need to manually add a `children` field.
 // See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/31945
 // and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32843
-type WithChildrenIfReactComponentClass<
-    C extends string | React.ComponentType<any>
-> = C extends React.ComponentClass<any> ? { children?: React.ReactNode } : {};
+type WithChildrenIfReactComponentClass<C extends string | React.ComponentType<any>> = C extends React.ComponentClass<
+    any
+>
+    ? { children?: React.ReactNode }
+    : {};
 
 type StyledComponentPropsWithAs<
     C extends string | React.ComponentType<any>,
@@ -92,71 +110,46 @@ type StyledComponentPropsWithAs<
     T extends object,
     O extends object,
     A extends keyof any
-> = StyledComponentProps<C, T, O, A> & { as?: C, forwardedAs?: F };
+> = StyledComponentProps<C, T, O, A> & { as?: C; forwardedAs?: F };
 
 export type FalseyValue = undefined | null | false;
-export type Interpolation<P> =
-    | InterpolationValue
-    | InterpolationFunction<P>
-    | FlattenInterpolation<P>;
+export type Interpolation<P> = InterpolationValue | InterpolationFunction<P> | FlattenInterpolation<P>;
 // cannot be made a self-referential interface, breaks WithPropNested
 // see https://github.com/microsoft/TypeScript/issues/34796
 export type FlattenInterpolation<P> = ReadonlyArray<Interpolation<P>>;
-export type InterpolationValue =
-    | string
-    | number
-    | FalseyValue
-    | Keyframes
-    | StyledComponentInterpolation
-    | CSSObject;
-export type SimpleInterpolation =
-    | InterpolationValue
-    | FlattenSimpleInterpolation;
+export type InterpolationValue = string | number | FalseyValue | Keyframes | StyledComponentInterpolation | CSSObject;
+export type SimpleInterpolation = InterpolationValue | FlattenSimpleInterpolation;
 export type FlattenSimpleInterpolation = ReadonlyArray<SimpleInterpolation>;
 
 export type InterpolationFunction<P> = (props: P) => Interpolation<P>;
 
-type Attrs<P, A extends Partial<P>, T> =
-    | ((props: ThemedStyledProps<P, T>) => A)
-    | A;
+type Attrs<P, A extends Partial<P>, T> = ((props: ThemedStyledProps<P, T>) => A) | A;
 
 export type ThemedGlobalStyledClassProps<P, T> = WithOptionalTheme<P, T> & {
     suppressMultiMountWarning?: boolean;
 };
 
-export interface GlobalStyleComponent<P, T>
-    extends React.ComponentClass<ThemedGlobalStyledClassProps<P, T>> {}
+export interface GlobalStyleComponent<P, T> extends React.ComponentClass<ThemedGlobalStyledClassProps<P, T>> {}
 
 // remove the call signature from StyledComponent so Interpolation can still infer InterpolationFunction
 type StyledComponentInterpolation =
-    | Pick<
-          StyledComponentBase<any, any, any, any>,
-          keyof StyledComponentBase<any, any>
-      >
-    | Pick<
-          StyledComponentBase<any, any, any>,
-          keyof StyledComponentBase<any, any>
-      >;
+    | Pick<StyledComponentBase<any, any, any, any>, keyof StyledComponentBase<any, any>>
+    | Pick<StyledComponentBase<any, any, any>, keyof StyledComponentBase<any, any>>;
 
 // abuse Pick to strip the call signature from ForwardRefExoticComponent
-type ForwardRefExoticBase<P> = Pick<
-    React.ForwardRefExoticComponent<P>,
-    keyof React.ForwardRefExoticComponent<any>
->;
+type ForwardRefExoticBase<P> = Pick<React.ForwardRefExoticComponent<P>, keyof React.ForwardRefExoticComponent<any>>;
 
 // Config to be used with withConfig
 export interface StyledConfig<O extends object = {}> {
     // TODO: Add all types from the original StyledComponentWrapperProperties
-    shouldForwardProp?: (prop: keyof O, defaultValidatorFn: ((prop: keyof O) => boolean)) => boolean;
+    shouldForwardProp?: (prop: keyof O, defaultValidatorFn: (prop: keyof O) => boolean) => boolean;
 }
 
 // extracts React defaultProps
-type ReactDefaultProps<C> = C extends { defaultProps: infer D; } ? D : never;
+type ReactDefaultProps<C> = C extends { defaultProps: infer D } ? D : never;
 
 // any doesn't count as assignable to never in the extends clause, and we default A to never
-export type AnyStyledComponent =
-    | StyledComponent<any, any, any, any>
-    | StyledComponent<any, any, any>;
+export type AnyStyledComponent = StyledComponent<any, any, any, any> | StyledComponent<any, any, any>;
 
 export type StyledComponent<
     C extends string | React.ComponentType<any>,
@@ -165,7 +158,9 @@ export type StyledComponent<
     A extends keyof any = never
 > = // the "string" allows this to be used as an object key
     // I really want to avoid this if possible but it's the only way to use nesting with object styles...
-    string & StyledComponentBase<C, T, O, A> & hoistNonReactStatics.NonReactStatics<C extends React.ComponentType<any> ? C : never>;
+    string &
+        StyledComponentBase<C, T, O, A> &
+        hoistNonReactStatics.NonReactStatics<C extends React.ComponentType<any> ? C : never>;
 
 export interface StyledComponentBase<
     C extends string | React.ComponentType<any>,
@@ -174,25 +169,23 @@ export interface StyledComponentBase<
     A extends keyof any = never
 > extends ForwardRefExoticBase<StyledComponentProps<C, T, O, A>> {
     // add our own fake call signature to implement the polymorphic 'as' prop
-    (
-        props: StyledComponentProps<C, T, O, A> & { as?: never, forwardedAs?: never }
-      ): React.ReactElement<StyledComponentProps<C, T, O, A>>;
+    (props: StyledComponentProps<C, T, O, A> & { as?: never; forwardedAs?: never }): React.ReactElement<
+        StyledComponentProps<C, T, O, A>
+    >;
     <AsC extends string | React.ComponentType<any> = C, FAsC extends string | React.ComponentType<any> = AsC>(
-      props: StyledComponentPropsWithAs<AsC, FAsC, T, O, A>
+        props: StyledComponentPropsWithAs<AsC, FAsC, T, O, A>,
     ): React.ReactElement<StyledComponentPropsWithAs<AsC, FAsC, T, O, A>>;
 
     withComponent<WithC extends AnyStyledComponent>(
-        component: WithC
+        component: WithC,
     ): StyledComponent<
         StyledComponentInnerComponent<WithC>,
         T,
         O & StyledComponentInnerOtherProps<WithC>,
         A | StyledComponentInnerAttrs<WithC>
     >;
-    withComponent<
-        WithC extends keyof JSX.IntrinsicElements | React.ComponentType<any>
-    >(
-        component: WithC
+    withComponent<WithC extends keyof JSX.IntrinsicElements | React.ComponentType<any>>(
+        component: WithC,
     ): StyledComponent<WithC, T, O, A>;
 }
 
@@ -207,27 +200,15 @@ export interface ThemedStyledFunctionBase<
         first:
             | TemplateStringsArray
             | CSSObject
-            | InterpolationFunction<
-                  ThemedStyledProps<StyledComponentPropsWithRef<C> & O, T>
-              >,
-        ...rest: Array<
-            Interpolation<
-                ThemedStyledProps<StyledComponentPropsWithRef<C> & O, T>
-            >
-        >
+            | InterpolationFunction<ThemedStyledProps<StyledComponentPropsWithRef<C> & O, T>>,
+        ...rest: Array<Interpolation<ThemedStyledProps<StyledComponentPropsWithRef<C> & O, T>>>
     ): StyledComponent<C, T, O, A>;
     <U extends object>(
         first:
             | TemplateStringsArray
             | CSSObject
-            | InterpolationFunction<
-                  ThemedStyledProps<StyledComponentPropsWithRef<C> & O & U, T>
-              >,
-        ...rest: Array<
-            Interpolation<
-                ThemedStyledProps<StyledComponentPropsWithRef<C> & O & U, T>
-            >
-        >
+            | InterpolationFunction<ThemedStyledProps<StyledComponentPropsWithRef<C> & O & U, T>>,
+        ...rest: Array<Interpolation<ThemedStyledProps<StyledComponentPropsWithRef<C> & O & U, T>>>
     ): StyledComponent<C, T, O & U, A>;
 }
 
@@ -245,40 +226,53 @@ export interface ThemedStyledFunction<
             [others: string]: any;
         } = {}
     >(
-        attrs: Attrs<StyledComponentPropsWithRef<C> & U, NewA, T>
+        attrs: Attrs<StyledComponentPropsWithRef<C> & U, NewA, T>,
     ): ThemedStyledFunction<C, T, O & NewA, A | keyof NewA>;
 
-    withConfig: <Props extends O = O>(config: StyledConfig<StyledComponentPropsWithRef<C> & Props>) => ThemedStyledFunction<C, T, Props, A>;
+    withConfig: <Props extends O = O>(
+        config: StyledConfig<StyledComponentPropsWithRef<C> & Props>,
+    ) => ThemedStyledFunction<C, T, Props, A>;
 }
 
-export type StyledFunction<
-    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>
-> = ThemedStyledFunction<C, any>;
+export type StyledFunction<C extends keyof JSX.IntrinsicElements | React.ComponentType<any>> = ThemedStyledFunction<
+    C,
+    any
+>;
 
 type ThemedStyledComponentFactories<T extends object> = {
-    [TTag in keyof JSX.IntrinsicElements]: ThemedStyledFunction<TTag, T>
+    [TTag in keyof JSX.IntrinsicElements]: ThemedStyledFunction<TTag, T>;
 };
 
-export type StyledComponentInnerComponent<
-    C extends React.ComponentType<any>
-> = C extends StyledComponent<infer I, any, any, any> ? I :
-    C extends StyledComponent<infer I, any, any> ? I :
-    C;
+export type StyledComponentInnerComponent<C extends React.ComponentType<any>> = C extends StyledComponent<
+    infer I,
+    any,
+    any,
+    any
+>
+    ? I
+    : C extends StyledComponent<infer I, any, any>
+    ? I
+    : C;
 export type StyledComponentPropsWithRef<
     C extends keyof JSX.IntrinsicElements | React.ComponentType<any>
 > = C extends AnyStyledComponent
     ? React.ComponentPropsWithRef<StyledComponentInnerComponent<C>>
     : React.ComponentPropsWithRef<C>;
-export type StyledComponentInnerOtherProps<C extends AnyStyledComponent> =
-    C extends StyledComponent<any, any, infer O, any> ? O :
-    C extends StyledComponent<any, any, infer O> ? O :
-    never;
-export type StyledComponentInnerAttrs<
-    C extends AnyStyledComponent
-> = C extends StyledComponent<any, any, any, infer A> ? A : never;
+export type StyledComponentInnerOtherProps<C extends AnyStyledComponent> = C extends StyledComponent<
+    any,
+    any,
+    infer O,
+    any
+>
+    ? O
+    : C extends StyledComponent<any, any, infer O>
+    ? O
+    : never;
+export type StyledComponentInnerAttrs<C extends AnyStyledComponent> = C extends StyledComponent<any, any, any, infer A>
+    ? A
+    : never;
 
-export interface ThemedBaseStyledInterface<T extends object>
-    extends ThemedStyledComponentFactories<T> {
+export interface ThemedBaseStyledInterface<T extends object> extends ThemedStyledComponentFactories<T> {
     <C extends AnyStyledComponent>(component: C): ThemedStyledFunction<
         StyledComponentInnerComponent<C>,
         T,
@@ -288,66 +282,44 @@ export interface ThemedBaseStyledInterface<T extends object>
     <C extends keyof JSX.IntrinsicElements | React.ComponentType<any>>(
         // unfortunately using a conditional type to validate that it can receive a `theme?: Theme`
         // causes tests to fail in TS 3.1
-        component: C
+        component: C,
     ): ThemedStyledFunction<C, T>;
 }
 
-export type ThemedStyledInterface<T extends object> = ThemedBaseStyledInterface<
-    AnyIfEmpty<T>
->;
+export type ThemedStyledInterface<T extends object> = ThemedBaseStyledInterface<AnyIfEmpty<T>>;
 export type StyledInterface = ThemedStyledInterface<DefaultTheme>;
 
 export interface BaseThemedCssFunction<T extends object> {
+    (first: TemplateStringsArray | CSSObject, ...interpolations: SimpleInterpolation[]): FlattenSimpleInterpolation;
     (
-        first: TemplateStringsArray | CSSObject,
-        ...interpolations: SimpleInterpolation[]
-    ): FlattenSimpleInterpolation;
-    (
-        first:
-            | TemplateStringsArray
-            | CSSObject
-            | InterpolationFunction<ThemedStyledProps<{}, T>>,
+        first: TemplateStringsArray | CSSObject | InterpolationFunction<ThemedStyledProps<{}, T>>,
         ...interpolations: Array<Interpolation<ThemedStyledProps<{}, T>>>
     ): FlattenInterpolation<ThemedStyledProps<{}, T>>;
     <P extends object>(
-        first:
-            | TemplateStringsArray
-            | CSSObject
-            | InterpolationFunction<ThemedStyledProps<P, T>>,
+        first: TemplateStringsArray | CSSObject | InterpolationFunction<ThemedStyledProps<P, T>>,
         ...interpolations: Array<Interpolation<ThemedStyledProps<P, T>>>
     ): FlattenInterpolation<ThemedStyledProps<P, T>>;
 }
 
-export type ThemedCssFunction<T extends object> = BaseThemedCssFunction<
-    AnyIfEmpty<T>
->;
+export type ThemedCssFunction<T extends object> = BaseThemedCssFunction<AnyIfEmpty<T>>;
 
 // Helper type operators
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, "theme"> & {
+type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, 'theme'> & {
     theme?: T;
 };
 type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
 
-export interface ThemedStyledComponentsModule<
-    T extends object,
-    U extends object = T
-> {
+export interface ThemedStyledComponentsModule<T extends object, U extends object = T> {
     default: ThemedStyledInterface<T>;
 
     css: ThemedCssFunction<T>;
 
     // unfortunately keyframes can't interpolate props from the theme
-    keyframes(
-        strings: TemplateStringsArray | CSSKeyframes,
-        ...interpolations: SimpleInterpolation[]
-    ): Keyframes;
+    keyframes(strings: TemplateStringsArray | CSSKeyframes, ...interpolations: SimpleInterpolation[]): Keyframes;
 
     createGlobalStyle<P extends object = {}>(
-        first:
-            | TemplateStringsArray
-            | CSSObject
-            | InterpolationFunction<ThemedStyledProps<P, T>>,
+        first: TemplateStringsArray | CSSObject | InterpolationFunction<ThemedStyledProps<P, T>>,
         ...interpolations: Array<Interpolation<ThemedStyledProps<P, T>>>
     ): GlobalStyleComponent<P, T>;
 
@@ -368,18 +340,12 @@ declare const styled: StyledInterface;
 
 export const css: ThemedCssFunction<DefaultTheme>;
 
-export type BaseWithThemeFnInterface<T extends object> = <
-    C extends React.ComponentType<any>
->(
+export type BaseWithThemeFnInterface<T extends object> = <C extends React.ComponentType<any>>(
     // this check is roundabout because the extends clause above would
     // not allow any component that accepts _more_ than theme as a prop
-    component: React.ComponentProps<C> extends { theme?: T } ? C : never
-) => React.ForwardRefExoticComponent<
-    WithOptionalTheme<React.ComponentPropsWithRef<C>, T>
->;
-export type WithThemeFnInterface<T extends object> = BaseWithThemeFnInterface<
-    AnyIfEmpty<T>
->;
+    component: React.ComponentProps<C> extends { theme?: T } ? C : never,
+) => React.ForwardRefExoticComponent<WithOptionalTheme<React.ComponentPropsWithRef<C>, T>>;
+export type WithThemeFnInterface<T extends object> = BaseWithThemeFnInterface<AnyIfEmpty<T>>;
 export const withTheme: WithThemeFnInterface<DefaultTheme>;
 
 export function useTheme(): DefaultTheme;
@@ -397,18 +363,17 @@ export interface ThemeProviderProps<T extends object, U extends object = T> {
     children?: React.ReactNode;
     theme: T | ((theme: U) => T);
 }
-export type BaseThemeProviderComponent<
-    T extends object,
-    U extends object = T
-> = React.ComponentClass<ThemeProviderProps<T, U>>;
-export type ThemeProviderComponent<
-    T extends object,
-    U extends object = T
-> = BaseThemeProviderComponent<AnyIfEmpty<T>, AnyIfEmpty<U>>;
+export type BaseThemeProviderComponent<T extends object, U extends object = T> = React.ComponentClass<
+    ThemeProviderProps<T, U>
+>;
+export type ThemeProviderComponent<T extends object, U extends object = T> = BaseThemeProviderComponent<
+    AnyIfEmpty<T>,
+    AnyIfEmpty<U>
+>;
 export const ThemeProvider: ThemeProviderComponent<AnyIfEmpty<DefaultTheme>>;
 // NOTE: this technically starts as undefined, but allowing undefined is unhelpful when used correctly
 export const ThemeContext: React.Context<AnyIfEmpty<DefaultTheme>>;
-export const ThemeConsumer: typeof ThemeContext["Consumer"];
+export const ThemeConsumer: typeof ThemeContext['Consumer'];
 
 export interface Keyframes {
     getName(): string;
@@ -420,27 +385,18 @@ export function keyframes(
 ): Keyframes;
 
 export function createGlobalStyle<P extends object = {}>(
-    first:
-        | TemplateStringsArray
-        | CSSObject
-        | InterpolationFunction<ThemedStyledProps<P, DefaultTheme>>,
+    first: TemplateStringsArray | CSSObject | InterpolationFunction<ThemedStyledProps<P, DefaultTheme>>,
     ...interpolations: Array<Interpolation<ThemedStyledProps<P, DefaultTheme>>>
 ): GlobalStyleComponent<P, DefaultTheme>;
 
-export function isStyledComponent(
-    target: any
-): target is StyledComponent<any, any>;
+export function isStyledComponent(target: any): target is StyledComponent<any, any>;
 
 export class ServerStyleSheet {
-    collectStyles(
-        tree: React.ReactNode
-    ): React.ReactElement<{ sheet: ServerStyleSheet }>;
+    collectStyles(tree: React.ReactNode): React.ReactElement<{ sheet: ServerStyleSheet }>;
 
     getStyleTags(): string;
     getStyleElement(): Array<React.ReactElement<{}>>;
-    interleaveWithNodeStream(
-        readableStream: NodeJS.ReadableStream
-    ): NodeJS.ReadableStream;
+    interleaveWithNodeStream(readableStream: NodeJS.ReadableStream): NodeJS.ReadableStream;
     readonly instance: this;
     seal(): void;
 }
@@ -463,9 +419,7 @@ export interface StyleSheetManagerProps {
     target?: HTMLElement;
 }
 
-export class StyleSheetManager extends React.Component<
-    StyleSheetManagerProps
-> {}
+export class StyleSheetManager extends React.Component<StyleSheetManagerProps> {}
 
 /**
  * The CSS prop is not declared by default in the types as it would cause 'css' to be present
@@ -494,9 +448,6 @@ export class StyleSheetManager extends React.Component<
  * ```
  */
 // ONLY string literals and inline invocations of css`` are supported, anything else crashes the plugin
-export type CSSProp<T = AnyIfEmpty<DefaultTheme>> =
-    | string
-    | CSSObject
-    | FlattenInterpolation<ThemeProps<T>>;
+export type CSSProp<T = AnyIfEmpty<DefaultTheme>> = string | CSSObject | FlattenInterpolation<ThemeProps<T>>;
 
 export default styled;

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -106,10 +106,10 @@ type WithChildrenIfReactComponentClass<C extends string | React.ComponentType<an
 
 type StyledComponentPropsWithAs<
     C extends string | React.ComponentType<any>,
-    F extends string | React.ComponentType<any>,
     T extends object,
     O extends object,
-    A extends keyof any
+    A extends keyof any,
+    F extends string | React.ComponentType<any> = C
 > = StyledComponentProps<C, T, O, A> & { as?: C; forwardedAs?: F };
 
 export type FalseyValue = undefined | null | false;
@@ -173,8 +173,8 @@ export interface StyledComponentBase<
         StyledComponentProps<C, T, O, A>
     >;
     <AsC extends string | React.ComponentType<any> = C, FAsC extends string | React.ComponentType<any> = AsC>(
-        props: StyledComponentPropsWithAs<AsC, FAsC, T, O, A>,
-    ): React.ReactElement<StyledComponentPropsWithAs<AsC, FAsC, T, O, A>>;
+        props: StyledComponentPropsWithAs<AsC, T, O, A, FAsC>,
+    ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A, FAsC>>;
 
     withComponent<WithC extends AnyStyledComponent>(
         component: WithC,

--- a/types/styled-components/native.d.ts
+++ b/types/styled-components/native.d.ts
@@ -2,36 +2,36 @@ import * as ReactNative from 'react-native';
 import * as React from 'react';
 
 export {
-  css,
-  DefaultTheme,
-  isStyledComponent,
-  ThemeConsumer,
-  ThemeContext,
-  ThemeProps,
-  ThemeProvider,
-  withTheme,
-  useTheme,
+    css,
+    DefaultTheme,
+    isStyledComponent,
+    ThemeConsumer,
+    ThemeContext,
+    ThemeProps,
+    ThemeProvider,
+    withTheme,
+    useTheme,
 } from './index';
 
 import {
-  AnyStyledComponent,
-  DefaultTheme,
-  isStyledComponent,
-  StyledComponentInnerAttrs,
-  StyledComponentInnerComponent,
-  StyledComponentInnerOtherProps,
-  ThemedCssFunction,
-  ThemedStyledFunction,
-  ThemedStyledInterface,
-  ThemeProviderComponent,
-  WithThemeFnInterface
+    AnyStyledComponent,
+    DefaultTheme,
+    isStyledComponent,
+    StyledComponentInnerAttrs,
+    StyledComponentInnerComponent,
+    StyledComponentInnerOtherProps,
+    ThemedCssFunction,
+    ThemedStyledFunction,
+    ThemedStyledInterface,
+    ThemeProviderComponent,
+    WithThemeFnInterface,
 } from './index';
 
 type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
 
 export type ReactNativeThemedStyledFunction<
-  C extends React.ComponentType<any>,
-  T extends object,
+    C extends React.ComponentType<any>,
+    T extends object
 > = ThemedStyledFunction<C, T>;
 
 // Copied over from "ThemedBaseStyledInterface" in index.d.ts in order to remove DOM element typings
@@ -45,193 +45,68 @@ interface ReactNativeThemedBaseStyledInterface<T extends object> {
     <C extends React.ComponentType<any>>(
         // unfortunately using a conditional type to validate that it can receive a `theme?: Theme`
         // causes tests to fail in TS 3.1
-        component: C
+        component: C,
     ): ThemedStyledFunction<C, T>;
 }
 
-type ReactNativeThemedStyledInterface<T extends object> = ReactNativeThemedBaseStyledInterface<
-    AnyIfEmpty<T>
->;
+type ReactNativeThemedStyledInterface<T extends object> = ReactNativeThemedBaseStyledInterface<AnyIfEmpty<T>>;
 
 export interface ReactNativeStyledInterface<T extends object> extends ReactNativeThemedStyledInterface<T> {
-  ActivityIndicator: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ActivityIndicator,
-    T
-  >;
-  ActivityIndicatorIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ActivityIndicator,
-    T
-  >;
-  Button: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Button,
-    T
-  >;
-  DatePickerIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.DatePickerIOS,
-    T
-  >;
-  DrawerLayoutAndroid: ReactNativeThemedStyledFunction<
-    typeof ReactNative.DrawerLayoutAndroid,
-    T
-  >;
-  Image: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Image,
-    T
-  >;
-  ImageBackground: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ImageBackground,
-    T
-  >;
-  KeyboardAvoidingView: ReactNativeThemedStyledFunction<
-    typeof ReactNative.KeyboardAvoidingView,
-    T
-  >;
-  ListView: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ListView,
-    T
-  >;
-  Modal: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Modal,
-    T
-  >;
-  NavigatorIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.NavigatorIOS,
-    T
-  >;
-  Picker: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Picker,
-    T
-  >;
-  PickerIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.PickerIOS,
-    T
-  >;
-  ProgressBarAndroid: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ProgressBarAndroid,
-    T
-  >;
-  ProgressViewIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ProgressViewIOS,
-    T
-  >;
-  ScrollView: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ScrollView,
-    T
-  >;
-  SegmentedControlIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.SegmentedControlIOS,
-    T
-  >;
-  Slider: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Slider,
-    T
-  >;
-  SliderIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Slider,
-    T
-  >;
-  SnapshotViewIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.SnapshotViewIOS,
-    T
-  >;
-  Switch: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Switch,
-    T
-  >;
-  RecyclerViewBackedScrollView: ReactNativeThemedStyledFunction<
-    typeof ReactNative.RecyclerViewBackedScrollView,
-    T
-  >;
-  RefreshControl: ReactNativeThemedStyledFunction<
-    typeof ReactNative.RefreshControl,
-    T
-  >;
-  SafeAreaView: ReactNativeThemedStyledFunction<
-    typeof ReactNative.SafeAreaView,
-    T
-  >;
-  StatusBar: ReactNativeThemedStyledFunction<
-    typeof ReactNative.StatusBar,
-    T
-  >;
-  SwipeableListView: ReactNativeThemedStyledFunction<
-    typeof ReactNative.SwipeableListView,
-    T
-  >;
-  SwitchAndroid: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Switch,
-    T
-  >;
-  SwitchIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.SwitchIOS,
-    T
-  >;
-  TabBarIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.TabBarIOS,
-    T
-  >;
-  Text: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Text,
-    T
-  >;
-  TextInput: ReactNativeThemedStyledFunction<
-    typeof ReactNative.TextInput,
-    T
-  >;
-  ToolbarAndroid: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ToolbarAndroid,
-    T
-  >;
-  TouchableHighlight: ReactNativeThemedStyledFunction<
-    typeof ReactNative.TouchableHighlight,
-    T
-  >;
-  TouchableNativeFeedback: ReactNativeThemedStyledFunction<
-    typeof ReactNative.TouchableNativeFeedback,
-    T
-  >;
-  TouchableOpacity: ReactNativeThemedStyledFunction<
-    typeof ReactNative.TouchableOpacity,
-    T
-  >;
-  TouchableWithoutFeedback: ReactNativeThemedStyledFunction<
-    typeof ReactNative.TouchableWithoutFeedback,
-    T
-  >;
-  View: ReactNativeThemedStyledFunction<
-    typeof ReactNative.View,
-    T
-  >;
-  ViewPagerAndroid: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ViewPagerAndroid,
-    T
-  >;
-  FlatList: ReactNativeThemedStyledFunction<
-    typeof ReactNative.FlatList,
-    T
-  >;
-  SectionList: ReactNativeThemedStyledFunction<
-    typeof ReactNative.SectionList,
-    T
-  >;
+    ActivityIndicator: ReactNativeThemedStyledFunction<typeof ReactNative.ActivityIndicator, T>;
+    ActivityIndicatorIOS: ReactNativeThemedStyledFunction<typeof ReactNative.ActivityIndicator, T>;
+    Button: ReactNativeThemedStyledFunction<typeof ReactNative.Button, T>;
+    DatePickerIOS: ReactNativeThemedStyledFunction<typeof ReactNative.DatePickerIOS, T>;
+    DrawerLayoutAndroid: ReactNativeThemedStyledFunction<typeof ReactNative.DrawerLayoutAndroid, T>;
+    Image: ReactNativeThemedStyledFunction<typeof ReactNative.Image, T>;
+    ImageBackground: ReactNativeThemedStyledFunction<typeof ReactNative.ImageBackground, T>;
+    KeyboardAvoidingView: ReactNativeThemedStyledFunction<typeof ReactNative.KeyboardAvoidingView, T>;
+    ListView: ReactNativeThemedStyledFunction<typeof ReactNative.ListView, T>;
+    Modal: ReactNativeThemedStyledFunction<typeof ReactNative.Modal, T>;
+    NavigatorIOS: ReactNativeThemedStyledFunction<typeof ReactNative.NavigatorIOS, T>;
+    Picker: ReactNativeThemedStyledFunction<typeof ReactNative.Picker, T>;
+    PickerIOS: ReactNativeThemedStyledFunction<typeof ReactNative.PickerIOS, T>;
+    ProgressBarAndroid: ReactNativeThemedStyledFunction<typeof ReactNative.ProgressBarAndroid, T>;
+    ProgressViewIOS: ReactNativeThemedStyledFunction<typeof ReactNative.ProgressViewIOS, T>;
+    ScrollView: ReactNativeThemedStyledFunction<typeof ReactNative.ScrollView, T>;
+    SegmentedControlIOS: ReactNativeThemedStyledFunction<typeof ReactNative.SegmentedControlIOS, T>;
+    Slider: ReactNativeThemedStyledFunction<typeof ReactNative.Slider, T>;
+    SliderIOS: ReactNativeThemedStyledFunction<typeof ReactNative.Slider, T>;
+    SnapshotViewIOS: ReactNativeThemedStyledFunction<typeof ReactNative.SnapshotViewIOS, T>;
+    Switch: ReactNativeThemedStyledFunction<typeof ReactNative.Switch, T>;
+    RecyclerViewBackedScrollView: ReactNativeThemedStyledFunction<typeof ReactNative.RecyclerViewBackedScrollView, T>;
+    RefreshControl: ReactNativeThemedStyledFunction<typeof ReactNative.RefreshControl, T>;
+    SafeAreaView: ReactNativeThemedStyledFunction<typeof ReactNative.SafeAreaView, T>;
+    StatusBar: ReactNativeThemedStyledFunction<typeof ReactNative.StatusBar, T>;
+    SwipeableListView: ReactNativeThemedStyledFunction<typeof ReactNative.SwipeableListView, T>;
+    SwitchAndroid: ReactNativeThemedStyledFunction<typeof ReactNative.Switch, T>;
+    SwitchIOS: ReactNativeThemedStyledFunction<typeof ReactNative.SwitchIOS, T>;
+    TabBarIOS: ReactNativeThemedStyledFunction<typeof ReactNative.TabBarIOS, T>;
+    Text: ReactNativeThemedStyledFunction<typeof ReactNative.Text, T>;
+    TextInput: ReactNativeThemedStyledFunction<typeof ReactNative.TextInput, T>;
+    ToolbarAndroid: ReactNativeThemedStyledFunction<typeof ReactNative.ToolbarAndroid, T>;
+    TouchableHighlight: ReactNativeThemedStyledFunction<typeof ReactNative.TouchableHighlight, T>;
+    TouchableNativeFeedback: ReactNativeThemedStyledFunction<typeof ReactNative.TouchableNativeFeedback, T>;
+    TouchableOpacity: ReactNativeThemedStyledFunction<typeof ReactNative.TouchableOpacity, T>;
+    TouchableWithoutFeedback: ReactNativeThemedStyledFunction<typeof ReactNative.TouchableWithoutFeedback, T>;
+    View: ReactNativeThemedStyledFunction<typeof ReactNative.View, T>;
+    ViewPagerAndroid: ReactNativeThemedStyledFunction<typeof ReactNative.ViewPagerAndroid, T>;
+    FlatList: ReactNativeThemedStyledFunction<typeof ReactNative.FlatList, T>;
+    SectionList: ReactNativeThemedStyledFunction<typeof ReactNative.SectionList, T>;
 }
 
-export interface ReactNativeThemedStyledComponentsModule<
-  T extends object,
-  U extends object = T
-> {
-  default: ReactNativeStyledInterface<T>;
+export interface ReactNativeThemedStyledComponentsModule<T extends object, U extends object = T> {
+    default: ReactNativeStyledInterface<T>;
 
-  css: ThemedCssFunction<T>;
+    css: ThemedCssFunction<T>;
 
-  withTheme: WithThemeFnInterface<T>;
-  ThemeProvider: ThemeProviderComponent<T, U>;
-  ThemeConsumer: React.Consumer<T>;
-  ThemeContext: React.Context<T>;
-  useTheme(): T;
+    withTheme: WithThemeFnInterface<T>;
+    ThemeProvider: ThemeProviderComponent<T, U>;
+    ThemeConsumer: React.Consumer<T>;
+    ThemeContext: React.Context<T>;
+    useTheme(): T;
 
-  // This could be made to assert `target is StyledComponent<any, T>` instead, but that feels not type safe
-  isStyledComponent: typeof isStyledComponent;
+    // This could be made to assert `target is StyledComponent<any, T>` instead, but that feels not type safe
+    isStyledComponent: typeof isStyledComponent;
 }
 
 declare const styled: ReactNativeStyledInterface<DefaultTheme>;

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
-import * as ReactDOMServer from "react-dom/server";
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import * as ReactDOMServer from 'react-dom/server';
 
 import styled, {
     css,
@@ -17,9 +17,9 @@ import styled, {
     ThemedStyledComponentsModule,
     FlattenSimpleInterpolation,
     SimpleInterpolation,
-    FlattenInterpolation
-} from "styled-components";
-import {} from "styled-components/cssprop";
+    FlattenInterpolation,
+} from 'styled-components';
+import {} from 'styled-components/cssprop';
 
 /**
  * general usage
@@ -77,8 +77,8 @@ const TomatoButton = styled(MyButton)`
 
 const CustomizableButton = styled(MyButton)`
     /* Adapt the colors based on primary prop */
-    background: ${props => (props.primary ? "palevioletred" : "white")};
-    color: ${props => (props.primary ? "white" : "palevioletred")};
+    background: ${props => (props.primary ? 'palevioletred' : 'white')};
+    color: ${props => (props.primary ? 'white' : 'palevioletred')};
 
     font-size: 1em;
     margin: 1em;
@@ -91,7 +91,7 @@ const example = css`
     font-size: 1.5em;
     text-align: center;
     color: ${props => props.theme.primary};
-    border-color: ${"red"};
+    border-color: ${'red'};
 `;
 
 const fadeIn = keyframes`
@@ -127,7 +127,7 @@ const ComponentWithKeyframe = styled.div`
 `;
 
 const theme = {
-    main: "mediumseagreen"
+    main: 'mediumseagreen',
 };
 
 const ExampleGlobalStyle = createGlobalStyle`
@@ -148,9 +148,7 @@ class Example extends React.Component {
                 <>
                     <ExampleGlobalStyle />
                     <Wrapper>
-                        <Title>
-                            Hello World, this is my first styled component!
-                        </Title>
+                        <Title>Hello World, this is my first styled component!</Title>
 
                         <Input placeholder="@mxstbr" type="text" />
                         <TomatoButton name="demo" />
@@ -163,13 +161,13 @@ class Example extends React.Component {
 
 // css which only uses simple interpolations without functions
 const cssWithValues1 = css`
-    font-size: ${14} ${"pt"};
+    font-size: ${14} ${'pt'};
 `;
 // css which uses other simple interpolations without functions
 const cssWithValues2 = css`
-  ${cssWithValues1}
-  ${[cssWithValues1, cssWithValues1]}
-  font-weight: ${"bold"};
+    ${cssWithValues1}
+    ${[cssWithValues1, cssWithValues1]}
+  font-weight: ${'bold'};
 `;
 
 // css which uses function interpolations with common props
@@ -177,18 +175,18 @@ const cssWithFunc1 = css`
     font-size: ${props => props.theme.fontSizePt}pt;
 `;
 const cssWithFunc2 = css`
-  ${cssWithFunc1}
-  ${props => cssWithFunc1}
+    ${cssWithFunc1}
+    ${props => cssWithFunc1}
   ${[cssWithFunc1, cssWithValues1]}
 `;
 // such css can be used in styled components
 const styledButton = styled.button`
-  ${cssWithValues1} ${[cssWithValues1, cssWithValues2]}
+    ${cssWithValues1} ${[cssWithValues1, cssWithValues2]}
   ${cssWithFunc1} ${[cssWithFunc1, cssWithFunc2]}
   ${() => [cssWithFunc1, cssWithFunc2]}
 `;
 
-const name = "hey";
+const name = 'hey';
 
 const ThemedMyButton = withTheme(MyButton);
 <ThemedMyButton name={name} />;
@@ -220,14 +218,12 @@ const Article = styled.section`
         color: green;
     }
     ${p => (p.theme.useAlternativeLink ? AlternativeLink : Link)} {
-        color: black
+        color: black;
     }
 `;
 
 // A Link instance should be backed by an HTMLAnchorElement
-const ComposedLink = () => (
-    <Link onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined} />
-);
+const ComposedLink = () => <Link onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined} />;
 
 /**
  * construction via string tag
@@ -235,18 +231,14 @@ const ComposedLink = () => (
 
 // Create a <LinkFromString> react component that renders an <a> which is
 // centered, palevioletred and sized at 1.5em
-const LinkFromString = styled("a")`
+const LinkFromString = styled('a')`
     font-size: 1.5em;
     text-align: center;
     color: palevioletred;
 `;
 
 // A LinkFromString instance should be backed by an HTMLAnchorElement
-const MyOtherComponent = () => (
-    <LinkFromString
-        onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined}
-    />
-);
+const MyOtherComponent = () => <LinkFromString onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined} />;
 
 // Create a <LinkFromStringWithProps> react component that renders an <a>
 // which takes extra props
@@ -254,26 +246,23 @@ interface LinkProps {
     canClick: boolean;
 }
 
-const LinkFromStringWithProps = styled("a")`
+const LinkFromStringWithProps = styled('a')`
     font-size: 1.5em;
     text-align: center;
-    color: ${(a: LinkProps) => (a.canClick ? "palevioletred" : "gray")};
+    color: ${(a: LinkProps) => (a.canClick ? 'palevioletred' : 'gray')};
 `;
 
 // A LinkFromStringWithProps instance should be backed by an HTMLAnchorElement
 const MyOtherComponentWithProps = () => (
-    <LinkFromStringWithProps
-        canClick={false}
-        onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined}
-    />
+    <LinkFromStringWithProps canClick={false} onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined} />
 );
 
 // Create a <LinkFromStringWithPropsAndGenerics> react component that renders an <a>
 // which takes extra props passed as a generic type argument
-const LinkFromStringWithPropsAndGenerics = styled("a")<LinkProps>`
+const LinkFromStringWithPropsAndGenerics = styled('a')<LinkProps>`
     font-size: 1.5em;
     text-align: center;
-    color: ${a => (a.canClick ? "palevioletred" : "gray")};
+    color: ${a => (a.canClick ? 'palevioletred' : 'gray')};
 `;
 
 // A LinkFromStringWithPropsAndGenerics instance should be backed by an HTMLAnchorElement
@@ -293,19 +282,19 @@ interface ObjectStyleProps {
 }
 
 const functionReturningStyleObject = (props: ObjectStyleProps) => ({
-    padding: props.size === "big" ? "10px" : 2
+    padding: props.size === 'big' ? '10px' : 2,
 });
 
 const ObjectStylesBox = styled.div`
     ${functionReturningStyleObject} ${{
-        backgroundColor: "red",
+        backgroundColor: 'red',
 
         // Supports nested objects (pseudo selectors, media queries, etc)
-        "@media screen and (min-width: 800px)": {
-            backgroundColor: "blue"
+        '@media screen and (min-width: 800px)': {
+            backgroundColor: 'blue',
         },
 
-        fontSize: 2
+        fontSize: 2,
     }};
 `;
 <ObjectStylesBox size="big" />;
@@ -316,11 +305,11 @@ const ObjectStylesBox = styled.div`
 
 const AttrsInput = styled.input.attrs({
     // we can define static props
-    type: "password",
+    type: 'password',
 
     // or we can define dynamic ones
-    margin: (props: any) => (props.size as string) || "1em",
-    padding: (props: any) => (props.size as string) || "1em"
+    margin: (props: any) => (props.size as string) || '1em',
+    padding: (props: any) => (props.size as string) || '1em',
 })`
     color: palevioletred;
     font-size: 1em;
@@ -333,12 +322,12 @@ const AttrsInput = styled.input.attrs({
 `;
 
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30042
-const AttrsWithOnlyNewProps = styled.h2.attrs({ as: "h1" })`
-    color: ${props => (props.as === "h1" ? "red" : "blue")};
-    font-size: ${props => (props.as === "h1" ? 2 : 1)};
+const AttrsWithOnlyNewProps = styled.h2.attrs({ as: 'h1' })`
+    color: ${props => (props.as === 'h1' ? 'red' : 'blue')};
+    font-size: ${props => (props.as === 'h1' ? 2 : 1)};
 `;
 
-const AttrsInputExtra = styled(AttrsInput).attrs({ autoComplete: "off" })``;
+const AttrsInputExtra = styled(AttrsInput).attrs({ autoComplete: 'off' })``;
 <AttrsInputExtra />;
 
 /**
@@ -350,16 +339,16 @@ const AttrsInputExtra = styled(AttrsInput).attrs({ autoComplete: "off" })``;
  */
 
 // $ExpectError
-const WithConfig = styled("div").withConfig()`
+const WithConfig = styled('div').withConfig()`
     color: red;
 `;
 
-styled("div").withConfig({})`
+styled('div').withConfig({})`
     color: red;
 `;
 
-styled("div").withConfig<{ myProp: boolean }>({
-    shouldForwardProp: (prop, defaultValidatorFn) => prop === "myProp",
+styled('div').withConfig<{ myProp: boolean }>({
+    shouldForwardProp: (prop, defaultValidatorFn) => prop === 'myProp',
 })<{ otherProp: string }>`
     color: red;
     ${p => {
@@ -374,8 +363,8 @@ styled("div").withConfig<{ myProp: boolean }>({
     }}
 `;
 
-styled("input").withConfig({
-    shouldForwardProp: (prop) => prop === "disabled",
+styled('input').withConfig({
+    shouldForwardProp: prop => prop === 'disabled',
 })`
     color: red;
 `;
@@ -392,13 +381,13 @@ styled('div').withConfig({
     color: red;
 `;
 
-styled("div").withConfig<{ test: boolean }>({
+styled('div').withConfig<{ test: boolean }>({
     // $ExpectError
-    shouldForwardProp: (prop, defaultValidatorFn) => prop === "invalidProp" && true,
+    shouldForwardProp: (prop, defaultValidatorFn) => prop === 'invalidProp' && true,
 })`
-   color: red;
-   ${p => p.test && css``}
-   ${p => p.invalidProp && css``} // $ExpectError
+    color: red;
+    ${p => p.test && css``}
+    ${p => p.invalidProp && css``} // $ExpectError
 `;
 
 /**
@@ -437,14 +426,14 @@ const ThemedButton = styled.button`
 
 // Define our `fg` and `bg` on the theme
 const theme2 = {
-    fg: "palevioletred",
-    bg: "white"
+    fg: 'palevioletred',
+    bg: 'white',
 };
 
 // This theme swaps `fg` and `bg`
 const invertTheme = ({ fg, bg }: { fg: string; bg: string }) => ({
     fg: bg,
-    bg: fg
+    bg: fg,
 });
 
 const MyApp = (
@@ -467,7 +456,7 @@ class MyComponent extends React.Component<ThemeProps<{}>> {
     render() {
         const { theme } = this.props;
 
-        console.log("Current theme: ", theme);
+        console.log('Current theme: ', theme);
 
         return <h1>Hello</h1>;
     }
@@ -475,10 +464,12 @@ class MyComponent extends React.Component<ThemeProps<{}>> {
 
 const ThemedMyComponent = withTheme(MyComponent);
 
-<ThemedMyComponent ref={ref => {
-    // $ExpectType MyComponent | null
-    ref;
-}}/>;
+<ThemedMyComponent
+    ref={ref => {
+        // $ExpectType MyComponent | null
+        ref;
+    }}
+/>;
 const themedRef = React.createRef<MyComponent>();
 <ThemedMyComponent ref={themedRef} />;
 
@@ -489,13 +480,11 @@ interface WithThemeProps {
     text: string;
 }
 
-const Component = (props: WithThemeProps) => (
-    <div style={{ color: props.theme.color }}>{props.text}</div>
-);
+const Component = (props: WithThemeProps) => <div style={{ color: props.theme.color }}>{props.text}</div>;
 
 const ComponentWithTheme = withTheme(Component);
-<ComponentWithTheme text={"hi"} />; // ok
-<ComponentWithTheme text={"hi"} theme={{ color: "red" }} />; // ok
+<ComponentWithTheme text={'hi'} />; // ok
+<ComponentWithTheme text={'hi'} theme={{ color: 'red' }} />; // ok
 <ThemeConsumer>{theme => <Component text="hi" theme={theme} />}</ThemeConsumer>;
 
 /**
@@ -515,7 +504,7 @@ class ClassComponent extends React.Component {
 isStyledComponent(StyledComponent);
 isStyledComponent(StatelessComponent);
 isStyledComponent(ClassComponent);
-isStyledComponent("div");
+isStyledComponent('div');
 
 /**
  * server side rendering
@@ -546,9 +535,7 @@ const css2 = sheet2.getStyleElement();
 
 const sheet3 = new ServerStyleSheet();
 const appStream = ReactDOMServer.renderToNodeStream(<Title>Hello world</Title>);
-const wrappedCssStream: NodeJS.ReadableStream = sheet3.interleaveWithNodeStream(
-    appStream
-);
+const wrappedCssStream: NodeJS.ReadableStream = sheet3.interleaveWithNodeStream(appStream);
 
 /**
  * StyledComponent.withComponent
@@ -588,54 +575,46 @@ class Random extends React.Component<any, any> {
     }
 }
 
-const WithComponentH2 = WithComponentH1.withComponent("h2");
-const WithComponentAbbr = WithComponentH1.withComponent("abbr");
+const WithComponentH2 = WithComponentH1.withComponent('h2');
+const WithComponentAbbr = WithComponentH1.withComponent('abbr');
 
-const WithComponentAnchor = WithComponentH1.withComponent("a");
+const WithComponentAnchor = WithComponentH1.withComponent('a');
 const AnchorContainer = () => (
-    <WithComponentAnchor href="https://example.com">
-        withComponent Anchor
-    </WithComponentAnchor>
+    <WithComponentAnchor href="https://example.com">withComponent Anchor</WithComponentAnchor>
 );
 
 const WithComponentRandomHeading = WithComponentH1.withComponent(Random);
 
-const WithComponentCompA: React.SFC<{ a: number; className?: string }> = ({
-    className
-}) => <div className={className} />;
-const WithComponentCompB: React.SFC<{ b: number; className?: string }> = ({
-    className
-}) => <div className={className} />;
+const WithComponentCompA: React.SFC<{ a: number; className?: string }> = ({ className }) => (
+    <div className={className} />
+);
+const WithComponentCompB: React.SFC<{ b: number; className?: string }> = ({ className }) => (
+    <div className={className} />
+);
 const WithComponentStyledA = styled(WithComponentCompA)`
     color: ${(props: { color: string }) => props.color};
 `;
 
 const WithComponentFirstStyledA = styled(WithComponentStyledA).attrs({
-    a: 1
+    a: 1,
 })``;
 
-const WithComponentFirstStyledB = WithComponentFirstStyledA.withComponent(
-    WithComponentCompB
-);
+const WithComponentFirstStyledB = WithComponentFirstStyledA.withComponent(WithComponentCompB);
 
-const WithComponentFirstStyledANew = styled(WithComponentStyledA).attrs(
-    props => ({ a: 1 })
-)``;
+const WithComponentFirstStyledANew = styled(WithComponentStyledA).attrs(props => ({ a: 1 }))``;
 
 const test = () => [
-    <WithComponentFirstStyledA color={"black"} />,
-    <WithComponentFirstStyledB b={2} color={"black"} />,
-    <WithComponentFirstStyledANew color={"black"} />
+    <WithComponentFirstStyledA color={'black'} />,
+    <WithComponentFirstStyledB b={2} color={'black'} />,
+    <WithComponentFirstStyledANew color={'black'} />,
 ];
 
-const WithComponentRequired = styled((props: { to: string }) => (
-    <a href={props.to} />
-))``;
+const WithComponentRequired = styled((props: { to: string }) => <a href={props.to} />)``;
 // These tests pass in tsservice, but they fail in dtslint. I do not know why.
 // <WithComponentRequired href=''/>; // $ExpectError
 // <WithComponentRequired to=''/>;
 
-const WithComponentRequired2 = WithComponentRequired.withComponent("a");
+const WithComponentRequired2 = WithComponentRequired.withComponent('a');
 // These tests pass in tsservice, but they fail in dtslint. I do not know why.
 // <WithComponentRequired2 href=''/>;
 // <WithComponentRequired2 to=''/>; // $ExpectError
@@ -659,34 +638,26 @@ const forwardedAsTest = (
 );
 
 type ExternalAsComponentProps = {
-  as?: string | React.ComponentType<any>;
-  type: "primitive" | "complex";
+    as?: string | React.ComponentType<any>;
+    type: 'primitive' | 'complex';
 };
 const ExternalAsComponent: React.FC<ExternalAsComponentProps> = () => null;
 const WrappedExternalAsComponent = styled(ExternalAsComponent)``;
 const ForwardedAsWithWrappedExternalTest = (
-  <>
-    <WrappedExternalAsComponent forwardedAs="h2" type="primitive" />
-    <WrappedExternalAsComponent forwardedAs={WithComponentH2} type="complex" />
-  </>
-)
+    <>
+        <WrappedExternalAsComponent forwardedAs="h2" type="primitive" />
+        <WrappedExternalAsComponent forwardedAs={WithComponentH2} type="complex" />
+    </>
+);
 const ForwardedAsWithNestedAsExternalTest = (
-  <>
-    <ForwardedAsNestedComponent
-      as={ExternalAsComponent}
-      forwardedAs="h2"
-      type="primitive"
-    />
-    <ForwardedAsNestedComponent
-      as={ExternalAsComponent}
-      forwardedAs={WithComponentH2}
-      type="complex"
-    />
-  </>
+    <>
+        <ForwardedAsNestedComponent as={ExternalAsComponent} forwardedAs="h2" type="primitive" />
+        <ForwardedAsNestedComponent as={ExternalAsComponent} forwardedAs={WithComponentH2} type="complex" />
+    </>
 );
 
 interface TestContainerProps {
-    size: "big" | "small";
+    size: 'big' | 'small';
     test?: boolean;
 }
 const TestContainer = ({ size, test }: TestContainerProps) => {
@@ -698,7 +669,7 @@ const StyledTestContainer = styled(TestContainer)`
 `;
 
 interface Test2ContainerProps {
-    type: "foo" | "bar";
+    type: 'foo' | 'bar';
 }
 class Test2Container extends React.Component<Test2ContainerProps> {
     render() {
@@ -706,9 +677,7 @@ class Test2Container extends React.Component<Test2ContainerProps> {
     }
 }
 
-const containerTest = (
-    <StyledTestContainer as={Test2Container} type='foo' />
-);
+const containerTest = <StyledTestContainer as={Test2Container} type="foo" />;
 
 // 4.0 refs
 
@@ -727,7 +696,7 @@ const StyledStyledDiv = styled(StyledDiv)``;
 <StyledStyledDiv ref={divFnRef} />;
 <StyledStyledDiv ref="string" />; // $ExpectError
 
-const StyledA = StyledDiv.withComponent("a");
+const StyledA = StyledDiv.withComponent('a');
 // No longer generating a type error as of Feb. 6th, 2019
 // <StyledA ref={divRef} />; // $ExpectError
 <StyledA
@@ -739,20 +708,14 @@ const StyledA = StyledDiv.withComponent("a");
 
 async function typedThemes() {
     const theme = {
-        color: "green"
+        color: 'green',
     };
 
     // abuse "await import(...)" to be able to reference the styled-components namespace
     // without actually doing a top level namespace import
-    const {
-        default: styled,
-        css,
-        createGlobalStyle,
-        ThemeProvider,
-        ThemeConsumer
-    } = (await import("styled-components")) as any as ThemedStyledComponentsModule<
-        typeof theme
-    >;
+    const { default: styled, css, createGlobalStyle, ThemeProvider, ThemeConsumer } = ((await import(
+        'styled-components'
+    )) as any) as ThemedStyledComponentsModule<typeof theme>;
 
     const ThemedDiv = styled.div`
         background: ${props => {
@@ -770,7 +733,7 @@ async function typedThemes() {
         props.tabIndex;
 
         return {
-            background: props.theme.color
+            background: props.theme.color,
         };
     });
     const ThemedDiv3 = styled.div(props => {
@@ -799,8 +762,8 @@ async function typedThemes() {
     const themedCssWithNesting = css(props => ({
         color: props.theme.color,
         [ThemedDiv3]: {
-            color: "green"
-        }
+            color: 'green',
+        },
     }));
 
     const Global = createGlobalStyle`
@@ -845,7 +808,7 @@ async function typedThemes() {
 }
 
 async function reexportCompatibility() {
-    const sc = await import("styled-components");
+    const sc = await import('styled-components');
     const themed = sc as ThemedStyledComponentsModule<any>;
 
     let { ...scExports } = sc;
@@ -866,18 +829,13 @@ async function themeAugmentation() {
         accent: string;
     }
 
-    const base = (await import("styled-components")) as any as ThemedStyledComponentsModule<
-        BaseTheme
-    >;
-    const extra = (await import("styled-components")) as any as ThemedStyledComponentsModule<
-        ExtraTheme,
-        BaseTheme
-    >;
+    const base = ((await import('styled-components')) as any) as ThemedStyledComponentsModule<BaseTheme>;
+    const extra = ((await import('styled-components')) as any) as ThemedStyledComponentsModule<ExtraTheme, BaseTheme>;
 
     return (
         <base.ThemeProvider
             theme={{
-                background: "black"
+                background: 'black',
             }}
         >
             <>
@@ -889,7 +847,7 @@ async function themeAugmentation() {
                 <extra.ThemeProvider
                     theme={base => ({
                         ...base,
-                        accent: "blue"
+                        accent: 'blue',
                     })}
                 >
                     <extra.ThemeConsumer>{() => null}</extra.ThemeConsumer>
@@ -911,16 +869,16 @@ async function themeAugmentation() {
 // }
 
 function cssProp() {
-    function Custom(props: React.ComponentPropsWithoutRef<"div">) {
+    function Custom(props: React.ComponentPropsWithoutRef<'div'>) {
         return <div {...props} />;
     }
 
-    const myCss = "background: blue;";
+    const myCss = 'background: blue;';
 
     return (
         <>
             <div css="background: blue;" />
-            <div css={{ background: "blue" }} />
+            <div css={{ background: 'blue' }} />
             <div
                 // would be nice to be able to turn this into an error as it also crashes the plugin,
                 // but this is how optional properties work in TypeScript...
@@ -934,7 +892,7 @@ function cssProp() {
             />
             <div
                 // but this crashes the plugin, even though it's valid type-wise and we can't forbid it
-                css={css({ background: "blue" })}
+                css={css({ background: 'blue' })}
             />
             <div
                 // this also crashes the plugin, only inline strings or css template tag work
@@ -942,7 +900,7 @@ function cssProp() {
             />
             <div
                 css={css`
-                    background: ${() => "blue"};
+                    background: ${() => 'blue'};
                 `}
             />
             <div
@@ -964,7 +922,7 @@ function cssProp() {
             />
             <Custom
                 css={css`
-                    background: ${() => "blue"};
+                    background: ${() => 'blue'};
                 `}
             />
             <Custom
@@ -983,57 +941,57 @@ function cssProp() {
 
 function validateArgumentsAndReturns() {
     const t1: FlattenSimpleInterpolation[] = [
-        css({ color: "blue" }),
+        css({ color: 'blue' }),
         css`
             color: blue;
         `,
         css`
-            color: ${"blue"};
-        `
+            color: ${'blue'};
+        `,
     ];
     const t4: FlattenInterpolation<any> = [
         css`
-            color: ${() => "blue"};
+            color: ${() => 'blue'};
         `,
-        css(() => ({ color: "blue" })),
+        css(() => ({ color: 'blue' })),
         css(
             () =>
                 css`
-                    color: "blue";
-                `
-        )
+                    color: 'blue';
+                `,
+        ),
     ];
 
     // if the first argument is array-like it's always treated as a string[], this breaks things
     css(
         // $ExpectError
         css`
-            ${{ color: "blue" }}
-        `
+            ${{ color: 'blue' }}
+        `,
     );
     // _technically_ valid as styled-components doesn't look at .raw but best not to support it
     // $ExpectError
     css([]);
 
-    styled.div({ color: "blue" });
+    styled.div({ color: 'blue' });
     styled.div(props => ({ color: props.theme.color }));
     styled.div`
-        color: ${"blue"};
+        color: ${'blue'};
     `;
     // These don't work for the same reason css doesn't work
     styled.div(
         // $ExpectError
         css`
-            ${{ color: "blue" }}
-        `
+            ${{ color: 'blue' }}
+        `,
     );
     // $ExpectError
     styled.div([]);
 
     createGlobalStyle({
-        ":root": {
-            color: "blue"
-        }
+        ':root': {
+            color: 'blue',
+        },
     });
     createGlobalStyle`
         :root {
@@ -1041,15 +999,15 @@ function validateArgumentsAndReturns() {
         }
     `;
     createGlobalStyle(() => ({
-        ":root": {
-            color: "blue"
-        }
+        ':root': {
+            color: 'blue',
+        },
     }));
     // these are invalid for the same reason as in styled.div
     // $ExpectError
     createGlobalStyle(css`
         :root {
-            color: ${() => "blue"};
+            color: ${() => 'blue'};
         }
     `);
     // $ExpectError
@@ -1064,7 +1022,7 @@ function validateDefaultProps() {
 
     class MyComponent extends React.PureComponent<Props> {
         static defaultProps = {
-            optionalProp: 'fallback'
+            optionalProp: 'fallback',
         };
 
         render() {
@@ -1079,7 +1037,7 @@ function validateDefaultProps() {
     }
 
     const StyledComponent = styled(MyComponent)`
-        color: red
+        color: red;
     `;
 
     <MyComponent requiredProp />;
@@ -1099,8 +1057,10 @@ function validateDefaultProps() {
     }
 
     const OtherStyledComponent = withDefaultProps(
-        styled(MyComponent)` color: red `,
-        { requiredProp: true }
+        styled(MyComponent)`
+            color: red;
+        `,
+        { requiredProp: true },
     );
 
     <OtherStyledComponent />;
@@ -1112,18 +1072,22 @@ interface WrapperProps {
     className?: string;
 }
 export class WrapperClass extends React.Component<WrapperProps> {
-    render() { return <div />; }
+    render() {
+        return <div />;
+    }
 }
 const StyledWrapperClass = styled(WrapperClass)``;
 // React.Component typings always add `children` to props, so this should accept children
 const wrapperClass = <StyledWrapperClass>Text</StyledWrapperClass>;
 
-export class WrapperClassFuncChild extends React.Component<WrapperProps & {children: () => any}> {
-    render() { return <div />; }
+export class WrapperClassFuncChild extends React.Component<WrapperProps & { children: () => any }> {
+    render() {
+        return <div />;
+    }
 }
 const StyledWrapperClassFuncChild = styled(WrapperClassFuncChild)``;
 // React.Component typings always add `children` to props, so this should accept children
-const wrapperClassNoChildrenGood = <StyledWrapperClassFuncChild>{() => "text"}</StyledWrapperClassFuncChild>;
+const wrapperClassNoChildrenGood = <StyledWrapperClassFuncChild>{() => 'text'}</StyledWrapperClassFuncChild>;
 const wrapperClassNoChildren = <StyledWrapperClassFuncChild>Text</StyledWrapperClassFuncChild>; // $ExpectError
 
 const WrapperFunction: React.FunctionComponent<WrapperProps> = () => <div />;
@@ -1138,9 +1102,15 @@ const wrapperFunc = <StyledWrapperFunc>Text</StyledWrapperFunc>; // $ExpectError
 
 // Test if static properties added to the underlying component is passed through.
 function staticPropertyPassthrough() {
-    interface AProps { a: number; }
-    interface BProps { b?: string; }
-    interface BState { b?: string; }
+    interface AProps {
+        a: number;
+    }
+    interface BProps {
+        b?: string;
+    }
+    interface BState {
+        b?: string;
+    }
     class A extends React.Component<AProps> {}
     class B extends React.Component {
         static A = A;
@@ -1157,12 +1127,12 @@ function staticPropertyPassthrough() {
     const StyledB = styled(B)``;
     const StyledC = styled(C)``;
     <StyledB.A />; // $ExpectError
-    <StyledB.A a='a' />; // $ExpectError
+    <StyledB.A a="a" />; // $ExpectError
     <StyledB.A a={0} />;
     StyledB.PUBLIC; // $ExpectError
     StyledB.componentDidMount(); // $ExpectError
-    StyledB.F({ b: 'b' } , {  b: 'b' });
-    StyledB.getDerivedStateFromProps({ b: 'b' } , { b: 'b' }); // $ExpectError
+    StyledB.F({ b: 'b' }, { b: 'b' });
+    StyledB.getDerivedStateFromProps({ b: 'b' }, { b: 'b' }); // $ExpectError
     <StyledC.A a={0} />;
     StyledC.F();
 }
@@ -1178,7 +1148,7 @@ function unionTest() {
         issue: number;
     }
 
-    type SomethingToRead = (Book | Magazine);
+    type SomethingToRead = Book | Magazine;
 
     const Readable: React.FunctionComponent<SomethingToRead> = props => {
         if (props.kind === 'magazine') {
@@ -1189,7 +1159,7 @@ function unionTest() {
     };
 
     const StyledReadable = styled(Readable)`
-        font-size: ${props => props.kind === 'book' ? 16 : 14}
+        font-size: ${props => (props.kind === 'book' ? 16 : 14)};
     `;
 
     // undesired, fix was reverted because of https://github.com/Microsoft/TypeScript/issues/30663
@@ -1199,11 +1169,15 @@ function unionTest() {
 
 function unionTest2() {
     // Union of two non-overlapping types
-    type Props = {
-        foo: number, bar?: undefined
-    } | {
-        foo?: undefined, bar: string
-    };
+    type Props =
+        | {
+              foo: number;
+              bar?: undefined;
+          }
+        | {
+              foo?: undefined;
+              bar: string;
+          };
 
     const C = styled.div<Props>``;
 

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -658,6 +658,33 @@ const forwardedAsTest = (
     </>
 );
 
+type ExternalAsComponentProps = {
+  as?: string | React.ComponentType<any>;
+  type: "primitive" | "complex";
+};
+const ExternalAsComponent: React.FC<ExternalAsComponentProps> = () => null;
+const WrappedExternalAsComponent = styled(ExternalAsComponent)``;
+const ForwardedAsWithWrappedExternalTest = (
+  <>
+    <WrappedExternalAsComponent forwardedAs="h2" type="primitive" />
+    <WrappedExternalAsComponent forwardedAs={WithComponentH2} type="complex" />
+  </>
+)
+const ForwardedAsWithNestedAsExternalTest = (
+  <>
+    <ForwardedAsNestedComponent
+      as={ExternalAsComponent}
+      forwardedAs="h2"
+      type="primitive"
+    />
+    <ForwardedAsNestedComponent
+      as={ExternalAsComponent}
+      forwardedAs={WithComponentH2}
+      type="complex"
+    />
+  </>
+);
+
 interface TestContainerProps {
     size: "big" | "small";
     test?: boolean;

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -637,10 +637,10 @@ const forwardedAsTest = (
     </>
 );
 
-type ExternalAsComponentProps = {
+interface ExternalAsComponentProps {
     as?: string | React.ComponentType<any>;
     type: 'primitive' | 'complex';
-};
+}
 const ExternalAsComponent: React.FC<ExternalAsComponentProps> = () => null;
 const WrappedExternalAsComponent = styled(ExternalAsComponent)``;
 const ForwardedAsWithWrappedExternalTest = (

--- a/types/styled-components/test/native.tsx
+++ b/types/styled-components/test/native.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
-import * as ReactNative from "react-native";
-import * as ReactDOMServer from "react-dom/server";
+import * as React from 'react';
+import * as ReactNative from 'react-native';
+import * as ReactDOMServer from 'react-dom/server';
 
 import styled, {
     css,
@@ -10,30 +10,30 @@ import styled, {
     withTheme,
     ThemeConsumer,
     ReactNativeThemedStyledComponentsModule,
-} from "styled-components/native";
-import {} from "styled-components/cssprop";
+} from 'styled-components/native';
+import {} from 'styled-components/cssprop';
 
 const StyledView = styled.View`
-  background-color: papayawhip;
+    background-color: papayawhip;
 `;
 
 const StyledText = styled(ReactNative.Text)`
-  color: palevioletred;
+    color: palevioletred;
 `;
 
 class MyReactNativeComponent extends React.Component {
-  render() {
-    return (
-      <StyledView>
-        <StyledText>Hello World!</StyledText>
-      </StyledView>
-    );
-  }
+    render() {
+        return (
+            <StyledView>
+                <StyledText>Hello World!</StyledText>
+            </StyledView>
+        );
+    }
 }
 
 const ValidProp = <StyledText adjustsFontSizeToFit />;
 const invalidProp = <StyledText randoName={2} />; // $ExpectError
-const invalidTag = styled.div` margin-top: 5px; `; // $ExpectError
+const invalidTag = styled.div``; // $ExpectError
 
 interface MyTheme {
     primary: string;
@@ -60,139 +60,134 @@ const TomatoButton = styled(MyButton)`
 const tomatoElement = <TomatoButton name="needed" />;
 
 async function typedThemes() {
-  const theme = {
-      color: "green"
-  };
-
-  // abuse "await import(...)" to be able to reference the styled-components namespace
-  // without actually doing a top level namespace import
-  const {
-      default: styled,
-      css,
-      ThemeProvider,
-      ThemeConsumer
-  } = (await import("styled-components/native")) as any as ReactNativeThemedStyledComponentsModule<
-      typeof theme
-  >;
-
-  const ThemedView = styled.View`
-      background: ${props => {
-          // $ExpectType string
-          props.theme.color;
-          // $ExpectType string | undefined
-          props.testID;
-          return props.theme.color;
-      }};
-  `;
-  const ThemedView2 = styled.View(props => {
-    // $ExpectType string
-    props.theme.color;
-    // $ExpectType string | undefined
-    props.testID;
-
-    return {
-        background: props.theme.color
+    const theme = {
+        color: 'green',
     };
-  });
-  const ThemedView3 = styled.View(props => {
-    // $ExpectType string
-    props.theme.color;
-    // $ExpectType string | undefined
-    props.testID;
 
-    return css`
-        background: ${props.theme.color};
+    // abuse "await import(...)" to be able to reference the styled-components namespace
+    // without actually doing a top level namespace import
+    const { default: styled, css, ThemeProvider, ThemeConsumer } = ((await import(
+        'styled-components/native'
+    )) as any) as ReactNativeThemedStyledComponentsModule<typeof theme>;
+
+    const ThemedView = styled.View`
+        background: ${props => {
+            // $ExpectType string
+            props.theme.color;
+            // $ExpectType string | undefined
+            props.testID;
+            return props.theme.color;
+        }};
     `;
-});
-const themedCss = css`
-    background: ${props => {
+    const ThemedView2 = styled.View(props => {
         // $ExpectType string
         props.theme.color;
-        // $ExpectType "theme"
-        type Keys = keyof typeof props;
-        return props.theme.color;
-    }};
-`;
-//  can't use a FlattenInterpolation as the first argument, would make broken css
-// $ExpectError
-const ThemedView4 = styled.View(themedCss);
+        // $ExpectType string | undefined
+        props.testID;
 
-const themedCssWithNesting = css(props => ({
-    color: props.theme.color,
-    [ThemedView3]: {
-        color: "green"
-    }
-}));
+        return {
+            background: props.theme.color,
+        };
+    });
+    const ThemedView3 = styled.View(props => {
+        // $ExpectType string
+        props.theme.color;
+        // $ExpectType string | undefined
+        props.testID;
 
-return (
-    <ThemeProvider theme={theme}>
-        <>
-            <ThemedView />
-            <ThemedView2 />
-            <ThemedView3 />
-            <ThemeConsumer>
-                {theme => {
-                    // $ExpectType string
-                    theme.color;
-                    return theme.color;
-                }}
-            </ThemeConsumer>
-        </>
-    </ThemeProvider>
-  );
+        return css`
+            background: ${props.theme.color};
+        `;
+    });
+    const themedCss = css`
+        background: ${props => {
+            // $ExpectType string
+            props.theme.color;
+            // $ExpectType "theme"
+            type Keys = keyof typeof props;
+            return props.theme.color;
+        }};
+    `;
+    //  can't use a FlattenInterpolation as the first argument, would make broken css
+    // $ExpectError
+    const ThemedView4 = styled.View(themedCss);
+
+    const themedCssWithNesting = css(props => ({
+        color: props.theme.color,
+        [ThemedView3]: {
+            color: 'green',
+        },
+    }));
+
+    return (
+        <ThemeProvider theme={theme}>
+            <>
+                <ThemedView />
+                <ThemedView2 />
+                <ThemedView3 />
+                <ThemeConsumer>
+                    {theme => {
+                        // $ExpectType string
+                        theme.color;
+                        return theme.color;
+                    }}
+                </ThemeConsumer>
+            </>
+        </ThemeProvider>
+    );
 }
 
 async function reexportCompatibility() {
-  const sc = await import("styled-components/native");
-  const themed = sc as ReactNativeThemedStyledComponentsModule<any>;
+    const sc = await import('styled-components/native');
+    const themed = sc as ReactNativeThemedStyledComponentsModule<any>;
 
-  let { ...scExports } = sc;
-  let { ...themedExports } = themed;
-  // both branches must be assignable to each other
-  if (Math.random()) {
-      scExports = themedExports;
-  } else {
-      themedExports = scExports;
-  }
+    let { ...scExports } = sc;
+    let { ...themedExports } = themed;
+    // both branches must be assignable to each other
+    if (Math.random()) {
+        scExports = themedExports;
+    } else {
+        themedExports = scExports;
+    }
 }
 
 async function themeAugmentation() {
-  interface BaseTheme {
-      background: string;
-  }
-  interface ExtraTheme extends BaseTheme {
-      accent: string;
-  }
+    interface BaseTheme {
+        background: string;
+    }
+    interface ExtraTheme extends BaseTheme {
+        accent: string;
+    }
 
-  const base = (await import("styled-components/native")) as any as ReactNativeThemedStyledComponentsModule<
-      BaseTheme
-  >;
-  const extra = (await import("styled-components/native")) as any as ReactNativeThemedStyledComponentsModule<
-      ExtraTheme,
-      BaseTheme
-  >;
+    const base = ((await import('styled-components/native')) as any) as ReactNativeThemedStyledComponentsModule<
+        BaseTheme
+    >;
+    const extra = ((await import('styled-components/native')) as any) as ReactNativeThemedStyledComponentsModule<
+        ExtraTheme,
+        BaseTheme
+    >;
 
-  return (
-      <base.ThemeProvider
-          theme={{
-              background: "black"
-          }}
-      >
-          <>
-              <extra.ThemeProvider
-                  theme={base => base} // $ExpectError
-              >
-                  <extra.ThemeConsumer>{() => null}</extra.ThemeConsumer>
-              </extra.ThemeProvider>
-              <extra.ThemeProvider
-                  theme={base => ({
-                      ...base,
-                      accent: "blue"
-                  })}
-              >
-                  <extra.ThemeConsumer>{() => null}</extra.ThemeConsumer>
-              </extra.ThemeProvider>
-          </>
-      </base.ThemeProvider>
-  );
+    return (
+        <base.ThemeProvider
+            theme={{
+                background: 'black',
+            }}
+        >
+            <>
+                <extra.ThemeProvider
+                    theme={base => base} // $ExpectError
+                >
+                    <extra.ThemeConsumer>{() => null}</extra.ThemeConsumer>
+                </extra.ThemeProvider>
+                <extra.ThemeProvider
+                    theme={base => ({
+                        ...base,
+                        accent: 'blue',
+                    })}
+                >
+                    <extra.ThemeConsumer>{() => null}</extra.ThemeConsumer>
+                </extra.ThemeProvider>
+            </>
+        </base.ThemeProvider>
+    );
 }

--- a/types/styled-components/ts3.6/cssprop.d.ts
+++ b/types/styled-components/ts3.6/cssprop.d.ts
@@ -1,19 +1,19 @@
-import {} from "react";
-import { CSSProp } from ".";
+import {} from 'react';
+import { CSSProp } from '.';
 
-declare module "react" {
-  interface Attributes {
-      // NOTE: unlike the plain javascript version, it is not possible to get access
-      // to the element's own attributes inside function interpolations.
-      // Only theme will be accessible, and only with the DefaultTheme due to the global
-      // nature of this declaration.
-      // If you are writing this inline you already have access to all the attributes anyway,
-      // no need for the extra indirection.
-      /**
-       * If present, this React element will be converted by
-       * `babel-plugin-styled-components` into a styled component
-       * with the given css as its styles.
-       */
-      css?: CSSProp;
-  }
+declare module 'react' {
+    interface Attributes {
+        // NOTE: unlike the plain javascript version, it is not possible to get access
+        // to the element's own attributes inside function interpolations.
+        // Only theme will be accessible, and only with the DefaultTheme due to the global
+        // nature of this declaration.
+        // If you are writing this inline you already have access to all the attributes anyway,
+        // no need for the extra indirection.
+        /**
+         * If present, this React element will be converted by
+         * `babel-plugin-styled-components` into a styled component
+         * with the given css as its styles.
+         */
+        css?: CSSProp;
+    }
 }

--- a/types/styled-components/ts3.6/index.d.ts
+++ b/types/styled-components/ts3.6/index.d.ts
@@ -6,8 +6,8 @@ declare global {
     }
 }
 
-import * as CSS from "csstype";
-import * as React from "react";
+import * as CSS from 'csstype';
+import * as React from 'react';
 import * as hoistNonReactStatics from 'hoist-non-react-statics';
 
 export type CSSProperties = CSS.Properties<string | number>;
@@ -32,15 +32,14 @@ export type StyledProps<P> = ThemedStyledProps<P, AnyIfEmpty<DefaultTheme>>;
 // If declared props have indexed properties, ignore default props entirely as keyof gets widened
 // Wrap in an outer-level conditional type to allow distribution over props that are unions
 type Defaultize<P, D> = P extends any
-    ? string extends keyof P ? P :
-        & Pick<P, Exclude<keyof P, keyof D>>
-        & Partial<Pick<P, Extract<keyof P, keyof D>>>
-        & Partial<Pick<D, Exclude<keyof D, keyof P>>>
+    ? string extends keyof P
+        ? P
+        : Pick<P, Exclude<keyof P, keyof D>> &
+              Partial<Pick<P, Extract<keyof P, keyof D>>> &
+              Partial<Pick<D, Exclude<keyof D, keyof P>>>
     : never;
 
-type ReactDefaultizedProps<C, P> = C extends { defaultProps: infer D; }
-    ? Defaultize<P, D>
-    : P;
+type ReactDefaultizedProps<C, P> = C extends { defaultProps: infer D } ? Defaultize<P, D> : P;
 
 export type StyledComponentProps<
     // The Component from whose props are derived
@@ -54,13 +53,13 @@ export type StyledComponentProps<
 > =
     // Distribute O if O is a union type
     O extends object
-    ? WithOptionalTheme<
-          Omit<ReactDefaultizedProps<C, React.ComponentPropsWithRef<C>> & O, A> &
-              Partial<Pick<React.ComponentPropsWithRef<C> & O, A>>,
-          T
-      > &
-          WithChildrenIfReactComponentClass<C>
-    : never;
+        ? WithOptionalTheme<
+              Omit<ReactDefaultizedProps<C, React.ComponentPropsWithRef<C>> & O, A> &
+                  Partial<Pick<React.ComponentPropsWithRef<C> & O, A>>,
+              T
+          > &
+              WithChildrenIfReactComponentClass<C>
+        : never;
 
 // Because of React typing quirks, when getting props from a React.ComponentClass,
 // we need to manually add a `children` field.
@@ -75,59 +74,34 @@ type StyledComponentPropsWithAs<
     T extends object,
     O extends object,
     A extends keyof any
-> = StyledComponentProps<C, T, O, A> & { as?: C, forwardedAs?: C };
+> = StyledComponentProps<C, T, O, A> & { as?: C; forwardedAs?: C };
 
 export type FalseyValue = undefined | null | false;
-export type Interpolation<P> =
-    | InterpolationValue
-    | FlattenInterpolation<P>
-    | InterpolationFunction<P>;
+export type Interpolation<P> = InterpolationValue | FlattenInterpolation<P> | InterpolationFunction<P>;
 // must be an interface to be self-referential
-export interface FlattenInterpolation<P>
-    extends ReadonlyArray<Interpolation<P>> {}
-export type InterpolationValue =
-    | string
-    | number
-    | FalseyValue
-    | Keyframes
-    | StyledComponentInterpolation
-    | CSSObject;
-export type SimpleInterpolation =
-    | InterpolationValue
-    | FlattenSimpleInterpolation;
+export interface FlattenInterpolation<P> extends ReadonlyArray<Interpolation<P>> {}
+export type InterpolationValue = string | number | FalseyValue | Keyframes | StyledComponentInterpolation | CSSObject;
+export type SimpleInterpolation = InterpolationValue | FlattenSimpleInterpolation;
 // must be an interface to be self-referential
-export interface FlattenSimpleInterpolation
-    extends ReadonlyArray<SimpleInterpolation> {}
+export interface FlattenSimpleInterpolation extends ReadonlyArray<SimpleInterpolation> {}
 
 export type InterpolationFunction<P> = (props: P) => Interpolation<P>;
 
-type Attrs<P, A extends Partial<P>, T> =
-    | ((props: ThemedStyledProps<P, T>) => A)
-    | A;
+type Attrs<P, A extends Partial<P>, T> = ((props: ThemedStyledProps<P, T>) => A) | A;
 
 export type ThemedGlobalStyledClassProps<P, T> = WithOptionalTheme<P, T> & {
     suppressMultiMountWarning?: boolean;
 };
 
-export interface GlobalStyleComponent<P, T>
-    extends React.ComponentClass<ThemedGlobalStyledClassProps<P, T>> {}
+export interface GlobalStyleComponent<P, T> extends React.ComponentClass<ThemedGlobalStyledClassProps<P, T>> {}
 
 // remove the call signature from StyledComponent so Interpolation can still infer InterpolationFunction
 type StyledComponentInterpolation =
-    | Pick<
-          StyledComponentBase<any, any, any, any>,
-          keyof StyledComponentBase<any, any>
-      >
-    | Pick<
-          StyledComponentBase<any, any, any>,
-          keyof StyledComponentBase<any, any>
-      >;
+    | Pick<StyledComponentBase<any, any, any, any>, keyof StyledComponentBase<any, any>>
+    | Pick<StyledComponentBase<any, any, any>, keyof StyledComponentBase<any, any>>;
 
 // abuse Pick to strip the call signature from ForwardRefExoticComponent
-type ForwardRefExoticBase<P> = Pick<
-    React.ForwardRefExoticComponent<P>,
-    keyof React.ForwardRefExoticComponent<any>
->;
+type ForwardRefExoticBase<P> = Pick<React.ForwardRefExoticComponent<P>, keyof React.ForwardRefExoticComponent<any>>;
 
 // Config to be used with withConfig
 export interface StyledConfig<O extends object = {}> {
@@ -136,12 +110,10 @@ export interface StyledConfig<O extends object = {}> {
 }
 
 // extracts React defaultProps
-type ReactDefaultProps<C> = C extends { defaultProps: infer D; } ? D : never;
+type ReactDefaultProps<C> = C extends { defaultProps: infer D } ? D : never;
 
 // any doesn't count as assignable to never in the extends clause, and we default A to never
-export type AnyStyledComponent =
-    | StyledComponent<any, any, any, any>
-    | StyledComponent<any, any, any>;
+export type AnyStyledComponent = StyledComponent<any, any, any, any> | StyledComponent<any, any, any>;
 
 export type StyledComponent<
     C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
@@ -150,7 +122,9 @@ export type StyledComponent<
     A extends keyof any = never
 > = // the "string" allows this to be used as an object key
     // I really want to avoid this if possible but it's the only way to use nesting with object styles...
-    string & StyledComponentBase<C, T, O, A> & hoistNonReactStatics.NonReactStatics<C extends React.ComponentType<any> ? C : never>;
+    string &
+        StyledComponentBase<C, T, O, A> &
+        hoistNonReactStatics.NonReactStatics<C extends React.ComponentType<any> ? C : never>;
 
 export interface StyledComponentBase<
     C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
@@ -180,21 +154,19 @@ export interface StyledComponentBase<
              */
             as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
             forwardedAs?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
-        }
+        },
     ): React.ReactElement<StyledComponentProps<C, T, O, A>>;
 
     withComponent<WithC extends AnyStyledComponent>(
-        component: WithC
+        component: WithC,
     ): StyledComponent<
         StyledComponentInnerComponent<WithC>,
         T,
         O & StyledComponentInnerOtherProps<WithC>,
         A | StyledComponentInnerAttrs<WithC>
     >;
-    withComponent<
-        WithC extends keyof JSX.IntrinsicElements | React.ComponentType<any>
-    >(
-        component: WithC
+    withComponent<WithC extends keyof JSX.IntrinsicElements | React.ComponentType<any>>(
+        component: WithC,
     ): StyledComponent<WithC, T, O, A>;
 }
 
@@ -209,27 +181,15 @@ export interface ThemedStyledFunctionBase<
         first:
             | TemplateStringsArray
             | CSSObject
-            | InterpolationFunction<
-                  ThemedStyledProps<StyledComponentPropsWithRef<C> & O, T>
-              >,
-        ...rest: Array<
-            Interpolation<
-                ThemedStyledProps<StyledComponentPropsWithRef<C> & O, T>
-            >
-        >
+            | InterpolationFunction<ThemedStyledProps<StyledComponentPropsWithRef<C> & O, T>>,
+        ...rest: Array<Interpolation<ThemedStyledProps<StyledComponentPropsWithRef<C> & O, T>>>
     ): StyledComponent<C, T, O, A>;
     <U extends object>(
         first:
             | TemplateStringsArray
             | CSSObject
-            | InterpolationFunction<
-                  ThemedStyledProps<StyledComponentPropsWithRef<C> & O & U, T>
-              >,
-        ...rest: Array<
-            Interpolation<
-                ThemedStyledProps<StyledComponentPropsWithRef<C> & O & U, T>
-            >
-        >
+            | InterpolationFunction<ThemedStyledProps<StyledComponentPropsWithRef<C> & O & U, T>>,
+        ...rest: Array<Interpolation<ThemedStyledProps<StyledComponentPropsWithRef<C> & O & U, T>>>
     ): StyledComponent<C, T, O & U, A>;
 }
 
@@ -247,40 +207,53 @@ export interface ThemedStyledFunction<
             [others: string]: any;
         } = {}
     >(
-        attrs: Attrs<StyledComponentPropsWithRef<C> & U, NewA, T>
+        attrs: Attrs<StyledComponentPropsWithRef<C> & U, NewA, T>,
     ): ThemedStyledFunction<C, T, O & NewA, A | keyof NewA>;
 
-    withConfig: <Props extends O = O>(config: StyledConfig<StyledComponentPropsWithRef<C> & Props>) => ThemedStyledFunction<C, T, Props, A>;
+    withConfig: <Props extends O = O>(
+        config: StyledConfig<StyledComponentPropsWithRef<C> & Props>,
+    ) => ThemedStyledFunction<C, T, Props, A>;
 }
 
-export type StyledFunction<
-    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>
-> = ThemedStyledFunction<C, any>;
+export type StyledFunction<C extends keyof JSX.IntrinsicElements | React.ComponentType<any>> = ThemedStyledFunction<
+    C,
+    any
+>;
 
 type ThemedStyledComponentFactories<T extends object> = {
-    [TTag in keyof JSX.IntrinsicElements]: ThemedStyledFunction<TTag, T>
+    [TTag in keyof JSX.IntrinsicElements]: ThemedStyledFunction<TTag, T>;
 };
 
-export type StyledComponentInnerComponent<
-    C extends React.ComponentType<any>
-> = C extends StyledComponent<infer I, any, any, any> ? I :
-    C extends StyledComponent<infer I, any, any> ? I :
-    C;
+export type StyledComponentInnerComponent<C extends React.ComponentType<any>> = C extends StyledComponent<
+    infer I,
+    any,
+    any,
+    any
+>
+    ? I
+    : C extends StyledComponent<infer I, any, any>
+    ? I
+    : C;
 export type StyledComponentPropsWithRef<
     C extends keyof JSX.IntrinsicElements | React.ComponentType<any>
 > = C extends AnyStyledComponent
     ? React.ComponentPropsWithRef<StyledComponentInnerComponent<C>>
     : React.ComponentPropsWithRef<C>;
-export type StyledComponentInnerOtherProps<C extends AnyStyledComponent> =
-    C extends StyledComponent<any, any, infer O, any> ? O :
-    C extends StyledComponent<any, any, infer O> ? O :
-    never;
-export type StyledComponentInnerAttrs<
-    C extends AnyStyledComponent
-> = C extends StyledComponent<any, any, any, infer A> ? A : never;
+export type StyledComponentInnerOtherProps<C extends AnyStyledComponent> = C extends StyledComponent<
+    any,
+    any,
+    infer O,
+    any
+>
+    ? O
+    : C extends StyledComponent<any, any, infer O>
+    ? O
+    : never;
+export type StyledComponentInnerAttrs<C extends AnyStyledComponent> = C extends StyledComponent<any, any, any, infer A>
+    ? A
+    : never;
 
-export interface ThemedBaseStyledInterface<T extends object>
-    extends ThemedStyledComponentFactories<T> {
+export interface ThemedBaseStyledInterface<T extends object> extends ThemedStyledComponentFactories<T> {
     <C extends AnyStyledComponent>(component: C): ThemedStyledFunction<
         StyledComponentInnerComponent<C>,
         T,
@@ -290,66 +263,44 @@ export interface ThemedBaseStyledInterface<T extends object>
     <C extends keyof JSX.IntrinsicElements | React.ComponentType<any>>(
         // unfortunately using a conditional type to validate that it can receive a `theme?: Theme`
         // causes tests to fail in TS 3.1
-        component: C
+        component: C,
     ): ThemedStyledFunction<C, T>;
 }
 
-export type ThemedStyledInterface<T extends object> = ThemedBaseStyledInterface<
-    AnyIfEmpty<T>
->;
+export type ThemedStyledInterface<T extends object> = ThemedBaseStyledInterface<AnyIfEmpty<T>>;
 export type StyledInterface = ThemedStyledInterface<DefaultTheme>;
 
 export interface BaseThemedCssFunction<T extends object> {
+    (first: TemplateStringsArray | CSSObject, ...interpolations: SimpleInterpolation[]): FlattenSimpleInterpolation;
     (
-        first: TemplateStringsArray | CSSObject,
-        ...interpolations: SimpleInterpolation[]
-    ): FlattenSimpleInterpolation;
-    (
-        first:
-            | TemplateStringsArray
-            | CSSObject
-            | InterpolationFunction<ThemedStyledProps<{}, T>>,
+        first: TemplateStringsArray | CSSObject | InterpolationFunction<ThemedStyledProps<{}, T>>,
         ...interpolations: Array<Interpolation<ThemedStyledProps<{}, T>>>
     ): FlattenInterpolation<ThemedStyledProps<{}, T>>;
     <P extends object>(
-        first:
-            | TemplateStringsArray
-            | CSSObject
-            | InterpolationFunction<ThemedStyledProps<P, T>>,
+        first: TemplateStringsArray | CSSObject | InterpolationFunction<ThemedStyledProps<P, T>>,
         ...interpolations: Array<Interpolation<ThemedStyledProps<P, T>>>
     ): FlattenInterpolation<ThemedStyledProps<P, T>>;
 }
 
-export type ThemedCssFunction<T extends object> = BaseThemedCssFunction<
-    AnyIfEmpty<T>
->;
+export type ThemedCssFunction<T extends object> = BaseThemedCssFunction<AnyIfEmpty<T>>;
 
 // Helper type operators
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, "theme"> & {
+type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, 'theme'> & {
     theme?: T;
 };
 type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
 
-export interface ThemedStyledComponentsModule<
-    T extends object,
-    U extends object = T
-> {
+export interface ThemedStyledComponentsModule<T extends object, U extends object = T> {
     default: ThemedStyledInterface<T>;
 
     css: ThemedCssFunction<T>;
 
     // unfortunately keyframes can't interpolate props from the theme
-    keyframes(
-        strings: TemplateStringsArray | CSSKeyframes,
-        ...interpolations: SimpleInterpolation[]
-    ): Keyframes;
+    keyframes(strings: TemplateStringsArray | CSSKeyframes, ...interpolations: SimpleInterpolation[]): Keyframes;
 
     createGlobalStyle<P extends object = {}>(
-        first:
-            | TemplateStringsArray
-            | CSSObject
-            | InterpolationFunction<ThemedStyledProps<P, T>>,
+        first: TemplateStringsArray | CSSObject | InterpolationFunction<ThemedStyledProps<P, T>>,
         ...interpolations: Array<Interpolation<ThemedStyledProps<P, T>>>
     ): GlobalStyleComponent<P, T>;
 
@@ -370,18 +321,12 @@ declare const styled: StyledInterface;
 
 export const css: ThemedCssFunction<DefaultTheme>;
 
-export type BaseWithThemeFnInterface<T extends object> = <
-    C extends React.ComponentType<any>
->(
+export type BaseWithThemeFnInterface<T extends object> = <C extends React.ComponentType<any>>(
     // this check is roundabout because the extends clause above would
     // not allow any component that accepts _more_ than theme as a prop
-    component: React.ComponentProps<C> extends { theme?: T } ? C : never
-) => React.ForwardRefExoticComponent<
-    WithOptionalTheme<React.ComponentPropsWithRef<C>, T>
->;
-export type WithThemeFnInterface<T extends object> = BaseWithThemeFnInterface<
-    AnyIfEmpty<T>
->;
+    component: React.ComponentProps<C> extends { theme?: T } ? C : never,
+) => React.ForwardRefExoticComponent<WithOptionalTheme<React.ComponentPropsWithRef<C>, T>>;
+export type WithThemeFnInterface<T extends object> = BaseWithThemeFnInterface<AnyIfEmpty<T>>;
 export const withTheme: WithThemeFnInterface<DefaultTheme>;
 
 export function useTheme(): DefaultTheme;
@@ -399,18 +344,17 @@ export interface ThemeProviderProps<T extends object, U extends object = T> {
     children?: React.ReactNode;
     theme: T | ((theme: U) => T);
 }
-export type BaseThemeProviderComponent<
-    T extends object,
-    U extends object = T
-> = React.ComponentClass<ThemeProviderProps<T, U>>;
-export type ThemeProviderComponent<
-    T extends object,
-    U extends object = T
-> = BaseThemeProviderComponent<AnyIfEmpty<T>, AnyIfEmpty<U>>;
+export type BaseThemeProviderComponent<T extends object, U extends object = T> = React.ComponentClass<
+    ThemeProviderProps<T, U>
+>;
+export type ThemeProviderComponent<T extends object, U extends object = T> = BaseThemeProviderComponent<
+    AnyIfEmpty<T>,
+    AnyIfEmpty<U>
+>;
 export const ThemeProvider: ThemeProviderComponent<AnyIfEmpty<DefaultTheme>>;
 // NOTE: this technically starts as undefined, but allowing undefined is unhelpful when used correctly
 export const ThemeContext: React.Context<AnyIfEmpty<DefaultTheme>>;
-export const ThemeConsumer: typeof ThemeContext["Consumer"];
+export const ThemeConsumer: typeof ThemeContext['Consumer'];
 
 export interface Keyframes {
     getName(): string;
@@ -422,27 +366,18 @@ export function keyframes(
 ): Keyframes;
 
 export function createGlobalStyle<P extends object = {}>(
-    first:
-        | TemplateStringsArray
-        | CSSObject
-        | InterpolationFunction<ThemedStyledProps<P, DefaultTheme>>,
+    first: TemplateStringsArray | CSSObject | InterpolationFunction<ThemedStyledProps<P, DefaultTheme>>,
     ...interpolations: Array<Interpolation<ThemedStyledProps<P, DefaultTheme>>>
 ): GlobalStyleComponent<P, DefaultTheme>;
 
-export function isStyledComponent(
-    target: any
-): target is StyledComponent<any, any>;
+export function isStyledComponent(target: any): target is StyledComponent<any, any>;
 
 export class ServerStyleSheet {
-    collectStyles(
-        tree: React.ReactNode
-    ): React.ReactElement<{ sheet: ServerStyleSheet }>;
+    collectStyles(tree: React.ReactNode): React.ReactElement<{ sheet: ServerStyleSheet }>;
 
     getStyleTags(): string;
     getStyleElement(): Array<React.ReactElement<{}>>;
-    interleaveWithNodeStream(
-        readableStream: NodeJS.ReadableStream
-    ): NodeJS.ReadableStream;
+    interleaveWithNodeStream(readableStream: NodeJS.ReadableStream): NodeJS.ReadableStream;
     readonly instance: this;
     seal(): void;
 }
@@ -456,7 +391,7 @@ export type StylisPlugin = (
     column: number,
     length: number,
     at: number,
-    depth: number
+    depth: number,
 ) => string | void;
 
 export interface StyleSheetManagerProps {
@@ -467,9 +402,7 @@ export interface StyleSheetManagerProps {
     target?: HTMLElement;
 }
 
-export class StyleSheetManager extends React.Component<
-    StyleSheetManagerProps
-> {}
+export class StyleSheetManager extends React.Component<StyleSheetManagerProps> {}
 
 /**
  * The CSS prop is not declared by default in the types as it would cause 'css' to be present
@@ -498,9 +431,6 @@ export class StyleSheetManager extends React.Component<
  * ```
  */
 // ONLY string literals and inline invocations of css`` are supported, anything else crashes the plugin
-export type CSSProp<T = AnyIfEmpty<DefaultTheme>> =
-    | string
-    | CSSObject
-    | FlattenInterpolation<ThemeProps<T>>;
+export type CSSProp<T = AnyIfEmpty<DefaultTheme>> = string | CSSObject | FlattenInterpolation<ThemeProps<T>>;
 
 export default styled;

--- a/types/styled-components/ts3.6/index.d.ts
+++ b/types/styled-components/ts3.6/index.d.ts
@@ -73,8 +73,9 @@ type StyledComponentPropsWithAs<
     C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
     T extends object,
     O extends object,
-    A extends keyof any
-> = StyledComponentProps<C, T, O, A> & { as?: C; forwardedAs?: C };
+    A extends keyof any,
+    F extends keyof JSX.IntrinsicElements | React.ComponentType<any> = C
+> = StyledComponentProps<C, T, O, A> & { as?: C; forwardedAs?: F };
 
 export type FalseyValue = undefined | null | false;
 export type Interpolation<P> = InterpolationValue | FlattenInterpolation<P> | InterpolationFunction<P>;
@@ -140,9 +141,9 @@ export interface StyledComponentBase<
     // (
     //     props: StyledComponentProps<C, T, O, A> & { as?: never }
     //   ): React.ReactElement<StyledComponentProps<C, T, O, A>>
-    // <AsC extends keyof JSX.IntrinsicElements | React.ComponentType<any> = C>(
-    //   props: StyledComponentPropsWithAs<AsC, T, O, A>
-    // ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A>>
+    // <AsC extends keyof JSX.IntrinsicElements | React.ComponentType<any> = C, FAsC extends keyof JSX.IntrinsicElements | React.ComponentType<any> = AsC>(
+    //   props: StyledComponentPropsWithAs<AsC, T, O, A, FAsC>
+    // ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A, FAsC>>
 
     // TODO (TypeScript 3.2): delete this overload
     (

--- a/types/styled-components/ts3.6/index.d.ts
+++ b/types/styled-components/ts3.6/index.d.ts
@@ -133,30 +133,13 @@ export interface StyledComponentBase<
     O extends object = {},
     A extends keyof any = never
 > extends ForwardRefExoticBase<StyledComponentProps<C, T, O, A>> {
-    // add our own fake call signature to implement the polymorphic 'as' prop
-    // NOTE: TS <3.2 will refuse to infer the generic and this component becomes impossible to use in JSX
-    // just the presence of the overload is enough to break JSX
-    //
-    // TODO (TypeScript 3.2): actually makes the 'as' prop polymorphic
-    // (
-    //     props: StyledComponentProps<C, T, O, A> & { as?: never }
-    //   ): React.ReactElement<StyledComponentProps<C, T, O, A>>
-    // <AsC extends keyof JSX.IntrinsicElements | React.ComponentType<any> = C, FAsC extends keyof JSX.IntrinsicElements | React.ComponentType<any> = AsC>(
-    //   props: StyledComponentPropsWithAs<AsC, T, O, A, FAsC>
-    // ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A, FAsC>>
-
-    // TODO (TypeScript 3.2): delete this overload
-    (
-        props: StyledComponentProps<C, T, O, A> & {
-            /**
-             * Typing Note: prefer using .withComponent for now as it is actually type-safe.
-             *
-             * String types need to be cast to themselves to become literal types (as={'a' as 'a'}).
-             */
-            as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
-            forwardedAs?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
-        },
-    ): React.ReactElement<StyledComponentProps<C, T, O, A>>;
+    (props: StyledComponentProps<C, T, O, A> & { as?: never }): React.ReactElement<StyledComponentProps<C, T, O, A>>;
+    <
+        AsC extends keyof JSX.IntrinsicElements | React.ComponentType<any> = C,
+        FAsC extends keyof JSX.IntrinsicElements | React.ComponentType<any> = AsC
+    >(
+        props: StyledComponentPropsWithAs<AsC, T, O, A, FAsC>,
+    ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A, FAsC>>;
 
     withComponent<WithC extends AnyStyledComponent>(
         component: WithC,

--- a/types/styled-components/ts3.6/native.d.ts
+++ b/types/styled-components/ts3.6/native.d.ts
@@ -2,36 +2,36 @@ import * as ReactNative from 'react-native';
 import * as React from 'react';
 
 export {
-  css,
-  DefaultTheme,
-  isStyledComponent,
-  ThemeConsumer,
-  ThemeContext,
-  ThemeProps,
-  ThemeProvider,
-  withTheme,
-  useTheme,
+    css,
+    DefaultTheme,
+    isStyledComponent,
+    ThemeConsumer,
+    ThemeContext,
+    ThemeProps,
+    ThemeProvider,
+    withTheme,
+    useTheme,
 } from './index';
 
 import {
-  AnyStyledComponent,
-  DefaultTheme,
-  isStyledComponent,
-  StyledComponentInnerAttrs,
-  StyledComponentInnerComponent,
-  StyledComponentInnerOtherProps,
-  ThemedCssFunction,
-  ThemedStyledFunction,
-  ThemedStyledInterface,
-  ThemeProviderComponent,
-  WithThemeFnInterface
+    AnyStyledComponent,
+    DefaultTheme,
+    isStyledComponent,
+    StyledComponentInnerAttrs,
+    StyledComponentInnerComponent,
+    StyledComponentInnerOtherProps,
+    ThemedCssFunction,
+    ThemedStyledFunction,
+    ThemedStyledInterface,
+    ThemeProviderComponent,
+    WithThemeFnInterface,
 } from './index';
 
 type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
 
 export type ReactNativeThemedStyledFunction<
-  C extends React.ComponentType<any>,
-  T extends object,
+    C extends React.ComponentType<any>,
+    T extends object
 > = ThemedStyledFunction<C, T>;
 
 // Copied over from "ThemedBaseStyledInterface" in index.d.ts in order to remove DOM element typings
@@ -45,193 +45,68 @@ interface ReactNativeThemedBaseStyledInterface<T extends object> {
     <C extends React.ComponentType<any>>(
         // unfortunately using a conditional type to validate that it can receive a `theme?: Theme`
         // causes tests to fail in TS 3.1
-        component: C
+        component: C,
     ): ThemedStyledFunction<C, T>;
 }
 
-type ReactNativeThemedStyledInterface<T extends object> = ReactNativeThemedBaseStyledInterface<
-    AnyIfEmpty<T>
->;
+type ReactNativeThemedStyledInterface<T extends object> = ReactNativeThemedBaseStyledInterface<AnyIfEmpty<T>>;
 
 export interface ReactNativeStyledInterface<T extends object> extends ReactNativeThemedStyledInterface<T> {
-  ActivityIndicator: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ActivityIndicator,
-    T
-  >;
-  ActivityIndicatorIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ActivityIndicator,
-    T
-  >;
-  Button: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Button,
-    T
-  >;
-  DatePickerIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.DatePickerIOS,
-    T
-  >;
-  DrawerLayoutAndroid: ReactNativeThemedStyledFunction<
-    typeof ReactNative.DrawerLayoutAndroid,
-    T
-  >;
-  Image: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Image,
-    T
-  >;
-  ImageBackground: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ImageBackground,
-    T
-  >;
-  KeyboardAvoidingView: ReactNativeThemedStyledFunction<
-    typeof ReactNative.KeyboardAvoidingView,
-    T
-  >;
-  ListView: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ListView,
-    T
-  >;
-  Modal: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Modal,
-    T
-  >;
-  NavigatorIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.NavigatorIOS,
-    T
-  >;
-  Picker: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Picker,
-    T
-  >;
-  PickerIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.PickerIOS,
-    T
-  >;
-  ProgressBarAndroid: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ProgressBarAndroid,
-    T
-  >;
-  ProgressViewIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ProgressViewIOS,
-    T
-  >;
-  ScrollView: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ScrollView,
-    T
-  >;
-  SegmentedControlIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.SegmentedControlIOS,
-    T
-  >;
-  Slider: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Slider,
-    T
-  >;
-  SliderIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Slider,
-    T
-  >;
-  SnapshotViewIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.SnapshotViewIOS,
-    T
-  >;
-  Switch: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Switch,
-    T
-  >;
-  RecyclerViewBackedScrollView: ReactNativeThemedStyledFunction<
-    typeof ReactNative.RecyclerViewBackedScrollView,
-    T
-  >;
-  RefreshControl: ReactNativeThemedStyledFunction<
-    typeof ReactNative.RefreshControl,
-    T
-  >;
-  SafeAreaView: ReactNativeThemedStyledFunction<
-    typeof ReactNative.SafeAreaView,
-    T
-  >;
-  StatusBar: ReactNativeThemedStyledFunction<
-    typeof ReactNative.StatusBar,
-    T
-  >;
-  SwipeableListView: ReactNativeThemedStyledFunction<
-    typeof ReactNative.SwipeableListView,
-    T
-  >;
-  SwitchAndroid: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Switch,
-    T
-  >;
-  SwitchIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.SwitchIOS,
-    T
-  >;
-  TabBarIOS: ReactNativeThemedStyledFunction<
-    typeof ReactNative.TabBarIOS,
-    T
-  >;
-  Text: ReactNativeThemedStyledFunction<
-    typeof ReactNative.Text,
-    T
-  >;
-  TextInput: ReactNativeThemedStyledFunction<
-    typeof ReactNative.TextInput,
-    T
-  >;
-  ToolbarAndroid: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ToolbarAndroid,
-    T
-  >;
-  TouchableHighlight: ReactNativeThemedStyledFunction<
-    typeof ReactNative.TouchableHighlight,
-    T
-  >;
-  TouchableNativeFeedback: ReactNativeThemedStyledFunction<
-    typeof ReactNative.TouchableNativeFeedback,
-    T
-  >;
-  TouchableOpacity: ReactNativeThemedStyledFunction<
-    typeof ReactNative.TouchableOpacity,
-    T
-  >;
-  TouchableWithoutFeedback: ReactNativeThemedStyledFunction<
-    typeof ReactNative.TouchableWithoutFeedback,
-    T
-  >;
-  View: ReactNativeThemedStyledFunction<
-    typeof ReactNative.View,
-    T
-  >;
-  ViewPagerAndroid: ReactNativeThemedStyledFunction<
-    typeof ReactNative.ViewPagerAndroid,
-    T
-  >;
-  FlatList: ReactNativeThemedStyledFunction<
-    typeof ReactNative.FlatList,
-    T
-  >;
-  SectionList: ReactNativeThemedStyledFunction<
-    typeof ReactNative.SectionList,
-    T
-  >;
+    ActivityIndicator: ReactNativeThemedStyledFunction<typeof ReactNative.ActivityIndicator, T>;
+    ActivityIndicatorIOS: ReactNativeThemedStyledFunction<typeof ReactNative.ActivityIndicator, T>;
+    Button: ReactNativeThemedStyledFunction<typeof ReactNative.Button, T>;
+    DatePickerIOS: ReactNativeThemedStyledFunction<typeof ReactNative.DatePickerIOS, T>;
+    DrawerLayoutAndroid: ReactNativeThemedStyledFunction<typeof ReactNative.DrawerLayoutAndroid, T>;
+    Image: ReactNativeThemedStyledFunction<typeof ReactNative.Image, T>;
+    ImageBackground: ReactNativeThemedStyledFunction<typeof ReactNative.ImageBackground, T>;
+    KeyboardAvoidingView: ReactNativeThemedStyledFunction<typeof ReactNative.KeyboardAvoidingView, T>;
+    ListView: ReactNativeThemedStyledFunction<typeof ReactNative.ListView, T>;
+    Modal: ReactNativeThemedStyledFunction<typeof ReactNative.Modal, T>;
+    NavigatorIOS: ReactNativeThemedStyledFunction<typeof ReactNative.NavigatorIOS, T>;
+    Picker: ReactNativeThemedStyledFunction<typeof ReactNative.Picker, T>;
+    PickerIOS: ReactNativeThemedStyledFunction<typeof ReactNative.PickerIOS, T>;
+    ProgressBarAndroid: ReactNativeThemedStyledFunction<typeof ReactNative.ProgressBarAndroid, T>;
+    ProgressViewIOS: ReactNativeThemedStyledFunction<typeof ReactNative.ProgressViewIOS, T>;
+    ScrollView: ReactNativeThemedStyledFunction<typeof ReactNative.ScrollView, T>;
+    SegmentedControlIOS: ReactNativeThemedStyledFunction<typeof ReactNative.SegmentedControlIOS, T>;
+    Slider: ReactNativeThemedStyledFunction<typeof ReactNative.Slider, T>;
+    SliderIOS: ReactNativeThemedStyledFunction<typeof ReactNative.Slider, T>;
+    SnapshotViewIOS: ReactNativeThemedStyledFunction<typeof ReactNative.SnapshotViewIOS, T>;
+    Switch: ReactNativeThemedStyledFunction<typeof ReactNative.Switch, T>;
+    RecyclerViewBackedScrollView: ReactNativeThemedStyledFunction<typeof ReactNative.RecyclerViewBackedScrollView, T>;
+    RefreshControl: ReactNativeThemedStyledFunction<typeof ReactNative.RefreshControl, T>;
+    SafeAreaView: ReactNativeThemedStyledFunction<typeof ReactNative.SafeAreaView, T>;
+    StatusBar: ReactNativeThemedStyledFunction<typeof ReactNative.StatusBar, T>;
+    SwipeableListView: ReactNativeThemedStyledFunction<typeof ReactNative.SwipeableListView, T>;
+    SwitchAndroid: ReactNativeThemedStyledFunction<typeof ReactNative.Switch, T>;
+    SwitchIOS: ReactNativeThemedStyledFunction<typeof ReactNative.SwitchIOS, T>;
+    TabBarIOS: ReactNativeThemedStyledFunction<typeof ReactNative.TabBarIOS, T>;
+    Text: ReactNativeThemedStyledFunction<typeof ReactNative.Text, T>;
+    TextInput: ReactNativeThemedStyledFunction<typeof ReactNative.TextInput, T>;
+    ToolbarAndroid: ReactNativeThemedStyledFunction<typeof ReactNative.ToolbarAndroid, T>;
+    TouchableHighlight: ReactNativeThemedStyledFunction<typeof ReactNative.TouchableHighlight, T>;
+    TouchableNativeFeedback: ReactNativeThemedStyledFunction<typeof ReactNative.TouchableNativeFeedback, T>;
+    TouchableOpacity: ReactNativeThemedStyledFunction<typeof ReactNative.TouchableOpacity, T>;
+    TouchableWithoutFeedback: ReactNativeThemedStyledFunction<typeof ReactNative.TouchableWithoutFeedback, T>;
+    View: ReactNativeThemedStyledFunction<typeof ReactNative.View, T>;
+    ViewPagerAndroid: ReactNativeThemedStyledFunction<typeof ReactNative.ViewPagerAndroid, T>;
+    FlatList: ReactNativeThemedStyledFunction<typeof ReactNative.FlatList, T>;
+    SectionList: ReactNativeThemedStyledFunction<typeof ReactNative.SectionList, T>;
 }
 
-export interface ReactNativeThemedStyledComponentsModule<
-  T extends object,
-  U extends object = T
-> {
-  default: ReactNativeStyledInterface<T>;
+export interface ReactNativeThemedStyledComponentsModule<T extends object, U extends object = T> {
+    default: ReactNativeStyledInterface<T>;
 
-  css: ThemedCssFunction<T>;
+    css: ThemedCssFunction<T>;
 
-  withTheme: WithThemeFnInterface<T>;
-  ThemeProvider: ThemeProviderComponent<T, U>;
-  ThemeConsumer: React.Consumer<T>;
-  ThemeContext: React.Context<T>;
-  useTheme(): T;
+    withTheme: WithThemeFnInterface<T>;
+    ThemeProvider: ThemeProviderComponent<T, U>;
+    ThemeConsumer: React.Consumer<T>;
+    ThemeContext: React.Context<T>;
+    useTheme(): T;
 
-  // This could be made to assert `target is StyledComponent<any, T>` instead, but that feels not type safe
-  isStyledComponent: typeof isStyledComponent;
+    // This could be made to assert `target is StyledComponent<any, T>` instead, but that feels not type safe
+    isStyledComponent: typeof isStyledComponent;
 }
 
 declare const styled: ReactNativeStyledInterface<DefaultTheme>;

--- a/types/styled-components/ts3.6/test/index.tsx
+++ b/types/styled-components/ts3.6/test/index.tsx
@@ -637,6 +637,27 @@ const forwardedAsTest = (
     </>
 );
 
+type ExternalAsComponentProps = {
+    as?: string | React.ComponentType<any>;
+    type: 'primitive' | 'complex';
+};
+
+const ExternalAsComponent: React.FC<ExternalAsComponentProps> = () => null;
+const WrappedExternalAsComponent = styled(ExternalAsComponent)``;
+const ForwardedAsWithWrappedExternalTest = (
+    <>
+        <WrappedExternalAsComponent forwardedAs="h2" type="primitive" />
+        <WrappedExternalAsComponent forwardedAs={WithComponentH2} type="complex" />
+    </>
+);
+// TODO: Needs corresponding fix in StyledComponentBase
+// const ForwardedAsWithNestedAsExternalTest = (
+//     <>
+//         <ForwardedAsNestedComponent as={ExternalAsComponent} forwardedAs="h2" type="primitive" />
+//         <ForwardedAsNestedComponent as={ExternalAsComponent} forwardedAs={WithComponentH2} type="complex" />
+//     </>
+// );
+
 interface TestContainerProps {
     size: 'big' | 'small';
     test?: boolean;

--- a/types/styled-components/ts3.6/test/index.tsx
+++ b/types/styled-components/ts3.6/test/index.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
-import * as ReactDOMServer from "react-dom/server";
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import * as ReactDOMServer from 'react-dom/server';
 
 import styled, {
     css,
@@ -17,11 +17,11 @@ import styled, {
     ThemedStyledComponentsModule,
     FlattenSimpleInterpolation,
     SimpleInterpolation,
-    FlattenInterpolation
+    FlattenInterpolation,
+    // tslint:disable-next-line:no-relative-import-in-test
+} from '..';
 // tslint:disable-next-line:no-relative-import-in-test
-} from "..";
-// tslint:disable-next-line:no-relative-import-in-test
-import {} from "../cssprop";
+import {} from '../cssprop';
 
 /**
  * general usage
@@ -79,8 +79,8 @@ const TomatoButton = styled(MyButton)`
 
 const CustomizableButton = styled(MyButton)`
     /* Adapt the colors based on primary prop */
-    background: ${props => (props.primary ? "palevioletred" : "white")};
-    color: ${props => (props.primary ? "white" : "palevioletred")};
+    background: ${props => (props.primary ? 'palevioletred' : 'white')};
+    color: ${props => (props.primary ? 'white' : 'palevioletred')};
 
     font-size: 1em;
     margin: 1em;
@@ -93,7 +93,7 @@ const example = css`
     font-size: 1.5em;
     text-align: center;
     color: ${props => props.theme.primary};
-    border-color: ${"red"};
+    border-color: ${'red'};
 `;
 
 const fadeIn = keyframes`
@@ -129,7 +129,7 @@ const ComponentWithKeyframe = styled.div`
 `;
 
 const theme = {
-    main: "mediumseagreen"
+    main: 'mediumseagreen',
 };
 
 const ExampleGlobalStyle = createGlobalStyle`
@@ -150,9 +150,7 @@ class Example extends React.Component {
                 <>
                     <ExampleGlobalStyle />
                     <Wrapper>
-                        <Title>
-                            Hello World, this is my first styled component!
-                        </Title>
+                        <Title>Hello World, this is my first styled component!</Title>
 
                         <Input placeholder="@mxstbr" type="text" />
                         <TomatoButton name="demo" />
@@ -165,13 +163,13 @@ class Example extends React.Component {
 
 // css which only uses simple interpolations without functions
 const cssWithValues1 = css`
-    font-size: ${14} ${"pt"};
+    font-size: ${14} ${'pt'};
 `;
 // css which uses other simple interpolations without functions
 const cssWithValues2 = css`
-  ${cssWithValues1}
-  ${[cssWithValues1, cssWithValues1]}
-  font-weight: ${"bold"};
+    ${cssWithValues1}
+    ${[cssWithValues1, cssWithValues1]}
+  font-weight: ${'bold'};
 `;
 
 // css which uses function interpolations with common props
@@ -179,18 +177,18 @@ const cssWithFunc1 = css`
     font-size: ${props => props.theme.fontSizePt}pt;
 `;
 const cssWithFunc2 = css`
-  ${cssWithFunc1}
-  ${props => cssWithFunc1}
+    ${cssWithFunc1}
+    ${props => cssWithFunc1}
   ${[cssWithFunc1, cssWithValues1]}
 `;
 // such css can be used in styled components
 const styledButton = styled.button`
-  ${cssWithValues1} ${[cssWithValues1, cssWithValues2]}
+    ${cssWithValues1} ${[cssWithValues1, cssWithValues2]}
   ${cssWithFunc1} ${[cssWithFunc1, cssWithFunc2]}
   ${() => [cssWithFunc1, cssWithFunc2]}
 `;
 
-const name = "hey";
+const name = 'hey';
 
 const ThemedMyButton = withTheme(MyButton);
 <ThemedMyButton name={name} />;
@@ -222,14 +220,12 @@ const Article = styled.section`
         color: green;
     }
     ${p => (p.theme.useAlternativeLink ? AlternativeLink : Link)} {
-        color: black
+        color: black;
     }
 `;
 
 // A Link instance should be backed by an HTMLAnchorElement
-const ComposedLink = () => (
-    <Link onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined} />
-);
+const ComposedLink = () => <Link onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined} />;
 
 /**
  * construction via string tag
@@ -237,18 +233,14 @@ const ComposedLink = () => (
 
 // Create a <LinkFromString> react component that renders an <a> which is
 // centered, palevioletred and sized at 1.5em
-const LinkFromString = styled("a")`
+const LinkFromString = styled('a')`
     font-size: 1.5em;
     text-align: center;
     color: palevioletred;
 `;
 
 // A LinkFromString instance should be backed by an HTMLAnchorElement
-const MyOtherComponent = () => (
-    <LinkFromString
-        onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined}
-    />
-);
+const MyOtherComponent = () => <LinkFromString onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined} />;
 
 // Create a <LinkFromStringWithProps> react component that renders an <a>
 // which takes extra props
@@ -256,26 +248,23 @@ interface LinkProps {
     canClick: boolean;
 }
 
-const LinkFromStringWithProps = styled("a")`
+const LinkFromStringWithProps = styled('a')`
     font-size: 1.5em;
     text-align: center;
-    color: ${(a: LinkProps) => (a.canClick ? "palevioletred" : "gray")};
+    color: ${(a: LinkProps) => (a.canClick ? 'palevioletred' : 'gray')};
 `;
 
 // A LinkFromStringWithProps instance should be backed by an HTMLAnchorElement
 const MyOtherComponentWithProps = () => (
-    <LinkFromStringWithProps
-        canClick={false}
-        onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined}
-    />
+    <LinkFromStringWithProps canClick={false} onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined} />
 );
 
 // Create a <LinkFromStringWithPropsAndGenerics> react component that renders an <a>
 // which takes extra props passed as a generic type argument
-const LinkFromStringWithPropsAndGenerics = styled("a")<LinkProps>`
+const LinkFromStringWithPropsAndGenerics = styled('a')<LinkProps>`
     font-size: 1.5em;
     text-align: center;
-    color: ${a => (a.canClick ? "palevioletred" : "gray")};
+    color: ${a => (a.canClick ? 'palevioletred' : 'gray')};
 `;
 
 // A LinkFromStringWithPropsAndGenerics instance should be backed by an HTMLAnchorElement
@@ -295,19 +284,19 @@ interface ObjectStyleProps {
 }
 
 const functionReturningStyleObject = (props: ObjectStyleProps) => ({
-    padding: props.size === "big" ? "10px" : 2
+    padding: props.size === 'big' ? '10px' : 2,
 });
 
 const ObjectStylesBox = styled.div`
     ${functionReturningStyleObject} ${{
-        backgroundColor: "red",
+        backgroundColor: 'red',
 
         // Supports nested objects (pseudo selectors, media queries, etc)
-        "@media screen and (min-width: 800px)": {
-            backgroundColor: "blue"
+        '@media screen and (min-width: 800px)': {
+            backgroundColor: 'blue',
         },
 
-        fontSize: 2
+        fontSize: 2,
     }};
 `;
 <ObjectStylesBox size="big" />;
@@ -318,11 +307,11 @@ const ObjectStylesBox = styled.div`
 
 const AttrsInput = styled.input.attrs({
     // we can define static props
-    type: "password",
+    type: 'password',
 
     // or we can define dynamic ones
-    margin: (props: any) => (props.size as string) || "1em",
-    padding: (props: any) => (props.size as string) || "1em"
+    margin: (props: any) => (props.size as string) || '1em',
+    padding: (props: any) => (props.size as string) || '1em',
 })`
     color: palevioletred;
     font-size: 1em;
@@ -335,12 +324,12 @@ const AttrsInput = styled.input.attrs({
 `;
 
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30042
-const AttrsWithOnlyNewProps = styled.h2.attrs({ as: "h1" })`
-    color: ${props => (props.as === "h1" ? "red" : "blue")};
-    font-size: ${props => (props.as === "h1" ? 2 : 1)};
+const AttrsWithOnlyNewProps = styled.h2.attrs({ as: 'h1' })`
+    color: ${props => (props.as === 'h1' ? 'red' : 'blue')};
+    font-size: ${props => (props.as === 'h1' ? 2 : 1)};
 `;
 
-const AttrsInputExtra = styled(AttrsInput).attrs({ autoComplete: "off" })``;
+const AttrsInputExtra = styled(AttrsInput).attrs({ autoComplete: 'off' })``;
 <AttrsInputExtra />;
 /**
  * withConfig
@@ -351,16 +340,16 @@ const AttrsInputExtra = styled(AttrsInput).attrs({ autoComplete: "off" })``;
  */
 
 // $ExpectError
-const WithConfig = styled("div").withConfig()`
+const WithConfig = styled('div').withConfig()`
     color: red;
 `;
 
-styled("div").withConfig({})`
+styled('div').withConfig({})`
     color: red;
 `;
 
-styled("div").withConfig<{ myProp: boolean }>({
-    shouldForwardProp: (prop, defaultValidatorFn) => prop === "myProp",
+styled('div').withConfig<{ myProp: boolean }>({
+    shouldForwardProp: (prop, defaultValidatorFn) => prop === 'myProp',
 })<{ otherProp: string }>`
     color: red;
     ${p => {
@@ -375,8 +364,8 @@ styled("div").withConfig<{ myProp: boolean }>({
     }}
 `;
 
-styled("input").withConfig({
-    shouldForwardProp: (prop) => prop === "disabled",
+styled('input').withConfig({
+    shouldForwardProp: prop => prop === 'disabled',
 })`
     color: red;
 `;
@@ -393,13 +382,13 @@ styled('div').withConfig({
     color: red;
 `;
 
-styled("div").withConfig<{ test: boolean }>({
+styled('div').withConfig<{ test: boolean }>({
     // $ExpectError
-    shouldForwardProp: (prop, defaultValidatorFn) => prop === "invalidProp" && true,
+    shouldForwardProp: (prop, defaultValidatorFn) => prop === 'invalidProp' && true,
 })`
-   color: red;
-   ${p => p.test && css``}
-   ${p => p.invalidProp && css``} // $ExpectError
+    color: red;
+    ${p => p.test && css``}
+    ${p => p.invalidProp && css``} // $ExpectError
 `;
 
 /**
@@ -438,14 +427,14 @@ const ThemedButton = styled.button`
 
 // Define our `fg` and `bg` on the theme
 const theme2 = {
-    fg: "palevioletred",
-    bg: "white"
+    fg: 'palevioletred',
+    bg: 'white',
 };
 
 // This theme swaps `fg` and `bg`
 const invertTheme = ({ fg, bg }: { fg: string; bg: string }) => ({
     fg: bg,
-    bg: fg
+    bg: fg,
 });
 
 const MyApp = (
@@ -468,7 +457,7 @@ class MyComponent extends React.Component<ThemeProps<{}>> {
     render() {
         const { theme } = this.props;
 
-        console.log("Current theme: ", theme);
+        console.log('Current theme: ', theme);
 
         return <h1>Hello</h1>;
     }
@@ -491,13 +480,11 @@ interface WithThemeProps {
     text: string;
 }
 
-const Component = (props: WithThemeProps) => (
-    <div style={{ color: props.theme.color }}>{props.text}</div>
-);
+const Component = (props: WithThemeProps) => <div style={{ color: props.theme.color }}>{props.text}</div>;
 
 const ComponentWithTheme = withTheme(Component);
-<ComponentWithTheme text={"hi"} />; // ok
-<ComponentWithTheme text={"hi"} theme={{ color: "red" }} />; // ok
+<ComponentWithTheme text={'hi'} />; // ok
+<ComponentWithTheme text={'hi'} theme={{ color: 'red' }} />; // ok
 <ThemeConsumer>{theme => <Component text="hi" theme={theme} />}</ThemeConsumer>;
 
 /**
@@ -517,7 +504,7 @@ class ClassComponent extends React.Component {
 isStyledComponent(StyledComponent);
 isStyledComponent(StatelessComponent);
 isStyledComponent(ClassComponent);
-isStyledComponent("div");
+isStyledComponent('div');
 
 /**
  * server side rendering
@@ -548,9 +535,7 @@ const css2 = sheet2.getStyleElement();
 
 const sheet3 = new ServerStyleSheet();
 const appStream = ReactDOMServer.renderToNodeStream(<Title>Hello world</Title>);
-const wrappedCssStream: NodeJS.ReadableStream = sheet3.interleaveWithNodeStream(
-    appStream
-);
+const wrappedCssStream: NodeJS.ReadableStream = sheet3.interleaveWithNodeStream(appStream);
 
 /**
  * StyledComponent.withComponent
@@ -590,54 +575,46 @@ class Random extends React.Component<any, any> {
     }
 }
 
-const WithComponentH2 = WithComponentH1.withComponent("h2");
-const WithComponentAbbr = WithComponentH1.withComponent("abbr");
+const WithComponentH2 = WithComponentH1.withComponent('h2');
+const WithComponentAbbr = WithComponentH1.withComponent('abbr');
 
-const WithComponentAnchor = WithComponentH1.withComponent("a");
+const WithComponentAnchor = WithComponentH1.withComponent('a');
 const AnchorContainer = () => (
-    <WithComponentAnchor href="https://example.com">
-        withComponent Anchor
-    </WithComponentAnchor>
+    <WithComponentAnchor href="https://example.com">withComponent Anchor</WithComponentAnchor>
 );
 
 const WithComponentRandomHeading = WithComponentH1.withComponent(Random);
 
-const WithComponentCompA: React.SFC<{ a: number; className?: string }> = ({
-    className
-}) => <div className={className} />;
-const WithComponentCompB: React.SFC<{ b: number; className?: string }> = ({
-    className
-}) => <div className={className} />;
+const WithComponentCompA: React.SFC<{ a: number; className?: string }> = ({ className }) => (
+    <div className={className} />
+);
+const WithComponentCompB: React.SFC<{ b: number; className?: string }> = ({ className }) => (
+    <div className={className} />
+);
 const WithComponentStyledA = styled(WithComponentCompA)`
     color: ${(props: { color: string }) => props.color};
 `;
 
 const WithComponentFirstStyledA = styled(WithComponentStyledA).attrs({
-    a: 1
+    a: 1,
 })``;
 
-const WithComponentFirstStyledB = WithComponentFirstStyledA.withComponent(
-    WithComponentCompB
-);
+const WithComponentFirstStyledB = WithComponentFirstStyledA.withComponent(WithComponentCompB);
 
-const WithComponentFirstStyledANew = styled(WithComponentStyledA).attrs(
-    props => ({ a: 1 })
-)``;
+const WithComponentFirstStyledANew = styled(WithComponentStyledA).attrs(props => ({ a: 1 }))``;
 
 const test = () => [
-    <WithComponentFirstStyledA color={"black"} />,
-    <WithComponentFirstStyledB b={2} color={"black"} />,
-    <WithComponentFirstStyledANew color={"black"} />
+    <WithComponentFirstStyledA color={'black'} />,
+    <WithComponentFirstStyledB b={2} color={'black'} />,
+    <WithComponentFirstStyledANew color={'black'} />,
 ];
 
-const WithComponentRequired = styled((props: { to: string }) => (
-    <a href={props.to} />
-))``;
+const WithComponentRequired = styled((props: { to: string }) => <a href={props.to} />)``;
 // These tests pass in tsservice, but they fail in dtslint. I do not know why.
 // <WithComponentRequired href=''/>; // $ExpectError
 // <WithComponentRequired to=''/>;
 
-const WithComponentRequired2 = WithComponentRequired.withComponent("a");
+const WithComponentRequired2 = WithComponentRequired.withComponent('a');
 // These tests pass in tsservice, but they fail in dtslint. I do not know why.
 // <WithComponentRequired2 href=''/>;
 // <WithComponentRequired2 to=''/>; // $ExpectError
@@ -661,7 +638,7 @@ const forwardedAsTest = (
 );
 
 interface TestContainerProps {
-    size: "big" | "small";
+    size: 'big' | 'small';
     test?: boolean;
 }
 const TestContainer = ({ size, test }: TestContainerProps) => {
@@ -673,7 +650,7 @@ const StyledTestContainer = styled(TestContainer)`
 `;
 
 interface Test2ContainerProps {
-    type: "foo" | "bar";
+    type: 'foo' | 'bar';
 }
 class Test2Container extends React.Component<Test2ContainerProps> {
     render() {
@@ -704,7 +681,7 @@ const StyledStyledDiv = styled(StyledDiv)``;
 <StyledStyledDiv ref={divFnRef} />;
 <StyledStyledDiv ref="string" />; // $ExpectError
 
-const StyledA = StyledDiv.withComponent("a");
+const StyledA = StyledDiv.withComponent('a');
 // No longer generating a type error as of Feb. 6th, 2019
 // <StyledA ref={divRef} />; // $ExpectError
 <StyledA
@@ -716,7 +693,7 @@ const StyledA = StyledDiv.withComponent("a");
 
 async function typedThemes() {
     const theme = {
-        color: "green"
+        color: 'green',
     };
 
     // abuse "await import(...)" to be able to reference the styled-components namespace
@@ -726,11 +703,9 @@ async function typedThemes() {
         css,
         createGlobalStyle,
         ThemeProvider,
-        ThemeConsumer
-    // tslint:disable-next-line:no-relative-import-in-test
-    } = (await import("..")) as any as ThemedStyledComponentsModule<
-        typeof theme
-    >;
+        ThemeConsumer,
+        // tslint:disable-next-line:no-relative-import-in-test
+    } = ((await import('..')) as any) as ThemedStyledComponentsModule<typeof theme>;
 
     const ThemedDiv = styled.div`
         background: ${props => {
@@ -748,7 +723,7 @@ async function typedThemes() {
         props.tabIndex;
 
         return {
-            background: props.theme.color
+            background: props.theme.color,
         };
     });
     const ThemedDiv3 = styled.div(props => {
@@ -777,8 +752,8 @@ async function typedThemes() {
     const themedCssWithNesting = css(props => ({
         color: props.theme.color,
         [ThemedDiv3]: {
-            color: "green"
-        }
+            color: 'green',
+        },
     }));
 
     const Global = createGlobalStyle`
@@ -806,7 +781,7 @@ async function typedThemes() {
 
 async function reexportCompatibility() {
     // tslint:disable-next-line:no-relative-import-in-test
-    const sc = await import("..");
+    const sc = await import('..');
     const themed = sc as ThemedStyledComponentsModule<any>;
 
     let { ...scExports } = sc;
@@ -828,19 +803,14 @@ async function themeAugmentation() {
     }
 
     // tslint:disable-next-line:no-relative-import-in-test
-    const base = (await import("..")) as any as ThemedStyledComponentsModule<
-        BaseTheme
-    >;
+    const base = ((await import('..')) as any) as ThemedStyledComponentsModule<BaseTheme>;
     // tslint:disable-next-line:no-relative-import-in-test
-    const extra = (await import("..")) as any as ThemedStyledComponentsModule<
-        ExtraTheme,
-        BaseTheme
-    >;
+    const extra = ((await import('..')) as any) as ThemedStyledComponentsModule<ExtraTheme, BaseTheme>;
 
     return (
         <base.ThemeProvider
             theme={{
-                background: "black"
+                background: 'black',
             }}
         >
             <>
@@ -852,7 +822,7 @@ async function themeAugmentation() {
                 <extra.ThemeProvider
                     theme={base => ({
                         ...base,
-                        accent: "blue"
+                        accent: 'blue',
                     })}
                 >
                     <extra.ThemeConsumer>{() => null}</extra.ThemeConsumer>
@@ -874,16 +844,16 @@ async function themeAugmentation() {
 // }
 
 function cssProp() {
-    function Custom(props: React.ComponentPropsWithoutRef<"div">) {
+    function Custom(props: React.ComponentPropsWithoutRef<'div'>) {
         return <div {...props} />;
     }
 
-    const myCss = "background: blue;";
+    const myCss = 'background: blue;';
 
     return (
         <>
             <div css="background: blue;" />
-            <div css={{ background: "blue" }} />
+            <div css={{ background: 'blue' }} />
             <div
                 // would be nice to be able to turn this into an error as it also crashes the plugin,
                 // but this is how optional properties work in TypeScript...
@@ -897,7 +867,7 @@ function cssProp() {
             />
             <div
                 // but this crashes the plugin, even though it's valid type-wise and we can't forbid it
-                css={css({ background: "blue" })}
+                css={css({ background: 'blue' })}
             />
             <div
                 // this also crashes the plugin, only inline strings or css template tag work
@@ -905,7 +875,7 @@ function cssProp() {
             />
             <div
                 css={css`
-                    background: ${() => "blue"};
+                    background: ${() => 'blue'};
                 `}
             />
             <div
@@ -927,7 +897,7 @@ function cssProp() {
             />
             <Custom
                 css={css`
-                    background: ${() => "blue"};
+                    background: ${() => 'blue'};
                 `}
             />
             <Custom
@@ -946,57 +916,57 @@ function cssProp() {
 
 function validateArgumentsAndReturns() {
     const t1: FlattenSimpleInterpolation[] = [
-        css({ color: "blue" }),
+        css({ color: 'blue' }),
         css`
             color: blue;
         `,
         css`
-            color: ${"blue"};
-        `
+            color: ${'blue'};
+        `,
     ];
     const t4: FlattenInterpolation<any> = [
         css`
-            color: ${() => "blue"};
+            color: ${() => 'blue'};
         `,
-        css(() => ({ color: "blue" })),
+        css(() => ({ color: 'blue' })),
         css(
             () =>
                 css`
-                    color: "blue";
-                `
-        )
+                    color: 'blue';
+                `,
+        ),
     ];
 
     // if the first argument is array-like it's always treated as a string[], this breaks things
     css(
         // $ExpectError
         css`
-            ${{ color: "blue" }}
-        `
+            ${{ color: 'blue' }}
+        `,
     );
     // _technically_ valid as styled-components doesn't look at .raw but best not to support it
     // $ExpectError
     css([]);
 
-    styled.div({ color: "blue" });
+    styled.div({ color: 'blue' });
     styled.div(props => ({ color: props.theme.color }));
     styled.div`
-        color: ${"blue"};
+        color: ${'blue'};
     `;
     // These don't work for the same reason css doesn't work
     styled.div(
         // $ExpectError
         css`
-            ${{ color: "blue" }}
-        `
+            ${{ color: 'blue' }}
+        `,
     );
     // $ExpectError
     styled.div([]);
 
     createGlobalStyle({
-        ":root": {
-            color: "blue"
-        }
+        ':root': {
+            color: 'blue',
+        },
     });
     createGlobalStyle`
         :root {
@@ -1004,15 +974,15 @@ function validateArgumentsAndReturns() {
         }
     `;
     createGlobalStyle(() => ({
-        ":root": {
-            color: "blue"
-        }
+        ':root': {
+            color: 'blue',
+        },
     }));
     // these are invalid for the same reason as in styled.div
     // $ExpectError
     createGlobalStyle(css`
         :root {
-            color: ${() => "blue"};
+            color: ${() => 'blue'};
         }
     `);
     // $ExpectError
@@ -1027,7 +997,7 @@ function validateDefaultProps() {
 
     class MyComponent extends React.PureComponent<Props> {
         static defaultProps = {
-            optionalProp: 'fallback'
+            optionalProp: 'fallback',
         };
 
         render() {
@@ -1042,7 +1012,7 @@ function validateDefaultProps() {
     }
 
     const StyledComponent = styled(MyComponent)`
-        color: red
+        color: red;
     `;
 
     // this test is failing in TS 2.9 but not in 3.0
@@ -1063,8 +1033,10 @@ function validateDefaultProps() {
     }
 
     const OtherStyledComponent = withDefaultProps(
-        styled(MyComponent)` color: red `,
-        { requiredProp: true }
+        styled(MyComponent)`
+            color: red;
+        `,
+        { requiredProp: true },
     );
 
     // this test is failing in TS 3.1 but not in 3.2
@@ -1077,18 +1049,22 @@ interface WrapperProps {
     className?: string;
 }
 export class WrapperClass extends React.Component<WrapperProps> {
-    render() { return <div />; }
+    render() {
+        return <div />;
+    }
 }
 const StyledWrapperClass = styled(WrapperClass)``;
 // React.Component typings always add `children` to props, so this should accept children
 const wrapperClass = <StyledWrapperClass>Text</StyledWrapperClass>;
 
-export class WrapperClassFuncChild extends React.Component<WrapperProps & {children: () => any}> {
-    render() { return <div />; }
+export class WrapperClassFuncChild extends React.Component<WrapperProps & { children: () => any }> {
+    render() {
+        return <div />;
+    }
 }
 const StyledWrapperClassFuncChild = styled(WrapperClassFuncChild)``;
 // React.Component typings always add `children` to props, so this should accept children
-const wrapperClassNoChildrenGood = <StyledWrapperClassFuncChild>{() => "text"}</StyledWrapperClassFuncChild>;
+const wrapperClassNoChildrenGood = <StyledWrapperClassFuncChild>{() => 'text'}</StyledWrapperClassFuncChild>;
 const wrapperClassNoChildren = <StyledWrapperClassFuncChild>Text</StyledWrapperClassFuncChild>; // $ExpectError
 
 const WrapperFunction: React.FunctionComponent<WrapperProps> = () => <div />;
@@ -1103,9 +1079,15 @@ const wrapperFunc = <StyledWrapperFunc>Text</StyledWrapperFunc>; // $ExpectError
 
 // Test if static properties added to the underlying component is passed through.
 function staticPropertyPassthrough() {
-    interface AProps { a: number; }
-    interface BProps { b?: string; }
-    interface BState { b?: string; }
+    interface AProps {
+        a: number;
+    }
+    interface BProps {
+        b?: string;
+    }
+    interface BState {
+        b?: string;
+    }
     class A extends React.Component<AProps> {}
     class B extends React.Component<BProps, BState> {
         static A = A;
@@ -1117,12 +1099,12 @@ function staticPropertyPassthrough() {
     }
     const StyledB = styled(B)``;
     <StyledB.A />; // $ExpectError
-    <StyledB.A a='a' />; // $ExpectError
+    <StyledB.A a="a" />; // $ExpectError
     <StyledB.A a={0} />;
     StyledB.PUBLIC; // $ExpectError
     StyledB.componentDidMount(); // $ExpectError
-    StyledB.F({ b: 'b' } , { b: 'b' });
-    StyledB.getDerivedStateFromProps({ b: 'b' } , { b: 'b' }); // $ExpectError
+    StyledB.F({ b: 'b' }, { b: 'b' });
+    StyledB.getDerivedStateFromProps({ b: 'b' }, { b: 'b' }); // $ExpectError
 }
 
 function unionTest() {
@@ -1136,7 +1118,7 @@ function unionTest() {
         issue: number;
     }
 
-    type SomethingToRead = (Book | Magazine);
+    type SomethingToRead = Book | Magazine;
 
     const Readable: React.FunctionComponent<SomethingToRead> = props => {
         if (props.kind === 'magazine') {
@@ -1147,7 +1129,7 @@ function unionTest() {
     };
 
     const StyledReadable = styled(Readable)`
-        font-size: ${props => props.kind === 'book' ? 16 : 14}
+        font-size: ${props => (props.kind === 'book' ? 16 : 14)};
     `;
 
     // undesired, fix was reverted because of https://github.com/Microsoft/TypeScript/issues/30663
@@ -1157,11 +1139,15 @@ function unionTest() {
 
 function unionTest2() {
     // Union of two non-overlapping types
-    type Props = {
-        foo: number, bar?: undefined
-    } | {
-        foo?: undefined, bar: string
-    };
+    type Props =
+        | {
+              foo: number;
+              bar?: undefined;
+          }
+        | {
+              foo?: undefined;
+              bar: string;
+          };
 
     const C = styled.div<Props>``;
 

--- a/types/styled-components/ts3.6/test/index.tsx
+++ b/types/styled-components/ts3.6/test/index.tsx
@@ -637,10 +637,10 @@ const forwardedAsTest = (
     </>
 );
 
-type ExternalAsComponentProps = {
+interface ExternalAsComponentProps {
     as?: string | React.ComponentType<any>;
     type: 'primitive' | 'complex';
-};
+}
 
 const ExternalAsComponent: React.FC<ExternalAsComponentProps> = () => null;
 const WrappedExternalAsComponent = styled(ExternalAsComponent)``;

--- a/types/styled-components/ts3.6/test/index.tsx
+++ b/types/styled-components/ts3.6/test/index.tsx
@@ -678,11 +678,7 @@ class Test2Container extends React.Component<Test2ContainerProps> {
     }
 }
 
-const containerTest = (
-    // TODO (TypeScript 3.2): once the polymorphic overload is un-commented-out this should be the correct test
-    // <StyledTestContainer as={Test2Container} type='foo' />
-    <StyledTestContainer as={Test2Container} size="small" />
-);
+const containerTest = <StyledTestContainer as={Test2Container} type="foo" />;
 
 // 4.0 refs
 

--- a/types/styled-components/ts3.6/test/index.tsx
+++ b/types/styled-components/ts3.6/test/index.tsx
@@ -650,13 +650,12 @@ const ForwardedAsWithWrappedExternalTest = (
         <WrappedExternalAsComponent forwardedAs={WithComponentH2} type="complex" />
     </>
 );
-// TODO: Needs corresponding fix in StyledComponentBase
-// const ForwardedAsWithNestedAsExternalTest = (
-//     <>
-//         <ForwardedAsNestedComponent as={ExternalAsComponent} forwardedAs="h2" type="primitive" />
-//         <ForwardedAsNestedComponent as={ExternalAsComponent} forwardedAs={WithComponentH2} type="complex" />
-//     </>
-// );
+const ForwardedAsWithNestedAsExternalTest = (
+    <>
+        <ForwardedAsNestedComponent as={ExternalAsComponent} forwardedAs="h2" type="primitive" />
+        <ForwardedAsNestedComponent as={ExternalAsComponent} forwardedAs={WithComponentH2} type="complex" />
+    </>
+);
 
 interface TestContainerProps {
     size: 'big' | 'small';

--- a/types/styled-components/ts3.6/test/native.tsx
+++ b/types/styled-components/ts3.6/test/native.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
-import * as ReactNative from "react-native";
-import * as ReactDOMServer from "react-dom/server";
+import * as React from 'react';
+import * as ReactNative from 'react-native';
+import * as ReactDOMServer from 'react-dom/server';
 
 import styled, {
     css,
@@ -10,32 +10,32 @@ import styled, {
     withTheme,
     ThemeConsumer,
     ReactNativeThemedStyledComponentsModule,
+    // tslint:disable-next-line:no-relative-import-in-test
+} from '../native';
 // tslint:disable-next-line:no-relative-import-in-test
-} from "../native";
-// tslint:disable-next-line:no-relative-import-in-test
-import {} from "../cssprop";
+import {} from '../cssprop';
 
 const StyledView = styled.View`
-  background-color: papayawhip;
+    background-color: papayawhip;
 `;
 
 const StyledText = styled(ReactNative.Text)`
-  color: palevioletred;
+    color: palevioletred;
 `;
 
 class MyReactNativeComponent extends React.Component {
-  render() {
-    return (
-      <StyledView>
-        <StyledText>Hello World!</StyledText>
-      </StyledView>
-    );
-  }
+    render() {
+        return (
+            <StyledView>
+                <StyledText>Hello World!</StyledText>
+            </StyledView>
+        );
+    }
 }
 
 const ValidProp = <StyledText adjustsFontSizeToFit />;
 const invalidProp = <StyledText randoName={2} />; // $ExpectError
-const invalidTag = styled.div` margin-top: 5px; `; // $ExpectError
+const invalidTag = styled.div``; // $ExpectError
 
 interface MyTheme {
     primary: string;
@@ -62,143 +62,139 @@ const TomatoButton = styled(MyButton)`
 const tomatoElement = <TomatoButton name="needed" />;
 
 async function typedThemes() {
-  const theme = {
-      color: "green"
-  };
-
-  // abuse "await import(...)" to be able to reference the styled-components namespace
-  // without actually doing a top level namespace import
-  const {
-      default: styled,
-      css,
-      ThemeProvider,
-      ThemeConsumer
-  // tslint:disable-next-line:no-relative-import-in-test
-  } = (await import("../native")) as any as ReactNativeThemedStyledComponentsModule<
-      typeof theme
-  >;
-
-  const ThemedView = styled.View`
-      background: ${props => {
-          // $ExpectType string
-          props.theme.color;
-          // $ExpectType string | undefined
-          props.testID;
-          return props.theme.color;
-      }};
-  `;
-  const ThemedView2 = styled.View(props => {
-    // $ExpectType string
-    props.theme.color;
-    // $ExpectType string | undefined
-    props.testID;
-
-    return {
-        background: props.theme.color
+    const theme = {
+        color: 'green',
     };
-  });
-  const ThemedView3 = styled.View(props => {
-    // $ExpectType string
-    props.theme.color;
-    // $ExpectType string | undefined
-    props.testID;
 
-    return css`
-        background: ${props.theme.color};
+    // abuse "await import(...)" to be able to reference the styled-components namespace
+    // without actually doing a top level namespace import
+    const {
+        default: styled,
+        css,
+        ThemeProvider,
+        ThemeConsumer,
+        // tslint:disable-next-line:no-relative-import-in-test
+    } = ((await import('../native')) as any) as ReactNativeThemedStyledComponentsModule<typeof theme>;
+
+    const ThemedView = styled.View`
+        background: ${props => {
+            // $ExpectType string
+            props.theme.color;
+            // $ExpectType string | undefined
+            props.testID;
+            return props.theme.color;
+        }};
     `;
-});
-const themedCss = css`
-    background: ${props => {
+    const ThemedView2 = styled.View(props => {
         // $ExpectType string
         props.theme.color;
-        // $ExpectType "theme"
-        type Keys = keyof typeof props;
-        return props.theme.color;
-    }};
-`;
-//  can't use a FlattenInterpolation as the first argument, would make broken css
-// $ExpectError
-const ThemedView4 = styled.View(themedCss);
+        // $ExpectType string | undefined
+        props.testID;
 
-const themedCssWithNesting = css(props => ({
-    color: props.theme.color,
-    [ThemedView3]: {
-        color: "green"
-    }
-}));
+        return {
+            background: props.theme.color,
+        };
+    });
+    const ThemedView3 = styled.View(props => {
+        // $ExpectType string
+        props.theme.color;
+        // $ExpectType string | undefined
+        props.testID;
 
-return (
-    <ThemeProvider theme={theme}>
-        <>
-            <ThemedView />
-            <ThemedView2 />
-            <ThemedView3 />
-            <ThemeConsumer>
-                {theme => {
-                    // $ExpectType string
-                    theme.color;
-                    return theme.color;
-                }}
-            </ThemeConsumer>
-        </>
-    </ThemeProvider>
-  );
+        return css`
+            background: ${props.theme.color};
+        `;
+    });
+    const themedCss = css`
+        background: ${props => {
+            // $ExpectType string
+            props.theme.color;
+            // $ExpectType "theme"
+            type Keys = keyof typeof props;
+            return props.theme.color;
+        }};
+    `;
+    //  can't use a FlattenInterpolation as the first argument, would make broken css
+    // $ExpectError
+    const ThemedView4 = styled.View(themedCss);
+
+    const themedCssWithNesting = css(props => ({
+        color: props.theme.color,
+        [ThemedView3]: {
+            color: 'green',
+        },
+    }));
+
+    return (
+        <ThemeProvider theme={theme}>
+            <>
+                <ThemedView />
+                <ThemedView2 />
+                <ThemedView3 />
+                <ThemeConsumer>
+                    {theme => {
+                        // $ExpectType string
+                        theme.color;
+                        return theme.color;
+                    }}
+                </ThemeConsumer>
+            </>
+        </ThemeProvider>
+    );
 }
 
 async function reexportCompatibility() {
-  // tslint:disable-next-line:no-relative-import-in-test
-  const sc = await import("../native");
-  const themed = sc as ReactNativeThemedStyledComponentsModule<any>;
+    // tslint:disable-next-line:no-relative-import-in-test
+    const sc = await import('../native');
+    const themed = sc as ReactNativeThemedStyledComponentsModule<any>;
 
-  let { ...scExports } = sc;
-  let { ...themedExports } = themed;
-  // both branches must be assignable to each other
-  if (Math.random()) {
-      scExports = themedExports;
-  } else {
-      themedExports = scExports;
-  }
+    let { ...scExports } = sc;
+    let { ...themedExports } = themed;
+    // both branches must be assignable to each other
+    if (Math.random()) {
+        scExports = themedExports;
+    } else {
+        themedExports = scExports;
+    }
 }
 
 async function themeAugmentation() {
-  interface BaseTheme {
-      background: string;
-  }
-  interface ExtraTheme extends BaseTheme {
-      accent: string;
-  }
+    interface BaseTheme {
+        background: string;
+    }
+    interface ExtraTheme extends BaseTheme {
+        accent: string;
+    }
 
-  // tslint:disable-next-line:no-relative-import-in-test
-  const base = (await import("../native")) as any as ReactNativeThemedStyledComponentsModule<
-      BaseTheme
-  >;
-  // tslint:disable-next-line:no-relative-import-in-test
-  const extra = (await import("../native")) as any as ReactNativeThemedStyledComponentsModule<
-      ExtraTheme,
-      BaseTheme
-  >;
+    // tslint:disable-next-line:no-relative-import-in-test
+    const base = ((await import('../native')) as any) as ReactNativeThemedStyledComponentsModule<BaseTheme>;
+    // tslint:disable-next-line:no-relative-import-in-test
+    const extra = ((await import('../native')) as any) as ReactNativeThemedStyledComponentsModule<
+        ExtraTheme,
+        BaseTheme
+    >;
 
-  return (
-      <base.ThemeProvider
-          theme={{
-              background: "black"
-          }}
-      >
-          <>
-              <extra.ThemeProvider
-                  theme={base => base} // $ExpectError
-              >
-                  <extra.ThemeConsumer>{() => null}</extra.ThemeConsumer>
-              </extra.ThemeProvider>
-              <extra.ThemeProvider
-                  theme={base => ({
-                      ...base,
-                      accent: "blue"
-                  })}
-              >
-                  <extra.ThemeConsumer>{() => null}</extra.ThemeConsumer>
-              </extra.ThemeProvider>
-          </>
-      </base.ThemeProvider>
-  );
+    return (
+        <base.ThemeProvider
+            theme={{
+                background: 'black',
+            }}
+        >
+            <>
+                <extra.ThemeProvider
+                    theme={base => base} // $ExpectError
+                >
+                    <extra.ThemeConsumer>{() => null}</extra.ThemeConsumer>
+                </extra.ThemeProvider>
+                <extra.ThemeProvider
+                    theme={base => ({
+                        ...base,
+                        accent: 'blue',
+                    })}
+                >
+                    <extra.ThemeConsumer>{() => null}</extra.ThemeConsumer>
+                </extra.ThemeProvider>
+            </>
+        </base.ThemeProvider>
+    );
 }

--- a/types/styled-components/v3/index.d.ts
+++ b/types/styled-components/v3/index.d.ts
@@ -18,27 +18,16 @@ export type StyledProps<P> = ThemedStyledProps<P, any>;
 
 export type ThemedOuterStyledProps<P, T> = P & {
     theme?: T;
-    innerRef?:
-        | ((instance: any) => void)
-        | React.RefObject<HTMLElement | SVGElement | React.Component>;
+    innerRef?: ((instance: any) => void) | React.RefObject<HTMLElement | SVGElement | React.Component>;
 };
 export type OuterStyledProps<P> = ThemedOuterStyledProps<P, any>;
 
 export type FalseyValue = undefined | null | false;
 export type Interpolation<P> =
     | FlattenInterpolation<P>
-    | ReadonlyArray<
-          FlattenInterpolation<P> | ReadonlyArray<FlattenInterpolation<P>>
-      >;
-export type FlattenInterpolation<P> =
-    | InterpolationValue
-    | InterpolationFunction<P>;
-export type InterpolationValue =
-    | string
-    | number
-    | Styles
-    | FalseyValue
-    | StyledComponentClass<any, any>;
+    | ReadonlyArray<FlattenInterpolation<P> | ReadonlyArray<FlattenInterpolation<P>>>;
+export type FlattenInterpolation<P> = InterpolationValue | InterpolationFunction<P>;
+export type InterpolationValue = string | number | Styles | FalseyValue | StyledComponentClass<any, any>;
 export type SimpleInterpolation =
     | InterpolationValue
     | ReadonlyArray<InterpolationValue | ReadonlyArray<InterpolationValue>>;
@@ -49,23 +38,16 @@ export interface Styles {
 export type InterpolationFunction<P> = (props: P) => Interpolation<P>;
 
 type Attrs<P, A extends Partial<P>, T> = {
-    [K in keyof A]: ((props: ThemedStyledProps<P, T>) => A[K]) | A[K]
+    [K in keyof A]: ((props: ThemedStyledProps<P, T>) => A[K]) | A[K];
 };
 
-export interface StyledComponentClass<P, T, O = P>
-    extends React.ComponentClass<ThemedOuterStyledProps<O, T>> {
+export interface StyledComponentClass<P, T, O = P> extends React.ComponentClass<ThemedOuterStyledProps<O, T>> {
     extend: ThemedStyledFunction<P, T, O>;
 
     withComponent<K extends keyof JSX.IntrinsicElements>(
         tag: K,
-    ): StyledComponentClass<
-        JSX.IntrinsicElements[K],
-        T,
-        JSX.IntrinsicElements[K] & O
-    >;
-    withComponent<U = {}>(
-        element: React.ComponentType<U>,
-    ): StyledComponentClass<U, T, U & O>;
+    ): StyledComponentClass<JSX.IntrinsicElements[K], T, JSX.IntrinsicElements[K] & O>;
+    withComponent<U = {}>(element: React.ComponentType<U>): StyledComponentClass<U, T, U & O>;
 }
 
 export interface ThemedStyledFunction<P, T, O = P> {
@@ -85,25 +67,21 @@ export interface ThemedStyledFunction<P, T, O = P> {
 export type StyledFunction<P> = ThemedStyledFunction<P, any>;
 
 type ThemedStyledComponentFactories<T> = {
-    [TTag in keyof JSX.IntrinsicElements]: ThemedStyledFunction<
-        JSX.IntrinsicElements[TTag],
-        T
-    >
+    [TTag in keyof JSX.IntrinsicElements]: ThemedStyledFunction<JSX.IntrinsicElements[TTag], T>;
 };
 
-export interface ThemedBaseStyledInterface<T>
-    extends ThemedStyledComponentFactories<T> {
-    <P, TTag extends keyof JSX.IntrinsicElements>(
-        tag: TTag,
-    ): ThemedStyledFunction<P, T, P & JSX.IntrinsicElements[TTag]>;
-    <P, O>(component: StyledComponentClass<P, T, O>): ThemedStyledFunction<
+export interface ThemedBaseStyledInterface<T> extends ThemedStyledComponentFactories<T> {
+    <P, TTag extends keyof JSX.IntrinsicElements>(tag: TTag): ThemedStyledFunction<
         P,
         T,
-        O
+        P & JSX.IntrinsicElements[TTag]
     >;
-    <P extends { [prop: string]: any; theme?: T }>(
-        component: React.ComponentType<P>,
-    ): ThemedStyledFunction<P, T, WithOptionalTheme<P, T>>;
+    <P, O>(component: StyledComponentClass<P, T, O>): ThemedStyledFunction<P, T, O>;
+    <P extends { [prop: string]: any; theme?: T }>(component: React.ComponentType<P>): ThemedStyledFunction<
+        P,
+        T,
+        WithOptionalTheme<P, T>
+    >;
 }
 
 export type ThemedStyledInterface<T> = ThemedBaseStyledInterface<Extract<keyof T, string> extends never ? any : T>;
@@ -114,29 +92,21 @@ export interface DefaultTheme {}
 export interface ThemeProviderProps<T> {
     theme?: T | ((theme: T) => T);
 }
-export type BaseThemeProviderComponent<T> = React.ComponentClass<
-    ThemeProviderProps<T>
-    >;
+export type BaseThemeProviderComponent<T> = React.ComponentClass<ThemeProviderProps<T>>;
 export type ThemeProviderComponent<T> = BaseThemeProviderComponent<Extract<keyof T, string> extends never ? any : T>;
 export interface BaseThemedCssFunction<T> {
-    (
-        strings: TemplateStringsArray,
-        ...interpolations: SimpleInterpolation[]
-    ): InterpolationValue[];
-    <P>(
-        strings: TemplateStringsArray,
-        ...interpolations: Array<Interpolation<ThemedStyledProps<P, T>>>
-    ): Array<FlattenInterpolation<ThemedStyledProps<P, T>>>;
+    (strings: TemplateStringsArray, ...interpolations: SimpleInterpolation[]): InterpolationValue[];
+    <P>(strings: TemplateStringsArray, ...interpolations: Array<Interpolation<ThemedStyledProps<P, T>>>): Array<
+        FlattenInterpolation<ThemedStyledProps<P, T>>
+    >;
 }
 export type ThemedCssFunction<T> = BaseThemedCssFunction<Extract<keyof T, string> extends never ? any : T>;
 
 // Helper type operators
 type KeyofBase = keyof any;
-type Diff<T extends KeyofBase, U extends KeyofBase> = ({ [P in T]: P } &
-    { [P in U]: never })[T];
+type Diff<T extends KeyofBase, U extends KeyofBase> = ({ [P in T]: P } & { [P in U]: never })[T];
 type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
-type DiffBetween<T, U> = Pick<T, Diff<keyof T, keyof U>> &
-    Pick<U, Diff<keyof U, keyof T>>;
+type DiffBetween<T, U> = Pick<T, Diff<keyof T, keyof U>> & Pick<U, Diff<keyof U, keyof T>>;
 type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, 'theme'> & {
     theme?: T;
 };
@@ -145,14 +115,8 @@ export interface ThemedStyledComponentsModule<T> {
     default: ThemedStyledInterface<T>;
 
     css: ThemedCssFunction<T>;
-    keyframes(
-        strings: TemplateStringsArray,
-        ...interpolations: SimpleInterpolation[]
-    ): string;
-    injectGlobal(
-        strings: TemplateStringsArray,
-        ...interpolations: SimpleInterpolation[]
-    ): void;
+    keyframes(strings: TemplateStringsArray, ...interpolations: SimpleInterpolation[]): string;
+    injectGlobal(strings: TemplateStringsArray, ...interpolations: SimpleInterpolation[]): void;
     withTheme: WithThemeFnInterface<T>;
 
     ThemeProvider: ThemeProviderComponent<T>;
@@ -163,26 +127,18 @@ declare const styled: StyledInterface;
 export const css: ThemedCssFunction<DefaultTheme>;
 
 export type BaseWithThemeFnInterface<T> = <P extends { theme?: T }>(
-        component: React.ComponentType<P>,
-    ) => React.ComponentClass<WithOptionalTheme<P, T>>;
+    component: React.ComponentType<P>,
+) => React.ComponentClass<WithOptionalTheme<P, T>>;
 export type WithThemeFnInterface<T> = BaseWithThemeFnInterface<Extract<keyof T, string> extends never ? any : T>;
 export const withTheme: WithThemeFnInterface<DefaultTheme>;
 
-export function keyframes(
-    strings: TemplateStringsArray,
-    ...interpolations: SimpleInterpolation[]
-): string;
+export function keyframes(strings: TemplateStringsArray, ...interpolations: SimpleInterpolation[]): string;
 
-export function injectGlobal(
-    strings: TemplateStringsArray,
-    ...interpolations: SimpleInterpolation[]
-): void;
+export function injectGlobal(strings: TemplateStringsArray, ...interpolations: SimpleInterpolation[]): void;
 
 export function consolidateStreamedStyles(): void;
 
-export function isStyledComponent(
-    target: any,
-): target is StyledComponentClass<{}, {}>;
+export function isStyledComponent(target: any): target is StyledComponentClass<{}, {}>;
 
 export const ThemeProvider: ThemeProviderComponent<object>;
 
@@ -195,20 +151,14 @@ interface StyleSheetManagerProps {
     target?: Node;
 }
 
-export class StyleSheetManager extends React.Component<
-    StyleSheetManagerProps
-> {}
+export class StyleSheetManager extends React.Component<StyleSheetManagerProps> {}
 
 export class ServerStyleSheet {
-    collectStyles(
-        tree: React.ReactNode,
-    ): React.ReactElement<StylesheetComponentProps>;
+    collectStyles(tree: React.ReactNode): React.ReactElement<StylesheetComponentProps>;
 
     getStyleTags(): string;
     getStyleElement(): Array<React.ReactElement<{}>>;
-    interleaveWithNodeStream(
-        readableStream: NodeJS.ReadableStream,
-    ): NodeJS.ReadableStream;
+    interleaveWithNodeStream(readableStream: NodeJS.ReadableStream): NodeJS.ReadableStream;
     instance: StyleSheet;
 }
 

--- a/types/styled-components/v3/styled-components-tests.tsx
+++ b/types/styled-components/v3/styled-components-tests.tsx
@@ -116,9 +116,7 @@ class Example extends React.Component {
         return (
             <ThemeProvider theme={theme}>
                 <Wrapper>
-                    <Title>
-                        Hello World, this is my first styled component!
-                    </Title>
+                    <Title>Hello World, this is my first styled component!</Title>
 
                     <Input placeholder="@mxstbr" type="text" />
                     <TomatoButton name="demo" />
@@ -135,8 +133,8 @@ const cssWithValues1 = css`
 `;
 // css which uses other simple interpolations without functions
 const cssWithValues2 = css`
-  ${cssWithValues1}
-  ${[cssWithValues1, cssWithValues1]}
+    ${cssWithValues1}
+    ${[cssWithValues1, cssWithValues1]}
   font-weight: ${'bold'};
 `;
 // injectGlobal accepts simple interpolations if they're not using functions
@@ -151,13 +149,13 @@ const cssWithFunc1 = css`
     font-size: ${props => props.theme.fontSizePt}pt;
 `;
 const cssWithFunc2 = css`
-  ${cssWithFunc1}
-  ${props => cssWithFunc1}
+    ${cssWithFunc1}
+    ${props => cssWithFunc1}
   ${[cssWithFunc1, cssWithValues1]}
 `;
 // such css can be used in styled components
 const styledButton = styled.button`
-  ${cssWithValues1} ${[cssWithValues1, cssWithValues2]}
+    ${cssWithValues1} ${[cssWithValues1, cssWithValues2]}
   ${cssWithFunc1} ${[cssWithFunc1, cssWithFunc2]}
   ${() => [cssWithFunc1, cssWithFunc2]}
 `;
@@ -201,14 +199,12 @@ const Article = styled.section`
         color: green;
     }
     ${p => (p.theme.useAlternativeLink ? AlternativeLink : Link)} {
-        color: black
+        color: black;
     }
 `;
 
 // A Link instance should be backed by an HTMLAnchorElement
-const ComposedLink = () => (
-    <Link onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined} />
-);
+const ComposedLink = () => <Link onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined} />;
 
 /**
  * construction via string tag
@@ -223,11 +219,7 @@ const LinkFromString = styled('a')`
 `;
 
 // A LinkFromString instance should be backed by an HTMLAnchorElement
-const MyOtherComponent = () => (
-    <LinkFromString
-        onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined}
-    />
-);
+const MyOtherComponent = () => <LinkFromString onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined} />;
 
 // Create a <LinkFromStringWithProps> react component that renders an <a>
 // which takes extra props
@@ -243,10 +235,7 @@ const LinkFromStringWithProps = styled('a')`
 
 // A LinkFromStringWithProps instance should be backed by an HTMLAnchorElement
 const MyOtherComponentWithProps = () => (
-    <LinkFromStringWithProps
-        canClick={false}
-        onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined}
-    />
+    <LinkFromStringWithProps canClick={false} onClick={(e: React.MouseEvent<HTMLAnchorElement>) => undefined} />
 );
 
 // Create a <LinkFromStringWithPropsAndGenerics> react component that renders an <a>
@@ -414,9 +403,7 @@ interface WithThemeProps {
     text: string;
 }
 
-const Component = (props: WithThemeProps) => (
-    <div style={{ color: props.theme.color }}>{props.text}</div>
-);
+const Component = (props: WithThemeProps) => <div style={{ color: props.theme.color }}>{props.text}</div>;
 
 const ComponentWithTheme = withTheme(Component);
 
@@ -470,9 +457,7 @@ const css2 = sheet2.getStyleElement();
 
 const sheet3 = new ServerStyleSheet();
 const appStream = ReactDOMServer.renderToNodeStream(<Title>Hello world</Title>);
-const wrappedCssStream: NodeJS.ReadableStream = sheet3.interleaveWithNodeStream(
-    appStream,
-);
+const wrappedCssStream: NodeJS.ReadableStream = sheet3.interleaveWithNodeStream(appStream);
 
 /**
  * StyledComponent.withComponent
@@ -517,19 +502,17 @@ const WithComponentAbbr = WithComponentH1.withComponent('abbr');
 
 const WithComponentAnchor = WithComponentH1.withComponent('a');
 const AnchorContainer = () => (
-    <WithComponentAnchor href="https://example.com">
-        withComponent Anchor
-    </WithComponentAnchor>
+    <WithComponentAnchor href="https://example.com">withComponent Anchor</WithComponentAnchor>
 );
 
 const WithComponentRandomHeading = WithComponentH1.withComponent(Random);
 
-const WithComponentCompA: React.SFC<{ a: number; className?: string }> = ({
-    className,
-}) => <div className={className} />;
-const WithComponentCompB: React.SFC<{ b: number; className?: string }> = ({
-    className,
-}) => <div className={className} />;
+const WithComponentCompA: React.SFC<{ a: number; className?: string }> = ({ className }) => (
+    <div className={className} />
+);
+const WithComponentCompB: React.SFC<{ b: number; className?: string }> = ({ className }) => (
+    <div className={className} />
+);
 const WithComponentStyledA = styled(WithComponentCompA)`
     color: ${(props: { color: string }) => props.color};
 `;
@@ -538,11 +521,6 @@ const WithComponentFirstStyledA = styled(WithComponentStyledA).attrs({
     a: 1,
 })``;
 
-const WithComponentFirstStyledB = WithComponentFirstStyledA.withComponent(
-    WithComponentCompB,
-);
+const WithComponentFirstStyledB = WithComponentFirstStyledA.withComponent(WithComponentCompB);
 
-const test = () => [
-    <WithComponentFirstStyledA color={'black'} />,
-    <WithComponentFirstStyledB b={2} color={'black'} />,
-];
+const test = () => [<WithComponentFirstStyledA color={'black'} />, <WithComponentFirstStyledB b={2} color={'black'} />];


### PR DESCRIPTION
This allows the `as` and `forwardedAs` props to vary from each other, which is appropriate because they have different targets.

This also runs prettier (per the doc recommendations) on the `styled-components/` directory in a second commit, generating a lot of visual updates without changing anything. Look at the first commit for the functional changes.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://styled-components.com/docs/api#forwardedas-prop
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)