### PR TITLE
[mapbox-gl] Add Expression type to *-sort-key properties

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -1998,7 +1998,7 @@ declare namespace mapboxgl {
     }
 
     export interface FillLayout extends Layout {
-        'fill-sort-key'?: number;
+        'fill-sort-key'?: number | Expression;
     }
 
     export interface FillPaint {
@@ -2040,7 +2040,7 @@ declare namespace mapboxgl {
         'line-join'?: 'bevel' | 'round' | 'miter' | Expression;
         'line-miter-limit'?: number | Expression;
         'line-round-limit'?: number | Expression;
-        'line-sort-key'?: number;
+        'line-sort-key'?: number | Expression;
     }
 
     export interface LinePaint {
@@ -2159,7 +2159,7 @@ declare namespace mapboxgl {
     }
 
     export interface CircleLayout extends Layout {
-        'circle-sort-key'?: number;
+        'circle-sort-key'?: number | Expression;
     }
 
     export interface CirclePaint {

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -1353,7 +1353,7 @@ const backgroundPaint: mapboxgl.BackgroundPaint = {
 };
 
 const fillLayout: mapboxgl.FillLayout = {
-    'fill-sort-key': 0,
+    'fill-sort-key': eitherType(0, expression),
 };
 
 const fillPaint: mapboxgl.FillPaint = {
@@ -1397,7 +1397,7 @@ const lineLayout: mapboxgl.LineLayout = {
     'line-join': eitherType('bevel', 'round', 'miter', expression),
     'line-miter-limit': eitherType(0, expression),
     'line-round-limit': eitherType(0, expression),
-    'line-sort-key': 0,
+    'line-sort-key': eitherType(0, expression),
 };
 
 const linePaint: mapboxgl.LinePaint = {
@@ -1523,7 +1523,7 @@ const rasterPaint: mapboxgl.RasterPaint = {
 
 const circleLayout: mapboxgl.CircleLayout = {
     visibility: eitherType('visible', 'none'),
-    'circle-sort-key': 0,
+    'circle-sort-key': eitherType(0, expression),
 };
 
 const circlePaint: mapboxgl.CirclePaint = {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#layout-circle-circle-sort-key
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
