### PR TITLE
Update bottomBarHighlight type

### DIFF
--- a/types/react-native-onboarding-swiper/index.d.ts
+++ b/types/react-native-onboarding-swiper/index.d.ts
@@ -136,7 +136,7 @@ export interface Props {
      * A bool flag indicating whether the bottom bar should be highlighted.
      * @default true
      */
-    bottomBarHighlight?: number;
+    bottomBarHighlight?: boolean;
 
     /**
      * A bool flag indicating whether the status bar should change with the background color.


### PR DESCRIPTION
Propo bottomBarHighlight is supposed to be a boolean. Thus, I suggest changing the bottomBarHighlight type from number to boolean.

At line 244 in the [index.js](https://github.com/jfilter/react-native-onboarding-swiper/blob/master/src/index.js) we have
`bottomBarHighlight: PropTypes.bool`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [  ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [source](https://github.com/jfilter/react-native-onboarding-swiper/blob/master/src/index.js)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

