### PR TITLE
[@ember/component] add setComponentTemplate and getComponentTemplate

### DIFF
--- a/types/ember__component/index.d.ts
+++ b/types/ember__component/index.d.ts
@@ -13,11 +13,11 @@ import CoreView from "@ember/component/-private/core-view";
 import ClassNamesSupport from "@ember/component/-private/class-names-support";
 import ViewMixin from "@ember/component/-private/view-mixin";
 import ActionSupport from "@ember/component/-private/action-support";
+import { TemplateFactory } from 'ember-cli-htmlbars';
 
-// tslint:disable-next-line:strict-export-declare-modifiers
-interface TemplateFactory {
-    __htmlbars_inline_precompile_template_factory: any;
-}
+export function setComponentTemplate<T extends object>(template: TemplateFactory, obj: T): T;
+
+export function getComponentTemplate(obj: object): TemplateFactory | null;
 
 /**
  * A component is an isolated piece of UI, represented by a template and an

--- a/types/ember__component/package.json
+++ b/types/ember__component/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "ember-cli-htmlbars": ">=4.3.1"
+    }
+}

--- a/types/ember__component/test/component.ts
+++ b/types/ember__component/test/component.ts
@@ -1,6 +1,6 @@
-import Component from '@ember/component';
+import Component, { setComponentTemplate, getComponentTemplate } from '@ember/component';
 import Object, { computed, get } from '@ember/object';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { assertType } from './lib/assert';
 
 Component.extend({
@@ -121,3 +121,12 @@ Component.extend({
         // rendered element is clicked
     },
 });
+
+const DotExtendComponent = Component.extend({});
+// this has a big ugly type signature, we test return type below
+setComponentTemplate(hbs`<h1>Test</h1>`, DotExtendComponent);
+getComponentTemplate(DotExtendComponent); // $ExpectType TemplateFactory | null
+
+class ClassComponent extends Component {}
+setComponentTemplate(hbs`<h1>Test</h1>`, ClassComponent); // $ExpectType typeof ClassComponent
+getComponentTemplate(ClassComponent); // $ExpectType TemplateFactory | null


### PR DESCRIPTION
Adds types for `setComponentTemplate` and `getComponentTemplate` from [RFC #481](https://github.com/emberjs/rfcs/blob/master/text/0481-component-templates-co-location.md#low-level-primitives), implemented in https://github.com/emberjs/ember.js/pull/18158

From [RFC #481](https://github.com/emberjs/rfcs/blob/master/text/0481-component-templates-co-location.md#build-time-transformations):

> The low-level `setComponentTemplate` and `getComponentTemplate` APIs are not intended to be called by end-users directly, even though they will be **public** and part of our semver stability guarantee.

Needs: https://github.com/microsoft/DefinitelyTyped-tools/pull/153 first

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emberjs/rfcs/blob/master/text/0481-component-templates-co-location.md#low-level-primitives, https://github.com/emberjs/ember.js/blob/7763d7aa72445c88a0e63da800266465bef14ce1/packages/%40ember/-internals/glimmer/lib/utils/component-template.ts#L10-L39
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~