### PR TITLE
[eslint] add 'readonly' | 'readable' | 'writable' | 'writeable' to eslint config's globals field

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -421,6 +421,10 @@ linter.verify(SOURCE, { parserOptions: { ecmaVersion: 6, ecmaFeatures: { globalR
 linter.verify(SOURCE, { parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } }, 'test.js');
 linter.verify(SOURCE, { env: { node: true } }, 'test.js');
 linter.verify(SOURCE, { globals: { foo: true } }, 'test.js');
+linter.verify(SOURCE, { globals: { foo: 'readonly' } }, 'test.js');
+linter.verify(SOURCE, { globals: { foo: 'readable' } }, 'test.js');
+linter.verify(SOURCE, { globals: { foo: 'writable' } }, 'test.js');
+linter.verify(SOURCE, { globals: { foo: 'writeable' } }, 'test.js');
 linter.verify(SOURCE, { parser: 'custom-parser' }, 'test.js');
 linter.verify(SOURCE, { settings: { info: 'foo' } }, 'test.js');
 linter.verify(SOURCE, { processor: 'a-plugin/a-processor' }, 'test.js');

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -489,7 +489,7 @@ export namespace Linter {
         $schema?: string;
         env?: { [name: string]: boolean };
         extends?: string | string[];
-        globals?: { [name: string]: boolean };
+        globals?: { [name: string]: boolean | 'readonly' | 'readable' | 'writable' | 'writeable' };
         noInlineConfig?: boolean;
         overrides?: ConfigOverride[];
         parser?: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://eslint.org/docs/user-guide/configuring#specifying-globals>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Boolean value for `globals` is deprecated in ESLint.