### PR TITLE
[@ember/component] add @ember/component/template-only

### DIFF
--- a/types/ember__component/template-only.d.ts
+++ b/types/ember__component/template-only.d.ts
@@ -1,0 +1,15 @@
+// This class is not intended to be directly constructable.
+declare class _TemplateOnlyComponent {
+    // Type brand to simulate a nominal type.
+    declare private brand: 'TemplateOnlyComponent';
+    toString(): string;
+}
+
+// Export an interface instead to prevent construction.
+// tslint:disable-next-line:no-empty-interface
+export interface TemplateOnlyComponent extends _TemplateOnlyComponent {}
+
+export default function templateOnly(moduleName?: string): TemplateOnlyComponent;
+
+// Shut off automatic exporting.
+export {};

--- a/types/ember__component/test/template-only.ts
+++ b/types/ember__component/test/template-only.ts
@@ -1,0 +1,7 @@
+import templateOnly, { TemplateOnlyComponent } from '@ember/component/template-only';
+
+const to = templateOnly(); // $ExpectType TemplateOnlyComponent
+
+to.toString(); // $ExpectType string
+
+new TemplateOnlyComponent(); // $ExpectError

--- a/types/ember__component/tsconfig.json
+++ b/types/ember__component/tsconfig.json
@@ -27,6 +27,7 @@
         "index.d.ts",
         "test/lib/assert.ts",
         "test/component.ts",
-        "test/helper.ts"
+        "test/helper.ts",
+        "test/template-only.ts"
     ]
 }


### PR DESCRIPTION
This adds `@ember/component/template-only` to the definitions for `@ember/component`.

Closes: https://github.com/typed-ember/ember-cli-typescript/issues/1360

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emberjs/ember.js/blob/ee8a894980fad6664a26ba78c8d949891abf811b/packages/%40ember/component/template-only.ts#L10-L41
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~
