### PR TITLE
[imap] improve typing for config.tlsOptions

### DIFF
--- a/types/imap/index.d.ts
+++ b/types/imap/index.d.ts
@@ -5,6 +5,7 @@
 
 /// <reference types="node" />
 import { EventEmitter } from 'events';
+import { TlsOptions } from 'tls';
 
 declare namespace Connection {
 
@@ -26,7 +27,7 @@ declare namespace Connection {
         /** Perform implicit TLS connection? Default: false */
         tls?: boolean;
         /** Options object to pass to tls.connect() Default: (none) */
-        tlsOptions?: Object;
+        tlsOptions?: TlsOptions;
         /** Set to 'always' to always attempt connection upgrades via STARTTLS, 'required' only if upgrading is required, or 'never' to never attempt upgrading. Default: 'never' */
         autotls?: string;
         /** Number of milliseconds to wait for a connection to be established. Default: 10000 */


### PR DESCRIPTION
Use tls.TlsOptions instead of Object as type for config.tlsOptions

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mscdex/node-imap/blob/867aa88a335a266b904e0271afa36f69af31a869/lib/Connection.js#L128
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
