### PR TITLE
Fix css-minimizer-webpack-plugin types to work with Webpack 5

### DIFF
--- a/types/css-minimizer-webpack-plugin/index.d.ts
+++ b/types/css-minimizer-webpack-plugin/index.d.ts
@@ -2,12 +2,17 @@
 // Project: https://github.com/webpack-contrib/css-minimizer-webpack-plugin
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-import { Plugin } from 'webpack';
+import { Compiler, WebpackPluginInstance } from 'webpack';
 import { CssNanoOptions } from 'cssnano';
 import { SourceMapOptions } from 'postcss';
 
-declare class CssMinimizerPlugin extends Plugin {
+declare class CssMinimizerPlugin implements WebpackPluginInstance {
     constructor(options?: CssMinimizerPlugin.Options);
+
+    /**
+     * Apply the plugin
+     */
+    apply(compiler: Compiler): void;
 }
 
 declare namespace CssMinimizerPlugin {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

closes: #49354
