### PR TITLE
Add typings for markdown-it-highlightjs

### DIFF
--- a/types/markdown-it-highlightjs/index.d.ts
+++ b/types/markdown-it-highlightjs/index.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for markdown-it-highlightjs 3.3
+// Project: https://github.com/valeriangalliat/markdown-it-highlightjs
+// Definitions by: Wilson Gramer <https://github.com/WilsonGramer>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.5
+
+import hljs = require('highlight.js');
+import { PluginWithOptions } from 'markdown-it';
+
+declare const highlightjs: PluginWithOptions<{
+    /**
+     * Whether to automatically detect language if not specified.
+     */
+    auto?: boolean;
+
+    /**
+     * Whether to add the `hljs` class to raw code blocks (not fenced blocks).
+     */
+    code?: boolean;
+
+    /**
+     * Register other languages which are not included in the standard pack.
+     */
+    register?: {
+        [language: string]: (hljs?: HLJSApi) => Language;
+    };
+
+    /**
+     * Whether to highlight inline code.
+     */
+    inline?: boolean;
+}>;
+
+export = highlightjs;

--- a/types/markdown-it-highlightjs/markdown-it-highlightjs-tests.ts
+++ b/types/markdown-it-highlightjs/markdown-it-highlightjs-tests.ts
@@ -1,0 +1,83 @@
+// Tests from markdown-it-highlightjs/test.js
+
+import { strictEqual as equal } from 'assert';
+import sql = require('highlight.js/lib/languages/sql');
+import md = require('markdown-it');
+import highlightjs = require('markdown-it-highlightjs');
+
+equal(
+    md().use(highlightjs).render('```js\nconsole.log(42)\n```'),
+    `<pre><code class="hljs language-js"><span class="hljs-built_in">console</span>.log(<span class="hljs-number">42</span>)
+  </code></pre>
+  `,
+);
+
+equal(
+    md().use(highlightjs).render('```\ntest\n```'),
+    `<pre><code class="hljs"><span class="hljs-keyword">test
+  </span></code></pre>
+  `,
+);
+
+equal(
+    md().use(highlightjs).render('    test\n'),
+    `<pre><code class="hljs">test
+  </code></pre>
+  `,
+);
+
+equal(
+    md().use(highlightjs, { code: false }).render('    test\n'),
+    `<pre><code>test
+  </code></pre>
+  `,
+);
+
+equal(
+    md().use(highlightjs).render('```\n<?php echo 42;\n```'),
+    `<pre><code class="hljs"><span class="hljs-meta">&lt;?php</span> <span class="hljs-keyword">echo</span> <span class="hljs-number">42</span>;
+  </code></pre>
+  `,
+);
+
+equal(
+    md().use(highlightjs, { auto: false }).render('```\n<?php echo 42;\n```'),
+    `<pre><code class="hljs">&lt;?php echo 42;
+  </code></pre>
+  `,
+);
+
+equal(
+    md()
+        .use(highlightjs, { register: { test: sql } })
+        .render('```test\nSELECT * FROM TABLE;\n```'),
+    `<pre><code class="hljs language-test"><span class="hljs-keyword">SELECT</span> * <span class="hljs-keyword">FROM</span> <span class="hljs-keyword">TABLE</span>;
+  </code></pre>
+  `,
+);
+
+// Inline works with pandoc format e.g. `code`{.lang}
+equal(
+    md().use(highlightjs, { inline: true }).renderInline('`console.log(42)`{.js}'),
+    '<code class="language-js"><span class="hljs-built_in">console</span>.log(<span class="hljs-number">42</span>)</code>',
+);
+
+// Inline works with kramdown format e.g. `code`{:.lang}
+equal(
+    md().use(highlightjs, { inline: true }).renderInline('`console.log(42)`{:.js}'),
+    '<code class="language-js"><span class="hljs-built_in">console</span>.log(<span class="hljs-number">42</span>)</code>',
+);
+
+// Inline is not enabled by default
+equal(md().use(highlightjs).renderInline('`console.log(42)`{.js}'), '<code>console.log(42)</code>{.js}');
+
+// Inline uses same auto behaviour as blocks.
+equal(
+    md().use(highlightjs, { inline: true }).renderInline('`console.log(42)`'),
+    '<code>console.<span class="hljs-built_in">log</span>(<span class="hljs-number">42</span>)</code>',
+);
+
+equal(
+    md().use(highlightjs, { inline: true, auto: false }).renderInline('`console.log(42)`'),
+    '<code>console.log(42)</code>',
+);

--- a/types/markdown-it-highlightjs/package.json
+++ b/types/markdown-it-highlightjs/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "highlight.js": "^10.1.0"
+    }
+}

--- a/types/markdown-it-highlightjs/tsconfig.json
+++ b/types/markdown-it-highlightjs/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "markdown-it-highlightjs-tests.ts"
+    ]
+}

--- a/types/markdown-it-highlightjs/tslint.json
+++ b/types/markdown-it-highlightjs/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This pull request depends on #49293, which removes the outdated typings for `highlight.js` — `highlight.js` provides its own typings now.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.