### PR TITLE
chore(pvutils): remove references to dom lib

### DIFF
--- a/types/pvutils/index.d.ts
+++ b/types/pvutils/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/PeculiarVentures/pvutils
 // Definitions by: Stepan Miroshin <https://github.com/microshine>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
+// Minimum TypeScript Version: 3.2
 
 export = PvUtils
 
@@ -112,7 +113,7 @@ declare namespace PvUtils {
      */
     function fromBase64(input: string, useUrlTemplate?: boolean, cutTailZeros?: boolean): string;
 
-    function arrayBufferToString(buffer: BufferSource): string;
+    function arrayBufferToString(buffer: ArrayBuffer | ArrayBufferView): string;
     function stringToArrayBuffer(str: string): ArrayBuffer;
 
     /**

--- a/types/pvutils/index.d.ts
+++ b/types/pvutils/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pvutils
+// Type definitions for pvutils 1.0
 // Project: https://github.com/PeculiarVentures/pvutils
 // Definitions by: Stepan Miroshin <https://github.com/microshine>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/types/pvutils/pvutils-tests.ts
+++ b/types/pvutils/pvutils-tests.ts
@@ -37,6 +37,7 @@ pvutils.fromBase64("", true, true).charAt(0);
 
 pvutils.arrayBufferToString(new ArrayBuffer(0)).charAt(0);
 pvutils.arrayBufferToString(new Uint8Array(0)).charAt(0);
+pvutils.arrayBufferToString(new DataView(new Uint8Array(0))).charAt(0);
 
 pvutils.stringToArrayBuffer("").byteLength;
 

--- a/types/pvutils/tsconfig.json
+++ b/types/pvutils/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
The library does not exclusively target the browser, and dom lib was
only used to reference the BufferSource convenience type.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L19939
  - https://www.npmjs.com/package/pvutils
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.