### PR TITLE
Added PDFPageProxy#getPermissions

### DIFF
--- a/types/pdfjs-dist/index.d.ts
+++ b/types/pdfjs-dist/index.d.ts
@@ -289,7 +289,7 @@ interface PDFDocumentProxy {
      *  A promise that is resolved with an array that is a tree outline (if it has one) of the PDF.  @see PDFTreeNode
      **/
     getOutline(): PDFPromise<PDFTreeNode[]>;
-    
+
     /**
      *  A promise that is resolved with an array that is a permission of the PDF.
      **/

--- a/types/pdfjs-dist/index.d.ts
+++ b/types/pdfjs-dist/index.d.ts
@@ -291,7 +291,7 @@ interface PDFDocumentProxy {
     getOutline(): PDFPromise<PDFTreeNode[]>;
 
     /**
-     *  A promise that is resolved with an array that is a permission of the PDF.
+     *  A promise that is resolved with an array that contains the permission flags for the PDF document.
      **/
     getPermissions(): PDFPromise<number[]>;
 

--- a/types/pdfjs-dist/index.d.ts
+++ b/types/pdfjs-dist/index.d.ts
@@ -289,6 +289,11 @@ interface PDFDocumentProxy {
      *  A promise that is resolved with an array that is a tree outline (if it has one) of the PDF.  @see PDFTreeNode
      **/
     getOutline(): PDFPromise<PDFTreeNode[]>;
+    
+    /**
+     *  A promise that is resolved with an array that is a permission of the PDF.
+     **/
+    getPermissions(): PDFPromise<number[]>;
 
     /**
      * A promise that is resolved with the info and metadata of the PDF.


### PR DESCRIPTION
I added `PDFPageProxy.getPermissions`. I didn't test it because it was a trivial changes, adding one of many properties for that object.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:



If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/mozilla/pdfjs-dist/blob/75ce02e272754adb384a1d9b1878a5609b6ea746/types/display/api.d.ts#L724>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
