### PR TITLE
react-bootstrap: Add bsClass prop definition to Panel

### DIFF
--- a/types/react-bootstrap/lib/Panel.d.ts
+++ b/types/react-bootstrap/lib/Panel.d.ts
@@ -9,6 +9,7 @@ import PanelFooter = require('./PanelFooter');
 
 declare namespace Panel {
     export interface PanelProps extends TransitionCallbacks, React.HTMLProps<Panel> {
+        bsClass?: string;
         bsStyle?: string;
         defaultExpanded?: boolean;
         eventKey?: any;

--- a/types/react-bootstrap/test/react-bootstrap-tests.tsx
+++ b/types/react-bootstrap/test/react-bootstrap-tests.tsx
@@ -292,6 +292,13 @@ export class ReactBootstrapTest extends Component {
                 </div>
 
                 <div style={style}>
+                  <Panel bsClass="custom-class">
+                    <Panel.Body>Panel content</Panel.Body>
+                    <Panel.Footer>Panel footer</Panel.Footer>
+                  </Panel>
+                </div>
+
+                <div style={style}>
                   <div>
                     <Panel bsStyle="primary">
                       <Panel.Heading>


### PR DESCRIPTION
The `bsClass` prop in the parent `Panel` component [is not documented](https://react-bootstrap-v3.netlify.app/components/panel/#panels-props-accordion) in react-bootstrap v0.33.1, however, it is present in the source code and is functional.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

**Changing an existing definition**
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
   1. Source code line that uses the missing `bsClass` prop: https://github.com/react-bootstrap/react-bootstrap/blob/414bea983cd63d51a909a1ef7a4e293c0fbb7f66/src/Panel.js#L86
   2. Discussion of the prop's behaviour in the react-bootstrap repo: https://github.com/react-bootstrap/react-bootstrap/issues/2954
- [X] Include tests for your changes: Added a test [here](types/react-bootstrap/test/react-bootstrap-tests.tsx).
