### PR TITLE
`react-aria-menubutton`: allow ref forwarding

### DIFF
--- a/types/react-aria-menubutton/index.d.ts
+++ b/types/react-aria-menubutton/index.d.ts
@@ -77,7 +77,7 @@ export interface ButtonProps<T extends HTMLElement>
  * Each `Button` must be wrapped in a Wrapper, and each Wrapper can wrap only
  * one `Button`.
  */
-export class Button extends React.Component<ButtonProps<HTMLElement>> {}
+export const Button: React.ForwardRefExoticComponent<ButtonProps<HTMLElement>>;
 
 export interface MenuProps<T extends HTMLElement>
     extends React.HTMLProps<T> {

--- a/types/react-aria-menubutton/react-aria-menubutton-tests.tsx
+++ b/types/react-aria-menubutton/react-aria-menubutton-tests.tsx
@@ -151,3 +151,9 @@ class MenuWithRenderProp extends React.Component {
         );
     }
 }
+
+// Test for forwarding ref
+{
+    const buttonRef = React.useRef<HTMLElement | null>(null);
+    <Button ref={buttonRef}>Select a word</Button>;
+}


### PR DESCRIPTION
Ref forwarding was added in https://github.com/davidtheclark/react-aria-menubutton/pull/113.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/davidtheclark/react-aria-menubutton/pull/113
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.