### PR TITLE
[react-color/v2] Updated onChange handlers for custom pickers

### DIFF
--- a/types/react-color/v2/index.d.ts
+++ b/types/react-color/v2/index.d.ts
@@ -55,7 +55,8 @@ export interface RenderersProps {
         canvas: any;
     };
 }
-export type ColorChangeHandler = (color: ColorState) => void;
+
+export type ColorChangeHandler<T = HSLColor|HSVColor|RGBColor> = (color: T) => void;
 
 export { default as AlphaPicker, AlphaPickerProps } from "./lib/components/alpha/Alpha";
 export { default as BlockPicker, BlockPickerProps } from "./lib/components/block/Block";

--- a/types/react-color/v2/lib/components/common/Alpha.d.ts
+++ b/types/react-color/v2/lib/components/common/Alpha.d.ts
@@ -1,5 +1,5 @@
 import { Component, ComponentType, CSSProperties } from "react";
-import { CustomPickerInjectedProps, RenderersProps } from "../../..";
+import { CustomPickerInjectedProps, HSLColor, RenderersProps } from "../../..";
 
 export interface AlphaStyle {
     alpha?: CSSProperties;
@@ -10,7 +10,12 @@ export interface AlphaStyle {
     slider?: CSSProperties;
 }
 
-export interface AlphaProps extends RenderersProps, CustomPickerInjectedProps {
+export interface AlphaColorResult extends HSLColor {
+    a: number;
+    source: "rgb";
+}
+
+export interface AlphaProps extends RenderersProps, CustomPickerInjectedProps<AlphaColorResult> {
     pointer?: ComponentType;
     radius?: string;
     shadow?: string;

--- a/types/react-color/v2/lib/components/common/ColorWrap.d.ts
+++ b/types/react-color/v2/lib/components/common/ColorWrap.d.ts
@@ -1,5 +1,5 @@
 import { ComponentType } from "react";
-import { Color, ColorState, ColorChangeHandler } from "../../..";
+import { Color, ColorState, ColorChangeHandler, HSLColor, HSVColor, RGBColor } from "../../..";
 import { Classes } from "reactcss";
 
 type SetDifference<A, B> = A extends B ? never : A;
@@ -8,8 +8,8 @@ type Diff<T, U> = Pick<T, SetDifference<keyof T, keyof U>>;
 
 export type OnChangeHandler = (colorState: ColorState) => void;
 
-export interface CustomPickerInjectedProps extends Partial<ColorState> {
-    onChange: ColorChangeHandler;
+export interface CustomPickerInjectedProps<T = HSLColor | HSVColor | RGBColor> extends Partial<ColorState> {
+    onChange: ColorChangeHandler<T>;
 }
 
 export interface CustomPickerProps {
@@ -17,7 +17,7 @@ export interface CustomPickerProps {
     className?: string;
     styles?: Partial<Classes<any>>;
     onChange?: OnChangeHandler;
-    onChangeComplete?: OnChangeHandler;
+    onChangeComplete?: OnChangeHandler; // e: ColorState
 }
 
 export default function CustomPicker<A>(

--- a/types/react-color/v2/lib/components/common/EditableInput.d.ts
+++ b/types/react-color/v2/lib/components/common/EditableInput.d.ts
@@ -1,20 +1,25 @@
 import { Component, CSSProperties } from "react";
 import { CustomPickerInjectedProps } from "../../..";
 
+export type Remove<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
 export interface EditableInputStyles {
     input?: CSSProperties;
     label?: CSSProperties;
     wrap?: CSSProperties;
 }
 
-export interface EditableInputProps extends CustomPickerInjectedProps {
-    label?: string;
+export type EditableInputColorResult<T> = [T] extends [string] ? { [key in T]: string } : string;
+
+export interface EditableInputProps<A = string | undefined> extends Remove<CustomPickerInjectedProps, "onChange"> {
+    label?: A;
     arrowOffset?: number;
     placeholder?: string;
     value?: string | number;
     style?: EditableInputStyles;
     dragLabel?: boolean;
     dragMax?: number;
+    onChange?: (change: EditableInputColorResult<A>) => void;
 }
 
-export default class EditableInput extends Component<EditableInputProps> {}
+export default class EditableInput<A extends string | undefined> extends Component<EditableInputProps<A>> {}

--- a/types/react-color/v2/lib/components/common/Hue.d.ts
+++ b/types/react-color/v2/lib/components/common/Hue.d.ts
@@ -1,7 +1,12 @@
 import { Component, ComponentType } from "react";
-import { CustomPickerInjectedProps } from "../../..";
+import { CustomPickerInjectedProps, HSLColor } from "../../..";
 
-export interface HueProps extends CustomPickerInjectedProps {
+export interface HueColorResult extends HSLColor {
+    a: number;
+    source: "hsl";
+}
+
+export interface HueProps extends CustomPickerInjectedProps<HueColorResult> {
     direction?: "horizontal" | "vertical";
     pointer?: ComponentType;
     radius?: string;

--- a/types/react-color/v2/lib/components/common/Saturation.d.ts
+++ b/types/react-color/v2/lib/components/common/Saturation.d.ts
@@ -1,5 +1,5 @@
 import { Component, CSSProperties, ComponentType } from "react";
-import { CustomPickerInjectedProps } from "../../..";
+import { CustomPickerInjectedProps, HSVColor } from "../../..";
 
 export interface SaturationStyle {
     color?: CSSProperties;
@@ -9,7 +9,12 @@ export interface SaturationStyle {
     circle?: CSSProperties;
 }
 
-export interface SaturationProps extends CustomPickerInjectedProps {
+export interface SaturationColorResult extends HSVColor {
+    a: number;
+    source: "hsv";
+}
+
+export interface SaturationProps extends CustomPickerInjectedProps<SaturationColorResult> {
     radius?: string;
     shadow?: string;
     style?: SaturationStyle;

--- a/types/react-color/v2/react-color-tests.tsx
+++ b/types/react-color/v2/react-color-tests.tsx
@@ -24,6 +24,10 @@ import {
     Hue,
     Saturation
 } from "react-color/lib/components/common";
+import { AlphaColorResult } from "react-color/lib/components/common/Alpha";
+import { HueColorResult } from "react-color/lib/components/common/Hue";
+import { SaturationColorResult } from "react-color/lib/components/common/Saturation";
+import { EditableInputColorResult } from "react-color/lib/components/common/EditableInput";
 
 interface CustomProps extends CustomPickerInjectedProps {
     customProp: string;
@@ -31,6 +35,40 @@ interface CustomProps extends CustomPickerInjectedProps {
 
 const CustomComponent: React.ComponentType<CustomProps> = (props: CustomProps) => {
     const { customProp } = props;
+
+    function onChangeAlpha(color: AlphaColorResult) {
+        console.log(color);
+        color.a; // $ExpectType number
+        color.h; // $ExpectType number
+        color.s; // $ExpectType number
+        color.l; // $ExpectType number
+        color.source; // $ExpectType "rgb"
+    }
+    function onChangeHue(color: HueColorResult) {
+        console.log(color);
+        color.a; // $ExpectType number
+        color.h; // $ExpectType number
+        color.s; // $ExpectType number
+        color.l; // $ExpectType number
+        color.source; // $ExpectType "hsl"
+    }
+    function onChangeSaturation(color: SaturationColorResult) {
+        console.log(color);
+        color.a; // $ExpectType number
+        color.h; // $ExpectType number
+        color.s; // $ExpectType number
+        color.v; // $ExpectType number
+        color.source; // $ExpectType "hsv"
+    }
+    function onChangeInput(color: EditableInputColorResult<'test'>) {
+        console.log(color);
+        color.test; // $ExpectType string
+    }
+    function onChangeInputNoLabel(color: string) {
+        console.log(color);
+        color; // $ExpectType string
+    }
+
     return (
         <div>
             {customProp}
@@ -41,6 +79,7 @@ const CustomComponent: React.ComponentType<CustomProps> = (props: CustomProps) =
                 direction="horizontal"
                 pointer={() => <div />}
                 {...props}
+                onChange={onChangeAlpha}
             />
             <Checkboard
                 size={10}
@@ -59,6 +98,7 @@ const CustomComponent: React.ComponentType<CustomProps> = (props: CustomProps) =
                 dragLabel
                 dragMax={10}
                 {...props}
+                onChange={onChangeInput}
             />
             <Hue
                 direction="horizontal"
@@ -66,6 +106,7 @@ const CustomComponent: React.ComponentType<CustomProps> = (props: CustomProps) =
                 radius="25px"
                 shadow="5px 10px"
                 {...props}
+                onChange={onChangeHue}
             />
             <Saturation
                 radius="25px"
@@ -73,7 +114,12 @@ const CustomComponent: React.ComponentType<CustomProps> = (props: CustomProps) =
                 pointer={() => <div />}
                 style={{ circle: { display: "block" } }}
                 {...props}
+                onChange={onChangeSaturation}
             />
+
+            <EditableInput onChange={onChangeInputNoLabel} />
+            // prettier-ignore
+            <EditableInput label="Fails" onChange={onChangeInput} /> // $ExpectError
         </div>
     );
 };


### PR DESCRIPTION
> This PR is in reference to #49246. The original PR changed the v3 typings for react-color instead of the intended v2 typings. This PR has the actual v2 edits.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

Here is an example for why the changes were made. The below references Alpha but the same applies to Hue, and Saturation.

[react-color/src/helpers/alpha.js](https://github.com/casesandberg/react-color/blob/8849f74a7ff96784b7d3cc031b3e415736dcbfe8/src/helpers/alpha.js#L39)
```js
export const calculateChange = (...) => {
...
    return {
        h: hsl.h,
        s: hsl.s,
        l: hsl.l,
        a,
        source: 'rgb',
    }
...
}
```
Which in turn is used by [react-color/src/components/common/Alpha.js](https://github.com/casesandberg/react-color/blob/8849f74a7ff96784b7d3cc031b3e415736dcbfe8/src/components/common/Alpha.js#L13)
```jsx
export class Alpha extends (PureComponent || Component) {
...
    handleChange = (e) => {
      const change = alpha.calculateChange(e, this.props.hsl, this.props.direction, this.props.a, this.container)
      change && typeof this.props.onChange === 'function' && this.props.onChange(change, e)
    }
...
    return (
    ...
        <div
            style={ styles.container }
            ref={ container => this.container = container }
            onMouseDown={ this.handleMouseDown }
            onTouchMove={ this.handleChange }
            onTouchStart={ this.handleChange }
        >
        ...
        </div>
    ...
    )
...
}
```

EditableInput differs in that it returns either a the value or a key-value object depending on whether the label is set.
[react-color/src/components/common/EditableInput.js](https://github.com/casesandberg/react-color/blob/8849f74a7ff96784b7d3cc031b3e415736dcbfe8/src/components/common/EditableInput.js#L79)
```js
export class EditableInput extends (PureComponent || Component) {
...
    setUpdatedValue(value, e) {
        const onChangeValue = this.props.label ? this.getValueObjectWithLabel(value) : value
        this.props.onChange && this.props.onChange(onChangeValue, e)
    
        this.setState({ value })
      }
...
}
```

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.