### PR TITLE
marked: Added missing type: 'def' to Marked.Tokens.Def

### DIFF
--- a/types/marked/index.d.ts
+++ b/types/marked/index.d.ts
@@ -250,7 +250,6 @@ declare namespace marked {
         | Tokens.Paragraph
         | Tokens.HTML
         | Tokens.Text
-        | Tokens.Def
         | Tokens.Escape
         | Tokens.Tag
         | Tokens.Image

--- a/types/marked/marked-tests.ts
+++ b/types/marked/marked-tests.ts
@@ -79,6 +79,12 @@ console.log(parser.parse(parseTestTokens));
 console.log(marked.Parser.parse(parseTestTokens));
 const parserOptions: marked.MarkedOptions = parser.options;
 
+marked
+    .lexer('')
+    .find((elem): elem is marked.Tokens.Paragraph => {
+        return elem.type === 'paragraph';
+    });
+
 const links = ['http', 'image'];
 const inlineLexer = new marked.InlineLexer(links);
 console.log(inlineLexer.output('http://'));
@@ -87,3 +93,4 @@ console.log(marked.InlineLexer.rules);
 const inlineLexerOptions: marked.MarkedOptions = inlineLexer.options;
 
 marked.use({ renderer });
+

--- a/types/marked/marked-tests.ts
+++ b/types/marked/marked-tests.ts
@@ -93,4 +93,3 @@ console.log(marked.InlineLexer.rules);
 const inlineLexerOptions: marked.MarkedOptions = inlineLexer.options;
 
 marked.use({ renderer });
-


### PR DESCRIPTION
We _(a large group of coworkers mob programming this from @Codecademy, hi everyone!)_ are pretty sure the `Tokens` union type as returned by `lexer()` should not indicate that `Def` is a possible token to output. In experimenting with the demo page and link defs, we couldn't find a way to make it output any nodes that don't have a `type` member: including `Def`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://marked.js.org/demo & https://github.github.com/gfm/#link-reference-definitions & https://raw.githubusercontent.com/markedjs/marked/master/test/specs/new/def_blocks.md
- ~[ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- ~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~
