### PR TITLE
[eslint] accept string not string[] for ignorePattern option of capitalized-comments rule

### DIFF
--- a/types/eslint/OTHER_FILES.txt
+++ b/types/eslint/OTHER_FILES.txt
@@ -1,9 +1,0 @@
-rules/best-practices.d.ts
-rules/deprecated.d.ts
-rules/ecmascript-6.d.ts
-rules/index.d.ts
-rules/node-commonjs.d.ts
-rules/possible-errors.d.ts
-rules/strict-mode.d.ts
-rules/stylistic-issues.d.ts
-rules/variables.d.ts

--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -1,5 +1,6 @@
 import { Comment, WhileStatement } from 'estree';
 import { AST, SourceCode, Rule, Linter, ESLint, CLIEngine, RuleTester, Scope } from 'eslint';
+import { ESLintRules } from 'eslint/rules';
 
 const SOURCE = `var foo = bar;`;
 
@@ -620,6 +621,18 @@ resultsPromise.then(results => {
         }
     }
 });
+
+//#endregion
+
+//#region ESLintRules
+
+let eslintConfig: Linter.Config<ESLintRules>;
+
+eslintConfig = {
+    rules: {
+        'capitalized-comments': [2, 'always', { ignorePattern: 'const|let' }],
+    }
+};
 
 //#endregion
 

--- a/types/eslint/rules/stylistic-issues.d.ts
+++ b/types/eslint/rules/stylistic-issues.d.ts
@@ -138,7 +138,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
     'capitalized-comments': Linter.RuleEntry<[
         'always' | 'never',
         Partial<{
-            ignorePattern: string[];
+            ignorePattern: string;
             /**
              * @default false
              */


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://eslint.org/docs/rules/capitalized-comments#options>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The `ignorePattern` option of the ESLint `capitalized-comments` rule accepts a `string` and not a `string[]` (https://eslint.org/docs/rules/capitalized-comments#options).
