### PR TITLE
[bull-arena] Remove bull-arena heavy dependencies

### DIFF
--- a/types/bull-arena/bull-arena-tests.ts
+++ b/types/bull-arena/bull-arena-tests.ts
@@ -1,5 +1,6 @@
 import Arena from 'bull-arena';
 import express from 'express';
+import Bull from 'bull';
 
 const router = express.Router();
 
@@ -18,5 +19,6 @@ const arena = Arena({
             redis: {},
         },
     ],
+    Bull,
 });
 router.use('/', arena);

--- a/types/bull-arena/index.d.ts
+++ b/types/bull-arena/index.d.ts
@@ -7,9 +7,6 @@
 
 import { RequestHandler } from "express";
 import { ClientOpts } from "redis";
-import Bull = require("bull");
-import Bee = require("bee-queue");
-import { Queue } from "bullmq";
 
 declare function Arena(
     options: BullArena.MiddlewareOptions,
@@ -18,10 +15,22 @@ declare function Arena(
 
 declare namespace BullArena {
     interface MiddlewareOptions {
-        Bull?: typeof Bull;
-        Bee?: typeof Bee;
-        BullMQ?: typeof Queue;
+        Bull?: QueueConstructor;
+        Bee?: QueueConstructor;
+        BullMQ?: QueueConstructor;
         queues: Array<QueueOptions & ConnectionOptions>;
+    }
+
+    interface QueueConstructor {
+        new (queueName: string, opts?: QueueOptions): Queue;
+    }
+
+    interface Queue {
+        // Interface of Queue is much larger and
+        // inconsistent between different packages.
+        // We are using an example method here
+        // that is consistent across all providers.
+        getJob(jobId: string): Promise<unknown>;
     }
 
     interface MiddlewareListenOptions {

--- a/types/bull-arena/package.json
+++ b/types/bull-arena/package.json
@@ -1,7 +1,5 @@
 {
     "private": true,
     "dependencies": {
-        "bee-queue": "^1.2.3",
-        "bullmq": "^1.9.0"
     }
 }


### PR DESCRIPTION
Bull arena is a web interface for different background jobs implementations.
Currently using types package is a problem because it explicitly brings 2 possible background jobs packages as dependencies when they are optional.

Solution: remove reliance on those packages and use basic required interface declaration instead.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bee-queue/arena/blob/fc44bc9de43f85ba7c420b457f0de653141201dc/CHANGELOG.md#300-2020-08-05
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
