### PR TITLE
update(express-jwt): version 6.0

### DIFF
--- a/types/express-jwt/express-jwt-tests.ts
+++ b/types/express-jwt/express-jwt-tests.ts
@@ -1,19 +1,22 @@
-
 import express = require('express');
 import jwt = require('express-jwt');
 import unless = require('express-unless');
 
-var app = express();
+const app = express();
 
 app.use(jwt({
+    algorithms: ['HS256'],
     secret: 'shhhhhhared-secret'
 }));
+
 app.use(jwt({
+    algorithms: ['HS256'],
     secret: 'shhhhhhared-secret',
     userProperty: 'auth'
 }));
 
 app.use(jwt({
+    algorithms: ['HS256'],
     secret: (req: express.Request,
         payload: any,
         done: (err: any, secret: string) => void) => {
@@ -23,6 +26,7 @@ app.use(jwt({
 }));
 
 app.use(jwt({
+    algorithms: ['HS256'],
     secret: (req: express.Request,
         header: any,
         payload: any,
@@ -32,13 +36,15 @@ app.use(jwt({
     userProperty: 'auth'
 }));
 
-var jwtCheck = jwt({
+const jwtCheck = jwt({
+    algorithms: ['HS256'],
     secret: 'shhhhhhared-secret'
 });
 jwtCheck.unless = unless;
+
 app.use(jwtCheck.unless({ path: '/api/login' }));
 
-app.use(function (err: any, req: express.Request, res: express.Response, next: express.NextFunction) {
+app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
     if (err) {
         if (err instanceof jwt.UnauthorizedError) {
             res.status(err.status);

--- a/types/express-jwt/index.d.ts
+++ b/types/express-jwt/index.d.ts
@@ -1,11 +1,11 @@
-// Type definitions for express-jwt
+// Type definitions for express-jwt 6.0
 // Project: https://www.npmjs.org/package/express-jwt
 // Definitions by:  Wonshik Kim <https://github.com/wokim>
 //                  Kacper Polak <https://github.com/kacepe>
 //                  Sl1MBoy <https://github.com/Sl1MBoy>
 //                  Milan Mimra <https://github.com/milan-mimra>
+//                  Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 import express = require('express');
 import unless = require('express-unless');
@@ -14,27 +14,32 @@ export = jwt;
 
 declare function jwt(options: jwt.Options): jwt.RequestHandler;
 declare namespace jwt {
-    export type secretType = string | Buffer
-    export type ErrorCode =
+    type secretType = string | Buffer;
+    type ErrorCode =
         "revoked_token" |
         "invalid_token" |
         "credentials_bad_scheme" |
         "credentials_bad_format" |
-        "credentials_required"
+        "credentials_required";
 
-    export interface SecretCallbackLong {
+    interface SecretCallbackLong {
         (req: express.Request, header: any, payload: any, done: (err: any, secret?: secretType) => void): void;
     }
-    export interface SecretCallback {
+    interface SecretCallback {
         (req: express.Request, payload: any, done: (err: any, secret?: secretType) => void): void;
     }
-    export interface IsRevokedCallback {
+    interface IsRevokedCallback {
         (req: express.Request, payload: any, done: (err: any, revoked?: boolean) => void): void;
     }
-    export interface GetTokenCallback {
+    interface GetTokenCallback {
         (req: express.Request): any;
     }
-    export interface Options {
+    interface Options {
+        /**
+         * The algorithms parameter is required to prevent potential downgrade attacks when providing third party libraries as secrets.
+         * {@link https://github.com/auth0/express-jwt/blob/5fb8c88067b9448d746d04ab60ad3b1996c7e310/README.md#required-parameters}
+         */
+        algorithms: string[];
         secret: secretType | SecretCallback | SecretCallbackLong;
         userProperty?: string;
         credentialsRequired?: boolean;
@@ -43,11 +48,11 @@ declare namespace jwt {
         getToken?: GetTokenCallback;
         [property: string]: any;
     }
-    export interface RequestHandler extends express.RequestHandler {
+    interface RequestHandler extends express.RequestHandler {
         unless: typeof unless;
     }
 
-    export class UnauthorizedError extends Error  {
+    class UnauthorizedError extends Error  {
         status: number;
         message: string;
         name: 'UnauthorizedError';

--- a/types/express-jwt/tslint.json
+++ b/types/express-jwt/tslint.json
@@ -1,13 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "dt-header": false,
-        "no-var-keyword": false,
-        "only-arrow-functions": false,
-        "prefer-const": false,
-        "semicolon": false,
-        "space-before-function-paren": false,
-        "strict-export-declare-modifiers": false,
-        "trim-file": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
Version 6.0 is breaking, it requires `algorithms` to be always set when
initializing module:
https://github.com/auth0/express-jwt/blob/5fb8c88067b9448d746d04ab60ad3b1996c7e310/README.md#required-parameters
https://github.com/auth0/express-jwt/compare/v5.3.3...v6.0.0

- version bump
- amend tests
- cleanup DT settings defaulting to DT recommended ones
- add version, so package can be versioned
- maintainer added

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.