### PR TITLE
[mapbox-gl] Use discriminated union for Layer

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -1871,18 +1871,8 @@ declare namespace mapboxgl {
         | HeatmapPaint
         | HillshadePaint;
 
-    export interface Layer {
+    export interface LayerBase {
         id: string;
-        type?:
-            | 'fill'
-            | 'line'
-            | 'symbol'
-            | 'circle'
-            | 'fill-extrusion'
-            | 'raster'
-            | 'background'
-            | 'heatmap'
-            | 'hillshade';
 
         metadata?: any;
         ref?: string;
@@ -1897,9 +1887,72 @@ declare namespace mapboxgl {
         interactive?: boolean;
 
         filter?: any[];
-        layout?: AnyLayout;
-        paint?: AnyPaint;
     }
+
+    interface BackgroundLayer extends LayerBase {
+        type: "background";
+        layout?: BackgroundLayout;
+        paint?: BackgroundPaint;
+    }
+
+    interface CircleLayer extends LayerBase {
+        type: "circle";
+        layout?: CircleLayout;
+        paint?: CirclePaint;
+    }
+
+    interface FillExtrusionLayer extends LayerBase {
+        type: "fill-extrusion";
+        layout?: FillExtrusionLayout;
+        paint?: FillExtrusionPaint;
+    }
+
+    interface FillLayer extends LayerBase {
+        type: "fill";
+        layout?: FillLayout;
+        paint?: FillPaint;
+    }
+
+    interface HeatmapLayer extends LayerBase {
+        type: "heatmap";
+        layout?: HeatmapLayout;
+        paint?: HeatmapPaint;
+    }
+
+    interface HillshadeLayer extends LayerBase {
+        type: "hillshade";
+        layout?: HillshadeLayout;
+        paint?: HillshadePaint;
+    }
+
+    interface LineLayer extends LayerBase {
+        type: "line";
+        layout?: LineLayout;
+        paint?: LinePaint;
+    }
+
+    interface RasterLayer extends LayerBase {
+        type: "raster";
+        layout?: RasterLayout;
+        paint?: RasterPaint;
+    }
+
+    interface SymbolLayer extends LayerBase {
+        type: "symbol";
+        layout?: SymbolLayout;
+        paint?: SymbolPaint;
+    }
+
+    export type Layer =
+        | BackgroundLayer
+        | CircleLayer
+        | FillExtrusionLayer
+        | FillLayer
+        | HeatmapLayer
+        | HillshadeLayer
+        | LineLayer
+        | RasterLayer
+        | SymbolLayer;
 
     // See https://docs.mapbox.com/mapbox-gl-js/api/#customlayerinterface
     export interface CustomLayerInterface {

--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -1871,7 +1871,7 @@ declare namespace mapboxgl {
         | HeatmapPaint
         | HillshadePaint;
 
-    export interface LayerBase {
+    interface LayerBase {
         id: string;
 
         metadata?: any;

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -1640,6 +1640,22 @@ expectType<mapboxgl.AnyPaint>(
     ),
 );
 
+/*
+ * Make sure layer gets proper Paint, corresponding to layer's type
+ */
+
+expectType<mapboxgl.Layer>({ id: "unique", type: "background", paint: { 'background-opacity': 1 } });
+// $ExpectError
+expectType<mapboxgl.Layer>({ id: "unique", type: "background", paint: { 'line-opacity': 1 } });
+
+expectType<mapboxgl.Layer>({ id: "unique", type: "fill", paint: { 'fill-opacity': 1 } });
+// $ExpectError
+expectType<mapboxgl.Layer>({ id: "unique", type: "fill", paint: { 'line-opacity': 1 } });
+
+expectType<mapboxgl.Layer>({ id: "unique", type: "line", paint: { 'line-opacity': 1 } });
+// $ExpectError
+expectType<mapboxgl.Layer>({ id: "unique", type: "line", paint: { 'fill-opacity': 1 } });
+
 /**
  * Test map.addImage()
  */


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#paint-property
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
