### PR TITLE
Add fg-loadcss type definitions

### DIFF
--- a/types/fg-loadcss/fg-loadcss-tests.ts
+++ b/types/fg-loadcss/fg-loadcss-tests.ts
@@ -1,0 +1,10 @@
+import { loadCSS, onloadCSS } from "fg-loadcss";
+
+loadCSS("example.css");
+loadCSS("example.css", document.body);
+loadCSS("example.css", document.body, "print");
+const foo = loadCSS("example.css", document.body, "print", { integrity: "sha123-abc" });
+
+onloadCSS(foo, () => {
+	console.log("Loaded!");
+});

--- a/types/fg-loadcss/fg-loadcss-tests.ts
+++ b/types/fg-loadcss/fg-loadcss-tests.ts
@@ -1,10 +1,10 @@
-import { loadCSS } from "fg-loadcss";
+import loadCSS  = require("fg-loadcss");
 
 loadCSS("example.css");
 loadCSS("example.css", document.body);
 loadCSS("example.css", document.body, "print");
 const foo = loadCSS("example.css", document.body, "print", { integrity: "sha123-abc" });
 
-onloadCSS(foo, () => {
+window.onloadCSS(foo, () => {
     console.log("Loaded!");
 });

--- a/types/fg-loadcss/fg-loadcss-tests.ts
+++ b/types/fg-loadcss/fg-loadcss-tests.ts
@@ -6,5 +6,5 @@ loadCSS("example.css", document.body, "print");
 const foo = loadCSS("example.css", document.body, "print", { integrity: "sha123-abc" });
 
 onloadCSS(foo, () => {
-	console.log("Loaded!");
+    console.log("Loaded!");
 });

--- a/types/fg-loadcss/fg-loadcss-tests.ts
+++ b/types/fg-loadcss/fg-loadcss-tests.ts
@@ -1,4 +1,4 @@
-import { loadCSS, onloadCSS } from "fg-loadcss";
+import { loadCSS } from "fg-loadcss";
 
 loadCSS("example.css");
 loadCSS("example.css", document.body);

--- a/types/fg-loadcss/index.d.ts
+++ b/types/fg-loadcss/index.d.ts
@@ -3,6 +3,12 @@
 // Definitions by: Noah Overcash <https://github.com/ncovercash>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export function loadCSS(href: string, before?: HTMLElement, media?: string, attributes?: Record<string, string>): HTMLLinkElement;
+declare namespace FgLoadcss {
+    function loadCSS(href: string, before?: HTMLElement, media?: string, attributes?: Record<string, string>): HTMLLinkElement;
+}
 
-export function onloadCSS(stylesheet: HTMLLinkElement, callback: () => void): void;
+declare module "fg-loadcss" {
+    export = FgLoadcss;
+}
+
+declare var onloadCSS: (stylesheet: HTMLLinkElement, callback: () => void) => void;

--- a/types/fg-loadcss/index.d.ts
+++ b/types/fg-loadcss/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for fg-loadcss 3.1
+// Project: https://github.com/filamentgroup/loadCSS
+// Definitions by: Noah Overcash <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function loadCSS(href: string, before?: HTMLElement, media?: string, attributes?: Record<string, string>): HTMLLinkElement;
+
+export function onloadCSS(stylesheet: HTMLLinkElement, callback: () => void): void;

--- a/types/fg-loadcss/index.d.ts
+++ b/types/fg-loadcss/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for fg-loadcss 3.1
 // Project: https://github.com/filamentgroup/loadCSS
-// Definitions by: Noah Overcash <https://github.com/me>
+// Definitions by: Noah Overcash <https://github.com/ncovercash>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export function loadCSS(href: string, before?: HTMLElement, media?: string, attributes?: Record<string, string>): HTMLLinkElement;

--- a/types/fg-loadcss/index.d.ts
+++ b/types/fg-loadcss/index.d.ts
@@ -3,12 +3,19 @@
 // Definitions by: Noah Overcash <https://github.com/ncovercash>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace FgLoadcss {
-    function loadCSS(href: string, before?: HTMLElement, media?: string, attributes?: Record<string, string>): HTMLLinkElement;
-}
+export as namespace loadCSS;
 
-declare module "fg-loadcss" {
-    export = FgLoadcss;
-}
+declare function loadCSS(
+    href: string,
+    before?: HTMLElement,
+    media?: string,
+    attributes?: Record<string, string>,
+): HTMLLinkElement;
 
-declare var onloadCSS: (stylesheet: HTMLLinkElement, callback: () => void) => void;
+export = loadCSS;
+
+declare global {
+    interface Window {
+        onloadCSS: (stylesheet: HTMLLinkElement, callback: () => void) => void;
+    }
+}

--- a/types/fg-loadcss/tsconfig.json
+++ b/types/fg-loadcss/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "dom",
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "fg-loadcss-tests.ts"
+    ]
+}

--- a/types/fg-loadcss/tslint.json
+++ b/types/fg-loadcss/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Original repo: https://github.com/filamentgroup/loadCSS

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
