### PR TITLE
[@types/carbon-components-react] Update "value" type of NumberInput to contain empty string

### DIFF
--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -615,6 +615,7 @@ const controlledPasswordInputWithRef = <TextInput.ControlledPasswordInput id="my
 
 // NumberInput
 const numberInput = <NumberInput id="my-id" value={12} />;
+const emptyNumberInput = <NumberInput id="empty-id" value="" />;
 
 // FileUploader
 const fileUploaderHasOnChange = <FileUploader onChange={e => {}} />;

--- a/types/carbon-components-react/lib/components/NumberInput/NumberInput.d.ts
+++ b/types/carbon-components-react/lib/components/NumberInput/NumberInput.d.ts
@@ -20,7 +20,7 @@ export interface NumberInputProps extends Omit<ReactInputAttr, ExcludedAttribute
     label?: React.ReactNode,
     light?: boolean,
     size?: Extract<CarbonInputSize, "sm" | "xl">,
-    value: number,
+    value: number | '',
     warn?: boolean,
     warnText?: React.ReactNode,
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [discussion](https://github.com/carbon-design-system/carbon/issues/7225)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
