### PR TITLE
Fix module function declaration confusion for fg-loadcss

### DIFF
--- a/types/fg-loadcss/fg-loadcss-tests.ts
+++ b/types/fg-loadcss/fg-loadcss-tests.ts
@@ -1,4 +1,4 @@
-import loadCSS  = require("fg-loadcss");
+import { loadCSS } from 'fg-loadcss';
 
 loadCSS("example.css");
 loadCSS("example.css", document.body);

--- a/types/fg-loadcss/index.d.ts
+++ b/types/fg-loadcss/index.d.ts
@@ -3,16 +3,12 @@
 // Definitions by: Noah Overcash <https://github.com/ncovercash>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export as namespace loadCSS;
-
-declare function loadCSS(
+export function loadCSS(
     href: string,
     before?: HTMLElement,
     media?: string,
     attributes?: Record<string, string>,
 ): HTMLLinkElement;
-
-export = loadCSS;
 
 declare global {
     interface Window {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **(N/A)**
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

On the original PR to add this package, #49578 , it seems the final fixes that @peterblazejewicz had suggested were accidentally approved and the PR merged before they could be added to the source, leading to a broken current version of @types/fg-loadcss.  This fixes that issue using the latest suggestions from the aforementioned thread.