### PR TITLE
Fix type of err in xml2js

### DIFF
--- a/types/xml2js/xml2js-tests.ts
+++ b/types/xml2js/xml2js-tests.ts
@@ -2,11 +2,11 @@ import xml2js = require('xml2js');
 import * as processors from 'xml2js/lib/processors';
 import fs = require('fs');
 
-xml2js.parseString('<root>Hello xml2js!</root>', (err: Error, result: any) => { });
+xml2js.parseString('<root>Hello xml2js!</root>', (err: Error | null, result: any) => { });
 
 xml2js.parseStringPromise('<root>Hello xml2js!</root>');
 
-xml2js.parseString('<root>Hello xml2js!</root>', {trim: true}, (err: Error, result: any) => { });
+xml2js.parseString('<root>Hello xml2js!</root>', {trim: true}, (err: Error | null, result: any) => { });
 
 xml2js.parseStringPromise('<root>Hello xml2js!</root>', {trim: true});
 
@@ -34,14 +34,14 @@ xml2js.parseString('<root>Hello xml2js!</root>', {
     attrValueProcessors: undefined,
     tagNameProcessors: undefined,
     valueProcessors: undefined
-}, (err: Error, result: any) => { });
+}, (err: Error | null, result: any) => { });
 
 xml2js.parseString('<root>Hello xml2js!</root>', {
     attrNameProcessors: [processors.firstCharLowerCase, xml2js.processors.normalize],
     attrValueProcessors: [processors.normalize],
     tagNameProcessors: [processors.stripPrefix],
     valueProcessors: [processors.parseBooleans, processors.parseNumbers]
-}, (err: Error, result: any) => { });
+}, (err: Error | null, result: any) => { });
 
 let builder = new xml2js.Builder({
     renderOpts: {
@@ -85,7 +85,7 @@ v2Defaults.async = false;
 v2Defaults.chunkSize = 20000;
 
 fs.readFile(__dirname + '/foo.xml', (err, data) => {
-    parser.parseString(data, (err: Error, result: any) => {
+    parser.parseString(data, (err: Error | null, result: any) => {
         console.dir(result);
         console.log('Done parseString');
     });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Leonidas-from-XIV/node-xml2js/blob/1832e0b6b2de30a5e326d1cf21708cd32305a538/src/parser.coffee#L235
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The callback function does obviously not always return an error. It only return the error if something actually went wrong and it does return `null` otherwise. This can be seen in the linked source code. This is important otherwise typescript-eslint might complain about unnecessary conditionals, when using the normal pattern for handling the error like this:

```typescript
parseString(xmlData, (err, result) => {
    // always truthy according to current typing, which is wrong.
    if (err) {
    // handle error
    } else {
        console.log(result)
    }
})
``` 