### PR TITLE
[@brainhubeu/react-carousel] fix: DotsProps missing className

### DIFF
--- a/types/brainhubeu__react-carousel/brainhubeu__react-carousel-tests.tsx
+++ b/types/brainhubeu__react-carousel/brainhubeu__react-carousel-tests.tsx
@@ -102,7 +102,13 @@ class MyCarousel extends React.Component<MyCarouselProps, MyCarouselState> {
                     <img alt="image-2"/>
                     <img alt="image-3"/>
                 </Carousel>
-                <Dots number={slides.length} value={value} onChange={this.handleChange} rtl={false}/>
+                <Dots
+                    number={slides.length}
+                    value={value}
+                    onChange={this.handleChange}
+                    rtl={false}
+                    className="some-class"
+                />
             </>
         );
     }

--- a/types/brainhubeu__react-carousel/index.d.ts
+++ b/types/brainhubeu__react-carousel/index.d.ts
@@ -15,6 +15,7 @@ export interface DotsProps {
     value?: number;
     onChange?(value: number): void;
     rtl?: boolean;
+    className?: string;
 }
 
 export class Dots extends React.Component<DotsProps> {
@@ -48,7 +49,7 @@ export interface CarouselProps {
     draggable?: boolean;
     animationSpeed?: number;
     className?: string;
-    breakpoints?: Pick<CarouselProps, Exclude<keyof CarouselProps, "breakpoints">>;
+    breakpoints?: Pick<CarouselProps, Exclude<keyof CarouselProps, "breakpoints" | "plugins">>;
     plugins?: Array<string|CarouselPluginTypes>;
 }
 


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/brainhubeu/react-carousel/blob/master/react-carousel/src/components/CarouselDots.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Closes #49400