### PR TITLE
Add type definitions for arrive.js

### DIFF
--- a/types/arrive/arrive-tests.ts
+++ b/types/arrive/arrive-tests.ts
@@ -1,0 +1,56 @@
+/// <reference types="jquery"/>
+
+document.arrive('a.foobar', function() {
+    this.getAttribute('href');
+});
+
+document.arrive('a.foobar', { fireOnAttributesModification: true, existing: true, onceOnly: true }, function() {
+    this.getAttribute('href');
+});
+
+window.arrive('a.foobar', function() {
+    this.getAttribute('href');
+});
+
+document.getElementsByClassName('foobar').arrive('.fizzbuzz', function() {
+    this.getAttribute('href');
+});
+
+$(document).arrive(".test-elem", function() {
+    const $newElem = $(this);
+});
+
+$(".container-1").arrive(".test-elem", function() {
+    const $newElem = $(this);
+});
+
+$(document).arrive(".test-elem", (newElem) => {
+    const $newElem = $(newElem);
+});
+
+document.unbindArrive();
+
+$(document).unbindArrive();
+
+$(document).unbindArrive(".test-elem");
+
+const callbackFunc = () => {
+};
+
+$(document).unbindArrive(callbackFunc);
+
+$(document).unbindArrive(".test-elem", callbackFunc);
+
+Arrive.unbindAllArrive();
+
+document.unbindLeave();
+
+$(document).unbindLeave();
+
+$(document).unbindLeave(".test-elem");
+
+$(document).unbindLeave(callbackFunc);
+
+$(document).unbindLeave(".test-elem", callbackFunc);
+
+Arrive.unbindAllLeave();

--- a/types/arrive/index.d.ts
+++ b/types/arrive/index.d.ts
@@ -1,0 +1,68 @@
+// Type definitions for arrive 2.4
+// Project: https://github.com/uzairfarooq/arrive
+// Definitions by: Vijay Pemmaraju <https://github.com/vijaypemmaraju>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// required for declare global to work
+export { };
+
+interface Options {
+    fireOnAttributesModification?: boolean;
+    onceOnly?: boolean;
+    existing?: boolean;
+}
+
+type ArriveSignature = (element: string, handlerOrOptions: ((this: Element, element: Element) => void) | Options, handler?: (this: Element, element: Element) => void) => void;
+type UnbindArriveSignature = (elementOrHandler?: string | ((this: Element, element: Element) => void), handler?: (this: Element, element: Element) => void) => void;
+type LeaveSignature = (element: string, handlerOrOptions: ((this: Element, element: Element) => void) | Options, handler?: (this: Element) => void) => void;
+type UnbindLeaveSignature = (elementOrHandler?: string | ((this: Element, element: Element) => void), handler?: (this: Element, element: Element) => void) => void;
+
+declare global {
+    // tslint:disable-next-line no-unnecessary-class
+    class Arrive {
+        static unbindAllArrive: () => void;
+        static unbindAllLeave: () => void;
+    }
+
+    interface Document {
+        arrive: ArriveSignature;
+        unbindArrive: UnbindArriveSignature;
+        leave: LeaveSignature;
+        unbindLeave: UnbindLeaveSignature;
+    }
+
+    interface JQuery {
+        arrive: ArriveSignature;
+        unbindArrive: UnbindArriveSignature;
+        leave: LeaveSignature;
+        unbindLeave: UnbindLeaveSignature;
+    }
+
+    interface Window {
+        arrive: ArriveSignature;
+        unbindArrive: UnbindArriveSignature;
+        leave: LeaveSignature;
+        unbindLeave: UnbindLeaveSignature;
+    }
+
+    interface NodeList {
+        arrive: ArriveSignature;
+        unbindArrive: UnbindArriveSignature;
+        leave: LeaveSignature;
+        unbindLeave: UnbindLeaveSignature;
+    }
+
+    interface HTMLElement {
+        arrive: ArriveSignature;
+        unbindArrive: UnbindArriveSignature;
+        leave: LeaveSignature;
+        unbindLeave: UnbindLeaveSignature;
+    }
+
+    interface HTMLCollectionBase {
+        arrive: ArriveSignature;
+        unbindArrive: UnbindArriveSignature;
+        leave: LeaveSignature;
+        unbindLeave: UnbindLeaveSignature;
+    }
+}

--- a/types/arrive/index.d.ts
+++ b/types/arrive/index.d.ts
@@ -52,7 +52,7 @@ declare global {
         unbindLeave: UnbindLeaveSignature;
     }
 
-    interface HTMLElement {
+    interface Element {
         arrive: ArriveSignature;
         unbindArrive: UnbindArriveSignature;
         leave: LeaveSignature;

--- a/types/arrive/tsconfig.json
+++ b/types/arrive/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "arrive-tests.ts"
+    ]
+}

--- a/types/arrive/tslint.json
+++ b/types/arrive/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Adds typing for [arrive](https://www.npmjs.com/package/arrive). The typing's a bit weird since the package basically hoists itself to various global objects (Document, Window, etc), but I think I was able to use the global declaration to get around that.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
