### PR TITLE
fix(express-mysql-session): Update MySQLStoreClass to inherit expressSession.Store

### DIFF
--- a/types/express-mysql-session/express-mysql-session-tests.ts
+++ b/types/express-mysql-session/express-mysql-session-tests.ts
@@ -21,3 +21,9 @@ const sessionStore = new MySQLStore(options);
 sessionStore.close();
 sessionStore.get('my-session-id', (error, session) => {});
 sessionStore.all();
+sessionStore.load('my-session-id', (error, session) => {});
+sessionStore.on('connect', () => {});
+session({
+    secret: 'secret',
+    store: sessionStore,
+});

--- a/types/express-mysql-session/index.d.ts
+++ b/types/express-mysql-session/index.d.ts
@@ -37,7 +37,7 @@ declare namespace MySQLStore {
     type MySQLStore = MySQLStoreClass;
 }
 
-declare class MySQLStoreClass {
+declare class MySQLStoreClass extends expressSession.Store {
     constructor(options: MySQLStore.Options, connection?: any, callback?: (error: any) => void);
 
     setDefaultOptions(): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46576
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

### Description

With
- @types/express-session@^1.17.1 
- @types/express-mysql-session@2.1.1

`ts` raises an error below.

![Screen Shot 2020-11-13 at 23 49 03](https://user-images.githubusercontent.com/44729662/99084850-d204f200-260a-11eb-92ab-7bb009cdf316.png)

![Screen Shot 2020-11-13 at 23 34 10](https://user-images.githubusercontent.com/44729662/99083348-c3b5d680-2608-11eb-84ce-ca8ec2993dad.png)

The changes in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46576 bring this error.
(I think https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46576 includes some breaking changes...)

#### The error occurs because...

in @types/express-session@^1.17.1, the type of `SessionOptions.store` is `Store` (`Store | MemoryStore` previously).

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/4d59767cffd1823798e0a4ef53465af5ec373c86/types/express-session/index.d.ts#L81-L85

and the current type definition of `MySQLStoreClass` is missing some properties in `Store`.

This PR corrects this situation.

In javascript implementation, `MySQLStore`(, which corresponds to `MySQLStoreClass` in Typescript) actually inherits `Store`.

https://github.com/chill117/express-mysql-session/blob/77bbeb67254e6143914ba9f35a5cdf55790d5344/index.js#L59