### PR TITLE
Babel plugin macros param config

### DIFF
--- a/types/babel-plugin-macros/babel-plugin-macros-tests.ts
+++ b/types/babel-plugin-macros/babel-plugin-macros-tests.ts
@@ -1,14 +1,18 @@
 import { createMacro, MacroError, References, Options, MacroParams, MacroHandler } from 'babel-plugin-macros';
 
 const macro = createMacro(
-    ({ references, state, babel }) => {
+    ({ references, state, babel,config }) => {
         Object.keys(references).forEach(() => {});
         references.default.forEach(() => {});
         state.abc = 123;
         babel.parse("console.log('Hello world!')");
+        if (config) {
+            config.xyz = 7;
+        }
+
         throw new MacroError('testing');
     },
     { configName: 'test' },
 );
 
-macro() === 'Hello world!';
+macro() === 'Hello world!';q

--- a/types/babel-plugin-macros/babel-plugin-macros-tests.ts
+++ b/types/babel-plugin-macros/babel-plugin-macros-tests.ts
@@ -15,4 +15,4 @@ const macro = createMacro(
     { configName: 'test' },
 );
 
-macro() === 'Hello world!';q
+macro() === 'Hello world!';

--- a/types/babel-plugin-macros/babel-plugin-macros-tests.ts
+++ b/types/babel-plugin-macros/babel-plugin-macros-tests.ts
@@ -1,7 +1,7 @@
 import { createMacro, MacroError, References, Options, MacroParams, MacroHandler } from 'babel-plugin-macros';
 
 const macro = createMacro(
-    ({ references, state, babel,config }) => {
+    ({ references, state, babel, config }) => {
         Object.keys(references).forEach(() => {});
         references.default.forEach(() => {});
         state.abc = 123;

--- a/types/babel-plugin-macros/index.d.ts
+++ b/types/babel-plugin-macros/index.d.ts
@@ -23,6 +23,7 @@ declare namespace babelPluginMacros {
         references: { default: Babel.NodePath[] } & References;
         state: Babel.PluginPass;
         babel: typeof Babel;
+        config?: {[key: string]: any};
     }
 
     type MacroHandler = (params: MacroParams) => void;

--- a/types/babel-plugin-macros/index.d.ts
+++ b/types/babel-plugin-macros/index.d.ts
@@ -23,7 +23,7 @@ declare namespace babelPluginMacros {
         references: { default: Babel.NodePath[] } & References;
         state: Babel.PluginPass;
         babel: typeof Babel;
-        config?: {[key: string]: any};
+        config?: { [key: string]: any };
     }
 
     type MacroHandler = (params: MacroParams) => void;


### PR DESCRIPTION
Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
I run test in a different local project.
I could not run "npm test YOUR_PACKAGE_NAME" because "sh: dtslint: command not found".
Because of this I run npm install and got the following errors "
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: definitely-typed@0.0.3
npm ERR! Found: typescript@4.2.0-dev.20201113
npm ERR! node_modules/typescript
npm ERR!   dev typescript@"next" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer typescript@">= 3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.7.0-dev || >= 3.8.0-dev || >= 3.9.0-dev || >= 4.0.0-dev" from dtslint@4.0.5
npm ERR! node_modules/dtslint
npm ERR!   dev dtslint@"latest" from the root project
npm ERR!   peer dtslint@"*" from @definitelytyped/dtslint-runner@0.0.60
npm ERR!   node_modules/@definitelytyped/dtslint-runner
npm ERR!     dev @definitelytyped/dtslint-runner@"latest" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
"
 
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
Could not install the dependencies. See above: Add or edit tests to reflect the change

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/author.md#config
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
