### PR TITLE
copy-webpack-plugin Change absolute reference of webpack types to relative path reference

### DIFF
--- a/types/copy-webpack-plugin/index.d.ts
+++ b/types/copy-webpack-plugin/index.d.ts
@@ -4,7 +4,7 @@
 //                 avin-kavish  <https://github.com/avin-kavish>
 //                 Piotr Błażejewicz  <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-import { Plugin } from 'webpack';
+import { Plugin } from '../webpack';
 
 interface ObjectPattern {
     /**


### PR DESCRIPTION
Change absolute reference of webpack types to relative path reference

Fix for _Module '"../../webpack/types"' has no exported member 'Plugin'_ #49528