### PR TITLE
[mathjs] Fix concat interface argument types

### DIFF
--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -1224,7 +1224,7 @@ declare namespace math {
          * @param args Two or more matrices
          * @returns Concatenated matrix
          */
-        concat(...args: Array<MathArray | Matrix>): MathArray | Matrix;
+        concat(...args: Array<MathArray | Matrix | number | BigNumber>): MathArray | Matrix;
 
         /**
          * Calculate the cross product for two vectors in three dimensional

--- a/types/mathjs/mathjs-tests.ts
+++ b/types/mathjs/mathjs-tests.ts
@@ -318,6 +318,12 @@ Matrices examples
         }); // returns [6, 4, 3]
         math.filter(['23', 'foo', '100', '55', 'bar'], /[0-9]+/); // returns ["23", "100", "55"]
     }
+
+    // concat matrix
+    {
+        math.concat([[0, 1, 2]], [[1, 2, 3]]); // returns [[ 0, 1, 2, 1, 2, 3 ]]
+        math.concat([[0, 1, 2]], [[1, 2, 3]], 0); // returns [[ 0, 1, 2 ], [ 1, 2, 3 ]]
+    }
 }
 
 /*


### PR DESCRIPTION
This pull request fixes an issue with the argument types of the concat mathjs function for matrices. The related issue can be found [here](https://github.com/josdejong/mathjs/issues/2014). The added types are now equal to the[ real input types of the concat function](https://github.com/josdejong/mathjs/blob/76b9a0d435907f5684f81b5a5bb009d51946a8da/src/function/matrix/concat.js#L43).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Fixed issue: https://github.com/josdejong/mathjs/issues/2014