### PR TITLE
feat(react): Support react-jsx and react-jsxdev

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for React 16.9
+// Type definitions for React 16.14
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>
 //                 AssureSign <http://www.assuresign.com>

--- a/types/react/jsx-dev-runtime.d.ts
+++ b/types/react/jsx-dev-runtime.d.ts
@@ -1,0 +1,2 @@
+// Expose `JSX` namespace in `global` namespace
+import './';

--- a/types/react/jsx-runtime.d.ts
+++ b/types/react/jsx-runtime.d.ts
@@ -1,0 +1,2 @@
+// Expose `JSX` namespace in `global` namespace
+import './';

--- a/types/react/v15/OTHER_FILES.txt
+++ b/types/react/v15/OTHER_FILES.txt
@@ -1,3 +1,2 @@
-experimental.d.ts
 jsx-dev-runtime.d.ts
 jsx-runtime.d.ts

--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for React 15.6
+// Type definitions for React 15.7
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>
 //                 AssureSign <http://www.assuresign.com>

--- a/types/react/v15/jsx-dev-runtime.d.ts
+++ b/types/react/v15/jsx-dev-runtime.d.ts
@@ -1,0 +1,2 @@
+// Expose `JSX` namespace in `global` namespace
+import './';

--- a/types/react/v15/jsx-runtime.d.ts
+++ b/types/react/v15/jsx-runtime.d.ts
@@ -1,0 +1,2 @@
+// Expose `JSX` namespace in `global` namespace
+import './';


### PR DESCRIPTION
Adds support for `"jsx": "react-jsx"` and `"jsx": "react-jsxdev"` compiler options in TypeScript 4.1 (backports jsx-runtime*.d.ts from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48971).

I don't know how I could test this in the DT repo. Ideally we could control the TS version + compiler options in a test matrix.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:   
  - [TypeScript 4.1 jsx factories](https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#jsx-factories)
  - [React 16.14 changelog](https://github.com/facebook/react/releases/tag/v16.14.0)
  - [React 15.7 changelog](https://github.com/facebook/react/releases/tag/v15.7.0)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
