### PR TITLE
Update `marked` type definition to remove first parameter of `walkTokens` field from `MarkOptions`

### DIFF
--- a/types/marked/index.d.ts
+++ b/types/marked/index.d.ts
@@ -518,7 +518,7 @@ declare namespace marked {
          * Each token is passed by reference so updates are persisted when passed to the parser.
          * The return value of the function is ignored.
          */
-        walkTokens?: (tokens: TokensList, callback: (token: Token) => void) => any;
+        walkTokens?: (callback: (token: Token) => void) => any;
         /**
          * Generate closing slash for self-closing tags (<br/> instead of <br>)
          */

--- a/types/marked/marked-tests.ts
+++ b/types/marked/marked-tests.ts
@@ -15,7 +15,7 @@ let options: marked.MarkedOptions = {
     smartypants: false,
     tokenizer: new marked.Tokenizer(),
     renderer: new marked.Renderer(),
-    walkTokens: (tokens: marked.TokensList, callback: (token: marked.Token) => void) => {}
+    walkTokens: (callback: (token: marked.Token) => void) => {}
 };
 
 options.highlight = (code: string, lang: string, callback: (error: any | undefined, code?: string) => void) => {


### PR DESCRIPTION
Remove first parameter of `walkTokens` field from `MarkOptions`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://marked.js.org/using_pro
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.