### PR TITLE
[hookrouter] Improve type inference for useRoutes

### DIFF
--- a/types/hookrouter/hookrouter-tests.ts
+++ b/types/hookrouter/hookrouter-tests.ts
@@ -16,7 +16,7 @@ import {
     getBasepath,
     resolvePath,
     prepareRoute,
-    useQueryParams
+    useQueryParams,
 } from 'hookrouter';
 
 // $ExpectType AProps

--- a/types/hookrouter/hookrouter-tests.ts
+++ b/types/hookrouter/hookrouter-tests.ts
@@ -34,7 +34,7 @@ useControlledInterceptor();
 // $ExpectType string[]
 interceptRoute('/route1', '/route2');
 
-// $ExpectType RouteObject | null
+// $ExpectType RouteObject<any> | null
 get(2);
 
 // $ExpectType void
@@ -75,3 +75,13 @@ getWorkingPath('id');
 
 // $ExpectType string
 getTitle();
+
+// $ExpectType number
+useRoutes({
+    '/': () => 42,
+});
+
+// $ExpectType () => number
+useRoutes({
+    '/': () => () => 1 + 1,
+});

--- a/types/hookrouter/hookrouter-tests.ts
+++ b/types/hookrouter/hookrouter-tests.ts
@@ -76,12 +76,15 @@ getWorkingPath('id');
 // $ExpectType string
 getTitle();
 
-// $ExpectType number
+// $ExpectType number | null
 useRoutes({
     '/': () => 42,
 });
 
-// $ExpectType () => number
+// $ExpectType (() => number) | null
 useRoutes({
     '/': () => () => 1 + 1,
 });
+
+// $ExpectType any
+useRoutes({} as any);

--- a/types/hookrouter/index.d.ts
+++ b/types/hookrouter/index.d.ts
@@ -57,6 +57,6 @@ export function getPath(): string;
 export function usePath(active?: boolean, withBasePath?: boolean): string;
 export function updatePathHooks(): void;
 export function getWorkingPath(parentRouterId: string): string;
-export function useRoutes<T>(routeObj: HookRouter.RouteObject<T>): T | null;
+export function useRoutes<T = any>(routeObj: HookRouter.RouteObject<T>): T | null;
 export function useTitle(inString: string): void;
 export function getTitle(): string;

--- a/types/hookrouter/index.d.ts
+++ b/types/hookrouter/index.d.ts
@@ -57,6 +57,6 @@ export function getPath(): string;
 export function usePath(active?: boolean, withBasePath?: boolean): string;
 export function updatePathHooks(): void;
 export function getWorkingPath(parentRouterId: string): string;
-export function useRoutes<T>(routeObj: HookRouter.RouteObject<T>): T;
+export function useRoutes<T>(routeObj: HookRouter.RouteObject<T>): T | null;
 export function useTitle(inString: string): void;
 export function getTitle(): string;

--- a/types/hookrouter/index.d.ts
+++ b/types/hookrouter/index.d.ts
@@ -8,7 +8,7 @@ export namespace HookRouter {
     type InterceptedPath = string | null;
     interface AProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> { href: string; }
     interface QueryParams { [key: string]: any; }
-    interface RouteObject { [key: string]: (params: QueryParams) => any; }
+    interface RouteObject<T = any> { [key: string]: (params: QueryParams) => T; }
 }
 export function setLinkProps(props: HookRouter.AProps): HookRouter.AProps;
 export function A(props: HookRouter.AProps): React.ReactHTMLElement<HTMLAnchorElement>;
@@ -51,6 +51,6 @@ export function getPath(): string;
 export function usePath(active?: boolean, withBasePath?: boolean): string;
 export function updatePathHooks(): void;
 export function getWorkingPath(parentRouterId: string): string;
-export function useRoutes(routeObj: HookRouter.RouteObject): any;
+export function useRoutes<T>(routeObj: HookRouter.RouteObject<T>): T;
 export function useTitle(inString: string): void;
 export function getTitle(): string;

--- a/types/hookrouter/index.d.ts
+++ b/types/hookrouter/index.d.ts
@@ -6,9 +6,15 @@
 import * as React from 'react';
 export namespace HookRouter {
     type InterceptedPath = string | null;
-    interface AProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> { href: string; }
-    interface QueryParams { [key: string]: any; }
-    interface RouteObject<T = any> { [key: string]: (params: QueryParams) => T; }
+    interface AProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+        href: string;
+    }
+    interface QueryParams {
+        [key: string]: any;
+    }
+    interface RouteObject<T = any> {
+        [key: string]: (params: QueryParams) => T;
+    }
 }
 export function setLinkProps(props: HookRouter.AProps): HookRouter.AProps;
 export function A(props: HookRouter.AProps): React.ReactHTMLElement<HTMLAnchorElement>;
@@ -19,12 +25,12 @@ export function useControlledInterceptor(): [
     HookRouter.InterceptedPath,
     typeof confirmNavigation,
     typeof resetPath,
-    typeof stopInterception
+    typeof stopInterception,
 ];
 export function interceptRoute(previousRoute: string, nextRoute: string): string[];
 export function get(componentId: number): HookRouter.RouteObject | null;
 export function remove(componentId: number): void;
-export function useInterceptor(handlerFn: (...args: any[]) => any): () => typeof remove;
+export function useInterceptor(handlerFn: (currentPath: string, nextPath: string) => string): () => typeof remove;
 export function setQueryParams(inObj: HookRouter.QueryParams, replace?: boolean): void;
 export function getQueryParams(): HookRouter.QueryParams;
 export function queryStringToObject(inStr: string): HookRouter.QueryParams;
@@ -34,7 +40,7 @@ export function useRedirect(
     fromURL: string,
     toURL: string,
     queryParams?: HookRouter.QueryParams | null,
-    replace?: boolean
+    replace?: boolean,
 ): void;
 export function setBasepath(inBasepath: string): void;
 export function getBasepath(): string;
@@ -44,7 +50,7 @@ export function navigate(
     url: string,
     replace?: boolean,
     queryParams?: HookRouter.QueryParams | null,
-    replaceQueryParams?: boolean
+    replaceQueryParams?: boolean,
 ): void;
 export function setPath(inPath: string): void;
 export function getPath(): string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Paratron/hookrouter/blob/master/src-docs/pages/en/02_routing.md#defining-routes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
