### PR TITLE
Update reflexbox for emotion 11

### DIFF
--- a/types/reflexbox/index.d.ts
+++ b/types/reflexbox/index.d.ts
@@ -8,12 +8,11 @@
 //                 Erin Noe-Payne <https://github.com/autoric>
 //                 akameco <https://github.com/akameco>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// TypeScript Version: 3.5
 
 import * as React from 'react';
 import * as StyledSystem from 'styled-system';
 import { StyledComponent } from '@emotion/styled/types/index';
-import { Omit } from '@emotion/styled-base/types/helper';
 
 export interface BoxProps
     extends StyledSystem.SpaceProps,
@@ -26,8 +25,7 @@ export interface BoxProps
 
 export type BoxType = StyledComponent<
     JSX.IntrinsicElements['div'],
-    Omit<JSX.IntrinsicElements['div'] & BoxProps, keyof React.ClassAttributes<any>>,
-    {}
+    Omit<JSX.IntrinsicElements['div'] & BoxProps, keyof React.ClassAttributes<any>>
 >;
 
 export const Box: BoxType;

--- a/types/reflexbox/package.json
+++ b/types/reflexbox/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@emotion/styled": "*"
+        "@emotion/styled": "*",
+        "@emotion/react": "*"
     }
 }


### PR DESCRIPTION
1. @emotion/react is now a peer dependency of @emotion/styled, so needs to be added to package.json.
2. Omit no longer ships in @emotion/styled/types/helpers, so reflexbox needs to use the built-in one from TS 3.5 and above.
