### PR TITLE
Bugfix not-needed script argument parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ For a good example package, see [base64-js](https://github.com/DefinitelyTyped/D
 
 When a package [bundles](http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) its own types, types should be removed from Definitely Typed to avoid confusion.
 
-You can remove it by running `npm run not-needed — typingsPackageName asOfVersion [libraryName]`.
+You can remove it by running `npm run not-needed -- typingsPackageName asOfVersion [libraryName]`.
 * `typingsPackageName`: This is the name of the directory to delete.
 * `asOfVersion`: A stub will be published to `@types/foo` with this version. Should be higher than any currently published version, and should be a version of `foo` on npm.
 * `libraryName`: Name of npm package that replaces the Definitely Typed types. Usually this is identical to "typingsPackageName", in which case you can omit it.

--- a/scripts/not-needed.js
+++ b/scripts/not-needed.js
@@ -5,9 +5,9 @@ const path = require("path");
 
 const typingsPackageName = process.argv[2];
 const asOfVersion = process.argv[3];
-const libraryName = process.argv[5] || typingsPackageName;
+const libraryName = process.argv[4] || typingsPackageName;
 
-if (process.argv.length !== 5 && process.argv.length !== 6) {
+if (process.argv.length !== 4 && process.argv.length !== 5) {
 	console.log("Usage: npm run not-needed -- typingsPackageName asOfVersion [libraryName]");
 	process.exit(1);
 }


### PR DESCRIPTION
this is a fix for regression in not-needed script introduced in #49620 by removing of the forth parameter and not shifting the fifth