### PR TITLE
[datatables.net-fixedcolumns] Fix some definitions and compliance with v3.3.1

### DIFF
--- a/types/datatables.net-fixedcolumns/datatables.net-fixedcolumns-tests.ts
+++ b/types/datatables.net-fixedcolumns/datatables.net-fixedcolumns-tests.ts
@@ -7,4 +7,29 @@ $(document).ready(() => {
             rightColumns: 1
         }
     };
+
+    let cellIndex: DataTables.CellIndexReturn = {
+        column: 4,
+        row: 1,
+        columnVisible: 0,
+    };
+
+    let dt = $('#example').DataTable();
+    const cells = dt.cells();
+
+    dt = cells.fixedNodes();
+
+    const cell = dt.cell(":contains('Not shipped')");
+    const node = cell.fixedNode();
+
+    node.cloneNode();
+
+    const fixedColumns = dt.fixedColumns();
+    dt = fixedColumns.update();
+    cellIndex = fixedColumns.cellIndex(node);
+    dt = fixedColumns.relayout();
+    const rowIndex: number = fixedColumns.rowIndex();
+
+    const rows = dt.rows();
+    dt = rows.recalcHeight();
 });

--- a/types/datatables.net-fixedcolumns/index.d.ts
+++ b/types/datatables.net-fixedcolumns/index.d.ts
@@ -1,83 +1,105 @@
-// Type definitions for datatables.net-fixedcolumns 3.2
+// Type definitions for datatables.net-fixedcolumns 3.3
 // Project: https://datatables.net
 // Definitions by: Konstantin Kuznetsov <https://github.com/Arik-neKrol>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 4.0
 
 /// <reference types="jquery" />
 /// <reference types="datatables.net"/>
 
 declare namespace DataTables {
     interface Settings {
-        /*
-         * FixedColumns extension options
+        /**
+         * @description Enable and configure the FixedColumns extension for DataTables.
+         * @see {@link https://datatables.net/reference/option/fixedColumns}
          */
         fixedColumns?: boolean | FixedColumnsSettings;
     }
 
     interface FixedColumnsSettings {
-        /*
+        /**
          * Row height matching algorithm to use
          *
-         * The algorithm to use. This can be one of (see below for full description):
-         * 'none' | 'semiauto' | 'auto'
+         * FixedColumns has three different algorithms that it can use: 'none', 'semiauto', 'auto'
+         * @see {@link https://datatables.net/reference/option/fixedColumns.heightMatch}
          */
         heightMatch?: 'none' | 'semiauto' | 'auto';
 
-        /*
-         * The number of columns on the left hand side of the table to fix in place.
+        /**
+         * @description The number of columns on the left hand side of the table to fix in place.
+         * @see {@link https://datatables.net/reference/option/fixedColumns.leftColumns}
          */
         leftColumns?: number;
 
-        /*
-         * The number of columns on the right hand side of the table to fix in place.
+        /**
+         * @description The number of columns on the right hand side of the table to fix in place.
+         * @see {@link https://datatables.net/reference/option/fixedColumns.rightColumns}
          */
         rightColumns?: number;
     }
 
     interface Api {
-        /*
-        * Get FixedColumns Api
-        */
+        /**
+         * @description Namespacing for FixedColumns methods - FixedColumns' methods are available on the returned API instance.
+         * @see {@link https://datatables.net/reference/api/fixedColumns()}
+         */
         fixedColumns(): FixedColumnsMethods;
     }
 
     interface FixedColumnsMethods extends Api {
-        /*
-        * Update the data shown in the FixedColumns
-        */
+        /**
+         * @description Update the data shown in the FixedColumns.
+         * @see {@link https://datatables.net/reference/api/fixedColumns().update()}
+         */
         update(): Api;
 
-        /*
-        * Redraw the fixed columns based on new table size
-        */
+        /**
+         * @description Redraw the fixed columns based on new table size
+         * @see {@link https://datatables.net/reference/api/fixedColumns().relayout()}
+         */
         relayout(): Api;
 
-        /*
-        * @Deprecated(use dt.row(this).index())
-        * Get the row index of a row in a fixed column
-        */
+        /**
+         * @deprecated
+         * Deprecated as of v3.2.1. Use dt.row(this).index() instead
+         *
+         * Get the row index of a row in a fixed column
+         */
         rowIndex(): number;
 
-        /*
-        * @Deprecated(use dt.cell(this).index())
-        * Get the cell index of a cell in a fixed column
-        */
-        cellIndex(): CellIndex;
-    }
-
-    /*
-    */
-    interface CellIndex {
-        row: number;
-        column: number;
-        columnVisible: number;
+        /**
+         * @deprecated
+         * Deprecated as of v3.2.1 use dt.cell(this).index() instead
+         *
+         * Get the cell index of a cell in a fixed column
+         *
+         * @param row The cell (td or th) to get the cell index of. This can be either a cell in the fixed columns or in the host DataTable.
+         */
+        cellIndex(row: JQuery | Node): CellIndexReturn;
     }
 
     interface RowsMethods {
-        /*
-         * Recalculate the height of one or more rows after a data change
+        /**
+         * @description Mark the heights of the selected rows (from rows()) to be recalculated on the next draw.
+         * @see {@link https://datatables.net/reference/api/rows().recalcHeight()}
          */
         recalcHeight(): Api;
+    }
+
+    interface CellMethods {
+        /**
+         * @description Get the fixed column cell node for a cell or the cell from the original DataTable if there is no matching fixed cell found.
+         * @see {@link https://datatables.net/reference/api/cell().fixedNode()}
+         */
+        fixedNode(): Node;
+    }
+
+    interface CellsMethods {
+        /**
+         * @description Get the fixed column cell nodes for multiple cells or an Api instance containing
+         * the cells from the original DataTable if there is no matching fixed cell found.
+         * @see {@link https://datatables.net/reference/api/cells().fixedNodes()}
+         */
+        fixedNodes(): Api;
     }
 }


### PR DESCRIPTION
* Update description to match jsDoc standards
* Update som description with dt documentation formulation
* Fix cellIndex method definition
* Add fixedNode and fixedNodes methods definition

See the most up to date documentation at https://datatables.net/extensions/fixedcolumns/

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
