### PR TITLE
Fix @xstyled/styled-components Box component type, and add hooks type for 1.19

### DIFF
--- a/types/xstyled__styled-components/index.d.ts
+++ b/types/xstyled__styled-components/index.d.ts
@@ -10,7 +10,7 @@ import _styled, {
     DefaultTheme,
     FlattenSimpleInterpolation,
 } from 'styled-components';
-import { SystemProps } from '@xstyled/system'
+import { SystemProps } from '@xstyled/system';
 export * from 'styled-components';
 
 /**
@@ -45,8 +45,7 @@ export interface DefaultBreakpoints {
     xl: any;
 }
 
-
-type BreakpointName = keyof DefaultBreakpoints
+type BreakpointName = keyof DefaultBreakpoints;
 
 type BreakpointObject<ArgType> = {
     [Key in BreakpointName]?: ArgType;

--- a/types/xstyled__styled-components/index.d.ts
+++ b/types/xstyled__styled-components/index.d.ts
@@ -13,7 +13,7 @@ import _styled, {
 } from 'styled-components';
 export * from 'styled-components';
 
-interface Breakpoints {
+export interface Breakpoints {
     xs: any;
     sm: any;
     md: any;
@@ -21,8 +21,16 @@ interface Breakpoints {
     xl: any;
 }
 
+declare module 'styled-components' {
+    interface DefaultTheme {
+        breakpoints?: Breakpoints
+    }
+}
+
+type BreakpointName = keyof Breakpoints
+
 type BreakpointObject<ArgType> = {
-    [Key in keyof Breakpoints]?: ArgType;
+    [Key in BreakpointName]?: ArgType;
 };
 
 /* Augments a type to be Type | BreakpointObject<Type>,
@@ -31,6 +39,17 @@ type BreakpointObject<ArgType> = {
 type WithBreakpointArgs<Props> = {
     [Key in keyof Props]?: Props[Key] | BreakpointObject<Props[Key]>;
 };
+
+
+export function useBreakpoints(): Breakpoints;
+
+export function useViewportWidth(): number | string;
+
+export function useBreakpoint(): BreakpointName;
+
+export function useUp(_bereakpointName: BreakpointName): boolean;
+
+export function useDown(_bereakpointName: BreakpointName): boolean;
 
 interface BoxPropsBase {
     /* See props documentation at:

--- a/types/xstyled__styled-components/index.d.ts
+++ b/types/xstyled__styled-components/index.d.ts
@@ -11,6 +11,7 @@ import _styled, {
     DefaultTheme,
     FlattenSimpleInterpolation,
 } from 'styled-components';
+import { SystemProps } from '@xstyled/system'
 export * from 'styled-components';
 
 export interface Breakpoints {
@@ -51,110 +52,7 @@ export function useUp(_bereakpointName: BreakpointName): boolean;
 
 export function useDown(_bereakpointName: BreakpointName): boolean;
 
-interface BoxPropsBase {
-    /* See props documentation at:
-     * https://www.smooth-code.com/open-source/smooth-ui/docs/box/#box-2
-     */
-    background: number | string;
-    backgroundColor: number | string;
-    backgroundImage: number | string;
-    backgroundSize: number | string;
-    backgroundPosition: number | string;
-    backgroundRepeat: number | string;
-    opacity: number | string;
-    overflow: number | string;
-    transition: number | string;
-    border: number | string;
-    borderTop: number | string;
-    borderTopColor: number | string;
-    borderRight: number | string;
-    borderRightColor: number | string;
-    borderBottom: number | string;
-    borderBottomColor: number | string;
-    borderLeft: number | string;
-    borderLeftColor: number | string;
-    borderColor: number | string;
-    borderWidth: number | string;
-    borderStyle: number | string;
-    borderRadius: number | string;
-    display: number | string;
-    alignItems: number | string;
-    alignContent: number | string;
-    justifyContent: number | string;
-    justifyItems: number | string;
-    flexWrap: number | string;
-    flexBasis: number | string;
-    flexDirection: number | string;
-    flex: number | string;
-    justifySelf: number | string;
-    alignSelf: number | string;
-    order: number | string;
-    gridGap: number | string;
-    gridColumnGap: number | string;
-    gridRowGap: number | string;
-    gridColumn: number | string;
-    gridRow: number | string;
-    gridAutoFlow: number | string;
-    gridAutoColumns: number | string;
-    gridAutoRows: number | string;
-    gridTemplateColumns: number | string;
-    gridTemplateRows: number | string;
-    gridTemplateAreas: number | string;
-    gridArea: number | string;
-    width: number | string;
-    height: number | string;
-    maxWidth: number | string;
-    maxHeight: number | string;
-    minWidth: number | string;
-    minHeight: number | string;
-    size: number | string;
-    verticalAlign: number | string;
-    position: number | string;
-    zIndex: number | string;
-    top: number | string;
-    right: number | string;
-    bottom: number | string;
-    left: number | string;
-    boxShadow: number | string;
-    textShadow: number | string;
-    margin: number | string;
-    m: number | string;
-    marginTop: number | string;
-    mt: number | string;
-    marginRight: number | string;
-    mr: number | string;
-    marginBottom: number | string;
-    mb: number | string;
-    marginLeft: number | string;
-    ml: number | string;
-    mx: number | string;
-    my: number | string;
-    padding: number | string;
-    p: number | string;
-    paddingTop: number | string;
-    pt: number | string;
-    paddingRight: number | string;
-    pr: number | string;
-    paddingBottom: number | string;
-    pb: number | string;
-    paddingLeft: number | string;
-    pl: number | string;
-    px: number | string;
-    py: number | string;
-    fontFamily: number | string;
-    fontSize: number | string;
-    lineHeight: number | string;
-    fontWeight: number | string;
-    textAlign: number | string;
-    letterSpacing: number | string;
-    color: number | string;
-    textTransform: number | string;
-    row: number | string;
-    col: number | string;
-}
-
-/* adds support for { xs: arg } and makes all props optional */
-export type BoxProps = WithBreakpointArgs<BoxPropsBase>;
+export type BoxProps = WithBreakpointArgs<SystemProps>;
 
 // TODO: If styled-components default tags are overridden,
 // these will work

