### PR TITLE
Allow react-native PressableStateCallbackType to be augmented

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -471,9 +471,9 @@ export interface Insets {
     right?: number;
 }
 
-export type PressableStateCallbackType = Readonly<{
-    pressed: boolean;
-}>;
+export interface PressableStateCallbackType {
+    readonly pressed: boolean;
+}
 
 export interface PressableAndroidRippleConfig {
     color?: null | ColorValue;


### PR DESCRIPTION
Following this comment: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48723#issuecomment-728839382

Switching to an interface allow type augmentation, which is needed for `react-native-web` since this project also exposes `hovered` and `focused`.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/necolas/react-native-web/blob/0.14.8/packages/react-native-web/src/exports/Pressable/index.js#L24
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **(not needed)**
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing) **(not needed)**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed. **(not needed)**