### PR TITLE
fix(youtube): add onYouTubeIframeAPIReady

### DIFF
--- a/types/youtube/index.d.ts
+++ b/types/youtube/index.d.ts
@@ -13,6 +13,10 @@
  * @see https://developers.google.com/youtube/iframe_api_reference
  * @see https://developers.google.com/youtube/player_parameters
  */
+interface Window {
+    onYouTubeIframeAPIReady(): void;
+}
+
 declare namespace YT
 {
     /**
@@ -958,7 +962,7 @@ declare namespace YT
          * @param listener   Handler for the event.
          */
         removeEventListener<TEvent extends PlayerEvent>(eventName: keyof Events, listener: (event: TEvent) => void): void;
-        
+
         /**
          * @returns The DOM node for the embedded <iframe>.
          */

--- a/types/youtube/youtube-tests.ts
+++ b/types/youtube/youtube-tests.ts
@@ -281,3 +281,5 @@ player.addEventListener("onApiChange", (event: YT.PlayerEvent) => {});
 const frame: HTMLIFrameElement = player.getIframe();
 
 player.destroy();
+
+window.onYouTubeIframeAPIReady = () => {}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/youtube/iframe_api_reference#Requirements
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
