### PR TITLE
fix(is-url): Use typeguard for non-string args

### DIFF
--- a/types/is-url/index.d.ts
+++ b/types/is-url/index.d.ts
@@ -6,4 +6,4 @@
 
 export = isUrl
 
-declare function isUrl(string: string): boolean;
+declare function isUrl(maybeUrl: unknown): maybeUrl is string;

--- a/types/is-url/is-url-tests.ts
+++ b/types/is-url/is-url-tests.ts
@@ -6,5 +6,5 @@ var isValid1: boolean = isUrl('hogepiyo');
 var isValid2: boolean = isUrl('');
 var isValid3: boolean = isUrl(undefined);
 var isValid4: boolean = isUrl(4);
-var isValid4: boolean = isUrl({});
-var isValid4: boolean = isUrl(true);
+var isValid5: boolean = isUrl({});
+var isValid6: boolean = isUrl(true);

--- a/types/is-url/is-url-tests.ts
+++ b/types/is-url/is-url-tests.ts
@@ -5,3 +5,6 @@ var isValid0: boolean = isUrl('https://github.com/segmentio/is-url');
 var isValid1: boolean = isUrl('hogepiyo');
 var isValid2: boolean = isUrl('');
 var isValid3: boolean = isUrl(undefined);
+var isValid4: boolean = isUrl(4);
+var isValid4: boolean = isUrl({});
+var isValid4: boolean = isUrl(true);


### PR DESCRIPTION
Currently the types for is-url require the argument to be a string, but the package has [a check if the argument is a string](https://github.com/segmentio/is-url/blob/master/index.js#L27). I changed the type to use a typeguard to correctly type use of isUrl with non-string arguments

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/segmentio/is-url/blob/master/index.js#L27
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
