### PR TITLE
[gestalt]: Update gestalt definition to be in sync with 14.26

### DIFF
--- a/types/gestalt/gestalt-tests.tsx
+++ b/types/gestalt/gestalt-tests.tsx
@@ -79,8 +79,8 @@ const MasonryComponent = ({}) => {
     ]}
 />;
 <Badge text="Nicolas" />;
-<Box />;
-<Button text={'Click me'} />;
+<Box ref={React.createRef<HTMLDivElement>()} />;
+<Button ref={React.createRef<HTMLAnchorElement>()} text={'Click me'} />;
 <ButtonGroup>
     <Button text={'Click me'} />
     <Button text={'Click me'} />

--- a/types/gestalt/gestalt-tests.tsx
+++ b/types/gestalt/gestalt-tests.tsx
@@ -1,4 +1,5 @@
 import {
+    ActivationCard,
     Avatar,
     AvatarPair,
     Badge,
@@ -25,6 +26,7 @@ import {
     Mask,
     Masonry,
     Modal,
+    Module,
     Pog,
     Provider,
     Pulsar,
@@ -33,6 +35,7 @@ import {
     SearchField,
     SegmentedControl,
     SelectList,
+    Sheet,
     Spinner,
     Stack,
     Sticky,
@@ -53,7 +56,12 @@ import * as React from 'react';
 const MasonryComponent = ({}) => {
     return <div>Masonry</div>;
 };
-
+<ActivationCard
+    status="notStarted"
+    statusMessage="Not started"
+    title="Claim your website"
+    message="Grow distribution and track Pins linked to your website"
+/>;
 <Avatar name="Nicolas" />;
 <AvatarPair
     size="md"
@@ -107,6 +115,18 @@ const MasonryComponent = ({}) => {
 <Mask />;
 <Masonry comp={MasonryComponent} items={[{}]} />;
 <Modal accessibilityModalLabel="modal" onDismiss={() => {}} />;
+<Module.Expandable
+    id="ModuleExample1"
+    accessibilityExpandLabel="Expand the module"
+    accessibilityCollapseLabel="Collapse the module"
+    items={[
+        {
+            title: 'Title',
+            summary: ['summary1', 'summary2', 'summary3'],
+            children: <Text size="md">Children1</Text>,
+        },
+    ]}
+></Module.Expandable>;
 <Pog />;
 <Provider colorScheme={'light'} id="docsExample" />;
 <Pulsar />;
@@ -117,6 +137,14 @@ const MasonryComponent = ({}) => {
 <SearchField accessibilityLabel="Demo Search Field" id="searchField" onChange={({ value }) => value} />;
 <SegmentedControl items={[]} selectedItemIndex={1} onChange={() => {}} />;
 <SelectList id="city" onChange={({ value }) => value} options={[]} />;
+<Sheet
+    accessibilityDismissButtonLabel="Dismiss"
+    accessibilitySheetLabel="Example sheet to demonstrate different sizes"
+    onDismiss={() => {}}
+    footer={<Heading>Footer</Heading>}
+>
+    {({ onDismissStart }) => <Heading>Content {onDismissStart}</Heading>}
+</Sheet>;
 <Stack alignItems="center" gap={2}>
     <div />
     <div />
@@ -153,6 +181,36 @@ const MasonryComponent = ({}) => {
                 <Text>September 19, 1979</Text>
             </Table.Cell>
         </Table.Row>
+        <Table.RowExpandable
+            accessibilityExpandLabel="Expand"
+            accessibilityCollapseLabel="Collapse"
+            id="row1"
+            onExpand={() => {}}
+            expandedContents={
+                <Box maxWidth={236} padding={2} column={12}>
+                    <Card image={<Avatar name="luna avatar" src="https://i.ibb.co/QY9qR7h/luna.png" />}>
+                        <Text align="center" weight="bold">
+                            <Link href="https://pinterest.com">
+                                <Box paddingX={3} paddingY={2}>
+                                    Luna's Info
+                                </Box>
+                            </Link>
+                        </Text>
+                        <Text>Row expanded</Text>
+                    </Card>
+                </Box>
+            }
+        >
+            <Table.Cell>
+                <Text>Luna Lovegood</Text>
+            </Table.Cell>
+            <Table.Cell>
+                <Text>Ravenclaw</Text>
+            </Table.Cell>
+            <Table.Cell>
+                <Text>June 25, 1993</Text>
+            </Table.Cell>
+        </Table.RowExpandable>
     </Table.Body>
     <Table.Footer>The end</Table.Footer>
 </Table>;
@@ -193,10 +251,10 @@ const MasonryComponent = ({}) => {
     placeholder="Select a Label"
 />;
 <Video
-  aspectRatio={853 / 480}
-  captions=""
-  poster="https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217"
-  src="http://media.w3.org/2010/05/bunny/movie.mp4"
+    aspectRatio={853 / 480}
+    captions=""
+    poster="https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217"
+    src="http://media.w3.org/2010/05/bunny/movie.mp4"
 />;
 <Icon accessibilityLabel={'sup'} icon={'add'} dangerouslySetSvgPath={{ __path: 'something' }} />;
 <IconButton accessibilityLabel={'something'} icon={'add-pin'} />;

--- a/types/gestalt/gestalt-tests.tsx
+++ b/types/gestalt/gestalt-tests.tsx
@@ -50,6 +50,8 @@ import {
     Tooltip,
     Typeahead,
     Video,
+    FixedZIndex,
+    CompositeZIndex,
 } from 'gestalt';
 import * as React from 'react';
 
@@ -258,3 +260,6 @@ const MasonryComponent = ({}) => {
 />;
 <Icon accessibilityLabel={'sup'} icon={'add'} dangerouslySetSvgPath={{ __path: 'something' }} />;
 <IconButton accessibilityLabel={'something'} icon={'add-pin'} />;
+
+new FixedZIndex(1);
+new CompositeZIndex([new FixedZIndex(1), new CompositeZIndex([new FixedZIndex(1)])]);

--- a/types/gestalt/index.d.ts
+++ b/types/gestalt/index.d.ts
@@ -12,11 +12,16 @@
 
 import * as React from 'react';
 
+/**
+ * Helpers
+ */
+
 export type AbstractEventHandler<T extends React.SyntheticEvent<HTMLElement> | Event, U = {}> = (
     arg: U & {
         readonly event: T;
     },
 ) => void;
+export type ReactForwardRef<T, P> = React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>>;
 
 /**
  * ActivationCard Props Interface
@@ -1258,12 +1263,12 @@ export class ActivationCard extends React.Component<ActivationCardProps, any> {}
 export class Avatar extends React.Component<AvatarProps, any> {}
 export class AvatarPair extends React.Component<AvatarPairProps, any> {}
 export class Badge extends React.Component<BadgeProps, any> {}
-export class Box extends React.Component<BoxProps, any> {}
-export class Button extends React.Component<ButtonProps, any> {}
+export const Box: ReactForwardRef<HTMLDivElement, BoxProps>;
+export const Button: ReactForwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>;
 export class ButtonGroup extends React.Component<ButtonGroupProps, any> {}
 export class Callout extends React.Component<CalloutProps, any> {}
 export class Card extends React.Component<CardProps, any> {}
-export class Checkbox extends React.Component<CheckboxProps, any> {}
+export const Checkbox: ReactForwardRef<HTMLInputElement, CheckboxProps>;
 export class Collage extends React.Component<CollageProps, any> {}
 export class Column extends React.Component<ColumnProps, any> {}
 export class Container extends React.Component<ContainerProps, any> {}
@@ -1272,27 +1277,27 @@ export class Flyout extends React.Component<FlyoutProps, any> {}
 export class GroupAvatar extends React.Component<GroupAvatarProps, any> {}
 export class Heading extends React.Component<HeaderProps, any> {}
 export class Icon extends React.Component<IconProps, any> {}
-export class IconButton extends React.Component<IconButtonProps, any> {}
+export const IconButton: ReactForwardRef<HTMLButtonElement | HTMLAnchorElement, IconButtonProps>;
 export class Image extends React.Component<ImageProps, any> {}
 export class Label extends React.Component<LabelProps, any> {}
 export class Layer extends React.Component<LayerProps, any> {}
 export class Letterbox extends React.Component<LetterboxProps, any> {}
-export class Link extends React.Component<LinkProps, any> {}
+export const Link: ReactForwardRef<HTMLAnchorElement, LinkProps>;
 export class Mask extends React.Component<MaskProps, any> {}
 export class Masonry extends React.Component<MasonryProps, any> {}
-export class Modal extends React.Component<ModalProps, any> {}
+export const Modal: ReactForwardRef<HTMLDivElement, ModalProps>;
 export class Module extends React.Component<{}, any> {
     static Expandable: React.FC<ModuleExpandableProps>;
 }
 export class Pog extends React.Component<PogProps, any> {}
 export class Provider extends React.Component<ProviderProps, any> {}
 export class Pulsar extends React.Component<PulsarProps, any> {}
-export class RadioButton extends React.Component<RadioButtonProps, any> {}
+export const RadioButton: ReactForwardRef<HTMLInputElement, RadioButtonProps>;
 export class Row extends React.Component<RowProps, any> {}
-export class SearchField extends React.Component<SearchFieldProps, any> {}
+export const SearchField: ReactForwardRef<HTMLInputElement, SearchFieldProps>;
 export class SegmentedControl extends React.Component<SegmentedControlProps, any> {}
 export class SelectList extends React.Component<SelectListProps, any> {}
-export class Sheet extends React.Component<SheetProps, any> {}
+export const Sheet: ReactForwardRef<HTMLDivElement, SheetProps>;
 export class Spinner extends React.Component<SpinnerProps, any> {}
 export class Stack extends React.Component<StackProps, any> {}
 export class Sticky extends React.Component<StickyProps, any> {}
@@ -1308,11 +1313,11 @@ export class Table extends React.Component<TableProps, any> {
     static SortableHeaderCell: React.FC<TableSortableHeaderCellProps>;
 }
 export class Tabs extends React.Component<TabsProps, any> {}
-export class TapArea extends React.Component<TapAreaProps, any> {}
+export const TapArea: ReactForwardRef<HTMLButtonElement | HTMLAnchorElement, TapAreaProps>;
 export class Text extends React.Component<TextProps, any> {}
-export class TextArea extends React.Component<TextAreaProps, any> {}
-export class TextField extends React.Component<TextFieldProps, any> {}
+export const TextArea: ReactForwardRef<HTMLTextAreaElement, TextAreaProps>;
+export const TextField: ReactForwardRef<HTMLInputElement, TextFieldProps>;
 export class Toast extends React.Component<ToastProps, any> {}
 export class Tooltip extends React.Component<TooltipProps, any> {}
-export class Typeahead extends React.Component<TypeaheadProps, any> {}
+export const Typeahead: ReactForwardRef<HTMLInputElement, TypeaheadProps>;
 export class Video extends React.Component<VideoProps, any> {}

--- a/types/gestalt/index.d.ts
+++ b/types/gestalt/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for gestalt 12.13
+// Type definitions for gestalt 14.26
 // Project: https://github.com/pinterest/gestalt, https://pinterest.github.io/gestalt
 // Definitions by: Nicolás Serrano Arévalo <https://github.com/serranoarevalo>
 //                 Josh Gachnang <https://github.com/joshgachnang>
@@ -17,6 +17,33 @@ export type AbstractEventHandler<T extends React.SyntheticEvent<HTMLElement> | E
         readonly event: T;
     },
 ) => void;
+
+/*
+ActivationCard Props Interface
+https://gestalt.netlify.app/ActivationCard
+*/
+
+export interface ActivationCardProps {
+    message: string;
+    status: 'notStarted' | 'pending' | 'needsAttention' | 'complete';
+    statusMessage: string;
+    title: string;
+    dismissButton?: {
+        accessibilityLabel: string;
+        onDismiss: () => void;
+    };
+    link?: {
+        accessibilityLabel?: string;
+        href: string;
+        label: string;
+        onClick?: AbstractEventHandler<
+            | React.MouseEvent<HTMLButtonElement>
+            | React.MouseEvent<HTMLAnchorElement>
+            | React.KeyboardEvent<HTMLAnchorElement>
+            | React.KeyboardEvent<HTMLButtonElement>
+        >;
+    };
+}
 
 /*
 Avatar Props Interface
@@ -67,7 +94,7 @@ export interface BoxProps {
     alignContent?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly' | 'stretch';
     alignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch';
     alignSelf?: 'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stretch';
-    borderSize?: 'sm' | 'lg' | 'none';
+    borderStyle?: 'sm' | 'lg' | 'shadow' | 'none';
     bottom?: boolean;
     children?: React.ReactNode;
     color?:
@@ -161,7 +188,6 @@ export interface BoxProps {
     mdPaddingY?: UnsignedUpTo12;
     lgPaddingY?: UnsignedUpTo12;
     position?: 'static' | 'absolute' | 'relative' | 'fixed';
-    ref?: React.Ref<'div'>;
     right?: boolean;
     role?: string;
     rounding?: 'pill' | 'circle' | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
@@ -197,11 +223,11 @@ export interface ButtonProps {
         | React.KeyboardEvent<HTMLAnchorElement>
         | React.KeyboardEvent<HTMLButtonElement>
     >;
-    ref?: React.Ref<'button'> | React.Ref<'a'>;
     rel?: 'none' | 'nofollow';
     role?: 'button' | 'link';
     selected?: boolean;
     size?: 'sm' | 'md' | 'lg';
+    tabIndex?: -1 | 0;
     target?: null | 'self' | 'blank';
     type?: 'submit' | 'button';
 }
@@ -221,9 +247,15 @@ https://gestalt.netlify.app/Callout
 */
 
 export interface LinkData {
+    accessibilityLabel?: string;
     href: string;
     label: string;
-    onClick?: AbstractEventHandler<React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>>;
+    onClick?: AbstractEventHandler<
+        | React.MouseEvent<HTMLAnchorElement>
+        | React.KeyboardEvent<HTMLAnchorElement>
+        | React.MouseEvent<HTMLButtonElement>
+        | React.KeyboardEvent<HTMLButtonElement>
+    >;
 }
 
 export interface CalloutProps {
@@ -264,13 +296,14 @@ export interface CheckboxProps {
     disabled?: boolean;
     errorMessage?: string;
     hasError?: boolean;
+    image?: React.ReactNode;
     indeterminate?: boolean;
     label?: string;
     name?: string;
 
     onClick?: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { checked: boolean }>;
-    ref?: React.Ref<'input'>;
     size?: 'sm' | 'md';
+    subtext?: string;
 }
 /*
 Collage Props Interface
@@ -588,13 +621,17 @@ export interface IconButtonProps {
 
     dangerouslySetSvgPath?: { __path: string };
     disabled?: boolean;
+    href?: string;
     icon?: Icons;
     iconColor?: 'gray' | 'darkGray' | 'red' | 'white';
     onClick?: AbstractEventHandler<React.MouseEvent<HTMLButtonElement>>;
     padding?: 1 | 2 | 3 | 4 | 5;
-    ref?: React.Ref<'button'>;
+    rel?: 'none' | 'nofollow';
+    role?: 'button' | 'link';
     selected?: boolean;
     size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+    tabIndex?: -1 | 0;
+    target?: null | 'self' | 'blank';
 }
 
 /*
@@ -634,6 +671,7 @@ https://gestalt.netlify.app/Layer
 
 export interface LayerProps {
     children: React.ReactNode;
+    zIndex?: { index(): number };
 }
 
 /*
@@ -718,9 +756,27 @@ export interface ModalProps {
     closeOnOutsideClick?: boolean;
     footer?: React.ReactNode;
     heading?: string | React.ReactNode;
-    ref?: React.Ref<'div'>;
     role?: 'alertdialog' | 'dialog';
     size?: 'sm' | 'md' | 'lg' | number;
+}
+
+/*
+Module Props Interface
+https://gestalt.netlify.app/Module
+*/
+
+export interface ModuleExpandableProps {
+    accessibilityCollapseLabel: string;
+    accessibilityExpandLabel: string;
+    id: string;
+    items: ReadonlyArray<{
+        title: string;
+        icon?: Icons;
+        summary?: ReadonlyArray<string>;
+        type?: 'info' | 'error';
+        iconAccessibilityLabel?: string;
+        children?: React.ReactNode;
+    }>;
 }
 
 /*
@@ -772,10 +828,12 @@ export interface RadioButtonProps {
     onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { checked: boolean }>;
     checked?: boolean;
     disabled?: boolean;
+    image?: React.ReactNode;
     label?: string;
     name?: string;
-    value?: string;
     size?: 'sm' | 'md';
+    subtext?: string;
+    value?: string;
 }
 
 /*
@@ -815,7 +873,6 @@ export interface SearchFieldProps {
     onBlur?: (args: { event: React.SyntheticEvent<HTMLInputElement> }) => void;
     onFocus?: (args: { value: string; syntheticEvent: React.SyntheticEvent<HTMLInputElement> }) => void;
     placeholder?: string;
-    ref?: React.Ref<'input'>;
     size?: 'md' | 'lg';
     value?: string;
 }
@@ -850,6 +907,23 @@ export interface SelectListProps {
     placeholder?: string;
     size?: 'md' | 'lg';
     value?: string;
+}
+
+/*
+Sheet Props Interface
+https://gestalt.netlify.app/Sheet
+*/
+export type SheetNodeOrRenderProp = ((prop: { onDismissStart: () => void }) => React.ReactNode) | React.ReactNode;
+export interface SheetProps {
+    accessibilityDismissButtonLabel: string;
+    accessibilitySheetLabel: string;
+    onDismiss: () => void;
+    children?: SheetNodeOrRenderProp;
+    closeOnOutsideClick?: boolean;
+    footer?: SheetNodeOrRenderProp;
+    heading?: string;
+    size?: 'sm' | 'md' | 'lg';
+    subHeading?: SheetNodeOrRenderProp;
 }
 
 /*
@@ -921,7 +995,7 @@ https://gestalt.netlify.app/Table
 */
 
 export interface TableProps {
-    borderSize?: 'sm' | 'none';
+    borderStyle?: 'sm' | 'none';
     children?: React.ReactNode;
     maxHeight?: 'number' | 'string';
 }
@@ -951,6 +1025,21 @@ export interface TableHeaderCellProps extends TableCellProps {
 
 export interface TableRowProps {
     children?: React.ReactNode;
+}
+
+export interface TableRowExpandableProps {
+    accessibilityCollapseLabel: string;
+    accessibilityExpandLabel: string;
+    expandedContents: React.ReactNode;
+    id: string;
+    children?: React.ReactNode;
+    hoverStyle?: 'none' | 'gray';
+    onExpand?: AbstractEventHandler<
+        | React.MouseEvent<HTMLButtonElement>
+        | React.MouseEvent<HTMLAnchorElement>
+        | React.KeyboardEvent<HTMLAnchorElement>
+        | React.KeyboardEvent<HTMLButtonElement>
+    >;
 }
 
 export interface TableSortableHeaderCellProps extends TableHeaderCellProps {
@@ -988,15 +1077,24 @@ export interface TapAreaProps {
     disabled?: boolean;
     fullHeight?: boolean;
     fullWidth?: boolean;
+    href?: string;
     mouseCursor?: 'copy' | 'grab' | 'grabbing' | 'move' | 'noDrop' | 'pointer' | 'zoomIn' | 'zoomOut';
-    onBlur?: AbstractEventHandler<React.FocusEvent<HTMLDivElement>>;
-    onFocus?: AbstractEventHandler<React.FocusEvent<HTMLDivElement>>;
-    onMouseEnter?: AbstractEventHandler<React.MouseEvent<HTMLDivElement>>;
-    onMouseLeave?: AbstractEventHandler<React.MouseEvent<HTMLDivElement>>;
-    onTap?: AbstractEventHandler<React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>>;
-    ref?: React.Ref<'div'>;
-    tapStyle?: 'none' | 'compress';
+    onBlur?: AbstractEventHandler<React.FocusEvent<HTMLDivElement | HTMLAnchorElement>>;
+    onFocus?: AbstractEventHandler<React.FocusEvent<HTMLDivElement | HTMLAnchorElement>>;
+    onMouseEnter?: AbstractEventHandler<React.MouseEvent<HTMLDivElement | HTMLAnchorElement>>;
+    onMouseLeave?: AbstractEventHandler<React.MouseEvent<HTMLDivElement | HTMLAnchorElement>>;
+    onTap?: AbstractEventHandler<
+        | React.MouseEvent<HTMLDivElement>
+        | React.KeyboardEvent<HTMLDivElement>
+        | React.MouseEvent<HTMLAnchorElement>
+        | React.KeyboardEvent<HTMLAnchorElement>
+    >;
+    rel?: 'none' | 'nofollow';
+    role?: 'button' | 'link';
     rounding?: 'pill' | 'circule' | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+    tabIndex?: -1 | 0;
+    tapStyle?: 'none' | 'compress';
+    target?: null | 'self' | 'blank';
 }
 
 /*
@@ -1072,7 +1170,6 @@ export interface TextFieldProps {
     onFocus?: (args: { event: React.SyntheticEvent<React.FocusEvent<HTMLInputElement>>; value: string }) => void;
     onKeyDown?: (args: { event: React.SyntheticEvent<React.KeyboardEvent<HTMLInputElement>>; value: string }) => void;
     placeholder?: string;
-    ref?: React.Ref<'input'>;
     size?: 'md' | 'lg';
     type?: 'date' | 'email' | 'number' | 'password' | 'text' | 'url';
     value?: string;
@@ -1102,6 +1199,9 @@ export interface TooltipProps {
     idealDirection?: 'up' | 'right' | 'down' | 'left';
     inline?: boolean;
     link?: React.ReactNode;
+    zIndex?: {
+        index(): number;
+    };
 }
 
 /*
@@ -1134,7 +1234,6 @@ export interface TypeaheadProps {
             | undefined;
     }) => void;
     placeholder?: string;
-    ref?: React.Ref<'input'>;
     size?: 'md' | 'lg';
     value?: string;
 }
@@ -1162,6 +1261,7 @@ export interface VideoProps {
     controls?: boolean;
     crossOrigin?: 'anonymous' | 'use-credentials';
     loop?: boolean;
+    objectFit?: 'fill' | 'contain' | 'cover' | 'none' | 'scale-down';
     onDurationChange?: (args: { event: React.SyntheticEvent<HTMLVideoElement>; duration: number }) => void;
     onEnded?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>>;
     onFullscreenChange?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>, { fullscreen: boolean }>;
@@ -1179,6 +1279,7 @@ export interface VideoProps {
     poster?: string;
 }
 
+export class ActivationCard extends React.Component<ActivationCardProps, any> {}
 export class Avatar extends React.Component<AvatarProps, any> {}
 export class AvatarPair extends React.Component<AvatarPairProps, any> {}
 export class Badge extends React.Component<BadgeProps, any> {}
@@ -1205,6 +1306,9 @@ export class Link extends React.Component<LinkProps, any> {}
 export class Mask extends React.Component<MaskProps, any> {}
 export class Masonry extends React.Component<MasonryProps, any> {}
 export class Modal extends React.Component<ModalProps, any> {}
+export class Module extends React.Component<{}, any> {
+    static Expandable: React.FC<ModuleExpandableProps>;
+}
 export class Pog extends React.Component<PogProps, any> {}
 export class Provider extends React.Component<ProviderProps, any> {}
 export class Pulsar extends React.Component<PulsarProps, any> {}
@@ -1213,6 +1317,7 @@ export class Row extends React.Component<RowProps, any> {}
 export class SearchField extends React.Component<SearchFieldProps, any> {}
 export class SegmentedControl extends React.Component<SegmentedControlProps, any> {}
 export class SelectList extends React.Component<SelectListProps, any> {}
+export class Sheet extends React.Component<SheetProps, any> {}
 export class Spinner extends React.Component<SpinnerProps, any> {}
 export class Stack extends React.Component<StackProps, any> {}
 export class Sticky extends React.Component<StickyProps, any> {}
@@ -1224,6 +1329,7 @@ export class Table extends React.Component<TableProps, any> {
     static Header: React.FC<TableHeaderProps>;
     static HeaderCell: React.FC<TableHeaderCellProps>;
     static Row: React.FC<TableRowProps>;
+    static RowExpandable: React.FC<TableRowExpandableProps>;
     static SortableHeaderCell: React.FC<TableSortableHeaderCellProps>;
 }
 export class Tabs extends React.Component<TabsProps, any> {}

--- a/types/gestalt/index.d.ts
+++ b/types/gestalt/index.d.ts
@@ -18,11 +18,10 @@ export type AbstractEventHandler<T extends React.SyntheticEvent<HTMLElement> | E
     },
 ) => void;
 
-/*
-ActivationCard Props Interface
-https://gestalt.netlify.app/ActivationCard
-*/
-
+/**
+ * ActivationCard Props Interface
+ * https://gestalt.netlify.app/ActivationCard
+ */
 export interface ActivationCardProps {
     message: string;
     status: 'notStarted' | 'pending' | 'needsAttention' | 'complete';
@@ -45,11 +44,10 @@ export interface ActivationCardProps {
     };
 }
 
-/*
-Avatar Props Interface
-https://gestalt.netlify.app/Avatar
-*/
-
+/**
+ * Avatar Props Interface
+ * https://gestalt.netlify.app/Avatar
+ */
 export interface AvatarProps {
     name: string;
     accessibilityLabel?: string;
@@ -62,11 +60,10 @@ export interface AvatarProps {
 export type UnsignedUpTo12 = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 export type SignedUpTo12 = -12 | -11 | -10 | -9 | -8 | -7 | -6 | -5 | -4 | -3 | -2 | -1 | UnsignedUpTo12;
 
-/*
-AvatarPair Props Interface
-https://gestalt.netlify.app/AvatarPair
-*/
-
+/**
+ * AvatarPair Props Interface
+ * https://gestalt.netlify.app/AvatarPair
+ */
 export interface AvatarPairProps {
     collaborators: ReadonlyArray<{
         name: string;
@@ -75,21 +72,19 @@ export interface AvatarPairProps {
     size?: 'md' | 'lg' | 'fit';
 }
 
-/*
-Badge Props Interface
-https://gestalt.netlify.app/Badge
-*/
-
+/**
+ * Badge Props Interface
+ * https://gestalt.netlify.app/Badge
+ */
 export interface BadgeProps {
     text: string;
     position?: 'middle' | 'top';
 }
 
-/*
-Box Props Interface
-https://gestalt.netlify.app/Box
-*/
-
+/**
+ * Box Props Interface
+ * https://gestalt.netlify.app/Box
+ */
 export interface BoxProps {
     alignContent?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly' | 'stretch';
     alignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch';
@@ -195,16 +190,13 @@ export interface BoxProps {
     userSelect?: 'auto' | 'none';
     width?: number | string;
     wrap?: boolean;
-    zIndex?: {
-        index(): number;
-    };
+    zIndex?: Indexable;
 }
 
-/*
-Button Props Interface
-https://gestalt.netlify.app/Button
-*/
-
+/**
+ * Button Props Interface
+ * https://gestalt.netlify.app/Button
+ */
 export interface ButtonProps {
     text: string;
     accessibilityControls?: string;
@@ -232,19 +224,13 @@ export interface ButtonProps {
     type?: 'submit' | 'button';
 }
 
-/*
-ButtonGroup Props Interface
-https://gestalt.netlify.app/ButtonGroup
-*/
-
+/**
+ * ButtonGroup Props Interface
+ * https://gestalt.netlify.app/ButtonGroup
+ */
 export interface ButtonGroupProps {
     children?: React.ReactNode;
 }
-
-/*
-Callout Props Interface
-https://gestalt.netlify.app/Callout
-*/
 
 export interface LinkData {
     accessibilityLabel?: string;
@@ -258,6 +244,10 @@ export interface LinkData {
     >;
 }
 
+/**
+ * Callout Props Interface
+ * https://gestalt.netlify.app/Callout
+ */
 export interface CalloutProps {
     iconAccessibilityLabel: string;
     message: string;
@@ -271,11 +261,10 @@ export interface CalloutProps {
     title?: string;
 }
 
-/*
-Card Props Interface
-https://gestalt.netlify.app/Card
-*/
-
+/**
+ * Card Props Interface
+ * https://gestalt.netlify.app/Card
+ */
 export interface CardProps {
     active?: boolean;
     children?: React.ReactNode;
@@ -284,11 +273,10 @@ export interface CardProps {
     onMouseLeave?: (args: { event: React.SyntheticEvent<React.MouseEvent<HTMLDivElement>> }) => void;
 }
 
-/*
-Checkbox Props Interface
-https://gestalt.netlify.app/Checkbox
-*/
-
+/**
+ * Checkbox Props Interface
+ * https://gestalt.netlify.app/Checkbox
+ */
 export interface CheckboxProps {
     id: string;
     onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { checked: boolean }>;
@@ -305,11 +293,11 @@ export interface CheckboxProps {
     size?: 'sm' | 'md';
     subtext?: string;
 }
-/*
-Collage Props Interface
-https://gestalt.netlify.app/Column
-*/
 
+/**
+ * Collage Props Interface
+ * https://gestalt.netlify.app/Column
+ */
 export interface CollageProps {
     columns: number;
     height: number;
@@ -320,11 +308,10 @@ export interface CollageProps {
     layoutKey?: number;
 }
 
-/*
-Column Props Interface
-https://gestalt.netlify.app/Column
-*/
-
+/**
+ * Column Props Interface
+ * https://gestalt.netlify.app/Column
+ */
 export interface ColumnProps {
     span: UnsignedUpTo12;
     smSpan?: UnsignedUpTo12;
@@ -333,20 +320,18 @@ export interface ColumnProps {
     children?: React.ReactNode;
 }
 
-/*
-Container Props Interface
-https://gestalt.netlify.app/Container
-*/
-
+/**
+ * Container Props Interface
+ * https://gestalt.netlify.app/Container
+ */
 export interface ContainerProps {
     children?: React.ReactNode;
 }
 
-/*
-Flyout Props Interface
-https://gestalt.netlify.app/Flyout
-*/
-
+/**
+ * Flyout Props Interface
+ * https://gestalt.netlify.app/Flyout
+ */
 export interface FlyoutProps {
     anchor: HTMLElement; // ideally a HTMLAnchorElement
     onDismiss: () => void;
@@ -359,22 +344,20 @@ export interface FlyoutProps {
     size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'flexible' | number;
 }
 
-/*
-GroupAvatar Props Interface
-https://gestalt.netlify.app/GroupAvatar
-*/
-
+/**
+ * GroupAvatar Props Interface
+ * https://gestalt.netlify.app/GroupAvatar
+ */
 export interface GroupAvatarProps {
     collaborators: ReadonlyArray<{ name: string; src?: string }>;
     outline?: boolean;
     size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'fit';
 }
 
-/*
-Heading Props Interface
-https://gestalt.netlify.app/Heading
-*/
-
+/**
+ * Heading Props Interface
+ * https://gestalt.netlify.app/Heading
+ */
 export interface HeaderProps {
     accessibilityLevel?: 1 | 2 | 3 | 4 | 5 | 6;
     align?: 'left' | 'right' | 'center' | 'justify';
@@ -402,11 +385,6 @@ export interface HeaderProps {
     size?: 'sm' | 'md' | 'lg';
     truncate?: boolean;
 }
-
-/*
-Icon Props Interface
-https://gestalt.netlify.app/Icon
-*/
 
 export type Icons =
     | 'ad'
@@ -580,6 +558,10 @@ export type Icons =
     | 'workflow-status-unstarted'
     | 'workflow-status-warning';
 
+/**
+ * Icon Props Interface
+ * https://gestalt.netlify.app/Icon
+ */
 export interface IconProps {
     accessibilityLabel: string;
 
@@ -607,11 +589,10 @@ export interface IconProps {
     size?: number | string;
 }
 
-/*
-IconButton Props Interface
-https://gestalt.netlify.app/IconButton
-*/
-
+/**
+ * IconButton Props Interface
+ * https://gestalt.netlify.app/IconButton
+ */
 export interface IconButtonProps {
     bgColor?: 'transparent' | 'darkGray' | 'transparentDarkGray' | 'gray' | 'lightGray' | 'white' | 'red';
     accessibilityControls?: string;
@@ -634,11 +615,10 @@ export interface IconButtonProps {
     target?: null | 'self' | 'blank';
 }
 
-/*
-Image Props Interface
-https://gestalt.netlify.app/Image
-*/
-
+/**
+ * Image Props Interface
+ * https://gestalt.netlify.app/Image
+ */
 export interface ImageProps {
     alt: string;
     color: string;
@@ -655,30 +635,28 @@ export interface ImageProps {
     srcSet?: string;
 }
 
-/*
-Label Props Interface
-https://gestalt.netlify.app/Label
-*/
-
+/**
+ * Label Props Interface
+ * https://gestalt.netlify.app/Label
+ */
 export interface LabelProps {
     htmlFor: string;
     children?: React.ReactNode;
 }
-/*
-Layer Interface
-https://gestalt.netlify.app/Layer
-*/
 
+/**
+ * Layer Props Interface
+ * https://gestalt.netlify.app/Layer
+ */
 export interface LayerProps {
     children: React.ReactNode;
-    zIndex?: { index(): number };
+    zIndex?: Indexable;
 }
 
-/*
-Letterbox Props Interface
-https://gestalt.netlify.app/Letterbox
-*/
-
+/**
+ * Letterbox Props Interface
+ * https://gestalt.netlify.app/Letterbox
+ */
 export interface LetterboxProps {
     contentAspectRatio: number;
     height: number;
@@ -686,11 +664,10 @@ export interface LetterboxProps {
     children?: React.ReactNode;
 }
 
-/*
-Link Props Interface
-https://gestalt.netlify.app/Link
-*/
-
+/**
+ * Link Props Interface
+ * https://gestalt.netlify.app/Link
+ */
 export interface LinkProps {
     href: string;
     accessibilityLabel?: string;
@@ -709,11 +686,10 @@ export interface LinkProps {
     target?: null | 'self' | 'blank';
 }
 
-/*
-Mask Props Interface
-https://gestalt.netlify.app/Mask
-*/
-
+/**
+ * Mask Props Interface
+ * https://gestalt.netlify.app/Mask
+ */
 export interface MaskProps {
     children?: React.ReactNode;
     height?: number | string;
@@ -723,11 +699,10 @@ export interface MaskProps {
     willChangeTransform?: boolean;
 }
 
-/*
-Masonry Props Interface
-https://gestalt.netlify.app/Masonry
-*/
-
+/**
+ * Masonry Props Interface
+ * https://gestalt.netlify.app/Masonry
+ */
 export interface MasonryProps<T = any> {
     comp: React.ComponentType<{ data: T; itemIdx?: number; isMeasuring?: boolean }>;
     items: T[];
@@ -744,11 +719,10 @@ export interface MasonryProps<T = any> {
     virtualize?: boolean;
 }
 
-/*
-Modal Props Interface
-https://gestalt.netlify.app/Modal
-*/
-
+/**
+ * Modal Props Interface
+ * https://gestalt.netlify.app/Modal
+ */
 export interface ModalProps {
     accessibilityModalLabel: string;
     onDismiss: () => void;
@@ -760,10 +734,10 @@ export interface ModalProps {
     size?: 'sm' | 'md' | 'lg' | number;
 }
 
-/*
-Module Props Interface
-https://gestalt.netlify.app/Module
-*/
+/**
+ * Module Props Interface
+ * https://gestalt.netlify.app/Module
+ */
 
 export interface ModuleExpandableProps {
     accessibilityCollapseLabel: string;
@@ -779,11 +753,10 @@ export interface ModuleExpandableProps {
     }>;
 }
 
-/*
-Pog Props Interface
-https://gestalt.netlify.app/Pog
-*/
-
+/**
+ * Pog Props Interface
+ * https://gestalt.netlify.app/Pog
+ */
 export interface PogProps {
     accessibilityLabel?: string;
     active?: boolean;
@@ -798,31 +771,28 @@ export interface PogProps {
     size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 }
 
-/*
-Provider Props Interface
-https://gestalt.netlify.app/ProviderProps
-*/
-
+/**
+ * Provider Props Interface
+ * https://gestalt.netlify.app/ProviderProps
+ */
 export interface ProviderProps {
     colorScheme?: 'light' | 'dark' | 'userPreference';
     id?: string;
 }
 
-/*
-Pulsar Props Interface
-https://gestalt.netlify.app/Pulsar
-*/
-
+/**
+ * Pulsar Props Interface
+ * https://gestalt.netlify.app/Pulsar
+ */
 export interface PulsarProps {
     paused?: boolean;
     size?: number;
 }
 
-/*
-RadioButton Props Interface
-https://gestalt.netlify.app/RadioButton
-*/
-
+/**
+ * RadioButton Props Interface
+ * https://gestalt.netlify.app/RadioButton
+ */
 export interface RadioButtonProps {
     id: string;
     onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { checked: boolean }>;
@@ -836,11 +806,10 @@ export interface RadioButtonProps {
     value?: string;
 }
 
-/*
-Row Props Interface
-https://gestalt.netlify.app/Row
-*/
-
+/**
+ * Row Props Interface
+ * https://gestalt.netlify.app/Row
+ */
 export interface RowProps {
     alignContent?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly' | 'stretch';
     alignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch';
@@ -859,11 +828,10 @@ export interface RowProps {
     wrap?: boolean;
 }
 
-/*
-SearchField Props Interface
-https://gestalt.netlify.app/SearchField
-*/
-
+/**
+ * SearchField Props Interface
+ * https://gestalt.netlify.app/SearchField
+ */
 export interface SearchFieldProps {
     accessibilityLabel: string;
     id: string;
@@ -877,11 +845,10 @@ export interface SearchFieldProps {
     value?: string;
 }
 
-/*
-SegmentedControl Props Interface
-https://gestalt.netlify.app/SegmentedControl
-*/
-
+/**
+ * SegmentedControl Props Interface
+ * https://gestalt.netlify.app/SegmentedControl
+ */
 export interface SegmentedControlProps {
     items: React.ReactNode[];
     onChange: (args: { event: React.SyntheticEvent<React.MouseEvent>; activeIndex: number }) => void;
@@ -890,11 +857,10 @@ export interface SegmentedControlProps {
     size?: 'md' | 'lg';
 }
 
-/*
-SelectList Props Interface
-https://gestalt.netlify.app/SelectList
-*/
-
+/**
+ * SelectList Props Interface
+ * https://gestalt.netlify.app/SelectList
+ */
 export interface SelectListProps {
     id: string;
     onChange: (args: { event: React.SyntheticEvent<HTMLElement>; value: string }) => void;
@@ -909,10 +875,10 @@ export interface SelectListProps {
     value?: string;
 }
 
-/*
-Sheet Props Interface
-https://gestalt.netlify.app/Sheet
-*/
+/**
+ * Sheet Props Interface
+ * https://gestalt.netlify.app/Sheet
+ */
 export type SheetNodeOrRenderProp = ((prop: { onDismissStart: () => void }) => React.ReactNode) | React.ReactNode;
 export interface SheetProps {
     accessibilityDismissButtonLabel: string;
@@ -926,11 +892,10 @@ export interface SheetProps {
     subHeading?: SheetNodeOrRenderProp;
 }
 
-/*
-Spinner Props Interface
-https://gestalt.netlify.app/Spinner
-*/
-
+/**
+ * Spinner Props Interface
+ * https://gestalt.netlify.app/Spinner
+ */
 export interface SpinnerProps {
     accessibilityLabel: string;
     show: boolean;
@@ -938,11 +903,10 @@ export interface SpinnerProps {
     size?: 'sm' | 'md';
 }
 
-/*
-Stack Props Interface
-https://gestalt.netlify.app/Stack
-*/
-
+/**
+ * Stack Props Interface
+ * https://gestalt.netlify.app/Stack
+ */
 export interface StackProps {
     alignContent?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly' | 'stretch';
     alignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch';
@@ -961,11 +925,10 @@ export interface StackProps {
     wrap?: boolean;
 }
 
-/*
-Sticky Props Interface
-https://gestalt.netlify.app/Sticky
-*/
-
+/**
+ * Sticky Props Interface
+ * https://gestalt.netlify.app/Sticky
+ */
 export interface StickyProps {
     bottom?: number | string;
     children?: React.ReactNode;
@@ -973,14 +936,13 @@ export interface StickyProps {
     left?: number | string;
     right?: number | string;
     top?: number | string;
-    zIndex?: { index(): number };
+    zIndex?: Indexable;
 }
 
-/*
-Switch Props Interface
-https://gestalt.netlify.app/Switch
-*/
-
+/**
+ * Switch Props Interface
+ * https://gestalt.netlify.app/Switch
+ */
 export interface SwitchProps {
     id: string;
     onChange: (args: { event: React.SyntheticEvent<HTMLInputElement>; value: boolean }) => void;
@@ -989,11 +951,10 @@ export interface SwitchProps {
     switched?: boolean;
 }
 
-/*
-Table Props Interface
-https://gestalt.netlify.app/Table
-*/
-
+/**
+ * Table Props Interface
+ * https://gestalt.netlify.app/Table
+ */
 export interface TableProps {
     borderStyle?: 'sm' | 'none';
     children?: React.ReactNode;
@@ -1050,11 +1011,10 @@ export interface TableSortableHeaderCellProps extends TableHeaderCellProps {
     status: 'active' | 'inactive';
 }
 
-/*
-Tabs Props Interface
-https://gestalt.netlify.app/Tabs
-*/
-
+/**
+ * Tabs Props Interface
+ * https://gestalt.netlify.app/Tabs
+ */
 export interface TabsProps {
     activeTabIndex: number;
     onChange: (args: { event: React.SyntheticEvent<React.MouseEvent>; activeTabIndex: number }) => void;
@@ -1063,11 +1023,10 @@ export interface TabsProps {
     wrap?: boolean;
 }
 
-/*
-TabArea Props Interface
-https://gestalt.netlify.app/TapArea
-*/
-
+/**
+ * TabArea Props Interface
+ * https://gestalt.netlify.app/TapArea
+ */
 export interface TapAreaProps {
     accessibilityControls?: string;
     accessibilityExpanded?: boolean;
@@ -1097,11 +1056,10 @@ export interface TapAreaProps {
     target?: null | 'self' | 'blank';
 }
 
-/*
-Text Props Interface
-https://gestalt.netlify.app/Text
-*/
-
+/**
+ * Text Props Interface
+ * https://gestalt.netlify.app/Text
+ */
 export interface TextProps {
     align?: 'left' | 'right' | 'center' | 'justify';
     children?: React.ReactNode;
@@ -1131,11 +1089,10 @@ export interface TextProps {
     weight?: 'bold' | 'normal';
 }
 
-/*
-TextArea Interface Props
-https://gestalt.netlify.app/TextArea
-*/
-
+/**
+ * TextArea Props Interface
+ * https://gestalt.netlify.app/TextArea
+ */
 export interface TextAreaProps {
     id: string;
     onChange: (args: { event: React.SyntheticEvent<HTMLTextAreaElement>; value: string }) => void;
@@ -1152,11 +1109,10 @@ export interface TextAreaProps {
     value?: string;
 }
 
-/*
-TextField Interface Props
-https://gestalt.netlify.app/TextField
-*/
-
+/**
+ * TextField Props Interface
+ * https://gestalt.netlify.app/TextField
+ */
 export interface TextFieldProps {
     id: string;
     onChange: (args: { event: React.SyntheticEvent<HTMLInputElement>; value: string }) => void;
@@ -1175,11 +1131,10 @@ export interface TextFieldProps {
     value?: string;
 }
 
-/*
-Toast Interface Props
-https://gestalt.netlify.app/Toast
-*/
-
+/**
+ * Toast Props Interface
+ * https://gestalt.netlify.app/Toast
+ */
 export interface ToastProps {
     button?: React.ReactNode;
     color?: 'darkGray' | 'red';
@@ -1188,27 +1143,23 @@ export interface ToastProps {
     thumbnailShape?: 'circle' | 'rectangle' | 'square';
 }
 
-/*
-Tooltip Interface Props
-https://gestalt.netlify.app/Tooltip
-*/
-
+/**
+ * Tooltip Props Interface
+ * https://gestalt.netlify.app/Tooltip
+ */
 export interface TooltipProps {
     children: React.ReactNode;
     text: string;
     idealDirection?: 'up' | 'right' | 'down' | 'left';
     inline?: boolean;
     link?: React.ReactNode;
-    zIndex?: {
-        index(): number;
-    };
+    zIndex?: Indexable;
 }
 
-/*
-Typeahead Interface Props
-https://gestalt.netlify.app/Typeahead
-*/
-
+/**
+ * Typeahead Props Interface
+ * https://gestalt.netlify.app/Typeahead
+ */
 export interface TypeaheadProps {
     id: string;
     noResultText: string;
@@ -1238,11 +1189,10 @@ export interface TypeaheadProps {
     value?: string;
 }
 
-/*
-Video Props Interface
-https://gestalt.netlify.app/Video
-*/
-
+/**
+ * Video Props Interface
+ * https://gestalt.netlify.app/Video
+ */
 export interface VideoProps {
     accessibilityMaximizeLabel?: string;
     accessibilityMinimizeLabel?: string;
@@ -1277,6 +1227,31 @@ export interface VideoProps {
 
     playsInline?: boolean;
     poster?: string;
+}
+
+/**
+ * https://gestalt.netlify.app/ZIndexClasses#zindex
+ */
+export interface Indexable {
+    index(): number;
+}
+
+/**
+ * https://gestalt.netlify.app/ZIndexClasses#FixedZIndex
+ */
+export class FixedZIndex implements Indexable {
+    z: number;
+    constructor(z: number);
+    index(): number;
+}
+
+/**
+ * https://gestalt.netlify.app/ZIndexClasses#CompositeZIndex
+ */
+export class CompositeZIndex implements Indexable {
+    deps: Array<FixedZIndex | CompositeZIndex>;
+    constructor(deps: Array<FixedZIndex | CompositeZIndex>);
+    index(): number;
 }
 
 export class ActivationCard extends React.Component<ActivationCardProps, any> {}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://gestalt.netlify.app/What's%20New
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.


P.S.
Removed all refs definitions since it causes errors when passing props from a parent component to a gestalt props