### PR TITLE
[hapi__inert] confine option can also be string path

### DIFF
--- a/types/hapi__inert/hapi__inert-tests.ts
+++ b/types/hapi__inert/hapi__inert-tests.ts
@@ -1,7 +1,4 @@
-import {
-    Server,
-    Lifecycle,
-} from '@hapi/hapi';
+import { Server, Lifecycle } from '@hapi/hapi';
 
 import * as path from 'path';
 import * as inert from '@hapi/inert';
@@ -10,9 +7,9 @@ const server = new Server({
     port: 3000,
     routes: {
         files: {
-            relativeTo: path.join(__dirname, 'public')
-        }
-    }
+            relativeTo: path.join(__dirname, 'public'),
+        },
+    },
 });
 
 const provision = async () => {
@@ -35,9 +32,19 @@ const provision = async () => {
             directory: {
                 path: '.',
                 redirectToSlash: true,
-                index: true
-            }
-        }
+                index: true,
+            },
+        },
+    });
+
+    server.route({
+        method: 'GET',
+        path: '/{param*}',
+        handler(request, h) {
+            return h.file('awesome.png', {
+                confine: './images',
+            });
+        },
     });
 
     // https://github.com/hapijs/inert#serving-a-single-file
@@ -45,8 +52,8 @@ const provision = async () => {
         method: 'GET',
         path: '/{path*}',
         handler: {
-            file: 'page.html'
-        }
+            file: 'page.html',
+        },
     });
 
     // https://github.com/hapijs/inert#customized-file-response
@@ -60,7 +67,7 @@ const provision = async () => {
             }
 
             return reply.file(path).vary('x-magic');
-        }
+        },
     });
 
     const handler: Lifecycle.Method = (request, h) => {
@@ -81,7 +88,7 @@ const provision = async () => {
 
     const directory: inert.DirectoryHandlerRouteObject = {
         path: '',
-        listing: true
+        listing: true,
     };
 
     server.route({
@@ -97,9 +104,9 @@ const provision = async () => {
                         return [''];
                     }
                     return new Error('');
-                }
+                },
             },
         },
-        options: { files: { relativeTo: __dirname } }
+        options: { files: { relativeTo: __dirname } },
     });
 };

--- a/types/hapi__inert/index.d.ts
+++ b/types/hapi__inert/index.d.ts
@@ -6,10 +6,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import {
-    Plugin,
-    Request,
-} from '@hapi/hapi';
+import { Plugin, Request } from '@hapi/hapi';
 
 declare namespace inert {
     type RequestHandler<T> = (request: Request) => T;
@@ -19,7 +16,7 @@ declare namespace inert {
          * confine - serve file relative to this directory and returns 403 Forbidden if the path resolves outside the confine directory.
          * Defaults to true which uses the relativeTo route option as the confine. Set to false to disable this security feature.
          */
-        confine?: boolean;
+        confine?: boolean | string;
         /**
          * filename - an optional filename to specify if sending a 'Content-Disposition' header, defaults to the basename of path
          */
@@ -38,7 +35,7 @@ declare namespace inert {
         /**
          * lookupMap - an object which maps content encoding to expected file name extension. Defaults to `{ gzip: '.gz' }.
          */
-        lookupMap?: {[index: string]: string};
+        lookupMap?: { [index: string]: string };
         /**
          * etagMethod - specifies the method used to calculate the ETag header response. Available values:
          *  * 'hash' - SHA1 sum of the file contents, suitable for distributed deployments. Default value.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).



If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/inert/blob/28b4caa6a6d9dc6ad45a88966fe767cd7d2261ca/lib/index.js#L23
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.