### PR TITLE
Update gestalt types to be in sync with 14.28

### DIFF
--- a/types/gestalt/gestalt-tests.tsx
+++ b/types/gestalt/gestalt-tests.tsx
@@ -49,6 +49,7 @@ import {
     Toast,
     Tooltip,
     Typeahead,
+    Upsell,
     Video,
     FixedZIndex,
     CompositeZIndex,
@@ -252,6 +253,7 @@ const MasonryComponent = ({}) => {
     options={[{ value: 'Hello', label: 'World' }]}
     placeholder="Select a Label"
 />;
+<Upsell message="Hello world" />;
 <Video
     aspectRatio={853 / 480}
     captions=""

--- a/types/gestalt/index.d.ts
+++ b/types/gestalt/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for gestalt 14.26
+// Type definitions for gestalt 14.28.1
 // Project: https://github.com/pinterest/gestalt, https://pinterest.github.io/gestalt
 // Definitions by: Nicolás Serrano Arévalo <https://github.com/serranoarevalo>
 //                 Josh Gachnang <https://github.com/joshgachnang>
@@ -1195,6 +1195,21 @@ export interface TypeaheadProps {
 }
 
 /**
+ * Upsell Props Interface
+ * https://gestalt.netlify.app/Upsell
+ */
+export interface UpsellProps {
+    dismissButton?: {
+        accessibilityLabel: string;
+        onDismiss: () => void;
+    };
+    message: string;
+    primaryLink?: LinkData;
+    secondaryLink?: LinkData;
+    title?: string;
+}
+
+/**
  * Video Props Interface
  * https://gestalt.netlify.app/Video
  */
@@ -1320,4 +1335,5 @@ export const TextField: ReactForwardRef<HTMLInputElement, TextFieldProps>;
 export class Toast extends React.Component<ToastProps, any> {}
 export class Tooltip extends React.Component<TooltipProps, any> {}
 export const Typeahead: ReactForwardRef<HTMLInputElement, TypeaheadProps>;
+export class Upsell extends React.Component<UpsellProps, any> {}
 export class Video extends React.Component<VideoProps, any> {}

--- a/types/gestalt/index.d.ts
+++ b/types/gestalt/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for gestalt 14.28.1
+// Type definitions for gestalt 14.28
 // Project: https://github.com/pinterest/gestalt, https://pinterest.github.io/gestalt
 // Definitions by: Nicolás Serrano Arévalo <https://github.com/serranoarevalo>
 //                 Josh Gachnang <https://github.com/joshgachnang>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [new component PR](https://github.com/pinterest/gestalt/pull/1283)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
