### PR TITLE
Fix tsconfigs of d3/v5 dependents

### DIFF
--- a/types/dagre-d3/tsconfig.json
+++ b/types/dagre-d3/tsconfig.json
@@ -16,6 +16,9 @@
         "paths": {
             "d3": [
                 "d3/v5"
+            ],
+            "d3-array": [
+                "d3-array/v1"
             ]
         },
         "types": [],

--- a/types/react-faux-dom/react-faux-dom-tests.tsx
+++ b/types/react-faux-dom/react-faux-dom-tests.tsx
@@ -28,14 +28,16 @@ interface ChartProps extends ReactFauxDomProps {
 
 class MyReactComponent extends React.Component<ChartProps> {
   componentDidMount() {
-    if (this.props.connectFauxDOM && this.props.animateFauxDOM) {
-      const faux = this.props.connectFauxDOM('div', 'chart');
-      d3.select(faux)
-        .append('div')
-        .html('Hello World!');
-      this.props.animateFauxDOM(800);
-      console.log(this.props.isAnimatingFauxDOM());
-    }
+      if (this.props.connectFauxDOM) {
+          if (this.props.animateFauxDOM) {
+              const faux = this.props.connectFauxDOM('div', 'chart');
+              d3.select(faux)
+                  .append('div')
+                  .html('Hello World!');
+              this.props.animateFauxDOM(800);
+              console.log(this.props.isAnimatingFauxDOM());
+          }
+      }
   }
 
   componentDidUpdate() {

--- a/types/react-faux-dom/tsconfig.json
+++ b/types/react-faux-dom/tsconfig.json
@@ -16,6 +16,9 @@
         "paths": {
             "d3": [
                 "d3/v5"
+            ],
+            "d3-array": [
+                "d3-array/v1"
             ]
         },
         "types": [],

--- a/types/venn/tsconfig.json
+++ b/types/venn/tsconfig.json
@@ -16,6 +16,9 @@
         "paths": {
             "d3": [
                 "d3/v5"
+            ],
+            "d3-array": [
+                "d3-array/v1"
             ]
         },
         "types": [],


### PR DESCRIPTION
Due to the way versions are stored in Definitely Typed, tsconfigs of `@types/d3@5` dependents need to explicitly reroute dependencies of d3 to their respective old versions. Normal users of `@types/d3@5` won't have to do this because the published package doesn't cram all versions of the package into a single directory structure.

Also I worked around a bug in the uncalled-function check in typescript@next: microsoft/TypeScript#41586