### PR TITLE
react-native-calendars: add missing style prop in CalendarTheme

### DIFF
--- a/types/react-native-calendars/index.d.ts
+++ b/types/react-native-calendars/index.d.ts
@@ -51,6 +51,9 @@ export interface CalendarTheme {
     textSectionTitleColor?: string;
     todayTextColor?: string;
     indicatorColor?: string;
+    textDayStyle?: TextStyle;
+    dotStyle?: ViewStyle;
+    arrowStyle?: ViewStyle;
 
     // Theme ID's to style for
     'stylesheet.calendar.header'?: CalendarThemeIdStyle;

--- a/types/react-native-calendars/react-native-calendars-tests.tsx
+++ b/types/react-native-calendars/react-native-calendars-tests.tsx
@@ -218,6 +218,15 @@ const workout = { key: 'workout', color: 'green' };
         textDayFontSize: 16,
         textMonthFontSize: 16,
         textDayHeaderFontSize: 16,
+        textDayStyle: {
+            fontSize: 20,
+        },
+        dotStyle: {
+            backgroundColor: 'white',
+        },
+        arrowStyle: {
+            padding: 0,
+        },
     }}
 />;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wix/react-native-calendars/blob/70cb88000b84868146dff281ee72487184f6252b/src/style.js#L29-L31
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
