### PR TITLE
[gulp-codecov] add definition

### DIFF
--- a/types/gulp-codecov/gulp-codecov-tests.ts
+++ b/types/gulp-codecov/gulp-codecov-tests.ts
@@ -1,0 +1,166 @@
+import gulp = require("gulp");
+import codecov = require("gulp-codecov");
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov())
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({}))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({
+            branch: '',
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({
+            build: '',
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({
+            clear: true,
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({
+            commit: '',
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({
+            disable: '',
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({
+            dump: true,
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({
+            env: '',
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({
+            file: '',
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({
+            flags: '',
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({
+            'gcov-args': '',
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({
+            'gcov-exec': '',
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({
+            'gcov-glob': '',
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({
+            'gcov-root': '',
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({
+            pipe: true,
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({
+            root: '',
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({
+            slug: '',
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({
+            token: '',
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({
+            url: '',
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('test', () => {
+    gulp.src('src/**/*.js')
+        .pipe(codecov({
+            yml: '',
+        }))
+        .pipe(gulp.dest('dist'));
+});

--- a/types/gulp-codecov/index.d.ts
+++ b/types/gulp-codecov/index.d.ts
@@ -1,0 +1,36 @@
+// Type definitions for gulp-codecov 3.0
+// Project: https://github.com/eddiemoore/gulp-codecov
+// Definitions by: Rodolfo Aguirre <https://github.com/roddolf>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node"/>
+
+import * as stream from "stream";
+
+declare namespace gulpCodecov {
+    interface CodecovOptions {
+        branch?: string;
+        build?: string;
+        clear?: boolean;
+        commit?: string;
+        disable?: string;
+        dump?: boolean;
+        env?: string;
+        file?: string;
+        flags?: string;
+        'gcov-args'?: string;
+        'gcov-exec'?: string;
+        'gcov-glob'?: string;
+        'gcov-root'?: string;
+        pipe?: boolean;
+        root?: string;
+        slug?: string;
+        token?: string;
+        url?: string;
+        yml?: string;
+    }
+}
+
+declare function gulpCodecov(options?: gulpCodecov.CodecovOptions): stream.Transform;
+
+export = gulpCodecov;

--- a/types/gulp-codecov/tsconfig.json
+++ b/types/gulp-codecov/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "gulp-codecov-tests.ts"
+    ]
+}

--- a/types/gulp-codecov/tslint.json
+++ b/types/gulp-codecov/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/gulp-sourcemaps/tsconfig.json
+++ b/types/gulp-sourcemaps/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/gulp-sourcemaps/tsconfig.json
+++ b/types/gulp-sourcemaps/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": true,
+        "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.


Project: https://github.com/eddiemoore/gulp-codecov
Options are taken from: https://github.com/codecov/codecov-node/blob/master/bin/codecov
