### PR TITLE
fix(autosuggest-highlight): Fix matches type

### DIFF
--- a/types/autosuggest-highlight/autosuggest-highlight-tests.ts
+++ b/types/autosuggest-highlight/autosuggest-highlight-tests.ts
@@ -2,8 +2,8 @@ import match = require('autosuggest-highlight/match');
 import parse = require('autosuggest-highlight/parse');
 
 function matchTest() {
-    let matches = match('some text', 'te'); // $ExpectType number[] | number[][]
-    matches = match('some sweet text', 's s'); // $ExpectType number[] | number[][]
+    let matches = match('some text', 'te'); // $ExpectType [number, number][]
+    matches = match('some sweet text', 's s'); // $ExpectType [number, number][]
 }
 
 function parseTest() {

--- a/types/autosuggest-highlight/match/index.d.ts
+++ b/types/autosuggest-highlight/match/index.d.ts
@@ -1,3 +1,3 @@
-declare function match(text: string, query: string): number[] | number[][];
+declare function match(text: string, query: string): Array<[number, number]>;
 
 export = match;

--- a/types/autosuggest-highlight/parse/index.d.ts
+++ b/types/autosuggest-highlight/parse/index.d.ts
@@ -1,3 +1,3 @@
-declare function parse(text: string, matches: number[] | number[][]): Array<{ text: string; highlight: boolean; }>;
+declare function parse(text: string, matches: Array<[number, number]>): Array<{ text: string; highlight: boolean }>;
 
 export = parse;


### PR DESCRIPTION
The existing type wasn't correct. The `matches` array only ever contains tuples with `start` and `end` values (e.g. `[[0, 4], [6, 8]]`). I avoided using named tuple elements since they're only available as of TypeScript 4.0 and I wanted to maintain a high level of compatibility.

Checklists:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/autosuggest-highlight/v/3.1.1
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
