### PR TITLE
[@types/carbon-components-react] Update types to match 7.24.x

### DIFF
--- a/types/carbon-components-react/index.d.ts
+++ b/types/carbon-components-react/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for carbon-components-react 7.23
+// Type definitions for carbon-components-react 7.24
 // Project: https://github.com/carbon-design-system/carbon/tree/master/packages/react
 // Definitions by: Kyle Albert <https://github.com/kalbert312>
 //                 Sebastien Gregoire <https://github.com/sgregoire>

--- a/types/carbon-components-react/lib/components/Button/Button.d.ts
+++ b/types/carbon-components-react/lib/components/Button/Button.d.ts
@@ -19,7 +19,7 @@ export interface ButtonRenderIconRenderProps {
 }
 
 // this is split due to a typing issue with the specialized buttons (SecondaryButton, etc)
-interface ButtonKindProps {
+export interface ButtonKindProps {
     kind?: ButtonKind;  // required by has default value
 }
 

--- a/types/carbon-components-react/lib/components/Dropdown/Dropdown.Skeleton.d.ts
+++ b/types/carbon-components-react/lib/components/Dropdown/Dropdown.Skeleton.d.ts
@@ -1,11 +1,13 @@
 import * as React from "react";
 import { ReactDivAttr } from "../../../typings/shared";
+import { ListBoxSize } from "../ListBox/ListBoxPropTypes";
 
 export interface DropdownSkeletonProps extends ReactDivAttr {
     /**
      * @deprecated
      */
     inline?: boolean,
+    size?: ListBoxSize;
 }
 
 declare const DropdownSkeleton: React.FC<DropdownSkeletonProps>;

--- a/types/carbon-components-react/lib/components/Tab/Tab.d.ts
+++ b/types/carbon-components-react/lib/components/Tab/Tab.d.ts
@@ -21,8 +21,8 @@ export interface TabCustomAnchorProviderProps extends TabCustomButtonProvidedPro
 
 export interface TabStandaloneProps extends Omit<ReactLIAttr, ExcludedAttributes> {
     disabled?: boolean;
-    handleTabClick(index: TabStandaloneProps["index"], event: React.MouseEvent<HTMLLIElement>): void,
-    handleTabKeyDown(index: TabStandaloneProps["index"], event: React.KeyboardEvent<HTMLLIElement>): void,
+    handleTabClick?(index: TabStandaloneProps["index"], event: React.MouseEvent<HTMLLIElement>): void,
+    handleTabKeyDown?(index: TabStandaloneProps["index"], event: React.KeyboardEvent<HTMLLIElement>): void,
     /**
      * @deprecated
      */

--- a/types/carbon-components-react/lib/components/UIShell/SideNavLink.d.ts
+++ b/types/carbon-components-react/lib/components/UIShell/SideNavLink.d.ts
@@ -6,7 +6,7 @@ import {
     SideNavSharedProps,
     SideNavSizingProps,
     FCReturn,
-    FCProps,
+    ForwardRefProps,
 } from "../../../typings/shared";
 import { LinkProps } from "./Link";
 
@@ -21,6 +21,6 @@ export declare function createCustomSideNavLink<E extends object = {}>(
     element: SideNavLinkProps['element']
 ): SideNavLinkFC<Omit<E, 'element'>>;
 
-declare function SideNavLink<E extends object = ReactAnchorAttr>(props: FCProps<SideNavLinkProps<E>>): FCReturn;
+declare function SideNavLink<E extends object = ReactAnchorAttr>(props: ForwardRefProps<HTMLElement, SideNavLinkProps<E>>): FCReturn;
 
 export default SideNavLink;

--- a/types/carbon-components-react/typings/shared.d.ts
+++ b/types/carbon-components-react/typings/shared.d.ts
@@ -72,7 +72,7 @@ export interface SideNavSizingProps {
 //  function component with no generics: export declare const Comp: React.FC<PropsInterface>;
 //  function component with generics: export declare function Comp<T extends SomeType>(props: FCProps<PropsInterface<T>>): FCReturn;
 //  forwardRef component with no generics: export declare const Comp: ForwardRefReturn<HTMLElement, PropsInterface>;
-//  forwardRef component with generics: export declare function Comp<T extends SomeType>(props: ForwardRefProps<PropsInterface<T>>): FCReturn;
+//  forwardRef component with generics: export declare function Comp<T extends SomeType>(props: ForwardRefProps<HTMLElement, PropsInterface<T>>): FCReturn;
 //
 export type FCProps<P = {}> = Parameters<React.FC<P>>[0];
 export type FCReturn = ReturnType<React.FC>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/carbon-design-system/carbon/tree/v10.24.0/packages/react
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
