### PR TITLE
[react-redux] connect now preserves discriminated unions

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -56,6 +56,8 @@ export type RootStateOrAny = AnyIfEmpty<DefaultRootState>;
 // Omit taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
+export type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never;
+
 export interface DispatchProp<A extends Action = AnyAction> {
     dispatch: Dispatch<A>;
 }
@@ -117,10 +119,11 @@ export type ConnectedComponent<
 // Injects props and removes them from the prop requirements.
 // Will not pass through the injected props if they are passed in during
 // render. Also adds new prop requirements from TNeedsProps.
+// Uses distributive omit to preserve discriminated unions part of original prop type
 export type InferableComponentEnhancerWithProps<TInjectedProps, TNeedsProps> =
     <C extends ComponentType<Matching<TInjectedProps, GetProps<C>>>>(
         component: C
-    ) => ConnectedComponent<C, Omit<GetProps<C>, keyof Shared<TInjectedProps, GetProps<C>>> & TNeedsProps>;
+    ) => ConnectedComponent<C, DistributiveOmit<GetProps<C>, keyof Shared<TInjectedProps, GetProps<C>>> & TNeedsProps>;
 
 // Injects props and removes them from the prop requirements.
 // Will not pass through the injected props if they are passed in during

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1536,3 +1536,27 @@ function testConnectDefaultState() {
         return state;
     });
 }
+
+function testPreserveDiscriminatedUnions() {
+    type OwnPropsT = {
+        color: string
+    } & (
+        | {
+            type: 'plain'
+        }
+        | {
+            type: 'localized'
+            params: Record<string, string> | undefined
+        }
+    );
+
+    class MyText extends React.Component<OwnPropsT> {}
+
+    const ConnectedMyText = connect()(MyText);
+    const someParams = { key: 'value', foo: 'bar' };
+
+    <ConnectedMyText type="plain" color="red" />;
+    <ConnectedMyText type="plain" color="red" params={someParams} />; // $ExpectError
+    <ConnectedMyText type="localized" color="red" />; // $ExpectError
+    <ConnectedMyText type="localized" color="red" params={someParams} />;
+}


### PR DESCRIPTION
Related to https://github.com/DefinitelyTyped/DefinitelyTyped/issues/35315

Due to the fact that, while building the props of the connected component, the prop type of the wrapped component is passed through Omit, discriminated unions in the original prop type are lost. I've added a DistributiveOmit type and use that instead of Omit to preserve discriminated unions in the original prop type.

An example use-case can be found in the tests.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>> - welp, it's kind of a given that the prop type behaviour of the original component should be preserved. Not sure if I can find a URL to support this claim /shrug