### PR TITLE
ProseMirror-state: Union type for state.selection

### DIFF
--- a/types/prosemirror-state/index.d.ts
+++ b/types/prosemirror-state/index.d.ts
@@ -428,7 +428,7 @@ export class EditorState<S extends Schema = any> {
   /**
    * The selection.
    */
-  selection: Selection<S>;
+  selection: TextSelection<S> | NodeSelection<S> | AllSelection<S>;
   /**
    * A set of marks to apply to the next input. Will be null when
    * no explicit marks have been set.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

The editor state documentation says its just a `Selection`: https://prosemirror.net/docs/ref/#state.EditorState.selection

But if you look at [how it is being used within internal packages](https://github.com/ProseMirror/prosemirror-commands/blob/1c5e9397932ecc615f3a4a976175d3c0a6928eae/src/commands.js#L280), `$cursor` is only available on `TextSelection` and [in other places](https://github.com/ProseMirror/prosemirror-commands/blob/1c5e9397932ecc615f3a4a976175d3c0a6928eae/src/commands.js#L300) we're checking instanceof the subclasses.

