### PR TITLE
[@types/relay-runtime]: added getFragmentIdentifier

### DIFF
--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -181,6 +181,7 @@ export { requestSubscription } from './lib/subscription/requestSubscription';
 export { RelayProfiler } from './lib/util/RelayProfiler';
 export { default as getRelayHandleKey } from './lib/util/getRelayHandleKey';
 export { default as getRequestIdentifier } from './lib/util/getRequestIdentifier';
+export { default as getFragmentIdentifier } from './lib/util/getFragmentIdentifier';
 
 // INTERNAL-ONLY
 export { RelayConcreteNode } from './lib/util/RelayConcreteNode';

--- a/types/relay-runtime/lib/util/getFragmentIdentifier.d.ts
+++ b/types/relay-runtime/lib/util/getFragmentIdentifier.d.ts
@@ -1,0 +1,3 @@
+import type { ReaderFragment } from './ReaderNode';
+
+export default function getFragmentIdentifier(fragmentNode: ReaderFragment, fragmentRef: any): string;

--- a/types/relay-runtime/lib/util/getFragmentIdentifier.d.ts
+++ b/types/relay-runtime/lib/util/getFragmentIdentifier.d.ts
@@ -1,3 +1,3 @@
-import type { ReaderFragment } from './ReaderNode';
+import { ReaderFragment } from './ReaderNode';
 
 export default function getFragmentIdentifier(fragmentNode: ReaderFragment, fragmentRef: any): string;


### PR DESCRIPTION
This PR added [getFragmentIdentifier](https://github.com/facebook/relay/blob/v10.1.0/packages/relay-runtime/util/getFragmentIdentifier.js)
https://github.com/facebook/relay/blob/master/packages/relay-runtime/index.js#L324

```js
function getFragmentIdentifier(
  fragmentNode: ReaderFragment,
  fragmentRef: mixed,
): string

```

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.