### PR TITLE
[rx-lite] [rx-lite-time] Remove missing deprecated operators to match RxJS 4.1.0

### DIFF
--- a/types/rx-lite-time/index.d.ts
+++ b/types/rx-lite-time/index.d.ts
@@ -8,16 +8,6 @@
 declare namespace Rx {
     interface Observable<T> {
         delaySubscription(dueTime: number, scheduler?: IScheduler): Observable<T>;
-        delayWithSelector(delayDurationSelector: (item: T) => number): Observable<T>;
-        delayWithSelector(subscriptionDelay: number, delayDurationSelector: (item: T) => number): Observable<T>;
-
-        timeoutWithSelector<TTimeout>(firstTimeout: Observable<TTimeout>, timeoutdurationSelector?: (item: T) => Observable<TTimeout>, other?: Observable<T>): Observable<T>;
-
-        debounceWithSelector<TTimeout>(debounceDurationSelector: (item: T) => Observable<TTimeout>): Observable<T>;
-        /**
-         * @deprecated use #debounceWithSelector instead.
-         */
-        throttleWithSelector<TTimeout>(debounceDurationSelector: (item: T) => Observable<TTimeout>): Observable<T>;
 
         skipLastWithTime(duration: number, scheduler?: IScheduler): Observable<T>;
         takeLastWithTime(duration: number, timerScheduler?: IScheduler, loopScheduler?: IScheduler): Observable<T>;

--- a/types/rx-lite/index.d.ts
+++ b/types/rx-lite/index.d.ts
@@ -673,8 +673,12 @@ declare namespace Rx {
     interface Observable<T> {
         delay(dueTime: Date, scheduler?: IScheduler): Observable<T>;
         delay(dueTime: number, scheduler?: IScheduler): Observable<T>;
+        delay(delayDurationSelector: (item: T) => Observable<number> | IPromise<number>): Observable<T>;
+        delay(subscriptionDelay: Observable<number>, delayDurationSelector: (item: T) => Observable<number> | IPromise<number>): Observable<T>;
 
         debounce(dueTime: number, scheduler?: IScheduler): Observable<T>;
+        debounce(debounceDurationSelector: (item: T) => Observable<any> | IPromise<any>): Observable<T>;
+
         throttleWithTimeout(dueTime: number, scheduler?: IScheduler): Observable<T>;
         /**
          * @deprecated use #debounce or #throttleWithTimeout instead.
@@ -690,6 +694,8 @@ declare namespace Rx {
 
         timeout(dueTime: Date, other?: Observable<T>, scheduler?: IScheduler): Observable<T>;
         timeout(dueTime: number, other?: Observable<T>, scheduler?: IScheduler): Observable<T>;
+        timeout<TTimeout>(timeoutDurationSelector: (item: T) => Observable<TTimeout>, other?: Observable<T>): Observable<T>;
+        timeout<TTimeout>(firstTimeout: Observable<TTimeout>, timeoutDurationSelector: (item: T) => Observable<TTimeout>, other?: Observable<T>): Observable<T>;
     }
 
     interface ObservableStatic {

--- a/types/rx-lite/index.d.ts
+++ b/types/rx-lite/index.d.ts
@@ -268,8 +268,6 @@ declare namespace Rx {
         distinctUntilChanged<TValue>(keySelector?: (value: T) => TValue, comparer?: (x: TValue, y: TValue) => boolean): Observable<T>;
         do(observer: Observer<T>): Observable<T>;
         do(onNext?: (value: T) => void, onError?: (exception: Error) => void, onCompleted?: () => void): Observable<T>;
-        doAction(observer: Observer<T>): Observable<T>;    // alias for do
-        doAction(onNext?: (value: T) => void, onError?: (exception: Error) => void, onCompleted?: () => void): Observable<T>;    // alias for do
         tap(observer: Observer<T>): Observable<T>;    // alias for do
         tap(onNext?: (value: T) => void, onError?: (exception: Error) => void, onCompleted?: () => void): Observable<T>;    // alias for do
 
@@ -281,7 +279,6 @@ declare namespace Rx {
         tapOnCompleted(onCompleted: () => void, thisArg?: any): Observable<T>;
 
         finally(action: () => void): Observable<T>;
-        finallyAction(action: () => void): Observable<T>;    // alias for finally
         ignoreElements(): Observable<T>;
         materialize(): Observable<Notification<T>>;
         repeat(repeatCount?: number): Observable<T>;
@@ -521,20 +518,11 @@ declare namespace Rx {
          * @since 2.2.28
          */
         just<T>(value: T, scheduler?: IScheduler): Observable<T>;    // alias for return
-        returnValue<T>(value: T, scheduler?: IScheduler): Observable<T>;    // alias for return
         throw<T>(exception: Error, scheduler?: IScheduler): Observable<T>;
-        throwException<T>(exception: Error, scheduler?: IScheduler): Observable<T>;    // alias for throw
-        throwError<T>(error: Error, scheduler?: IScheduler): Observable<T>;    // alias for throw
 
         catch<T>(sources: IPromise<T>[] | Observable<T>[]): Observable<T>;
         catch<T>(...sources: Observable<T>[]): Observable<T>;
         catch<T>(...sources: IPromise<T>[]): Observable<T>;
-        catchException<T>(sources: IPromise<T>[] | Observable<T>[]): Observable<T>;    // alias for catch
-        catchException<T>(...sources: Observable<T>[]): Observable<T>;    // alias for catch
-        catchException<T>(...sources: IPromise<T>[]): Observable<T>;    // alias for catch
-        catchError<T>(sources: IPromise<T>[] | Observable<T>[]): Observable<T>;    // alias for catch
-        catchError<T>(...sources: Observable<T>[]): Observable<T>;    // alias for catch
-        catchError<T>(...sources: IPromise<T>[]): Observable<T>;    // alias for catch
 
         combineLatest<T, T2>(first: Observable<T> | IPromise<T>, second: Observable<T2> | IPromise<T2>): Observable<[T, T2]>;
         combineLatest<T, T2, TResult>(first: Observable<T> | IPromise<T>, second: Observable<T2> | IPromise<T2>, resultSelector: (v1: T, v2: T2) => TResult): Observable<TResult>;

--- a/types/rx-lite/rx-lite-tests.ts
+++ b/types/rx-lite/rx-lite-tests.ts
@@ -115,7 +115,7 @@ function test_publish() {
 
     const source = interval
         .take(2)
-        .doAction(x => {
+        .do(x => {
             console.log('Side effect');
         });
 

--- a/types/rx-lite/rx-lite-tests.ts
+++ b/types/rx-lite/rx-lite-tests.ts
@@ -148,3 +148,39 @@ function test_publish() {
     // => Completed
     // => Completed
 }
+
+function test_delay() {
+    // With Date dueTime
+    obsNum = Rx.Observable.range(0, 3).delay(new Date());
+
+    // With number dueTime
+    obsNum = Rx.Observable.range(0, 3).delay(4200);
+
+    // With selector
+    obsNum = Rx.Observable.range(0, 3).delay(item => Rx.Observable.return(item));
+
+    // With subscription delay and selector
+    obsNum = Rx.Observable.range(0, 3).delay(Rx.Observable.return(4200), item => Rx.Observable.return(item));
+}
+
+function test_debounce() {
+    // With number dueTime
+    obsNum = Rx.Observable.range(0, 3).debounce(4200);
+
+    // With selector
+    obsNum = Rx.Observable.range(0, 3).debounce(item => Rx.Observable.return(item));
+}
+
+function test_timeout() {
+    // With Date dueTime
+    obsNum = Rx.Observable.range(0, 3).timeout(new Date());
+
+    // With number dueTime
+    obsNum = Rx.Observable.range(0, 3).timeout(4200);
+
+    // With selector
+    obsNum = Rx.Observable.range(0, 3).timeout(item => Rx.Observable.return(item));
+
+    // With firstTimeout and selector
+    obsNum = Rx.Observable.range(0, 3).timeout(Rx.Observable.return(4200), item => Rx.Observable.return(item));
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Deprecations in RxJS 3.0](https://github.com/Reactive-Extensions/RxJS/releases/tag/v3.0.0), [Collapsing of Operators in RxJS 4.0](https://github.com/Reactive-Extensions/RxJS/releases/tag/v4.0.0)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
