### PR TITLE
[react-select] Added group support to `isValidNewOption` for CreatableProps

### DIFF
--- a/types/react-select/src/Creatable.d.ts
+++ b/types/react-select/src/Creatable.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Select, { Props as SelectProps } from './Select';
-import { OptionsType, ValueType, ActionMeta, OptionTypeBase } from './types';
+import { OptionsType, GroupedOptionsType, ValueType, ActionMeta, OptionTypeBase } from './types';
 import { cleanValue } from './utils';
 import manageState from './stateManager';
 
@@ -14,7 +14,11 @@ export interface CreatableProps<OptionType extends OptionTypeBase> {
   formatCreateLabel?: (inputValue: string) => React.ReactNode;
   /* Determines whether the "create new ..." option should be displayed based on
      the current input value, select value and options array. */
-  isValidNewOption?: (inputValue: string, value: ValueType<OptionType>, options: OptionsType<OptionType>) => boolean;
+  isValidNewOption?: (
+    inputValue: string,
+    value: ValueType<OptionType>,
+    options: OptionsType<OptionType> | GroupedOptionsType<OptionType>,
+   ) => boolean;
   /* Returns the data for the new option when it is created. Used to display the
      value, and is passed to `onChange`. */
   getNewOptionData?: (inputValue: string, optionLabel: React.ReactNode) => OptionType;

--- a/types/react-select/test/examples/CreatableGroup.tsx
+++ b/types/react-select/test/examples/CreatableGroup.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+import CreatableSelect from 'react-select/creatable';
+import { ColourOption, groupedOptions, FlavourOption } from '../data';
+
+export default class CreatableGroup extends React.Component {
+  handleIsValidNewOption = (inputValue: any, value: any, groups: any) => {
+    for (const group of groups) {
+      console.group(`Group: ${group.label}`);
+      for (const option of group.options) {
+        console.log(`Option: ${option.label}`);
+      }
+      console.groupEnd();
+    }
+
+    return true;
+  }
+  render() {
+    return (
+      <CreatableSelect<ColourOption | FlavourOption>
+        isValidNewOption={this.handleIsValidNewOption}
+        options={groupedOptions}
+      />
+    );
+  }
+}

--- a/types/react-select/tsconfig.json
+++ b/types/react-select/tsconfig.json
@@ -39,6 +39,7 @@
         "test/examples/ControlledMenu.tsx",
         "test/examples/CreatableAdvanced.tsx",
         "test/examples/CreatableInputOnly.tsx",
+        "test/examples/CreatableGroup.tsx",
         "test/examples/CreatableMulti.tsx",
         "test/examples/CreatableSingle.tsx",
         "test/examples/CreateFilter.tsx",


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react-select.com/props
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

