### PR TITLE
Improves type coverage for braintree-web-drop-in

### DIFF
--- a/types/braintree-web-drop-in/index.d.ts
+++ b/types/braintree-web-drop-in/index.d.ts
@@ -1,8 +1,12 @@
 // Type definitions for braintree-web-drop-in 1.22
 // Project: https://github.com/braintree/braintree-web-dropin
 // Definitions by: Saoud Rizwan <https://github.com/saoudrizwan>
+//                 Ricard Solé Casas <https://github.com/iamricard>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.3
+
+/// <reference types="googlepay" />
+/// <reference types="applepayjs" />
 
 /*
 USAGE:
@@ -13,11 +17,16 @@ Some objects, such as as the payload returned from Dropin.requestPaymentMethod, 
 https://braintree.github.io/braintree-web-drop-in/docs/current/module-braintree-web-drop-in.html
 */
 
+import { ApplePayPaymentRequest } from 'braintree-web/modules/apple-pay';
+import { HostedFieldsField } from 'braintree-web/modules/hosted-fields';
+import { ThreeDSecureVerifyPayload } from 'braintree-web/modules/three-d-secure';
+import { ButtonStyle } from 'paypal-checkout-components';
+
 // Options
 
 export interface Options {
     authorization: string;
-    container: any;
+    container: string | HTMLElement;
     locale?: string;
     translations?: object;
     paymentOptionPriority?: string[];
@@ -27,17 +36,17 @@ export interface Options {
     venmo?: venmoCreateOptions | boolean;
     applePay?: applePayCreateOptions;
     googlePay?: googlePayCreateOptions;
-    dataCollector?: dataCollectorOptions;
-    threeDSecure?: threeDSecureOptions;
+    dataCollector?: dataCollectorOptions | boolean;
+    threeDSecure?: boolean | threeDSecureOptions;
     vaultManager?: boolean;
     preselectVaultedPaymentMethod?: boolean;
 }
 
 export interface applePayCreateOptions {
-    buttonStyle?: string;
+    buttonStyle?: 'black' | 'white' | 'white-outline';
     displayName: string;
     applePaySessionVersion?: number;
-    paymentRequest: any;
+    paymentRequest: ApplePayPaymentRequest;
 }
 
 export interface cardCreateOptions {
@@ -47,7 +56,12 @@ export interface cardCreateOptions {
               required?: boolean;
           };
     overrides?: {
-        fields?: object;
+        fields?: {
+            number?: HostedFieldsField;
+            cvv?: HostedFieldsField;
+            expirationDate?: HostedFieldsField;
+            postalCode?: HostedFieldsField;
+        };
         styles?: object;
     };
     clearFieldsAfterTokenization?: boolean;
@@ -59,24 +73,26 @@ export interface cardCreateOptions {
 
 export interface dataCollectorOptions {
     kount?: boolean;
-    paypal?: boolean;
 }
 
 export interface googlePayCreateOptions {
     merchantId: string;
     googlePayVersion?: string;
-    transactionInfo: any;
-    button?: any;
+    transactionInfo: google.payments.api.TransactionInfo;
+    button?: google.payments.api.ButtonOptions;
 }
 
 export interface paypalCreateOptions {
-    flow: "checkout" | "vault";
+    flow: 'checkout' | 'vault';
     amount?: string | number;
     currency?: string;
-    buttonStyle?: string;
+    buttonStyle?: Partial<ButtonStyle>;
     commit?: boolean;
 }
 
+/**
+ * @deprecated
+ */
 export interface threeDSecureOptions {
     amount: string;
 }
@@ -88,47 +104,136 @@ export interface venmoCreateOptions {
 // Dropin
 
 export interface PaymentMethodRequestablePayload {
-    type: "CreditCard" | "PayPalAccount";
+    type: 'CreditCard' | 'PayPalAccount';
     paymentMethodIsSelected: boolean;
 }
 
 export interface PaymentOptionSelectedPayload {
-    paymentOption: "card" | "paypal" | "paypalCredit";
+    paymentOption: 'card' | 'paypal' | 'paypalCredit';
 }
 
 export interface Dropin {
     clearSelectedPaymentMethod(): void;
     isPaymentMethodRequestable(): boolean;
-    on(event: "noPaymentMethodRequestable", handler: () => void): void;
-    on(
-        event: "paymentMethodRequestable",
-        handler: (payload: PaymentMethodRequestablePayload) => void
-    ): void;
-    on(
-        event: "paymentOptionSelected",
-        handler: (payload: PaymentOptionSelectedPayload) => void
-    ): void;
-    off(event: "noPaymentMethodRequestable", handler: () => void): void;
-    off(
-        event: "paymentMethodRequestable",
-        handler: (payload: PaymentMethodRequestablePayload) => void
-    ): void;
-    off(
-        event: "paymentOptionSelected",
-        handler: (payload: PaymentOptionSelectedPayload) => void
-    ): void;
-    requestPaymentMethod(callback: (error: object | null, payload: PaymentMethodPayload | undefined) => void): void;
+    on(event: 'noPaymentMethodRequestable', handler: () => void): void;
+    on(event: 'paymentMethodRequestable', handler: (payload: PaymentMethodRequestablePayload) => void): void;
+    on(event: 'paymentOptionSelected', handler: (payload: PaymentOptionSelectedPayload) => void): void;
+    off(event: 'noPaymentMethodRequestable', handler: () => void): void;
+    off(event: 'paymentMethodRequestable', handler: (payload: PaymentMethodRequestablePayload) => void): void;
+    off(event: 'paymentOptionSelected', handler: (payload: PaymentOptionSelectedPayload) => void): void;
+    requestPaymentMethod(options: object, callback: RequestPaymentMethodCallback): void;
+    requestPaymentMethod(callback: RequestPaymentMethodCallback): void;
     requestPaymentMethod(): Promise<PaymentMethodPayload>;
     teardown(callback: (error: object | null | undefined) => void): void;
     teardown(): Promise<void>;
 }
 
-export interface PaymentMethodPayload {
+export type RequestPaymentMethodCallback = (error: object | null, payload: PaymentMethodPayload) => void;
+
+export type PaymentMethodPayload =
+    | applePayPaymentMethodPayload
+    | cardPaymentMethodPayload
+    | googlePayPaymentMethodPayload
+    | paypalPaymentMethodPayload
+    | venmoPaymentMethodPayload;
+
+export interface binData {
+    commercial: string;
+    countryOfIssuance: string;
+    debit: 'Yes' | 'No' | 'Unknown';
+    durbinRegulated: 'Yes' | 'No' | 'Unknown';
+    healthcare: 'Yes' | 'No' | 'Unknown';
+    issuingBank: string;
+    payroll: 'Yes' | 'No' | 'Unknown';
+    prepaid: 'Yes' | 'No' | 'Unknown';
+    productId: string;
+}
+
+export interface applePayPaymentMethodPayload {
     nonce: string;
-    details: object;
-    type: "CreditCard" | "PayPalAccount" | "VenmoAccount" | "AndroidPayCard" | "ApplePayCard";
-    deviceData: string | null;
-    [key: string]: any;
+    vaulted?: boolean;
+    details: {
+        cardType: string;
+        cardHolderName: string;
+        dpanLastTwo: string;
+        rawPaymentData: ApplePayJS.ApplePayPayment;
+    };
+    description: string;
+    type: 'ApplePayCard';
+    binData: binData;
+    deviceData?: string;
+}
+
+export interface cardPaymentMethodPayload {
+    nonce: string;
+    details: {
+        bin: string;
+        cardType: string;
+        expirationMonth: string;
+        expirationYear: string;
+        cardholderName: string;
+        lastFour: string;
+        lastTwo: string;
+    };
+    type: 'CreditCard';
+    binData: binData;
+    vaulted?: boolean;
+    deviceData?: string;
+    liabilityShifted?: boolean;
+    liabilityShiftPossible?: boolean;
+    threeDSecureInfo?: ThreeDSecureVerifyPayload;
+}
+
+export interface googlePayPaymentMethodPayload {
+    nonce: string;
+    details: {
+        cardType: string;
+        lastFour: string;
+        lastTwo: string;
+        isNetworkTokenized: boolean;
+        bin: string;
+        rawPaymentData: google.payments.api.PaymentData;
+    };
+    type: 'AndroidPayCard';
+    binData: binData;
+    deviceData?: string;
+}
+
+export interface Address {
+    recipientName: string;
+    line1: string;
+    line2: string;
+    city: string;
+    state: string;
+    postalCode: string;
+    countryCode: string;
+}
+
+export interface paypalPaymentMethodPayload {
+    nonce: string;
+    vaulted?: boolean;
+    details: {
+        email: string;
+        payerId: string;
+        firstName: string;
+        lastName: string;
+        countryCode?: string;
+        phone?: string;
+        shippingAddress?: Address;
+        billingAddress?: Address;
+    };
+    type: 'PayPalAccount';
+    deviceData?: string;
+}
+
+export interface venmoPaymentMethodPayload {
+    nonce: string;
+    vaulted?: boolean;
+    details: {
+        username: string;
+    };
+    type: 'VenmoAccount';
+    deviceData?: string;
 }
 
 // Methods

--- a/types/braintree-web-drop-in/test/braintree-web-drop-in-global.test.ts
+++ b/types/braintree-web-drop-in/test/braintree-web-drop-in-global.test.ts
@@ -1,4 +1,9 @@
-import { PaymentMethodRequestablePayload, PaymentOptionSelectedPayload } from "braintree-web-drop-in";
+import {
+    Dropin,
+    PaymentMethodRequestablePayload,
+    PaymentOptionSelectedPayload,
+    cardPaymentMethodPayload,
+} from 'braintree-web-drop-in';
 
 braintree.dropin.create({ authorization: "", container: "my-div" }, (error, myDropin) => {
     if (error) {
@@ -18,50 +23,61 @@ braintree.dropin.create({ authorization: "", container: "my-div" }, (error, myDr
         paymentOptionPriority: ["card", "paypal", "paypalCredit", "venmo", "applePay"],
         card: {
             cardholderName: {
-                required: false
+                required: false,
             },
             overrides: {
                 fields: {},
-                styles: {}
+                styles: {},
             },
             clearFieldsAfterTokenization: false,
             vault: {
                 allowVaultCardOverride: false,
-                vaultCard: false
-            }
+                vaultCard: false,
+            },
         },
         paypal: {
             flow: "checkout",
             amount: 1,
             currency: "USD",
-            buttonStyle: "red",
-            commit: false
+            buttonStyle: {},
+            commit: false,
         },
         paypalCredit: undefined,
         venmo: {
-            allowNewBrowserTab: false
+            allowNewBrowserTab: false,
         },
         applePay: {
-            buttonStyle: "red",
+            buttonStyle: "white-outline",
             displayName: "name",
             applePaySessionVersion: 1,
-            paymentRequest: {}
+            paymentRequest: {
+                countryCode: "US",
+                currencyCode: "USD",
+                supportedNetworks: ["visa", "masterCard"],
+                merchantCapabilities: ["supports3DS"],
+                total: { label: "Your Label", amount: "10.00" },
+            },
         },
         googlePay: {
             merchantId: "",
             googlePayVersion: "",
-            transactionInfo: {},
-            button: {}
+            transactionInfo: {
+                currencyCode: "USD",
+                totalPriceStatus: "FINAL",
+                totalPrice: "100.00",
+            },
+            button: {
+                onClick: (event) => {}
+            },
         },
         dataCollector: {
             kount: false,
-            paypal: false
         },
         threeDSecure: {
-            amount: "1"
+            amount: "1",
         },
         vaultManager: false,
-        preselectVaultedPaymentMethod: false
+        preselectVaultedPaymentMethod: false,
     });
 
     myDropin.clearSelectedPaymentMethod();
@@ -79,7 +95,7 @@ braintree.dropin.create({ authorization: "", container: "my-div" }, (error, myDr
     }
 
     myDropin.on("noPaymentMethodRequestable", onNoPaymentMethodRequestable);
-    myDropin.on('paymentMethodRequestable', onPaymentMethodRequestable);
+    myDropin.on("paymentMethodRequestable", onPaymentMethodRequestable);
     myDropin.on("paymentOptionSelected", onPaymentOptionSelected);
 
     myDropin.off("noPaymentMethodRequestable", onNoPaymentMethodRequestable);
@@ -93,11 +109,16 @@ braintree.dropin.create({ authorization: "", container: "my-div" }, (error, myDr
     });
 
     const myPayload = await myDropin.requestPaymentMethod();
+    const type: 'AndroidPayCard' | 'ApplePayCard' | 'CreditCard' | 'PayPalAccount' | 'VenmoAccount' = myPayload.type;
+    switch (myPayload.type) {
+        case 'AndroidPayCard':
+        case 'ApplePayCard':
+        case 'CreditCard':
+            const countryOfIssuance: string = myPayload.binData.countryOfIssuance;
+    }
     const details: object = myPayload.details;
-    const deviceData: string | null = myPayload.deviceData;
+    const deviceData: string | undefined = myPayload.deviceData;
     const nonce: string = myPayload.nonce;
-    const type: "CreditCard" | "PayPalAccount" | "VenmoAccount" | "AndroidPayCard" | "ApplePayCard" = myPayload.type;
-    const countryOfIssuance: string = myPayload.binData.countryOfIssuance;
 
     myDropin.teardown(error => {
         if (error) {

--- a/types/braintree-web-drop-in/test/braintree-web-drop-in-module.test.ts
+++ b/types/braintree-web-drop-in/test/braintree-web-drop-in-module.test.ts
@@ -18,50 +18,61 @@ dropin.create({ authorization: "", container: "my-div" }, (error, myDropin) => {
         paymentOptionPriority: ["card", "paypal", "paypalCredit", "venmo", "applePay"],
         card: {
             cardholderName: {
-                required: false
+                required: false,
             },
             overrides: {
                 fields: {},
-                styles: {}
+                styles: {},
             },
             clearFieldsAfterTokenization: false,
             vault: {
                 allowVaultCardOverride: false,
-                vaultCard: false
-            }
+                vaultCard: false,
+            },
         },
         paypal: {
             flow: "checkout",
             amount: 1,
             currency: "USD",
-            buttonStyle: "red",
-            commit: false
+            buttonStyle: {},
+            commit: false,
         },
         paypalCredit: undefined,
         venmo: {
-            allowNewBrowserTab: false
+            allowNewBrowserTab: false,
         },
         applePay: {
-            buttonStyle: "red",
+            buttonStyle: "white-outline",
             displayName: "name",
             applePaySessionVersion: 1,
-            paymentRequest: {}
+            paymentRequest: {
+                countryCode: "US",
+                currencyCode: "USD",
+                supportedNetworks: ["visa", "masterCard"],
+                merchantCapabilities: ["supports3DS"],
+                total: { label: "Your Label", amount: "10.00" },
+            },
         },
         googlePay: {
             merchantId: "",
             googlePayVersion: "",
-            transactionInfo: {},
-            button: {}
+            transactionInfo: {
+                currencyCode: "USD",
+                totalPriceStatus: "FINAL",
+                totalPrice: "100.00",
+            },
+            button: {
+                onClick: (event) => {}
+            },
         },
         dataCollector: {
             kount: false,
-            paypal: false
         },
         threeDSecure: {
-            amount: "1"
+            amount: "1",
         },
         vaultManager: false,
-        preselectVaultedPaymentMethod: false
+        preselectVaultedPaymentMethod: false,
     };
     const myDropin = await dropin.create(myOptions);
 
@@ -94,11 +105,16 @@ dropin.create({ authorization: "", container: "my-div" }, (error, myDropin) => {
     });
 
     const myPayload = await myDropin.requestPaymentMethod();
+    const type: 'AndroidPayCard' | 'ApplePayCard' | 'CreditCard' | 'PayPalAccount' | 'VenmoAccount' = myPayload.type;
+    switch (myPayload.type) {
+        case 'AndroidPayCard':
+        case 'ApplePayCard':
+        case 'CreditCard':
+            const countryOfIssuance: string = myPayload.binData.countryOfIssuance;
+    }
     const details: object = myPayload.details;
-    const deviceData: string | null = myPayload.deviceData;
+    const deviceData: string | undefined = myPayload.deviceData;
     const nonce: string = myPayload.nonce;
-    const type: "CreditCard" | "PayPalAccount" | "VenmoAccount" | "AndroidPayCard" | "ApplePayCard" = myPayload.type;
-    const countryOfIssuance: string = myPayload.binData.countryOfIssuance;
 
     myDropin.teardown(error => {
         if (error) {

--- a/types/braintree-web-drop-in/tsconfig.json
+++ b/types/braintree-web-drop-in/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
The braintree-web-drop-in definitions were a little bit incomplete and
also wrong in some cases. All types are available in BT's JSDoc:
https://braintree.github.io/braintree-web-drop-in/docs/current/module-braintree-web-drop-in.html#.create

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://braintree.github.io/braintree-web-drop-in/docs/current/module-braintree-web-drop-in.html#.create
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
