### PR TITLE
QuickJS Types for `std` and `os` imports

### DIFF
--- a/types/quickjs/os/index.d.ts
+++ b/types/quickjs/os/index.d.ts
@@ -1,0 +1,315 @@
+import { ERRNO, PATH, FileFlags, FileHandle, Dict } from '../baseTypes.js';
+import { SEEK_SET, SEEK_CUR, SEEK_END } from 'std';
+
+declare module 'os' {
+	/**
+	 * Open a file. Return a handle or < 0 if error.
+	 */
+	export function open(
+		filename: PATH,
+		flags: FileFlags | number,
+		mode?: number
+	): FileHandle;
+
+	/** POSIX open flags.  */
+	export const O_RDONLY = 0;
+	/** POSIX open flags.  */
+	export const O_WRONLY = 1;
+	/** POSIX open flags.  */
+	export const O_RDWR = 2;
+	/** POSIX open flags.  */
+	export const O_APPEND = 1024;
+	/** POSIX open flags.  */
+	export const O_CREAT = 64;
+	/** POSIX open flags.  */
+	export const O_EXCL = 128;
+	/** POSIX open flags.  */
+	export const O_TRUNC = 512;
+
+	/** (Windows specific). Open the file in text mode. The default is binary mode.  */
+	export const O_TEXT: number;
+
+	/**
+	 * Close the file handle `fd`.
+	 */
+	export function close(fd: FileHandle): ERRNO;
+
+	/**
+	 * Seek in the file. Use `std.SEEK_*` for `whence`. `offset` is either a number or a bigint. If `offset` is a bigint, a bigint is returned too.
+	 */
+	export function seek(
+		fd: FileHandle,
+		offset: number,
+		whence: typeof SEEK_SET | typeof SEEK_CUR | typeof SEEK_END
+	): number;
+	export function seek(
+		fd: FileHandle,
+		offset: bigint,
+		whence: typeof SEEK_SET | typeof SEEK_CUR | typeof SEEK_END
+	): bigint;
+
+	/**
+	 * Read length bytes from the file handle fd to the ArrayBuffer buffer at byte position offset. Return the number of read bytes or < 0 if error.
+	 */
+	export function read(
+		fd: FileHandle,
+		buffer: ArrayBuffer,
+		offset: number,
+		length: number
+	): number;
+
+	/**
+	 * Write length bytes to the file handle fd from the ArrayBuffer buffer at byte position offset. Return the number of written bytes or < 0 if error.
+	 */
+	export function write(
+		fd: FileHandle,
+		buffer: ArrayBuffer,
+		offset: number,
+		length: number
+	): number;
+
+	/**
+	 * Return `true` is `fd` is a TTY (terminal) handle.
+	 */
+	export function isatty(fd: FileHandle): boolean;
+
+	/**
+	 * Return the TTY size as `[width, height]` or `null` if not available.
+	 */
+	export function ttyGetWinSize(
+		fd: FileHandle
+	): [width: number, height: number] | null;
+
+	/**
+	 * Set the TTY in raw mode.
+	 */
+	export function ttySetRaw(fd: FileHandle): void;
+
+	/**
+	 * Remove a file. Return 0 if OK or `-errno`.
+	 */
+	export function remove(filename: PATH): ERRNO;
+
+	/**
+	 * Rename a file. Return 0 if OK or `-errno`.
+	 */
+	export function rename(oldname: PATH, newname: PATH): ERRNO;
+
+	/**
+	 * Return `[str, err]` where `str` is the canonicalized absolute pathname of `path` and `err` the error code.
+	 */
+	export function realpath(path: PATH): [str: PATH, err: ERRNO];
+
+	/**
+	 * Return `[str, err]` where `str` is the current working directory and `err` the error code.
+	 */
+	export function getcwd(): [str: PATH, err: ERRNO];
+
+	/**
+	 * Change the current directory. Return 0 if OK or `-errno`.
+	 */
+	export function chdir(path: string): ERRNO;
+
+	/**
+	 * Create a directory at `path`. Return 0 if OK or `-errno`.
+	 */
+	export function mkdir(path: string, mode: number): ERRNO;
+
+	/**
+	 * Return `[obj, err]` where `obj` is an object containing the file status of `path`. `err` is the error code. The following fields are defined in `obj`: dev, ino, mode, nlink, uid, gid, rdev, size, blocks, atime, mtime, ctime. The times are specified in milliseconds since 1970.
+	 */
+	export function stat(
+		path: PATH
+	): [
+		obj: {
+			dev: number;
+			ino: number;
+			mode: STAT_MODE;
+			nlink: number;
+			uid: number;
+			gid: number;
+			rdev: number;
+			size: number;
+			blocks: number;
+			atime: number;
+			mtime: number;
+			ctime: number;
+		},
+		err: ERRNO
+	];
+
+	/**
+	 * `lstat()` is the same as `stat()` excepts that it returns information about the link itself.
+	 */
+	export function lstat(path: PATH): ReturnType<typeof stat>;
+
+	/** Constants to interpret the `mode` property returned by `stat()`. They have the same value as in the C system header `sys/stat.h`.  */
+	export const S_IFMT = 61440;
+	export const S_IFIFO = 4096;
+	export const S_IFCHR = 8192;
+	export const S_IFDIR = 16384;
+	export const S_IFBLK = 24576;
+	export const S_IFREG = 32768;
+	export const S_IFSOCK = 49152;
+	export const S_IFLNK = 40960;
+	export const S_ISGID = 1024;
+	export const S_ISUID = 2048;
+
+	type STAT_MODE =
+		| typeof S_IFMT
+		| typeof S_IFIFO
+		| typeof S_IFCHR
+		| typeof S_IFDIR
+		| typeof S_IFBLK
+		| typeof S_IFREG
+		| typeof S_IFSOCK
+		| typeof S_IFLNK
+		| typeof S_ISGID
+		| typeof S_ISUID;
+
+	/**
+	 * Change the access and modification times of the file `path`. The times are specified in milliseconds since 1970. Return 0 if OK or `-errno`.
+	 */
+	export function utimes(path: PATH, atime: number, mtime: number): ERRNO;
+
+	/**
+	 * Create a link at `linkpath` containing the string `target`. Return 0 if OK or `-errno`.
+	 */
+	export function symlink(target: PATH, linkpath: PATH): ERRNO;
+
+	/**
+	 * Return `[str, err]` where `str` is the link target and `err` the error code.
+	 */
+	export function readlink(path: PATH): [str: PATH, err: ERRNO];
+
+	/**
+	 * Return `[array, err]` where array is an array of strings containing the filenames of the directory `path`. `err` is the error code.
+	 */
+	export function readdir(path: PATH): [array: PATH[], err: ERRNO];
+
+	/**
+	 * Add a read handler to the file handle `fd`. `func` is called each time there is data pending for `fd`. A single read handler per file handle is supported. Use `func = null` to remove the handler.
+	 */
+	export function setReadHandler(fd: FileHandle, func: Function): void;
+
+	/**
+	 * Add a write handler to the file handle `fd`. `func` is called each time data can be written to `fd`. A single write handler per file handle is supported. Use `func = null` to remove the handler.
+	 */
+	export function setWriteHandler(fd: FileHandle, func: Function): void;
+
+	/**
+	 * Call the function `func` when the signal `signal` happens. Only a single handler per signal number is supported. Use `null` to set the default handler or `undefined` to ignore the signal. Signal handlers can only be defined in the main thread.
+	 */
+	export function signal(signal: POSIXSIG, func: Function): void;
+
+	/** POSIX signal numbers. */
+	export const SIGINT = 2;
+	/** POSIX signal numbers. */
+	export const SIGABRT = 6;
+	/** POSIX signal numbers. */
+	export const SIGFPE = 8;
+	/** POSIX signal numbers. */
+	export const SIGILL = 4;
+	/** POSIX signal numbers. */
+	export const SIGSEGV = 11;
+	/** POSIX signal numbers. */
+	export const SIGTERM = 15;
+
+	type POSIXSIG =
+		| typeof SIGINT
+		| typeof SIGABRT
+		| typeof SIGFPE
+		| typeof SIGILL
+		| typeof SIGSEGV
+		| typeof SIGTERM;
+
+	type ExecOptions = {
+		/** Boolean (default = true). If true, wait until the process is terminated. In this case, `exec` return the exit code if positive or the negated signal number if the process was interrupted by a signal. If false, do not block and return the process id of the child.  */
+		block: boolean;
+
+		/** Boolean (default = true). If true, the file is searched in the `PATH` environment variable. */
+		usePath: boolean;
+
+		/** String (default = `args[0]`). Set the file to be executed. */
+		file: PATH;
+
+		/** String. If present, set the working directory of the new process. */
+		cwd: PATH;
+
+		/** If present, set the handle in the child for stdin, stdout or stderr. */
+		stdin: FileHandle;
+		/** If present, set the handle in the child for stdin, stdout or stderr. */
+		stdout: FileHandle;
+		/** If present, set the handle in the child for stdin, stdout or stderr. */
+		stderr: FileHandle;
+
+		/** Object. If present, set the process environment from the object key-value pairs. Otherwise use the same environment as the current process. */
+		env: Dict<string>;
+
+		/** Integer. If present, the process uid with `setuid`. */
+		uid: number;
+
+		/** Integer. If present, the process gid with `setgid`. */
+		gid: number;
+	};
+
+	/**
+	 * Execute a process with the arguments `args`. i.e. `['echo', 'hi']`
+	 */
+	export function exec(args: string[], options?: Partial<ExecOptions>): ERRNO;
+
+	/** `waitpid` Unix system call. Return the array `[ret, status]`. `ret` contains `-errno` in case of error. */
+	export function waitpid(
+		pid: number,
+		options: typeof WNOHANG
+	): [ret: ERRNO, status: number];
+
+	/** Constant for the options argument of waitpid. */
+	export const WNOHANG: number;
+
+	/** `dup` Unix system call. */
+	export function dup(fd: FileHandle): FileHandle | ERRNO;
+
+	/** `dup2` Unix system call. */
+	export function dup2(
+		oldfd: FileHandle,
+		newfd: FileHandle
+	): FileHandle | ERRNO;
+
+	/** `pipe` Unix system call. Return two handles as `[read_fd, write_fd]` or `null` in case of error. */
+	export function pipe(): [read_fd: FileHandle, write_fd: FileHandle] | null;
+
+	/** Sleep during `delay_ms` milliseconds. */
+	export function sleep(delay_ms: number): ERRNO;
+
+	/** Call the function `func` after delay `ms`. Return a handle to the timer. */
+	export function setTimeout(func: Function, delay: number): {};
+
+	/** Cancel a timer. */
+	export function clearTimeout(handle: {}): void;
+
+	/** Return a string representing the platform: "linux", "darwin", "win32" or "js". */
+	export const platform: 'linux' | 'darwin' | 'win32' | 'js';
+
+	export class Worker {
+		/**
+		 * Constructor to create a new thread (worker) with an API close to the `WebWorkers`. `module_filename` is a string specifying the module filename which is executed in the newly created thread. As for dynamically imported module, it is relative to the current script or module path. Threads normally don’t share any data and communicate between each other with messages. Nested workers are not supported. An example is available in `tests/test_worker.js`.
+		 */
+		constructor(module_filename: PATH);
+
+		/** In the created worker, Worker.parent represents the parent worker and is used to send or receive messages.  */
+		static parent: Worker;
+
+		/**
+		 * Send a message to the corresponding worker. msg is cloned in the destination worker using an algorithm similar to the HTML structured clone algorithm. SharedArrayBuffer are shared between workers.
+		 *
+		 * Current limitations: `Map` and `Set` are not supported yet.
+		 * */
+		postMessage(msg: any): void;
+
+		/**
+		 * Getter and setter. Set a function which is called each time a message is received. The function is called with a single argument. It is an object with a `data` property containing the received message. The thread is not terminated if there is at least one non `null` `onmessage` handler.
+		 */
+		onmessage: ({ data: any }) => any;
+	}
+}

