### PR TITLE
fix(@babel/core): add more `TransformCaller` types

### DIFF
--- a/types/babel__core/babel__core-tests.ts
+++ b/types/babel__core/babel__core-tests.ts
@@ -52,7 +52,7 @@ checkOptions({ envName: 'banana' });
 // $ExpectError
 checkOptions({ envName: null });
 checkOptions({ caller: { name: '@babel/register' } });
-checkOptions({ caller: { name: 'babel-jest', supportsStaticESM: false } });
+checkOptions({ caller: { name: 'babel-jest', supportsStaticESM: false, supportsTopLevelAwait: true } });
 // don't add an index signature; users should augment the interface instead if they need to
 // $ExpectError
 checkOptions({ caller: { name: '', tomato: true } });

--- a/types/babel__core/index.d.ts
+++ b/types/babel__core/index.d.ts
@@ -330,6 +330,8 @@ export interface TransformCaller {
     // e.g. set to true by `babel-loader` and false by `babel-jest`
     supportsStaticESM?: boolean;
     supportsDynamicImport?: boolean;
+    supportsExportNamespaceFrom?: boolean;
+    supportsTopLevelAwait?: boolean;
     // augment this with a "declare module '@babel/core' { ... }" if you need more keys
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/babel/babel/blob/b649f8d192dd1c62e2a31d856a7c39ff21d70dd5/packages/babel-preset-env/src/index.js#L209-L223
  - https://babeljs.io/docs/en/options#caller
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

While one can extend it to more keys in our own code, supporting the ones that `@babel/preset-env` looks at by default makes sense to me