### PR TITLE
[object-fit-images] Optional 'images' argument

### DIFF
--- a/types/object-fit-images/index.d.ts
+++ b/types/object-fit-images/index.d.ts
@@ -8,6 +8,6 @@ export as namespace objectFillImages;
 export = objectFillImages;
 
 declare function objectFillImages(
-    images: string | HTMLElement | HTMLElement[] | NodeList | null,
+    images?: string | HTMLElement | HTMLElement[] | NodeList | null,
     options?: { watchMQ?: boolean; skipTest?: boolean },
 ): void;


### PR DESCRIPTION
Both arguments are optional according to the documentation.  First parameter must be omitted or null to enable auto mode.
https://github.com/fregante/object-fit-images#usage

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.