### PR TITLE
[mongoose] add missing option "optimisticConcurrency" to interface SchemaOptions

### DIFF
--- a/types/mongoose/v4/index.d.ts
+++ b/types/mongoose/v4/index.d.ts
@@ -853,6 +853,12 @@ declare module "mongoose" {
      * assigned is Date.
      */
     timestamps?: any;
+    /**
+     * Defaults to false. Provides optimistic
+     * concurrency support for `save()`. `versionKey`
+     * must be set if this is true.
+     */
+    optimisticConcurrency?: boolean;
   }
 
   /*

--- a/types/mongoose/v4/mongoose-tests.ts
+++ b/types/mongoose/v4/mongoose-tests.ts
@@ -373,6 +373,7 @@ new mongoose.Schema({ name: { type: String, validate: [
   { validator: () => {return true}, msg: 'uh oh' },
   { validator: () => {return true}, msg: 'failed' }
 ]}});
+new mongoose.Schema({ status: String, photos: [String] }, { optimisticConcurrency: true });
 animalSchema.statics.findByName = function(name: any, cb: any) {
   return this.find({ name: new RegExp(name, 'i') }, cb);
 };


### PR DESCRIPTION
Mongoose 5.10 added support for the `optimisticConcurrency` option in SchemaOptions.
- [Reference documentation](https://mongoosejs.com/docs/guide.html#optimisticConcurrency)
- This was added in [v5.10.0 / 2020-08-14](https://github.com/Automattic/mongoose/blob/master/History.md#5100--2020-08-14) so version header was not updated (currently 5.10.9)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [here](https://github.com/Automattic/mongoose/blob/master/History.md#5100--2020-08-14)
- [ ] *N/A* If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] *N/A* If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
