### PR TITLE
[jasmine-ajax] Add missing response properties: statusText, responseURL, responseJSON

### DIFF
--- a/types/jasmine-ajax/index.d.ts
+++ b/types/jasmine-ajax/index.d.ts
@@ -5,9 +5,10 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-interface JasmineAjaxResponse extends JasmineAjaxRequestStubReturnOptions {
-    status: number;
-}
+/**
+ * @deprecated Use JasmineAjaxRequestStubReturnOptions instead
+ */
+interface JasmineAjaxResponse extends JasmineAjaxRequestStubReturnOptions {}
 
 interface JasmineAjaxRequest extends XMLHttpRequest {
     url: string;

--- a/types/jasmine-ajax/index.d.ts
+++ b/types/jasmine-ajax/index.d.ts
@@ -5,10 +5,16 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-/**
- * @deprecated Use JasmineAjaxRequestStubReturnOptions instead
- */
-type JasmineAjaxResponse = JasmineAjaxRequestStubReturnOptions;
+interface JasmineAjaxResponse {
+    status?: number;
+    statusText?: string;
+    responseText?: string;
+    response?: string;
+    responseURL?: string;
+    responseJSON?: any;
+    contentType?: string;
+    responseHeaders?: { [key: string]: string };
+}
 
 interface JasmineAjaxRequest extends XMLHttpRequest {
     url: string;
@@ -37,16 +43,10 @@ interface JasmineAjaxRequestTracker {
     filter(urlToMatch: string): JasmineAjaxRequest[];
 }
 
-interface JasmineAjaxRequestStubReturnOptions {
-    status?: number;
-    statusText?: string;
-    contentType?: string;
-    response?: string;
-    responseText?: string;
-    responseURL?: string;
-    responseJSON?: any;
-    responseHeaders?: { [key: string]: string };
-}
+/**
+ * @deprecated Use JasmineAjaxResponse instead
+ */
+type JasmineAjaxRequestStubReturnOptions = JasmineAjaxResponse;
 
 interface JasmineAjaxRequestStubErrorOptions {
     status?: number;
@@ -58,7 +58,7 @@ interface JasmineAjaxRequestStub {
     query: string;
     data: string;
     method: string;
-    andReturn(options: JasmineAjaxRequestStubReturnOptions): void;
+    andReturn(options: JasmineAjaxResponse): void;
     andError(options: JasmineAjaxRequestStubErrorOptions): void;
     andTimeout(): void;
     andCallFunction(functionToCall: (request: JasmineAjaxRequest) => void): void;

--- a/types/jasmine-ajax/index.d.ts
+++ b/types/jasmine-ajax/index.d.ts
@@ -5,13 +5,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-interface JasmineAjaxResponse {
-    status?: number;
-    statusText?: string;
-    responseText?: string;
-    response?: string;
-    contentType?: string;
-    responseHeaders?: { [key: string]: string };
+interface JasmineAjaxResponse extends JasmineAjaxRequestStubReturnOptions {
+    status: number;
 }
 
 interface JasmineAjaxRequest extends XMLHttpRequest {
@@ -43,9 +38,12 @@ interface JasmineAjaxRequestTracker {
 
 interface JasmineAjaxRequestStubReturnOptions {
     status?: number;
+    statusText?: string;
     contentType?: string;
     response?: string;
     responseText?: string;
+    responseURL?: string;
+    responseJSON?: any;
     responseHeaders?: { [key: string]: string };
 }
 

--- a/types/jasmine-ajax/index.d.ts
+++ b/types/jasmine-ajax/index.d.ts
@@ -8,7 +8,7 @@
 /**
  * @deprecated Use JasmineAjaxRequestStubReturnOptions instead
  */
-interface JasmineAjaxResponse extends JasmineAjaxRequestStubReturnOptions {}
+type JasmineAjaxResponse = JasmineAjaxRequestStubReturnOptions;
 
 interface JasmineAjaxRequest extends XMLHttpRequest {
     url: string;

--- a/types/jasmine-ajax/jasmine-ajax-tests.ts
+++ b/types/jasmine-ajax/jasmine-ajax-tests.ts
@@ -1435,8 +1435,11 @@ describe('RequestStub', () => {
     it('has methods', () => {
         jasmine.Ajax.stubRequest('/foo').andReturn({
             status: 200,
+            statusText: 'OK',
             contentType: 'application/json',
             responseText: '{"success": true}',
+            responseURL: 'http://example.com/foo',
+            responseJSON: { success: true },
             responseHeaders: { 'X-Example': 'a value' },
         });
         jasmine.Ajax.stubRequest('/bar').andReturn({});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jasmine/jasmine-ajax/blob/faed4ca10297b1c8d4f0ba13491067f34a1d88ab/src/fakeRequest.js#L257
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
