### PR TITLE
Correct the type of dat.gui __folders

### DIFF
--- a/types/dat.gui/dat.gui-tests.ts
+++ b/types/dat.gui/dat.gui-tests.ts
@@ -173,3 +173,10 @@ var FizzyText = function () {
     });
 }
 
+{
+    // __folders is a name --> GUI mapping, not a list.
+    const gui = new dat.GUI();
+    gui.addFolder('folder name');
+    const folder = gui.__folders['folder name'];
+    folder.add({value: 0}, 'value');
+}

--- a/types/dat.gui/index.d.ts
+++ b/types/dat.gui/index.d.ts
@@ -62,7 +62,7 @@ export class GUI {
     constructor(option?: GUIParams);
 
     __controllers: GUIController[];
-    __folders: GUI[];
+    __folders: {[folderName: string]: GUI};
     domElement: HTMLElement;
 
     add(target: Object, propName:string, min?: number, max?: number, step?: number): GUIController;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/dataarts/dat.gui/blob/51d1a37b00326c232f34d9b80dc6dea2bec8595b/src/dat/gui/GUI.js#L636
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
