### PR TITLE
Update iitc header

### DIFF
--- a/types/iitc/index.d.ts
+++ b/types/iitc/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package IITC (Ingress Intel Total Conversation) 0.30
+// Type definitions for IITC (Ingress Intel Total Conversation) 0.30
 // Project: https://github.com/IITC-CE/ingress-intel-total-conversion
 // Definitions by: McBen <https://github.com/McBen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
It's now on npm, so doesn't need the non-npm marker.