### PR TITLE
xml2js: Fix parser and builder options

### DIFF
--- a/types/xml2js/index.d.ts
+++ b/types/xml2js/index.d.ts
@@ -12,7 +12,7 @@
 
 /// <reference types="node"/>
 import { EventEmitter } from 'events';
-export * as processors from './lib/processors';
+import * as processors from './lib/processors';
 
 export function parseString(str: convertableToString, callback: (err: Error, result: any) => void): void;
 export function parseString(
@@ -130,3 +130,5 @@ export interface OptionsV2 extends Options {
 export interface convertableToString {
     toString(): string;
 }
+
+export { processors };

--- a/types/xml2js/index.d.ts
+++ b/types/xml2js/index.d.ts
@@ -12,27 +12,82 @@
 
 /// <reference types="node"/>
 import { EventEmitter } from 'events';
-import * as processors from './lib/processors';
+export * as processors from './lib/processors';
 
 export function parseString(str: convertableToString, callback: (err: Error, result: any) => void): void;
-export function parseString(str: convertableToString, options: OptionsV2, callback: (err: Error, result: any) => void): void;
-export function parseStringPromise(str: convertableToString, options?: OptionsV2): Promise<any>;
+export function parseString(
+    str: convertableToString,
+    options: ParserOptions,
+    callback: (err: Error, result: any) => void,
+): void;
+export function parseStringPromise(str: convertableToString, options?: ParserOptions): Promise<any>;
 
 export const defaults: {
     '0.1': Options;
     '0.2': OptionsV2;
 };
 
+export interface XmlDeclarationAttributes {
+    version: string;
+    encoding?: string;
+    standalone?: boolean;
+}
+
+export interface RenderOptions {
+    pretty?: boolean;
+    indent?: string;
+    newline?: string;
+}
+
 export class Builder {
-    constructor(options?: OptionsV2);
+    constructor(options?: BuilderOptions);
     buildObject(rootObj: any): string;
 }
 
 export class Parser extends EventEmitter {
-    constructor(options?: OptionsV2);
+    constructor(options?: ParserOptions);
     parseString(str: convertableToString, cb?: Function): void;
     parseStringPromise(str: convertableToString): Promise<any>;
     reset(): void;
+}
+
+export interface ParserOptions {
+    attrkey?: string;
+    charkey?: string;
+    explicitCharkey?: boolean;
+    trim?: boolean;
+    normalizeTags?: boolean;
+    normalize?: boolean;
+    explicitRoot?: boolean;
+    emptyTag?: any;
+    explicitArray?: boolean;
+    ignoreAttrs?: boolean;
+    mergeAttrs?: boolean;
+    validator?: Function;
+    xmlns?: boolean;
+    explicitChildren?: boolean;
+    childkey?: string;
+    preserveChildrenOrder?: boolean;
+    charsAsChildren?: boolean;
+    includeWhiteChars?: boolean;
+    async?: boolean;
+    strict?: boolean;
+    attrNameProcessors?: Array<(name: string) => any>;
+    attrValueProcessors?: Array<(value: string, name: string) => any>;
+    tagNameProcessors?: Array<(name: string) => any>;
+    valueProcessors?: Array<(value: string, name: string) => any>;
+}
+
+export interface BuilderOptions {
+    attrkey?: string;
+    charkey?: string;
+    rootName?: string;
+    renderOpts?: RenderOptions;
+    xmldec?: XmlDeclarationAttributes;
+    doctype?: any;
+    headless?: boolean;
+    allowSurrogateChars?: boolean;
+    cdata?: boolean;
 }
 
 export interface Options {
@@ -64,17 +119,9 @@ export interface Options {
 export interface OptionsV2 extends Options {
     preserveChildrenOrder?: boolean;
     rootName?: string;
-    xmldec?: {
-        version: string;
-        encoding?: string;
-        standalone?: boolean;
-    };
+    xmldec?: XmlDeclarationAttributes;
     doctype?: any;
-    renderOpts?: {
-        pretty?: boolean;
-        indent?: string;
-        newline?: string;
-    };
+    renderOpts?: RenderOptions;
     headless?: boolean;
     chunkSize?: number;
     cdata?: boolean;
@@ -83,5 +130,3 @@ export interface OptionsV2 extends Options {
 export interface convertableToString {
     toString(): string;
 }
-
-export { processors };

--- a/types/xml2js/xml2js-tests.ts
+++ b/types/xml2js/xml2js-tests.ts
@@ -79,10 +79,18 @@ parser.on('end', (result: any) => {
 
 const v1Defaults = xml2js.defaults['0.1'];
 v1Defaults.async = true;
+new xml2js.Parser(v1Defaults);
+new xml2js.Builder(v1Defaults);
+xml2js.parseString('', v1Defaults, () => undefined);
+xml2js.parseStringPromise('', v1Defaults);
 
 const v2Defaults = xml2js.defaults['0.2'];
 v2Defaults.async = false;
 v2Defaults.chunkSize = 20000;
+new xml2js.Parser(v2Defaults);
+new xml2js.Builder(v2Defaults);
+xml2js.parseString('', v2Defaults, () => undefined);
+xml2js.parseStringPromise('', v2Defaults);
 
 fs.readFile(__dirname + '/foo.xml', (err, data) => {
     parser.parseString(data, (err: Error | null, result: any) => {


### PR DESCRIPTION
There was some typing confusion in this package. `xml2js` supplies some default option constants which mix parser and builder options, and these types were reused for the actual parser and builder classes. Instead, define those options separately and ensure that the defaults are compatible in tests.

Resolves #49184.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - <https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/README.md#options>
  - <https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/README.md#options-for-the-builder-class>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