--- a/types/quickjs/std/index.d.ts
+++ b/types/quickjs/std/index.d.ts
@@ -55,7 +55,6 @@ declare module 'std' {
 		errorObj?: Partial<{ errno: ERRNO }>
 	): N<FILE>;
 
-	//TODO: figure out type of `fd`
 	/**
 	 * Open a file from a file handle (wrapper to the libc `fdopen()`). Return the FILE object or `null` in case of I/O error. If `errorObj` is not undefined, set its `errno` property to the error code or to 0 if no error occured.
 	 */
@@ -141,12 +140,9 @@ declare module 'std' {
 	export function getenv(name: string): string;
 
 	/**
-	 * 
-		Download `url` using the `curl` command line utility. `options` is an optional object containing the following optional properties:
-		
-    binary - Boolean (default = false). If true, the response is an ArrayBuffer instead of a string. When a string is returned, the data is assumed to be UTF-8 encoded.
-		
-		full - Boolean (default = false). If true, returns an object contains the properties response (response content), responseHeaders (headers separated by CRLF), status (status code). response is null is case of protocol or network error. If full is false, only the response is returned if the status is between 200 and 299. Otherwise null is returned.
+	 * Download `url` using the `curl` command line utility. `options` is an optional object containing the following optional properties:
+     * binary - Boolean (default = false). If true, the response is an ArrayBuffer instead of a string. When a string is returned, the data is assumed to be UTF-8 encoded.
+	 * full - Boolean (default = false). If true, returns an object contains the properties response (response content), responseHeaders (headers separated by CRLF), status (status code). response is null is case of protocol or network error. If full is false, only the response is returned if the status is between 200 and 299. Otherwise null is returned.
 	 */
 	export function urlGet(
 		url: string,

--- a/types/quickjs/std/index.d.ts
+++ b/types/quickjs/std/index.d.ts
@@ -1,0 +1,273 @@
+import {
+	ERRNO,
+	PATH,
+	SCRIPT,
+	N,
+	FileFlags,
+	LimFileFlags,
+	TODOType,
+	HTTPResponseObject,
+	Json,
+	FileHandle,
+} from 'baseTypes';
+
+declare module 'std' {
+	/**
+	 * Exit the process.
+	 **/
+	export function exit(n: ERRNO): never;
+
+	/**
+	 * Evaluate the string `str` as a script (global eval). `options` is an optional object containing the following optional properties:
+	 *
+	 * backtrace_barrier: boolean (default = false). If true, error backtraces do not list the stack frames below the evalScript.
+	 */
+	export function evalScript(
+		str: SCRIPT,
+		options?: Partial<{ backtrace_barrier: boolean }>
+	): any;
+
+	/**
+	 * Evaluate the file `filename` as a script (global eval).
+	 */
+	export function loadScript(filename: PATH): any;
+
+	/**
+	 * Load the file `filename` and return it as a string assuming UTF-8 encoding. Return `null` in case of I/O error.
+	 */
+	export function loadFile(filename: PATH): string | null;
+
+	/**
+	 * Open a file (wrapper to the libc `fopen()`). Return the FILE object or `null` in case of I/O error. If `errorObj` is not undefined, set its `errno` property to the error code or to 0 if no error occured.
+	 */
+	export function open(
+		filename: PATH,
+		flags: FileFlags,
+		errorObj?: Partial<{ errno: ERRNO }>
+	): N<FILE>;
+
+	/**
+	 * Open a process by creating a pipe (wrapper to the libc `popen()`). Return the FILE object or `null` in case of I/O error. If `errorObj` is not undefined, set its `errno` property to the error code or to 0 if no error occured.
+	 */
+	export function popen(
+		filename: PATH,
+		flags: LimFileFlags,
+		errorObj?: Partial<{ errno: ERRNO }>
+	): N<FILE>;
+
+	//TODO: figure out type of `fd`
+	/**
+	 * Open a file from a file handle (wrapper to the libc `fdopen()`). Return the FILE object or `null` in case of I/O error. If `errorObj` is not undefined, set its `errno` property to the error code or to 0 if no error occured.
+	 */
+	export function fdopen(
+		fd: FileHandle,
+		flags: FileFlags,
+		errorObj?: Partial<{ errno: ERRNO }>
+	): N<FILE>;
+
+	/**
+	 * Open a temporary file. Return the FILE object or `null` in case of I/O error. If `errorObj` is not undefined, set its `errno` property to the error code or to 0 if no error occured.
+	 */
+	export function tmpfile(errorObj?: Partial<{ errno: ERRNO }>): N<FILE>;
+
+	/**
+	 * Equivalent to `std.out.puts(str)`.
+	 */
+	export function puts(str: string): void;
+
+	/**
+	 * Equivalent to `std.out.printf(fmt, ...args)`.
+	 */
+	export function printf(fmt: string, ...args: string[]): void;
+
+	/**
+	 * Equivalent to the libc sprintf().
+	 */
+	export function sprintf(fmt: string, ...args: string[]): void;
+
+	// /**
+	//  * Wrappers to the libc file stdin, stdout, stderr.
+	//  */
+	// export const in: FILE;
+
+	// export const out: FILE;
+
+	// export const err: FILE;
+
+	type SEEK_CONST = number;
+
+	/**
+	 * Constants for seek().
+	 */
+	export const SEEK_SET: SEEK_CONST & 0;
+	/**
+	 * Constants for seek().
+	 */
+	export const SEEK_CUR: SEEK_CONST & 1;
+	/**
+	 * Constants for seek().
+	 */
+	export const SEEK_END: SEEK_CONST & 2;
+
+	/**
+	 * Enumeration object containing the integer value of common errors (additional error codes may be defined)
+	 */
+	export enum Error {
+		EINVAL = 22,
+		EIO = 5,
+		EACCES = 13,
+		EEXIST = 17,
+		ENOSPC = 28,
+		ENOSYS = 38,
+		EBUSY = 16,
+		ENOENT = 2,
+		EPERM = 1,
+		EPIPE = 32,
+	}
+
+	/**
+	 * Return a string that describes the error `errno`.
+	 */
+	export function strerror(errno: ERRNO): string;
+
+	/**
+	 * Manually invoke the cycle removal algorithm. The cycle removal algorithm is automatically started when needed, so this function is useful in case of specific memory constraints or for testing.
+	 */
+	export function gc(): void;
+
+	/**
+	 * Return the value of the environment variable `name` or `undefined` if it is not defined.
+	 */
+	export function getenv(name: string): string;
+
+	/**
+	 * 
+		Download `url` using the `curl` command line utility. `options` is an optional object containing the following optional properties:
+		
+    binary - Boolean (default = false). If true, the response is an ArrayBuffer instead of a string. When a string is returned, the data is assumed to be UTF-8 encoded.
+		
+		full - Boolean (default = false). If true, returns an object contains the properties response (response content), responseHeaders (headers separated by CRLF), status (status code). response is null is case of protocol or network error. If full is false, only the response is returned if the status is between 200 and 299. Otherwise null is returned.
+	 */
+	export function urlGet(
+		url: string,
+		options?: Partial<{ binary: false; full: false }>
+	): string;
+	export function urlGet(
+		url: string,
+		options: Partial<{ binary: true; full: false }>
+	): ArrayBuffer;
+	export function urlGet(
+		url: string,
+		options: Partial<{ binary: false; full: true }>
+	): HTTPResponseObject<string>;
+	export function urlGet(
+		url: string,
+		options: Partial<{ binary: true; full: true }>
+	): HTTPResponseObject<ArrayBuffer>;
+	/**
+	 * Parse str using a superset of JSON.parse. The following extensions are accepted:
+	 * * Single line and multiline comments
+	 * * unquoted properties (ASCII-only Javascript identifiers)
+	 * * trailing comma in array and object definitions
+	 * * single quoted strings
+	 * * \f and \v are accepted as space characters
+	 * * leading plus in numbers
+	 * * octal (0o prefix) and hexadecimal (0x prefix) numbers
+	 */
+	export function parseExtJSON(str: string): Json;
+
+	interface FILE {
+		/**
+		 * Close the file. Return 0 if OK or `-errno` in case of I/O error.
+		 */
+		close(): ERRNO;
+
+		/**
+		 * Outputs the string with the UTF-8 encoding.
+		 */
+		puts(str: string): void;
+
+		/**
+		 * Formatted printf.
+		 *
+		 * The same formats as the standard C library `printf` are supported. Integer format types (e.g. `%d`) truncate the Numbers or BigInts to 32 bits. Use the `l` modifier (e.g. `%ld`) to truncate to 64 bits.
+		 */
+		printf(fmt: string, ...args: string[]): void;
+
+		/**
+		 * Flush the buffered file.
+		 */
+		flush(): void;
+
+		/**
+		 * Seek to a given file position (whence is std.SEEK_*). offset can be a number or a bigint. Return 0 if OK or -errno in case of I/O error.
+		 */
+		seek(
+			offset: number | bigint,
+			whence: typeof SEEK_SET | typeof SEEK_CUR | typeof SEEK_END
+		): ERRNO;
+
+		/**
+		 * Return the current file position.
+		 */
+		tell(): number;
+
+		/**
+		 * Return the current file position as a bigint.
+		 */
+		tello(): bigint;
+
+		/**
+		 * Return true if end of file.
+		 */
+		eof(): boolean;
+
+		/**
+		 * Return the associated OS handle.
+		 */
+		fileno(): number;
+
+		/**
+		 * Return true if there was an error.
+		 */
+		error(): boolean;
+
+		/**
+		 * Clear the error indication.
+		 */
+		clearerr(): void;
+
+		/**
+		 * Read `length` bytes from the file to the ArrayBuffer `buffer` at byte position `position` (wrapper to the libc `fread`).
+		 *
+		 * Returns number of bytes read.
+		 */
+		read(buffer: ArrayBuffer, position: number, length: number): number;
+
+		/**
+		 * Write `length` bytes from the file to the ArrayBuffer `buffer` at byte position `position` (wrapper to the libc `fread`).
+		 *
+		 * Returns number of bytes written.
+		 */
+		write(buffer: ArrayBuffer, position: number, length: number): number;
+
+		/**
+		 * Return the next line from the file, assuming UTF-8 encoding, excluding the trailing line feed.
+		 */
+		getline(): string;
+
+		/**
+		 * Read `max_size` bytes from the file and return them as a string assuming UTF-8 encoding. If `max_size` is not present, the file is read up its end.
+		 */
+		readAsString(max_size?: number): string;
+
+		/**
+		 * Return the next byte from the file. Return -1 if the end of file is reached.
+		 */
+		getByte(): number;
+		/**
+		 * Write one byte to the file.
+		 */
+		putByte(c: number): void;
+	}
+}


### PR DESCRIPTION
These are declaration files for the QuickJS [std](https://bellard.org/quickjs/quickjs.html#std-module) and [os](https://bellard.org/quickjs/quickjs.html#os-module) imports. I wrote these by hand using the provided information on the website, and thought that others might want them as well.

- [*] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`