### PR TITLE
jest-environment-puppeteer - delete duplicate [review needed]

### DIFF
--- a/types/jest-environment-puppeteer/index.d.ts
+++ b/types/jest-environment-puppeteer/index.d.ts
@@ -60,7 +60,6 @@ declare class PuppeteerEnvironment extends NodeEnvironment {
 }
 
 declare global {
-    const browser: Browser;
     const context: BrowserContext;
     const page: Page;
     const jestPuppeteer: JestPuppeteer;


### PR DESCRIPTION
Currently, I get errors when I try to build a project which contains these type definitions, and this is the error:

```console
../../node_modules/@types/jest-environment-puppeteer/index.d.ts:63:11 - error TS2649: Cannot augment module 'browser' with value exports because it resolves to a non-module entity.

63     const browser: Browser;
             ~~~~~~~


Found 1 error.
```

```console
Cannot augment module 'browser' with value exports because it resolves to a non-module entity.ts(2649)
```

since the same thing (or not equivalent but similar) is defined a few lines above:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/92e6989c95b472a732176f7e8997c7655d6f8b27/types/jest-environment-puppeteer/index.d.ts#L50-L55

---

version: `4.4.0`

I don't know if this is the correct fix! Please correct if needed
