### PR TITLE
[server-destroy] Fix types and update tests

### DIFF
--- a/types/server-destroy/index.d.ts
+++ b/types/server-destroy/index.d.ts
@@ -1,17 +1,18 @@
-// Type definitions for server-destroy 1.0
+// Type definitions for server-destroy 1.1
 // Project: https://github.com/isaacs/server-destroy#readme
 // Definitions by: Gyula Szalai <https://github.com/gyszalai>
+//                 Anatoly Pitikin <https://github.com/xapdkop>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node" />
 
-import * as http from "http";
+import * as net from "net";
 
-declare module "http" {
+declare module "net" {
     interface Server {
         destroy(callback?: () => void): void;
     }
 }
 
-declare function enableDestroy(server: http.Server): void;
+declare function enableDestroy(server: net.Server): void;
 
 export = enableDestroy;

--- a/types/server-destroy/index.d.ts
+++ b/types/server-destroy/index.d.ts
@@ -9,7 +9,7 @@ import * as net from "net";
 
 declare module "net" {
     interface Server {
-        destroy(callback?: () => void): void;
+        destroy(callback?: (err?: Error) => void): void;
     }
 }
 

--- a/types/server-destroy/index.d.ts
+++ b/types/server-destroy/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for server-destroy 1.1
+// Type definitions for server-destroy 1.0
 // Project: https://github.com/isaacs/server-destroy#readme
 // Definitions by: Gyula Szalai <https://github.com/gyszalai>
 //                 Anatoly Pitikin <https://github.com/xapdkop>

--- a/types/server-destroy/server-destroy-tests.ts
+++ b/types/server-destroy/server-destroy-tests.ts
@@ -1,7 +1,37 @@
 import enableDestroy = require('server-destroy');
 
-import { Server } from "http";
-const server = {} as any as Server;
-enableDestroy(server);
-server.destroy();
-server.destroy(() => {});
+import * as net from "net";
+import * as tls from "tls";
+import * as http from "http";
+import * as https from "https";
+import * as http2 from "http2";
+
+const netServer = {} as unknown as net.Server;
+enableDestroy(netServer);
+netServer.destroy();
+netServer.destroy(() => {});
+
+const tlsServer = {} as unknown as tls.Server;
+enableDestroy(tlsServer);
+tlsServer.destroy();
+tlsServer.destroy(() => {});
+
+const httpServer = {} as unknown as http.Server;
+enableDestroy(httpServer);
+httpServer.destroy();
+httpServer.destroy(() => {});
+
+const httpsServer = {} as unknown as https.Server;
+enableDestroy(httpsServer);
+httpsServer.destroy();
+httpsServer.destroy(() => {});
+
+const http2Server = {} as unknown as http2.Http2Server;
+enableDestroy(http2Server);
+http2Server.destroy();
+http2Server.destroy(() => {});
+
+const http2SecureServer = {} as unknown as http2.Http2SecureServer;
+enableDestroy(http2SecureServer);
+http2SecureServer.destroy();
+http2SecureServer.destroy(() => {});


### PR DESCRIPTION
Use net.Server instead of http.Server (since http.Server based on net.Server)
This will allow to use the package not only for http.Server but also for http2.Http2Server and http2.Http2SecureServer (and any other servers based on net.Server)

Also fixed `callback`'s type to match the one from net.Server.close (since `callback` is internally [passed](https://github.com/isaacs/server-destroy/blob/13f04e499dac6e739fb8fb5fac8745cb083ef87e/index.js#L15) to `server.close` method

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/http.html#http_class_http_server https://nodejs.org/api/net.html#net_class_net_server https://nodejs.org/api/http2.html#http2_class_http2server https://nodejs.org/api/http2.html#http2_class_http2secureserver
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.