### PR TITLE
feat(firefox-webext-browser/webRequest): added types for the StreamFilter

### DIFF
--- a/types/firefox-webext-browser/firefox-webext-browser-tests.ts
+++ b/types/firefox-webext-browser/firefox-webext-browser-tests.ts
@@ -85,3 +85,15 @@ browser.tabs.captureVisibleTab();
 browser.tabs.captureVisibleTab(15);
 browser.tabs.captureVisibleTab(15, {format: 'png'});
 browser.tabs.captureVisibleTab({format: 'png'});
+
+const filter = browser.webRequest.filterResponseData('1234');
+filter.onerror = () => console.log(filter.error);
+filter.ondata = ({data}) => console.log(data);
+filter.onstart = () => console.log('start');
+filter.onstop = (_event: Event) => console.log('stop');
+filter.suspend();
+filter.resume();
+filter.write(new Uint8Array(32));
+filter.close();
+filter.disconnect();
+console.log(filter.status);

--- a/types/firefox-webext-browser/index.d.ts
+++ b/types/firefox-webext-browser/index.d.ts
@@ -5143,7 +5143,7 @@ declare namespace browser.webRequest {
 
         /**
          * Writes response data to the output stream.
-         * @param {Uint8Array | ArrayBuffer} data
+         * @param data
          */
         write(data: Uint8Array | ArrayBuffer): void;
 
@@ -5199,8 +5199,8 @@ declare namespace browser.webRequest {
 
     /**
      * Create a `StreamFilter` object for a request.
-     * @param {string} requestId
-     * @returns {browser.webRequest._StreamFilter}
+     * @param requestId
+     * @returns
      */
     function filterResponseData(requestId: string): _StreamFilter;
 

--- a/types/firefox-webext-browser/index.d.ts
+++ b/types/firefox-webext-browser/index.d.ts
@@ -5116,6 +5116,75 @@ declare namespace browser.webRequest {
         hasListener(cb: TCallback): boolean;
     }
 
+    interface _StreamFilterDataEvent extends Event {
+        readonly data: ArrayBuffer;
+    }
+
+    interface _StreamFilter {
+        /**
+         * Closes the request. Any further response data is discarded.
+         */
+        close(): void;
+
+        /**
+         * Disconnects the filter from the request. The browser will handle further data.
+         */
+        disconnect(): void;
+
+        /**
+         * Resumes a suspended request.
+         */
+        resume(): void;
+
+        /**
+         * Suspends a request. After this is called, no more data will be delivered until the request is resumed with a call to `resume()`.
+         */
+        suspend(): void;
+
+        /**
+         * Writes response data to the output stream.
+         * @param {Uint8Array | ArrayBuffer} data
+         */
+        write(data: Uint8Array | ArrayBuffer): void;
+
+        /**
+         * Event handler which is called when incoming data is available.
+         */
+        ondata: ((event: _StreamFilterDataEvent) => void) | null;
+
+        /**
+         * Event handler which is called when an error has occurred.
+         */
+        onerror: ((event: Event) => void) | null;
+
+        /**
+         * Event handler which is called when the stream is about to start receiving data.
+         */
+        onstart: ((event: Event) => void) | null;
+
+        /**
+         * Event handler which is called when the stream has no more data to deliver or has closed.
+         */
+        onstop: ((event: Event) => void) | null;
+
+        /**
+         * When `onerror` is called, this will describe the error.
+         */
+        readonly error: string;
+
+        /**
+         * Describes the current status of the stream.
+         */
+        readonly status:
+            | 'uninitialized'
+            | 'transferringdata'
+            | 'finishedtransferringdata'
+            | 'suspended'
+            | 'closed'
+            | 'disconnected'
+            | 'failed';
+    }
+
     /* webRequest properties */
     /**
      * The maximum number of times that `handlerBehaviorChanged` can be called per 10 minute sustained interval. `handlerBehaviorChanged` is an expensive function call that shouldn't be called often.
@@ -5128,8 +5197,12 @@ declare namespace browser.webRequest {
      */
     function handlerBehaviorChanged(): Promise<void>;
 
-    /** ... */
-    function filterResponseData(requestId: string): object; /*StreamFilter*/
+    /**
+     * Create a `StreamFilter` object for a request.
+     * @param {string} requestId
+     * @returns {browser.webRequest._StreamFilter}
+     */
+    function filterResponseData(requestId: string): _StreamFilter;
 
     /**
      * Retrieves the security information for the request. Returns a promise that will resolve to a SecurityInfo object.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [here](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/filterResponseData)
<!-- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. -->
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
<!-- - [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. -->
