### PR TITLE
Add types for knex-cleaner

### DIFF
--- a/types/knex-cleaner/index.d.ts
+++ b/types/knex-cleaner/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for knex-cleaner 1.3
+// Project: https://github.com/steven-ferguson/knex-cleaner
+// Definitions by: Karol Goraus <https://github.com/Szarlus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+import * as Knex from 'knex';
+
+export interface KnexCleanerOptions {
+    /**
+     * Choose between simply deleting all rows from table or truncating it completely. Default is 'truncate'
+     */
+    mode?: 'truncate' | 'delete';
+
+    /**
+     * Used to tell PostgresSQL to reset the ID counter, default is true
+     */
+    restartIdentity?: boolean;
+
+    /**
+     * List of tables to ignore. Empty array by default.
+     */
+    ignoreTables?: string[];
+}
+
+export function clean(knex: Knex, options?: KnexCleanerOptions): Promise<void>;

--- a/types/knex-cleaner/knex-cleaner-tests.ts
+++ b/types/knex-cleaner/knex-cleaner-tests.ts
@@ -1,0 +1,15 @@
+import { clean } from 'knex-cleaner';
+import * as Knex from 'knex';
+
+const knex: Knex = Knex({ dialect: 'pg' });
+
+clean(knex); // $ExpectType Promise<void>
+clean(knex, {}); // $ExpectType Promise<void>
+clean(knex, { mode: 'delete', restartIdentity: false, ignoreTables: ['table1', 'table2'] }); // $ExpectType Promise<void>
+clean(knex, { mode: 'delete' }); // $ExpectType Promise<void>
+clean(knex, { restartIdentity: false }); // $ExpectType Promise<void>
+clean(knex, { ignoreTables: ['table1', 'table2'] }); // $ExpectType Promise<void>
+clean(knex, { restartIdentity: false, ignoreTables: ['table1', 'table2'] }); // $ExpectType Promise<void>
+clean(knex, { mode: 'delete', ignoreTables: ['table1', 'table2'] }); // $ExpectType Promise<void>
+clean(knex, { mode: 'delete', restartIdentity: false }); // $ExpectType Promise<void>
+clean(knex, { unknown: 1 }); // $ExpectError

--- a/types/knex-cleaner/package.json
+++ b/types/knex-cleaner/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "knex": "^0.16.1"
+    }
+}

--- a/types/knex-cleaner/tsconfig.json
+++ b/types/knex-cleaner/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "knex-cleaner-tests.ts"
+    ]
+}

--- a/types/knex-cleaner/tslint.json
+++ b/types/knex-cleaner/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.