### PR TITLE
ProseMirror-model: Export ProsemirrorNode type so we can use it.

### DIFF
--- a/types/prosemirror-model/index.d.ts
+++ b/types/prosemirror-model/index.d.ts
@@ -463,7 +463,7 @@ export class Mark<S extends Schema = any> {
  * **Do not** directly mutate the properties of a `Node` object. See
  * [the guide](/docs/guide/#doc) for more information.
  */
-declare class ProsemirrorNode<S extends Schema = any> {
+export class ProsemirrorNode<S extends Schema = any> {
   /**
    * The type of node that this is.
    */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

The problem I'm running into here is that its challenging use `ProsemirrorNode` as a type. For example:

```ts
const blocks: Array<ProsemirrorNode<EditorSchema>> = []
state.doc.nodesBetween(
	state.selection.from,
	state.selection.to,
	(node) => {
		if (node.isBlock) {
			blocks.push(node)
			return false
		}
	}
)
```

In order to do this, I'm currently using the following workaround:

```ts
type ProsemirrorNode<S extends Schema> = 
	ReturnType<NodeType<S>["create"]>
```

Ideally we'd just export `ProsemirrorNode` type and we're good to go.
