### PR TITLE
Updating copy-webpack-plugin 6.3+ to use the default webpack 5 typings instead of the @types/webpack one

### DIFF
--- a/types/copy-webpack-plugin/index.d.ts
+++ b/types/copy-webpack-plugin/index.d.ts
@@ -1,10 +1,10 @@
-// Type definitions for copy-webpack-plugin 6.2
+// Type definitions for copy-webpack-plugin 6.3
 // Project: https://github.com/webpack-contrib/copy-webpack-plugin
 // Definitions by: flying-sheep <https://github.com/flying-sheep>
 //                 avin-kavish  <https://github.com/avin-kavish>
 //                 Piotr Błażejewicz  <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-import { Plugin } from 'webpack';
+import { WebpackPluginInstance as Plugin } from 'webpack';
 
 interface ObjectPattern {
     /**


### PR DESCRIPTION
Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/49528
copy-webpack-plugin 6.3+, they upgraded the webpack support to version 5 which includes its own typings
