### PR TITLE
[@ember/routing] add RouteInfoWithAttributes, etc,

### DIFF
--- a/types/ember__routing/-private/route-info-with-attributes.d.ts
+++ b/types/ember__routing/-private/route-info-with-attributes.d.ts
@@ -1,0 +1,24 @@
+import RouteInfo from './route-info';
+
+// https://api.emberjs.com/ember/3.6/classes/RouteInfoWithAttributes
+/**
+ * A `RouteInfoWithAttributes` is an object that contains
+ * metadata, including the resolved value from the routes
+ * `model` hook. Like `RouteInfo`, a `RouteInfoWithAttributes`
+ * represents a specific route within a Transition.
+ * It is read-only and internally immutable. It is also not
+ * observable, because a Transition instance is never
+ * changed after creation.
+ */
+export default interface RouteInfoWithAttributes extends RouteInfo {
+    /**
+     * This is the resolved return value from the
+     * route's model hook.
+     */
+    readonly attributes: unknown;
+    /**
+     * Will contain the result `Route#buildRouteInfoMetadata`
+     * for the corresponding Route.
+     */
+    readonly metadata: unknown;
+}

--- a/types/ember__routing/-private/transition.d.ts
+++ b/types/ember__routing/-private/transition.d.ts
@@ -1,4 +1,5 @@
 import RouteInfo from './route-info';
+import RouteInfoWithAttributes from './route-info-with-attributes';
 
 export default interface Transition<T = any> extends Partial<Promise<T>> {
     /**
@@ -12,7 +13,7 @@ export default interface Transition<T = any> extends Partial<Promise<T>> {
      * It's important to note that a `RouteInfo` is a linked list and this property is simply the head node of the list.
      * In the case of an initial render, `from` will be set to `null`.
      */
-    readonly from: RouteInfo | null;
+    readonly from: RouteInfoWithAttributes | null;
     /**
      * The Transition's internal promise.
      * Calling `.then` on this property is that same as calling `.then` on the Transition object itself,
@@ -25,7 +26,7 @@ export default interface Transition<T = any> extends Partial<Promise<T>> {
      * This property is a `RouteInfo` object that represents where the router is transitioning to.
      * It's important to note that a `RouteInfo` is a linked list and this property is simply the leafmost route.
      */
-    readonly to: RouteInfo;
+    readonly to: RouteInfo | RouteInfoWithAttributes;
     /**
      * Aborts the Transition. Note you can also implicitly abort a transition
      * by initiating another transition while a previous one is underway.

--- a/types/ember__routing/route.d.ts
+++ b/types/ember__routing/route.d.ts
@@ -493,4 +493,34 @@ export default class Route extends EmberObject.extend(ActionHandler, Evented) {
      * redirecting, or decorating the transition from the currently active routes.
      */
     willTransition(transition: Transition): void;
+
+    /**
+     * Allows you to produce custom metadata for the route.
+     * The return value of this method will be attached to
+     * its corresponding RouteInfoWithAttributes object.
+     * Example
+     * ```app/routes/posts/index.js
+     * import Route from '@ember/routing/route';
+     * export default class PostsIndexRoute extends Route {
+     *   buildRouteInfoMetadata() {
+     *     return { title: 'Posts Page' }
+     *   }
+     * }
+     * ```
+     * ```app/routes/application.js
+     * import Route from '@ember/routing/route';
+     * import { inject as service } from '@ember/service';
+     * export default class ApplicationRoute extends Route {
+     *   @service router
+     *   constructor() {
+     *     super(...arguments);
+     *     this.router.on('routeDidChange', transition => {
+     *       document.title = transition.to.metadata.title;
+     *       // would update document's title to "Posts Page"
+     *     });
+     *   }
+     * }
+     * ```
+     */
+    buildRouteInfoMetadata(): unknown;
 }

--- a/types/ember__routing/router-service.d.ts
+++ b/types/ember__routing/router-service.d.ts
@@ -298,4 +298,25 @@ export default class RouterService extends Service {
      * the browser including the app's `rootURL`.
      */
     recognizeAndLoad(url: string): RouteInfoWithAttributes;
+
+    /**
+     * The `rootURL` property represents the URL of the root of
+     * the application, '/' by default.
+     * This prefix is assumed on all routes defined on this app.
+     * IF you change the `rootURL` in your environment configuration
+     * like so:
+     * ```config/environment.js
+     * 'use strict';
+     * module.exports = function(environment) {
+     *   let ENV = {
+     *     modulePrefix: 'router-service',
+     *     environment,
+     *     rootURL: '/my-root',
+     *   …
+     *   }
+     * ]
+     * ```
+     * This property will return `/my-root`.
+     */
+    readonly rootURL: string;
 }

--- a/types/ember__routing/router-service.d.ts
+++ b/types/ember__routing/router-service.d.ts
@@ -1,4 +1,5 @@
 import RouteInfo from '@ember/routing/-private/route-info';
