### PR TITLE
[@types/jsrsasign] JWS.sign password can be an object

### DIFF
--- a/types/jsrsasign/jsrsasign-tests.ts
+++ b/types/jsrsasign/jsrsasign-tests.ts
@@ -6,6 +6,10 @@ ec.getPublicKeyXYHex();
 ec.parseSigHex('30...');
 ec.parseSigHexInHexRS('30...');
 
+const mac = new KJUR.crypto.Mac({ alg: 'HS256', pass: { hex: '1a2b3c' }});
+mac.setPassword('123-abc');
+mac.setPassword({ rstr: "\x61\x61"});
+
 KJUR.crypto.ECDSA.getName('2b8104000a');
 
 new KJUR.asn1.cades.OtherHash('1234');
@@ -24,3 +28,6 @@ KEYUTIL.getKey('pemPKCS1PrivateKey');
 
 b64toBA('ZXhhbXBsZQ=='); // $ExpectType number[]
 b64tohex('ZXhhbXBsZQ=='); // $ExpectType string
+
+KJUR.jws.JWS.sign(null, { alg: 'HS256' }, 'payload', { utf8: '123abc' });
+KJUR.jws.JWS.sign(null, { alg: 'HS256' }, 'payload', '123abc');

--- a/types/jsrsasign/modules/KJUR/crypto/Mac.d.ts
+++ b/types/jsrsasign/modules/KJUR/crypto/Mac.d.ts
@@ -112,6 +112,6 @@ declare namespace jsrsasign.KJUR.crypto {
          * // set password by explicit Base64URL string
          * mac.setPassword({"b64u": "Mb-c3f_"});
          */
-        setPassword(pass: string | object): void;
+        setPassword(pass: string | { [type: string]: string }): void;
     }
 }

--- a/types/jsrsasign/modules/KJUR/crypto/Mac.d.ts
+++ b/types/jsrsasign/modules/KJUR/crypto/Mac.d.ts
@@ -112,6 +112,6 @@ declare namespace jsrsasign.KJUR.crypto {
          * // set password by explicit Base64URL string
          * mac.setPassword({"b64u": "Mb-c3f_"});
          */
-        setPassword(pass: string): void;
+        setPassword(pass: string | object): void;
     }
 }

--- a/types/jsrsasign/modules/KJUR/jws/JWS.d.ts
+++ b/types/jsrsasign/modules/KJUR/jws/JWS.d.ts
@@ -170,7 +170,7 @@ declare namespace jsrsasign.KJUR.jws {
          * // header and payload can be passed by both string and object
          * sJWS = KJUR.jws.JWS.sign(null, '{alg:"HS256",cty:"JWT"}', '{age:21}', "aaa");
          */
-        function sign(alg: string | null, spHead: string | { alg: string }, spPayload: string | object, pass?: string): string;
+        function sign(alg: string | null, spHead: string | { alg: string }, spPayload: string | object, pass?: string | object): string;
 
         /**
          * verify JWS signature by specified key or certificate

--- a/types/jsrsasign/modules/KJUR/jws/JWS.d.ts
+++ b/types/jsrsasign/modules/KJUR/jws/JWS.d.ts
@@ -170,7 +170,7 @@ declare namespace jsrsasign.KJUR.jws {
          * // header and payload can be passed by both string and object
          * sJWS = KJUR.jws.JWS.sign(null, '{alg:"HS256",cty:"JWT"}', '{age:21}', "aaa");
          */
-        function sign(alg: string | null, spHead: string | { alg: string }, spPayload: string | object, pass?: string | object): string;
+        function sign(alg: string | null, spHead: string | { alg: string }, spPayload: string | object, pass?: string | { [type: string]: string }): string;
 
         /**
          * verify JWS signature by specified key or certificate


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://kjur.github.io/jsrsasign/api/symbols/KJUR.jws.JWS.html#.sign
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

fixes #49266 