### PR TITLE
[@types/mongoose] add strongly typed asyncIterator to DocumentQuery

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -804,6 +804,8 @@ declare module "mongoose" {
    *   expose its interface to enable type-checking.
    */
   class QueryCursor<T extends Document> extends stream.Readable {
+    [Symbol.asyncIterator](): AsyncIterableIterator<T>;
+
     /**
      * A QueryCursor is a concurrency primitive for processing query results
      * one document at a time. A QueryCursor fulfills the Node.js streams3 API,

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -1961,6 +1961,8 @@ declare module "mongoose" {
    */
   class Query<T> extends DocumentQuery<T, any> { }
   class DocumentQuery<T, DocType extends Document, QueryHelpers = {}> extends mquery {
+    [Symbol.asyncIterator](): AsyncIterableIterator<DocType>;
+
     /**
      * Specifies a javascript function or expression to pass to MongoDBs query system.
      * Only use $where when you have a condition that cannot be met using other MongoDB

--- a/types/mongoose/test/model.ts
+++ b/types/mongoose/test/model.ts
@@ -104,6 +104,11 @@ MongoModel.find({ name: 'john', age: { $gte: 18 }}, function (err, docs) {
     docs[0].remove();
     docs[1].execPopulate();
 });
+async () => {
+    for await (const item of MongoModel.find({})) {
+        item.model;
+    }
+};
 MongoModel.find({ name: /john/i }, 'name friends', function (err, docs) { })
 MongoModel.find({ name: /john/i }, null, { skip: 10 })
 MongoModel.find({ name: /john/i }, null, { skip: 10 }, function (err, docs) {});

--- a/types/mongoose/tslint.json
+++ b/types/mongoose/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         "array-type": false,
         "arrow-return-shorthand": false,
+        "await-promise": false,
         "ban-types": false,
         "comment-format": false,
         "dt-header": false,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://mongoosejs.com/docs/api/querycursor.html#query_Query-Symbol.asyncIterator
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

Also, it fixes #49494