### PR TITLE
fix(braintree-web-drop-in): extends definition further

### DIFF
--- a/types/braintree-web-drop-in/index.d.ts
+++ b/types/braintree-web-drop-in/index.d.ts
@@ -121,11 +121,23 @@ export interface Dropin {
     off(event: 'noPaymentMethodRequestable', handler: () => void): void;
     off(event: 'paymentMethodRequestable', handler: (payload: PaymentMethodRequestablePayload) => void): void;
     off(event: 'paymentOptionSelected', handler: (payload: PaymentOptionSelectedPayload) => void): void;
-    requestPaymentMethod(options: object, callback: RequestPaymentMethodCallback): void;
+    requestPaymentMethod(options: PaymentMethodOptions, callback: RequestPaymentMethodCallback): void;
     requestPaymentMethod(callback: RequestPaymentMethodCallback): void;
-    requestPaymentMethod(): Promise<PaymentMethodPayload>;
+    requestPaymentMethod(options?: PaymentMethodOptions): Promise<PaymentMethodPayload>;
     teardown(callback: (error: object | null | undefined) => void): void;
     teardown(): Promise<void>;
+}
+
+export interface PaymentMethodOptions {
+    threeDSecure: {
+        amount: string;
+        challengeRequested?: boolean;
+        exemptionRequested?: boolean;
+        email?: string;
+        mobilePhoneNumber?: string;
+        billingAddress?: object;
+        additionalInformation?: object;
+    };
 }
 
 export type RequestPaymentMethodCallback = (error: object | null, payload: PaymentMethodPayload) => void;

--- a/types/braintree-web-drop-in/test/braintree-web-drop-in-global.test.ts
+++ b/types/braintree-web-drop-in/test/braintree-web-drop-in-global.test.ts
@@ -5,7 +5,7 @@ import {
     cardPaymentMethodPayload,
 } from 'braintree-web-drop-in';
 
