### PR TITLE
pica: Fix cancelToken type

### DIFF
--- a/types/pica/index.d.ts
+++ b/types/pica/index.d.ts
@@ -33,7 +33,7 @@ declare namespace pica {
         // 0..255. Default = 0. Threshold for applying unsharp mask.
         unsharpThreshold?: number;
         // Promise instance. If defined, current operation will be terminated on rejection.
-        cancelToken?: string;
+        cancelToken?: Promise<unknown>;
     }
 
     interface PicaResizeBufferOptions {

--- a/types/pica/test/pica-tests.cjs.ts
+++ b/types/pica/test/pica-tests.cjs.ts
@@ -43,3 +43,7 @@ const resizeBufferOptions: pica.PicaResizeBufferOptions = {
 };
 resizer.resizeBuffer(resizeBufferOptions);
 resizerWithOptions.resizeBuffer(resizeBufferOptions);
+
+resizer.resize(image, canvas, {
+    cancelToken: new Promise((resolve, reject) => setTimeout(resolve, 1_000)),
+});

--- a/types/pica/test/pica-tests.global.ts
+++ b/types/pica/test/pica-tests.global.ts
@@ -40,3 +40,7 @@ const resizeBufferOptions: pica.PicaResizeBufferOptions = {
 };
 resizer.resizeBuffer(resizeBufferOptions);
 resizerWithOptions.resizeBuffer(resizeBufferOptions);
+
+resizer.resize(image, canvas, {
+    cancelToken: new Promise((resolve, reject) => setTimeout(resolve, 1_000)),
+});


### PR DESCRIPTION
> cancelToken - Promise instance. If defined, current operation will be
> terminated on rejection.

see: https://github.com/nodeca/pica#resizefrom-to-options---promise
see: https://github.com/nodeca/pica/blob/95bd7b7e3a39b81bef3d9d6a7c81f18b18c35446/index.js#L233-L239

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodeca/pica/blob/95bd7b7e3a39b81bef3d9d6a7c81f18b18c35446/index.js#L233-L239
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.