### PR TITLE
fix: add minDate and maxDate for DayPickerRangeController and DayPickerSingleDateController in @types/react-dates

### DIFF
--- a/types/react-dates/index.d.ts
+++ b/types/react-dates/index.d.ts
@@ -786,6 +786,8 @@ export type DayPickerRangeControllerShape = RenderMonthProps &
         onDatesChange: (arg: { startDate: moment.Moment | null; endDate: moment.Moment | null }) => void;
         startDateOffset?: (day: moment.Moment) => moment.Moment;
         endDateOffset?: (day: moment.Moment) => moment.Moment;
+        minDate?: moment.Moment | null;
+        maxDate?: moment.Moment | null;
 
         focusedInput: FocusedInputShape | null;
         onFocusChange: (arg: FocusedInputShape | null) => void;
@@ -853,6 +855,8 @@ export type DayPickerSingleDateControllerShape = RenderMonthProps &
         | 'isRTL'
     > & {
         date: moment.Moment | null;
+        minDate?: moment.Moment | null;
+        maxDate?: moment.Moment | null;
         onDateChange: (date: moment.Moment | null) => void;
 
         focused: boolean;

--- a/types/react-dates/react-dates-tests.tsx
+++ b/types/react-dates/react-dates-tests.tsx
@@ -499,6 +499,7 @@ const DayPickerRangeControllerFullTest: React.FC = () => (
         renderWeekHeaderElement={day => <span>{day}</span>}
         showKeyboardShortcuts={false}
         startDate={moment()}
+        minDate={moment()}
         startDateOffset={day => day.subtract(3, 'days')}
         transitionDuration={5}
         verticalBorderSpacing={5}
@@ -526,6 +527,7 @@ const DayPickerSingleDateControllerFullTest: React.FC = () => (
     <DayPickerSingleDateController
         calendarInfoPosition="top"
         date={moment()}
+        minDate={moment()}
         dayAriaLabelFormat="dd"
         dayPickerNavigationInlineStyles={{ width: '10' }}
         daySize={50}

--- a/types/react-dates/react-dates-tests.tsx
+++ b/types/react-dates/react-dates-tests.tsx
@@ -500,7 +500,7 @@ const DayPickerRangeControllerFullTest: React.FC = () => (
         showKeyboardShortcuts={false}
         startDate={moment()}
         minDate={moment()}
-        maxDate={moment().add('30', 'days')}
+        maxDate={moment().add(30, 'days')}
         startDateOffset={day => day.subtract(3, 'days')}
         transitionDuration={5}
         verticalBorderSpacing={5}
@@ -529,7 +529,7 @@ const DayPickerSingleDateControllerFullTest: React.FC = () => (
         calendarInfoPosition="top"
         date={moment()}
         minDate={moment()}
-        maxDate={moment().add('30', 'days')}
+        maxDate={moment().add(30, 'days')}
         dayAriaLabelFormat="dd"
         dayPickerNavigationInlineStyles={{ width: '10' }}
         daySize={50}

--- a/types/react-dates/react-dates-tests.tsx
+++ b/types/react-dates/react-dates-tests.tsx
@@ -500,6 +500,7 @@ const DayPickerRangeControllerFullTest: React.FC = () => (
         showKeyboardShortcuts={false}
         startDate={moment()}
         minDate={moment()}
+        maxDate={moment().add('30', 'days')}
         startDateOffset={day => day.subtract(3, 'days')}
         transitionDuration={5}
         verticalBorderSpacing={5}
@@ -528,6 +529,7 @@ const DayPickerSingleDateControllerFullTest: React.FC = () => (
         calendarInfoPosition="top"
         date={moment()}
         minDate={moment()}
+        maxDate={moment().add('30', 'days')}
         dayAriaLabelFormat="dd"
         dayPickerNavigationInlineStyles={{ width: '10' }}
         daySize={50}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/airbnb/react-dates/blob/master/src/components/DayPickerRangeController.jsx#L53
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.