### PR TITLE
fix(react): Add explicit dependency on csstype for v16

### DIFF
--- a/types/react/v16/package.json
+++ b/types/react/v16/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+      "csstype": "^3.0.2"
+    }
+  }


### PR DESCRIPTION
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/49713

I forgot to move the package.json when creating v16 types in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48971.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- ~[ ]~ Provide a URL to documentation or source code which provides context for the suggested changes
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- ~[ ]~ If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
