### PR TITLE
Let ReactTimeago accept props of intrinsic elements

### DIFF
--- a/types/react-timeago/index.d.ts
+++ b/types/react-timeago/index.d.ts
@@ -27,11 +27,11 @@ declare namespace ReactTimeago {
         nextFormatter?: Formatter
     ) => React.ReactNode;
 
-    interface ReactTimeagoProps<T extends React.ComponentType> {
+    interface ReactTimeagoProps<T extends React.ComponentType | keyof JSX.IntrinsicElements = 'time'> {
         readonly live?: boolean;
         readonly minPeriod?: number;
         readonly maxPeriod?: number;
-        readonly component?: string | T;
+        readonly component?: T;
         readonly title?: string;
         readonly formatter?: Formatter;
         readonly date: string | number | Date;
@@ -40,7 +40,7 @@ declare namespace ReactTimeago {
 }
 
 declare class ReactTimeago<
-    T extends React.ComponentType
+    T extends React.ComponentType | keyof JSX.IntrinsicElements
 > extends React.Component<
     ReactTimeago.ReactTimeagoProps<T> & React.ComponentProps<T>
 > {}

--- a/types/react-timeago/react-timeago-tests.tsx
+++ b/types/react-timeago/react-timeago-tests.tsx
@@ -28,6 +28,14 @@ const ReactTimeagoAllOptions: JSX.Element = (
     />
 );
 
+const ReactTimeagoDefaultComponentProps: JSX.Element = (
+    // Note that the default component is <time/>, which has a style prop.
+    <ReactTimeago
+        date={new Date()}
+        style={{marginTop: 42}}
+    />
+);
+
 // inspired by react-native
 class Text extends React.Component<{
     style?: Array<{}>;


### PR DESCRIPTION
The type argument `T` is the type of the inner component that the `<ReactTimeago/>` component renders. By default, it is [`<time/>`](https://github.com/nmn/react-timeago/blob/bf499d7dea062c79af76968a4d4d942e2d7b5131/src/index.js#L64), but there's the `<ReactTimeago component/>` prop that allows users to override the inner component.

The `<ReactTimeago/>` component passes all props it does not recognize through to the inner component, which is why the typings expose `React.ComponentProps<T>` as part of the outer prop types. However, this does not work for intrinsic elements as the inner component including the default `<time/>` element, because the constraint `'time' extends React.ComponentType` is not satisfied. The changes to the unit test in this commit reproduce this issue:

```
DefinitelyTyped/types/react-timeago/react-timeago-tests.tsx:36:9
ERROR: 36:9  expect  TypeScript@4.2 compile error:
No overload matches this call.
  Overload 1 of 2, '(props: ReactTimeagoProps<ComponentType<{}>> | (ReactTimeagoProps<ComponentType<{}>> & { children?: ReactNode; }) | Readonly<...> | Readonly<...>): ReactTimeago<...>', gave the following error.
    Type '{ date: Date; title: string; style: { marginTop: number; }; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<ReactTimeago<ComponentType<{}>>> & Readonly<ReactTimeagoProps<...>> & Readonly<...>) | (IntrinsicAttributes & ... 2 more ... & Readonly<...>)'.
      Property 'style' does not exist on type '(IntrinsicAttributes & IntrinsicClassAttributes<ReactTimeago<ComponentType<{}>>> & Readonly<ReactTimeagoProps<...>> & Readonly<...>) | (IntrinsicAttributes & ... 2 more ... & Readonly<...>)'.
  Overload 2 of 2, '(props: ReactTimeagoProps<ComponentType<{}>> | (ReactTimeagoProps<ComponentType<{}>> & { children?: ReactNode; }), context: any): ReactTimeago<...>', gave the following error.
    Type '{ date: Date; title: string; style: { marginTop: number; }; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<ReactTimeago<ComponentType<{}>>> & Readonly<ReactTimeagoProps<...>> & Readonly<...>) | (IntrinsicAttributes & ... 2 more ... & Readonly<...>)'.
      Property 'style' does not exist on type '(IntrinsicAttributes & IntrinsicClassAttributes<ReactTimeago<ComponentType<{}>>> & Readonly<ReactTimeagoProps<...>> & Readonly<...>) | (IntrinsicAttributes & ... 2 more ... & Readonly<...>)'.
```

The fix is to add `keyof JSX.IntrinsicElements` to the type bound for `T`, so that TypeScript can infer it correctly.
For the `ReactTimeagoProps`, the the default `T = 'time'` is added explicitly because type inference does not work when callers use the props type in isolation (before constructing the component).
This change also allows tightening the type of the `component` prop to just `T`, enforcing that it matches the exposed props. This could be a breaking change for callers who were using the component and its props inconsistently/wrongly.

---------------------------------

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test react-timeago`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint react-timeago`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nmn/react-timeago/blob/bf499d7dea062c79af76968a4d4d942e2d7b5131/src/index.js#L64
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)