### PR TITLE
Update main Sinon API and Sandbox API to reflect versions >= 8.0.0

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -22,9 +22,7 @@ interface Document {} // tslint:disable-line no-empty-interface
 
 declare namespace Sinon {
     type MatchArguments<T> = {
-        [K in keyof T]: SinonMatcher
-            | (T[K] extends object ? MatchArguments<T[K]> : never)
-            | T[K];
+        [K in keyof T]: SinonMatcher | (T[K] extends object ? MatchArguments<T[K]> : never) | T[K];
     };
 
     interface SinonSpyCallApi<TArgs extends any[] = any[], TReturnValue = any> {
@@ -86,7 +84,7 @@ declare namespace Sinon {
          * Uses deep comparison for objects and arrays. Use spy.returned(sinon.match.same(obj)) for strict comparison (see matchers).
          * @param value
          */
-        returned(value: TReturnValue|SinonMatcher): boolean;
+        returned(value: TReturnValue | SinonMatcher): boolean;
         /**
          * Returns true if spy threw an exception at least once.
          */
@@ -172,9 +170,9 @@ declare namespace Sinon {
 
     interface SinonSpy<TArgs extends any[] = any[], TReturnValue = any>
         extends Pick<
-                SinonSpyCallApi<TArgs, TReturnValue>,
-                Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, 'args'>
-            > {
+            SinonSpyCallApi<TArgs, TReturnValue>,
+            Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, 'args'>
+        > {
         // Properties
         /**
          * The number of recorded calls.
@@ -378,20 +376,17 @@ declare namespace Sinon {
          * The original method can be restored by calling object.method.restore().
          * The returned spy is the function object which replaced the original method. spy === object.method.
          */
-        <T, K extends keyof T>(obj: T, method: K): T[K] extends (
-            ...args: infer TArgs
-        ) => infer TReturnValue
+        <T, K extends keyof T>(obj: T, method: K): T[K] extends (...args: infer TArgs) => infer TReturnValue
             ? SinonSpy<TArgs, TReturnValue>
             : SinonSpy;
 
-        <T, K extends keyof T>(obj: T, method: K, types: Array<('get'|'set')>): PropertyDescriptor & {
+        <T, K extends keyof T>(obj: T, method: K, types: Array<'get' | 'set'>): PropertyDescriptor & {
             get: SinonSpy<[], T[K]>;
             set: SinonSpy<[T[K]], void>;
         };
     }
 
-    interface SinonStub<TArgs extends any[] = any[], TReturnValue = any>
-        extends SinonSpy<TArgs, TReturnValue> {
+    interface SinonStub<TArgs extends any[] = any[], TReturnValue = any> extends SinonSpy<TArgs, TReturnValue> {
         /**
          * Resets the stub’s behaviour to the default behaviour
          * You can reset behaviour of all stubs using sinon.resetBehavior()
@@ -436,7 +431,9 @@ declare namespace Sinon {
          * The Promise library can be overwritten using the usingPromise method.
          * Since sinon@2.0.0
          */
-        resolves(value?: TReturnValue extends PromiseLike<infer TResolveValue> ? TResolveValue : any): SinonStub<TArgs, TReturnValue>;
+        resolves(
+            value?: TReturnValue extends PromiseLike<infer TResolveValue> ? TResolveValue : any,
+        ): SinonStub<TArgs, TReturnValue>;
         /**
          * Causes the stub to return a Promise which resolves to the argument at the provided index.
          * stub.resolvesArg(0); causes the stub to return a Promise which resolves to the first argument.
@@ -512,11 +509,7 @@ declare namespace Sinon {
          * @param context
          * @param args
          */
-        callsArgOnWith(
-            index: number,
-            context: any,
-            ...args: any[]
-        ): SinonStub<TArgs, TReturnValue>;
+        callsArgOnWith(index: number, context: any, ...args: any[]): SinonStub<TArgs, TReturnValue>;
         /**
          * Same as their corresponding non-Async counterparts, but with callback being deferred at called after all instructions in the current call stack are processed.
          * In Node environment the callback is deferred with process.nextTick.
@@ -543,11 +536,7 @@ declare namespace Sinon {
          * In Node environment the callback is deferred with process.nextTick.
          * In a browser the callback is deferred with setTimeout(callback, 0).
          */
-        callsArgOnWithAsync(
-            index: number,
-            context: any,
-            ...args: any[]
-        ): SinonStub<TArgs, TReturnValue>;
+        callsArgOnWithAsync(index: number, context: any, ...args: any[]): SinonStub<TArgs, TReturnValue>;
         /**
          * Makes the stub call the provided @param func when invoked.
          * @param func
@@ -612,11 +601,7 @@ declare namespace Sinon {
         /**
          * Like above but with an additional parameter to pass the this context.
          */
-        yieldsToOn(
-            property: string,
-            context: any,
-            ...args: any[]
-        ): SinonStub<TArgs, TReturnValue>;
+        yieldsToOn(property: string, context: any, ...args: any[]): SinonStub<TArgs, TReturnValue>;
         /**
          * Same as their corresponding non-Async counterparts, but with callback being deferred at called after all instructions in the current call stack are processed.
          * In Node environment the callback is deferred with process.nextTick.
@@ -648,11 +633,7 @@ declare namespace Sinon {
          * @param context
          * @param args
          */
-        yieldsToOnAsync(
-            property: string,
-            context: any,
-            ...args: any[]
-        ): SinonStub<TArgs, TReturnValue>;
+        yieldsToOnAsync(property: string, context: any, ...args: any[]): SinonStub<TArgs, TReturnValue>;
         /**
          * Stubs the method only for the provided arguments.
          * This is useful to be more expressive in your assertions, where you can access the spy with the same call.
@@ -684,9 +665,7 @@ declare namespace Sinon {
          * An exception is thrown if the property is not already a function.
          * The original function can be restored by calling object.method.restore(); (or stub.restore();).
          */
-        <T, K extends keyof T>(obj: T, method: K): T[K] extends (
-            ...args: infer TArgs
-        ) => infer TReturnValue
+        <T, K extends keyof T>(obj: T, method: K): T[K] extends (...args: infer TArgs) => infer TReturnValue
             ? SinonStub<TArgs, TReturnValue>
             : SinonStub;
     }
@@ -908,13 +887,7 @@ declare namespace Sinon {
          * @param filter
          */
         addFilter(
-            filter: (
-                method: string,
-                url: string,
-                async: boolean,
-                username: string,
-                password: string
-            ) => boolean
+            filter: (method: string, url: string, async: boolean, username: string, password: string) => boolean,
         ): void;
         /**
          * By assigning a function to the onCreate property of the returned object from useFakeXMLHttpRequest()
@@ -981,10 +954,7 @@ declare namespace Sinon {
         /**
          * Responds to all requests to given URL, e.g. /posts/1.
          */
-        respondWith(
-            url: string,
-            fn: (xhr: SinonFakeXMLHttpRequest) => void
-        ): void;
+        respondWith(url: string, fn: (xhr: SinonFakeXMLHttpRequest) => void): void;
         /**
          * Responds to all method requests to the given URL with the given response.
          * method is an HTTP verb.
@@ -999,11 +969,7 @@ declare namespace Sinon {
          * Responds to all method requests to the given URL with the given response.
          * method is an HTTP verb.
          */
-        respondWith(
-            method: string,
-            url: string,
-            fn: (xhr: SinonFakeXMLHttpRequest) => void
-        ): void;
+        respondWith(method: string, url: string, fn: (xhr: SinonFakeXMLHttpRequest) => void): void;
         /**
          * URL may be a regular expression, e.g. /\\/post\\//\\d+
          * If the response is a Function, it will be passed any capture groups from the regular expression along with the XMLHttpRequest object:
@@ -1018,10 +984,7 @@ declare namespace Sinon {
          * URL may be a regular expression, e.g. /\\/post\\//\\d+
          * If the response is a Function, it will be passed any capture groups from the regular expression along with the XMLHttpRequest object:
          */
-        respondWith(
-            url: RegExp,
-            fn: (xhr: SinonFakeXMLHttpRequest) => void
-        ): void;
+        respondWith(url: RegExp, fn: (xhr: SinonFakeXMLHttpRequest) => void): void;
         /**
          * Responds to all method requests to URLs matching the regular expression.
          */
@@ -1033,11 +996,7 @@ declare namespace Sinon {
         /**
          * Responds to all method requests to URLs matching the regular expression.
          */
-        respondWith(
-            method: string,
-            url: RegExp,
-            fn: (xhr: SinonFakeXMLHttpRequest) => void
-        ): void;
+        respondWith(method: string, url: RegExp, fn: (xhr: SinonFakeXMLHttpRequest) => void): void;
         /**
          * Causes all queued asynchronous requests to receive a response.
          * If none of the responses added through respondWith match, the default response is [404, {}, ""].
@@ -1149,7 +1108,10 @@ declare namespace Sinon {
          * @param spyOrSpyCall
          * @param args
          */
-        calledWith<TArgs extends any[]>(spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>, ...args: MatchArguments<TArgs>): void;
+        calledWith<TArgs extends any[]>(
+            spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
+            ...args: MatchArguments<TArgs>
+        ): void;
         /**
          * Passes if spy was always called with the provided arguments.
          * @param spy
@@ -1190,10 +1152,7 @@ declare namespace Sinon {
          * This behaves the same way as sinon.assert.calledWith(spy, sinon.match(arg1), sinon.match(arg2), ...).
          * It's possible to assert on a dedicated spy call: sinon.assert.calledWithMatch(spy.secondCall, arg1, arg2, ...);.
          */
-        calledWithMatch<TArgs extends any[]>(
-            spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
-            ...args: TArgs
-        ): void;
+        calledWithMatch<TArgs extends any[]>(spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>, ...args: TArgs): void;
         /**
          * Passes if spy was called once with matching arguments.
          * This behaves the same way as calling both sinon.assert.calledOnce(spy) and
@@ -1500,15 +1459,15 @@ declare namespace Sinon {
      * @template TType Object type being stubbed.
      */
     type SinonStubbedInstance<TType> = {
-        [P in keyof TType]: SinonStubbedMember<TType[P]>
+        [P in keyof TType]: SinonStubbedMember<TType[P]>;
     };
 
     /**
      * Replaces a type with a Sinon stub if it's a function.
      */
-    type SinonStubbedMember<T> = T extends (
-        ...args: infer TArgs
-    ) => infer TReturnValue ? SinonStub<TArgs, TReturnValue> : T;
+    type SinonStubbedMember<T> = T extends (...args: infer TArgs) => infer TReturnValue
+        ? SinonStub<TArgs, TReturnValue>
+        : T;
 
     interface SinonFake {
         /**
@@ -1592,9 +1551,7 @@ declare namespace Sinon {
          * You would have to call either clock.next(), clock.tick(), clock.runAll() or clock.runToLast() (see example below). Please refer to the lolex documentation for more information.
          * @param config
          */
-        useFakeTimers(
-            config?: number | Date | Partial<SinonFakeTimersConfig>
-        ): SinonFakeTimers;
+        useFakeTimers(config?: number | Date | Partial<SinonFakeTimersConfig>): SinonFakeTimers;
         /**
          * Causes Sinon to replace the native XMLHttpRequest object in browsers that support it with a custom implementation which does not send actual requests.
          * In browsers that support ActiveXObject, this constructor is replaced, and fake objects are returned for XMLHTTP progIds.
@@ -1645,11 +1602,7 @@ declare namespace Sinon {
          * replacement can be any value, including spies, stubs and fakes.
          * This method only works on non-accessor properties, for replacing accessors, use sandbox.replaceGetter() and sandbox.replaceSetter().
          */
-        replace<T, TKey extends keyof T>(
-            obj: T,
-            prop: TKey,
-            replacement: T[TKey]
-        ): T[TKey];
+        replace<T, TKey extends keyof T>(obj: T, prop: TKey, replacement: T[TKey]): T[TKey];
         /**
          * Replaces getter for property on object with replacement argument. Attempts to replace an already replaced getter cause an exception.
          * replacement must be a Function, and can be instances of spies, stubs and fakes.
@@ -1657,11 +1610,7 @@ declare namespace Sinon {
          * @param prop
          * @param replacement
          */
-        replaceGetter<T, TKey extends keyof T>(
-            obj: T,
-            prop: TKey,
-            replacement: () => T[TKey]
-        ): () => T[TKey];
+        replaceGetter<T, TKey extends keyof T>(obj: T, prop: TKey, replacement: () => T[TKey]): () => T[TKey];
         /**
          * Replaces setter for property on object with replacement argument. Attempts to replace an already replaced setter cause an exception.
          * replacement must be a Function, and can be instances of spies, stubs and fakes.
@@ -1672,7 +1621,7 @@ declare namespace Sinon {
         replaceSetter<T, TKey extends keyof T>(
             obj: T,
             prop: TKey,
-            replacement: (val: T[TKey]) => void
+            replacement: (val: T[TKey]) => void,
         ): (val: T[TKey]) => void;
 
         /**
@@ -1686,8 +1635,11 @@ declare namespace Sinon {
          */
         createStubInstance<TType>(
             constructor: StubbableType<TType>,
-            overrides?: { [K in keyof TType]?:
-                SinonStubbedMember<TType[K]> | (TType[K] extends (...args: any[]) => infer R ? R : TType[K]) }
+            overrides?: {
+                [K in keyof TType]?:
+                    | SinonStubbedMember<TType[K]>
+                    | (TType[K] extends (...args: any[]) => infer R ? R : TType[K]);
+            },
         ): SinonStubbedInstance<TType>;
     }
 
@@ -1712,6 +1664,15 @@ declare namespace Sinon {
          */
         createSandbox(config?: Partial<SinonSandboxConfig>): SinonSandbox;
         defaultConfig: Partial<SinonSandboxConfig>;
+
+        /**
+         * Add a custom behavior.
+         * The name will be available as a function on stubs, and the chaining mechanism
+         * will be set up for you (e.g. no need to return anything from your function,
+         * its return value will be ignored). The fn will be passed the fake instance
+         * as its first argument, and then the user's arguments.
+         */
+        addBehavior: (name: string, fn: (fake: SinonStub, ...userArgs: any[] ) => void ) => void;
     }
 
     interface LegacySandbox {

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1646,7 +1646,6 @@ declare namespace Sinon {
     interface SinonApi {
         fake: SinonFake;
         match: SinonMatch;
-        spyCall(...args: any[]): SinonSpyCall;
         expectation: SinonExpectationStatic;
 
         clock: {

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1521,6 +1521,7 @@ declare namespace Sinon {
         clock: SinonFakeTimers;
         requests: SinonFakeXMLHttpRequest[];
         server: SinonFakeServer;
+        match: SinonMatch;
         /**
          * Works exactly like sinon.spy
          */
@@ -1533,6 +1534,8 @@ declare namespace Sinon {
          * Works exactly like sinon.mock
          */
         mock: SinonMockStatic;
+
+        fake: SinonFake;
 
         /**
          * * No param : Causes Sinon to replace the global setTimeout, clearTimeout, setInterval, clearInterval, setImmediate, clearImmediate, process.hrtime, performance.now(when available)
@@ -1644,8 +1647,6 @@ declare namespace Sinon {
     }
 
     interface SinonApi {
-        fake: SinonFake;
-        match: SinonMatch;
         expectation: SinonExpectationStatic;
 
         clock: {

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1673,6 +1673,14 @@ declare namespace Sinon {
          * as its first argument, and then the user's arguments.
          */
         addBehavior: (name: string, fn: (fake: SinonStub, ...userArgs: any[] ) => void ) => void;
+
+
+        /**
+         * Replace the default formatter used when formatting ECMAScript object
+         * An example converts a basic object, such as  {id: 42 }, to a string
+         * on a format of your choosing, such as "{ id: 42 }"
+         */
+        setFormatter: (customFormatter: (...args: any[]) => string) => void
     }
 
     interface LegacySandbox {

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1672,27 +1672,17 @@ declare namespace Sinon {
          * its return value will be ignored). The fn will be passed the fake instance
          * as its first argument, and then the user's arguments.
          */
-        addBehavior: (name: string, fn: (fake: SinonStub, ...userArgs: any[] ) => void ) => void;
-
+        addBehavior: (name: string, fn: (fake: SinonStub, ...userArgs: any[]) => void) => void;
 
         /**
          * Replace the default formatter used when formatting ECMAScript object
          * An example converts a basic object, such as  {id: 42 }, to a string
          * on a format of your choosing, such as "{ id: 42 }"
          */
-        setFormatter: (customFormatter: (...args: any[]) => string) => void
+        setFormatter: (customFormatter: (...args: any[]) => string) => void;
     }
 
-    interface LegacySandbox {
-        sandbox: {
-            /**
-             * @deprecated Since 5.0, use `sinon.createSandbox` instead
-             */
-            create(config?: Partial<SinonSandboxConfig>): SinonSandbox;
-        };
-    }
-
-    type SinonStatic = SinonSandbox & LegacySandbox & SinonApi;
+    type SinonStatic = SinonSandbox & SinonApi;
 }
 
 declare const Sinon: Sinon.SinonStatic;

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -1,4 +1,4 @@
-import sinon = require("sinon");
+import sinon = require('sinon');
 
 function testSandbox() {
     const obj = {};
@@ -7,17 +7,17 @@ function testSandbox() {
         injectInto: obj,
         properties: ['spy', 'stub'],
         useFakeTimers: true,
-        useFakeServer: true
+        useFakeServer: true,
     });
     sinon.createSandbox({
-        injectInto: null
+        injectInto: null,
     });
     sinon.createSandbox({
         useFakeTimers: {
             now: 1000,
-            shouldAdvanceTime: false
+            shouldAdvanceTime: false,
         },
-        useFakeServer: sinon.fakeServer.create()
+        useFakeServer: sinon.fakeServer.create(),
     });
     sinon.createSandbox(sinon.defaultConfig);
     sinon.sandbox.create();
@@ -35,7 +35,7 @@ function testSandbox() {
     sb.useFakeTimers(1000);
     sb.useFakeTimers(new Date());
     sb.useFakeTimers({
-        now: 1000
+        now: 1000,
     });
 
     const xhr = sb.useFakeXMLHttpRequest();
@@ -55,24 +55,32 @@ function testSandbox() {
 
     const replaceMe = {
         prop: 5,
-        method() { return 6; },
-        get getter() { return 7; },
-        get setter() { return true; },
-        set setter(val) { }
+        method() {
+            return 6;
+        },
+        get getter() {
+            return 7;
+        },
+        get setter() {
+            return true;
+        },
+        set setter(val) {},
     };
 
     sb.replace(replaceMe, 'prop', 10);
     sb.replace(replaceMe, 'method', sb.spy());
     sb.replaceGetter(replaceMe, 'getter', () => 14);
-    sb.replaceSetter(replaceMe, 'setter', (v) => { });
+    sb.replaceSetter(replaceMe, 'setter', v => {});
 
     const cls = class {
-        foo(arg1: string, arg2: number): number { return 1; }
+        foo(arg1: string, arg2: number): number {
+            return 1;
+        }
         bar: number;
     };
     const PrivateFoo = class {
-        private constructor() { }
-        foo() { }
+        private constructor() {}
+        foo() {}
         bar: number;
         static create() {
             return new PrivateFoo();
@@ -90,7 +98,7 @@ function testSandbox() {
     const privateFooBar: number = privateFooStubbedInstance.bar;
     sb.createStubInstance(cls, {
         foo: sinon.stub<[string, number], number>().returns(1),
-        bar: 1
+        bar: 1,
     });
     sb.createStubInstance(cls, {
         foo: 1, // used as return value
@@ -105,12 +113,12 @@ function testFakeServer() {
         autoRespond: true,
         autoRespondAfter: 3,
         fakeHTTPMethods: true,
-        respondImmediately: false
+        respondImmediately: false,
     });
 
     sinon.fakeServer.create({
         autoRespond: true,
-        autoRespondAfter: 3
+        autoRespondAfter: 3,
     });
 }
 
@@ -126,7 +134,7 @@ function testXHR() {
 
     sinon.FakeXMLHttpRequest.useFilters = true;
     sinon.FakeXMLHttpRequest.addFilter((method, url, async, user, pass) => true);
-    sinon.FakeXMLHttpRequest.onCreate = (xhr) => { };
+    sinon.FakeXMLHttpRequest.onCreate = xhr => {};
     sinon.FakeXMLHttpRequest.restore();
 }
 
@@ -137,7 +145,7 @@ function testClock() {
     let now: sinon.SinonTimerId = 0;
     now = clock.now;
 
-    const fn = () => { };
+    const fn = () => {};
     const fnWithArgs = (a: number, b: string) => {};
 
     clock.setTimeout(fn, 0);
@@ -205,14 +213,14 @@ function testExpectation() {
 
 function testMatch() {
     const obj = {};
-    const fn = () => { };
+    const fn = () => {};
 
     sinon.match(5).test(5);
     sinon.match('str').test('foo');
     sinon.match(/foo/).test('foo');
     sinon.match({ a: 5, b: 6 }).test({});
-    sinon.match((v) => true).test('foo');
-    sinon.match((v) => true, 'some message').test('foo');
+    sinon.match(v => true).test('foo');
+    sinon.match(v => true, 'some message').test('foo');
     sinon.match.any.test('foo');
     sinon.match.defined.test('foo');
     sinon.match.truthy.test('foo');
@@ -222,7 +230,12 @@ function testMatch() {
     sinon.match.string.test('foo');
     sinon.match.object.test('foo');
     sinon.match.func.test(fn);
-    sinon.match.map.test(new Map([['a', 1], ['b', 2]]));
+    sinon.match.map.test(
+        new Map([
+            ['a', 1],
+            ['b', 2],
+        ]),
+    );
     sinon.match.set.test(new Set([1, 2, 3]));
     sinon.match.array.test([1, 2, 3]);
     sinon.match.regexp.test('foo');
@@ -244,12 +257,19 @@ function testMatch() {
     sinon.match.array.startsWith([{ a: 'b' }]).test([]);
     sinon.match.array.deepEquals([{ a: 'b' }]).test([]);
     sinon.match.array.contains([{ a: 'b' }]).test([]);
-    sinon.match.map.deepEquals(new Map([['a', true], ['b', false]])).test(new Map());
+    sinon.match.map
+        .deepEquals(
+            new Map([
+                ['a', true],
+                ['b', false],
+            ]),
+        )
+        .test(new Map());
     sinon.match.map.contains(new Map([['a', true]])).test(new Map());
 }
 
 function testFake() {
-    const fn = () => { };
+    const fn = () => {};
     let fake = sinon.fake();
 
     fake = sinon.fake(() => true);
@@ -358,10 +378,14 @@ function testAssert() {
 
 function testTypedSpy() {
     const cls = class {
-        get accessorTest() { return 5; }
-        set accessorTest(v: number) { }
-        get getterTest() { return 5; }
-        set setterTest(v: number) { }
+        get accessorTest() {
+            return 5;
+        }
+        set accessorTest(v: number) {}
+        get getterTest() {
+            return 5;
+        }
+        set setterTest(v: number) {}
         foo(a: number, b: string): number {
             return 3;
         }
@@ -408,10 +432,14 @@ function testTypedSpy() {
 function testSpy() {
     let fn = (arg: string, arg2: number): boolean => true;
     const obj = class {
-        foo() { }
-        foobar(p1?: string) { return p1; }
-        set bar(val: number) { }
-        get bar() { return 0; }
+        foo() {}
+        foobar(p1?: string) {
+            return p1;
+        }
+        set bar(val: number) {}
+        get bar() {
+            return 0;
+        }
     };
     const instance = new obj();
 
@@ -518,11 +546,21 @@ function testSpy() {
 
 function testStub() {
     const obj = class {
-        foo(arg: string): number { return 1; }
-        promiseFunc() { return Promise.resolve('foo'); }
-        promiseLikeFunc() { return Promise.resolve('foo') as PromiseLike<string>; }
-        unresolvableReturnFunc(): any { return Promise.resolve(); }
-        fooDeep(arg: { s: string }): void { return undefined; }
+        foo(arg: string): number {
+            return 1;
+        }
+        promiseFunc() {
+            return Promise.resolve('foo');
+        }
+        promiseLikeFunc() {
+            return Promise.resolve('foo') as PromiseLike<string>;
+        }
+        unresolvableReturnFunc(): any {
+            return Promise.resolve();
+        }
+        fooDeep(arg: { s: string }): void {
+            return undefined;
+        }
     };
     const instance = new obj();
 
@@ -534,8 +572,7 @@ function testStub() {
     promiseStub.resolves('test');
     promiseStub.resolves(123); // $ExpectError
 
-    const promiseUnresolvableReturn =
-        sinon.stub(instance, 'unresolvableReturnFunc');
+    const promiseUnresolvableReturn = sinon.stub(instance, 'unresolvableReturnFunc');
     promiseUnresolvableReturn.resolves(['anything', 123, true]);
 
     const promiseLikeStub = sinon.stub(instance, 'promiseLikeFunc');
@@ -573,10 +610,10 @@ function testStub() {
     stub.callsArgOnAsync(1, instance);
     stub.callsArgWithAsync(1, 'a', 2);
     stub.callsArgOnWithAsync(1, instance, 'a', 2);
-    stub.callsFake((s1, s2, s3) => { });
-    stub.callsFake(() => { });
+    stub.callsFake((s1, s2, s3) => {});
+    stub.callsFake(() => {});
     stub.get(() => true);
-    stub.set((v) => { });
+    stub.set(v => {});
     stub.onCall(1).returns(true);
     stub.onFirstCall().resolves('foo');
     stub.onSecondCall().resolves('foo');
@@ -629,7 +666,7 @@ function testTypedStub() {
     stub2 = sinon.stub(foo, 'bar');
     const result: boolean = stub(42, 'qux');
     const fooStub: sinon.SinonStubbedInstance<Foo> = {
-        bar: sinon.stub()
+        bar: sinon.stub(),
     };
 }
 
@@ -640,4 +677,10 @@ function testMock() {
     mock.expects('method').atLeast(2).atMost(5);
     mock.restore();
     mock.verify();
+}
+
+function testAddBehavior() {
+    sinon.addBehavior('returnsNum', function (fake, n) {
+        fake.returns(n);
+    });
 }

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -687,3 +687,7 @@ function testAddBehavior() {
         fake.returns(n);
     });
 }
+
+function testSetFormatter(){
+    sinon.setFormatter( (...args) => JSON.stringify(args));
+}

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -25,6 +25,9 @@ function testSandbox() {
 
     const sb = sinon.createSandbox();
 
+    sb.fake.returns(42);
+    sb.match(/foo/).test('foo')
+
     sb.assert.pass('foo');
     sb.clock.tick(1000);
     sb.spy();

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -20,13 +20,11 @@ function testSandbox() {
         useFakeServer: sinon.fakeServer.create(),
     });
     sinon.createSandbox(sinon.defaultConfig);
-    sinon.sandbox.create();
-    sinon.sandbox.create(sinon.defaultConfig);
 
     const sb = sinon.createSandbox();
 
     sb.fake.returns(42);
-    sb.match(/foo/).test('foo')
+    sb.match(/foo/).test('foo');
 
     sb.assert.pass('foo');
     sb.clock.tick(1000);
@@ -683,11 +681,11 @@ function testMock() {
 }
 
 function testAddBehavior() {
-    sinon.addBehavior('returnsNum', function (fake, n) {
+    sinon.addBehavior('returnsNum', (fake, n) => {
         fake.returns(n);
     });
 }
 
-function testSetFormatter(){
-    sinon.setFormatter( (...args) => JSON.stringify(args));
+function testSetFormatter() {
+    sinon.setFormatter((...args) => JSON.stringify(args));
 }


### PR DESCRIPTION
The current Sinon API is basically that of the Sandbox API and some additional methods. This basically moves some of those to where they actually belong and removes some methods which have long since been removed. `sandbox.fake` was added in Sinon 5 and the deprecated methods removed in Sinon 8, for instance.

Most of the changes are just whitespace changes from Prettier. See the individual commits for sanity.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Changelog for v8](https://github.com/sinonjs/sinon/blob/master/CHANGELOG.md#800--2019-12-22) and current exported API: https://github.com/sinonjs/sinon/blob/master/lib/sinon.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
