### PR TITLE
[@types/babel__traverse] fix NodePath.get inferring loose type

### DIFF
--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -334,3 +334,14 @@ function testNullishPath(
     const expectedType: t.Node['type'] | undefined = actualType;
     actualType = expectedType;
 }
+
+function nodePathGetTypeInference(nodePath: NodePath<t.Node>) {
+    // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/49433
+    if (nodePath.isMemberExpression()) {
+        // $ExpectType NodePath<Expression>
+        nodePath.get('object');
+
+        // $ExpectError
+        nodePath.get('foo');
+    }
+}

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -539,8 +539,7 @@ export class NodePath<T = Node> {
         ? Array<NodePath<T[K][number]>>
         : T[K] extends Node | null | undefined
         ? NodePath<T[K]>
-        : never;
-    get(key: string, context?: boolean | TraversalContext): NodePath | NodePath[];
+        : (NodePath | NodePath[]);
 
     getBindingIdentifiers(duplicates?: boolean): Node[];
 


### PR DESCRIPTION
Unfortunately, it doesn't seem possible to keep the loose behavior when
passing an unknown string to get() because handling any string will
always supersede the type-safe behavior. It should still be possible to
have loose types by doing: `path.get('foo' as keyof t.Node)`. One
shouldn't do this anyways as it isn't type-safe.

See also:
  - https://github.com/microsoft/TypeScript/issues/15086
  - https://github.com/microsoft/TypeScript/issues/14107

fixes #49433

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/49433
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.