### PR TITLE
[vue-moment] added duration initializer from Moment

### DIFF
--- a/types/vue-moment/index.d.ts
+++ b/types/vue-moment/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
-import { Moment, MomentFormatSpecification, MomentInput } from 'moment';
+import { Moment, MomentFormatSpecification, MomentInput, Duration, DurationInputArg2, DurationInputArg1 } from 'moment';
 import { PluginObject } from 'vue';
 
 declare namespace VueMomentPlugin {
@@ -17,6 +17,7 @@ declare namespace VueMomentPlugin {
         (options: Options): void;
         (inp?: MomentInput, format?: MomentFormatSpecification, strict?: boolean): Moment;
         (inp?: MomentInput, format?: MomentFormatSpecification, language?: string, strict?: boolean): Moment;
+        duration(inp?: DurationInputArg1, unit?: DurationInputArg2): Duration;
     }
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [x ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/moment/moment/blob/develop/moment.d.ts#L707>>
- [no new version of the JS library] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [already there ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
