### PR TITLE
[react-native] fix return type of Image.prefetch (Promise)

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -4040,7 +4040,7 @@ export class Image extends ImageBase {
         success: (width: number, height: number) => void,
         failure?: (error: any) => void,
     ): any;
-    static prefetch(url: string): any;
+    static prefetch(url: string): Promise<boolean>;
     static abortPrefetch?(requestId: number): void;
     static queryCache?(urls: string[]): Promise<{ [url: string]: 'memory' | 'disk' | 'disk/memory' }>;
 

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -1059,6 +1059,13 @@ export class ImageTest extends React.Component {
             (width, height) => console.log(width, height),
             error => console.error(error),
         );
+        Image.prefetch(uri).then((success) => {
+            if (success) {
+                console.log('Image prefetch success');
+            } else {
+                console.log('Image prefetch has an issue');
+            }
+        });
     }
 
     handleOnLoad = (e: NativeSyntheticEvent<ImageLoadEventData>) => {

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -1059,13 +1059,7 @@ export class ImageTest extends React.Component {
             (width, height) => console.log(width, height),
             error => console.error(error),
         );
-        Image.prefetch(uri).then((success) => {
-            if (success) {
-                console.log('Image prefetch success');
-            } else {
-                console.log('Image prefetch has an issue');
-            }
-        });
+        Image.prefetch(uri); // $ExpectType Promise<boolean>
     }
 
     handleOnLoad = (e: NativeSyntheticEvent<ImageLoadEventData>) => {


### PR DESCRIPTION
The official docs do not tell the return type of Image.prefetch.
https://reactnative.dev/docs/image#prefetch
From testing on iOS and Android on RN-0.63.3 the return was always boolean true.
I can't tell for sure if the Promise returns a boolean or something else.

----
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactnative.dev/docs/image#prefetch
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
