### PR TITLE
[node] Fix type signature of ReadStream and WriteStream close method to include optional callback

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -143,7 +143,7 @@ declare module "fs" {
     }
 
     export class ReadStream extends stream.Readable {
-        close(): void;
+        close(cb?: NoParamCallback): void;
         bytesRead: number;
         path: string | Buffer;
         pending: boolean;
@@ -211,7 +211,7 @@ declare module "fs" {
     }
 
     export class WriteStream extends stream.Writable {
-        close(): void;
+        close(cb?: NoParamCallback): void;
         bytesWritten: number;
         path: string | Buffer;
         pending: boolean;

--- a/types/node/v10/fs.d.ts
+++ b/types/node/v10/fs.d.ts
@@ -8,6 +8,8 @@ declare module "fs" {
      */
     type PathLike = string | Buffer | URL;
 
+    type NoParamCallback = (err: NodeJS.ErrnoException | null) => void;
+
     type BinaryData = Buffer | DataView | NodeJS.TypedArray;
     class Stats {
         isFile(): boolean;
@@ -83,7 +85,7 @@ declare module "fs" {
     }
 
     class ReadStream extends stream.Readable {
-        close(): void;
+        close(cb?: NoParamCallback): void;
         bytesRead: number;
         path: string | Buffer;
 
@@ -114,7 +116,7 @@ declare module "fs" {
     }
 
     class WriteStream extends stream.Writable {
-        close(): void;
+        close(cb?: NoParamCallback): void;
         bytesWritten: number;
         path: string | Buffer;
 

--- a/types/node/v11/fs.d.ts
+++ b/types/node/v11/fs.d.ts
@@ -8,6 +8,8 @@ declare module "fs" {
      */
     type PathLike = string | Buffer | URL;
 
+    type NoParamCallback = (err: NodeJS.ErrnoException | null) => void;
+
     type BinaryData = Buffer | DataView | NodeJS.TypedArray;
     class Stats {
         isFile(): boolean;
@@ -78,7 +80,7 @@ declare module "fs" {
     }
 
     class ReadStream extends stream.Readable {
-        close(): void;
+        close(cb?: NoParamCallback): void;
         bytesRead: number;
         path: string | Buffer;
 
@@ -109,7 +111,7 @@ declare module "fs" {
     }
 
     class WriteStream extends stream.Writable {
-        close(): void;
+        close(cb?: NoParamCallback): void;
         bytesWritten: number;
         path: string | Buffer;
 

--- a/types/node/v12/fs.d.ts
+++ b/types/node/v12/fs.d.ts
@@ -131,7 +131,7 @@ declare module "fs" {
     }
 
     class ReadStream extends stream.Readable {
-        close(): void;
+        close(cb?: NoParamCallback): void;
         bytesRead: number;
         path: string | Buffer;
 
@@ -162,7 +162,7 @@ declare module "fs" {
     }
 
     class WriteStream extends stream.Writable {
-        close(): void;
+        close(cb?: NoParamCallback): void;
         bytesWritten: number;
         path: string | Buffer;
 

--- a/types/node/v13/fs.d.ts
+++ b/types/node/v13/fs.d.ts
@@ -131,7 +131,7 @@ declare module "fs" {
     }
 
     class ReadStream extends stream.Readable {
-        close(): void;
+        close(cb?: NoParamCallback): void;
         bytesRead: number;
         path: string | Buffer;
         pending: boolean;
@@ -199,7 +199,7 @@ declare module "fs" {
     }
 
     class WriteStream extends stream.Writable {
-        close(): void;
+        close(cb?: NoParamCallback): void;
         bytesWritten: number;
         path: string | Buffer;
         pending: boolean;


### PR DESCRIPTION
This pull requests updates the type signature on WriteStream.close and ReadStream.close to include the optional callback parameter. 

Here's a reference to the current node source code which shows that callback parameter https://github.com/nodejs/node/blob/master/lib/internal/fs/streams.js. 

This functionality has been in node since at least version 10 (probably more, that's just as far back as I checked) so I updated the type definitions in those versions as well


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
