### PR TITLE
[express-session] Restore SessionData.cookie

### DIFF
--- a/types/express-session/express-session-tests.ts
+++ b/types/express-session/express-session-tests.ts
@@ -102,6 +102,18 @@ class MyStore extends Store {
         if (callback) callback();
     }
 
+    touch = (sid: string, session: SessionData, callback?: (err?: any) => void) => {
+        const currentSession = this.sessions[sid];
+        const sessionData: SessionData | null = currentSession ? JSON.parse(currentSession) : null;
+
+        if (sessionData) {
+            // Real case could compare cookie timestamps to determine if touch to Store backend is needed
+            sessionData.cookie = session.cookie;
+            this.sessions[sid] = JSON.stringify(currentSession);
+        }
+        if (callback) callback();
+    };
+
     destroy = (sid: string, callback?: (err?: any) => void): void => {
         this.sessions[sid] = undefined;
         this.sessions = JSON.parse(JSON.stringify(this.sessions));

--- a/types/express-session/express-session-tests.ts
+++ b/types/express-session/express-session-tests.ts
@@ -109,10 +109,10 @@ class MyStore extends Store {
         if (sessionData) {
             // Real case could compare cookie timestamps to determine if touch to Store backend is needed
             sessionData.cookie = session.cookie;
-            this.sessions[sid] = JSON.stringify(currentSession);
+            this.sessions[sid] = JSON.stringify(sessionData);
         }
         if (callback) callback();
-    };
+    }
 
     destroy = (sid: string, callback?: (err?: any) => void): void => {
         this.sessions[sid] = undefined;

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -210,8 +210,8 @@ declare namespace session {
      * }
      *
      */
-    // tslint:disable-next-line no-empty-interface
     interface SessionData {
+        cookie: Cookie;
     }
 
     interface CookieOptions {


### PR DESCRIPTION
Restore SessionData.cookie that is an existing attribute in express-session.

One can see the `.cookie` being accessed in https://github.com/expressjs/session/blob/a8641429502fcc076c4b2dcbd6b2320891c1650c/session/memory.js#L152 by touch() and being returned in https://github.com/expressjs/session/blob/master/session/memory.js#L174 by get().

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: See below
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [X] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Update from 1.17.0 to 1.17.2 was a breaking change as expected by @HoldYourWaffle in #46576 .

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/c85e409bc07d904d9eb94fd861bf79183f2ae96f/types/express-session/index.d.ts#L342 defines the session parameter type as SessionData.

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/c85e409bc07d904d9eb94fd861bf79183f2ae96f/types/express-session/index.d.ts#L214-L215 defines it as an empty interface.

Version 1.17.0 used to define SessionData with
```
    interface SessionData {
      [key: string]: any;
      cookie: SessionCookieData;
    }
```

