### PR TITLE
Add optional exit_on_error flag

### DIFF
--- a/types/argparse/argparse-tests.ts
+++ b/types/argparse/argparse-tests.ts
@@ -11,6 +11,7 @@ import {
     OPTIONAL,
     SUPPRESS,
     REMAINDER,
+    ArgumentError,
 } from 'argparse';
 let args: any;
 
@@ -351,7 +352,21 @@ args = constExample.parse_args('--foo x --bar --baz y --qux z a b c d e'.split('
 console.dir(args);
 console.log('-----------');
 
-const versionExample = new ArgumentParser({description: 'Add version'});
-versionExample.add_argument('-v', '--v', {action: 'version', version: '1.0.0'});
+const versionExample = new ArgumentParser({ description: 'Add version' });
+versionExample.add_argument('-v', '--v', { action: 'version', version: '1.0.0' });
 versionExample.print_help();
+console.log('-----------');
+
+const noExitOnError = new ArgumentParser({
+    exit_on_error: false
+});
+noExitOnError.add_argument('-f', '--foo', { action: 'store_true' });
+try {
+    noExitOnError.parse_args(['unknown']);
+} catch (err) {
+    if (err instanceof ArgumentError) {
+        const errorMessage: string = err.str();
+        console.log(errorMessage);
+    }
+}
 console.log('-----------');

--- a/types/argparse/index.d.ts
+++ b/types/argparse/index.d.ts
@@ -67,6 +67,7 @@ export interface ArgumentParserOptions {
     formatter_class?: { new (): HelpFormatter | ArgumentDefaultsHelpFormatter | RawDescriptionHelpFormatter | RawTextHelpFormatter };
     prog?: string;
     usage?: string;
+    exit_on_error?: boolean;
 }
 
 export interface ArgumentGroupOptions {
@@ -80,6 +81,13 @@ export abstract class Action {
     protected dest: string;
     constructor(options: ActionConstructorOptions);
     abstract call(parser: ArgumentParser, namespace: Namespace, values: string | string[], optionString: string | null): void;
+}
+
+// Can be used in conjunction with the exit_on_error flag to save the error message
+// and use it in a fashion other than printing to stdout.
+export class ArgumentError extends Error {
+    constructor(argument: Action, message: string);
+    str(): string;
 }
 
 // Passed to the Action constructor.  Subclasses are just expected to relay this to


### PR DESCRIPTION
Add ArgumentError type that extends Error (adds an str method that
returns the error message)
Add test in the end of argparse-tests.ts that demonstrates the usage
Refer to [exit_on_error](https://docs.python.org/3/library/argparse.html#exit-on-error) to see how it is used in the original library.
(It behaves and used the same way in this port)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] The following URL shows how this flag may be used in the original python package: [exit_on_error](https://docs.python.org/3/library/argparse.html#exit-on-error). There is a link to the documentation in the js port: [exit_on_error](https://github.com/nodeca/argparse/blob/174bd80df5b45519475b9e2f611090b5b453b243/argparse.js#L2519).