### PR TITLE
[select2] Added missing parameter for templateSelection

### DIFF
--- a/types/select2/index.d.ts
+++ b/types/select2/index.d.ts
@@ -228,7 +228,7 @@ export interface Options<Result = DataFormat | GroupedDataFormat, RemoteResult =
     sorter?: (data: Array<OptGroupData | OptionData | IdTextPair>) => Array<OptGroupData | OptionData | IdTextPair>;
     tags?: boolean;
     templateResult?: (result: LoadingData | Result) => string | JQuery | null;
-    templateSelection?: (selection: IdTextPair | LoadingData | Result) => string | JQuery;
+    templateSelection?: (selection: IdTextPair | LoadingData | Result, container: JQuery) => string | JQuery;
     theme?: string;
     tokenizer?: (input: string, selection: any[], selectCallback: () => void, options: Options) => string;
     tokenSeparators?: string[];

--- a/types/select2/select2-tests.ts
+++ b/types/select2/select2-tests.ts
@@ -406,7 +406,7 @@ $("select").select2({
 $("select").select2({
     templateSelection: (data: Select2.IdTextPair | Select2.LoadingData | Select2.OptionData, container: JQuery) => {
         if (data.id === "") {
-            container.css('background-color', '#f6f6f6');
+            container.css("background-color", "#f6f6f6");
 
             return "Custom styled placeholder";
         }

--- a/types/select2/select2-tests.ts
+++ b/types/select2/select2-tests.ts
@@ -404,9 +404,11 @@ $("select").select2({
 // Customizing placeholder appearance
 
 $("select").select2({
-    templateSelection: (data: Select2.IdTextPair | Select2.LoadingData | Select2.OptionData) => {
+    templateSelection: (data: Select2.IdTextPair | Select2.LoadingData | Select2.OptionData, container: JQuery) => {
         if (data.id === "") {
-            return "Custom styled placeholder text";
+            container.css('background-color', '#f6f6f6');
+
+            return "Custom styled placeholder";
         }
         return data.text;
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: An example with two parameters can be found here: https://select2.org/programmatic-control/retrieving-selections#using-a-jquery-selector
Additionally, in the sourcecode you can see that templateSelection is called with 2 params (https://github.com/select2/select2/blob/develop/src/js/select2/selection/multiple.js#L79-L84) and the container, passed into the display function, is the selectionContainer (https://github.com/select2/select2/blob/develop/src/js/select2/selection/multiple.js#L115-L116) which is a JQuery element (https://github.com/select2/select2/blob/develop/src/js/select2/selection/multiple.js#L86-L97). Similar code in single.js with a JQuery element as second param.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.