### PR TITLE
Fix mini-css-extract-plugin types to work with Webpack 5

### DIFF
--- a/types/mini-css-extract-plugin/index.d.ts
+++ b/types/mini-css-extract-plugin/index.d.ts
@@ -6,18 +6,25 @@
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { ChunkData, Plugin } from 'webpack';
+import { Configuration, Compiler } from 'webpack';
 
 /**
  * Lightweight CSS extraction webpack plugin
  * This plugin extract CSS into separate files. It creates a CSS file per JS file which contains CSS. It supports On-Demand-Loading of CSS and SourceMaps.
  * Configuration Detail: https://github.com/webpack-contrib/mini-css-extract-plugin#configuration
  */
-declare class MiniCssExtractPlugin extends Plugin {
-    /** webpack loader used always at the end of loaders list */
+declare class MiniCssExtractPlugin {
+    /**
+     * Webpack loader used always at the end of loaders list
+     */
     static loader: string;
 
     constructor(options?: MiniCssExtractPlugin.PluginOptions);
+
+    /**
+     * Apply the plugin
+     */
+    apply(compiler: Compiler): void;
 }
 
 declare namespace MiniCssExtractPlugin {
@@ -29,7 +36,7 @@ declare namespace MiniCssExtractPlugin {
          * This is particularly useful when dealing with multiple entry points and wanting to get more control out of the filename for a given entry point/chunk.
          * In the example below, we'll use filename to output the generated css into a different directory.
          */
-        filename?: string | ((chunkData: ChunkData) => string);
+        filename?: Required<Configuration>['output']['filename'];
         chunkFilename?: string;
         /**
          * For projects where CSS ordering has been mitigated through consistent

--- a/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
+++ b/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
@@ -77,6 +77,15 @@ configuration = {
     // ...
     plugins: [
         new MiniCssExtractPlugin({
+            filename: configuration.output!.filename,
+        }),
+    ],
+};
+
+configuration = {
+    // ...
+    plugins: [
+        new MiniCssExtractPlugin({
             esModule: true,
         }),
     ],
@@ -93,3 +102,5 @@ configuration = {
         }),
     ],
 };
+
+new MiniCssExtractPlugin().apply(new webpack.Compiler());


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.