### PR TITLE
[node] Clarify assert.strict type

### DIFF
--- a/types/node/assert.d.ts
+++ b/types/node/assert.d.ts
@@ -93,26 +93,30 @@ declare module 'assert' {
 
         const strict: Omit<
             typeof assert,
-            | 'strict'
-            | 'deepEqual'
-            | 'notDeepEqual'
             | 'equal'
             | 'notEqual'
+            | 'deepEqual'
+            | 'notDeepEqual'
             | 'ok'
             | 'strictEqual'
             | 'deepStrictEqual'
             | 'ifError'
+            | 'strict'
         > & {
             (value: any, message?: string | Error): asserts value;
-            strict: typeof strict;
-            deepEqual: typeof deepStrictEqual;
-            notDeepEqual: typeof notDeepStrictEqual;
             equal: typeof strictEqual;
             notEqual: typeof notStrictEqual;
-            ok(value: any, message?: string | Error): asserts value;
-            strictEqual<T>(actual: any, expected: T, message?: string | Error): asserts actual is T;
-            deepStrictEqual<T>(actual: any, expected: T, message?: string | Error): asserts actual is T;
-            ifError(value: any): asserts value is null | undefined;
+            deepEqual: typeof deepStrictEqual;
+            notDeepEqual: typeof notDeepStrictEqual;
+
+            // Mapped types and assertion functions are incompatible?
+            // TS2775: Assertions require every name in the call target
+            // to be declared with an explicit type annotation.
+            ok: typeof ok;
+            strictEqual: typeof strictEqual;
+            deepStrictEqual: typeof deepStrictEqual;
+            ifError: typeof ifError;
+            strict: typeof strict;
         };
     }
 

--- a/types/node/v10/assert.d.ts
+++ b/types/node/v10/assert.d.ts
@@ -64,26 +64,30 @@ declare module 'assert' {
 
         const strict: Omit<
             typeof assert,
-            | 'strict'
-            | 'deepEqual'
-            | 'notDeepEqual'
             | 'equal'
             | 'notEqual'
+            | 'deepEqual'
+            | 'notDeepEqual'
             | 'ok'
             | 'strictEqual'
             | 'deepStrictEqual'
             | 'ifError'
+            | 'strict'
         > & {
             (value: any, message?: string | Error): asserts value;
-            strict: typeof strict;
-            deepEqual: typeof deepStrictEqual;
-            notDeepEqual: typeof notDeepStrictEqual;
             equal: typeof strictEqual;
             notEqual: typeof notStrictEqual;
-            ok(value: any, message?: string | Error): asserts value;
-            strictEqual<T>(actual: any, expected: T, message?: string | Error): asserts actual is T;
-            deepStrictEqual<T>(actual: any, expected: T, message?: string | Error): asserts actual is T;
-            ifError(value: any): asserts value is null | undefined;
+            deepEqual: typeof deepStrictEqual;
+            notDeepEqual: typeof notDeepStrictEqual;
+
+            // Mapped types and assertion functions are incompatible?
+            // TS2775: Assertions require every name in the call target
+            // to be declared with an explicit type annotation.
+            ok: typeof ok;
+            strictEqual: typeof strictEqual;
+            deepStrictEqual: typeof deepStrictEqual;
+            ifError: typeof ifError;
+            strict: typeof strict;
         };
     }
 

--- a/types/node/v11/assert.d.ts
+++ b/types/node/v11/assert.d.ts
@@ -64,26 +64,30 @@ declare module 'assert' {
 
         const strict: Omit<
             typeof assert,
-            | 'strict'
-            | 'deepEqual'
-            | 'notDeepEqual'
             | 'equal'
             | 'notEqual'
+            | 'deepEqual'
+            | 'notDeepEqual'
             | 'ok'
             | 'strictEqual'
             | 'deepStrictEqual'
             | 'ifError'
+            | 'strict'
         > & {
             (value: any, message?: string | Error): asserts value;
-            strict: typeof strict;
-            deepEqual: typeof deepStrictEqual;
-            notDeepEqual: typeof notDeepStrictEqual;
             equal: typeof strictEqual;
             notEqual: typeof notStrictEqual;
-            ok(value: any, message?: string | Error): asserts value;
-            strictEqual<T>(actual: any, expected: T, message?: string | Error): asserts actual is T;
-            deepStrictEqual<T>(actual: any, expected: T, message?: string | Error): asserts actual is T;
-            ifError(value: any): asserts value is null | undefined;
+            deepEqual: typeof deepStrictEqual;
+            notDeepEqual: typeof notDeepStrictEqual;
+
+            // Mapped types and assertion functions are incompatible?
+            // TS2775: Assertions require every name in the call target
+            // to be declared with an explicit type annotation.
+            ok: typeof ok;
+            strictEqual: typeof strictEqual;
+            deepStrictEqual: typeof deepStrictEqual;
+            ifError: typeof ifError;
+            strict: typeof strict;
         };
     }
 

