### PR TITLE
Added type definitions for Timepicker Plugin for jQuery

### DIFF
--- a/types/timepicker/index.d.ts
+++ b/types/timepicker/index.d.ts
@@ -1,0 +1,144 @@
+// Type definitions for Timepicker Plugin for jQuery 1.13
+// Project: <https://github.com/jonthornton/jquery-timepicker>
+// Definitions by: doberkofler <https://github.com/doberkofler>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 4.0
+
+/// <reference types="jquery"/>
+
+interface JQueryTimepickerOptions {
+	// Override where the dropdown is appended.
+	// Takes either a string to use as a selector, a function that gets passed the clicked input element as argument or a jquery object to use directly.
+	// default: "body"
+	appendTo?: string|JQuery,
+
+	// A class name to apply to the HTML element that contains the timepicker dropdown.
+	// default: null
+	className?: string,
+
+	// Close the timepicker when the window is scrolled. (Replicates <select> behavior.)
+	// default: false
+	closeOnWindowScroll?: boolean,
+
+	// Disable selection of certain time ranges. Input is an array of time pairs, like [['3:00am', '4:30am'], ['5:00pm', '8:00pm']]. The start of the interval will be disabled but the end won't. default: []
+	disableTimeRanges?: Array<Array<string>>,
+
+	// Disable typing in the timepicker input box; force users to select from list. More information here.
+	// default: false
+	disableTextInput?: boolean,
+
+	// Disable the onscreen keyboard for touch devices. There can be instances where Firefox or Chrome have touch events enabled (such as on Surface tablets but not actually be a touch device. In this case disableTouchKeyboard will prevent the timepicker input field from being focused. More information here.
+	// default: false
+	disableTouchKeyboard?: boolean,
+
+	// The time against which showDuration will compute relative times. If this is a function, its result will be used.
+	// default: minTime
+	durationTime?: string,
+
+	// Force update the time to step settings as soon as it loses focus.
+	// default: false
+	forceRoundTime?: boolean,
+
+	// Language constants used in the timepicker. Can override the defaults by passing an object with one or more of the following properties: decimal, mins, hr, hrs.
+	// default: { am: 'am', pm: 'pm', AM: 'AM', PM: 'PM', decimal: '.', mins: 'mins', hr: 'hr', hrs: 'hrs' }
+	lang?: {am?: string, pm?: string, AM?: string, PM?: string, decimal?: string, mins?: string, hr?: string, hrs?: string},
+
+	// Set this to override CSS styling and set the list width to match the input element's width. Set to 1 to match input width, 2 to double input width, .5 to halve input width, etc. Set to null to let CSS determine the list width.
+	// default: null (CSS styling)
+	listWidth?: string,
+
+	// The time that should appear last in the dropdown list. Can be used to limit the range of time options.
+	// default: 24 hours after minTime
+	maxTime?: string,
+
+	// The time that should appear first in the dropdown list.
+	// default: 12:00am
+	minTime?: string,
+
+	// Adds one or more custom options to the top of the dropdown. Can accept several different value types:
+	// Boolean (true): Adds a "None" option that results in an empty input value
+	// String: Adds an option with a custom label that results in an empty input value
+	// Object: Similar to string, but allows customizing the element's class name and the resulting input value. Can contain label, value, and className properties. value must be a string type.
+	// Array: An array of strings or objects to add multiple non-time options
+	// default: false
+	noneOption?: boolean|string|Array<string>,
+
+	// By default the timepicker dropdown will be aligned to the bottom right of the input element, or aligned to the top left if there isn't enough room below the input. Force alignment with l (left), r (right), c (horizontal center), t (top), and b (bottom). Examples: tl, rb. default: 'l'
+	orientation?: string,
+
+	// Function used to compute rounded times. The function will receive time in seconds and a settings object as arguments. The function should handle a null value for seconds. default: round to nearest step
+	roundingFunction?: (seconds: number) => number,
+
+	// If no time value is selected, set the dropdown scroll position to show the time provided, e.g. "09:00". A time string, Date object, or integer (seconds past midnight) is acceptible, as well as the string 'now'.
+	// default: null
+	scrollDefault?: string,
+
+	// Update the input with the currently highlighted time value when the timepicker loses focus.
+	// default: false
+	selectOnBlur?: boolean,
+
+	// Show "24:00" as an option when using 24-hour time format. You must also set timeFormat for this option to work.
+	// default: false
+	show2400?: boolean,
+
+	// Shows the relative time for each item in the dropdown. minTime or durationTime must be set.
+	// default: false
+	showDuration?: boolean,
+
+	// Display a timepicker dropdown when the input fires a particular event. Set to null or an empty array to disable automatic display. Setting should be an array of strings. default: ['focus']
+	showOn?: Array<string>|null,
+
+	// DEPRECATED: Display a timepicker dropdown when the input gains focus.
+	// default: true
+	showOnFocus?: boolean,
+
+	// The amount of time, in minutes, between each item in the dropdown. Alternately, you can specify a function to generate steps dynamically. The function will receive a count integer (0, 1, 2...) and is expected to return a step integer.
+	// default: 30
+	step?: number,
+
+	// When scrolling on the edge of the picker, it prevent parent containers () to scroll. default: false
+	stopScrollPropagation?: boolean,
+
+	// How times should be displayed in the list and input element. Uses PHP's date() formatting syntax. Characters can be escaped with a preceeding double slash (e.g. H\\hi). Alternatively, you can specify a function instead of a string, to use completely custom time formatting. In this case, the format function receives a Date object and is expected to return a formatted time as a string. default: 'g:ia'
+	timeFormat?: string,
+
+	// Highlight the nearest corresponding time option as a value is typed into the form input.
+	// default: true
+	typeaheadHighlight?: boolean,
+
+	// Convert the input to an HTML <SELECT> control. This is ideal for small screen devices, or if you want to prevent the user from entering arbitrary values. This option is not compatible with the following options: appendTo, closeOnWindowScroll, disableTouchKeyboard, forceRoundTime, scrollDefault, selectOnBlur, typeAheadHighlight.
+	// default: false
+	useSelect?: boolean,
+
+	// If a time greater than 24 hours (27:30, for example) is entered, apply modolo 24 to create a valid time. Setting this to false will cause an input of 27:30 to result in a timeFormatError event.
+	// default: true
+	wrapHours?: boolean,
+}
+
+interface JQuery { // eslint-disable-line @typescript-eslint/no-unused-vars
+	timepicker(options: JQueryTimepickerOptions): JQuery,
+
+	/** Get the time as an integer, expressed as seconds from 12am. */
+	timepicker(methodName: 'getSecondsFromMidnight'): number,
+
+	/** Get the time using a Javascript Date object, relative to a Date object (default: today's date). */
+	timepicker(methodName: 'timepicker', date?: Date): Date,
+
+	/** Close the timepicker dropdown. */
+	timepicker(methodName: 'hide'): void,
+
+	/** Check if the timepicker attached to *a specific input* is visible. Not compatible with the `useSelect` option. */
+	timepicker(methodName: 'isVisible'): boolean,
+
+	/** Change the settings of an existing timepicker. Calling ```option``` on a visible timepicker will cause the picker to be hidden. */
+	timepicker(methodName: 'options', options: JQueryTimepickerOptions): void,
+
+	/** Unbind an existing timepicker element. */
+	timepicker(methodName: 'remove'): void,
+
+	/** Set the time using a Javascript Date object. */
+	timepicker(methodName: 'setTime', date: Date): void,
+
+	/** Display the timepicker dropdown. */
+	timepicker(methodName: 'show'): void,
+}

