### PR TITLE
[react-big-calendar] Added `handleDragStart` event handler to CalendarProps

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -293,6 +293,7 @@ export interface CalendarProps<TEvent extends object = Event, TResource extends 
     getNow?: () => Date;
     view?: View;
     events?: TEvent[];
+    handleDragStart?: (event: TEvent) => void;
     onNavigate?: (newDate: Date, view: View, action: NavigateAction) => void;
     onView?: (view: View) => void;
     onDrillDown?: (date: Date, view: View) => void;

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -107,6 +107,28 @@ class CalendarResource {
     ReactDOM.render(<Basic localizer={localizer} />, document.body);
 }
 
+// handle-drag-start Example Test
+{
+    interface Props {
+        localizer: DateLocalizer;
+    }
+    const HandleDragStart = ({ localizer }: Props) => (
+        <Calendar
+            events={getEvents()}
+            views={allViews}
+            step={60}
+            showMultiDayTimes
+            defaultDate={new Date(2015, 3, 1)}
+            localizer={localizer}
+            handleDragStart={console.log}
+        />
+    );
+
+    const localizer = dateFnsLocalizer(dateFnsConfig);
+
+    ReactDOM.render(<HandleDragStart localizer={localizer} />, document.body);
+}
+
 // Drag and Drop Example Test
 {
     class MyCalendar extends Calendar<CalendarEvent, CalendarResource> {}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test react-big-calendar`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

Calendar monthly view (props redirected from `CalendarProps`)
https://github.com/jquense/react-big-calendar/blob/ca8d77b89403217047a801711d90cf3f8e8339d5/src/Month.js#L225

that gets passed down to:

https://github.com/jquense/react-big-calendar/blob/ca8d77b89403217047a801711d90cf3f8e8339d5/src/Popup.js#L112

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

