### PR TITLE
chore: Adds in fetchKey for stale query refs

### DIFF
--- a/types/react-relay/lib/relay-experimental/EntryPointTypes.d.ts
+++ b/types/react-relay/lib/relay-experimental/EntryPointTypes.d.ts
@@ -53,6 +53,7 @@ export interface PreloadedQuery<
         kind: 'PreloadedQuery';
         environment: IEnvironment;
         environmentProviderOptions?: TEnvironmentProviderOptions | null;
+        fetchKey: string | number;
         fetchPolicy: PreloadFetchPolicy;
         networkCacheConfig?: CacheConfig | null;
         id?: string | null;


### PR DESCRIPTION
Adds in the fetchKey prop to PreloadedQueries see https://github.com/facebook/relay/commit/ba637156a233b55b769b939b23cbde06a6226cb8