### PR TITLE
fix(serve-favicon): compatibility for old import syntax

### DIFF
--- a/types/serve-favicon/index.d.ts
+++ b/types/serve-favicon/index.d.ts
@@ -18,13 +18,17 @@ import express = require('express');
  */
 declare function serveFavicon(
     path: string | Buffer,
-    options?: {
+    options?: serveFavicon.Options
+): express.RequestHandler;
+
+declare namespace serveFavicon {
+    interface Options {
         /**
          * The cache-control max-age directive in ms, defaulting to 1 day.
          * This can also be a string accepted by the `ms` module.
          */
         maxAge?: number | string;
-    },
-): express.RequestHandler;
+    }
+}
 
 export = serveFavicon;

--- a/types/serve-favicon/serve-favicon-tests.ts
+++ b/types/serve-favicon/serve-favicon-tests.ts
@@ -1,5 +1,5 @@
-import express = require('express');
-import favicon = require('serve-favicon');
+import * as express from 'express';
+import * as favicon from 'serve-favicon';
 
 const app = express();
 


### PR DESCRIPTION
This change intent is to provide support for older syntax version.

Thanks!

/cc @wszydlak

Fixes #49139

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)