### PR TITLE
[ttf2eot]: add definition for fontello/ttf2eot

### DIFF
--- a/types/ttf2eot/index.d.ts
+++ b/types/ttf2eot/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for ttf2eot 2.0
+// Project: https://github.com/fontello/ttf2eot#readme
+// Definitions by: Kaspar Vollenweider <https://github.com/casaper>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+declare function ttf2eot(ttf: Uint8Array): Buffer;
+
+export = ttf2eot;

--- a/types/ttf2eot/tsconfig.json
+++ b/types/ttf2eot/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ttf2eot-tests.ts"
+    ]
+}

--- a/types/ttf2eot/tslint.json
+++ b/types/ttf2eot/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/ttf2eot/ttf2eot-tests.ts
+++ b/types/ttf2eot/ttf2eot-tests.ts
@@ -1,0 +1,4 @@
+import ttf2eot = require('ttf2eot');
+
+const input = new Uint8Array(10);
+const result: Buffer = ttf2eot(input);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

Package Repo: [fontello/ttf2eot](https://github.com/fontello/ttf2eot)

**This is not my own package but they do not provide any type definitions and their project isn't in typescript**

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

~~If changing an existing definition:~~


~~If removing a declaration:~~

