### PR TITLE
[@ember/routing] add metadata to RouteInfo

### DIFF
--- a/types/ember__routing/-private/route-info-with-attributes.d.ts
+++ b/types/ember__routing/-private/route-info-with-attributes.d.ts
@@ -16,9 +16,4 @@ export default interface RouteInfoWithAttributes extends RouteInfo {
      * route's model hook.
      */
     readonly attributes: unknown;
-    /**
-     * Will contain the result `Route#buildRouteInfoMetadata`
-     * for the corresponding Route.
-     */
-    readonly metadata: unknown;
 }

--- a/types/ember__routing/-private/route-info.d.ts
+++ b/types/ember__routing/-private/route-info.d.ts
@@ -40,6 +40,11 @@ export default interface RouteInfo {
      */
     readonly queryParams: { [key: string]: string | undefined };
     /**
+     * Will contain the result `Route#buildRouteInfoMetadata`
+     * for the corresponding Route.
+     */
+    readonly metadata: unknown;
+    /**
      * Allows you to traverse through the linked list of `RouteInfo`s from the topmost to leafmost.
      * Returns the first `RouteInfo` in the linked list for which the callback returns true.
      *

--- a/types/ember__routing/test/router-service.ts
+++ b/types/ember__routing/test/router-service.ts
@@ -67,6 +67,11 @@ transition.to;
 // $ExpectError
 transition.to = 'to';
 
+// $ExpectType unknown
+transition.to.metadata;
+// $ExpectError
+transition.to.metadata = 'foo';
+
 // NOTE: we cannot check the validity of invocations with just route name and
 // query params beyond that the second argument is an object of some sort,
 // because TS will always resolve it to the `models` variant if the


### PR DESCRIPTION
Now that https://github.com/emberjs/ember.js/pull/19248 has gone in and updated the docs, this adds the `metadata` property to `RouteInfo` (actually moves it from `RouteInfoWithAttributes`, which inherits `RouteInfo`).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emberjs/ember.js/pull/19248
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~
