### PR TITLE
Add types for mapbox-gl-draw@1.1.2

### DIFF
--- a/types/mapbox__mapbox-gl-draw/index.d.ts
+++ b/types/mapbox__mapbox-gl-draw/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for @mapbox/mapbox-gl-draw 1.1
+// Project: https://github.com/mapbox/mapbox-gl-draw#readme
+// Definitions by: Ryan Vanbelkum <https://github.com/ryanvanbelkum>
+//                 Nathan Weber <https://github.com/nweber-gh>
+//                 Bryan Wain <https://github.com/bdwain>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+declare module "@mapbox/mapbox-gl-draw/src/constants" {
+  enum modes {
+    SIMPLE_SELECT,
+    DIRECT_SELECT,
+    DRAW_POINT,
+    DRAW_POLYGON,
+    DRAW_LINE_STRING,
+  }
+}
+
+declare module "@mapbox/mapbox-gl-draw" {
+  import { modes } from '@mapbox/mapbox-gl-draw/src/constants';
+  class MapboxDraw {
+     constructor(config: any);
+     set(collection: object): void;
+     getAll(): {features: any[]};
+     delete(id: string): void;
+     getMode(): modes;
+     getSelectedIds(): Array<string | number>;
+     changeMode(mode: modes, object: {featureId: string}): void;
+  }
+
+  export = MapboxDraw;
+}

--- a/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
+++ b/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
@@ -1,0 +1,31 @@
+import MapboxDraw from '@mapbox/mapbox-gl-draw';
+import { modes } from '@mapbox/mapbox-gl-draw/src/constants';
+
+const draw = new MapboxDraw({});
+
+// accepts any argument
+// $ExpectType void
+draw.set({
+    type: 'FeatureCollection',
+    features: []
+});
+
+// accepts no arguments
+// $ExpectType { features: any[]; }
+draw.getAll();
+
+// accepts string
+// $ExpectType void
+draw.delete('1');
+
+// accepts no arguments
+// $ExpectType modes
+draw.getMode();
+
+// accepts no arguments
+// $ExpectType (string | number)[]
+draw.getSelectedIds();
+
+// accepts modes, {featureId: string}
+// $ExpectType void
+draw.changeMode(modes.DIRECT_SELECT, {featureId: '1'});

--- a/types/mapbox__mapbox-gl-draw/tsconfig.json
+++ b/types/mapbox__mapbox-gl-draw/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "mapbox__mapbox-gl-draw-tests.ts"
+    ]
+}

--- a/types/mapbox__mapbox-gl-draw/tslint.json
+++ b/types/mapbox__mapbox-gl-draw/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

