### PR TITLE
update(diff): v5

### DIFF
--- a/types/diff/diff-tests.ts
+++ b/types/diff/diff-tests.ts
@@ -1,25 +1,25 @@
-import * as diff from 'diff';
+import Diff = require('diff');
 
 const one = 'beep boop';
 const other = 'beep boob blah';
 
-let changes = diff.diffChars(one, other);
+let changes = Diff.diffChars(one, other);
 examineChanges(changes);
 
 // $ExpectType void
-diff.diffChars(one, other, {
+Diff.diffChars(one, other, {
     callback: (err, value) => {
         err; // $ExpectType undefined
         value; // $ExpectType Change[] | undefined
     },
 });
 // $ExpectType void
-diff.diffChars(one, other, (err, value) => {
+Diff.diffChars(one, other, (err, value) => {
     err; // $ExpectType undefined
     value; // $ExpectType Change[] | undefined
 });
 
-const diffArraysResult = diff.diffArrays(['a', 'b', 'c'], ['a', 'c', 'd']);
+const diffArraysResult = Diff.diffArrays(['a', 'b', 'c'], ['a', 'c', 'd']);
 diffArraysResult.forEach(result => {
     result.added; // $ExpectType boolean | undefined
     result.removed; // $ExpectType boolean | undefined
@@ -34,12 +34,12 @@ const a: DiffObj = { value: 0 };
 const b: DiffObj = { value: 1 };
 const c: DiffObj = { value: 2 };
 const d: DiffObj = { value: 3 };
-const arrayOptions: diff.ArrayOptions<DiffObj, DiffObj> = {
+const arrayOptions: Diff.ArrayOptions<DiffObj, DiffObj> = {
     comparator: (left, right) => {
         return left.value === right.value;
     },
 };
-const arrayChanges = diff.diffArrays([a, b, c], [a, b, d], arrayOptions);
+const arrayChanges = Diff.diffArrays([a, b, c], [a, b, d], arrayOptions);
 arrayChanges.forEach(result => {
     result.added; // $ExpectType boolean | undefined
     result.removed; // $ExpectType boolean | undefined
@@ -49,7 +49,7 @@ arrayChanges.forEach(result => {
 
 // --------------------------
 
-class LineDiffWithoutWhitespace extends diff.Diff {
+class LineDiffWithoutWhitespace extends Diff.Diff {
     tokenize(value: string): any {
         return value.split(/^/m);
     }
@@ -63,7 +63,7 @@ const obj = new LineDiffWithoutWhitespace();
 changes = obj.diff(one, other);
 examineChanges(changes);
 
-function examineChanges(diff: diff.Change[]) {
+function examineChanges(diff: Diff.Change[]) {
     diff.forEach(part => {
         part.added; // $ExpectType boolean | undefined
         part.removed; // $ExpectType boolean | undefined
@@ -72,9 +72,9 @@ function examineChanges(diff: diff.Change[]) {
     });
 }
 
-function verifyPatchMethods(oldStr: string, newStr: string, uniDiff: diff.ParsedDiff) {
-    const verifyPatch = diff.parsePatch(
-        diff.createTwoFilesPatch('oldFile.ts', 'newFile.ts', oldStr, newStr, 'old', 'new', {
+function verifyPatchMethods(oldStr: string, newStr: string, uniDiff: Diff.ParsedDiff) {
+    const verifyPatch = Diff.parsePatch(
+        Diff.createTwoFilesPatch('oldFile.ts', 'newFile.ts', oldStr, newStr, 'old', 'new', {
             context: 1,
         })
     );
@@ -87,9 +87,9 @@ function verifyPatchMethods(oldStr: string, newStr: string, uniDiff: diff.Parsed
     }
 }
 function verifyApplyMethods(oldStr: string, newStr: string, uniDiffStr: string) {
-    const uniDiff = diff.parsePatch(uniDiffStr)[0];
-    const verifyApply = [diff.applyPatch(oldStr, uniDiff), diff.applyPatch(oldStr, [uniDiff])];
-    const options: diff.ApplyPatchesOptions = {
+    const uniDiff = Diff.parsePatch(uniDiffStr)[0];
+    const verifyApply = [Diff.applyPatch(oldStr, uniDiff), Diff.applyPatch(oldStr, [uniDiff])];
+    const options: Diff.ApplyPatchesOptions = {
         loadFile(index, callback) {
             index; // $ExpectType ParsedDiff
             callback(undefined, one);
@@ -117,14 +117,14 @@ function verifyApplyMethods(oldStr: string, newStr: string, uniDiffStr: string) 
         },
         fuzzFactor: 0
     };
-    diff.applyPatches([uniDiff], options);
-    diff.applyPatches(uniDiffStr, options);
+    Diff.applyPatches([uniDiff], options);
+    Diff.applyPatches(uniDiffStr, options);
 }
 
-const uniDiffPatch = diff.structuredPatch('oldFile.ts', 'newFile.ts', one, other, 'old', 'new', {
+const uniDiffPatch = Diff.structuredPatch('oldFile.ts', 'newFile.ts', one, other, 'old', 'new', {
     context: 1,
 });
 verifyPatchMethods(one, other, uniDiffPatch);
 
-const uniDiffStr = diff.createPatch('file.ts', one, other, 'old', 'new', { context: 1 });
+const uniDiffStr = Diff.createPatch('file.ts', one, other, 'old', 'new', { context: 1 });
 verifyApplyMethods(one, other, uniDiffStr);

--- a/types/diff/index.d.ts
+++ b/types/diff/index.d.ts
@@ -1,11 +1,11 @@
-// Type definitions for diff 4.0
+// Type definitions for diff 5.0
 // Project: https://github.com/kpdecker/jsdiff
 // Definitions by: vvakame <https://github.com/vvakame>
 //                 szdc <https://github.com/szdc>
 //                 moc-yuto <https://github.com/moc-yuto>
 //                 BendingBender <https://github.com/BendingBender>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
 
 export as namespace Diff;
 


### PR DESCRIPTION
- so the v5 is breaking and DT package should reflect this, so version
  is bumped up. In the v4 in DT the UMD global export was already
  correct (Diff), which means the v5/v4 DT api has the same shape, no
  actual changes to definition
https://github.com/kpdecker/jsdiff/compare/v4.0.2...v5.0.0
[`v4.0.2...v5.0.0`#diff-82200ce47f](https://github.com/kpdecker/jsdiff/compare/v4.0.2...v5.0.0#diff-82200ce47fa528129da57d8979b63119ebdc262e3d07cb7882fdb8d1ecdf4a00R9)
- tests updated to use original package naming conventions: `Diff` is a
  module, a `diff` is the outcome of calling the module methods
- maintainer added

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.