### PR TITLE
Update JQueryUI - DraggableEventUIParams

### DIFF
--- a/types/jqueryui/index.d.ts
+++ b/types/jqueryui/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jQueryUI 1.12.1
+// Type definitions for jQueryUI 1.12
 // Project: http://jqueryui.com/
 // Definitions by: Boris Yankov <https://github.com/borisyankov>, John Reilly <https://github.com/johnnyreilly>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/jqueryui/index.d.ts
+++ b/types/jqueryui/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for jQueryUI 1.12
 // Project: http://jqueryui.com/
-// Definitions by: Boris Yankov <https://github.com/borisyankov>, John Reilly <https://github.com/johnnyreilly>
+// Definitions by: Boris Yankov <https://github.com/borisyankov>, John Reilly <https://github.com/johnnyreilly>, Dieter Oberkofler <https://github.com/doberkofler>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/jqueryui/index.d.ts
+++ b/types/jqueryui/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jQueryUI 1.12
+// Type definitions for jQueryUI 1.12.1
 // Project: http://jqueryui.com/
 // Definitions by: Boris Yankov <https://github.com/borisyankov>, John Reilly <https://github.com/johnnyreilly>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -444,6 +444,7 @@ declare namespace JQueryUI {
     interface DraggableEventUIParams {
         helper: JQuery;
         position: { top: number; left: number; };
+        originalPosition: { top: number; left: number; };
         offset: { top: number; left: number; };
     }
 

--- a/types/jqueryui/jqueryui-tests.ts
+++ b/types/jqueryui/jqueryui-tests.ts
@@ -13,7 +13,9 @@ function test_draggable() {
     $("#draggable").draggable({
         start: () => { },
         drag: () => { },
-        stop: () => { }
+        stop: (event, ui) => {
+            var left = ui.originalPosition.left;
+        }
     });
     $("#draggable").draggable({ handle: "p" });
     $("#draggable2").draggable({ cancel: "p.ui-widget-header" });


### PR DESCRIPTION
The property originalPosition was missing in the DraggableEventUIParams type.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jqueryui.com/draggable/#content (but the documentation is also not up to date)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
