### PR TITLE
[@types/yargs] Coerced options with default should use type from coerce.

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -773,6 +773,7 @@ declare namespace yargs {
     type ToNumber<T> = (Exclude<T, undefined> extends any[] ? number[] : number) | Extract<T, undefined>;
 
     type InferredOptionType<O extends Options | PositionalOptions> =
+        O extends { default: any, coerce: (arg: any) => infer T } ? T :
         O extends { default: infer D } ? D :
         O extends { type: "count" } ? number :
         O extends { count: true } ? number :

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -1077,6 +1077,20 @@ function Argv$inferMultipleOptionTypes() {
         .demandOption(["a", "b", "c"])
         .argv;
 
+    // $ExpectType { [x: string]: unknown; a: number; b: string[]; _: string[]; $0: string; }
+    yargs
+        .options({
+            a: {
+                type: 'number',
+                default: 4
+            },
+            b: {
+                coerce: (arg: string) => arg.split(','),
+                default: 'one,two,three'
+            }
+        })
+        .argv;
+
     // $ExpectType { [x: string]: unknown; a: number | undefined; b: string | undefined; c: Color; _: string[]; $0: string; }
     yargs
         .choices({ a: [1, 2, 3], b: ["black", "white"], c: colors })


### PR DESCRIPTION
Currently, when [`coerce`](http://yargs.js.org/docs/#api-reference-coercekey-fn) exists on an option that also has a default, the type is inferred from the default instead of `coerce`. `coerce` still applies to the default though, so the final type should still be whatever the return type of `coerce` is.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

_Note: I ran prettier and it made a lot of changes. I opted not to commit those to this PR because it would make it very difficult to see the small change the PR is attempting to make. I'm happy to open a second PR with the changes from prettier if that would be helpful. For reference here were the changes from running `npm run prettier types/yargs/**/*.ts -- --write`._
```
types/yargs/index.d.ts         | 234 +++++++++++++++++++++--------
types/yargs/v10/index.d.ts     |  62 ++++++--
types/yargs/v10/yargs-tests.ts | 490 ++++++++++++++++++++++--------------------------------------
types/yargs/v11/index.d.ts     |  62 ++++++--
types/yargs/v11/yargs-tests.ts | 496 +++++++++++++++++++++++-------------------------------------
types/yargs/v12/index.d.ts     | 252 +++++++++++++++++++++++--------
types/yargs/v12/yargs-tests.ts | 734 +++++++++++++++++++++++++++++++++++------------------------------------------------------
types/yargs/v12/yargs.d.ts     |   6 +-
types/yargs/v13/index.d.ts     | 251 +++++++++++++++++++++++--------
types/yargs/v13/yargs-tests.ts | 801 +++++++++++++++++++++++++++++++++++++++----------------------------------------------------------
types/yargs/v13/yargs.d.ts     |   6 +-
types/yargs/v8/index.d.ts      |  20 ++-
types/yargs/v8/yargs-tests.ts  | 490 ++++++++++++++++++++++--------------------------------------
types/yargs/yargs-tests.ts     | 894 ++++++++++++++++++++++++++++++++++++++++++++-----------------------------------------------------------------
types/yargs/yargs.d.ts         |   6 +-
15 files changed, 2185 insertions(+), 2619 deletions(-)
```

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://yargs.js.org/docs/#api-reference-coercekey-fn
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.