### PR TITLE
[mongodb] fix AggregationCursor.unwind argument

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -2725,7 +2725,7 @@ export class AggregationCursor<T = Default> extends Cursor<T> {
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/AggregationCursor.html#unshift */
     unshift(stream: Buffer | string): void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/AggregationCursor.html#unwind */
-    unwind<U = T>(field: string): AggregationCursor<U>;
+    unwind<U = T>(field: string | { path: string; includeArrayIndex?: string; preserveNullAndEmptyArrays?: boolean; }): AggregationCursor<U>;
 }
 
 /** http://mongodb.github.io/node-mongodb-native/3.1/api/CommandCursor.html#~resultCallback */

--- a/types/mongodb/test/collection/aggregate.ts
+++ b/types/mongodb/test/collection/aggregate.ts
@@ -1,4 +1,4 @@
-import { connect, MongoError, AggregationCursor, Cursor } from 'mongodb';
+import { AggregationCursor, connect, Cursor, MongoError } from 'mongodb';
 import { connectionString } from '../index';
 
 // collection.aggregate tests
@@ -17,6 +17,8 @@ async function run() {
     collection.aggregate([{ $match: { bar: 1 } }]).limit(10);
     collection.aggregate([]).match({ bar: 1 }).limit(10);
     collection.aggregate().match({ bar: 1 }).limit(10);
+    collection.aggregate().unwind('total');
+    collection.aggregate().unwind({ path: 'total' });
 
     collection.aggregate<Payment>([{ $match: { bar: 1 } }], (err: MongoError, cursor: AggregationCursor<Payment>) => {
         cursor.limit(10);


### PR DESCRIPTION

When I check with the official document of [mongodb document](https://docs.mongodb.com/manual/reference/operator/aggregation/unwind/index.html), which allow to pass in object to the unwind pipeline. Afterward, I have check the [mongodb node driver document](https://mongodb.github.io/node-mongodb-native/3.6/api/lib_aggregation_cursor.js.html), this method is only passing the argument directly to the pipeline.
```javascript
unwind(field) {
  this.operation.addToPipeline({ $unwind: field });
  return this;
}
```
As a result, which should also allow to pass the following argument to ```unwind``` method.

```
{
    path: <field path>,
    includeArrayIndex: <string>,
    preserveNullAndEmptyArrays: <boolean>
}
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
