### PR TITLE
add type definitions for base64id

### DIFF
--- a/types/base64id/base64id-tests.ts
+++ b/types/base64id/base64id-tests.ts
@@ -1,0 +1,16 @@
+import { generateId, getRandomBytes, bytesBuffer, bytesBufferIndex, isGeneratingBytes, sequenceNumber } from 'base64id';
+
+const sampleId = generateId();
+const sampleRandomBytes = getRandomBytes(10);
+
+// $ExpectType Buffer
+const bytesBufferAfterExecution = bytesBuffer;
+
+// $ExpectType number
+const bytesBufferIndexAfterExecution = bytesBufferIndex;
+
+// $ExpectType boolean
+const isGeneratingBytesAfterExecution = isGeneratingBytes;
+
+// $ExpectType number
+const sequenceNumberAfterExecution = sequenceNumber;

--- a/types/base64id/index.d.ts
+++ b/types/base64id/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for base64id 2.0
+// Project: https://github.com/faeldt/base64id
+// Definitions by: Shadman Kolahzary <https://github.com/Kolahzary>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 4.0
+/// <reference types="node" />
+
+/**
+ * Generates a base64 id
+ */
+export function generateId(): string;
+
+/**
+ * Get random bytes
+ *
+ * Uses a buffer if available, falls back to crypto.randomBytes
+ */
+export function getRandomBytes(bytes: number): Buffer;
+
+export let bytesBuffer: Buffer;
+export let bytesBufferIndex: number;
+export let isGeneratingBytes: boolean;
+export let sequenceNumber: number;

--- a/types/base64id/tsconfig.json
+++ b/types/base64id/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "base64id-tests.ts"
+    ]
+}

--- a/types/base64id/tslint.json
+++ b/types/base64id/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
