### PR TITLE
fix(forest-express-sequelize/forest-express-mongoose): fix the type of the variable passed to getIdsFromRequest

### DIFF
--- a/types/forest-express-mongoose/forest-express-mongoose-tests.ts
+++ b/types/forest-express-mongoose/forest-express-mongoose-tests.ts
@@ -8,7 +8,7 @@ import {
     SmartActionOptions, SmartFieldOptions, SmartSegmentOptions,
     collection, CollectionOptions,
 } from 'forest-express-mongoose';
-import { RequestHandler } from 'express';
+import * as express from 'express';
 
 const MY_PUBLIC_ROUTES = PUBLIC_ROUTES;
 
@@ -63,7 +63,7 @@ recordsRemover.remove(['1234', '5678']);
 const recordSerializer = new RecordSerializer(model);
 recordSerializer.serialize([{}, {}]);
 
-let requestHandler: RequestHandler;
+let requestHandler: express.RequestHandler;
 const permissionMiddlewareCreator = new PermissionMiddlewareCreator('users');
 requestHandler = permissionMiddlewareCreator.list();
 requestHandler = permissionMiddlewareCreator.export();
@@ -198,3 +198,9 @@ const complexCollectionOptions: CollectionOptions = {
     }],
 };
 collection('complexCollection', complexCollectionOptions);
+
+const app = express();
+
+app.get('/', (request) => {
+    return recordsGetter.getIdsFromRequest(request);
+});

--- a/types/forest-express-mongoose/index.d.ts
+++ b/types/forest-express-mongoose/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Steve Bunlon <https://github.com/SteveBunlon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { RequestHandler, Response } from "express";
+import { RequestHandler, Response, Request } from "express";
 
 // Everything related to Forest constants
 
@@ -22,7 +22,7 @@ export class RecordGetter extends AbstractRecordTool {
 
 export class RecordsGetter extends AbstractRecordTool {
     getAll(params: Params): Promise<object[]>;
-    getIdsFromRequest(params: Params): Promise<string[]>;
+    getIdsFromRequest(request: Request): Promise<string[]>;
 }
 
 export class RecordsCounter extends AbstractRecordTool {

--- a/types/forest-express-sequelize/forest-express-sequelize-tests.ts
+++ b/types/forest-express-sequelize/forest-express-sequelize-tests.ts
@@ -8,7 +8,7 @@ import {
     SmartActionOptions, SmartFieldOptions, SmartSegmentOptions,
     collection, CollectionOptions
 } from 'forest-express-sequelize';
-import { RequestHandler } from 'express';
+import * as express from 'express';
 
 const MY_PUBLIC_ROUTES = PUBLIC_ROUTES;
 
@@ -63,7 +63,7 @@ recordsRemover.remove(['1234', '5678']);
 const recordSerializer = new RecordSerializer(model);
 recordSerializer.serialize([{}, {}]);
 
-let requestHandler: RequestHandler;
+let requestHandler: express.RequestHandler;
 const permissionMiddlewareCreator = new PermissionMiddlewareCreator('users');
 requestHandler = permissionMiddlewareCreator.list();
 requestHandler = permissionMiddlewareCreator.export();
@@ -198,3 +198,9 @@ const complexCollectionOptions: CollectionOptions = {
     }],
 };
 collection('complexCollection', complexCollectionOptions);
+
+const app = express();
+
+app.get('/', (request) => {
+    return recordsGetter.getIdsFromRequest(request);
+});

--- a/types/forest-express-sequelize/index.d.ts
+++ b/types/forest-express-sequelize/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Steve Bunlon <https://github.com/SteveBunlon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { RequestHandler, Response } from "express";
+import { RequestHandler, Response, Request } from "express";
 
 // Everything related to Forest constants
 
@@ -22,7 +22,7 @@ export class RecordGetter extends AbstractRecordTool {
 
 export class RecordsGetter extends AbstractRecordTool {
     getAll(params: Params): Promise<object[]>;
-    getIdsFromRequest(params: Params): Promise<string[]>;
+    getIdsFromRequest(request: Request): Promise<string[]>;
 }
 
 export class RecordsCounter extends AbstractRecordTool {


### PR DESCRIPTION
This PR fixes a bad type definition for two packages (forest-express-sequelize and forest-express-mongoose). 

The `getIdsFromRequest` should be given an express `Request` object, instead of the previously set type: `Params`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://docs.forestadmin.com/documentation/reference-guide/actions/create-and-manage-smart-actions#creating-a-smart-action>>
<<https://docs.forestadmin.com/woodshop/how-tos/translate-your-app-into-typescript>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
