### PR TITLE
Types for is-valid-zipcode

### DIFF
--- a/types/is-url/index.d.ts
+++ b/types/is-url/index.d.ts
@@ -3,6 +3,6 @@
 // Definitions by: Ryota Murohoshi <https://github.com/RyotaMurohoshi>
 // Definitions: https://github.com/RyotaMurohoshi/DefinitelyTyped
 
-export = isUrl;
+export = isUrl
 
 declare function isUrl(string: string): boolean;

--- a/types/is-url/index.d.ts
+++ b/types/is-url/index.d.ts
@@ -3,7 +3,6 @@
 // Definitions by: Ryota Murohoshi <https://github.com/RyotaMurohoshi>
 // Definitions: https://github.com/RyotaMurohoshi/DefinitelyTyped
 
-
-export = isUrl
+export = isUrl;
 
 declare function isUrl(string: string): boolean;

--- a/types/is-url/index.d.ts
+++ b/types/is-url/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Ryota Murohoshi <https://github.com/RyotaMurohoshi>
 // Definitions: https://github.com/RyotaMurohoshi/DefinitelyTyped
 
-export = isUrl;
+
+export = isUrl
 
 declare function isUrl(string: string): boolean;

--- a/types/is-valid-zipcode/index.d.ts
+++ b/types/is-valid-zipcode/index.d.ts
@@ -3,6 +3,6 @@
 // Definitions by: Dillon Mulroy <https://github.com/dmmulroy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function isValidFunction(zipcode: string, country?: string): boolean;
+declare function isValidZipcode(zipcode: string, country?: string): boolean;
 
-export = isValidFunction;
+export = isValidZipcode;

--- a/types/is-valid-zipcode/index.d.ts
+++ b/types/is-valid-zipcode/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for is-valid-zipcode 1.0
+// Project: https://github.com/hacdias/is-valid-zipcode#readme
+// Definitions by: Dillon Mulroy <https://github.com/dmmulroy>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function isValidFunction(zipcode: string, country?: string): boolean;
+
+export = isValidFunction;

--- a/types/is-valid-zipcode/is-valid-zipcode-tests.ts
+++ b/types/is-valid-zipcode/is-valid-zipcode-tests.ts
@@ -1,0 +1,7 @@
+import isValidZipcode = require('is-valid-zipcode');
+
+// $ExpectType boolean
+isValidZipcode('21060');
+
+// $ExpectType boolean
+isValidZipcode('2000-000', 'PT');

--- a/types/is-valid-zipcode/tsconfig.json
+++ b/types/is-valid-zipcode/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "is-valid-zipcode-tests.ts"
+    ]
+}

--- a/types/is-valid-zipcode/tslint.json
+++ b/types/is-valid-zipcode/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
