### PR TITLE
Add umami type definitions

### DIFF
--- a/types/umami/index.d.ts
+++ b/types/umami/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for umami 0.1
 // Project: https://github.com/mikecao/umami
-// Definitions by: Noah Overcash <https://github.com/me>
+// Definitions by: Noah Overcash <https://github.com/ncovercash>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var umami: umami.umami;

--- a/types/umami/index.d.ts
+++ b/types/umami/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for umami 0.1
+// Project: https://github.com/mikecao/umami
+// Definitions by: Noah Overcash <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare var umami: umami.umami;
+
+// Based on https://umami.is/docs/tracker-functions
+declare namespace umami {
+    interface umami {
+        (event_value: string): void;
+        trackEvent(event_value: string, event_type: string, url?: string, website_id?: string): void;
+        trackView(url: string, referrer?: string, website_id?: string): void;
+    }
+}

--- a/types/umami/tsconfig.json
+++ b/types/umami/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "umami-tests.ts"
+    ]
+}

--- a/types/umami/tslint.json
+++ b/types/umami/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/umami/umami-tests.ts
+++ b/types/umami/umami-tests.ts
@@ -1,0 +1,9 @@
+umami("custom_event");
+
+umami.trackEvent("custom_event", "custom_type");
+umami.trackEvent("custom_event", "custom_type", "https://example.com/");
+umami.trackEvent("custom_event", "custom_type", "https://example.com/", "94db1cb1-74f4-4a40-ad6c-962362670409");
+
+umami.trackView("https://example.com/");
+umami.trackView("https://example.com/", "https://example.com/test/");
+umami.trackView("https://example.com/", "https://example.com/test/", "94db1cb1-74f4-4a40-ad6c-962362670409");


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

This PR adds type support for the website analytics tool [Umami](https://umami.is/).  When used, Umami adds a global `umami` function to the window (similar to Google Analytic's `gtag`) which can be called in the ways described [here](https://umami.is/docs/tracker-functions).

I had to do some fiddling for the tests to pass and recognize `umami` as a global variable – if I did something wrong/non-standard, let me know and I will be glad to fix it!  I could not figure out how to use the default way of `export as namespace` from `dts-gen` due to the combination of a call signature and member functions on the `umami` object.
