### PR TITLE
Update Mui Datatable to v3.7

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -73,19 +73,9 @@ export interface MUIDataTableMeta {
     tableState: MUIDataTableState;
 }
 
-export interface MUIDataTableCustomHeadRenderer {
+export type MUIDataTableCustomHeadRenderer = Pick<MUIDataTableColumn, 'name' | 'label'> & Pick<MUIDataTableColumnOptions, 'customHeadRender' | 'display' | 'filter' | 'sort' | 'download' | 'empty' | 'print' | 'searchable' | 'viewColumns'> & {
     index: number;
-    name: MUIDataTableColumn['name'];
-    label: MUIDataTableColumn['label'];
-    customHeadRender: MUIDataTableColumnOptions['customHeadRender'];
-    display: MUIDataTableColumnOptions['display'];
-    filter: MUIDataTableColumnOptions['filter'];
-    sort: MUIDataTableColumnOptions['sort'];
-    download: MUIDataTableColumnOptions['download'];
-    empty: MUIDataTableColumnOptions['empty'];
-    print: MUIDataTableColumnOptions['print'];
-    searchable: MUIDataTableColumnOptions['searchable'];
-    viewColumns: MUIDataTableColumnOptions['viewColumns'];
+}
 }
 
 export interface MUIDataTableTextLabelsBody {
@@ -178,14 +168,14 @@ export interface MUIDataTableFilterOptions {
 
 export interface MUIDataTableCustomFilterListOptions {
     /**
-     * Function that return a string or array of strings use as the chip label(s)
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js
+     * Function that return a string or array of strings use as the chip label(s).
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js Example}
      */
     render?: (value: any) => React.ReactNode;
     /**
      * Function that returns a filterList allowing for custom filter updates
-     * when removing the filter chip. FilterType must be set to 'custom'
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js
+     * when removing the filter chip. FilterType must be set to 'custom'.
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js Example}
      */
     update?: (
         filterList: MUIDataTableState['filterList'],
@@ -205,7 +195,7 @@ export interface MUIDataTableColumnOptions {
      * Used to display data within all table cells of a given column.
      * The value returned from this function will be used for filtering in the filter dialog.
      * If this isn't need, you may want to consider customBodyRenderLite instead.
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/component/index.js
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/component/index.js Example}
      */
     customBodyRender?: (
         value: any,
@@ -216,7 +206,7 @@ export interface MUIDataTableColumnOptions {
      * Similar to and performing better than `customBodyRender`, however with the following caveats:
      * 1. The value returned from this function is not used for filtering, so the filter dialog will use the raw data from the data array.
      * 2. This method only gives you the dataIndex and rowIndex, leaving you to lookup the column value.
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/large-data-set/index.js
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/large-data-set/index.js Example}
      */
     customBodyRenderLite?: (dataIndex: number, rowIndex: number) => string | React.ReactNode;
     /**
@@ -241,7 +231,7 @@ export interface MUIDataTableColumnOptions {
     /**
      * Determines if the column can be dragged.
      * The draggableColumns.enabled option must also be true.
-     * @defaultValue true
+     * @default true
      */
     draggable?: boolean;
     /**
@@ -251,28 +241,28 @@ export interface MUIDataTableColumnOptions {
      * - false: Column is not visible but can be made so in the View Columns Popover
      * - 'excluded': Column is not visible and not toggleable in the View Column Popover
      *
-     * @defaultValue true
+     * @default true
      */
     display?: Display;
     /**
      * Display column in the CSV download file.
-     * @defaultValue true
+     * @default true
      */
     download?: boolean;
     /**
      * This denote whether the column has data or not.
      * For use with intentionally empty columns.
-     * @defaultValue false
+     * @default false
      */
     empty?: boolean;
     /**
      * Display column in filter list
-     * @defaultValue true
+     * @default true
      */
     filter?: boolean;
     /**
-     * Filter value list
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/column-filters/index.js
+     * Filter value list.
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/column-filters/index.js Example}
      */
     filterList?: string[];
     /**
@@ -283,59 +273,59 @@ export interface MUIDataTableColumnOptions {
     /**
      * Choice of filtering view. Takes priority over global filterType option.
      * Use 'custom' is you are supplying your own rendering via filterOptions.
-     * @defaultValue dropdown
+     * @default dropdown
      */
     filterType?: FilterType;
     /** Display hint icon with string as tooltip on hover. */
     hint?: string;
     /**
      * Display column when printing.
-     * @defaultValue true
+     * @default true
      */
     print?: boolean;
     /**
      * Exclude/include column from search results.
-     * @defaultValue true
+     * @default true
      */
     searchable?: boolean;
     /**
      * Is called for each header cell and allows you to return custom props for the header cell based on its data.
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js Example}
      */
     setCellHeaderProps?: (columnMeta: MUIDataTableCustomHeadRenderer) => object;
     /**
      * Is called for each cell and allows to you return custom props for this cell based on its data.
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js Example}
      */
     setCellProps?: (cellValue: string, rowIndex: number, columnIndex: number) => object;
     /**
      * Enable/disable sorting on column.
-     * @defaultValue true
+     * @default true
      */
     sort?: boolean;
     /**
      * Custom sort function for the column. Takes in an order string and returns a function that compares the two column values.
      * If this method and options.customSort are both defined, this method will take precedence.
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/column-sort/index.js
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/column-sort/index.js Example}
      */
     sortCompare?: (order: MUISortOptions['direction']) => (obj1: { data: any }, obj2: { data: any }) => number;
     /**
      * Causes the first click on a column to sort by desc rather than asc.
-     * @defaultValue false
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-columns/index.js
+     * @default false
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-columns/index.js Example}
      */
     sortDescFirst?: boolean;
     /**
      * Allows for a third click on a column header to undo any sorting on the column.
-     * @defaultValue false
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-columns/index.js
+     * @default false
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-columns/index.js Example}
      */
     sortThirdClickReset?: boolean;
     /** @deprecated use `sortOrder` instead */
     sortDirection?: 'asc' | 'desc' | 'none';
     /**
      * Allow user to toggle column visibility through 'View Column' list.
-     * @defaultValue true
+     * @default true
      */
     viewColumns?: boolean;
 }
@@ -358,7 +348,7 @@ export type MUIDataTableOptions = Partial<{
     /**
      * Works in conjuction with the customFilterDialogFooter options and make is so filters have to be confirmed before being apllied to the table.
      * When this option is true, the customFilterDialogFooter callback will receive an applyFilters function which, when called will apply the filter to the table.
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js Example}
      */
     confirmFilters: boolean;
     /**
@@ -377,7 +367,7 @@ export type MUIDataTableOptions = Partial<{
     ) => React.ReactNode;
     /**
      * Render a custom table footer.
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-footer/index.js
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-footer/index.js Example}
      */
     customFooter: (
         rowCount: number,
@@ -389,17 +379,17 @@ export type MUIDataTableOptions = Partial<{
     ) => React.ReactNode;
     /**
      * Override default row rendering with custom function.
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-rows/index.js
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-rows/index.js Example}
      */
     customRowRender: (data: any[], dataIndex: number, rowIndex: number) => React.ReactNode;
     /**
-     * Override default search with custom function
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js
+     * Override default search with custom function.
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js Example}
      */
     customSearch: (searchQuery: string, currentRow: any[], columns: any[]) => boolean;
     /**
-     * Render a custom table search
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search-render/CustomSearchRender.js
+     * Render a custom table search.
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search-render/CustomSearchRender.js Example}
      */
     customSearchRender: (
         searchText: string,
@@ -409,24 +399,24 @@ export type MUIDataTableOptions = Partial<{
     ) => React.Component | JSX.Element;
     /**
      * Override default sorting with custom function.
-     * If you just need to override the sorting for a particular column, see the sortCompare method in the Column options
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-sorting/index.js
+     * If you just need to override the sorting for a particular column, see the sortCompare method in the Column options.
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-sorting/index.js Example}
      */
     customSort: (data: any[], colIndex: number, order: string) => any[];
     /**
      * Render a footer under the table body but above the table's standard footer.
      * This is useful for creating footers for individual columns.
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-footer/index.js
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-footer/index.js Example}
      */
     customTableBodyFooterRender: (options: { data: any[]; selectableRows: SelectableRows; columns: any[] }) => any;
     /**
-     * Render a custom Toolbar
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-toolbar/CustomToolbar.js
+     * Render a custom Toolbar.
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-toolbar/CustomToolbar.js Example}
      */
     customToolbar: (data: { displayData: DisplayData }) => React.ReactNode;
     /**
-     * Render a custom selected row ToolBar
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-toolbarselect/CustomToolbarSelect.js
+     * Render a custom selected row ToolBar.
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-toolbarselect/CustomToolbarSelect.js Example}
      */
     customToolbarSelect: (
         selectedRows: { data: Array<{ index: number; dataIndex: number }>; lookup: { [key: number]: boolean } },
@@ -437,15 +427,15 @@ export type MUIDataTableOptions = Partial<{
     disableToolbarSelect: boolean;
     /**
      * Possible Values:
-     * true       = Button visible and clickable
-     * false      = Button not visible
-     * 'disabled' = Button is visible but not clickable
-     * @defaultValue true
+     * - true       = Button visible and clickable
+     * - false      = Button not visible
+     * - 'disabled' = Button is visible but not clickable
+     * @default true
      */
     download: ToolbarButton;
     /**
      * An object of options to change the output of the csv file.
-     * @defaultValue { filename: 'tableDownload.csv', separator: ',' }
+     * @default `{ filename: 'tableDownload.csv', separator: ',' }`
      */
     downloadOptions: Partial<{
         filename: string;
@@ -455,63 +445,65 @@ export type MUIDataTableOptions = Partial<{
     /**
      * An object of options describing how dragging columns should work.
      * The options are:
-     * enabled: boolean - Indeicated if draggable columns are enabled. Default is false
-     * transitionTime: number - The time in milliseconds it takes for columns to swap postions. Defaults to 300.
+     * `enabled: boolean` - Indicates if draggable columns are enabled. Default is `false`
+     * `transitionTime: number` - The time in milliseconds it takes for columns to swap positions. Default is `300`.
      *
      * To disable the dragging of a particular column, see the "draggable" option in the columns options.
      * Dragging a column to a new position updates the columnOrder array and triggers the onColumnOrderChange callback.
      */
     draggableColumns: MUIDataTableDraggableColumns;
     /**
-     * Shadow depth applied to the Paper component.
-     * @defaultValue 4
+     * Shadow depth applied to the `<Paper />` component.
+     * @default 4
      */
     elevation: number;
     /**
-     * If provided a non-empty string (ex: "."), it will use that value in the column's names to access nested data.
-     * For example, given a enableNestedDataAccess value of "." and a column name of "phone.cell", the column would use the value found in phone:{cell:"555-5555"}
+     * If a non-empty string (ex: `"."`) is provided, it will use that value in the column's names to access nested data.
+     *
+     * For example, given a value of `"."` for `enableNestedDataAccess` and a column name of `"phone.cell"`, the column would use the value found in phone: `{ cell:"555-5555" }`
+     *
      * Any amount of nesting will work.
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/data-as-objects/index.js
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/data-as-objects/index.js Example}
      */
     enableNestedDataAccess: string;
     /**
      * Enable/disable expandable rows.
-     * @defaultValue false
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/expandable-rows/index.js
+     * @default false
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/expandable-rows/index.js Example}
      */
     expandableRows: boolean;
     /**
      * Show/hide the expand all/collapse all row header for expandable row.
-     * @defaultValue true
+     * @default true
      */
     expandableRowsHeader: boolean;
     /**
      * Enable/disable expand trigger when row is clicked.
      * When false, only expand icon will trigger this action.
-     * @defaultValue false
+     * @default false
      */
     expandableRowsOnClick: boolean;
     /**
      * Possible Values:
-     * true       = Button visible and clickable
-     * false      = Button not visible
-     * 'disabled' = Button is visible but not clickable
-     * @defaultValue true
+     * - true       = Button visible and clickable
+     * - false      = Button not visible
+     * - 'disabled' = Button is visible but not clickable
+     * @default true
      */
     filter: ToolbarButton;
     /**
      * For array values, default checks if all the filter values are included in the array.
      * If false, checks if at least one of the filter values is in the array.
-     * @defaultValue true
-     * @link https://github.com/gregnb/mui-datatables/blob/bb0cf931decae7e5bec49a6b5f3343408bc4c0b5/examples/array-value-columns/index.js
+     * @default true
+     * {@link https://github.com/gregnb/mui-datatables/blob/bb0cf931decae7e5bec49a6b5f3343408bc4c0b5/examples/array-value-columns/index.js Example}
      */
     filterArrayFullMatch: boolean;
     /** Choice of filtering view. */
     filterType: FilterType;
     /**
      * Enable/disable a fixed header for the table
-     * @defaultValue true
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/fixed-header/index.js
+     * @default true
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/fixed-header/index.js Example}
      */
     fixedHeader: boolean;
     /** @deprecated use `fixedHeader` for **X** axis and `fixedSelectColumn` for **Y** axis */
@@ -523,21 +515,21 @@ export type MUIDataTableOptions = Partial<{
     };
     /**
      * Enable/disable fined select column.
-     * @defaultValue true
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/fixed-header/index.js
+     * @defaulte true
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/fixed-header/index.js Example}
      */
     fixedSelectColumn: boolean;
     /**
      * Enable/disable expansion or collapse on certain expandable rows with custom function.
-     * Returns true if not provided.
+     * Returns `true` if not provided.
      */
     isRowExpandable: (dataIndex: number, expandedRows?: MUIDataTableIsRowCheck) => boolean;
     /** Enable/disable selection on certain rows with custom function. Returns true if not provided. */
     isRowSelectable: (dataIndex: number, selectedRows?: MUIDataTableIsRowCheck) => boolean;
     /**
      * When true, the option adds a dropdown to the table's footer that allows a user to navigate to a specific page.
-     * @defaultValue false
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/large-data-set/index.js
+     * @default false
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/large-data-set/index.js Example}
      */
     jumpToPage: boolean;
     /** Callback function that triggers when a cell is clicked. */
@@ -558,7 +550,7 @@ export type MUIDataTableOptions = Partial<{
      * A callback function that triggers when the user downloads the CSV file.
      * In the callback, you can control what is written to the CSV file.
      * Return false to cancel download of file.
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/on-download/index.js
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/on-download/index.js Example}
      */
     onDownload: (
         buildHead: (columns: any) => string,
@@ -576,13 +568,13 @@ export type MUIDataTableOptions = Partial<{
     ) => void;
     /**
      * Callback function that is triggered when a user clicks the "X" on a filter chip.
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js Example}
      */
     onFilterChipClose: (index: number, removedFilter: string, filterList: MUIDataTableState['filterList']) => void;
     /**
      * Callback function that is triggered when a user presses the "confirm" button on the filter popover.
      * This occurs only if you've set `confirmFilters` option to `true`.
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js Example}
      */
     onFilterConfirm: (filterList: MUIDataTableState['filterList']) => void;
     /** Callback function that triggers when the filter dialog closes. */
@@ -603,7 +595,7 @@ export type MUIDataTableOptions = Partial<{
             data: Array<{ index: number; dataIndex: number }>;
         },
         newTableData: any[],
-    ) => void;
+    ) => void | false;
     /** Callback function that triggers when row(s) are selected/deselected. */
     onRowSelectionChange: (currentRowsSelected: any[], allRowsSelected: any[], rowsSelected?: any[]) => void;
     /** Callback function that triggers when the search text value has changed. */
@@ -622,20 +614,20 @@ export type MUIDataTableOptions = Partial<{
     page: number;
     /**
      * Enable/disable pagination.
-     * @defaultValue true
+     * @default true
      */
     pagination: boolean;
     /**
      * Possible Values:
-     * true       = Button visible and clickable
-     * false      = Button not visible
-     * 'disabled' = Button is visible but not clickable
-     * @defaultValue true
+     * - true       = Button visible and clickable
+     * - false      = Button not visible
+     * - 'disabled' = Button is visible but not clickable
+     * @default true
      */
     print: ToolbarButton;
     /**
      * Render Expandable rows.
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/expandable-rows/index.js
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/expandable-rows/index.js Example}
      */
     renderExpandableRow: (rowData: string[], rowMeta: { dataIndex: number; rowIndex: number }) => React.ReactNode;
     /** Enable/disable resizable columns. */
@@ -647,13 +639,13 @@ export type MUIDataTableOptions = Partial<{
      * - 'standarg': Table will stay in the standard mode but make small chnages to better fit the allocated space.
      * - 'simple': On very small devices the table rows will collapse into simple display.
      *
-     * @defaultValue vertical
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/simple/index.js
+     * @default 'vertical'
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/simple/index.js Example}
      */
     responsive: Responsive;
     /**
      * Enable/disalbe hover style over row.
-     * @defaultValue true
+     * @default true
      */
     rowHover: boolean;
     /** User provided expanded rows */
@@ -666,49 +658,49 @@ export type MUIDataTableOptions = Partial<{
     rowsSelected: any[];
     /**
      * Possible Values:
-     * true       = Button visible and clickable
-     * false      = Button not visible
-     * 'disabled' = Button is visible but not clickable
-     * @defaultValue true
+     * - true       = Button visible and clickable
+     * - false      = Button not visible
+     * - 'disabled' = Button is visible but not clickable
+     * @default true
      */
     search: ToolbarButton;
     /**
      * Initially displays search bar.
-     * @defaultValue false
+     * @default false
      */
     searchOpen: boolean;
     /**
      * Props applied to the search text box. You can set method callbacks like onBlur, onKeyUp, etc, this way.
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js Example}
      */
     searchProps: React.HTMLAttributes<HTMLInputElement>;
     /**
      * Search text placeholder.
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js Example}
      */
     searchPlaceholder: string;
     /** Search text for the table. */
     searchText: string;
     /**
      * Indicates if rows can be selected.
-     * @defaultValue multiple
+     * @default multiple
      */
     selectableRows: SelectableRows;
     /**
      * Show/hide the select all/deselect all checkbox header for selectable rows.
-     * @defaultValue true
+     * @default true
      */
     selectableRowsHeader: boolean;
     /**
      * Hides the checkboxes that appear when selectableRows is set to "multiple" or "single".
      * Can provide a more custom UX, especially when paired with selectableRowsOnClick.
-     * @defaultValue false
+     * @default false
      */
     selectableRowsHideCheckboxes: boolean;
     /**
      * Enable/disable select toggle when row is clicked.
      * When False, only checkbox will trigger this action.
-     * @defaultValue false
+     * @default false
      */
     selectableRowsOnClick: boolean;
     /**
@@ -718,68 +710,76 @@ export type MUIDataTableOptions = Partial<{
      * - 'above': Appears above the defualt toolbar.
      * - 'none': Select Toolbar never appears
      *
-     * @defaultValue replace
+     * @default replace
      */
     selectToolbarPlacement: 'replace' | 'above' | 'none';
     /**
      * Enable remote data source
-     * @defaultValue fale
+     * @default fale
      */
     serverSide: boolean;
     /**
      * Is called for each filter chip and allows you to place custom props on a filter chip.
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js Example}
      */
     setFilterChipProps: (colIndex: number, colName: string, data: ReadonlyArray<any[]>) => MUIDataTableChip;
     /**
      * Is called for each row and allows you to return custom props for this row based on its data.
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js Example}
      */
     setRowProps: (row: any[], dataIndex: number, rowIndex: number) => object;
     /**
      * Is called for the table and allows you to return custom props for the table based on its data.
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js Example}
      */
     setTableProps: () => object;
     /**
      * Enable/disable sort on all columns.
-     * @defaultValue true
+     * @default true
      */
     sort: boolean;
     /**
      * Enable/disable alphanumeric sorting of filter lists.
-     * @defaultValue true
+     * @default true
      */
     sortFilterList: boolean;
     /**
      * Sets the column to sort by and its sort direction.
      * To remove/reset sorting, input in an empty object.
      * The object options are the column name and the direction.
-     * @shape { name: string, direction: 'asc' | 'desc' }
-     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-columns/index.js
+     * @type `{ name: string, direction: 'asc' | 'desc' }`
+     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-columns/index.js Example}
      */
     sortOrder: MUISortOptions;
     /**
      * A string that is used internally for identifying the table.
-     * It's auto-generated, however, if you need it set to a custom value (ex: server-side rendering), you can set it via this property.
-     * @defaultValue auto-generated string
+     * This property is auto-generated. However, if you need it set to a custom value (ex: server-side rendering), you can set it here.
+     * @default auto-generated string
      */
     tableId: string;
     /**
-     * CSS string for the height of the table (ex: '500px', '100%', 'auto').
-     * @defaultValue 'auto'
+     * CSS string for the height of the table.
+     * @example '500px'
+     * @example '100%'
+     * @example 'auto'
+     * @default 'auto'
      */
     tableBodyHeight: string;
-    /** CSS string for the height of the table (ex: '500px', '100%', 'auto'). */
+    /**
+     * CSS string for the height of the table.
+     * @example '500px'
+     * @example '100%'
+     * @example 'auto'
+     */
     tableBodyMaxHeight: string;
     /** User provided labels to localize text. */
     textLabels: Partial<MUIDataTableTextLabels>;
     /**
      * Possible Values:
-     * true       = Button visible and clickable
-     * false      = Button not visible
-     * 'disabled' = Button is visible but not clickable
-     * @defaultValue true
+     * - true       = Button visible and clickable
+     * - false      = Button not visible
+     * - 'disabled' = Button is visible but not clickable
+     * @default true
      */
     viewColumns: ToolbarButton;
 }>;

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -73,10 +73,21 @@ export interface MUIDataTableMeta {
     tableState: MUIDataTableState;
 }
 
-export type MUIDataTableCustomHeadRenderer = Pick<MUIDataTableColumn, 'name' | 'label'> & Pick<MUIDataTableColumnOptions, 'customHeadRender' | 'display' | 'filter' | 'sort' | 'download' | 'empty' | 'print' | 'searchable' | 'viewColumns'> & {
-    index: number;
-}
-}
+export type MUIDataTableCustomHeadRenderer = Pick<MUIDataTableColumn, 'name' | 'label'> &
+    Pick<
+        MUIDataTableColumnOptions,
+        | 'customHeadRender'
+        | 'display'
+        | 'filter'
+        | 'sort'
+        | 'download'
+        | 'empty'
+        | 'print'
+        | 'searchable'
+        | 'viewColumns'
+    > & {
+        index: number;
+    };
 
 export interface MUIDataTableTextLabelsBody {
     noMatch: string | React.ReactNode;
@@ -747,7 +758,7 @@ export type MUIDataTableOptions = Partial<{
      * Sets the column to sort by and its sort direction.
      * To remove/reset sorting, input in an empty object.
      * The object options are the column name and the direction.
-     * @type `{ name: string, direction: 'asc' | 'desc' }`
+     * @shape { name: string, direction: 'asc' | 'desc' }
      * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-columns/index.js Example}
      */
     sortOrder: MUISortOptions;

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -146,13 +146,15 @@ export interface MUIDataTableTextLabels {
 export interface MUIDataTableFilterOptions {
     /**
      * Custom names for the filter fields.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/column-filters/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/column-filters/index.js)
      */
     names?: string[];
     /**
      * Custom rendering inside the filter dialog.
      * `filterList` must be of the same type in the main column options, that is an array of arrays, where each array corresponds to the filter list for a given column.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js)
      */
     display?: (
         filterList: MUIDataTableState['filterList'],
@@ -163,14 +165,15 @@ export interface MUIDataTableFilterOptions {
     ) => void;
     /**
      * custom filter logic.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js)
      */
     logic?: (prop: string, filterValue: any[]) => boolean;
     /**
      * A function to customize filter choices.
      * Use case: changing empty strings to "(empty)" in a dropdown.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js Example}
      *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js)
      */
     renderValue?: (value: string) => string;
     /** Will force a filter option to take up the grid's full width. */
@@ -180,13 +183,15 @@ export interface MUIDataTableFilterOptions {
 export interface MUIDataTableCustomFilterListOptions {
     /**
      * Function that return a string or array of strings use as the chip label(s).
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js)
      */
     render?: (value: any) => React.ReactNode;
     /**
      * Function that returns a filterList allowing for custom filter updates
      * when removing the filter chip. FilterType must be set to 'custom'.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js)
      */
     update?: (
         filterList: MUIDataTableState['filterList'],
@@ -206,7 +211,8 @@ export interface MUIDataTableColumnOptions {
      * Used to display data within all table cells of a given column.
      * The value returned from this function will be used for filtering in the filter dialog.
      * If this isn't need, you may want to consider customBodyRenderLite instead.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/component/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/component/index.js)
      */
     customBodyRender?: (
         value: any,
@@ -217,7 +223,8 @@ export interface MUIDataTableColumnOptions {
      * Similar to and performing better than `customBodyRender`, however with the following caveats:
      * 1. The value returned from this function is not used for filtering, so the filter dialog will use the raw data from the data array.
      * 2. This method only gives you the dataIndex and rowIndex, leaving you to lookup the column value.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/large-data-set/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/large-data-set/index.js)
      */
     customBodyRenderLite?: (dataIndex: number, rowIndex: number) => string | React.ReactNode;
     /**
@@ -273,7 +280,8 @@ export interface MUIDataTableColumnOptions {
     filter?: boolean;
     /**
      * Filter value list.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/column-filters/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/column-filters/index.js)
      */
     filterList?: string[];
     /**
@@ -301,12 +309,14 @@ export interface MUIDataTableColumnOptions {
     searchable?: boolean;
     /**
      * Is called for each header cell and allows you to return custom props for the header cell based on its data.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js)
      */
     setCellHeaderProps?: (columnMeta: MUIDataTableCustomHeadRenderer) => object;
     /**
      * Is called for each cell and allows to you return custom props for this cell based on its data.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js)
      */
     setCellProps?: (cellValue: string, rowIndex: number, columnIndex: number) => object;
     /**
@@ -317,19 +327,24 @@ export interface MUIDataTableColumnOptions {
     /**
      * Custom sort function for the column. Takes in an order string and returns a function that compares the two column values.
      * If this method and options.customSort are both defined, this method will take precedence.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/column-sort/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/column-sort/index.js)
      */
     sortCompare?: (order: MUISortOptions['direction']) => (obj1: { data: any }, obj2: { data: any }) => number;
     /**
      * Causes the first click on a column to sort by desc rather than asc.
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-columns/index.js)
+     *
      * @default false
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-columns/index.js Example}
      */
     sortDescFirst?: boolean;
     /**
      * Allows for a third click on a column header to undo any sorting on the column.
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-columns/index.js)
+     *
      * @default false
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-columns/index.js Example}
      */
     sortThirdClickReset?: boolean;
     /** @deprecated use `sortOrder` instead */
@@ -359,7 +374,8 @@ export type MUIDataTableOptions = Partial<{
     /**
      * Works in conjuction with the customFilterDialogFooter options and make is so filters have to be confirmed before being apllied to the table.
      * When this option is true, the customFilterDialogFooter callback will receive an applyFilters function which, when called will apply the filter to the table.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js)
      */
     confirmFilters: boolean;
     /**
@@ -378,7 +394,8 @@ export type MUIDataTableOptions = Partial<{
     ) => React.ReactNode;
     /**
      * Render a custom table footer.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-footer/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-footer/index.js)
      */
     customFooter: (
         rowCount: number,
@@ -390,17 +407,20 @@ export type MUIDataTableOptions = Partial<{
     ) => React.ReactNode;
     /**
      * Override default row rendering with custom function.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-rows/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-rows/index.js)
      */
     customRowRender: (data: any[], dataIndex: number, rowIndex: number) => React.ReactNode;
     /**
      * Override default search with custom function.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js)
      */
     customSearch: (searchQuery: string, currentRow: any[], columns: any[]) => boolean;
     /**
      * Render a custom table search.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search-render/CustomSearchRender.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search-render/CustomSearchRender.js)
      */
     customSearchRender: (
         searchText: string,
@@ -411,23 +431,27 @@ export type MUIDataTableOptions = Partial<{
     /**
      * Override default sorting with custom function.
      * If you just need to override the sorting for a particular column, see the sortCompare method in the Column options.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-sorting/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-sorting/index.js)
      */
     customSort: (data: any[], colIndex: number, order: string) => any[];
     /**
      * Render a footer under the table body but above the table's standard footer.
      * This is useful for creating footers for individual columns.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-footer/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-footer/index.js)
      */
     customTableBodyFooterRender: (options: { data: any[]; selectableRows: SelectableRows; columns: any[] }) => any;
     /**
      * Render a custom Toolbar.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-toolbar/CustomToolbar.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-toolbar/CustomToolbar.js)
      */
     customToolbar: (data: { displayData: DisplayData }) => React.ReactNode;
     /**
      * Render a custom selected row ToolBar.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-toolbarselect/CustomToolbarSelect.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-toolbarselect/CustomToolbarSelect.js)
      */
     customToolbarSelect: (
         selectedRows: { data: Array<{ index: number; dataIndex: number }>; lookup: { [key: number]: boolean } },
@@ -474,13 +498,15 @@ export type MUIDataTableOptions = Partial<{
      * For example, given a value of `"."` for `enableNestedDataAccess` and a column name of `"phone.cell"`, the column would use the value found in phone: `{ cell:"555-5555" }`
      *
      * Any amount of nesting will work.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/data-as-objects/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/data-as-objects/index.js)
      */
     enableNestedDataAccess: string;
     /**
      * Enable/disable expandable rows.
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/expandable-rows/index.js)
      * @default false
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/expandable-rows/index.js Example}
      */
     expandableRows: boolean;
     /**
@@ -505,16 +531,18 @@ export type MUIDataTableOptions = Partial<{
     /**
      * For array values, default checks if all the filter values are included in the array.
      * If false, checks if at least one of the filter values is in the array.
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/bb0cf931decae7e5bec49a6b5f3343408bc4c0b5/examples/array-value-columns/index.js)
      * @default true
-     * {@link https://github.com/gregnb/mui-datatables/blob/bb0cf931decae7e5bec49a6b5f3343408bc4c0b5/examples/array-value-columns/index.js Example}
      */
     filterArrayFullMatch: boolean;
     /** Choice of filtering view. */
     filterType: FilterType;
     /**
      * Enable/disable a fixed header for the table
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/fixed-header/index.js)
      * @default true
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/fixed-header/index.js Example}
      */
     fixedHeader: boolean;
     /** @deprecated use `fixedHeader` for **X** axis and `fixedSelectColumn` for **Y** axis */
@@ -526,8 +554,9 @@ export type MUIDataTableOptions = Partial<{
     };
     /**
      * Enable/disable fined select column.
-     * @defaulte true
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/fixed-header/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/fixed-header/index.js)
+     * @default true
      */
     fixedSelectColumn: boolean;
     /**
@@ -539,8 +568,9 @@ export type MUIDataTableOptions = Partial<{
     isRowSelectable: (dataIndex: number, selectedRows?: MUIDataTableIsRowCheck) => boolean;
     /**
      * When true, the option adds a dropdown to the table's footer that allows a user to navigate to a specific page.
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/large-data-set/index.js)
      * @default false
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/large-data-set/index.js Example}
      */
     jumpToPage: boolean;
     /** Callback function that triggers when a cell is clicked. */
@@ -561,7 +591,8 @@ export type MUIDataTableOptions = Partial<{
      * A callback function that triggers when the user downloads the CSV file.
      * In the callback, you can control what is written to the CSV file.
      * Return false to cancel download of file.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/on-download/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/on-download/index.js)
      */
     onDownload: (
         buildHead: (columns: any) => string,
@@ -579,13 +610,15 @@ export type MUIDataTableOptions = Partial<{
     ) => void;
     /**
      * Callback function that is triggered when a user clicks the "X" on a filter chip.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js)
      */
     onFilterChipClose: (index: number, removedFilter: string, filterList: MUIDataTableState['filterList']) => void;
     /**
      * Callback function that is triggered when a user presses the "confirm" button on the filter popover.
      * This occurs only if you've set `confirmFilters` option to `true`.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js)
      */
     onFilterConfirm: (filterList: MUIDataTableState['filterList']) => void;
     /** Callback function that triggers when the filter dialog closes. */
@@ -638,7 +671,8 @@ export type MUIDataTableOptions = Partial<{
     print: ToolbarButton;
     /**
      * Render Expandable rows.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/expandable-rows/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/expandable-rows/index.js)
      */
     renderExpandableRow: (rowData: string[], rowMeta: { dataIndex: number; rowIndex: number }) => React.ReactNode;
     /** Enable/disable resizable columns. */
@@ -650,8 +684,8 @@ export type MUIDataTableOptions = Partial<{
      * - 'standarg': Table will stay in the standard mode but make small chnages to better fit the allocated space.
      * - 'simple': On very small devices the table rows will collapse into simple display.
      *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/simple/index.js)
      * @default 'vertical'
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/simple/index.js Example}
      */
     responsive: Responsive;
     /**
@@ -682,12 +716,14 @@ export type MUIDataTableOptions = Partial<{
     searchOpen: boolean;
     /**
      * Props applied to the search text box. You can set method callbacks like onBlur, onKeyUp, etc, this way.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js)
      */
     searchProps: React.HTMLAttributes<HTMLInputElement>;
     /**
      * Search text placeholder.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js)
      */
     searchPlaceholder: string;
     /** Search text for the table. */
@@ -731,17 +767,20 @@ export type MUIDataTableOptions = Partial<{
     serverSide: boolean;
     /**
      * Is called for each filter chip and allows you to place custom props on a filter chip.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js)
      */
     setFilterChipProps: (colIndex: number, colName: string, data: ReadonlyArray<any[]>) => MUIDataTableChip;
     /**
      * Is called for each row and allows you to return custom props for this row based on its data.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js)
      */
     setRowProps: (row: any[], dataIndex: number, rowIndex: number) => object;
     /**
      * Is called for the table and allows you to return custom props for the table based on its data.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js Example}
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js)
      */
     setTableProps: () => object;
     /**
@@ -758,8 +797,9 @@ export type MUIDataTableOptions = Partial<{
      * Sets the column to sort by and its sort direction.
      * To remove/reset sorting, input in an empty object.
      * The object options are the column name and the direction.
+     *
+     * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-columns/index.js)
      * @shape { name: string, direction: 'asc' | 'desc' }
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-columns/index.js Example}
      */
     sortOrder: MUISortOptions;
     /**
@@ -1063,7 +1103,8 @@ export const DebounceTableSearch: React.ComponentType<DebouncedMUIDataTableSearc
 // Plugins
 /**
  * Function that returns a function for the customSearchRender method. This plug-in allows you to create a debounced search which can be useful for server-side tables and tables with large data sets.
- * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/large-data-set/index.js Example}
+ *
+ * [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/large-data-set/index.js)
  * @param debounceWait The amount of time to wait for each action - defaults to 200
  */
 export function debounceSearchRender(debounceWait?: number): MUIDataTableOptions['customSearchRender'];

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -73,8 +73,19 @@ export interface MUIDataTableMeta {
     tableState: MUIDataTableState;
 }
 
-export interface MUIDataTableCustomHeadRenderer extends MUIDataTableColumn {
+export interface MUIDataTableCustomHeadRenderer {
     index: number;
+    name: MUIDataTableColumn['name'];
+    label: MUIDataTableColumn['label'];
+    customHeadRender: MUIDataTableColumnOptions['customHeadRender'];
+    display: MUIDataTableColumnOptions['display'];
+    filter: MUIDataTableColumnOptions['filter'];
+    sort: MUIDataTableColumnOptions['sort'];
+    download: MUIDataTableColumnOptions['download'];
+    empty: MUIDataTableColumnOptions['empty'];
+    print: MUIDataTableColumnOptions['print'];
+    searchable: MUIDataTableColumnOptions['searchable'];
+    viewColumns: MUIDataTableColumnOptions['viewColumns'];
 }
 
 export interface MUIDataTableTextLabelsBody {
@@ -166,8 +177,21 @@ export interface MUIDataTableFilterOptions {
 }
 
 export interface MUIDataTableCustomFilterListOptions {
+    /**
+     * Function that return a string or array of strings use as the chip label(s)
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js
+     */
     render?: (value: any) => React.ReactNode;
-    update?: (...args: any[]) => string[];
+    /**
+     * Function that returns a filterList allowing for custom filter updates
+     * when removing the filter chip. FilterType must be set to 'custom'
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js
+     */
+    update?: (
+        filterList: MUIDataTableState['filterList'],
+        filterPos: number,
+        index: number,
+    ) => MUIDataTableState['filterList'];
 }
 
 export interface MUIDataTableColumnState extends MUIDataTableColumnOptions {
@@ -177,11 +201,11 @@ export interface MUIDataTableColumnState extends MUIDataTableColumnOptions {
 
 export interface MUIDataTableColumnOptions {
     /**
-     * Function that returns a string or React component. Used to display data
-     * within all table cells of a given column. The value returned from this
-     * function will be used for filtering in the filter dialog. If this isn't
-     * need, you may want to consider customBodyRenderLite instead.
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/component/index.js
+     * Function that returns a string or React component.
+     * Used to display data within all table cells of a given column.
+     * The value returned from this function will be used for filtering in the filter dialog.
+     * If this isn't need, you may want to consider customBodyRenderLite instead.
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/component/index.js
      */
     customBodyRender?: (
         value: string,
@@ -192,31 +216,128 @@ export interface MUIDataTableColumnOptions {
      * Similar to and performing better than `customBodyRender`, however with the following caveats:
      * 1. The value returned from this function is not used for filtering, so the filter dialog will use the raw data from the data array.
      * 2. This method only gives you the dataIndex and rowIndex, leaving you to lookup the column value.
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/large-data-set/index.js
      */
     customBodyRenderLite?: (dataIndex: number, rowIndex: number) => string | React.ReactNode;
+    /**
+     * Function that returns a string or React component.
+     * Used for creating a custom header to a column.
+     * This method only affects the display in the table's header, other areas of the table (such as the View Columns popover), will use the column's label.
+     */
     customHeadLabelRender?: (dataIndex: number, rowIndex: number) => string | React.ReactNode;
+    /**
+     * These options only affect the filter chips that display after filter are selected.
+     * To modify the filters themselves, see filterOptions.
+     */
     customFilterListOptions?: MUIDataTableCustomFilterListOptions;
+    /** @deprecated use customFilterListOptions.render */
     customFilterListRender?: (value: any) => string;
+    /** Function that returns a string or React component. Used as display for column header. */
     customHeadRender?: (
         columnMeta: MUIDataTableCustomHeadRenderer,
-        updateDirection: (params: any) => any,
+        handleToggleColumn: (columnIndex: number) => void,
+        sortOrder: MUISortOptions,
     ) => string | React.ReactNode;
+    /**
+     * Determines if the column can be dragged.
+     * The draggableColumns.enabled option must also be true.
+     * @defaultValue true
+     */
     draggable?: boolean;
-    display?: boolean | string;
+    /**
+     * Display the column.
+     * Possible values:
+     * - true: Column is visible and toggleable via the View Columns Popover
+     * - false: Column is not visible but can be made so in the View Columns Popover
+     * - 'excluded': Column is not visible and not toggleable in the View Column Popover
+     *
+     * @defaultValue true
+     */
+    display?: Display;
+    /**
+     * Display column in the CSV download file.
+     * @defaultValue true
+     */
     download?: boolean;
+    /**
+     * This denote whether the column has data or not.
+     * For use with intentionally empty columns.
+     * @defaultValue false
+     */
     empty?: boolean;
+    /**
+     * Display column in filter list
+     * @defaultValue true
+     */
     filter?: boolean;
+    /**
+     * Filter value list
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/column-filters/index.js
+     */
     filterList?: string[];
+    /**
+     * These options affect the filter display and functionality from the filter dialog.
+     * To modify the filter chip that display after selecting
+     * filters, see customFilterListOptions
+     */
     filterOptions?: MUIDataTableFilterOptions;
+    /**
+     * Choice of filtering view. Takes priority over global filterType option.
+     * Use 'custom' is you are supplying your own rendering via filterOptions.
+     * @defaultValue dropdown
+     */
     filterType?: FilterType;
+    /** Display hint icon with string as tooltip on hover. */
     hint?: string;
+    /**
+     * Display column when printing.
+     * @defaultValue true
+     */
     print?: boolean;
+    /**
+     * Exclude/include column from search results.
+     * @defaultValue true
+     */
     searchable?: boolean;
+    /**
+     * Is called for each header cell and allows you to return custom props for the header cell based on its data.
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js
+     */
     setCellHeaderProps?: (columnMeta: MUIDataTableCustomHeadRenderer) => object;
+    /**
+     * Is called for each cell and allows to you return custom props for this cell based on its data.
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js
+     */
     setCellProps?: (cellValue: string, rowIndex: number, columnIndex: number) => object;
+    /**
+     * Enable/disable sorting on column.
+     * @defaultValue true
+     */
     sort?: boolean;
+    /**
+     * Custom sort function for the column. Takes in an order string and returns a function that compares the two column values.
+     * If this method and options.customSort are both defined, this method will take precedence.
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/column-sort/index.js
+     */
+    sortCompare?: (order: MUISortOptions['direction']) => (obj1: { data: any }, obj2: { data: any }) => number;
+    /**
+     * Causes the first click on a column to sort by desc rather than asc.
+     * @defaultValue false
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-columns/index.js
+     */
+    sortDescFirst?: boolean;
+    /**
+     * Allows for a third click on a column header to undo any sorting on the column.
+     * @defaultValue false
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-columns/index.js
+     */
+    sortThirdClickReset?: boolean;
     /** @deprecated use `sortOrder` instead */
     sortDirection?: 'asc' | 'desc' | 'none';
+    /**
+     * Allow user to toggle column visibility through 'View Column' list.
+     * @defaultValue true
+     */
     viewColumns?: boolean;
 }
 
@@ -236,18 +357,15 @@ export type MUIDataTableOptions = Partial<{
     /** Enable/disalbe case sensitivity for search */
     caseSensitive: boolean;
     /**
-     * Works in conjuction with the customFilterDialogFooter options and make
-     * is so filters have to be confirmed before being apllied to the table.
-     * When this option is true, the customFilterDialogFooter callback will
-     * receive an applyFilters function which, when called will apply the
-     * filter to the table.
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js
+     * Works in conjuction with the customFilterDialogFooter options and make is so filters have to be confirmed before being apllied to the table.
+     * When this option is true, the customFilterDialogFooter callback will receive an applyFilters function which, when called will apply the filter to the table.
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js
      */
     confirmFilters: boolean;
     /**
-     * An array of numbers (column indices) indicating the order the columns
-     * should be displayed in. Defaults to the order provided by the Columns
-     * prop. This option is usefulif you'd like certain columns to swap position.
+     * An array of numbers (column indices) indicating the order the columns should be displayed in.
+     * Defaults to the order provided by the Columns prop.
+     * This option is useful if you'd like certain columns to swap position.
      * See draggableColumns option
      */
     columnOrder: number[];
@@ -260,7 +378,7 @@ export type MUIDataTableOptions = Partial<{
     ) => React.ReactNode;
     /**
      * Render a custom table footer.
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-footer/index.js
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-footer/index.js
      */
     customFooter: (
         rowCount: number,
@@ -272,17 +390,17 @@ export type MUIDataTableOptions = Partial<{
     ) => React.ReactNode;
     /**
      * Override default row rendering with custom function.
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-rows/index.js
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-rows/index.js
      */
     customRowRender: (data: any[], dataIndex: number, rowIndex: number) => React.ReactNode;
     /**
      * Override default search with custom function
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js
      */
     customSearch: (searchQuery: string, currentRow: any[], columns: any[]) => boolean;
     /**
      * Render a custom table search
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search-render/CustomSearchRender.js
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search-render/CustomSearchRender.js
      */
     customSearchRender: (
         searchText: string,
@@ -291,26 +409,25 @@ export type MUIDataTableOptions = Partial<{
         options: any,
     ) => React.Component | JSX.Element;
     /**
-     * Override default sorting with custom function. If you just need to
-     * override the sorting for a particular column, see the sortCompare method
-     * in the Column options
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-sorting/index.js
+     * Override default sorting with custom function.
+     * If you just need to override the sorting for a particular column, see the sortCompare method in the Column options
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-sorting/index.js
      */
     customSort: (data: any[], colIndex: number, order: string) => any[];
     /**
      * Render a footer under the table body but above the table's standard footer.
      * This is useful for creating footers for individual columns.
-     * @Example: https://github.com/gregnb/mui-datatables/blob/master/examples/customize-footer/index.js
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-footer/index.js
      */
     customTableBodyFooterRender: (options: { data: any[]; selectableRows: SelectableRows; columns: any[] }) => any;
     /**
      * Render a custom Toolbar
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-toolbar/CustomToolbar.js
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-toolbar/CustomToolbar.js
      */
     customToolbar: (data: { displayData: DisplayData }) => React.ReactNode;
     /**
      * Render a custom selected row ToolBar
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-toolbarselect/CustomToolbarSelect.js
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-toolbarselect/CustomToolbarSelect.js
      */
     customToolbarSelect: (
         selectedRows: { data: Array<{ index: number; dataIndex: number }>; lookup: { [key: number]: boolean } },
@@ -324,12 +441,12 @@ export type MUIDataTableOptions = Partial<{
      * true       = Button visible and clickable
      * false      = Button not visible
      * 'disabled' = Button is visible but not clickable
-     * @Default true
+     * @defaultValue true
      */
     download: ToolbarButton;
     /**
      * An object of options to change the output of the csv file.
-     * @Default { filename: 'tableDownload.csv', separator: ',' }
+     * @defaultValue { filename: 'tableDownload.csv', separator: ',' }
      */
     downloadOptions: Partial<{
         filename: string;
@@ -340,43 +457,40 @@ export type MUIDataTableOptions = Partial<{
      * An object of options describing how dragging columns should work.
      * The options are:
      * enabled: boolean - Indeicated if draggable columns are enabled. Default is false
-     * transitiontime: number - The time in milliseconds it takes for columns to
+     * transitionTime: number - The time in milliseconds it takes for columns to
      * swap postions. Defaults to 300.
      *
-     * To disable the dragging of a particular column, see the "draggable"
-     * option in the columns options. Dragging a column to a new position
-     * updates the columnOrder array and triggers the onColumnOrderChange callback.
+     * To disable the dragging of a particular column, see the "draggable" option in the columns options.
+     * Dragging a column to a new position updates the columnOrder array and triggers the onColumnOrderChange callback.
      */
     draggableColumns: MUIDataTableDraggableColumns;
     /**
      * Shadow depth applied to the Paper component.
-     * @Default 4
+     * @defaultValue 4
      */
     elevation: number;
     /**
-     * If provided a non-empty string (ex: "."), it will use that value in the
-     * column's names to access nested data. For example, given a
-     * enableNestedDataAccess value of "." and a column name of "phone.cell",
-     * the column would use the value found in phone:{cell:"555-5555"}
+     * If provided a non-empty string (ex: "."), it will use that value in the column's names to access nested data.
+     * For example, given a enableNestedDataAccess value of "." and a column name of "phone.cell", the column would use the value found in phone:{cell:"555-5555"}
      * Any amount of nesting will work.
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/data-as-objects/index.js
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/data-as-objects/index.js
      */
     enableNestedDataAccess: string;
     /**
      * Enable/disable expandable rows.
-     * @Default false
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/expandable-rows/index.js
+     * @defaultValue false
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/expandable-rows/index.js
      */
     expandableRows: boolean;
     /**
      * Show/hide the expand all/collapse all row header for expandable row.
-     * @Default true
+     * @defaultValue true
      */
     expandableRowsHeader: boolean;
     /**
-     * Enable/disable expand trigger when row is clicked. When false, only
-     * expand icon will trigger this action.
-     * @Default false
+     * Enable/disable expand trigger when row is clicked.
+     * When false, only expand icon will trigger this action.
+     * @defaultValue false
      */
     expandableRowsOnClick: boolean;
     /**
@@ -384,23 +498,22 @@ export type MUIDataTableOptions = Partial<{
      * true       = Button visible and clickable
      * false      = Button not visible
      * 'disabled' = Button is visible but not clickable
-     * @Default true
+     * @defaultValue true
      */
     filter: ToolbarButton;
     /**
-     * For array values, default checks if all the filter values are included
-     * in the array. If false, checks if at least one of the filter values is
-     * in the array.
-     * @Default true
-     * @Example https://github.com/gregnb/mui-datatables/blob/bb0cf931decae7e5bec49a6b5f3343408bc4c0b5/examples/array-value-columns/index.js
+     * For array values, default checks if all the filter values are included in the array.
+     * If false, checks if at least one of the filter values is in the array.
+     * @defaultValue true
+     * @link https://github.com/gregnb/mui-datatables/blob/bb0cf931decae7e5bec49a6b5f3343408bc4c0b5/examples/array-value-columns/index.js
      */
     filterArrayFullMatch: boolean;
     /** Choice of filtering view. */
     filterType: FilterType;
     /**
      * Enable/disable a fixed header for the table
-     * @Default true
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/fixed-header/index.js
+     * @defaultValue true
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/fixed-header/index.js
      */
     fixedHeader: boolean;
     /** @deprecated use `fixedHeader` for **X** axis and `fixedSelectColumn` for **Y** axis */
@@ -412,8 +525,8 @@ export type MUIDataTableOptions = Partial<{
     };
     /**
      * Enable/disable fined select column.
-     * @Default true
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/fixed-header/index.js
+     * @defaultValue true
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/fixed-header/index.js
      */
     fixedSelectColumn: boolean;
     /**
@@ -424,10 +537,9 @@ export type MUIDataTableOptions = Partial<{
     /** Enable/disable selection on certain rows with custom function. Returns true if not provided. */
     isRowSelectable: (dataIndex: number, selectedRows?: MUIDataTableIsRowCheck) => boolean;
     /**
-     * When true, the option adds a dropdown to the table's footer that allows
-     * a user to navigate to a specific page.
-     * @Default false
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/large-data-set/index.js
+     * When true, the option adds a dropdown to the table's footer that allows a user to navigate to a specific page.
+     * @defaultValue false
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/large-data-set/index.js
      */
     jumpToPage: boolean;
     /** Callback function that triggers when a cell is clicked. */
@@ -448,7 +560,7 @@ export type MUIDataTableOptions = Partial<{
      * A callback function that triggers when the user downloads the CSV file.
      * In the callback, you can control what is written to the CSV file.
      * Return false to cancel download of file.
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/on-download/index.js
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/on-download/index.js
      */
     onDownload: (
         buildHead: (columns: any) => string,
@@ -466,13 +578,13 @@ export type MUIDataTableOptions = Partial<{
     ) => void;
     /**
      * Callback function that is triggered when a user clicks the "X" on a filter chip.
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js
      */
     onFilterChipClose: (index: number, removedFilter: string, filterList: MUIDataTableState['filterList']) => void;
     /**
      * Callback function that is triggered when a user presses the "confirm" button on the filter popover.
      * This occurs only if you've set `confirmFilters` option to `true`.
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js
      */
     onFilterConfirm: (filterList: MUIDataTableState['filterList']) => void;
     /** Callback function that triggers when the filter dialog closes. */
@@ -512,7 +624,7 @@ export type MUIDataTableOptions = Partial<{
     page: number;
     /**
      * Enable/disable pagination.
-     * @Default true
+     * @defaultValue true
      */
     pagination: boolean;
     /**
@@ -520,12 +632,12 @@ export type MUIDataTableOptions = Partial<{
      * true       = Button visible and clickable
      * false      = Button not visible
      * 'disabled' = Button is visible but not clickable
-     * @Default true
+     * @defaultValue true
      */
     print: ToolbarButton;
     /**
      * Render Expandable rows.
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/expandable-rows/index.js
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/expandable-rows/index.js
      */
     renderExpandableRow: (rowData: string[], rowMeta: { dataIndex: number; rowIndex: number }) => React.ReactNode;
     /** Enable/disable resizable columns. */
@@ -533,19 +645,17 @@ export type MUIDataTableOptions = Partial<{
     /**
      * Enable/diable responsize table view.
      * Options:
-     * - 'vertical': In smaller view the table cells will collapse such that the heading
-     * is to the left of th cell value.
-     * - 'standarg': Table will stay in the standard mode but make small chnages to better
-     * fit the allocated space.
+     * - 'vertical': In smaller view the table cells will collapse such that the heading is to the left of th cell value.
+     * - 'standarg': Table will stay in the standard mode but make small chnages to better fit the allocated space.
      * - 'simple': On very small devices the table rows will collapse into simple display.
      *
-     * @Default vertical
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/simple/index.js
+     * @defaultValue vertical
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/simple/index.js
      */
     responsive: Responsive;
     /**
      * Enable/disalbe hover style over row.
-     * @Default true
+     * @defaultValue true
      */
     rowHover: boolean;
     /** User provided expanded rows */
@@ -561,47 +671,46 @@ export type MUIDataTableOptions = Partial<{
      * true       = Button visible and clickable
      * false      = Button not visible
      * 'disabled' = Button is visible but not clickable
-     * @Default true
+     * @defaultValue true
      */
     search: ToolbarButton;
     /**
      * Initially displays search bar.
-     * @Default false
+     * @defaultValue false
      */
     searchOpen: boolean;
     /**
      * Props applied to the search text box. You can set method callbacks like onBlur, onKeyUp, etc, this way.
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js
      */
     searchProps: React.HTMLAttributes<HTMLInputElement>;
     /**
      * Search text placeholder.
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js
      */
     searchPlaceholder: string;
     /** Search text for the table. */
     searchText: string;
     /**
      * Indicates if rows can be selected.
-     * @Default multiple
+     * @defaultValue multiple
      */
     selectableRows: SelectableRows;
     /**
      * Show/hide the select all/deselect all checkbox header for selectable rows.
-     * @Default true
+     * @defaultValue true
      */
     selectableRowsHeader: boolean;
     /**
-     * Hides the checkboxes that appear when selectableRows is set to "multiple"
-     * or "single". Can provide a more custom UX, especially when paired
-     * with selectableRowsOnClick.
-     * @Default false
+     * Hides the checkboxes that appear when selectableRows is set to "multiple" or "single".
+     * Can provide a more custom UX, especially when paired with selectableRowsOnClick.
+     * @defaultValue false
      */
     selectableRowsHideCheckboxes: boolean;
     /**
-     * Enable/disable select toggle when row is clicked. When False, only
-     * checkbox will trigger this action.
-     * @Default false
+     * Enable/disable select toggle when row is clicked.
+     * When False, only checkbox will trigger this action.
+     * @defaultValue false
      */
     selectableRowsOnClick: boolean;
     /**
@@ -611,56 +720,56 @@ export type MUIDataTableOptions = Partial<{
      * - 'above': Appears above the defualt toolbar.
      * - 'none': Select Toolbar never appears
      *
-     * @Default replace
+     * @defaultValue replace
      */
     selectToolbarPlacement: 'replace' | 'above' | 'none';
     /**
      * Enable remote data source
-     * @Default fale
+     * @defaultValue fale
      */
     serverSide: boolean;
     /**
      * Is called for each filter chip and allows you to place custom props on a filter chip.
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js
      */
     setFilterChipProps: (colIndex: number, colName: string, data: ReadonlyArray<any[]>) => MUIDataTableChip;
     /**
      * Is called for each row and allows you to return custom props for this row based on its data.
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js
      */
     setRowProps: (row: any[], dataIndex: number, rowIndex: number) => object;
     /**
      * Is called for the table and allows you to return custom props for the table based on its data.
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js
      */
     setTableProps: () => object;
     /**
      * Enable/disable sort on all columns.
-     * @Default true
+     * @defaultValue true
      */
     sort: boolean;
     /**
      * Enable/disable alphanumeric sorting of filter lists.
-     * @Default true
+     * @defaultValue true
      */
     sortFilterList: boolean;
     /**
-     * Sets the column to sort by and its sort direction. To remove/reset sorting,
-     * input in an empty object. The object options are the column name and
-     * the direction. { name: string, direction: 'asc' | 'desc' }
-     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-columns/index.js
+     * Sets the column to sort by and its sort direction.
+     * To remove/reset sorting, input in an empty object.
+     * The object options are the column name and the direction.
+     * @shape { name: string, direction: 'asc' | 'desc' }
+     * @link https://github.com/gregnb/mui-datatables/blob/master/examples/customize-columns/index.js
      */
     sortOrder: MUISortOptions;
     /**
-     * A string that is used internally for identifying the table. It's
-     * auto-generated, however, if you need it set to a custom value
-     * (ex: server-side rendering), you can set it via this property.
-     * @Default auto-generated string
+     * A string that is used internally for identifying the table.
+     * It's auto-generated, however, if you need it set to a custom value (ex: server-side rendering), you can set it via this property.
+     * @defaultValue auto-generated string
      */
     tableId: string;
     /**
      * CSS string for the height of the table (ex: '500px', '100%', 'auto').
-     * @Default 'auto'
+     * @defaultValue 'auto'
      */
     tableBodyHeight: string;
     /** CSS string for the height of the table (ex: '500px', '100%', 'auto'). */
@@ -672,7 +781,7 @@ export type MUIDataTableOptions = Partial<{
      * true       = Button visible and clickable
      * false      = Button not visible
      * 'disabled' = Button is visible but not clickable
-     * @Default true
+     * @defaultValue true
      */
     viewColumns: ToolbarButton;
 }>;

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -277,8 +277,7 @@ export interface MUIDataTableColumnOptions {
     filterList?: string[];
     /**
      * These options affect the filter display and functionality from the filter dialog.
-     * To modify the filter chip that display after selecting
-     * filters, see customFilterListOptions
+     * To modify the filter chip that display after selecting filters, see customFilterListOptions
      */
     filterOptions?: MUIDataTableFilterOptions;
     /**
@@ -457,8 +456,7 @@ export type MUIDataTableOptions = Partial<{
      * An object of options describing how dragging columns should work.
      * The options are:
      * enabled: boolean - Indeicated if draggable columns are enabled. Default is false
-     * transitionTime: number - The time in milliseconds it takes for columns to
-     * swap postions. Defaults to 300.
+     * transitionTime: number - The time in milliseconds it takes for columns to swap postions. Defaults to 300.
      *
      * To disable the dragging of a particular column, see the "draggable" option in the columns options.
      * Dragging a column to a new position updates the columnOrder array and triggers the onColumnOrderChange callback.

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -208,7 +208,7 @@ export interface MUIDataTableColumnOptions {
      * @link https://github.com/gregnb/mui-datatables/blob/master/examples/component/index.js
      */
     customBodyRender?: (
-        value: string,
+        value: any,
         tableMeta: MUIDataTableMeta,
         updateValue: (value: string) => void,
     ) => string | React.ReactNode;

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mui-datatables 3.4
+// Type definitions for mui-datatables 3.6
 // Project: https://github.com/gregnb/mui-datatables
 // Definitions by: Jeroen "Favna" Claassens <https://github.com/favna>
 //                 Ankith Konda <https://github.com/ankithkonda>
@@ -12,13 +12,14 @@
 
 import * as React from 'react';
 
-export type Display = 'true' | 'false' | 'excluded';
+export type Display = boolean | 'true' | 'false' | 'excluded';
 export type FilterType = 'dropdown' | 'checkbox' | 'multiselect' | 'textField' | 'custom';
 export type Responsive = 'vertical' | 'standard' | 'simple';
 export type SelectableRows = 'multiple' | 'single' | 'none';
 export type ChipVariant = 'outlined' | 'default';
 export type ChipColor = 'primary' | 'secondary' | 'default';
 export type ToolbarButton = boolean | 'true' | 'false' | 'disabled';
+export type DisplayData = Array<{ data: any[]; dataIndex: number }>;
 
 export interface MUISortOptions {
     name: string;
@@ -47,7 +48,7 @@ export interface MUIDataTableState {
     columns: MUIDataTableColumnState[];
     count: number;
     data: any[];
-    displayData: Array<{ dataIndex: number; data: any[] }>;
+    displayData: DisplayData;
     expandedRows: MUIDataTableStateRows;
     filterData: string[][];
     filterList: string[][];
@@ -87,6 +88,7 @@ export interface MUIDataTableTextLabelsPagination {
     next: string;
     previous: string;
     rowsPerPage: string;
+    jumpToPage: string;
 }
 
 export interface MUIDataTableTextLabelsToolbar {
@@ -174,6 +176,13 @@ export interface MUIDataTableColumnState extends MUIDataTableColumnOptions {
 }
 
 export interface MUIDataTableColumnOptions {
+    /**
+     * Function that returns a string or React component. Used to display data
+     * within all table cells of a given column. The value returned from this
+     * function will be used for filtering in the filter dialog. If this isn't
+     * need, you may want to consider customBodyRenderLite instead.
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/component/index.js
+     */
     customBodyRender?: (
         value: string,
         tableMeta: MUIDataTableMeta,
@@ -224,52 +233,175 @@ export interface MUIDataTableIsRowCheck {
 }
 
 export type MUIDataTableOptions = Partial<{
+    /** Enable/disalbe case sensitivity for search */
     caseSensitive: boolean;
+    /**
+     * Works in conjuction with the customFilterDialogFooter options and make
+     * is so filters have to be confirmed before being apllied to the table.
+     * When this option is true, the customFilterDialogFooter callback will
+     * receive an applyFilters function which, when called will apply the
+     * filter to the table.
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js
+     */
     confirmFilters: boolean;
+    /**
+     * An array of numbers (column indices) indicating the order the columns
+     * should be displayed in. Defaults to the order provided by the Columns
+     * prop. This option is usefulif you'd like certain columns to swap position.
+     * See draggableColumns option
+     */
+    columnOrder: number[];
+    /** User provided override for the total number of row. */
     count: number;
+    /** Add a custom footer to the filter dialog. */
     customFilterDialogFooter: (
         filterList: MUIDataTableState['filterList'],
         applyNewFilters?: (...args: any[]) => any,
     ) => React.ReactNode;
+    /**
+     * Render a custom table footer.
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-footer/index.js
+     */
     customFooter: (
         rowCount: number,
         page: number,
         rowsPerPage: number,
         changeRowsPerPage: (page: string | number) => void,
         changePage: (newPage: number) => void,
+        textLabels: Partial<MUIDataTableTextLabels>,
     ) => React.ReactNode;
+    /**
+     * Override default row rendering with custom function.
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-rows/index.js
+     */
     customRowRender: (data: any[], dataIndex: number, rowIndex: number) => React.ReactNode;
+    /**
+     * Override default search with custom function
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js
+     */
     customSearch: (searchQuery: string, currentRow: any[], columns: any[]) => boolean;
+    /**
+     * Render a custom table search
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search-render/CustomSearchRender.js
+     */
     customSearchRender: (
         searchText: string,
-        handleSearch: any,
-        hideSearch: any,
+        handleSearch: (text: string) => void,
+        hideSearch: () => void,
         options: any,
     ) => React.Component | JSX.Element;
+    /**
+     * Override default sorting with custom function. If you just need to
+     * override the sorting for a particular column, see the sortCompare method
+     * in the Column options
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-sorting/index.js
+     */
     customSort: (data: any[], colIndex: number, order: string) => any[];
+    /**
+     * Render a footer under the table body but above the table's standard footer.
+     * This is useful for creating footers for individual columns.
+     * @Example: https://github.com/gregnb/mui-datatables/blob/master/examples/customize-footer/index.js
+     */
     customTableBodyFooterRender: (options: { data: any[]; selectableRows: SelectableRows; columns: any[] }) => any;
-    customToolbar: () => React.ReactNode;
+    /**
+     * Render a custom Toolbar
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-toolbar/CustomToolbar.js
+     */
+    customToolbar: (data: { displayData: DisplayData }) => React.ReactNode;
+    /**
+     * Render a custom selected row ToolBar
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-toolbarselect/CustomToolbarSelect.js
+     */
     customToolbarSelect: (
         selectedRows: { data: Array<{ index: number; dataIndex: number }>; lookup: { [key: number]: boolean } },
-        displayData: Array<{ data: any[]; dataIndex: number }>,
+        displayData: DisplayData,
         setSelectedRows: (rows: number[]) => void,
     ) => React.ReactNode;
     /** @deprecated use `selectToolbarPlacement` instead */
     disableToolbarSelect: boolean;
-    draggableColumns: MUIDataTableDraggableColumns;
+    /**
+     * Possible Values:
+     * true       = Button visible and clickable
+     * false      = Button not visible
+     * 'disabled' = Button is visible but not clickable
+     * @Default true
+     */
     download: ToolbarButton;
+    /**
+     * An object of options to change the output of the csv file.
+     * @Default { filename: 'tableDownload.csv', separator: ',' }
+     */
     downloadOptions: Partial<{
         filename: string;
         separator: string;
         filterOptions: Partial<{ useDisplayedColumnsOnly: boolean; useDisplayedRowsOnly: boolean }>;
     }>;
+    /**
+     * An object of options describing how dragging columns should work.
+     * The options are:
+     * enabled: boolean - Indeicated if draggable columns are enabled. Default is false
+     * transitiontime: number - The time in milliseconds it takes for columns to
+     * swap postions. Defaults to 300.
+     *
+     * To disable the dragging of a particular column, see the "draggable"
+     * option in the columns options. Dragging a column to a new position
+     * updates the columnOrder array and triggers the onColumnOrderChange callback.
+     */
+    draggableColumns: MUIDataTableDraggableColumns;
+    /**
+     * Shadow depth applied to the Paper component.
+     * @Default 4
+     */
     elevation: number;
+    /**
+     * If provided a non-empty string (ex: "."), it will use that value in the
+     * column's names to access nested data. For example, given a
+     * enableNestedDataAccess value of "." and a column name of "phone.cell",
+     * the column would use the value found in phone:{cell:"555-5555"}
+     * Any amount of nesting will work.
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/data-as-objects/index.js
+     */
     enableNestedDataAccess: string;
+    /**
+     * Enable/disable expandable rows.
+     * @Default false
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/expandable-rows/index.js
+     */
     expandableRows: boolean;
+    /**
+     * Show/hide the expand all/collapse all row header for expandable row.
+     * @Default true
+     */
     expandableRowsHeader: boolean;
+    /**
+     * Enable/disable expand trigger when row is clicked. When false, only
+     * expand icon will trigger this action.
+     * @Default false
+     */
     expandableRowsOnClick: boolean;
+    /**
+     * Possible Values:
+     * true       = Button visible and clickable
+     * false      = Button not visible
+     * 'disabled' = Button is visible but not clickable
+     * @Default true
+     */
     filter: ToolbarButton;
+    /**
+     * For array values, default checks if all the filter values are included
+     * in the array. If false, checks if at least one of the filter values is
+     * in the array.
+     * @Default true
+     * @Example https://github.com/gregnb/mui-datatables/blob/bb0cf931decae7e5bec49a6b5f3343408bc4c0b5/examples/array-value-columns/index.js
+     */
+    filterArrayFullMatch: boolean;
+    /** Choice of filtering view. */
     filterType: FilterType;
+    /**
+     * Enable/disable a fixed header for the table
+     * @Default true
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/fixed-header/index.js
+     */
     fixedHeader: boolean;
     /** @deprecated use `fixedHeader` for **X** axis and `fixedSelectColumn` for **Y** axis */
     fixedHeaderOptions: {
@@ -278,15 +410,37 @@ export type MUIDataTableOptions = Partial<{
         /** @deprecated use `fixedSelectColumn` */
         yAxis: boolean;
     };
+    /**
+     * Enable/disable fined select column.
+     * @Default true
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/fixed-header/index.js
+     */
     fixedSelectColumn: boolean;
+    /**
+     * Enable/disable expansion or collapse on certain expandable rows with custom function.
+     * Returns true if not provided.
+     */
     isRowExpandable: (dataIndex: number, expandedRows?: MUIDataTableIsRowCheck) => boolean;
+    /** Enable/disable selection on certain rows with custom function. Returns true if not provided. */
     isRowSelectable: (dataIndex: number, selectedRows?: MUIDataTableIsRowCheck) => boolean;
+    /**
+     * When true, the option adds a dropdown to the table's footer that allows
+     * a user to navigate to a specific page.
+     * @Default false
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/large-data-set/index.js
+     */
+    jumpToPage: boolean;
+    /** Callback function that triggers when a cell is clicked. */
     onCellClick: (
         colData: any,
         cellMeta: { colIndex: number; rowIndex: number; dataIndex: number; event: React.MouseEvent },
     ) => void;
     onChangePage: (currentPage: number) => void;
+    /** Callback function that triggers when a page has changed. */
     onChangeRowsPerPage: (numberOfRows: number) => void;
+    /** Callback function that triggers when a column has been dragged to a new location. */
+    onColumnOrderChange: (newColumnOrder: number[], columnIndex: number, newPosition: number) => void;
+    /** Callback function that triggers when a column has been sorted. */
     onColumnSortChange: (changedColumn: string, direction: 'asc' | 'desc') => void;
     /** @deprecated use `onViewColumnsChange` instead */
     onColumnViewChange?: (changedColumn: string, action: string) => void;
@@ -294,6 +448,7 @@ export type MUIDataTableOptions = Partial<{
      * A callback function that triggers when the user downloads the CSV file.
      * In the callback, you can control what is written to the CSV file.
      * Return false to cancel download of file.
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/on-download/index.js
      */
     onDownload: (
         buildHead: (columns: any) => string,
@@ -301,68 +456,224 @@ export type MUIDataTableOptions = Partial<{
         columns: any,
         data: any,
     ) => string | boolean;
+    /** Callback function that triggers when filters have changed. */
     onFilterChange: (
         changedColumn: string | MUIDataTableColumn | null,
         filterList: MUIDataTableState['filterList'],
         type: FilterType | 'chip' | 'reset',
+        changedColumnIndex: number,
+        displayData: DisplayData,
     ) => void;
     /**
      * Callback function that is triggered when a user clicks the "X" on a filter chip.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js Example}
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js
      */
     onFilterChipClose: (index: number, removedFilter: string, filterList: MUIDataTableState['filterList']) => void;
     /**
      * Callback function that is triggered when a user presses the "confirm" button on the filter popover.
      * This occurs only if you've set `confirmFilters` option to `true`.
-     * {@link https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js Example}
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js
      */
     onFilterConfirm: (filterList: MUIDataTableState['filterList']) => void;
+    /** Callback function that triggers when the filter dialog closes. */
     onFilterDialogClose: () => void;
+    /** Callback function that triggers when the filter dialog opens. */
     onFilterDialogOpen: () => void;
+    /** Callback function that triggers when a row is clicked. */
     onRowClick: (rowData: string[], rowMeta: { dataIndex: number; rowIndex: number }) => void;
+    /** Callback function that triggers when row(s) are expanded/collapsed. */
     onRowExpansionChange: (currentRowsExpanded: any[], allRowsExpanded: any[], rowsExpanded?: any[]) => void;
-    onRowsDelete: (rowsDeleted: {
-        lookup: { [dataIndex: number]: boolean };
-        data: Array<{ index: number; dataIndex: number }>;
-    }) => void;
+    /**
+     * Callback function that triggers when row(s) are deleted.
+     * Returning false prevents row deletion.
+     */
+    onRowsDelete: (
+        rowsDeleted: {
+            lookup: { [dataIndex: number]: boolean };
+            data: Array<{ index: number; dataIndex: number }>;
+        },
+        newTableData: any[],
+    ) => void;
+    /** Callback function that triggers when row(s) are selected/deselected. */
     onRowSelectionChange: (currentRowsSelected: any[], allRowsSelected: any[], rowsSelected?: any[]) => void;
+    /** Callback function that triggers when the search text value has changed. */
     onSearchChange: (searchText: string | null) => void;
+    /** Callback function that triggers when the searchbox closes. */
     onSearchClose: () => void;
+    /** Callback function that triggers when the searchbox opens.  */
     onSearchOpen: () => void;
+    /** Callback function that triggers when table state has changed. */
     onTableChange: (action: string, tableState: MUIDataTableState) => void;
+    /** Callback function that triggers when table state has been initialized. */
     onTableInit: (action: string, tableState: MUIDataTableState) => void;
+    /** Callback function that triggers when a column view has been changed. Previously known as onColumnViewChange. */
     onViewColumnsChange: (changedColumn: string, action: string) => void;
+    /** User provided page for pagination */
     page: number;
+    /**
+     * Enable/disable pagination.
+     * @Default true
+     */
     pagination: boolean;
+    /**
+     * Possible Values:
+     * true       = Button visible and clickable
+     * false      = Button not visible
+     * 'disabled' = Button is visible but not clickable
+     * @Default true
+     */
     print: ToolbarButton;
+    /**
+     * Render Expandable rows.
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/expandable-rows/index.js
+     */
     renderExpandableRow: (rowData: string[], rowMeta: { dataIndex: number; rowIndex: number }) => React.ReactNode;
+    /** Enable/disable resizable columns. */
     resizableColumns: boolean;
+    /**
+     * Enable/diable responsize table view.
+     * Options:
+     * - 'vertical': In smaller view the table cells will collapse such that the heading
+     * is to the left of th cell value.
+     * - 'standarg': Table will stay in the standard mode but make small chnages to better
+     * fit the allocated space.
+     * - 'simple': On very small devices the table rows will collapse into simple display.
+     *
+     * @Default vertical
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/simple/index.js
+     */
     responsive: Responsive;
+    /**
+     * Enable/disalbe hover style over row.
+     * @Default true
+     */
     rowHover: boolean;
+    /** User provided expanded rows */
     rowsExpanded: any[];
+    /** Number of ros allowed per page. */
     rowsPerPage: number;
+    /** Options to provide in pagination for number of rows a user can select */
     rowsPerPageOptions: number[];
+    /** User provided array of number (dataIndexes) which indicated the selected row. */
     rowsSelected: any[];
+    /**
+     * Possible Values:
+     * true       = Button visible and clickable
+     * false      = Button not visible
+     * 'disabled' = Button is visible but not clickable
+     * @Default true
+     */
     search: ToolbarButton;
+    /**
+     * Initially displays search bar.
+     * @Default false
+     */
     searchOpen: boolean;
+    /**
+     * Props applied to the search text box. You can set method callbacks like onBlur, onKeyUp, etc, this way.
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js
+     */
     searchProps: React.HTMLAttributes<HTMLInputElement>;
+    /**
+     * Search text placeholder.
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js
+     */
     searchPlaceholder: string;
+    /** Search text for the table. */
     searchText: string;
+    /**
+     * Indicates if rows can be selected.
+     * @Default multiple
+     */
     selectableRows: SelectableRows;
+    /**
+     * Show/hide the select all/deselect all checkbox header for selectable rows.
+     * @Default true
+     */
     selectableRowsHeader: boolean;
+    /**
+     * Hides the checkboxes that appear when selectableRows is set to "multiple"
+     * or "single". Can provide a more custom UX, especially when paired
+     * with selectableRowsOnClick.
+     * @Default false
+     */
     selectableRowsHideCheckboxes: boolean;
+    /**
+     * Enable/disable select toggle when row is clicked. When False, only
+     * checkbox will trigger this action.
+     * @Default false
+     */
     selectableRowsOnClick: boolean;
+    /**
+     * Controls the visiblity of the Select Toolbar.
+     * Options:
+     * - 'replace': Select toolbar replaces default toolbar.
+     * - 'above': Appears above the defualt toolbar.
+     * - 'none': Select Toolbar never appears
+     *
+     * @Default replace
+     */
     selectToolbarPlacement: 'replace' | 'above' | 'none';
+    /**
+     * Enable remote data source
+     * @Default fale
+     */
     serverSide: boolean;
+    /**
+     * Is called for each filter chip and allows you to place custom props on a filter chip.
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js
+     */
     setFilterChipProps: (colIndex: number, colName: string, data: ReadonlyArray<any[]>) => MUIDataTableChip;
+    /**
+     * Is called for each row and allows you to return custom props for this row based on its data.
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js
+     */
     setRowProps: (row: any[], dataIndex: number, rowIndex: number) => object;
+    /**
+     * Is called for the table and allows you to return custom props for the table based on its data.
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js
+     */
     setTableProps: () => object;
+    /**
+     * Enable/disable sort on all columns.
+     * @Default true
+     */
     sort: boolean;
+    /**
+     * Enable/disable alphanumeric sorting of filter lists.
+     * @Default true
+     */
     sortFilterList: boolean;
+    /**
+     * Sets the column to sort by and its sort direction. To remove/reset sorting,
+     * input in an empty object. The object options are the column name and
+     * the direction. { name: string, direction: 'asc' | 'desc' }
+     * @Example https://github.com/gregnb/mui-datatables/blob/master/examples/customize-columns/index.js
+     */
     sortOrder: MUISortOptions;
+    /**
+     * A string that is used internally for identifying the table. It's
+     * auto-generated, however, if you need it set to a custom value
+     * (ex: server-side rendering), you can set it via this property.
+     * @Default auto-generated string
+     */
+    tableId: string;
+    /**
+     * CSS string for the height of the table (ex: '500px', '100%', 'auto').
+     * @Default 'auto'
+     */
     tableBodyHeight: string;
+    /** CSS string for the height of the table (ex: '500px', '100%', 'auto'). */
     tableBodyMaxHeight: string;
+    /** User provided labels to localize text. */
     textLabels: Partial<MUIDataTableTextLabels>;
+    /**
+     * Possible Values:
+     * true       = Button visible and clickable
+     * false      = Button not visible
+     * 'disabled' = Button is visible but not clickable
+     * @Default true
+     */
     viewColumns: ToolbarButton;
 }>;
 
@@ -577,7 +888,7 @@ export interface MUIDataTableToolbar {
     classes?: object;
     columns: MUIDataTableColumnDef[];
     data?: MUIDataTableData[];
-    displayData?: Array<{ data: any[]; dataIndex: number }>;
+    displayData?: DisplayData;
     filterData?: any[][];
     filterList?: MUIDataTableState['filterList'];
     filterUpdate?: (...args: any) => any;
@@ -595,7 +906,7 @@ export interface MUIDataTableToolbar {
 
 export interface MUIDataTableToolbarSelect {
     classes?: object;
-    displayData?: any;
+    displayData?: DisplayData;
     onRowsDelete?: (...args: any) => any;
     options: MUIDataTableOptions;
     rowSelected?: boolean;

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mui-datatables 3.6
+// Type definitions for mui-datatables 3.7
 // Project: https://github.com/gregnb/mui-datatables
 // Definitions by: Jeroen "Favna" Claassens <https://github.com/favna>
 //                 Ankith Konda <https://github.com/ankithkonda>
@@ -880,7 +880,7 @@ export interface MUIDataTableFilter {
     classes?: object;
     filterData: any[];
     filterList?: MUIDataTableState['filterList'];
-    onFilterRest?: (...args: any) => any;
+    onFilterReset?: (...args: any) => any;
     onFilterUpdate?: (...args: any) => any;
     options: MUIDataTableOptions;
 }

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -61,6 +61,7 @@ const MuiCustomTable: React.FC<Props> = props => {
         jumpToPage: true,
         fixedHeader: true,
         fixedSelectColumn: false,
+        sortOrder: { name: 'amount', direction: 'asc' },
         filterType: 'checkbox',
         responsive: 'standard',
         selectableRows: 'none',

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -13,6 +13,7 @@ const MuiCustomTable: React.FC<Props> = props => {
             label: 'id',
             options: {
                 draggable: true,
+                sortThirdClickReset: true,
             },
         },
         {
@@ -20,6 +21,9 @@ const MuiCustomTable: React.FC<Props> = props => {
             label: 'Name',
             options: {
                 filterType: 'custom',
+                sortCompare: order => (val1, val2) => {
+                    return (val1.data.length - val2.data.length) * (order === 'asc' ? 1 : -1);
+                },
                 customBodyRender: (value, tableMeta, updateValue) => {
                     return (
                         <input
@@ -54,6 +58,7 @@ const MuiCustomTable: React.FC<Props> = props => {
     ];
 
     const TableOptions: MUIDataTableOptions = {
+        jumpToPage: true,
         fixedHeader: true,
         fixedSelectColumn: false,
         filterType: 'checkbox',
@@ -140,6 +145,7 @@ const MuiCustomTable: React.FC<Props> = props => {
                 previous: 'Previous Page',
                 rowsPerPage: 'Rows per page:',
                 displayRows: 'of',
+                jumpToPage: 'Go To',
             },
             toolbar: {
                 search: 'Search',


### PR DESCRIPTION
- Updated table options and added comments
- Added comments to columnOptions and updated fields
- update to version 3.6
- closes #49048

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
 - [jumpToPage](https://github.com/gregnb/mui-datatables/commit/9e4cfc31c7e985dcf99d1ce49c4949df5e1d854e#diff-a7b4b387b79f6d34f7528923d6b281456f33dffc477ce1c785ccba0b27d3dd0e)
 - [3.6](https://github.com/gregnb/mui-datatables/blob/1edfd405b5b1ebb1af98c67f3efb4053a04260a1/README.md)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
