### PR TITLE
[@types/node] Add support for "node" URL

### DIFF
--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -553,3 +553,7 @@ declare module 'fs/promises' {
 
     function opendir(path: string, options?: OpenDirOptions): Promise<Dir>;
 }
+
+declare module 'node:fs/promises' {
+    export * from 'fs/promises';
+}


### PR DESCRIPTION
Node 14 introduced new imports feature:
```js
import { mkdir } from 'node:fs/promises';
```
See https://nodejs.org/dist/latest-v14.x/docs/api/esm.html#esm_node_imports
This PR adds it without breaking changes.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://nodejs.org/dist/latest-v14.x/docs/api/esm.html#esm_node_imports>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

