### PR TITLE
mongodb/MongoError.code can be a string

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -253,7 +253,7 @@ export class MongoError extends Error {
      * Checks the error to see if it has an error label
      */
     hasErrorLabel(label: string): boolean;
-    code?: number;
+    code?: number | string;
     /**
      * While not documented, the 'errmsg' prop is AFAIK the only way to find out
      * which unique index caused a duplicate key error. When you have multiple


### PR DESCRIPTION
A `MongoError.code` can be a string.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Did not do any of these tests... because I added 5 characters in the GH online editor. I'll test my changes if needed.

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/mongodb/node-mongodb-native/blob/cafaa1b925a0957bd52a3c2a57955387ff6c6b56/lib/utils.js#L668

When `MongoClient.connect()` is used offline, it'll return an error whose code is equal to `ECONNREFUSED`. Not much of a number. I need to use `((MongoError.code as unknown) as string)` each time I have to handle it...
The error is emitted by the snippet above. I tried to go back to the source of the error, but I got lost in the code...

Complete error in console, so you can test it by yourself (again, here 'error' comes from the callback of `MongoClient.connect`)
```shell
C:\Users\my-person\Documents\GitHub\my-repo\node_modules\mongodb\lib\utils.js:668
          throw error;
          ^

Error: querySrv ECONNREFUSED [my-cluster].mongodb.net        
    at QueryReqWrap.onresolve [as oncomplete] (dns.js:203:19) {
  errno: 'ECONNREFUSED',
  code: 'ECONNREFUSED',
  syscall: 'querySrv',
  hostname: '[my-cluster].mongodb.net'
}
```