### PR TITLE
[ramda] Improve R.tryCatch

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1952,9 +1952,8 @@ export function trim(str: string): string;
  * function and returns its result. Note that for effective composition with this function, both the tryer and
  * catcher functions must return the same type of results.
  */
-export function tryCatch<T, A = any>(tryer: (...args: readonly A[]) => T, catcher: (...args: readonly A[]) => T): (...args: readonly A[]) => T;
-export function tryCatch<T, A = any>(tryer: (...args: readonly A[]) => T): (catcher: (...args: readonly A[]) => T) => (...args: readonly A[]) => T;
-
+export function tryCatch<F extends (...args: readonly any[]) => any, RE = ReturnType<F>, E = unknown>(tryer: F, catcher: (error: E, ...args: _.F.Parameters<F>) => RE): (F | (() => RE));
+export function tryCatch<F extends (...args: readonly any[]) => any>(tryer: F): <RE = ReturnType<F>, E = unknown>(catcher: (error: E, ...args: _.F.Parameters<F>) => RE) => (F | (() => RE));
 /**
  * Gives a single-word string description of the (native) type of a value, returning such answers as 'Object',
  * 'Number', 'Array', or 'Null'. Does not attempt to distinguish user Object types any further, reporting them

--- a/types/ramda/test/tryCatch-tests.ts
+++ b/types/ramda/test/tryCatch-tests.ts
@@ -1,10 +1,10 @@
 import * as R from 'ramda';
 
 () => {
-  const a: boolean = R.tryCatch<boolean>(R.prop('x'), R.F)({ x: true }); // => true
-  const a1: boolean = R.tryCatch(R.prop<'x', true>('x'), R.F)({ x: true }); // => true
-  const b: boolean = R.tryCatch<boolean>(R.prop('x'), R.F)(null); // => false
-  const c: boolean = R.tryCatch<boolean>(R.and, R.F)(true, true); // => true
+    const a: boolean = R.tryCatch<boolean>(R.prop('x'), R.F)({ x: true }); // => true
+    const a1: boolean = R.tryCatch(R.prop<'x', true>('x'), R.F)({ x: true }); // => true
+    const b: boolean = R.tryCatch<boolean>(R.prop('x'), R.F)(null); // => false
+    const c: boolean = R.tryCatch<boolean>(R.and, R.F)(true, true); // => true
 
     /* test that type safety is increased when a second type argument is supplied */
 
@@ -46,4 +46,14 @@ import * as R from 'ramda';
 
     const k: number = R.tryCatch<number, number>(x => x + 1)(x => x)(2);
     const l: boolean = R.tryCatch<boolean>(R.T)(R.F)(true);
+
+    const f1 = R.tryCatch((x: number) => x, R.F); // $ExpectType ((x: number) => number) | (() => boolean)
+    const f2 = R.tryCatch(<T>(x: T) => x, R.F); // $ExpectType (() => boolean) | (<T>(x: T) => T)
+    const s1 = R.tryCatch((x: number) => x, R.F)(5); // $ExpectType number | boolean
+    const a11 = R.tryCatch(R.prop('x'), R.F)({ x: true }); // $ExpectType boolean
+    const a2 = R.tryCatch(R.prop<'x', true>('x'), R.F)({ x: true }); // $ExpectType boolean
+    const a3 = R.tryCatch(R.prop('x'), R.F)({ x: 13 }); // $ExpectType number | boolean
+    const b1 = R.tryCatch(R.prop('x'), R.F)(null); // $ExpectError
+    // Curried function call
+    const c1 = R.tryCatch(R.and, R.always(undefined))(true); // $ExpectType ((val2: any) => boolean) | undefined
 };

