### PR TITLE
[@types/atom] Fix: make keyname for config get-methods optional

### DIFF
--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -348,6 +348,7 @@ function testConfig() {
     atom.config.onDidChange("test", (event) => { event.oldValue; });
 
     // Managing Settings
+    atom.config.get();
     atom.config.get("test");
     atom.config.get("test", { scope: scopeDescriptor });
     atom.config.get("test", { excludeSources: ["test.source"] });
@@ -369,6 +370,7 @@ function testConfig() {
     for (const { scopeDescriptor, value } of allConfigValues) {
         scopes = scopeDescriptor.getScopesArray();
     }
+    atom.config.getAll();
     atom.config.getAll("test", { scope: scopeDescriptor });
     atom.config.getAll("test", { excludeSources: ["test"] });
     atom.config.getAll("test", { sources: ["test"] });

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -441,7 +441,7 @@ export interface Config {
 
     // Managing Settings
     /** Retrieves the setting for the given key. */
-    get<T extends keyof ConfigValues>(keyPath: T, options?: { sources?: string[],
+    get<T extends keyof ConfigValues>(keyPath?: T, options?: { sources?: string[],
         excludeSources?: string[], scope?: string[]|ScopeDescriptor }):
         ConfigValues[T];
 
@@ -459,7 +459,7 @@ export interface Config {
      *  Get all of the values for the given key-path, along with their associated
      *  scope selector.
      */
-    getAll<T extends keyof ConfigValues>(keyPath: T, options?: { sources?: string[],
+    getAll<T extends keyof ConfigValues>(keyPath?: T, options?: { sources?: string[],
         excludeSources?: string[], scope?: ScopeDescriptor }):
         Array<{ scopeDescriptor: ScopeDescriptor, value: ConfigValues[T] }>;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

I've created this PR in the knowledge that the tests are failing, hoping that we can find the cause for this.

```sh
1> Error: /Users/jan/Desktop/DefinitelyTyped/types/atom/atom-tests.ts:2440:53
1> ERROR: 2442:53  expect  TypeScript@4.2 compile error: 
1> This condition will always return true since the function is always defined. Did you mean to call it instead?
```

It is my understanding, that the error isn't within the scope of my change, since line 2442 (that's line 2440 before the change) is for the `editor.onWillInsertText()` method.

As for the change itself: Neither the documentation for [`get()`](https://flight-manual.atom.io/api/v1.53.0/Config/#instance-get) nor for [`getAll()`](https://flight-manual.atom.io/api/v1.53.0/Config/#instance-getAll) mentions the `keyPath` argument as optional. However, in both cases, an array containing *all* config settings is loaded, opposed to the configuration for a single package when `keyPath` is defined.
**Screenshots**

These screenshots were taken in the Atom developer tools (which are basically the same as the Chrome developer tools). Atom's entire API is exposed on the window, so it can be run directly in the console.

1. Run `getAll()` for the `core` package

![image](https://user-images.githubusercontent.com/1504938/99107637-71fc5480-25e6-11eb-9604-fb1cb640b215.png)

2. Run `getAll()` without specifying a package

![image](https://user-images.githubusercontent.com/1504938/99107827-bd166780-25e6-11eb-808f-320645777576.png)

Note that the properties for the `core` package are included

3. Run `get()` for the `core` package

![image](https://user-images.githubusercontent.com/1504938/99107968-edf69c80-25e6-11eb-9d7d-d894137b3d93.png)

4. Run `getAll()` without specifying a package

![image](https://user-images.githubusercontent.com/1504938/99107985-f2bb5080-25e6-11eb-8ad2-296c3cb8f2e6.png)

I hope we can sort out the error to get this change merged.