### PR TITLE
feat(@types/gulp-sourcemaps): updated modules typings

### DIFF
--- a/types/gulp-sourcemaps/gulp-sourcemaps-tests.ts
+++ b/types/gulp-sourcemaps/gulp-sourcemaps-tests.ts
@@ -1,5 +1,6 @@
-import gulp = require("gulp");
-import sourcemaps = require("gulp-sourcemaps");
+import gulp = require('gulp');
+import sourcemaps = require('gulp-sourcemaps');
+import File = require('vinyl');
 
 function plugin1(): NodeJS.ReadWriteStream { return null; }
 function plugin2(): NodeJS.ReadWriteStream { return null; }
@@ -68,6 +69,54 @@ gulp.task('javascript', function() {
             sourceRoot: function(file) {
                 return '/src';
             }
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('javascript', function() {
+    var stream = gulp.src('src/**/*.js')
+        .pipe(sourcemaps.init())
+        .pipe(plugin1())
+        .pipe(plugin2())
+        .pipe(sourcemaps.write({
+            destPath: "../maps"
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('javascript', function() {
+    var stream = gulp.src('src/**/*.js')
+        .pipe(sourcemaps.init())
+        .pipe(plugin1())
+        .pipe(plugin2())
+        .pipe(sourcemaps.write({
+            sourceMappingURL: function(file: File): string {
+                return `${file.basename}.map`;
+            }
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('javascript', function() {
+    var stream = gulp.src('src/**/*.js')
+        .pipe(sourcemaps.init())
+        .pipe(plugin1())
+        .pipe(plugin2())
+        .pipe(sourcemaps.write({
+            mapFile: function(mapFilePath: string): string {
+                return mapFilePath.replace('.js.map', '.map');
+            }
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+gulp.task('javascript', function() {
+    var stream = gulp.src('src/**/*.js')
+        .pipe(sourcemaps.init())
+        .pipe(plugin1())
+        .pipe(plugin2())
+        .pipe(sourcemaps.write({
+            charset: "utf-8"
         }))
         .pipe(gulp.dest('dist'));
 });

--- a/types/gulp-sourcemaps/index.d.ts
+++ b/types/gulp-sourcemaps/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for gulp-sourcemaps
 // Project: https://github.com/gulp-sourcemaps/gulp-sourcemaps
-// Definitions by: Asana <https://asana.com>
+// Definitions by: Phips Peter <https://github.com/pspeter3>
 //                 Concision <https://github.com/concision>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/gulp-sourcemaps/index.d.ts
+++ b/types/gulp-sourcemaps/index.d.ts
@@ -1,10 +1,12 @@
 // Type definitions for gulp-sourcemaps
-// Project: https://github.com/floridoo/gulp-sourcemaps
+// Project: https://github.com/gulp-sourcemaps/gulp-sourcemaps
 // Definitions by: Asana <https://asana.com>
+//                 Concision <https://github.com/concision>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node"/>
 
+import File = require("vinyl");
 
 interface InitOptions {
     loadMaps?: boolean;
@@ -13,6 +15,14 @@ interface InitOptions {
 
 interface WriteMapper {
     (file: string): string;
+}
+
+interface SourceUrlMapper {
+    (file: File): string;
+}
+
+interface MapFilenameMapper {
+    (mapFilePath: string): string;
 }
 
 interface CloneOptions {
@@ -25,6 +35,10 @@ interface WriteOptions {
     includeContent?: boolean;
     sourceRoot?: string | WriteMapper;
     sourceMappingURLPrefix?: string | WriteMapper;
+    sourceMappingURL?: SourceUrlMapper;
+    destPath?: string;
+    mapFile?: MapFilenameMapper;
+    charset?: BufferEncoding;
     clone?: boolean | CloneOptions;
 }
 


### PR DESCRIPTION
# Template

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint gulp-sourcemaps` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gulp-sourcemaps/gulp-sourcemaps#write-options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

# Description
Several typings for `WriteOptions` are currently missing, which are documented on the [gulp-sourcemaps/gulp-sourcemaps](https://github.com/gulp-sourcemaps/gulp-sourcemaps#write-options) repository. This PR adds all non-deprecated documented properties for `WriteOptions`.