### PR TITLE
pg: Includes properties of Client in class

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -249,6 +249,13 @@ export class ClientBase extends events.EventEmitter {
 }
 
 export class Client extends ClientBase {
+    user?: string;
+    database?: string;
+    port: number;
+    host: string;
+    password?: string;
+    ssl: boolean;
+
     constructor(config?: string | ClientConfig);
 
     end(): Promise<void>;

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -12,6 +12,14 @@ const client = new Client({
     application_name: 'DefinitelyTyped',
     keepAlive: true,
 });
+
+const user: string | undefined = client.user;
+const database: string | undefined = client.database;
+const port: number = client.port;
+const host: string = client.host;
+const password: string | undefined = client.password;
+const ssl: boolean = client.ssl;
+
 client.connect(err => {
     if (err) {
         console.error('Could not connect to postgres', err);


### PR DESCRIPTION
This change simply exposes existing properties from the Client class in the types so they can be accessed as they are expected to exist. This accounts for potentially undefined values based on the package logic, which uses a getter for environment variable fallbacks and a defaults module. Properties included are `user`, `database`, `port`, `host`, `password`, and `ssl`.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/brianc/node-postgres/blob/master/packages/pg/lib/client.js#L20
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