--- a/types/node/v11/tslint.json
+++ b/types/node/v11/tslint.json
@@ -3,6 +3,7 @@
   "rules": {
     "ban-types": false,
     "no-empty-interface": false,
+    "no-outside-dependencies": false,
     "no-single-declare-module": false,
     "strict-export-declare-modifiers": false,
     "unified-signatures": false

--- a/types/node/v12/assert.d.ts
+++ b/types/node/v12/assert.d.ts
@@ -82,26 +82,30 @@ declare module 'assert' {
 
         const strict: Omit<
             typeof assert,
-            | 'strict'
-            | 'deepEqual'
-            | 'notDeepEqual'
             | 'equal'
             | 'notEqual'
+            | 'deepEqual'
+            | 'notDeepEqual'
             | 'ok'
             | 'strictEqual'
             | 'deepStrictEqual'
             | 'ifError'
+            | 'strict'
         > & {
             (value: any, message?: string | Error): asserts value;
-            strict: typeof strict;
-            deepEqual: typeof deepStrictEqual;
-            notDeepEqual: typeof notDeepStrictEqual;
             equal: typeof strictEqual;
             notEqual: typeof notStrictEqual;
-            ok(value: any, message?: string | Error): asserts value;
-            strictEqual<T>(actual: any, expected: T, message?: string | Error): asserts actual is T;
-            deepStrictEqual<T>(actual: any, expected: T, message?: string | Error): asserts actual is T;
-            ifError(value: any): asserts value is null | undefined;
+            deepEqual: typeof deepStrictEqual;
+            notDeepEqual: typeof notDeepStrictEqual;
+
+            // Mapped types and assertion functions are incompatible?
+            // TS2775: Assertions require every name in the call target
+            // to be declared with an explicit type annotation.
+            ok: typeof ok;
+            strictEqual: typeof strictEqual;
+            deepStrictEqual: typeof deepStrictEqual;
+            ifError: typeof ifError;
+            strict: typeof strict;
         };
     }
 

--- a/types/node/v13/assert.d.ts
+++ b/types/node/v13/assert.d.ts
@@ -69,26 +69,30 @@ declare module 'assert' {
 
         const strict: Omit<
             typeof assert,
-            | 'strict'
-            | 'deepEqual'
-            | 'notDeepEqual'
             | 'equal'
             | 'notEqual'
+            | 'deepEqual'
+            | 'notDeepEqual'
             | 'ok'
             | 'strictEqual'
             | 'deepStrictEqual'
             | 'ifError'
+            | 'strict'
         > & {
             (value: any, message?: string | Error): asserts value;
-            strict: typeof strict;
-            deepEqual: typeof deepStrictEqual;
-            notDeepEqual: typeof notDeepStrictEqual;
             equal: typeof strictEqual;
             notEqual: typeof notStrictEqual;
-            ok(value: any, message?: string | Error): asserts value;
-            strictEqual<T>(actual: any, expected: T, message?: string | Error): asserts actual is T;
-            deepStrictEqual<T>(actual: any, expected: T, message?: string | Error): asserts actual is T;
-            ifError(value: any): asserts value is null | undefined;
+            deepEqual: typeof deepStrictEqual;
+            notDeepEqual: typeof notDeepStrictEqual;
+
+            // Mapped types and assertion functions are incompatible?
+            // TS2775: Assertions require every name in the call target
+            // to be declared with an explicit type annotation.
+            ok: typeof ok;
+            strictEqual: typeof strictEqual;
+            deepStrictEqual: typeof deepStrictEqual;
+            ifError: typeof ifError;
+            strict: typeof strict;
         };
     }
 

--- a/types/node/v13/tslint.json
+++ b/types/node/v13/tslint.json
@@ -3,6 +3,7 @@
   "rules": {
     "ban-types": false,
     "no-empty-interface": false,
+    "no-outside-dependencies": false,
     "no-single-declare-module": false,
     "no-unnecessary-class": false,
     "unified-signatures": false


### PR DESCRIPTION
@G-Rath I wondered [at this](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48452#pullrequestreview-501547369) at first too, what do you think about adding this explanation?
- I added a comment hinting at why the non-strict [assertion functions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions) are included as well as the renamed ones.
- I used `ok: typeof ok`, etc. instead of repeating the signatures to make it more obvious that they're merely a workaround and not being altered.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).