### PR TITLE
fix(terser-webpack-plugin): target `webpack@5`

### DIFF
--- a/types/terser-webpack-plugin/index.d.ts
+++ b/types/terser-webpack-plugin/index.d.ts
@@ -4,7 +4,7 @@
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Plugin } from 'webpack';
+import { Compiler, WebpackPluginInstance } from 'webpack';
 import { MinifyOptions } from 'terser';
 
 /**
@@ -86,8 +86,10 @@ declare namespace TerserPlugin {
     }
 }
 
-declare class TerserPlugin extends Plugin {
+declare class TerserPlugin implements WebpackPluginInstance {
     constructor(opts?: TerserPlugin.TerserPluginOptions);
+
+    apply: (compiler: Compiler) => void;
 }
 
 export = TerserPlugin;

--- a/types/terser-webpack-plugin/package.json
+++ b/types/terser-webpack-plugin/package.json
@@ -2,6 +2,6 @@
   "private": true,
   "dependencies": {
     "terser": "^5.3.8",
-    "webpack": "^5.0.0"
+    "webpack": "^5.1.0"
   }
 }

--- a/types/terser-webpack-plugin/package.json
+++ b/types/terser-webpack-plugin/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "terser": "^5.3.8"
+    "terser": "^5.3.8",
+    "webpack": "^5.0.0"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/48806

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
  _Not applicable. Tests already exist._ 
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
  _TS 4.1 is failing, because it looks up `source-map` in the repo root and not in the package-local `node_modules` directory._
  <details>
  <summary>Error Log</summary>

  ```
  Installing to /Users/jan/.dts/typescript-installs/4.0...
  Installed!

  Installing to /Users/jan/.dts/typescript-installs/4.1...
  Installed!

  Error: Errors in typescript@4.1 for external dependencies:
  ../uglify-js/index.d.ts(9,30): error TS7016: Could not find a declaration file for module 'source-map'. '/Users/jan/open-source/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
    Try `npm i --save-dev @types/source-map` if it exists or add a new declaration (.d.ts) file containing `declare module 'source-map';`
  ../webpack-sources/lib/CachedSource.d.ts(1,30): error TS7016: Could not find a declaration file for module 'source-map'. '/Users/jan/open-source/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
    Try `npm i --save-dev @types/source-map` if it exists or add a new declaration (.d.ts) file containing `declare module 'source-map';`
  ../webpack-sources/lib/ConcatSource.d.ts(2,28): error TS7016: Could not find a declaration file for module 'source-map'. '/Users/jan/open-source/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
    Try `npm i --save-dev @types/source-map` if it exists or add a new declaration (.d.ts) file containing `declare module 'source-map';`
  ../webpack-sources/lib/index.d.ts(1,30): error TS7016: Could not find a declaration file for module 'source-map'. '/Users/jan/open-source/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
    Try `npm i --save-dev @types/source-map` if it exists or add a new declaration (.d.ts) file containing `declare module 'source-map';`
  ../webpack-sources/lib/OriginalSource.d.ts(2,28): error TS7016: Could not find a declaration file for module 'source-map'. '/Users/jan/open-source/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
    Try `npm i --save-dev @types/source-map` if it exists or add a new declaration (.d.ts) file containing `declare module 'source-map';`
  ../webpack-sources/lib/Source.d.ts(2,30): error TS7016: Could not find a declaration file for module 'source-map'. '/Users/jan/open-source/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
    Try `npm i --save-dev @types/source-map` if it exists or add a new declaration (.d.ts) file containing `declare module 'source-map';`
  ../webpack-sources/lib/SourceMapSource.d.ts(1,50): error TS7016: Could not find a declaration file for module 'source-map'. '/Users/jan/open-source/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
    Try `npm i --save-dev @types/source-map` if it exists or add a new declaration (.d.ts) file containing `declare module 'source-map';`
  ../webpack/index.d.ts(46,30): error TS7016: Could not find a declaration file for module 'source-map'. '/Users/jan/open-source/DefinitelyTyped/node_modules/source-map/source-map.js' implicitly has an 'any' type.
    Try `npm i --save-dev @types/source-map` if it exists or add a new declaration (.d.ts) file containing `declare module 'source-map';`
  ```

  </details>


Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/webpack-contrib/terser-webpack-plugin/blob/8ef95a6cfc462f269bf1e828b79050f832a7faeb/src/index.js#L595-L648
  - https://github.com/webpack/webpack/blob/64f84a26f1aeab63a2b10722a582336420996d17/types.d.ts#L9888-L9898
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
  _It actually fixes the types for that version._
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
  _All tests already exist. This is merely updating the upstream types. Tests continue to pass._
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
