### PR TITLE
Create new definition @types/golang-wasm

### DIFF
--- a/types/golang-wasm/index.d.ts
+++ b/types/golang-wasm/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for non-npm package golang-wasm 1.15
+// Project: https://github.com/golang/go
+// Definitions by: Adam Pyle <https://github.com/pyle>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.7
+
+/**
+ * Go is the class as defined in the Golang `wasm_exec.js` distributable file required for WebAssembly.
+ * Golang WebAssembly wiki: https://github.com/golang/go/wiki/WebAssembly
+ */
+declare class Go {
+    argv: string[];
+    env: { [envKey: string]: string };
+    exit: (code: number) => void;
+    importObject: WebAssembly.Imports;
+    exited: boolean;
+    mem: DataView;
+    run(instance: WebAssembly.Instance): Promise<void>;
+}

--- a/types/golang-wasm/test/index.ts
+++ b/types/golang-wasm/test/index.ts
@@ -1,0 +1,5 @@
+const go = new Go();
+
+WebAssembly.instantiateStreaming(fetch('test.wasm'), go.importObject).then(result => {
+  go.run(result.instance);
+});

--- a/types/golang-wasm/tsconfig.json
+++ b/types/golang-wasm/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6",
+      "DOM"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "baseUrl": "../",
+    "typeRoots": [
+      "../"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts",
+    "test/index.ts"
+  ]
+}

--- a/types/golang-wasm/tslint.json
+++ b/types/golang-wasm/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
* `Go` class with all seemingly public properties and functions.
* Basic test using example on their wiki (https://github.com/golang/go/wiki/WebAssembly).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
