### PR TITLE
Updated prosemirror-model to include `hasRequiredAttrs` to `NodeType`

### DIFF
--- a/types/prosemirror-model/index.d.ts
+++ b/types/prosemirror-model/index.d.ts
@@ -1032,6 +1032,10 @@ export class NodeType<S extends Schema = any> {
    */
   isAtom: boolean;
   /**
+   * Tells you whether this node type has any required attributes.
+   */
+  hasRequiredAttrs: (): boolean
+  /**
    * Create a `Node` of this type. The given attributes are
    * checked and defaulted (you can pass `null` to use the type's
    * defaults entirely, if no required attributes exist). `content`

--- a/types/prosemirror-model/index.d.ts
+++ b/types/prosemirror-model/index.d.ts
@@ -1034,7 +1034,7 @@ export class NodeType<S extends Schema = any> {
   /**
    * Tells you whether this node type has any required attributes.
    */
-  hasRequiredAttrs(): boolean
+  hasRequiredAttrs(): boolean;
   /**
    * Create a `Node` of this type. The given attributes are
    * checked and defaulted (you can pass `null` to use the type's

--- a/types/prosemirror-model/index.d.ts
+++ b/types/prosemirror-model/index.d.ts
@@ -1034,7 +1034,7 @@ export class NodeType<S extends Schema = any> {
   /**
    * Tells you whether this node type has any required attributes.
    */
-  hasRequiredAttrs: (): boolean
+  hasRequiredAttrs(): boolean
   /**
    * Create a `Node` of this type. The given attributes are
    * checked and defaulted (you can pass `null` to use the type's


### PR DESCRIPTION
`hasRequiredAttrs` is listed [in the reference](https://prosemirror.net/docs/ref/#model.NodeType) but not the typescript .d.ts

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://prosemirror.net/docs/ref/#model.NodeType.hasRequiredAttrs