### PR TITLE
[post-robot] Fix typo in timeout type

### DIFF
--- a/types/post-robot/index.d.ts
+++ b/types/post-robot/index.d.ts
@@ -41,7 +41,7 @@ export function once(
 interface RegularRequestOptionsType {
     domain?: DomainMatcher;
     fireAndForget?: false;
-    timout?: number;
+    timeout?: number;
 }
 
 interface ResponseMessageEvent {
@@ -53,7 +53,7 @@ interface ResponseMessageEvent {
 interface FireAndForgetRequestOptionsType {
     domain?: DomainMatcher;
     fireAndForget?: true;
-    timout?: number;
+    timeout?: number;
 }
 
 // based on https://github.com/post-robot/src/public/send.js


### PR DESCRIPTION
Fixed the typo `timout` to `timeout`. You can see the correct name [in this documentation](https://github.com/krakenjs/post-robot/#set-a-timeout-for-a-response).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/krakenjs/post-robot/#set-a-timeout-for-a-response
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.