### PR TITLE
[jasmine] Add back jasmine.DiffBuilder.

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -246,6 +246,7 @@ declare namespace jasmine {
     }
 
     function clock(): Clock;
+    function DiffBuilder(): DiffBuilder;
 
     var matchersUtil: MatchersUtil;
 
@@ -403,8 +404,15 @@ declare namespace jasmine {
         message?: string;
     }
 
+    interface DiffBuilder {
+      setRoots(actual: any, expected: any): void;
+      recordMismatch(formatter?: (actual: any, expected: any, path?: any, prettyPrinter?: any) => string): void;
+      withPath(pathComponent: string, block: () => void): void;
+      getMessage(): string;
+    }
+
     interface MatchersUtil {
-        equals(a: any, b: any, customTesters?: ReadonlyArray<CustomEqualityTester>): boolean;
+        equals(a: any, b: any, customTesters?: ReadonlyArray<CustomEqualityTester>, diffBuilder?: DiffBuilder): boolean;
         contains<T>(haystack: ArrayLike<T> | string, needle: any, customTesters?: ReadonlyArray<CustomEqualityTester>): boolean;
         buildFailureMessage(matcherName: string, isNot: boolean, actual: any, ...expected: any[]): string;
 

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -1065,6 +1065,39 @@ describe("jasmine.any", () => {
     });
 });
 
+describe('DiffBuilder', function() {
+  it('can be passed to matchersUtil.equals', () => {
+      const differ = jasmine.DiffBuilder();
+      jasmine.matchersUtil.equals(1, 1, undefined, differ);
+  });
+
+  it('records the actual and expected objects', () => {
+      const diffBuilder = jasmine.DiffBuilder();
+      diffBuilder.setRoots({ x: 'actual' }, { x: 'expected' });
+      diffBuilder.recordMismatch();
+
+      expect(diffBuilder.getMessage()).toEqual(
+          "Expected Object({ x: 'actual' }) to equal Object({ x: 'expected' }).",
+      );
+  });
+
+  it("allows customization of the message", function() {
+      const diffBuilder = jasmine.DiffBuilder();
+      diffBuilder.setRoots({x: 'bar'}, {x: 'foo'});
+
+      function darthVaderFormatter(actual: any, expected: any, path: any) {
+          return `I find your lack of ${expected} disturbing. (was ${actual}, at ${path})`;
+      }
+
+      diffBuilder.withPath('x', () => {
+          diffBuilder.recordMismatch(darthVaderFormatter);
+      });
+
+      expect(diffBuilder.getMessage())
+          .toEqual("I find your lack of foo disturbing. (was bar, at $.x)");
+  });
+});
+
 describe('custom asymmetry', function() {
     const tester: jasmine.AsymmetricMatcher<string> = {
         asymmetricMatch: (actual: string, customTesters) => {


### PR DESCRIPTION
The change is a copy of PR #46476, which mistakenly got reverted.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: PR #46476
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
