### PR TITLE
Add types for elementary-circuits-directed-graph

### DIFF
--- a/types/elementary-circuits-directed-graph/elementary-circuits-directed-graph-tests.ts
+++ b/types/elementary-circuits-directed-graph/elementary-circuits-directed-graph-tests.ts
@@ -1,0 +1,16 @@
+import findCircuits = require('elementary-circuits-directed-graph');
+
+const adjacencyList = [
+    [1, 2],
+    [2, 3],
+    [1],
+    [0],
+];
+
+// $ExpectType number[][]
+findCircuits(adjacencyList);
+
+// $ExpectType void
+findCircuits(adjacencyList, (circuit) => {
+    circuit; // $ExpectType number[]
+});

--- a/types/elementary-circuits-directed-graph/index.d.ts
+++ b/types/elementary-circuits-directed-graph/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for elementary-circuits-directed-graph 1.2
+// Project: https://github.com/antoinerg/elementary-circuits-directed-graph#readme
+// Definitions by: Michon van Dooren <https://github.com/maienm>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Takes an adjacencyList and returns the circuits found therein.
+ */
+declare function findCircuits(adjacencyList: ReadonlyArray<ReadonlyArray<number>>): number[][];
+
+/**
+ * Takes an adjacencyList and a function which will be called for each circuit found therein. Doesn't return anything.
+ */
+declare function findCircuits(adjacencyList: ReadonlyArray<ReadonlyArray<number>>, cb: (circuit: number[]) => void): void;
+
+export = findCircuits;

--- a/types/elementary-circuits-directed-graph/tsconfig.json
+++ b/types/elementary-circuits-directed-graph/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "elementary-circuits-directed-graph-tests.ts"
+    ]
+}

--- a/types/elementary-circuits-directed-graph/tslint.json
+++ b/types/elementary-circuits-directed-graph/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.