### PR TITLE
fix(js-beautify): correct exported lib types

### DIFF
--- a/types/gulp-json-editor/index.d.ts
+++ b/types/gulp-json-editor/index.d.ts
@@ -5,11 +5,8 @@
 /// <reference types="node" />
 /// <reference types="js-beautify" />
 
-
-
 interface JEditor {
-    (mergeWith: any | ((json: any) => any),
-        jsBeautifyOptions?: JSBeautifyOptions): NodeJS.ReadWriteStream;
+    (mergeWith: any | ((json: any) => any), jsBeautifyOptions?: js_beautify.JSBeautifyOptions): NodeJS.ReadWriteStream;
 }
 
 declare const jeditor: JEditor;

--- a/types/js-beautify/index.d.ts
+++ b/types/js-beautify/index.d.ts
@@ -6,98 +6,83 @@
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-interface CoreBeautifyOptions {
-    disabled?: boolean;
-    eol?: string;
-    end_with_newline?: boolean;
-    indent_size?: number;
-    indent_char?: string;
-    indent_level?: number;
-    preserve_newlines?: boolean;
-    max_preserve_newlines?: number;
-    indent_with_tabs?: boolean;
-    wrap_line_length?: number;
-    indent_empty_lines?: boolean;
-    templating?: string[];
-}
-
-interface JSBeautifyOptions extends CoreBeautifyOptions {
-    brace_style?: 'collapse' | 'expand' | 'end-expand' | 'none' | 'preserve-inline';
-    unindent_chained_methods?: boolean;
-    break_chained_methods?: boolean;
-    space_in_paren?: boolean;
-    space_in_empty_paren?: boolean;
-    jslint_happy?: boolean;
-    space_after_anon_function?: boolean;
-    space_after_named_function?: boolean;
-    keep_array_indentation?: boolean;
-    space_before_conditional?: boolean;
-    unescape_strings?: boolean;
-    e4x?: boolean;
-    comma_first?: boolean;
-    operator_position?: 'before-newline' | 'after-newline' | 'preserve-newline';
-    test_output_raw?: boolean;
-}
-
-interface HTMLBeautifyOptions extends CoreBeautifyOptions {
-    templating?: string[];
-    indent_inner_html?: boolean;
-    indent_body_inner_html?: boolean;
-    indent_head_inner_html?: boolean;
-    indent_handlebars?: boolean;
-    wrap_attributes?:
-        | 'auto'
-        | 'force'
-        | 'force-aligned'
-        | 'force-expand-multiline'
-        | 'aligned-multiple'
-        | 'preserve'
-        | 'preserve-aligned';
-    wrap_attributes_indent_size?: number;
-    extra_liners?: string[];
-    inline?: string[];
-    void_elements?: string[];
-    unformatted?: string[];
-    content_unformatted?: string[];
-    unformatted_content_delimiter?: string;
-    indent_scripts?: 'normal' | 'keep' | 'separate';
-}
-
-interface CSSBeautifyOptions extends CoreBeautifyOptions {
-    selector_separator_newline?: boolean;
-    newline_between_rules?: boolean;
-    space_around_selector_separator?: boolean;
-    space_around_combinator?: boolean;
-}
-
-interface jsb {
-    (js_source_text: string, options?: JSBeautifyOptions): string;
-    js: (js_source_text: string, options?: JSBeautifyOptions) => string;
-    js_beautify: (js_source_text: string, options?: JSBeautifyOptions) => string;
-
-    css: (js_source_text: string, options?: CSSBeautifyOptions) => string;
-    css_beautify: (js_source_text: string, options?: CSSBeautifyOptions) => string;
-
-    html: (js_source_text: string, options?: HTMLBeautifyOptions) => string;
-    html_beautify: (js_source_text: string, options?: HTMLBeautifyOptions) => string;
-}
-
-declare var js_beautify: jsb;
-
-// tslint:disable:no-single-declare-module backward compatible change requires this exclusion
-// tslint:disable:no-declare-current-package backward compatible change requires this exclusion
-declare module 'js-beautify' {
-    // re-exports types for CJS without redefinition of the global exports
-    type _CoreBeautifyOptions = CoreBeautifyOptions;
-    type _CSSBeautifyOptions =  CSSBeautifyOptions;
-    type _JSBeautifyOptions = JSBeautifyOptions;
-    type _HTMLBeautifyOptions = HTMLBeautifyOptions;
-    namespace js_beautify {
-        type CoreBeautifyOptions = _CoreBeautifyOptions;
-        type CSSBeautifyOptions = _CSSBeautifyOptions;
-        type JSBeautifyOptions = _JSBeautifyOptions;
-        type HTMLBeautifyOptions = _HTMLBeautifyOptions;
+declare namespace js_beautify {
+    interface CoreBeautifyOptions {
+        disabled?: boolean;
+        eol?: string;
+        end_with_newline?: boolean;
+        indent_size?: number;
+        indent_char?: string;
+        indent_level?: number;
+        preserve_newlines?: boolean;
+        max_preserve_newlines?: number;
+        indent_with_tabs?: boolean;
+        wrap_line_length?: number;
+        indent_empty_lines?: boolean;
+        templating?: string[];
     }
 
-    export = js_beautify;
+    interface JSBeautifyOptions extends CoreBeautifyOptions {
+        brace_style?: 'collapse' | 'expand' | 'end-expand' | 'none' | 'preserve-inline';
+        unindent_chained_methods?: boolean;
+        break_chained_methods?: boolean;
+        space_in_paren?: boolean;
+        space_in_empty_paren?: boolean;
+        jslint_happy?: boolean;
+        space_after_anon_function?: boolean;
+        space_after_named_function?: boolean;
+        keep_array_indentation?: boolean;
+        space_before_conditional?: boolean;
+        unescape_strings?: boolean;
+        e4x?: boolean;
+        comma_first?: boolean;
+        operator_position?: 'before-newline' | 'after-newline' | 'preserve-newline';
+        test_output_raw?: boolean;
+    }
+
+    interface HTMLBeautifyOptions extends CoreBeautifyOptions {
+        templating?: string[];
+        indent_inner_html?: boolean;
+        indent_body_inner_html?: boolean;
+        indent_head_inner_html?: boolean;
+        indent_handlebars?: boolean;
+        wrap_attributes?:
+            | 'auto'
+            | 'force'
+            | 'force-aligned'
+            | 'force-expand-multiline'
+            | 'aligned-multiple'
+            | 'preserve'
+            | 'preserve-aligned';
+        wrap_attributes_indent_size?: number;
+        extra_liners?: string[];
+        inline?: string[];
+        void_elements?: string[];
+        unformatted?: string[];
+        content_unformatted?: string[];
+        unformatted_content_delimiter?: string;
+        indent_scripts?: 'normal' | 'keep' | 'separate';
+    }
+
+    interface CSSBeautifyOptions extends CoreBeautifyOptions {
+        selector_separator_newline?: boolean;
+        newline_between_rules?: boolean;
+        space_around_selector_separator?: boolean;
+        space_around_combinator?: boolean;
+    }
 }
+
+declare var js_beautify: {
+    (js_source_text: string, options?: js_beautify.JSBeautifyOptions): string;
+    js: (js_source_text: string, options?: js_beautify.JSBeautifyOptions) => string;
+    js_beautify: (js_source_text: string, options?: js_beautify.JSBeautifyOptions) => string;
+
+    css: (js_source_text: string, options?: js_beautify.CSSBeautifyOptions) => string;
+    css_beautify: (js_source_text: string, options?: js_beautify.CSSBeautifyOptions) => string;
+
+    html: (js_source_text: string, options?: js_beautify.HTMLBeautifyOptions) => string;
+    html_beautify: (js_source_text: string, options?: js_beautify.HTMLBeautifyOptions) => string;
+};
+
+export as namespace js_beautify;
+export = js_beautify;

--- a/types/js-beautify/js-beautify-tests.ts
+++ b/types/js-beautify/js-beautify-tests.ts
@@ -1,16 +1,18 @@
+import js_beautify = require('js-beautify');
+
 let bCSS = js_beautify.css('body{display:none;}');
 bCSS = js_beautify.css_beautify('body{display:none;}');
 
 let bHTML = js_beautify.html('<div/>');
 bHTML = js_beautify.html_beautify('<div/>');
 
-let emptyHTMLOptions: HTMLBeautifyOptions = {};
-let emptyCSSOptions: CSSBeautifyOptions = {};
-let emptyJSOptions: JSBeautifyOptions = {};
+const emptyHTMLOptions: js_beautify.HTMLBeautifyOptions = {};
+const emptyCSSOptions: js_beautify.CSSBeautifyOptions = {};
+const emptyJSOptions: js_beautify.JSBeautifyOptions = {};
 
-let simple: string = js_beautify("console.log('Hello world!');");
+const simple: string = js_beautify("console.log('Hello world!');");
 
-let JSoptions: JSBeautifyOptions = {
+const JSoptions: js_beautify.JSBeautifyOptions = {
     indent_size: 4,
     indent_char: ' ',
     eol: '\n',
@@ -37,7 +39,7 @@ let JSoptions: JSBeautifyOptions = {
     test_output_raw: true,
 };
 
-let HTMLoptions: HTMLBeautifyOptions = {
+const HTMLoptions: js_beautify.HTMLBeautifyOptions = {
     indent_size: 4,
     indent_char: ' ',
     eol: '\n',
@@ -51,7 +53,7 @@ let HTMLoptions: HTMLBeautifyOptions = {
     end_with_newline: false,
 };
 
-let CSSoptions: CSSBeautifyOptions = {
+const CSSoptions: js_beautify.CSSBeautifyOptions = {
     indent_size: 4,
     indent_char: ' ',
     eol: '\n',
@@ -63,6 +65,9 @@ let CSSoptions: CSSBeautifyOptions = {
     end_with_newline: false,
 };
 
-let full: string = js_beautify("console.log('Hello world!');", JSoptions);
+const full: string = js_beautify("console.log('Hello world!');", JSoptions);
 
-let markup: string = js_beautify("function render(){return <div> <img src='.' /></div>}", { ...JSoptions, e4x: true });
+const markup: string = js_beautify("function render(){return <div> <img src='.' /></div>}", {
+    ...JSoptions,
+    e4x: true,
+});


### PR DESCRIPTION
last PR that landed (#46933) caused a regression. see discussion at thread.

FYI @weswigham 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
