### PR TITLE
[honeybadger] add context property

### DIFF
--- a/types/honeybadger/honeybadger-tests.ts
+++ b/types/honeybadger/honeybadger-tests.ts
@@ -16,6 +16,9 @@ Honeybadger.setContext({
     user_id: 123,
 });
 
+const existingContext = Honeybadger.context;
+const userId = existingContext.user_id;
+
 Honeybadger.resetContext();
 
 Honeybadger.resetContext({

--- a/types/honeybadger/index.d.ts
+++ b/types/honeybadger/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for honeybadger 1.3
+// Type definitions for honeybadger 1.4
 // Project: https://github.com/honeybadger-io/honeybadger-node
 // Definitions by: Ryan Skrzypek <https://github.com/rskrz>
+//                 Levi Bostian <https://github.com/levibostian>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
@@ -34,6 +35,7 @@ declare namespace honeybadger {
     type CallbackFunction = (err: Error | null, notice: object | null) => void;
     type LambdaHandler = (event: object, context: object) => void;
     interface HoneyBadgerInstance extends EventEmitter {
+        context: any;
         configure: (options: ConfigureOptions) => void;
         notify: (err?: any, name?: any, extra?: CallbackFunction | metadata, callback?: CallbackFunction) => void;
         setContext: (context: object) => void;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This PR adds support to access the property `context` from Honeybadger so you can access the existing set context. This is documented in the source code of the module. 

* From [this code](https://github.com/honeybadger-io/honeybadger-node/blob/bd80a2fcdd37894cbcc50a3fdbaa5176b36ad388/lib/honeybadger.js#L216-L218), you can see that the Object of "Honeybadger" is the default export of the module. 
* This means that the result of [this function](https://github.com/honeybadger-io/honeybadger-node/blob/bd80a2fcdd37894cbcc50a3fdbaa5176b36ad388/lib/honeybadger.js#L15-L57) is what is exported as the module. 
* The property `context` is [part of that object](https://github.com/honeybadger-io/honeybadger-node/blob/bd80a2fcdd37894cbcc50a3fdbaa5176b36ad388/lib/honeybadger.js#L44) that is exported. 
* Context is manipulated in [a couple of functions](https://github.com/honeybadger-io/honeybadger-node/blob/bd80a2fcdd37894cbcc50a3fdbaa5176b36ad388/lib/honeybadger.js#L88-L102) but is not present in the type definitions to read the existing value. 