### PR TITLE
React-Big-Scheduler: Fix Scheduler component export syntax

### DIFF
--- a/types/react-big-scheduler/index.d.ts
+++ b/types/react-big-scheduler/index.d.ts
@@ -7,7 +7,7 @@
 import * as React from "react";
 import * as moment from "moment";
 
-export class Scheduler extends React.Component<SchedulerProps, any> { }
+export default class Scheduler extends React.Component<SchedulerProps, any> { }
 
 export interface SchedulerProps {
     schedulerData: SchedulerData;


### PR DESCRIPTION
Ran `npm run lint react-big-scheduler`, no error messages:
![Screenshot 2020-11-12 at 20 26 16](https://user-images.githubusercontent.com/20384291/99012753-66952480-2525-11eb-901e-decf3ca6dd57.png)

Original repository here: https://github.com/StephenChou1017/react-big-scheduler

Relevant LOC: https://github.com/StephenChou1017/react-big-scheduler/blob/76796959de2f86303f9d036c28562203d442267b/src/index.js#L488

In the original repository, the class component `Scheduler` has been exported as a default member - currently, the type definition here has it exported as a named component. This is creating the following error at runtime in React:

```
react-dom.development.js?7b7e:55 Uncaught Invariant Violation: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
```

For future reference/travellers, assuming this PR is merged, that in order to import the `Scheduler` component, the default import syntax will be used: (`import Scheduler from "react-big-scheduler"`)