### PR TITLE
fix(svg-path-parser): use discriminated union for Command

### DIFF
--- a/types/svg-path-parser/index.d.ts
+++ b/types/svg-path-parser/index.d.ts
@@ -6,13 +6,26 @@
 export function parseSVG(input: string): Command[];
 export function makeAbsolute(commands: Command[]): Command[];
 
-export interface Command {
+export type Command = (
+    MoveToCommand |
+    LineToCommand |
+    HorizontalLineToCommand |
+    VerticalLineToCommand |
+    ClosePathCommand |
+    CurveToCommand |
+    SmoothCurveToCommand |
+    QuadraticCurveToCommand |
+    SmoothQuadraticCurveToCommand |
+    EllipticalArcCommand
+);
+
+export interface BaseCommand {
     code: 'm' | 'M' | 'l' | 'L' | 'h' | 'H' | 'v' | 'V' | 'c' | 'C' | 's' | 'S' | 'q' | 'Q' | 't' | 'T' | 'a' | 'A' | 'z' | 'Z';
     command: 'moveto' | 'lineto' | 'horizontal lineto' | 'vertical lineto' | 'curveto' | 'smooth curveto' | 'quadratic curveto' | 'smooth quadratic curveto' | 'elliptical arc' | 'closepath';
     relative?: boolean;
 }
 
-export interface MoveToCommand {
+export interface MoveToCommand extends BaseCommand {
     code: 'm' | 'M';
     command: 'moveto';
     relative?: boolean;
@@ -20,7 +33,7 @@ export interface MoveToCommand {
     y: number;
 }
 
-export interface LineToCommand {
+export interface LineToCommand extends BaseCommand {
     code: 'l' | 'L';
     command: 'lineto';
     relative?: boolean;
@@ -28,27 +41,27 @@ export interface LineToCommand {
     y: number;
 }
 
-export interface HorizontalLineToCommand {
+export interface HorizontalLineToCommand extends BaseCommand {
     code: 'h' | 'H';
     command: 'horizontal lineto';
     relative?: boolean;
     x: number;
 }
 
-export interface VerticalLineToCommand {
+export interface VerticalLineToCommand extends BaseCommand {
     code: 'v' | 'V';
     command: 'vertical lineto';
     relative?: boolean;
     y: number;
 }
 
-export interface ClosePathCommand {
+export interface ClosePathCommand extends BaseCommand {
     code: 'z' | 'Z';
     command: 'closepath';
     relative?: boolean;
 }
 
-export interface CurveToCommand {
+export interface CurveToCommand extends BaseCommand {
     code: 'c' | 'C';
     command: 'curveto';
     relative?: boolean;
@@ -60,7 +73,7 @@ export interface CurveToCommand {
     y: number;
 }
 
-export interface SmoothCurveToCommand {
+export interface SmoothCurveToCommand extends BaseCommand {
     code: 's' | 'S';
     command: 'smooth curveto';
     relative?: boolean;
@@ -70,7 +83,7 @@ export interface SmoothCurveToCommand {
     y: number;
 }
 
-export interface QuadraticCurveToCommand {
+export interface QuadraticCurveToCommand extends BaseCommand {
     code: 'q' | 'Q';
     command: 'quadratic curveto';
     relative?: boolean;
@@ -80,7 +93,7 @@ export interface QuadraticCurveToCommand {
     y: number;
 }
 
-export interface SmoothQuadraticCurveToCommand {
+export interface SmoothQuadraticCurveToCommand extends BaseCommand {
     code: 't' | 'T';
     command: 'smooth quadratic curveto';
     relative?: boolean;
@@ -88,7 +101,7 @@ export interface SmoothQuadraticCurveToCommand {
     y: number;
 }
 
-export interface EllipticalArcCommand {
+export interface EllipticalArcCommand extends BaseCommand {
     code: 'a' | 'A';
     command: 'elliptical arc';
     relative?: boolean;


### PR DESCRIPTION
This allows using e.g. `switch(command.code)` with each branch automatically getting the correct type.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html#discriminating-unions
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
