### PR TITLE
Fix setup_future_usage param type of confirmCardPayment function in stripe-v3

### DIFF
--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -638,8 +638,9 @@ declare namespace stripe {
         save_payment_method?: boolean;
         /**
          * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+         * Valid values are: ["on_session", "off_session"]
          */
-        setup_future_usage?: boolean;
+        setup_future_usage?: string;
     }
     interface ConfirmCardPaymentOptions {
         /*

--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -638,9 +638,8 @@ declare namespace stripe {
         save_payment_method?: boolean;
         /**
          * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         * Valid values are: ["on_session", "off_session"]
          */
-        setup_future_usage?: string;
+        setup_future_usage?: "on_session" | "off_session";
     }
     interface ConfirmCardPaymentOptions {
         /*

--- a/types/stripe-v3/stripe-v3-tests.ts
+++ b/types/stripe-v3/stripe-v3-tests.ts
@@ -362,6 +362,7 @@ describe("Stripe elements", () => {
             .then(_result => {
                 // Handle result.error or result.paymentIntent
             });
+
         // stripe.confirmCardPayment(clientSecret,data?)
         stripe
             .confirmCardPayment(
@@ -379,11 +380,13 @@ describe("Stripe elements", () => {
                         },
                         name: 'Recipient name',
                     },
+                    setup_future_usage: 'off_session',
                 }
             )
             .then(_result => {
                 // Handle result.error or result.paymentIntent
             });
+
         // stripe.confirmCardPayment(clientSecret,data?,options?)
         stripe
             .confirmCardPayment(
@@ -395,6 +398,7 @@ describe("Stripe elements", () => {
                             name: 'Jenny Rosen',
                         },
                     },
+                    setup_future_usage: 'on_session',
                 },
                 {
                     handleActions: false,


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested: [Link to stripe docs: stripe.confirmCardPayment](https://stripe.com/docs/js/payment_intents/confirm_card_payment#stripe_confirm_card_payment-data-setup_future_usage)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