-braintree.dropin.create({ authorization: "", container: "my-div" }, (error, myDropin) => {
+braintree.dropin.create({ authorization: '', container: 'my-div' }, (error, myDropin) => {
     if (error) {
         return;
     }
@@ -16,11 +16,11 @@ braintree.dropin.create({ authorization: "", container: "my-div" }, (error, myDr
 
 (async () => {
     const myDropin = await braintree.dropin.create({
-        authorization: "",
-        container: "my-div",
-        locale: "en-US",
+        authorization: '',
+        container: 'my-div',
+        locale: 'en-US',
         translations: {},
-        paymentOptionPriority: ["card", "paypal", "paypalCredit", "venmo", "applePay"],
+        paymentOptionPriority: ['card', 'paypal', 'paypalCredit', 'venmo', 'applePay'],
         card: {
             cardholderName: {
                 required: false,
@@ -36,9 +36,9 @@ braintree.dropin.create({ authorization: "", container: "my-div" }, (error, myDr
             },
         },
         paypal: {
-            flow: "checkout",
+            flow: 'checkout',
             amount: 1,
-            currency: "USD",
+            currency: 'USD',
             buttonStyle: {},
             commit: false,
         },
@@ -47,34 +47,34 @@ braintree.dropin.create({ authorization: "", container: "my-div" }, (error, myDr
             allowNewBrowserTab: false,
         },
         applePay: {
-            buttonStyle: "white-outline",
-            displayName: "name",
+            buttonStyle: 'white-outline',
+            displayName: 'name',
             applePaySessionVersion: 1,
             paymentRequest: {
-                countryCode: "US",
-                currencyCode: "USD",
-                supportedNetworks: ["visa", "masterCard"],
-                merchantCapabilities: ["supports3DS"],
-                total: { label: "Your Label", amount: "10.00" },
+                countryCode: 'US',
+                currencyCode: 'USD',
+                supportedNetworks: ['visa', 'masterCard'],
+                merchantCapabilities: ['supports3DS'],
+                total: { label: 'Your Label', amount: '10.00' },
             },
         },
         googlePay: {
-            merchantId: "",
-            googlePayVersion: "",
+            merchantId: '',
+            googlePayVersion: '',
             transactionInfo: {
-                currencyCode: "USD",
-                totalPriceStatus: "FINAL",
-                totalPrice: "100.00",
+                currencyCode: 'USD',
+                totalPriceStatus: 'FINAL',
+                totalPrice: '100.00',
             },
             button: {
-                onClick: (event) => {}
+                onClick: event => {},
             },
         },
         dataCollector: {
             kount: false,
         },
         threeDSecure: {
-            amount: "1",
+            amount: '1',
         },
         vaultManager: false,
         preselectVaultedPaymentMethod: false,
@@ -87,20 +87,20 @@ braintree.dropin.create({ authorization: "", container: "my-div" }, (error, myDr
         return;
     }
     function onPaymentMethodRequestable({ type, paymentMethodIsSelected }: PaymentMethodRequestablePayload) {
-        const myType: "CreditCard" | "PayPalAccount" = type;
+        const myType: 'CreditCard' | 'PayPalAccount' = type;
         const myBool: boolean = paymentMethodIsSelected;
     }
     function onPaymentOptionSelected({ paymentOption }: PaymentOptionSelectedPayload) {
-        const myPaymentOption: "card" | "paypal" | "paypalCredit" = paymentOption;
+        const myPaymentOption: 'card' | 'paypal' | 'paypalCredit' = paymentOption;
     }
 
-    myDropin.on("noPaymentMethodRequestable", onNoPaymentMethodRequestable);
-    myDropin.on("paymentMethodRequestable", onPaymentMethodRequestable);
-    myDropin.on("paymentOptionSelected", onPaymentOptionSelected);
+    myDropin.on('noPaymentMethodRequestable', onNoPaymentMethodRequestable);
+    myDropin.on('paymentMethodRequestable', onPaymentMethodRequestable);
+    myDropin.on('paymentOptionSelected', onPaymentOptionSelected);
 
-    myDropin.off("noPaymentMethodRequestable", onNoPaymentMethodRequestable);
-    myDropin.off("paymentMethodRequestable", onPaymentMethodRequestable);
-    myDropin.off("paymentOptionSelected", onPaymentOptionSelected);
+    myDropin.off('noPaymentMethodRequestable', onNoPaymentMethodRequestable);
+    myDropin.off('paymentMethodRequestable', onPaymentMethodRequestable);
+    myDropin.off('paymentOptionSelected', onPaymentOptionSelected);
 
     myDropin.requestPaymentMethod((error, payload) => {
         if (error) {

--- a/types/braintree-web-drop-in/test/braintree-web-drop-in-module.test.ts
+++ b/types/braintree-web-drop-in/test/braintree-web-drop-in-module.test.ts
@@ -1,6 +1,6 @@
-import * as dropin from "braintree-web-drop-in";
+import * as dropin from 'braintree-web-drop-in';
 
-dropin.create({ authorization: "", container: "my-div" }, (error, myDropin) => {
+dropin.create({ authorization: '', container: 'my-div' }, (error, myDropin) => {
     if (error) {
         return;
     }
@@ -11,11 +11,11 @@ dropin.create({ authorization: "", container: "my-div" }, (error, myDropin) => {
 
 (async () => {
     const myOptions: dropin.Options = {
-        authorization: "",
-        container: "my-div",
-        locale: "en-US",
+        authorization: '',
+        container: 'my-div',
+        locale: 'en-US',
         translations: {},
-        paymentOptionPriority: ["card", "paypal", "paypalCredit", "venmo", "applePay"],
+        paymentOptionPriority: ['card', 'paypal', 'paypalCredit', 'venmo', 'applePay'],
         card: {
             cardholderName: {
                 required: false,
@@ -31,9 +31,9 @@ dropin.create({ authorization: "", container: "my-div" }, (error, myDropin) => {
             },
         },
         paypal: {
-            flow: "checkout",
+            flow: 'checkout',
             amount: 1,
-            currency: "USD",
+            currency: 'USD',
             buttonStyle: {},
             commit: false,
         },
@@ -42,34 +42,34 @@ dropin.create({ authorization: "", container: "my-div" }, (error, myDropin) => {
             allowNewBrowserTab: false,
         },
         applePay: {
-            buttonStyle: "white-outline",
-            displayName: "name",
+            buttonStyle: 'white-outline',
+            displayName: 'name',
             applePaySessionVersion: 1,
             paymentRequest: {
-                countryCode: "US",
-                currencyCode: "USD",
-                supportedNetworks: ["visa", "masterCard"],
-                merchantCapabilities: ["supports3DS"],
-                total: { label: "Your Label", amount: "10.00" },
+                countryCode: 'US',
+                currencyCode: 'USD',
+                supportedNetworks: ['visa', 'masterCard'],
+                merchantCapabilities: ['supports3DS'],
+                total: { label: 'Your Label', amount: '10.00' },
             },
         },
         googlePay: {
-            merchantId: "",
-            googlePayVersion: "",
+            merchantId: '',
+            googlePayVersion: '',
             transactionInfo: {
-                currencyCode: "USD",
-                totalPriceStatus: "FINAL",
-                totalPrice: "100.00",
+                currencyCode: 'USD',
+                totalPriceStatus: 'FINAL',
+                totalPrice: '100.00',
             },
             button: {
-                onClick: (event) => {}
+                onClick: event => {},
             },
         },
         dataCollector: {
             kount: false,
         },
         threeDSecure: {
-            amount: "1",
+            amount: '1',
         },
         vaultManager: false,
         preselectVaultedPaymentMethod: false,
@@ -83,20 +83,20 @@ dropin.create({ authorization: "", container: "my-div" }, (error, myDropin) => {
         return;
     }
     function onPaymentMethodRequestable({ type, paymentMethodIsSelected }: dropin.PaymentMethodRequestablePayload) {
-        const myType: "CreditCard" | "PayPalAccount" = type;
+        const myType: 'CreditCard' | 'PayPalAccount' = type;
         const myBool: boolean = paymentMethodIsSelected;
     }
     function onPaymentOptionSelected({ paymentOption }: dropin.PaymentOptionSelectedPayload) {
-        const myPaymentOption: "card" | "paypal" | "paypalCredit" = paymentOption;
+        const myPaymentOption: 'card' | 'paypal' | 'paypalCredit' = paymentOption;
     }
 
-    myDropin.on("noPaymentMethodRequestable", onNoPaymentMethodRequestable);
-    myDropin.on("paymentMethodRequestable", onPaymentMethodRequestable);
-    myDropin.on("paymentOptionSelected", onPaymentOptionSelected);
+    myDropin.on('noPaymentMethodRequestable', onNoPaymentMethodRequestable);
+    myDropin.on('paymentMethodRequestable', onPaymentMethodRequestable);
+    myDropin.on('paymentOptionSelected', onPaymentOptionSelected);
 
-    myDropin.off("noPaymentMethodRequestable", onNoPaymentMethodRequestable);
-    myDropin.off("paymentMethodRequestable", onPaymentMethodRequestable);
-    myDropin.off("paymentOptionSelected", onPaymentOptionSelected);
+    myDropin.off('noPaymentMethodRequestable', onNoPaymentMethodRequestable);
+    myDropin.off('paymentMethodRequestable', onPaymentMethodRequestable);
+    myDropin.off('paymentOptionSelected', onPaymentOptionSelected);
 
     myDropin.requestPaymentMethod((error, payload) => {
         if (error) {


### PR DESCRIPTION
I added some simple definitions of the three-d-secure options. I also
ran `npm run prettier types/braintree-web-drop-in/**/*.ts -- -w`.

The affected method is [here](https://braintree.github.io/braintree-web-drop-in/docs/current/Dropin.html#requestPaymentMethod).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://braintree.github.io/braintree-web-drop-in/docs/current/module-braintree-web-drop-in.html#.create
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/definitelytyped/definitelytyped/49661)
<!-- Reviewable:end -->
