### PR TITLE
fix: Add pg dynamic password support to ClientOptions

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -15,7 +15,7 @@ import { ConnectionOptions } from 'tls';
 export interface ClientConfig {
     user?: string;
     database?: string;
-    password?: string;
+    password?: string | (() => string | Promise<string>);
     port?: number;
     host?: string;
     connectionString?: string;

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -229,3 +229,13 @@ c = new Client({
     connectionString: 'connectionString',
     connectionTimeoutMillis: 1000, // connection timeout optionally specified
 });
+
+const dynamicPasswordSync = new Client({
+    password: () => 'sync-secret',
+});
+dynamicPasswordSync.connect();
+
+const dynamicPasswordAsync = new Client({
+    password: async () => 'sync-secret',
+});
+dynamicPasswordAsync.connect();


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/brianc/node-postgres/pull/1926
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

Adds typings to `pg` for connection config with dynamic passwords via a sync or async function. This was added to a pg v7.12.0 and the typings claim to be for 7.14 so this is a fix for incomplete typing for that property.