### PR TITLE
nodemailer-html-to-text: remove redundant tests

### DIFF
--- a/types/nodemailer-html-to-text/nodemailer-html-to-text-tests.ts
+++ b/types/nodemailer-html-to-text/nodemailer-html-to-text-tests.ts
@@ -1,4 +1,3 @@
-import * as formatters from 'html-to-text/lib/formatter';
 import * as nodemailer from 'nodemailer';
 import { htmlToText } from 'nodemailer-html-to-text';
 import { HtmlToTextOptions } from 'html-to-text';
@@ -17,14 +16,6 @@ function plugin_with_options_test() {
         tables: true,
         hideLinkHrefIfSameAsText: true,
         ignoreImage: true,
-        format: {
-            text: (el, options) => {
-                return formatters.text(el, options);
-            },
-            table: (el, walk, options) => {
-                return formatters.table(el, walk, options);
-            },
-        },
     };
 
     transporter.use('compile', htmlToText(options));


### PR DESCRIPTION
The formatter tests are included in the html-to-text tests so they are not needed here.  `html-to-text` v6 introduced breaking changes to the formatter api so these tests will fail.

**Note: this is only a change to the tests.**

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: PR #49531 CI tests are failing on this package
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
