### PR TITLE
[@types/css-minimizer-webpack-plugin]: Fix types to work with webpack 5

### DIFF
--- a/types/css-minimizer-webpack-plugin/css-minimizer-webpack-plugin-tests.ts
+++ b/types/css-minimizer-webpack-plugin/css-minimizer-webpack-plugin-tests.ts
@@ -1,3 +1,4 @@
+import { Compiler } from 'webpack';
 import CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 
 module.exports = {
@@ -46,3 +47,5 @@ module.exports = {
         ],
     },
 };
+
+new CssMinimizerPlugin().apply(new Compiler());

--- a/types/css-minimizer-webpack-plugin/index.d.ts
+++ b/types/css-minimizer-webpack-plugin/index.d.ts
@@ -2,12 +2,14 @@
 // Project: https://github.com/webpack-contrib/css-minimizer-webpack-plugin
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-import { Plugin } from 'webpack';
+import { Compiler } from 'webpack';
 import { CssNanoOptions } from 'cssnano';
 import { SourceMapOptions } from 'postcss';
 
-declare class CssMinimizerPlugin extends Plugin {
+declare class CssMinimizerPlugin {
     constructor(options?: CssMinimizerPlugin.Options);
+
+    apply(compiler: Compiler): void;
 }
 
 declare namespace CssMinimizerPlugin {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.