### PR TITLE
Provide better types for connect-flash

### DIFF
--- a/types/connect-flash/connect-flash-tests.ts
+++ b/types/connect-flash/connect-flash-tests.ts
@@ -13,5 +13,6 @@ app.use(flash({
 app.use(function(req: Express.Request, res: Express.Response, next: Function) {
     req.flash('Message');
     req.flash('info', 'Message');
+    req.flash('info', 'Message %s', 'parameter');
     req.flash();
 });

--- a/types/connect-flash/index.d.ts
+++ b/types/connect-flash/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for connect-flash
 // Project: https://github.com/jaredhanson/connect-flash
 // Definitions by: Andreas Gassmann <https://github.com/AndreasGassmann>
+//                 Drew Lemmy <https://github.com/Lemmmy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -9,8 +10,9 @@
 declare namespace Express {
     export interface Request {
         flash(): { [key: string]: string[] };
-        flash(message: string): any;
-        flash(event: string, message: string): any;
+        flash(message: string): string[];
+        flash(type: string, message: string[] | string): number;
+        flash(type: string, format: string, ...args: any[]): number;
     }
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jaredhanson/connect-flash/blob/65eecf76694c7d80f640036a7f833cc6db07e918/lib/flash.js#L59-L82
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Notes: The existing types for this package were *very lax*. All three functions were defined as returning `any`, which is blatantly untrue - the setter always returns the number of elements in the flash list with that key, and the getters always return an array. This PR also adds a missing function signature, `flash(type, format, ...args)` which allows the user to provide a `util.format`-compatible string with varargs.
