### PR TITLE
[puppeteer] add `page.mouse.wheel(options)` definition

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -9,6 +9,7 @@
 //                 Dave Cardwell <https://github.com/davecardwell>
 //                 Andrés Ortiz <https://github.com/angrykoala>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+//                 Pirasis Leelatanon <https://github.com/1pete>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -293,6 +294,19 @@ export interface MousePressOptions {
   clickCount?: number;
 }
 
+export interface MouseWheelOptions {
+  /**
+   * X delta in CSS pixels for mouse wheel event. Positive values emulate a scroll up and negative values a scroll down event.
+   * @default 0
+   */
+  deltaX?: number;
+  /**
+   * Y delta in CSS pixels for mouse wheel event. Positive values emulate a scroll right and negative values a scroll left event.
+   * @default 0
+   */
+  deltaY?: number;
+}
+
 export interface Mouse {
   /**
    * Shortcut for `mouse.move`, `mouse.down` and `mouse.up`.
@@ -319,6 +333,11 @@ export interface Mouse {
    * @param options The mouse press options.
    */
   up(options?: MousePressOptions): Promise<void>;
+  /**
+   * Dispatches a `mousewheel` event.
+   * @param options The mouse wheel options.
+   */
+  wheel(options?: MouseWheelOptions): Promise<void>;
 }
 
 export interface Touchscreen {

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -182,6 +182,12 @@ puppeteer.launch().then(async browser => {
   page.keyboard.press("Backspace");
   page.keyboard.sendCharacter("嗨");
 
+  // mouse events
+  await page.mouse.wheel();
+  await page.mouse.wheel({ deltaX: -100 });
+  await page.mouse.wheel({ deltaY: -100 });
+  await page.mouse.wheel({ deltaX: 100, deltaY: 100 });
+
   await page.tracing.start({ path: "trace.json" });
   await page.goto("https://www.google.com");
   await page.tracing.stop();


### PR DESCRIPTION
Reference: https://github.com/puppeteer/puppeteer/blob/v5.4.1/docs/api.md#mousewheeloptions

![image](https://user-images.githubusercontent.com/176037/97771808-3c318780-1b73-11eb-9960-8b069d215e73.png)

fixes #48710

