### PR TITLE
[jsforce] connection.request support generic types

### DIFF
--- a/types/jsforce/api/metadata.d.ts
+++ b/types/jsforce/api/metadata.d.ts
@@ -1,7 +1,6 @@
 import { Callback, Connection } from '../connection';
 import { EventEmitter } from 'events';
 import { Stream } from 'stream';
-import { Buffer } from 'buffer';
 
 interface DeployResult {
     id: string;

--- a/types/jsforce/connection.d.ts
+++ b/types/jsforce/connection.d.ts
@@ -174,7 +174,7 @@ export type ConnectionEvent = "refresh";
  */
 export abstract class BaseConnection extends EventEmitter {
     _baseUrl(): string;
-    request(info: RequestInfo | string, options?: HttpApiOptions, callback?: (err: Error, Object: object) => void): Promise<Object>;
+    request<T = object>(info: RequestInfo | string, options?: HttpApiOptions, callback?: (err: Error, Object: T) => void): Promise<T>;
     query<T>(soql: string, options?: ExecuteOptions, callback?: (err: Error, result: QueryResult<T>) => void): Query<QueryResult<T>>;
     queryMore<T>(locator: string, options?: ExecuteOptions, callback?: (err: Error, result: QueryResult<T>) => void): Promise<QueryResult<T>>;
     create<T>(type: string, records: Record<T> | Array<Record<T>>, options?: RestApiOptions,

--- a/types/jsforce/jsforce-tests.ts
+++ b/types/jsforce/jsforce-tests.ts
@@ -457,7 +457,19 @@ const requestInfo: sf.RequestInfo = {
     method: '',
     url: ''
 };
-salesforceConnection.request(requestInfo);
+
+// Default return type is Object
+ salesforceConnection.request(requestInfo).then((obj: Object) => {
+    console.log(obj);
+ });
+
+// Can typecast the return type, too
+interface MyFoo {
+    anything: string;
+}
+salesforceConnection.request<MyFoo>(requestInfo).then((myFoo: MyFoo) => {
+    console.log(myFoo.anything)
+});
 
 const queryOptions: sf.ExecuteOptions = {
     autoFetch: true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

### Changes
* Makes `connection.request(..)` function accept a generic type `T` to imply the return type from the promise/callback rather than hard coded to `Object`.
* For backwards compatibility, the default value for `T` is `Object`
