### PR TITLE
fix(serve-static): fix response constraint

### DIFF
--- a/types/serve-static/index.d.ts
+++ b/types/serve-static/index.d.ts
@@ -15,14 +15,14 @@ import * as http from "http";
  * The file to serve will be determined by combining req.url with the provided root directory.
  * When a file is not found, instead of sending a 404 response, this module will instead call next() to move on to the next middleware, allowing for stacking and fall-backs.
  */
-declare function serveStatic<R extends http.OutgoingMessage>(
+declare function serveStatic<R extends http.ServerResponse>(
     root: string,
     options?: serveStatic.ServeStaticOptions<R>
 ): serveStatic.RequestHandler<R>;
 
 declare namespace serveStatic {
     var mime: typeof m;
-    interface ServeStaticOptions<R extends http.OutgoingMessage = http.OutgoingMessage> {
+    interface ServeStaticOptions<R extends http.ServerResponse = http.ServerResponse> {
         /**
          * Enable or disable setting Cache-Control response header, defaults to true.
          * Disabling this will ignore the immutable and maxAge options.
@@ -95,11 +95,11 @@ declare namespace serveStatic {
         setHeaders?: (res: R, path: string, stat: any) => any;
     }
 
-    interface RequestHandler<R extends http.OutgoingMessage> {
+    interface RequestHandler<R extends http.ServerResponse> {
         (request: http.IncomingMessage, response: R, next: () => void): any;
     }
 
-    interface RequestHandlerConstructor<R extends http.OutgoingMessage> {
+    interface RequestHandlerConstructor<R extends http.ServerResponse> {
         (root: string, options?: ServeStaticOptions<R>): RequestHandler<R>;
         mime: typeof m;
     }

--- a/types/serve-static/serve-static-tests.ts
+++ b/types/serve-static/serve-static-tests.ts
@@ -32,6 +32,8 @@ serveStatic.mime.define({
 
 serveStatic('/does-not-assume-express', {
     setHeaders: function(res) {
+        // ServerResponse
+        res;
         // $ExpectError
         res.set("foo", "bar");
     }


### PR DESCRIPTION
I made a mistake in #48591 of using `http.OutgoingMessage` instead of `http.ServerResponse` which is fixed in this PR. It needs to be latter as it reflects in [`http.createServer`'s types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/768e1a92212b15889ab8b69ec1583b6d8499be62/types/node/http.d.ts#L405)


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see description
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.