### PR TITLE
[@types/apollo-upload-client] Restore explicit extract-files ^8.1.0 dependency

### DIFF
--- a/types/apollo-upload-client/package.json
+++ b/types/apollo-upload-client/package.json
@@ -2,6 +2,7 @@
     "private": true,
     "dependencies": {
         "@apollo/client": "^3.1.3",
+        "@types/extract-files": "^8.1.0",
         "graphql": "^15.3.0"
     }
 }


### PR DESCRIPTION
**NOTE: I don't know any way to test this since it's a missing dependency issue that only happens when installing the package through NPM.**

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes (see explanation below)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

**Summary** 

This PR restores the incorrectly removed dependency `"@types/extract-files"` to the minimum viable version (`"^8.1.0"`, currently the latest) so that this package can be installed correctly again.

**Explanation**

The `@types/apollo-upload-client` package explicitly depends on `@types/extract-files`, but it is not included in the package.

_Dependency:_
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d076add9f29db350a19bd94c37b197729cc02f87/types/apollo-upload-client/index.d.ts#L13-L14

_Missing from package.json:_ https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d076add9f29db350a19bd94c37b197729cc02f87/types/apollo-upload-client/package.json#L3-L6

The minimum required version of `@types/extra-files` is `8.1.0`, which was released [here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46002). This version includes the export of  `isExtractableFile` and the other related functions which is imported by `@types/apollo-upload-client`. This dependency can be seen [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d076add9f29db350a19bd94c37b197729cc02f87/types/apollo-upload-client/index.d.ts#L13-L14).

~@tyankatsu0105 [removed this required dependency in #46785](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46785), which has broken the installation of this package~. *looks like I misunderstood the change in this PR*

When installing from npm, the dependency shows up as `"*"` which is not correct as the minimum version of `@types/extract-files` is `8.1.0` as shown above. 

This PR restores the missing required minimum dependency version (though 8.1.0 is the current version). It will result in the following change when installing:

```diff
    "dependencies": {
        "@apollo/client": "^3.1.3",
-       "@types/extract-files": "*",
+       "@types/extract-files": "^8.1.0",
        "graphql": "^15.3.0"
    },
```