### PR TITLE
[text-to-svg] Add definitions

### DIFF
--- a/types/text-to-svg/index.d.ts
+++ b/types/text-to-svg/index.d.ts
@@ -90,6 +90,11 @@ declare class TextToSVG {
 }
 
 declare namespace TextToSVG {
+    /**
+     * Text anchor.
+     * If horizontal component is omitted, it defaults to left.
+     * If vertical component is omitted, it defaults to baseline.
+     */
     type Anchor =
         | 'left baseline'
         | 'left top'
@@ -102,7 +107,14 @@ declare namespace TextToSVG {
         | 'right baseline'
         | 'right top'
         | 'right bottom'
-        | 'right middle';
+        | 'right middle'
+        | 'baseline'
+        | 'top'
+        | 'bottom'
+        | 'middle'
+        | 'left'
+        | 'center'
+        | 'right';
 
     interface Metrics {
         x: number;

--- a/types/text-to-svg/index.d.ts
+++ b/types/text-to-svg/index.d.ts
@@ -1,0 +1,162 @@
+// Type definitions for text-to-svg 3.1
+// Project: https://github.com/shrhdk/text-to-svg
+// Definitions by: Moritz Mahringer <https://github.com/mormahr>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Font } from 'opentype.js';
+
+export type Anchor =
+    | 'left baseline'
+    | 'left top'
+    | 'left bottom'
+    | 'left middle'
+    | 'center baseline'
+    | 'center top'
+    | 'center bottom'
+    | 'center middle'
+    | 'right baseline'
+    | 'right top'
+    | 'right bottom'
+    | 'right middle';
+
+export interface Metrics {
+    x: number;
+    y: number;
+    baseline: number;
+    width: number;
+    height: number;
+    ascender: number;
+    descender: number;
+}
+
+export interface FontOptions {
+    /**
+     * Horizontal position of the beginning of the text.
+     * @default 0
+     */
+    x?: number | null;
+
+    /**
+     * Vertical position of the baseline of the text.
+     * @default 0
+     */
+    y?: number | null;
+
+    /**
+     * Size of the text.
+     * @default 72
+     */
+    fontSize?: number | null;
+
+    /**
+     * If true takes kerning information into account.
+     * @default true
+     */
+    kerning?: boolean | null;
+
+    /**
+     * Letter-spacing value in em.
+     */
+    letterSpacing?: number | null;
+
+    /**
+     * Tracking value in (em / 1000).
+     */
+    tracking?: number | null;
+
+    /**
+     * @default "left baseline"
+     */
+    anchor?: Anchor | null;
+}
+
+export interface GenerationOptions extends FontOptions {
+    /**
+     * Key-value pairs of attributes for `<path>` element.
+     */
+    attributes?: { [key: string]: string } | null;
+}
+
+export type LoadCallback = (error: Error | null, textToSVG: TextToSVG | null) => void;
+
+export default class TextToSVG {
+    /**
+     * Create an instance of the SVG generator, using an already parsed font file.
+     *
+     * You can also use {@see TextToSVG.loadSync} to create an instance with a font
+     * file path or from the default font.
+     *
+     * @param font parsed font file
+     */
+    constructor(font: Font);
+
+    /**
+     * Synchronously load a font from the filesystem and create a TextToSVG instance.
+     * For supported file types see the "opentype.js" documentation.
+     * If no path is provided, the default font will be used.
+     *
+     * @param file path to font file
+     */
+    static loadSync(file?: string | null): TextToSVG;
+
+    /**
+     * Asynchronously load a font from an URL and create a TextToSVG instance.
+     * For supported file types see the "opentype.js" documentation.
+     *
+     * @param url of font to load
+     * @param callback called, when instance has been created
+     */
+    static load(url: string, callback: LoadCallback): void;
+
+    /**
+     * Measure the width of the specified text.
+     *
+     * @param text to measure
+     * @param options font options
+     * @returns width of the text
+     */
+    getWidth(text: string, options?: FontOptions | null): number;
+
+    /**
+     * Measure the height of the font.
+     *
+     * @param fontSize to measure with
+     * @returns height of the font
+     */
+    getHeight(fontSize: number): number;
+
+    /**
+     * Measure the text metrics.
+     *
+     * @param text to measure
+     * @param options font options
+     */
+    getMetrics(text: string, options?: FontOptions | null): Metrics;
+
+    /**
+     * Generate SVG as a string with text converted to paths.
+     *
+     * @param text to measure
+     * @param options font options and attributes
+     * @returns SVG string
+     */
+    getSVG(text: string, options?: GenerationOptions | null): string;
+
+    /**
+     * Generate SVG `<path>` from text.
+     *
+     * @param text to measure
+     * @param options font options and attributes
+     * @returns SVG path element string
+     */
+    getPath(text: string, options?: GenerationOptions | null): string;
+
+    /**
+     * Generate SVG `<path>` `d` value.
+     *
+     * @param text to measure
+     * @param options font options and attributes
+     * @returns SVG path d attribute value
+     */
+    getD(text: string, options?: GenerationOptions | null): string;
+}

--- a/types/text-to-svg/index.d.ts
+++ b/types/text-to-svg/index.d.ts
@@ -5,81 +5,9 @@
 
 import { Font } from 'opentype.js';
 
-export type Anchor =
-    | 'left baseline'
-    | 'left top'
-    | 'left bottom'
-    | 'left middle'
-    | 'center baseline'
-    | 'center top'
-    | 'center bottom'
-    | 'center middle'
-    | 'right baseline'
-    | 'right top'
-    | 'right bottom'
-    | 'right middle';
+export = TextToSVG;
 
-export interface Metrics {
-    x: number;
-    y: number;
-    baseline: number;
-    width: number;
-    height: number;
-    ascender: number;
-    descender: number;
-}
-
-export interface FontOptions {
-    /**
-     * Horizontal position of the beginning of the text.
-     * @default 0
-     */
-    x?: number | null;
-
-    /**
-     * Vertical position of the baseline of the text.
-     * @default 0
-     */
-    y?: number | null;
-
-    /**
-     * Size of the text.
-     * @default 72
-     */
-    fontSize?: number | null;
-
-    /**
-     * If true takes kerning information into account.
-     * @default true
-     */
-    kerning?: boolean | null;
-
-    /**
-     * Letter-spacing value in em.
-     */
-    letterSpacing?: number | null;
-
-    /**
-     * Tracking value in (em / 1000).
-     */
-    tracking?: number | null;
-
-    /**
-     * @default "left baseline"
-     */
-    anchor?: Anchor | null;
-}
-
-export interface GenerationOptions extends FontOptions {
-    /**
-     * Key-value pairs of attributes for `<path>` element.
-     */
-    attributes?: { [key: string]: string } | null;
-}
-
-export type LoadCallback = (error: Error | null, textToSVG: TextToSVG | null) => void;
-
-export default class TextToSVG {
+declare class TextToSVG {
     /**
      * Create an instance of the SVG generator, using an already parsed font file.
      *
@@ -106,7 +34,7 @@ export default class TextToSVG {
      * @param url of font to load
      * @param callback called, when instance has been created
      */
-    static load(url: string, callback: LoadCallback): void;
+    static load(url: string, callback: TextToSVG.LoadCallback): void;
 
     /**
      * Measure the width of the specified text.
@@ -115,7 +43,7 @@ export default class TextToSVG {
      * @param options font options
      * @returns width of the text
      */
-    getWidth(text: string, options?: FontOptions | null): number;
+    getWidth(text: string, options?: TextToSVG.FontOptions | null): number;
 
     /**
      * Measure the height of the font.
@@ -131,7 +59,7 @@ export default class TextToSVG {
      * @param text to measure
      * @param options font options
      */
-    getMetrics(text: string, options?: FontOptions | null): Metrics;
+    getMetrics(text: string, options?: TextToSVG.FontOptions | null): TextToSVG.Metrics;
 
     /**
      * Generate SVG as a string with text converted to paths.
@@ -140,7 +68,7 @@ export default class TextToSVG {
      * @param options font options and attributes
      * @returns SVG string
      */
-    getSVG(text: string, options?: GenerationOptions | null): string;
+    getSVG(text: string, options?: TextToSVG.GenerationOptions | null): string;
 
     /**
      * Generate SVG `<path>` from text.
@@ -149,7 +77,7 @@ export default class TextToSVG {
      * @param options font options and attributes
      * @returns SVG path element string
      */
-    getPath(text: string, options?: GenerationOptions | null): string;
+    getPath(text: string, options?: TextToSVG.GenerationOptions | null): string;
 
     /**
      * Generate SVG `<path>` `d` value.
@@ -158,5 +86,81 @@ export default class TextToSVG {
      * @param options font options and attributes
      * @returns SVG path d attribute value
      */
-    getD(text: string, options?: GenerationOptions | null): string;
+    getD(text: string, options?: TextToSVG.GenerationOptions | null): string;
+}
+
+declare namespace TextToSVG {
+    type Anchor =
+        | 'left baseline'
+        | 'left top'
+        | 'left bottom'
+        | 'left middle'
+        | 'center baseline'
+        | 'center top'
+        | 'center bottom'
+        | 'center middle'
+        | 'right baseline'
+        | 'right top'
+        | 'right bottom'
+        | 'right middle';
+
+    interface Metrics {
+        x: number;
+        y: number;
+        baseline: number;
+        width: number;
+        height: number;
+        ascender: number;
+        descender: number;
+    }
+
+    interface FontOptions {
+        /**
+         * Horizontal position of the beginning of the text.
+         * @default 0
+         */
+        x?: number | null;
+
+        /**
+         * Vertical position of the baseline of the text.
+         * @default 0
+         */
+        y?: number | null;
+
+        /**
+         * Size of the text.
+         * @default 72
+         */
+        fontSize?: number | null;
+
+        /**
+         * If true takes kerning information into account.
+         * @default true
+         */
+        kerning?: boolean | null;
+
+        /**
+         * Letter-spacing value in em.
+         */
+        letterSpacing?: number | null;
+
+        /**
+         * Tracking value in (em / 1000).
+         */
+        tracking?: number | null;
+
+        /**
+         * @default "left baseline"
+         */
+        anchor?: Anchor | null;
+    }
+
+    interface GenerationOptions extends FontOptions {
+        /**
+         * Key-value pairs of attributes for `<path>` element.
+         */
+        attributes?: { [key: string]: string } | null;
+    }
+
+    type LoadCallback = (error: Error | null, textToSVG: TextToSVG | null) => void;
 }

--- a/types/text-to-svg/text-to-svg-tests.ts
+++ b/types/text-to-svg/text-to-svg-tests.ts
@@ -1,0 +1,43 @@
+import TextToSVG, { Metrics } from 'text-to-svg';
+
+// $ExpectType TextToSVG
+TextToSVG.loadSync();
+
+const textToSVG = TextToSVG.loadSync('../abc.woff2');
+
+// $ExpectType void
+TextToSVG.load('../abc.woff2', (error, textToSVG) => {
+    if (!error && textToSVG) {
+        textToSVG.getHeight(72);
+    }
+});
+
+// $ExpectType number
+textToSVG.getWidth('Hello world.');
+
+// $ExpectType number
+textToSVG.getHeight(72);
+
+// $ExpectType Metrics
+textToSVG.getMetrics('Hello world.', {
+    kerning: false,
+});
+
+// $ExpectType string
+textToSVG.getD('Hello world.', {
+    x: 10,
+    y: 20,
+});
+
+// $ExpectType string
+textToSVG.getPath('Hello world.', {
+    attributes: {
+        fill: 'red',
+    },
+});
+
+// $ExpectType string
+textToSVG.getSVG('Hello world.', {
+    letterSpacing: -1,
+    attributes: {},
+});

--- a/types/text-to-svg/tsconfig.json
+++ b/types/text-to-svg/tsconfig.json
@@ -15,7 +15,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
     },
     "files": [
         "index.d.ts",

--- a/types/text-to-svg/tsconfig.json
+++ b/types/text-to-svg/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "DOM"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "text-to-svg-tests.ts"
+    ]
+}

--- a/types/text-to-svg/tslint.json
+++ b/types/text-to-svg/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

The original package uses `export default class ...` and `module.exports = exports.default`. I'm not sure what the right structure for the definition is. My first commit is with the default ES6 style, but then i discovered the [class template](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-class-d-ts.html) and refactored it to use that structure.

I'm also unsure if there is a dict / object equivalent to `ReadonlyArray`. Should i use `ReadOnly<...>` for the attributes?