### PR TITLE
mssql: make database of config optional

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -194,7 +194,7 @@ export interface config {
     server: string;
     port?: number;
     domain?: string;
-    database: string;
+    database?: string;
     connectionTimeout?: number;
     requestTimeout?: number;
     stream?: boolean;

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -24,6 +24,8 @@ var config: sql.config = {
     }
 }
 
+var minimalConfig: sql.config = { server: 'ip' };
+
 var connectionStringTest: sql.ConnectionPool = new sql.ConnectionPool("connectionstring", (err) => {
     if (err) {
         return err;


### PR DESCRIPTION
The property is inherently optional and has to be omitted when eg. working with mssql when a database has yet to be created.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
 - I'm not sure what to provide here. I've been using this library to connect to servers without database and creating it, for a long time now.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