+import RouteInfoWithAttributes from '@ember/routing/-private/route-info-with-attributes';
 import Transition from '@ember/routing/-private/transition';
 import Service from '@ember/service';
 
@@ -265,4 +266,36 @@ export default class RouterService extends Service {
         name: 'routeDidChange' | 'routeWillChange',
         callback: (transition: Transition) => void
     ): RouterService;
+
+    /**
+     * Takes a string URL and returns a `RouteInfo` for the leafmost route represented
+     * by the URL. Returns `null` if the URL is not recognized. This method expects to
+     * receive the actual URL as seen by the browser including the app's `rootURL`.
+     * See [RouteInfo](/ember/release/classes/RouteInfo) for more info.
+     * In the following example `recognize` is used to verify if a path belongs to our
+     * application before transitioning to it.
+     * ```
+     * import Component from '@ember/component';
+     * import { inject as service } from '@ember/service';
+     * export default class extends Component {
+     *   @service router;
+     *   path = '/';
+     *   click() {
+     *     if (this.router.recognize(this.path)) {
+     *       this.router.transitionTo(this.path);
+     *     }
+     *   }
+     * }
+     * ```
+     */
+    recognize(url: string): RouteInfo;
+
+    /**
+     * Takes a string URL and returns a promise that resolves to a
+     * `RouteInfoWithAttributes` for the leafmost route represented by the URL.
+     * The promise rejects if the URL is not recognized or an unhandled exception
+     * is encountered. This method expects to receive the actual URL as seen by
+     * the browser including the app's `rootURL`.
+     */
+    recognizeAndLoad(url: string): RouteInfoWithAttributes;
 }

--- a/types/ember__routing/test/route.ts
+++ b/types/ember__routing/test/route.ts
@@ -147,6 +147,10 @@ class TransitionToExamples extends Route {
         // $ExpectType Transition<any>
         this.transitionTo('blog-comment', 1, '13', { queryParams: { includePost: true } });
     }
+
+    buildRouteInfoMetadata() {
+        return { foo: 'bar' };
+    }
 }
 
 class ApplicationController extends Controller {}

--- a/types/ember__routing/test/router-service.ts
+++ b/types/ember__routing/test/router-service.ts
@@ -82,3 +82,6 @@ router.transitionTo('someRoute', 1, '13', { queryParams: { areSupported: true } 
 router.recognize('foo/bar'); // $ExpectType RouteInfo
 
 router.recognizeAndLoad('foo/bar'); // $ExpectType RouteInfoWithAttributes
+
+router.rootURL; // $ExpectType string
+router.rootURL = 'foo'; // $ExpectError

--- a/types/ember__routing/test/router-service.ts
+++ b/types/ember__routing/test/router-service.ts
@@ -52,7 +52,7 @@ transition.send(false, 'error');
 
 transition.data = { some: 'data' };
 
-// $ExpectType RouteInfo | null
+// $ExpectType RouteInfoWithAttributes | null
 transition.from;
 // $ExpectError
 transition.from = 'from';
@@ -62,7 +62,7 @@ transition.promise;
 // $ExpectError
 transition.promise = 'promise';
 
-// $ExpectType RouteInfo
+// $ExpectType RouteInfo | RouteInfoWithAttributes
 transition.to;
 // $ExpectError
 transition.to = 'to';

--- a/types/ember__routing/test/router-service.ts
+++ b/types/ember__routing/test/router-service.ts
@@ -78,3 +78,7 @@ router.transitionTo('someRoute', 1);
 router.transitionTo('someRoute', 1, { queryParams: { areSupported: true } });
 router.transitionTo('someRoute', 1, '13');
 router.transitionTo('someRoute', 1, '13', { queryParams: { areSupported: true } });
+
+router.recognize('foo/bar'); // $ExpectType RouteInfo
+
+router.recognizeAndLoad('foo/bar'); // $ExpectType RouteInfoWithAttributes


### PR DESCRIPTION
This add [RouteInfoWithAttributes](https://api.emberjs.com/ember/3.6/classes/RouteInfoWithAttributes) and uses it in appropriate places. It also adds [buildRouteInfoMetadata](https://api.emberjs.com/ember/3.18/classes/Route/methods/buildRouteInfoMetadata?anchor=buildRouteInfoMetadata) to `@ember/routing/route` and [recognize](https://api.emberjs.com/ember/3.6/classes/RouterService/methods/recognize?anchor=recognize), [recognizeAndLoad](https://api.emberjs.com/ember/3.6/classes/RouterService/methods/recognize?anchor=recognizeAndLoad), and [rootURL](https://api.emberjs.com/ember/2.16/classes/RouterService/properties/rootURL?anchor=rootURL) to `@ember/routing/router-service`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.emberjs.com/ember/3.6/classes/RouteInfoWithAttributes
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~