### PR TITLE
[@types/puppeteer] Open `product` type to string but maintain intellisense

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -67,8 +67,6 @@ export interface JSONObject {
 }
 export type SerializableOrJSHandle = Serializable | JSHandle;
 
-export type Platform = 'mac' | 'win32' | 'win64' | 'linux';
-
 /**
  * We want to maintain intellisense for known values but remain open to unknown values. This type is a workaround for
  * [Microsoft/TypeScript#29729](https://github.com/Microsoft/TypeScript/issues/29729). It will be removed as soon as
@@ -76,6 +74,7 @@ export type Platform = 'mac' | 'win32' | 'win64' | 'linux';
  */
 type LiteralUnion<LiteralType> = LiteralType | (string & { _?: never });
 
+export type Platform = LiteralUnion<'mac' | 'win32' | 'win64' | 'linux'>;
 export type Product = LiteralUnion<'chrome' | 'firefox'>;
 
 /** Defines `$eval` and `$$eval` for Page, Frame and ElementHandle. */

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -69,7 +69,14 @@ export type SerializableOrJSHandle = Serializable | JSHandle;
 
 export type Platform = 'mac' | 'win32' | 'win64' | 'linux';
 
-export type Product = 'chrome' | 'firefox';
+/**
+ * We want to maintain intellisense for known values but remain open to unknown values. This type is a workaround for
+ * [Microsoft/TypeScript#29729](https://github.com/Microsoft/TypeScript/issues/29729). It will be removed as soon as
+ * it's not needed anymore.
+ */
+type LiteralUnion<LiteralType> = LiteralType | (string & { _?: never });
+
+export type Product = LiteralUnion<'chrome' | 'firefox'>;
 
 /** Defines `$eval` and `$$eval` for Page, Frame and ElementHandle. */
 export interface Evalable {
@@ -329,16 +336,16 @@ export interface MouseWheelOptions {
 }
 
 export interface MouseWheelOptions {
-  /**
-   * X delta in CSS pixels for mouse wheel event. Positive values emulate a scroll up and negative values a scroll down event.
-   * @default 0
-   */
-  deltaX?: number;
-  /**
-   * Y delta in CSS pixels for mouse wheel event. Positive values emulate a scroll right and negative values a scroll left event.
-   * @default 0
-   */
-  deltaY?: number;
+    /**
+     * X delta in CSS pixels for mouse wheel event. Positive values emulate a scroll up and negative values a scroll down event.
+     * @default 0
+     */
+    deltaX?: number;
+    /**
+     * Y delta in CSS pixels for mouse wheel event. Positive values emulate a scroll right and negative values a scroll left event.
+     * @default 0
+     */
+    deltaY?: number;
 }
 
 export interface Mouse {

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -1,3 +1,5 @@
+import * as crypto from "crypto";
+import * as fs from "fs";
 import * as puppeteer from "puppeteer";
 
 // Accessibility
@@ -82,9 +84,6 @@ puppeteer.launch().then(async browser => {
     bodyHandle
   );
 });
-
-import * as crypto from "crypto";
-import * as fs from "fs";
 
 puppeteer.launch().then(async browser => {
   const page = await browser.newPage();
@@ -226,10 +225,11 @@ puppeteer.launch().then(async browser => {
     });
     const options: puppeteer.FetcherOptions = {
         product: 'firefox',
-      };
-      const browserFetcher = puppeteer.createBrowserFetcher(options);
-      browserFetcher.product(); // $ExpectType Product
-      browserFetcher.revisionInfo('revision').product; // $ExpectType Product
+    };
+
+    const browserFetcher = puppeteer.createBrowserFetcher(options);
+    browserFetcher.product(); // $ExpectType LiteralUnion<"chrome" | "firefox">
+    browserFetcher.revisionInfo('revision').product; // $ExpectType LiteralUnion<"chrome" | "firefox">
 })();
 
 // Launching with default viewport disabled


### PR DESCRIPTION
Netflix's TVUI team is using `puppeteer` to instrument their internal browser "Gibbon". The `product` type is currently locked into being `'chrome' | 'firefox'` which is too limiting. Similarly, `platform` is too restrictive as we'd want to include more, e.g. `playstation`.

I'd like to open up the type to be `string` while still maintaining intellisense for the officially supported values. To achieve this I made these types `LiteralUnions`.