### PR TITLE
React Native: Add type support for StyleSheet.create to get function style value

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -5488,7 +5488,11 @@ interface SubscribableMixin {
 
 // @see https://github.com/facebook/react-native/blob/0.34-stable\Libraries\StyleSheet\StyleSheetTypes.js
 export namespace StyleSheet {
-    type NamedStyles<T> = { [P in keyof T]: ViewStyle | TextStyle | ImageStyle };
+    type AllStyles = ViewStyle | TextStyle | ImageStyle;
+    type StyleFunction = (...args: any[]) => AllStyles;
+    type NamedStyles<T> = {
+        [P in keyof T]: AllStyles | StyleFunction
+    };
 
     /**
      * Creates a StyleSheet style reference from the given object.

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -161,6 +161,7 @@ interface LocalStyles {
     container: ViewStyle;
     welcome: TextStyle;
     instructions: TextStyle;
+    styleFunction: (...args: any[]) => TextStyle;
 }
 
 const styles = StyleSheet.create<LocalStyles>({
@@ -180,6 +181,9 @@ const styles = StyleSheet.create<LocalStyles>({
         color: '#333333',
         marginBottom: 5,
     },
+    styleFunction: (textColor) => ({
+        color: textColor,
+    })
 });
 
 //alternative declaration of styles (inline typings)
@@ -348,6 +352,7 @@ class Welcome extends React.Component<ElementProps<View> & { color: string }> {
         const { color, ...props } = this.props;
         return (
             <View {...props} ref="rootView" style={[[styles.container], undefined, null, false]}>
+                <Text style={styles.styleFunction(color)}>Test For Style Function Type (support dynamic styling)</Text>
                 <Text style={styles.welcome}>Welcome to React Native</Text>
                 <Text style={styles.instructions}>To get started, edit index.ios.js</Text>
                 <Text style={styles.instructions}>


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://reactnative.dev/docs/stylesheet>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