--- a/types/xstyled__styled-components/index.d.ts
+++ b/types/xstyled__styled-components/index.d.ts
@@ -4,6 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
+import * as React from 'react';
 import _styled, {
     StyledComponent,
     ThemedStyledFunction,
@@ -12,6 +13,20 @@ import _styled, {
 } from 'styled-components';
 import { SystemProps } from '@xstyled/system';
 export * from 'styled-components';
+
+export interface ColorModeProviderProps {
+    children: React.ReactNode;
+    target: HTMLElement;
+    targetSelector: string;
+}
+
+export class ColorModeProvider extends React.Component<ColorModeProviderProps> {}
+
+export function useColorMode(): [string, (colorMode: string) => void];
+
+export function getColorModeInitScriptElement(): React.ReactElement;
+
+export function getColorModeInitScriptTag(options: { target: string }): string;
 
 /**
  * @xstyled/system provide default breakpoints

--- a/types/xstyled__styled-components/index.d.ts
+++ b/types/xstyled__styled-components/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @xstyled/styled-components 1.17
+// Type definitions for @xstyled/styled-components 1.19
 // Project: https://github.com/smooth-code/xstyled
 // Definitions by: Joseph Thomas <https://github.com/good-idea>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -147,7 +147,7 @@ export type BoxProps = WithBreakpointArgs<BoxPropsBase>;
 //   >
 // }
 
-export const Box: ThemedStyledFunction<'div', DefaultTheme, BoxProps>;
+export const Box: StyledComponent<'div', DefaultTheme, BoxProps>;
 
 export function breakpoints(styles: BreakpointObject<FlattenSimpleInterpolation | string>): TemplateStringsArray;
 

--- a/types/xstyled__styled-components/index.d.ts
+++ b/types/xstyled__styled-components/index.d.ts
@@ -6,7 +6,6 @@
 
 import _styled, {
     StyledComponent,
-    ThemedStyledInterface,
     ThemedStyledFunction,
     DefaultTheme,
     FlattenSimpleInterpolation,
@@ -14,7 +13,31 @@ import _styled, {
 import { SystemProps } from '@xstyled/system'
 export * from 'styled-components';
 
-export interface Breakpoints {
+/**
+ * @xstyled/system provide default breakpoints
+ *
+ * https://xstyled.dev/docs/responsive/#default-breakpoints
+ * https://github.com/smooth-code/xstyled/blob/master/packages/system/src/media.js#L4-L10
+ *
+ * see bellow tips if you customize breakpoints
+ *
+ * ```ts
+ * declare module '@xstyled/styled-components' {
+ *   interface DefaultBreakpoints {
+ *     thin: any;
+ *     fat: any;
+ *   }
+ * }
+ *
+ * declare module 'styled-components' {
+ *   interface DefaultTheme {
+ *       breakpoints?: DefaultBreakpoints
+ *   }
+ * }
+ * ```
+ */
+
+export interface DefaultBreakpoints {
     xs: any;
     sm: any;
     md: any;
@@ -22,13 +45,8 @@ export interface Breakpoints {
     xl: any;
 }
 
-declare module 'styled-components' {
-    interface DefaultTheme {
-        breakpoints?: Breakpoints
-    }
-}
 
-type BreakpointName = keyof Breakpoints
+type BreakpointName = keyof DefaultBreakpoints
 
 type BreakpointObject<ArgType> = {
     [Key in BreakpointName]?: ArgType;
@@ -41,8 +59,7 @@ type WithBreakpointArgs<Props> = {
     [Key in keyof Props]?: Props[Key] | BreakpointObject<Props[Key]>;
 };
 
-
-export function useBreakpoints(): Breakpoints;
+export function useBreakpoints(): DefaultBreakpoints;
 
 export function useViewportWidth(): number | string;
 

--- a/types/xstyled__styled-components/xstyled__styled-components-tests.tsx
+++ b/types/xstyled__styled-components/xstyled__styled-components-tests.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import styled, { css } from '@xstyled/styled-components';
+import styled, {
+    Box,
+    css,
+    useBreakpoint,
+    useBreakpoints,
+    useDown,
+    useUp,
+    useViewportWidth
+} from '@xstyled/styled-components';
 
 interface WithFoo {
     foo: boolean;
@@ -25,6 +33,34 @@ const sum = (a: number) => a * a;
 sum('b');
 
 const Main = () => {
+    const breakpoints = useBreakpoints()
+
+    const breakpoint = useBreakpoint()
+
+    // $ExpectError
+    breakpoint = 'abc'
+
+    let width = useViewportWidth()
+
+    // $ExpectError
+    width = false
+
+    let isUp = useUp('md')
+
+    // $ExpectError
+    isUp = useUp(1)
+
+    // $ExpectError
+    isUp = ''
+
+    let isDown = useDown('md')
+
+    // $ExpectError
+    isDown = useDown(1)
+
+    // $ExpectError
+    isDown = ''
+
     return (
         <>
             <WithRequiredProp foo={true} />
@@ -35,6 +71,16 @@ const Main = () => {
             // $ExpectError
             <StyledDiv mt={2} />
             <StyledDivBox mt={2} />
+            <Box
+                // $ExpectError
+                minWidth={breakpoints.thin}
+                maxWidth={breakpoints.md}
+                width={width}
+                mt={isUp ? 2 : 0}
+                mb={isDown ? 2 : 0}
+            >
+                We are on {breakpoint}
+            </Box>
         </>
     );
 };

--- a/types/xstyled__styled-components/xstyled__styled-components-tests.tsx
+++ b/types/xstyled__styled-components/xstyled__styled-components-tests.tsx
@@ -33,33 +33,33 @@ const sum = (a: number) => a * a;
 sum('b');
 
 const Main = () => {
-    const breakpoints = useBreakpoints()
+    const breakpoints = useBreakpoints();
 
-    const breakpoint = useBreakpoint()
-
-    // $ExpectError
-    breakpoint = 'abc'
-
-    let width = useViewportWidth()
+    const breakpoint = useBreakpoint();
 
     // $ExpectError
-    width = false
+    breakpoint = 'abc';
 
-    let isUp = useUp('md')
-
-    // $ExpectError
-    isUp = useUp(1)
+    let width = useViewportWidth();
 
     // $ExpectError
-    isUp = ''
+    width = false;
 
-    let isDown = useDown('md')
-
-    // $ExpectError
-    isDown = useDown(1)
+    let isUp = useUp('md');
 
     // $ExpectError
-    isDown = ''
+    isUp = useUp(1);
+
+    // $ExpectError
+    isUp = '';
+
+    let isDown = useDown('md');
+
+    // $ExpectError
+    isDown = useDown(1);
+
+    // $ExpectError
+    isDown = '';
 
     return (
         <Box

--- a/types/xstyled__styled-components/xstyled__styled-components-tests.tsx
+++ b/types/xstyled__styled-components/xstyled__styled-components-tests.tsx
@@ -6,7 +6,11 @@ import styled, {
     useBreakpoints,
     useDown,
     useUp,
-    useViewportWidth
+    useViewportWidth,
+    useColorMode,
+    ColorModeProvider,
+    getColorModeInitScriptElement,
+    getColorModeInitScriptTag
 } from '@xstyled/styled-components';
 
 interface WithFoo {
@@ -61,6 +65,13 @@ const Main = () => {
     // $ExpectError
     isDown = '';
 
+    const [colorMode, setColorMode] = useColorMode();
+
+    setColorMode(colorMode);
+
+    // $ExpectError
+    setColorMode(123);
+
     return (
         <Box
             as="main"
@@ -84,3 +95,17 @@ const Main = () => {
         </Box>
     );
 };
+
+const ColorMode = () => {
+    return (
+        <ColorModeProvider target={document.body} targetSelector="#small-react-app">
+            test
+            {getColorModeInitScriptElement()}
+        </ColorModeProvider>
+    );
+};
+
+let colorModeScriptTag = getColorModeInitScriptTag({ target: 'document.getElementById("small-react-app")' });
+
+// $ExpectError
+colorModeScriptTag = 111;

--- a/types/xstyled__styled-components/xstyled__styled-components-tests.tsx
+++ b/types/xstyled__styled-components/xstyled__styled-components-tests.tsx
@@ -62,7 +62,17 @@ const Main = () => {
     isDown = ''
 
     return (
-        <>
+        <Box
+            as="main"
+            // $ExpectError
+            minWidth={breakpoints.thin}
+            maxWidth={breakpoints.md}
+            width={width}
+            mt={isUp ? 2 : 0}
+            mb={isDown ? 2 : 0}
+        >
+            We are on {breakpoint}
+
             <WithRequiredProp foo={true} />
             <WithRequiredProp foo={false} />
             // $ExpectError
@@ -71,16 +81,6 @@ const Main = () => {
             // $ExpectError
             <StyledDiv mt={2} />
             <StyledDivBox mt={2} />
-            <Box
-                // $ExpectError
-                minWidth={breakpoints.thin}
-                maxWidth={breakpoints.md}
-                width={width}
-                mt={isUp ? 2 : 0}
-                mb={isDown ? 2 : 0}
-            >
-                We are on {breakpoint}
-            </Box>
-        </>
+        </Box>
     );
 };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

