### PR TITLE
Adds support for importing "wildcard" from "disposable-email-domains"

### DIFF
--- a/types/disposable-email-domains/disposable-email-domains-tests.ts
+++ b/types/disposable-email-domains/disposable-email-domains-tests.ts
@@ -1,7 +1,13 @@
-import * as disposable from 'disposable-email-domains';
+import disposableDomains from 'disposable-email-domains';
+import wildcardDomains from 'disposable-email-domains/wildcard';
 
-let length: number = disposable.length;
+let length: number = disposableDomains.length;
+let lengthWildcard: number = wildcardDomains.length;
 
-for (let domain of disposable) {
+for (let domain of disposableDomains) {
+  console.log(domain);
+}
+
+for (let domain of wildcardDomains) {
   console.log(domain);
 }

--- a/types/disposable-email-domains/index.d.ts
+++ b/types/disposable-email-domains/index.d.ts
@@ -1,7 +1,10 @@
 // Type definitions for disposable-email-domains v1.0
 // Project: https://github.com/ivolo/disposable-email-domains
 // Definitions by: Joshua DeVinney <https://github.com/geoffreak>
+//                 Alexander Håkansson <https://github.com/hsson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference path="wildcard.d.ts" />
+
 declare const domains: string[];
-export = domains;
+export default domains;

--- a/types/disposable-email-domains/wildcard.d.ts
+++ b/types/disposable-email-domains/wildcard.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for disposable-email-domains v1.0
+// Project: https://github.com/ivolo/disposable-email-domains
+// Definitions by: Alexander Håkansson <https://github.com/hsson>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare const wildcards: string[];
+export default wildcards;


### PR DESCRIPTION
Adds types for importing the wildcard domains as well from the `disposable-email-domains` library.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [github.com/ivolo/disposable-email-domains](https://github.com/ivolo/disposable-email-domains#nodejs)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
