### PR TITLE
[react-native] Add support for ref on Pressable

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -552,7 +552,7 @@ export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'sty
 }
 
 // TODO use React.AbstractComponent when available
-export const Pressable: React.FunctionComponent<PressableProps>;
+export const Pressable: React.ForwardRefExoticComponent<PressableProps & React.RefAttributes<View>>;
 
 /**
  * //FIXME: need to find documentation on which component is a TTouchable and can implement that interface

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -381,7 +381,9 @@ export class TouchableNativeFeedbackTest extends React.Component {
 }
 
 // PressableTest
-export class PressableTest extends React.Component {
+export class PressableTest extends React.Component<{}> {
+    private readonly myRef: React.RefObject<View> = React.createRef();
+
     onPressButton = (e: GestureResponderEvent) => {
         e.persist();
         e.isPropagationStopped();
@@ -391,7 +393,7 @@ export class PressableTest extends React.Component {
     render() {
         return (
             <>
-                <Pressable onPress={this.onPressButton} style={{ backgroundColor: 'blue' }}>
+                <Pressable ref={this.myRef} onPress={this.onPressButton} style={{ backgroundColor: 'blue' }}>
                     <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
                         <Text style={{ margin: 30 }}>Button</Text>
                     </View>


### PR DESCRIPTION
In the current solution, the `ref` prop was not available. I changed it to types matching the source which is basically a forwarded View component:

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.) ***(master dead on fork:)***:
```
Error: Errors in typescript@4.2 for external dependencies:
../react/index.d.ts(38,22): error TS2307: Cannot find module 'csstype' or its corresponding type declarations.
```
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
***master dead on fork: same output as above***

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/facebook/react-native/blob/f248ba1c8b15a12a0c590ce8211855cde31defe8/Libraries/Components/Pressable/Pressable.js

- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.