### PR TITLE
fix(luxon): Settings.defaultZone setter

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -522,7 +522,7 @@ export namespace Settings {
     let defaultLocale: string;
     let defaultNumberingSystem: string;
     let defaultOutputCalendar: string;
-    const defaultZone: Zone;
+    let defaultZone: Zone;
     let defaultZoneName: string;
     let throwOnInvalid: boolean;
     function now(): number;

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -206,13 +206,12 @@ Info.features().relative;
 Settings.defaultLocale;
 Settings.defaultLocale = 'en';
 Settings.defaultZoneName = 'Europe/Paris';
-Settings.throwOnInvalid = true;
-Settings.now();
-Settings.now = () => 0;
-Settings.resetCaches();
-
-// $ExpectError
+Settings.defaultZone; // $ExpectType Zone
 Settings.defaultZone = Settings.defaultZone;
+Settings.throwOnInvalid = true;
+Settings.now; // $ExpectType () => number
+Settings.now = () => Date.now() + 3000;
+Settings.resetCaches();
 
 // The following tests were coped from the docs
 // http://moment.github.io/luxon/docs/manual/


### PR DESCRIPTION
This add support for 'setter' for Settings.defaultZone,
The implementation reason is described here:
https://github.com/moment/luxon/pull/548#issuecomment-528789106
https://github.com/moment/luxon/blob/master/src/settings.js#L49

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)