### PR TITLE
Fix ArgumentParser.convert_arg_line_to_args method name

### DIFF
--- a/types/argparse/argparse-tests.ts
+++ b/types/argparse/argparse-tests.ts
@@ -50,6 +50,9 @@ args = simpleExample.parse_args('--foo 5 --bar 6'.split(' '));
 console.dir(args);
 console.log('-----------');
 
+console.dir(simpleExample.convert_arg_line_to_args("foo  bar   asd"));
+console.log('-----------');
+
 const choicesExample = new ArgumentParser({
     add_help: true,
     description: 'Argparse examples: choice'

--- a/types/argparse/index.d.ts
+++ b/types/argparse/index.d.ts
@@ -18,7 +18,7 @@ export class ArgumentParser extends ArgumentGroup {
     format_usage(): string;
     format_help(): string;
     parse_known_args(args?: string[], ns?: Namespace | object): any[];
-    convert_arg_line_to_arg(argLine: string): string[];
+    convert_arg_line_to_args(argLine: string): string[];
     exit(status: number, message: string): void;
     error(err: string | Error): void;
 }


### PR DESCRIPTION
Change convert_arg_line_to_arg to convert_arg_line_to_args in
ArgumentParser type declaration (probably a typo)

 - [x] Use a meaningful title for the pull request. Include the name of the package modified.
 - [x] Test the change in your own code. (Compile and run.)
 - [x] Add or edit tests to reflect the change. (Run with npm test YOUR_PACKAGE_NAME.)
 - [x] Follow the advice from the readme.
 - [x] Avoid common mistakes.
 - [x] Run npm run lint package-name (or tsc if no tslint.json is present).

You can see the method defined here [original package](https://github.com/nodeca/argparse/blob/174bd80df5b45519475b9e2f611090b5b453b243/argparse.js#L3124) and the declared one here [typedecl](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/41a291101db71a6d9b3d016fb655f46f9d061cd8/types/argparse/index.d.ts#L21) don't match. So I simply fixed the declaration.