### PR TITLE
[rusha] fix: types dont need node types

### DIFF
--- a/types/rusha/index.d.ts
+++ b/types/rusha/index.d.ts
@@ -4,17 +4,15 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 4.0
 
-/// <reference types="node" />
-
 interface Hash {
-    update(value: string|number[]|ArrayBuffer|Buffer): Hash;
+    update(value: string|number[]|ArrayBuffer): Hash;
     digest(encoding?: undefined): ArrayBuffer;
     digest(encoding: 'hex'): string;
 }
 
 interface RushaWorkerRequest {
     id: string;
-    data: string|number[]|ArrayBuffer|Buffer|Blob;
+    data: string|number[]|ArrayBuffer|Blob;
 }
 
 interface RushaWorkerResponse {


### PR DESCRIPTION
`Buffer`, via its `extends Uint8Array`, implements `ArrayBuffer`, so the explicit node `Buffer` typing is redundant.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.) _N/A?_
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: _N/A_ `rusha` is pure-javascript, and doesn't rely on anything in node, so the types shouldn't require node types.
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
- [ ] ~Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~
