### PR TITLE
[@types/relay-runtime]: 10.1.0 - CacheConfig

### DIFF
--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Eloy Durán <https://github.com/alloy>
 //                 Stephen Pittman <https://github.com/Stephen2>
 //                 Marais Rossouw <https://github.com/maraisr>
+//                 Lorenzo Di Giacomo <https://github.com/morrys>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/relay-runtime/lib/query/fetchQueryInternal.d.ts
+++ b/types/relay-runtime/lib/query/fetchQueryInternal.d.ts
@@ -1,15 +1,8 @@
-import { CacheConfig } from '../util/RelayRuntimeTypes';
 import { Environment, OperationDescriptor, RequestDescriptor } from '../store/RelayStoreTypes';
 import { GraphQLResponse } from '../network/RelayNetworkTypes';
 import { RelayObservable as Observable } from '../network/RelayObservable';
 
-export function fetchQuery(
-    environment: Environment,
-    operation: OperationDescriptor,
-    options?: {
-        networkCacheConfig?: CacheConfig;
-    },
-): Observable<GraphQLResponse>;
+export function fetchQuery(environment: Environment, operation: OperationDescriptor): Observable<GraphQLResponse>;
 
 export function fetchQueryDeduped(
     environment: Environment,

--- a/types/relay-runtime/lib/store/RelayModernEnvironment.d.ts
+++ b/types/relay-runtime/lib/store/RelayModernEnvironment.d.ts
@@ -59,18 +59,15 @@ export default class RelayModernEnvironment implements Environment {
     isServer(): boolean;
     execute(data: {
         operation: OperationDescriptor;
-        cacheConfig?: CacheConfig | null;
         updater?: SelectorStoreUpdater | null;
     }): RelayObservable<GraphQLResponse>;
     executeMutation({
-        cacheConfig,
         operation,
         optimisticResponse,
         optimisticUpdater,
         updater,
         uploadables,
     }: {
-        cacheConfig: CacheConfig | null;
         operation: OperationDescriptor;
         optimisticUpdater?: SelectorStoreUpdater | null;
         optimisticResponse?: { [key: string]: any } | null;

--- a/types/relay-runtime/lib/store/RelayModernEnvironment.d.ts
+++ b/types/relay-runtime/lib/store/RelayModernEnvironment.d.ts
@@ -19,7 +19,7 @@ import {
 import { Network, PayloadData, GraphQLResponse, UploadableMap } from '../network/RelayNetworkTypes';
 import { TaskScheduler } from './RelayModernQueryExecutor';
 import { RelayOperationTracker } from './RelayOperationTracker';
-import { Disposable, CacheConfig } from '../util/RelayRuntimeTypes';
+import { Disposable } from '../util/RelayRuntimeTypes';
 import { RelayObservable } from '../network/RelayObservable';
 
 export interface EnvironmentConfig {

--- a/types/relay-runtime/lib/store/RelayModernOperationDescriptor.d.ts
+++ b/types/relay-runtime/lib/store/RelayModernOperationDescriptor.d.ts
@@ -1,5 +1,5 @@
 import { ConcreteRequest } from '../util/RelayConcreteNode';
-import { Variables } from '../util/RelayRuntimeTypes';
+import { CacheConfig, Variables } from '../util/RelayRuntimeTypes';
 import { OperationDescriptor, RequestDescriptor } from './RelayStoreTypes';
 /**
  * Creates an instance of the `OperationDescriptor` type defined in
@@ -7,6 +7,14 @@ import { OperationDescriptor, RequestDescriptor } from './RelayStoreTypes';
  * are filtered to exclude variables that do not match defined arguments on the
  * operation, and default values are populated for null values.
  */
-export function createOperationDescriptor(request: ConcreteRequest, variables: Variables): OperationDescriptor;
+export function createOperationDescriptor(
+    request: ConcreteRequest,
+    variables: Variables,
+    cacheConfig: CacheConfig | null | undefined,
+): OperationDescriptor;
 
-export function createRequestDescriptor(request: ConcreteRequest, variables: Variables): RequestDescriptor;
+export function createRequestDescriptor(
+    request: ConcreteRequest,
+    variables: Variables,
+    cacheConfig: CacheConfig | null | undefined,
+): RequestDescriptor;

--- a/types/relay-runtime/lib/store/RelayModernOperationDescriptor.d.ts
+++ b/types/relay-runtime/lib/store/RelayModernOperationDescriptor.d.ts
@@ -1,5 +1,5 @@
 import { ConcreteRequest } from '../util/RelayConcreteNode';
-import { CacheConfig, Variables } from '../util/RelayRuntimeTypes';
+import { CacheConfig, DataID, Variables } from '../util/RelayRuntimeTypes';
 import { OperationDescriptor, RequestDescriptor } from './RelayStoreTypes';
 /**
  * Creates an instance of the `OperationDescriptor` type defined in
@@ -10,11 +10,12 @@ import { OperationDescriptor, RequestDescriptor } from './RelayStoreTypes';
 export function createOperationDescriptor(
     request: ConcreteRequest,
     variables: Variables,
-    cacheConfig: CacheConfig | null | undefined,
+    cacheConfig?: CacheConfig | null | undefined,
+    dataID?: DataID,
 ): OperationDescriptor;
 
 export function createRequestDescriptor(
     request: ConcreteRequest,
     variables: Variables,
-    cacheConfig: CacheConfig | null | undefined,
+    cacheConfig?: CacheConfig | null | undefined,
 ): RequestDescriptor;

--- a/types/relay-runtime/lib/store/RelayModernOperationDescriptor.d.ts
+++ b/types/relay-runtime/lib/store/RelayModernOperationDescriptor.d.ts
@@ -10,12 +10,12 @@ import { OperationDescriptor, RequestDescriptor } from './RelayStoreTypes';
 export function createOperationDescriptor(
     request: ConcreteRequest,
     variables: Variables,
-    cacheConfig?: CacheConfig | null | undefined,
+    cacheConfig?: CacheConfig | null,
     dataID?: DataID,
 ): OperationDescriptor;
 
 export function createRequestDescriptor(
     request: ConcreteRequest,
     variables: Variables,
-    cacheConfig?: CacheConfig | null | undefined,
+    cacheConfig?: CacheConfig | null,
 ): RequestDescriptor;

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -63,6 +63,7 @@ export interface RequestDescriptor {
     readonly identifier: RequestIdentifier;
     readonly node: ConcreteRequest;
     readonly variables: Variables;
+    readonly cacheConfig: CacheConfig | null | undefined;
 }
 
 /**
@@ -580,7 +581,6 @@ export interface Environment {
      */
     execute(config: {
         operation: OperationDescriptor;
-        cacheConfig?: CacheConfig | null;
         updater?: SelectorStoreUpdater | null;
     }): RelayObservable<GraphQLResponse>;
 
@@ -832,17 +832,17 @@ export type MissingFieldHandler =
  */
 export type RequiredFieldLogger = (
     arg:
-      | Readonly<{
-          kind: "missing_field.log",
-          owner: string,
-          fieldPath: string,
-        }>
-      | Readonly<{
-          kind: "missing_field.throw",
-          owner: string,
-          fieldPath: string,
-        }>
-  ) => void;
+        | Readonly<{
+              kind: 'missing_field.log';
+              owner: string;
+              fieldPath: string;
+          }>
+        | Readonly<{
+              kind: 'missing_field.throw';
+              owner: string;
+              fieldPath: string;
+          }>,
+) => void;
 
 /**
  * The results of normalizing a query.

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -63,7 +63,7 @@ export interface RequestDescriptor {
     readonly identifier: RequestIdentifier;
     readonly node: ConcreteRequest;
     readonly variables: Variables;
-    readonly cacheConfig: CacheConfig | null | undefined;
+    readonly cacheConfig: CacheConfig | null;
 }
 
 /**

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -1,6 +1,8 @@
 import {
+    CacheConfig,
     ConcreteRequest,
     ConnectionHandler,
+    DataID,
     Environment,
     getDefaultMissingFieldHandlers,
     Network,
@@ -11,10 +13,14 @@ import {
     RecordSource,
     RecordSourceSelectorProxy,
     Store,
+    Variables,
     commitLocalUpdate,
     ReaderFragment,
     isPromise,
     __internal,
+    graphql,
+    getRequest,
+    createOperationDescriptor,
 } from 'relay-runtime';
 
 const source = new RecordSource();
@@ -407,3 +413,22 @@ const p = Promise.resolve() as unknown;
 if (isPromise(p)) {
     p.then(() => console.log('Indeed a promise'));
 }
+
+
+const gqlQuery = graphql`
+    query ExampleQuery($pageID: ID!) {
+        page(id: $pageID) {
+            name
+        }
+   }
+`;
+
+const pageID = '110798995619330';
+const cacheConfig: CacheConfig = { force: true};
+const request = getRequest(gqlQuery);
+const variables: Variables = {pageID};
+const dataID: DataID = "dataID";
+const operation = createOperationDescriptor(request, variables);
+const operationWithCacheConfig = createOperationDescriptor(request, variables, cacheConfig);
+const operationWithDataID = createOperationDescriptor(request, variables, undefined, dataID);
+const operationWithAll = createOperationDescriptor(request, variables, cacheConfig, dataID);

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -414,7 +414,6 @@ if (isPromise(p)) {
     p.then(() => console.log('Indeed a promise'));
 }
 
-
 const gqlQuery = graphql`
     query ExampleQuery($pageID: ID!) {
         page(id: $pageID) {


### PR DESCRIPTION
In this PR I fix:
[RequestDescriptor](https://github.com/facebook/relay/blob/v10.1.0/packages/relay-runtime/store/RelayStoreTypes.js#L83-L88)
[createOperationDescriptor](https://github.com/facebook/relay/blob/v10.1.0/packages/relay-runtime/store/RelayModernOperationDescriptor.js#L35-L40)
[createRequestDescriptor](https://github.com/facebook/relay/blob/v10.1.0/packages/relay-runtime/store/RelayModernOperationDescriptor.js#L70-L74)
[fetchQuery internal](https://github.com/facebook/relay/blob/v10.1.0/packages/relay-runtime/query/fetchQueryInternal.js#L105-L108)

```js
export type RequestDescriptor = {|
  +identifier: RequestIdentifier,
  +node: ConcreteRequest,
  +variables: Variables,
  +cacheConfig: ?CacheConfig,
|};

function createOperationDescriptor(
  request: ConcreteRequest,
  variables: Variables,
  cacheConfig?: ?CacheConfig,
  dataID?: DataID = ROOT_ID,
): OperationDescriptor

function createRequestDescriptor(
  request: ConcreteRequest,
  variables: Variables,
  cacheConfig?: ?CacheConfig,
): RequestDescriptor

function fetchQuery(
  environment: IEnvironment,
  operation: OperationDescriptor,
): Observable<GraphQLResponse>

```

* RelayEnvironment

[execute](https://github.com/facebook/relay/blob/v10.1.0/packages/relay-runtime/store/RelayModernEnvironment.js#L362-L368)
[executeMutation](https://github.com/facebook/relay/blob/v10.1.0/packages/relay-runtime/store/RelayModernEnvironment.js#L413-L425)
```js
  execute({
    operation,
    updater,
  }: {|
    operation: OperationDescriptor,
    updater?: ?SelectorStoreUpdater,
  |}): RelayObservable<GraphQLResponse>

 executeMutation({
    operation,
    optimisticResponse,
    optimisticUpdater,
    updater,
    uploadables,
  }: {|
    operation: OperationDescriptor,
    optimisticUpdater?: ?SelectorStoreUpdater,
    optimisticResponse?: ?Object,
    updater?: ?SelectorStoreUpdater,
    uploadables?: ?UploadableMap,
  |}): RelayObservable<GraphQLResponse>
```

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
[mutationConfig](https://github.com/facebook/relay/blob/v10.0.1/packages/relay-runtime/mutations/commitMutation.js#L62-L84)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
