### PR TITLE
[xo] Update type definition of xo to 0.34

### DIFF
--- a/types/xo/index.d.ts
+++ b/types/xo/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for xo 0.28
+// Type definitions for xo 0.34
 // Project: https://github.com/xojs/xo#readme
 // Definitions by: Piotr Błażejewicz (Peter Blazejewicz) <https://github.com/peterblazejewicz>
+//                 Chuah Chee Shian (shian15810) <https://github.com/shian15810>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import eslint = require('eslint');
@@ -54,7 +55,7 @@ export type Options = {
     /** Set it to false to enforce no-semicolon style. */
     semicolon?: boolean;
     /** Set it to true to get 2-space indentation or specify the number of spaces. */
-    space?: number | string;
+    space?: boolean | number;
     /**
      * Use {@link https://github.com/benmosher/eslint-plugin-import/tree/master/resolvers/webpack}
      * to resolve import search paths. This is enabled automatically if a `webpack.config.js` file is found.

--- a/types/xo/xo-tests.ts
+++ b/types/xo/xo-tests.ts
@@ -6,6 +6,11 @@ import path = require('path');
 const glob = path.join(__dirname, '..', '*.md');
 
 const options: xo.Options = {};
+
+options.space = 2;
+options.space = true;
+options.space = false;
+
 options.webpack = {
     config: {
         resolve: {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/xojs/xo#space>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
