### PR TITLE
clean-css: Fix output sourceMap type

### DIFF
--- a/types/clean-css/clean-css-tests.ts
+++ b/types/clean-css/clean-css-tests.ts
@@ -19,9 +19,10 @@ new CleanCSS({ sourceMap: true, rebaseTo: pathToOutputDirectory })
     // see https://github.com/mozilla/source-map/#sourcemapgenerator for more details
     // see https://github.com/jakubpawlowicz/clean-css/blob/master/bin/cleancss#L114 on how it's used in clean-css' CLI
     console.log(minified.sourceMap);
+    minified.sourceMap.setSourceContent("bar.css", "");
 });
 
-const inputSourceMapAsString = 'input';
+const inputSourceMapAsString = '{"version":3,"sources":["foo.css"],"names":[],"mappings":"AAAA"}';
 new CleanCSS({ sourceMap: true, rebaseTo: pathToOutputDirectory })
   .minify(source, inputSourceMapAsString, (error: any, minified: CleanCSS.Output): void => {
     // access minified.sourceMap to access SourceMapGenerator object
@@ -32,12 +33,12 @@ new CleanCSS({ sourceMap: true, rebaseTo: pathToOutputDirectory })
 
 new CleanCSS({ sourceMap: true, rebaseTo: pathToOutputDirectory }).minify({
   'path/to/source/1': {
-    styles: '...styles...',
-    sourceMap: '...source-map...'
+    styles: source,
+    sourceMap: inputSourceMapAsString
   },
   'path/to/source/2': {
-    styles: '...styles...',
-    sourceMap: '...source-map...'
+    styles: source,
+    sourceMap: inputSourceMapAsString
   }
 }, (error: any, minified: CleanCSS.Output): void => {
   // access minified.sourceMap as above

--- a/types/clean-css/index.d.ts
+++ b/types/clean-css/index.d.ts
@@ -8,6 +8,8 @@
 import { RequestOptions as HttpsRequestOptions } from "https";
 import { RequestOptions as HttpRequestOptions } from "http";
 
+import { SourceMapGenerator } from "source-map";
+
 /**
  * Shared options passed when initializing a new instance of CleanCSS that returns either a promise or output
  */
@@ -92,7 +94,7 @@ declare namespace CleanCSS {
         /**
          * Output source map if requested with `sourceMap` option
          */
-        sourceMap: string;
+        sourceMap: SourceMapGenerator;
 
         /**
          * A list of errors raised

--- a/types/clean-css/package.json
+++ b/types/clean-css/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "source-map": "^0.6.0"
+  }
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jakubpawlowicz/clean-css#how-to-work-with-source-maps
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