--- a/types/timepicker/index.d.ts
+++ b/types/timepicker/index.d.ts
@@ -133,7 +133,7 @@ interface JQueryTimepickerOptions {
     wrapHours?: boolean;
 }
 
-interface JQuery { // eslint-disable-line @typescript-eslint/no-unused-vars
+interface JQuery {
     timepicker(options: JQueryTimepickerOptions): JQuery;
 
     /** Get the time as an integer, expressed as seconds from 12am. */

--- a/types/timepicker/index.d.ts
+++ b/types/timepicker/index.d.ts
@@ -10,135 +10,153 @@ interface JQueryTimepickerOptions {
 	// Override where the dropdown is appended.
 	// Takes either a string to use as a selector, a function that gets passed the clicked input element as argument or a jquery object to use directly.
 	// default: "body"
-	appendTo?: string|JQuery,
+	appendTo?: string|JQuery;
 
 	// A class name to apply to the HTML element that contains the timepicker dropdown.
 	// default: null
-	className?: string,
+	className?: string;
 
 	// Close the timepicker when the window is scrolled. (Replicates <select> behavior.)
 	// default: false
-	closeOnWindowScroll?: boolean,
+	closeOnWindowScroll?: boolean;
 
-	// Disable selection of certain time ranges. Input is an array of time pairs, like [['3:00am', '4:30am'], ['5:00pm', '8:00pm']]. The start of the interval will be disabled but the end won't. default: []
-	disableTimeRanges?: Array<Array<string>>,
+	// Disable selection of certain time ranges.
+	// Input is an array of time pairs, like [['3:00am', '4:30am'], ['5:00pm', '8:00pm']].
+	// The start of the interval will be disabled but the end won't. default: []
+	disableTimeRanges?: string[][];
 
 	// Disable typing in the timepicker input box; force users to select from list. More information here.
 	// default: false
-	disableTextInput?: boolean,
+	disableTextInput?: boolean;
 
-	// Disable the onscreen keyboard for touch devices. There can be instances where Firefox or Chrome have touch events enabled (such as on Surface tablets but not actually be a touch device. In this case disableTouchKeyboard will prevent the timepicker input field from being focused. More information here.
+	// Disable the onscreen keyboard for touch devices.
+	// There can be instances where Firefox or Chrome have touch events enabled (such as on Surface tablets but not actually be a touch device.
+	// In this case disableTouchKeyboard will prevent the timepicker input field from being focused. More information here.
 	// default: false
-	disableTouchKeyboard?: boolean,
+	disableTouchKeyboard?: boolean;
 
 	// The time against which showDuration will compute relative times. If this is a function, its result will be used.
 	// default: minTime
-	durationTime?: string,
+	durationTime?: string;
 
 	// Force update the time to step settings as soon as it loses focus.
 	// default: false
-	forceRoundTime?: boolean,
+	forceRoundTime?: boolean;
 
-	// Language constants used in the timepicker. Can override the defaults by passing an object with one or more of the following properties: decimal, mins, hr, hrs.
+	// Language constants used in the timepicker.
+	// Can override the defaults by passing an object with one or more of the following properties: decimal, mins, hr, hrs.
 	// default: { am: 'am', pm: 'pm', AM: 'AM', PM: 'PM', decimal: '.', mins: 'mins', hr: 'hr', hrs: 'hrs' }
-	lang?: {am?: string, pm?: string, AM?: string, PM?: string, decimal?: string, mins?: string, hr?: string, hrs?: string},
+	lang?: {am?: string, pm?: string, AM?: string, PM?: string, decimal?: string, mins?: string, hr?: string, hrs?: string};
 
-	// Set this to override CSS styling and set the list width to match the input element's width. Set to 1 to match input width, 2 to double input width, .5 to halve input width, etc. Set to null to let CSS determine the list width.
+	// Set this to override CSS styling and set the list width to match the input element's width.
+	// Set to 1 to match input width, 2 to double input width, .5 to halve input width, etc. Set to null to let CSS determine the list width.
 	// default: null (CSS styling)
-	listWidth?: string,
+	listWidth?: string;
 
 	// The time that should appear last in the dropdown list. Can be used to limit the range of time options.
 	// default: 24 hours after minTime
-	maxTime?: string,
+	maxTime?: string;
 
 	// The time that should appear first in the dropdown list.
 	// default: 12:00am
-	minTime?: string,
+	minTime?: string;
 
 	// Adds one or more custom options to the top of the dropdown. Can accept several different value types:
 	// Boolean (true): Adds a "None" option that results in an empty input value
 	// String: Adds an option with a custom label that results in an empty input value
-	// Object: Similar to string, but allows customizing the element's class name and the resulting input value. Can contain label, value, and className properties. value must be a string type.
+	// Object: Similar to string, but allows customizing the element's class name and the resulting input value.
+	// Can contain label, value, and className properties. value must be a string type.
 	// Array: An array of strings or objects to add multiple non-time options
 	// default: false
-	noneOption?: boolean|string|Array<string>,
+	noneOption?: boolean|string|string[];
 
-	// By default the timepicker dropdown will be aligned to the bottom right of the input element, or aligned to the top left if there isn't enough room below the input. Force alignment with l (left), r (right), c (horizontal center), t (top), and b (bottom). Examples: tl, rb. default: 'l'
-	orientation?: string,
+	// By default the timepicker dropdown will be aligned to the bottom right of the input element, or aligned to the top left if there isn't enough room below the input.
+	// Force alignment with l (left), r (right), c (horizontal center), t (top), and b (bottom). Examples: tl, rb. default: 'l'
+	orientation?: string;
 
-	// Function used to compute rounded times. The function will receive time in seconds and a settings object as arguments. The function should handle a null value for seconds. default: round to nearest step
-	roundingFunction?: (seconds: number) => number,
+	// Function used to compute rounded times. The function will receive time in seconds and a settings object as arguments.
+	// The function should handle a null value for seconds. default: round to nearest step
+	roundingFunction?: (seconds: number) => number;
 
-	// If no time value is selected, set the dropdown scroll position to show the time provided, e.g. "09:00". A time string, Date object, or integer (seconds past midnight) is acceptible, as well as the string 'now'.
+	// If no time value is selected, set the dropdown scroll position to show the time provided, e.g. "09:00".
+	// A time string, Date object, or integer (seconds past midnight) is acceptible, as well as the string 'now'.
 	// default: null
-	scrollDefault?: string,
+	scrollDefault?: string;
 
 	// Update the input with the currently highlighted time value when the timepicker loses focus.
 	// default: false
-	selectOnBlur?: boolean,
+	selectOnBlur?: boolean;
 
 	// Show "24:00" as an option when using 24-hour time format. You must also set timeFormat for this option to work.
 	// default: false
-	show2400?: boolean,
+	show2400?: boolean;
 
 	// Shows the relative time for each item in the dropdown. minTime or durationTime must be set.
 	// default: false
-	showDuration?: boolean,
+	showDuration?: boolean;
 
 	// Display a timepicker dropdown when the input fires a particular event. Set to null or an empty array to disable automatic display. Setting should be an array of strings. default: ['focus']
-	showOn?: Array<string>|null,
+	showOn?: string[]|null;
 
 	// DEPRECATED: Display a timepicker dropdown when the input gains focus.
 	// default: true
-	showOnFocus?: boolean,
+	showOnFocus?: boolean;
 
-	// The amount of time, in minutes, between each item in the dropdown. Alternately, you can specify a function to generate steps dynamically. The function will receive a count integer (0, 1, 2...) and is expected to return a step integer.
+	// The amount of time, in minutes, between each item in the dropdown.
+	// Alternately, you can specify a function to generate steps dynamically.
+	// The function will receive a count integer (0, 1, 2...) and is expected to return a step integer.
 	// default: 30
-	step?: number,
+	step?: number;
 
 	// When scrolling on the edge of the picker, it prevent parent containers () to scroll. default: false
-	stopScrollPropagation?: boolean,
+	stopScrollPropagation?: boolean;
 
-	// How times should be displayed in the list and input element. Uses PHP's date() formatting syntax. Characters can be escaped with a preceeding double slash (e.g. H\\hi). Alternatively, you can specify a function instead of a string, to use completely custom time formatting. In this case, the format function receives a Date object and is expected to return a formatted time as a string. default: 'g:ia'
-	timeFormat?: string,
+	// How times should be displayed in the list and input element. Uses PHP's date() formatting syntax.
+	// Characters can be escaped with a preceeding double slash (e.g. H\\hi).
+	// Alternatively, you can specify a function instead of a string, to use completely custom time formatting.
+	// In this case, the format function receives a Date object and is expected to return a formatted time as a string. default: 'g:ia'
+	timeFormat?: string;
 
 	// Highlight the nearest corresponding time option as a value is typed into the form input.
 	// default: true
-	typeaheadHighlight?: boolean,
+	typeaheadHighlight?: boolean;
 
-	// Convert the input to an HTML <SELECT> control. This is ideal for small screen devices, or if you want to prevent the user from entering arbitrary values. This option is not compatible with the following options: appendTo, closeOnWindowScroll, disableTouchKeyboard, forceRoundTime, scrollDefault, selectOnBlur, typeAheadHighlight.
+	// Convert the input to an HTML <SELECT> control.
+	// This is ideal for small screen devices, or if you want to prevent the user from entering arbitrary values.
+	// This option is not compatible with the following options: appendTo, closeOnWindowScroll, disableTouchKeyboard, forceRoundTime, scrollDefault, selectOnBlur, typeAheadHighlight.
 	// default: false
-	useSelect?: boolean,
+	useSelect?: boolean;
 
-	// If a time greater than 24 hours (27:30, for example) is entered, apply modolo 24 to create a valid time. Setting this to false will cause an input of 27:30 to result in a timeFormatError event.
+	// If a time greater than 24 hours (27:30, for example) is entered, apply modolo 24 to create a valid time.
+	// Setting this to false will cause an input of 27:30 to result in a timeFormatError event.
 	// default: true
-	wrapHours?: boolean,
+	wrapHours?: boolean;
 }
 
 interface JQuery { // eslint-disable-line @typescript-eslint/no-unused-vars
-	timepicker(options: JQueryTimepickerOptions): JQuery,
+	timepicker(options: JQueryTimepickerOptions): JQuery;
 
 	/** Get the time as an integer, expressed as seconds from 12am. */
-	timepicker(methodName: 'getSecondsFromMidnight'): number,
+	timepicker(methodName: 'getSecondsFromMidnight'): number;
 
 	/** Get the time using a Javascript Date object, relative to a Date object (default: today's date). */
-	timepicker(methodName: 'timepicker', date?: Date): Date,
+	timepicker(methodName: 'timepicker', date?: Date): Date;
 
 	/** Close the timepicker dropdown. */
-	timepicker(methodName: 'hide'): void,
+	timepicker(methodName: 'hide'): void;
 
 	/** Check if the timepicker attached to *a specific input* is visible. Not compatible with the `useSelect` option. */
-	timepicker(methodName: 'isVisible'): boolean,
+	timepicker(methodName: 'isVisible'): boolean;
 
 	/** Change the settings of an existing timepicker. Calling ```option``` on a visible timepicker will cause the picker to be hidden. */
-	timepicker(methodName: 'options', options: JQueryTimepickerOptions): void,
+	timepicker(methodName: 'options', options: JQueryTimepickerOptions): void;
 
 	/** Unbind an existing timepicker element. */
-	timepicker(methodName: 'remove'): void,
+	timepicker(methodName: 'remove'): void;
 
 	/** Set the time using a Javascript Date object. */
-	timepicker(methodName: 'setTime', date: Date): void,
+	timepicker(methodName: 'setTime', date: Date): void;
 
 	/** Display the timepicker dropdown. */
-	timepicker(methodName: 'show'): void,
+	timepicker(methodName: 'show'): void;
 }

--- a/types/timepicker/index.d.ts
+++ b/types/timepicker/index.d.ts
@@ -6,159 +6,157 @@
 
 /// <reference types="jquery"/>
 
-/* tslint:disable:unified-signatures */
-
 interface JQueryTimepickerOptions {
-	// Override where the dropdown is appended.
-	// Takes either a string to use as a selector, a function that gets passed the clicked input element as argument or a jquery object to use directly.
-	// default: "body"
-	appendTo?: string|JQuery;
+    // Override where the dropdown is appended.
+    // Takes either a string to use as a selector, a function that gets passed the clicked input element as argument or a jquery object to use directly.
+    // default: "body"
+    appendTo?: string|JQuery;
 
-	// A class name to apply to the HTML element that contains the timepicker dropdown.
-	// default: null
-	className?: string;
+    // A class name to apply to the HTML element that contains the timepicker dropdown.
+    // default: null
+    className?: string;
 
-	// Close the timepicker when the window is scrolled. (Replicates <select> behavior.)
-	// default: false
-	closeOnWindowScroll?: boolean;
+    // Close the timepicker when the window is scrolled. (Replicates <select> behavior.)
+    // default: false
+    closeOnWindowScroll?: boolean;
 
-	// Disable selection of certain time ranges.
-	// Input is an array of time pairs, like [['3:00am', '4:30am'], ['5:00pm', '8:00pm']].
-	// The start of the interval will be disabled but the end won't. default: []
-	disableTimeRanges?: string[][];
+    // Disable selection of certain time ranges.
+    // Input is an array of time pairs, like [['3:00am', '4:30am'], ['5:00pm', '8:00pm']].
+    // The start of the interval will be disabled but the end won't. default: []
+    disableTimeRanges?: string[][];
 
-	// Disable typing in the timepicker input box; force users to select from list. More information here.
-	// default: false
-	disableTextInput?: boolean;
+    // Disable typing in the timepicker input box; force users to select from list. More information here.
+    // default: false
+    disableTextInput?: boolean;
 
-	// Disable the onscreen keyboard for touch devices.
-	// There can be instances where Firefox or Chrome have touch events enabled (such as on Surface tablets but not actually be a touch device.
-	// In this case disableTouchKeyboard will prevent the timepicker input field from being focused. More information here.
-	// default: false
-	disableTouchKeyboard?: boolean;
+    // Disable the onscreen keyboard for touch devices.
+    // There can be instances where Firefox or Chrome have touch events enabled (such as on Surface tablets but not actually be a touch device.
+    // In this case disableTouchKeyboard will prevent the timepicker input field from being focused. More information here.
+    // default: false
+    disableTouchKeyboard?: boolean;
 
-	// The time against which showDuration will compute relative times. If this is a function, its result will be used.
-	// default: minTime
-	durationTime?: string;
+    // The time against which showDuration will compute relative times. If this is a function, its result will be used.
+    // default: minTime
+    durationTime?: string;
 
-	// Force update the time to step settings as soon as it loses focus.
-	// default: false
-	forceRoundTime?: boolean;
+    // Force update the time to step settings as soon as it loses focus.
+    // default: false
+    forceRoundTime?: boolean;
 
-	// Language constants used in the timepicker.
-	// Can override the defaults by passing an object with one or more of the following properties: decimal, mins, hr, hrs.
-	// default: { am: 'am', pm: 'pm', AM: 'AM', PM: 'PM', decimal: '.', mins: 'mins', hr: 'hr', hrs: 'hrs' }
-	lang?: {am?: string, pm?: string, AM?: string, PM?: string, decimal?: string, mins?: string, hr?: string, hrs?: string};
+    // Language constants used in the timepicker.
+    // Can override the defaults by passing an object with one or more of the following properties: decimal, mins, hr, hrs.
+    // default: { am: 'am', pm: 'pm', AM: 'AM', PM: 'PM', decimal: '.', mins: 'mins', hr: 'hr', hrs: 'hrs' }
+    lang?: {am?: string, pm?: string, AM?: string, PM?: string, decimal?: string, mins?: string, hr?: string, hrs?: string};
 
-	// Set this to override CSS styling and set the list width to match the input element's width.
-	// Set to 1 to match input width, 2 to double input width, .5 to halve input width, etc. Set to null to let CSS determine the list width.
-	// default: null (CSS styling)
-	listWidth?: string;
+    // Set this to override CSS styling and set the list width to match the input element's width.
+    // Set to 1 to match input width, 2 to double input width, .5 to halve input width, etc. Set to null to let CSS determine the list width.
+    // default: null (CSS styling)
+    listWidth?: string;
 
-	// The time that should appear last in the dropdown list. Can be used to limit the range of time options.
-	// default: 24 hours after minTime
-	maxTime?: string;
+    // The time that should appear last in the dropdown list. Can be used to limit the range of time options.
+    // default: 24 hours after minTime
+    maxTime?: string;
 
-	// The time that should appear first in the dropdown list.
-	// default: 12:00am
-	minTime?: string;
+    // The time that should appear first in the dropdown list.
+    // default: 12:00am
+    minTime?: string;
 
-	// Adds one or more custom options to the top of the dropdown. Can accept several different value types:
-	// Boolean (true): Adds a "None" option that results in an empty input value
-	// String: Adds an option with a custom label that results in an empty input value
-	// Object: Similar to string, but allows customizing the element's class name and the resulting input value.
-	// Can contain label, value, and className properties. value must be a string type.
-	// Array: An array of strings or objects to add multiple non-time options
-	// default: false
-	noneOption?: boolean|string|string[];
+    // Adds one or more custom options to the top of the dropdown. Can accept several different value types:
+    // Boolean (true): Adds a "None" option that results in an empty input value
+    // String: Adds an option with a custom label that results in an empty input value
+    // Object: Similar to string, but allows customizing the element's class name and the resulting input value.
+    // Can contain label, value, and className properties. value must be a string type.
+    // Array: An array of strings or objects to add multiple non-time options
+    // default: false
+    noneOption?: boolean|string|string[];
 
-	// By default the timepicker dropdown will be aligned to the bottom right of the input element, or aligned to the top left if there isn't enough room below the input.
-	// Force alignment with l (left), r (right), c (horizontal center), t (top), and b (bottom). Examples: tl, rb. default: 'l'
-	orientation?: string;
+    // By default the timepicker dropdown will be aligned to the bottom right of the input element, or aligned to the top left if there isn't enough room below the input.
+    // Force alignment with l (left), r (right), c (horizontal center), t (top), and b (bottom). Examples: tl, rb. default: 'l'
+    orientation?: string;
 
-	// Function used to compute rounded times. The function will receive time in seconds and a settings object as arguments.
-	// The function should handle a null value for seconds. default: round to nearest step
-	roundingFunction?: (seconds: number) => number;
+    // Function used to compute rounded times. The function will receive time in seconds and a settings object as arguments.
+    // The function should handle a null value for seconds. default: round to nearest step
+    roundingFunction?: (seconds: number) => number;
 
-	// If no time value is selected, set the dropdown scroll position to show the time provided, e.g. "09:00".
-	// A time string, Date object, or integer (seconds past midnight) is acceptible, as well as the string 'now'.
-	// default: null
-	scrollDefault?: string;
+    // If no time value is selected, set the dropdown scroll position to show the time provided, e.g. "09:00".
+    // A time string, Date object, or integer (seconds past midnight) is acceptible, as well as the string 'now'.
+    // default: null
+    scrollDefault?: string;
 
-	// Update the input with the currently highlighted time value when the timepicker loses focus.
-	// default: false
-	selectOnBlur?: boolean;
+    // Update the input with the currently highlighted time value when the timepicker loses focus.
+    // default: false
+    selectOnBlur?: boolean;
 
-	// Show "24:00" as an option when using 24-hour time format. You must also set timeFormat for this option to work.
-	// default: false
-	show2400?: boolean;
+    // Show "24:00" as an option when using 24-hour time format. You must also set timeFormat for this option to work.
+    // default: false
+    show2400?: boolean;
 
-	// Shows the relative time for each item in the dropdown. minTime or durationTime must be set.
-	// default: false
-	showDuration?: boolean;
+    // Shows the relative time for each item in the dropdown. minTime or durationTime must be set.
+    // default: false
+    showDuration?: boolean;
 
-	// Display a timepicker dropdown when the input fires a particular event. Set to null or an empty array to disable automatic display. Setting should be an array of strings. default: ['focus']
-	showOn?: string[]|null;
+    // Display a timepicker dropdown when the input fires a particular event. Set to null or an empty array to disable automatic display. Setting should be an array of strings. default: ['focus']
+    showOn?: string[]|null;
 
-	// DEPRECATED: Display a timepicker dropdown when the input gains focus.
-	// default: true
-	showOnFocus?: boolean;
+    // DEPRECATED: Display a timepicker dropdown when the input gains focus.
+    // default: true
+    showOnFocus?: boolean;
 
-	// The amount of time, in minutes, between each item in the dropdown.
-	// Alternately, you can specify a function to generate steps dynamically.
-	// The function will receive a count integer (0, 1, 2...) and is expected to return a step integer.
-	// default: 30
-	step?: number;
+    // The amount of time, in minutes, between each item in the dropdown.
+    // Alternately, you can specify a function to generate steps dynamically.
+    // The function will receive a count integer (0, 1, 2...) and is expected to return a step integer.
+    // default: 30
+    step?: number;
 
-	// When scrolling on the edge of the picker, it prevent parent containers () to scroll. default: false
-	stopScrollPropagation?: boolean;
+    // When scrolling on the edge of the picker, it prevent parent containers () to scroll. default: false
+    stopScrollPropagation?: boolean;
 
-	// How times should be displayed in the list and input element. Uses PHP's date() formatting syntax.
-	// Characters can be escaped with a preceeding double slash (e.g. H\\hi).
-	// Alternatively, you can specify a function instead of a string, to use completely custom time formatting.
-	// In this case, the format function receives a Date object and is expected to return a formatted time as a string. default: 'g:ia'
-	timeFormat?: string;
+    // How times should be displayed in the list and input element. Uses PHP's date() formatting syntax.
+    // Characters can be escaped with a preceeding double slash (e.g. H\\hi).
+    // Alternatively, you can specify a function instead of a string, to use completely custom time formatting.
+    // In this case, the format function receives a Date object and is expected to return a formatted time as a string. default: 'g:ia'
+    timeFormat?: string;
 
-	// Highlight the nearest corresponding time option as a value is typed into the form input.
-	// default: true
-	typeaheadHighlight?: boolean;
+    // Highlight the nearest corresponding time option as a value is typed into the form input.
+    // default: true
+    typeaheadHighlight?: boolean;
 
-	// Convert the input to an HTML <SELECT> control.
-	// This is ideal for small screen devices, or if you want to prevent the user from entering arbitrary values.
-	// This option is not compatible with the following options: appendTo, closeOnWindowScroll, disableTouchKeyboard, forceRoundTime, scrollDefault, selectOnBlur, typeAheadHighlight.
-	// default: false
-	useSelect?: boolean;
+    // Convert the input to an HTML <SELECT> control.
+    // This is ideal for small screen devices, or if you want to prevent the user from entering arbitrary values.
+    // This option is not compatible with the following options: appendTo, closeOnWindowScroll, disableTouchKeyboard, forceRoundTime, scrollDefault, selectOnBlur, typeAheadHighlight.
+    // default: false
+    useSelect?: boolean;
 
-	// If a time greater than 24 hours (27:30, for example) is entered, apply modolo 24 to create a valid time.
-	// Setting this to false will cause an input of 27:30 to result in a timeFormatError event.
-	// default: true
-	wrapHours?: boolean;
+    // If a time greater than 24 hours (27:30, for example) is entered, apply modolo 24 to create a valid time.
+    // Setting this to false will cause an input of 27:30 to result in a timeFormatError event.
+    // default: true
+    wrapHours?: boolean;
 }
 
 interface JQuery { // eslint-disable-line @typescript-eslint/no-unused-vars
-	timepicker(options: JQueryTimepickerOptions): JQuery;
+    timepicker(options: JQueryTimepickerOptions): JQuery;
 
-	/** Get the time as an integer, expressed as seconds from 12am. */
-	timepicker(methodName: 'getSecondsFromMidnight'): number;
+    /** Get the time as an integer, expressed as seconds from 12am. */
+    timepicker(methodName: 'getSecondsFromMidnight'): number;
 
-	/** Get the time using a Javascript Date object, relative to a Date object (default: today's date). */
-	timepicker(methodName: 'timepicker', date?: Date): Date;
+    /** Get the time using a Javascript Date object, relative to a Date object (default: today's date). */
+    timepicker(methodName: 'timepicker', date?: Date): Date;
 
-	/** Close the timepicker dropdown. */
-	timepicker(methodName: 'hide'): void;
+    /** Close the timepicker dropdown. */
+    timepicker(methodName: 'hide'): void;
 
-	/** Check if the timepicker attached to *a specific input* is visible. Not compatible with the `useSelect` option. */
-	timepicker(methodName: 'isVisible'): boolean;
+    /** Check if the timepicker attached to *a specific input* is visible. Not compatible with the `useSelect` option. */
+    timepicker(methodName: 'isVisible'): boolean;
 
-	/** Change the settings of an existing timepicker. Calling ```option``` on a visible timepicker will cause the picker to be hidden. */
-	timepicker(methodName: 'options', options: JQueryTimepickerOptions): void;
+    /** Change the settings of an existing timepicker. Calling ```option``` on a visible timepicker will cause the picker to be hidden. */
+    timepicker(methodName: 'options', options: JQueryTimepickerOptions): void;
 
-	/** Unbind an existing timepicker element. */
-	timepicker(methodName: 'remove'): void;
+    /** Unbind an existing timepicker element. */
+    timepicker(methodName: 'remove'): void; // tslint:disable-line:unified-signatures
 
-	/** Set the time using a Javascript Date object. */
-	timepicker(methodName: 'setTime', date: Date): void;
+    /** Set the time using a Javascript Date object. */
+    timepicker(methodName: 'setTime', date: Date): void;
 
-	/** Display the timepicker dropdown. */
-	timepicker(methodName: 'show'): void;
+    /** Display the timepicker dropdown. */
+    timepicker(methodName: 'show'): void; // tslint:disable-line:unified-signatures
 }

--- a/types/timepicker/index.d.ts
+++ b/types/timepicker/index.d.ts
@@ -2,7 +2,7 @@
 // Project: <https://github.com/jonthornton/jquery-timepicker>
 // Definitions by: doberkofler <https://github.com/doberkofler>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.0
+// TypeScript Version: 2.3
 
 /// <reference types="jquery"/>
 

--- a/types/timepicker/index.d.ts
+++ b/types/timepicker/index.d.ts
@@ -2,7 +2,7 @@
 // Project: <https://github.com/jonthornton/jquery-timepicker>
 // Definitions by: doberkofler <https://github.com/doberkofler>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.7
 
 /// <reference types="jquery"/>
 

--- a/types/timepicker/index.d.ts
+++ b/types/timepicker/index.d.ts
@@ -6,6 +6,8 @@
 
 /// <reference types="jquery"/>
 
+/* tslint:disable:unified-signatures */
+
 interface JQueryTimepickerOptions {
 	// Override where the dropdown is appended.
 	// Takes either a string to use as a selector, a function that gets passed the clicked input element as argument or a jquery object to use directly.

--- a/types/timepicker/timepicker-tests.ts
+++ b/types/timepicker/timepicker-tests.ts
@@ -1,0 +1,7 @@
+// without options
+$('#timepicker').timepicker({});
+
+// with options
+$('#timepicker').timepicker({
+    step: 60,
+});

--- a/types/timepicker/tsconfig.json
+++ b/types/timepicker/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "timepicker-tests.ts"
+    ]
+}

--- a/types/timepicker/tslint.json
+++ b/types/timepicker/tslint.json
@@ -1,5 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-    }
+    "extends": "dtslint/dt.json"
 }

--- a/types/timepicker/tslint.json
+++ b/types/timepicker/tslint.json
@@ -1,6 +1,5 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "unified-signatures": false
     }
 }

--- a/types/timepicker/tslint.json
+++ b/types/timepicker/tslint.json
@@ -1,0 +1,15 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "array-type": false,
+        "comment-format": false,
+        "max-line-length": false,
+        "no-consecutive-blank-lines": false,
+        "no-padding": false,
+        "no-trailing-whitespace": false,
+        "npm-naming": false,
+        "semicolon": false,
+        "trim-file": false,
+        "unified-signatures": false
+    }
+}

--- a/types/timepicker/tslint.json
+++ b/types/timepicker/tslint.json
@@ -1,15 +1,6 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "array-type": false,
-        "comment-format": false,
-        "max-line-length": false,
-        "no-consecutive-blank-lines": false,
-        "no-padding": false,
-        "no-trailing-whitespace": false,
-        "npm-naming": false,
-        "semicolon": false,
-        "trim-file": false,
         "unified-signatures": false
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
