### PR TITLE
Add new useUniqueDomain option to doubleclick-gpt

### DIFF
--- a/types/doubleclick-gpt/doubleclick-gpt-tests.ts
+++ b/types/doubleclick-gpt/doubleclick-gpt-tests.ts
@@ -223,7 +223,8 @@ googletag.pubads().setForceSafeFrame(true);
 let pageConfig = {
     allowOverlayExpansion: true,
     allowPushExpansion: true,
-    sandbox: true
+    sandbox: true,
+    useUniqueDomain: true
 };
 
 let slotConfig = {allowOverlayExpansion: false};

--- a/types/doubleclick-gpt/index.d.ts
+++ b/types/doubleclick-gpt/index.d.ts
@@ -78,7 +78,7 @@ declare namespace googletag {
         allowOverlayExpansion?: boolean;
         allowPushExpansion?: boolean;
         sandbox?: boolean;
-        useUniqueDomain?: boolean;
+        useUniqueDomain?: boolean | null;
     }
 
     interface Googletag {

--- a/types/doubleclick-gpt/index.d.ts
+++ b/types/doubleclick-gpt/index.d.ts
@@ -78,6 +78,7 @@ declare namespace googletag {
         allowOverlayExpansion?: boolean;
         allowPushExpansion?: boolean;
         sandbox?: boolean;
+        useUniqueDomain?: boolean;
     }
 
     interface Googletag {


### PR DESCRIPTION
Google recently added a new option, useUniqueDomain, to the SafeFrameConfig interface.
https://developers.google.com/publisher-tag/reference#boolean-useuniquedomain

Please fill in this template.

- [X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [X ] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
