### PR TITLE
Added Primitive JavaScript Types for Attributes properties for xast

### DIFF
--- a/types/xast/index.d.ts
+++ b/types/xast/index.d.ts
@@ -23,15 +23,8 @@ export interface Parent extends UnistParent {
 /**
  * Union Of All primitive JavaScript Types
  */
-export type Primitive =
-	| null
-	| undefined
-	| string
-	| number
-	| boolean
-	| symbol
-    | bigint;
-    
+export type Primitive = null | undefined | string | number | boolean | symbol | bigint;
+
 /**
  * Node in xast containing a value.
  */

--- a/types/xast/index.d.ts
+++ b/types/xast/index.d.ts
@@ -4,6 +4,7 @@
 //                 Titus Wormer <https://github.com/wooorm>
 //                 Christian Murphy <https://github.com/ChristianMurphy>
 //                 Junyoung Choi <https://github.com/rokt33r>
+//                 Malav Shah <https://github.com/malav2110>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -19,6 +20,18 @@ export interface Parent extends UnistParent {
     children: Array<Element | Text | Comment | Doctype | Instruction | Cdata>;
 }
 
+/**
+ * Union Of All primitive JavaScript Types
+ */
+export type Primitive =
+	| null
+	| undefined
+	| string
+	| number
+	| boolean
+	| symbol
+    | bigint;
+    
 /**
  * Node in xast containing a value.
  */
@@ -58,7 +71,7 @@ export interface Element extends Parent {
  * Information associated with an element.
  */
 export interface Attributes {
-    [name: string]: string | null | undefined;
+    [name: string]: Primitive;
 }
 
 /**

--- a/types/xast/xast-tests.ts
+++ b/types/xast/xast-tests.ts
@@ -89,6 +89,7 @@ const attributes: Attributes = {
     attributeName1: 'attributeValue',
     attributeName2: null,
     attributeName3: undefined,
+    attributeName4: 100
 };
 
 function getElement(): Element {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/syntax-tree/xast#attributevalue
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