--- a/types/ramda/test/tryCatch-tests.ts
+++ b/types/ramda/test/tryCatch-tests.ts
@@ -1,59 +1,114 @@
 import * as R from 'ramda';
 
 () => {
-    const a: boolean = R.tryCatch<boolean>(R.prop('x'), R.F)({ x: true }); // => true
-    const a1: boolean = R.tryCatch(R.prop<'x', true>('x'), R.F)({ x: true }); // => true
-    const b: boolean = R.tryCatch<boolean>(R.prop('x'), R.F)(null); // => false
-    const c: boolean = R.tryCatch<boolean>(R.and, R.F)(true, true); // => true
+    /* Type inference when catcher is typed */
+    R.tryCatch((x: number) => x, R.F)(5); // $ExpectType number | boolean
 
-    /* test that type safety is increased when a second type argument is supplied */
-
-    const d: number = R.tryCatch<number, number>(
-        x => x + 1,
-        x => x,
+    R.tryCatch(
+        (x: number) => x + 1,
+        err => err,
     )(6);
-    const e: number = R.tryCatch<number, number>(
-        (x, y) => x + y,
-        (x, y) => x * y,
+
+    R.tryCatch(
+        (x: number, y: number) => x + y,
+        (err, x, y) => x * y,
     )(6, 7);
-    const f: number = R.tryCatch<number, string>(x => +x, Number)('8');
+
+    R.tryCatch((x: string) => +x, Number)('8');
 
     // string cannot be assigned to number
-    const g = R.tryCatch<number, number>(
-        x => x + 1,
-        x => x,
+    R.tryCatch(
+        (x: number) => x + 1,
+        err => err,
     )('string'); // $ExpectError
 
-    // number cannot be assigned to boolean (in the catcher)
-    const h = R.tryCatch<boolean, number>(
-        x => x < 0,
-        x => x, // $ExpectError
-    )(5);
-
     // one argument is a string
-    const i: number = R.tryCatch<number, number>(
-        (x, y) => x + y,
-        (x, y) => x * y,
+    R.tryCatch(
+        (x: number, y: number) => x + y,
+        (err, x, y) => x * y,
     )(5, '6'); // $ExpectError
 
     // no arguments allowed if argument type is never
-    const j: number = R.tryCatch<number, never>(
+    R.tryCatch(
         () => 1,
         () => 2,
     )(12); // $ExpectError
 
-    /* testing currying */
+    // With currying
 
-    const k: number = R.tryCatch<number, number>(x => x + 1)(x => x)(2);
-    const l: boolean = R.tryCatch<boolean>(R.T)(R.F)(true);
+    R.tryCatch((x: number) => x + 1)(err => err)(2); // $ExpectType unknown
+    R.tryCatch((x: number) => x + 1)((err, x)  => x)(2); // $ExpectType number
 
-    const f1 = R.tryCatch((x: number) => x, R.F); // $ExpectType ((x: number) => number) | (() => boolean)
-    const f2 = R.tryCatch(<T>(x: T) => x, R.F); // $ExpectType (() => boolean) | (<T>(x: T) => T)
-    const s1 = R.tryCatch((x: number) => x, R.F)(5); // $ExpectType number | boolean
-    const a11 = R.tryCatch(R.prop('x'), R.F)({ x: true }); // $ExpectType boolean
-    const a2 = R.tryCatch(R.prop<'x', true>('x'), R.F)({ x: true }); // $ExpectType boolean
-    const a3 = R.tryCatch(R.prop('x'), R.F)({ x: 13 }); // $ExpectType number | boolean
-    const b1 = R.tryCatch(R.prop('x'), R.F)(null); // $ExpectError
-    // Curried function call
-    const c1 = R.tryCatch(R.and, R.always(undefined))(true); // $ExpectType ((val2: any) => boolean) | undefined
+    R.tryCatch((x: number) => x, R.F); // $ExpectType (() => boolean) | ((x: number) => number)
+    R.tryCatch((x: number) => x)(R.F); // $ExpectType ((x: number) => number) | (() => boolean)
+
+    /* Catcher type inference */
+
+    // $ExpectType number
+    R.tryCatch(
+        (x: number) => 1,
+        (err, x) => x * x,
+    )(12);
+
+    // $ExpectType string | number
+    R.tryCatch(
+        (x: number) => 1,
+    )(
+        (err, x) => x.toString(),
+    )(12);
+
+    // $ExpectType number | Error
+    R.tryCatch(
+        (x: number) => 1,
+        (err: Error, x) => err,
+    )(12);
+
+    // $ExpectType number | Error
+    R.tryCatch(
+        (x: number) => 1,
+    )(
+        (err: Error, x) => err,
+    )(12);
+
+    /* Generic functions */
+
+    const f1 = R.tryCatch(<T>(x: T) => x, R.F); // $ExpectType (() => boolean) | (<T>(x: T) => T)
+
+    f1('foobar'); // $ExpectType boolean | "foobar"
+    f1({}); // $ExpectType boolean | {}
+
+    R.tryCatch(<T extends string | number>(x: T) => x, R.F)(123); // $ExpectType boolean | 123
+    R.tryCatch(<T extends string | number>(x: T) => x, R.F)('asdf'); // $ExpectType boolean | "asdf"
+    R.tryCatch(<T extends string | number>(x: T) => x, R.F)(null); // $ExpectError
+
+    R.tryCatch(R.and, R.F)(true, true); // $ExpectType boolean
+    R.tryCatch(R.and)(R.F)(true, true); // $ExpectType boolean
+
+    // Generic function tryer inference
+    R.tryCatch(
+        <T extends string | number>(x: T) => x,
+        (err, x) => x // $ExpectType (err: unknown, x: string | number) => string | number
+    )(123); // $ExpectType 123
+
+    // Invalid number of args for the tryer
+    R.tryCatch(R.T)(R.F)(true); // $ExpectError
+
+    R.tryCatch(R.prop('x'), R.F)({ x: true }); // $ExpectType boolean
+    R.tryCatch(R.prop<'x', true>('x'), R.F)({ x: true }); // $ExpectType boolean
+    R.tryCatch(R.prop('x'), R.F)({ x: 13 }); // $ExpectType number | boolean
+    R.tryCatch(R.prop('x'))(R.F)({ x: 13 }); // $ExpectType number | boolean
+    R.tryCatch(R.prop('x'), R.F)(null); // $ExpectError
+    R.tryCatch(R.prop('x'), R.F)(null); // $ExpectError
+
+    // Curried generic tryer
+
+    // $ExpectType (() => "some-error") | (<Y>(y: Y) => { x: "arg"; y: Y; })
+    const gtf = R.tryCatch(
+        <X>(x: X) => <Y>(y: Y) => ({x, y}),
+        () => () => 'some-error' as const
+    )('arg' as const);
+
+    gtf('arg2' as const); // $ExpectType "some-error" | { x: "arg"; y: "arg2"; }
+
+    R.tryCatch(R.and, R.always(undefined))(true); // $ExpectType ((val2: any) => boolean) | undefined
 };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

This PR:
- Fixes invalid signature for the `R.tryCatch` `catcher` argument
- Improves type inference to work with generic `tryer` functions 
- Cleans up tests a bit

1. Current `catcher` type signature does not match actual function behaviour, its first argument should be the error that was thrown.
https://ramdajs.com/docs/#tryCatch
https://ramdajs.com/repl/#?let%20tryer%20%3D%20R.tryCatch%28%0A%20%20%28...args%29%20%3D%3E%20%7B%20%0A%20%20%20%20throw%20Error%28%27oops%27%29%3B%0A%20%20%7D%2C%20%0A%20%20%28...args%29%20%3D%3E%20args%0A%29%3B%0A%0Atryer%28%27a%27%2C%20%27b%27%29%0A

After some giving it some thought, I've made the `error` argument default to `unknown` as opposite to `any` to reduce mistaking the `catcher` type signature and to make it more type safe in general.

2. I've changed the type signature to support generic `catcher` functions, so stuff like:
```typescript
    const f1 = R.tryCatch(<T>(x: T) => x, R.F); // $ExpectType (() => boolean) | (<T>(x: T) => T)

    f1('foobar'); // $ExpectType boolean | "foobar"
    f1({}); // $ExpectType boolean | {}

    tryCatch(R.prop('x'), R.F)({ x: 13 }); // $ExpectType number | boolean
```
Should "just work" without providing any type arguments.

Even using generic `tryer` curried function seems to work fine:
```typescript
    const gtf = R.tryCatch(
        <X>(x: X) => <Y>(y: Y) => ({x, y}),
        () => () => 'some-error' as const
    )('arg' as const);

    gtf('arg2' as const); // $ExpectType "some-error" | { x: "arg"; y: "arg2"; }
```

The downside is, this MR introduces a breaking change to `R.tryCatch` type arguments. However, with improved type inference I hope that in existing codebases `R.tryCatch<>` type arguments could just be removed in most cases. :thinking: 