### PR TITLE
[@entropy/winston-elasticsearch-apm] feat: adding types to @entropy/winston-elasticsearch-apm

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -1129,12 +1129,6 @@
             "asOfVersion": "1.5.0"
         },
         {
-            "libraryName": "elastic-apm-node",
-            "typingsPackageName": "elastic-apm-node",
-            "sourceRepoURL": "https://github.com/elastic/apm-agent-nodejs",
-            "asOfVersion": "2.7.0"
-        },
-        {
             "libraryName": "electron",
             "typingsPackageName": "electron",
             "sourceRepoURL": "https://github.com/electron/electron",

--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -1129,6 +1129,12 @@
             "asOfVersion": "1.5.0"
         },
         {
+            "libraryName": "elastic-apm-node",
+            "typingsPackageName": "elastic-apm-node",
+            "sourceRepoURL": "https://github.com/elastic/apm-agent-nodejs",
+            "asOfVersion": "2.7.0"
+        },
+        {
             "libraryName": "electron",
             "typingsPackageName": "electron",
             "sourceRepoURL": "https://github.com/electron/electron",

--- a/types/entropy__winston-elasticsearch-apm/entropy__winston-elasticsearch-apm-tests.ts
+++ b/types/entropy__winston-elasticsearch-apm/entropy__winston-elasticsearch-apm-tests.ts
@@ -1,0 +1,17 @@
+import ElasticsearchApm from '@entropy/winston-elasticsearch-apm';
+import Agent from 'elastic-apm-node';
+import winston from 'winston';
+
+// $ExpectType Agent
+const apm = Agent.start({
+    serviceName: 'app',
+    serverUrl: 'http://localhost:8200',
+});
+
+// $ExpectType Logger
+const logger = winston.createLogger({
+    transports: [new ElasticsearchApm({ apm })] // $ExpectType ElasticsearchApm[]
+});
+
+// $ExpectType Logger
+logger.log({ level: 'error', message: 'an error' });

--- a/types/entropy__winston-elasticsearch-apm/entropy__winston-elasticsearch-apm-tests.ts
+++ b/types/entropy__winston-elasticsearch-apm/entropy__winston-elasticsearch-apm-tests.ts
@@ -1,6 +1,5 @@
 import ElasticsearchApm from '@entropy/winston-elasticsearch-apm';
 import Agent from 'elastic-apm-node';
-import winston from 'winston';
 
 // $ExpectType Agent
 const apm = Agent.start({
@@ -8,10 +7,5 @@ const apm = Agent.start({
     serverUrl: 'http://localhost:8200',
 });
 
-// $ExpectType Logger
-const logger = winston.createLogger({
-    transports: [new ElasticsearchApm({ apm })] // $ExpectType ElasticsearchApm[]
-});
-
-// $ExpectType Logger
-logger.log({ level: 'error', message: 'an error' });
+// $ExpectType ElasticsearchApm
+export const elasticsearchApm = new ElasticsearchApm({ apm });

--- a/types/entropy__winston-elasticsearch-apm/index.d.ts
+++ b/types/entropy__winston-elasticsearch-apm/index.d.ts
@@ -16,4 +16,5 @@ declare class ElasticsearchApm extends TransportStream {
     log(info: any, next: () => void): any;
 }
 
+// 1
 export default ElasticsearchApm;

--- a/types/entropy__winston-elasticsearch-apm/index.d.ts
+++ b/types/entropy__winston-elasticsearch-apm/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for @entropy/winston-elasticsearch-apm 1.0
+// Project: https://gitlab.entropy.cc/entropy/winston-elasticsearch-apm
+// Definitions by: Michael Vasyliv <https://github.com/michael-vasyliv>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import Agent = require('elastic-apm-node');
+import TransportStream = require('winston-transport');
+
+export interface ElasticsearchApmOptions extends TransportStream.TransportStreamOptions {
+    apm: typeof Agent;
+}
+
+declare class ElasticsearchApm extends TransportStream {
+    constructor(opts: ElasticsearchApmOptions);
+
+    log(info: any, next: () => void): any;
+}
+
+export default ElasticsearchApm;

--- a/types/entropy__winston-elasticsearch-apm/index.d.ts
+++ b/types/entropy__winston-elasticsearch-apm/index.d.ts
@@ -16,5 +16,4 @@ declare class ElasticsearchApm extends TransportStream {
     log(info: any, next: () => void): any;
 }
 
-// 1
 export default ElasticsearchApm;

--- a/types/entropy__winston-elasticsearch-apm/index.d.ts
+++ b/types/entropy__winston-elasticsearch-apm/index.d.ts
@@ -6,14 +6,16 @@
 import Agent = require('elastic-apm-node');
 import TransportStream = require('winston-transport');
 
-export interface ElasticsearchApmOptions extends TransportStream.TransportStreamOptions {
-    apm: typeof Agent;
-}
-
 declare class ElasticsearchApm extends TransportStream {
-    constructor(opts: ElasticsearchApmOptions);
+    constructor(opts: ElasticsearchApm.ElasticsearchApmOptions);
 
     log(info: any, next: () => void): any;
 }
 
-export default ElasticsearchApm;
+declare namespace ElasticsearchApm {
+    interface ElasticsearchApmOptions extends TransportStream.TransportStreamOptions {
+        apm: typeof Agent;
+    }
+  }
+
+export = ElasticsearchApm;

--- a/types/entropy__winston-elasticsearch-apm/package.json
+++ b/types/entropy__winston-elasticsearch-apm/package.json
@@ -1,8 +1,8 @@
 {
     "private": true,
     "dependencies": {
-        "winston-transport": "^4.4.0",
+        "elastic-apm-node": "^3.8.0",
         "logform": "^2.2.0",
-        "elastic-apm-node": "^3.8.0"
+        "winston-transport": "^4.4.0"
     }
 }

--- a/types/entropy__winston-elasticsearch-apm/package.json
+++ b/types/entropy__winston-elasticsearch-apm/package.json
@@ -3,7 +3,6 @@
     "dependencies": {
         "winston-transport": "^4.4.0",
         "logform": "^2.2.0",
-        "elastic-apm-node": "^3.8.0",
-        "winston": "^3.3.3"
+        "elastic-apm-node": "^3.8.0"
     }
 }

--- a/types/entropy__winston-elasticsearch-apm/package.json
+++ b/types/entropy__winston-elasticsearch-apm/package.json
@@ -1,0 +1,9 @@
+{
+    "private": true,
+    "dependencies": {
+        "winston-transport": "^4.4.0",
+        "logform": "^2.2.0",
+        "elastic-apm-node": "^3.8.0",
+        "winston": "^3.3.3"
+    }
+}

--- a/types/entropy__winston-elasticsearch-apm/tsconfig.json
+++ b/types/entropy__winston-elasticsearch-apm/tsconfig.json
@@ -1,0 +1,30 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true,
+        "paths": {
+            "@entropy/*": [
+                "entropy__*"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "entropy__winston-elasticsearch-apm-tests.ts"
+    ]
+}

--- a/types/entropy__winston-elasticsearch-apm/tslint.json
+++ b/types/entropy__winston-elasticsearch-apm/tslint.json
@@ -1,17 +1,4 @@
 {
     "extends": "dtslint/dt.json",
-    "rules": {
-        "npm-naming": [
-            true,
-            {
-                "mode": "code",
-                "errors": [
-                    [
-                        "NeedsExportEquals",
-                        false
-                    ]
-                ]
-            }
-        ]
-    }
+    "rules": {}
 }

--- a/types/entropy__winston-elasticsearch-apm/tslint.json
+++ b/types/entropy__winston-elasticsearch-apm/tslint.json
@@ -9,10 +9,6 @@
                     [
                         "NeedsExportEquals",
                         false
-                    ],
-                    [
-                        "NoDefaultExport",
-                        false
                     ]
                 ]
             }

--- a/types/entropy__winston-elasticsearch-apm/tslint.json
+++ b/types/entropy__winston-elasticsearch-apm/tslint.json
@@ -1,7 +1,6 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "unified-signatures": false,
         "npm-naming": [
             true,
             {

--- a/types/entropy__winston-elasticsearch-apm/tslint.json
+++ b/types/entropy__winston-elasticsearch-apm/tslint.json
@@ -1,4 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {}
+    "extends": "dtslint/dt.json"
 }

--- a/types/entropy__winston-elasticsearch-apm/tslint.json
+++ b/types/entropy__winston-elasticsearch-apm/tslint.json
@@ -1,0 +1,22 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "unified-signatures": false,
+        "npm-naming": [
+            true,
+            {
+                "mode": "code",
+                "errors": [
+                    [
+                        "NeedsExportEquals",
+                        false
+                    ],
+                    [
+                        "NoDefaultExport",
+                        false
+                    ]
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

