### PR TITLE
[scriptable-ios]: change addSpacer to accept no parameters

### DIFF
--- a/types/scriptable-ios/index.d.ts
+++ b/types/scriptable-ios/index.d.ts
@@ -3230,7 +3230,7 @@ declare class ListWidget {
      * @param length - Length of the spacer. Pass null to create a spacer with a flexible length.
      * @see https://docs.scriptable.app/listwidget/#-addspacer
      */
-    addSpacer(length: number): WidgetSpacer;
+    addSpacer(length?: number): WidgetSpacer;
 
     /**
      * _Add stack._
@@ -6346,7 +6346,7 @@ declare class WidgetStack {
      * @param length - Length of the spacer. Pass null to create a spacer with a flexible length.
      * @see https://docs.scriptable.app/widgetstack/#-addspacer
      */
-    addSpacer(length: number): WidgetSpacer;
+    addSpacer(length?: number): WidgetSpacer;
 
     /**
      * _Add stack._

--- a/types/scriptable-ios/scriptable-ios-tests.ts
+++ b/types/scriptable-ios/scriptable-ios-tests.ts
@@ -139,6 +139,7 @@
     listWidget.addImage("42");
 
     const widgetSpacer = listWidget.addSpacer(10);
+    listWidget.addSpacer();
     // $ExpectError
     listWidget.addSpacer("10");
 
@@ -444,6 +445,8 @@
     widgetStack.addImage(Image.fromFile("some/image.png"));
     // $ExpectType WidgetSpacer
     widgetStack.addSpacer(4);
+    // $ExpectType WidgetSpacer
+    widgetStack.addSpacer();
     // $ExpectType WidgetStack
     widgetStack.addStack();
     // $ExpectType void


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.scriptable.app/listwidget/#-addspacer
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.