### PR TITLE
react-date-range: Add classNames prop to CommonCalendarProps

### DIFF
--- a/types/react-date-range/index.d.ts
+++ b/types/react-date-range/index.d.ts
@@ -81,6 +81,8 @@ export interface CommonCalendarProps {
      * 'tr' - Turkish) default: none
      */
     lang?: LanguageType;
+    /** Custom class names for elements */
+    classNames?: Partial<ClassNames>;
 }
 
 export interface CalendarProps extends CommonCalendarProps {
@@ -162,3 +164,57 @@ export interface DateRangeObject {
 export const defaultRanges: {
     [measure: string]: DateRangeObject;
 };
+
+export interface ClassNames {
+    dateRangeWrapper: string;
+    calendarWrapper: string;
+    dateDisplay: string;
+    dateDisplayItem: string;
+    dateDisplayItemActive: string;
+    monthAndYearWrapper: string;
+    monthAndYearPickers: string;
+    nextPrevButton: string;
+    month: string;
+    weekDays: string;
+    weekDay: string;
+    days: string;
+    day: string;
+    dayNumber: string;
+    dayPassive: string;
+    dayToday: string;
+    dayStartOfWeek: string;
+    dayEndOfWeek: string;
+    daySelected: string;
+    dayDisabled: string;
+    dayStartOfMonth: string;
+    dayEndOfMonth: string;
+    dayWeekend: string;
+    dayStartPreview: string;
+    dayInPreview: string;
+    dayEndPreview: string;
+    dayHovered: string;
+    dayActive: string;
+    inRange: string;
+    endEdge: string;
+    startEdge: string;
+    prevButton: string;
+    nextButton: string;
+    selected: string;
+    months: string;
+    monthPicker: string;
+    yearPicker: string;
+    dateDisplayWrapper: string;
+    definedRangesWrapper: string;
+    staticRanges: string;
+    staticRange: string;
+    inputRanges: string;
+    inputRange: string;
+    inputRangeInput: string;
+    dateRangePickerWrapper: string;
+    staticRangeLabel: string;
+    staticRangeSelected: string;
+    monthName: string;
+    infiniteMonths: string;
+    monthsVertical: string;
+    monthsHorizontal: string; 
+}

--- a/types/react-date-range/index.d.ts
+++ b/types/react-date-range/index.d.ts
@@ -216,5 +216,5 @@ export interface ClassNames {
     monthName: string;
     infiniteMonths: string;
     monthsVertical: string;
-    monthsHorizontal: string; 
+    monthsHorizontal: string;
 }

--- a/types/react-date-range/index.d.ts
+++ b/types/react-date-range/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-date-range 1.0
+// Type definitions for react-date-range 1.1.3
 // Project: https://github.com/Adphorus/react-date-range/
 // Definitions by: Junbong Lee <https://github.com/Junbong>
 //                 John Demetriou <https://github.com/DevsAnon>

--- a/types/react-date-range/index.d.ts
+++ b/types/react-date-range/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-date-range 1.1.3
+// Type definitions for react-date-range 1.1
 // Project: https://github.com/Adphorus/react-date-range/
 // Definitions by: Junbong Lee <https://github.com/Junbong>
 //                 John Demetriou <https://github.com/DevsAnon>

--- a/types/react-date-range/react-date-range-tests.tsx
+++ b/types/react-date-range/react-date-range-tests.tsx
@@ -27,6 +27,9 @@ class ReactDatePicker extends React.Component<any, any> {
                         Calendar: { width: 200 },
                         PredefinedRanges: { marginLeft: 10, marginTop: 10 }
                     }}
+                    classNames={{
+                        dateDisplay: 'dateDisplayCustom'
+                    }}
                 />
             </div>
         );
@@ -61,6 +64,9 @@ class ReactDateRangePicker extends React.Component<any, any> {
                     theme={{
                         Calendar: { width: 200 },
                         PredefinedRanges: { marginLeft: 10, marginTop: 10 }
+                    }}
+                    classNames={{
+                        dateDisplay: 'dateDisplayCustom'
                     }}
                 />
             </div>


### PR DESCRIPTION
The `classNames` prop is missing and throws a type error when adding custom class names

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). -> fails on another package: `Error: Errors in typescript@4.1 for external dependencies: ../react/index.d.ts(38,22): error TS2307: Cannot find module 'csstype' or its corresponding type declarations.`

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hypeserver/react-date-range/blob/d8b46b8d80b0e6cb8c3843cf945dcf8745b6e739/src/styles.js#L1-L53
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
