### PR TITLE
[passport] Strongly type serialize-/deserializeUser with Express.User

### DIFF
--- a/types/passport-google-oauth20/index.d.ts
+++ b/types/passport-google-oauth20/index.d.ts
@@ -41,7 +41,7 @@ export interface Profile extends passport.Profile {
     _json: any;
 }
 
-export type VerifyCallback = (err?: string | Error, user?: any, info?: any) => void;
+export type VerifyCallback = (err?: string | Error, user?: Express.User, info?: any) => void;
 
 export class Strategy extends oauth2.Strategy {
     constructor(

--- a/types/passport-local-mongoose/passport-local-mongoose-tests.ts
+++ b/types/passport-local-mongoose/passport-local-mongoose-tests.ts
@@ -119,6 +119,15 @@ passport.use('login', new LocalStrategy({
     })
 );
 
+type _User = User;
+
+declare global {
+    namespace Express {
+        interface User extends PassportLocalModel<_User> {
+        }
+    }
+}
+
 passport.serializeUser(UserModel.serializeUser());
 passport.deserializeUser(UserModel.deserializeUser());
 

--- a/types/passport-oauth2/index.d.ts
+++ b/types/passport-oauth2/index.d.ts
@@ -52,7 +52,7 @@ declare namespace OAuth2Strategy {
         verify(req: Request, state: string, meta: Metadata, callback: StateStoreVerifyCallback): void;
     }
 
-    type VerifyCallback = (err?: Error | null, user?: object, info?: object) => void;
+    type VerifyCallback = (err?: Error | null, user?: Express.User, info?: object) => void;
 
     type VerifyFunction =
         ((accessToken: string, refreshToken: string, profile: any, verified: VerifyCallback) => void) |

--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -73,10 +73,10 @@ declare namespace passport {
         authenticate(strategy: string | string[] | Strategy, options: AuthenticateOptions, callback?: (...args: any[]) => any): AuthenticateRet;
         authorize(strategy: string | string[], callback?: (...args: any[]) => any): AuthorizeRet;
         authorize(strategy: string | string[], options: AuthorizeOptions, callback?: (...args: any[]) => any): AuthorizeRet;
-        serializeUser<TUser, TID>(fn: (user: TUser, done: (err: any, id?: TID) => void) => void): void;
-        serializeUser<TUser, TID, TR extends IncomingMessage = express.Request>(fn: (req: TR, user: TUser, done: (err: any, id?: TID) => void) => void): void;
-        deserializeUser<TUser, TID>(fn: (id: TID, done: (err: any, user?: TUser) => void) => void): void;
-        deserializeUser<TUser, TID, TR extends IncomingMessage = express.Request>(fn: (req: TR, id: TID, done: (err: any, user?: TUser) => void) => void): void;
+        serializeUser<TID>(fn: (user: Express.User, done: (err: any, id?: TID) => void) => void): void;
+        serializeUser<TID, TR extends IncomingMessage = express.Request>(fn: (req: TR, user: Express.User, done: (err: any, id?: TID) => void) => void): void;
+        deserializeUser<TID>(fn: (id: TID, done: (err: any, user?: Express.User) => void) => void): void;
+        deserializeUser<TID, TR extends IncomingMessage = express.Request>(fn: (req: TR, id: TID, done: (err: any, user?: Express.User) => void) => void): void;
         transformAuthInfo(fn: (info: any, done: (err: any, info: any) => void) => void): void;
     }
 

--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -102,7 +102,7 @@ declare namespace passport {
          * useful for third-party authentication strategies to pass profile
          * details.
          */
-        success(user: object, info?: object): void;
+        success(user: Express.User, info?: object): void;
         /**
          * Fail authentication, with optional `challenge` and `status`, defaulting
          * to 401.

--- a/types/passport/passport-tests.ts
+++ b/types/passport/passport-tests.ts
@@ -6,7 +6,7 @@ declare global {
     namespace Express {
         interface User {
             username: string;
-            id?: string;
+            id?: number;
         }
     }
 }
@@ -21,9 +21,7 @@ class TestStrategy extends passport.Strategy {
     name = 'test';
 
     authenticate(req: express.Request) {
-        const user: TestUser = {
-            id: 0,
-        };
+        const user: Express.User = { username: 'abc' };
         if (Math.random() > 0.5) {
             this.fail();
         } else {
@@ -50,24 +48,21 @@ const newFramework: passport.Framework = {
 passport.use(new TestStrategy());
 passport.framework(newFramework);
 
-interface TestUser {
-    id: number;
-}
-passport.serializeUser((user: TestUser, done: (err: any, id?: number) => void) => {
+passport.serializeUser((user, done: (err: any, id?: number) => void) => {
     done(null, user.id);
 });
-passport.serializeUser<TestUser, number>((user, done) => {
-    if (user.id > 0) {
+passport.serializeUser<number>((user, done) => {
+    if (user.id! > 0) {
         done(null, user.id);
     } else {
         done(new Error('user ID is invalid'));
     }
 });
 passport.deserializeUser((id, done) => {
-    done(null, { id });
+    done(null, { username: `${id}` });
 });
-passport.deserializeUser<TestUser, number>((id, done) => {
-    const fetchUser = (id: number): Promise<TestUser> => {
+passport.deserializeUser<number>((id, done) => {
+    const fetchUser = (id: number): Promise<Express.User> => {
         return Promise.reject(new Error(`user not found: ${id}`));
     };
 
@@ -167,7 +162,7 @@ app.use((req: express.Request, res: express.Response, next: (err?: any) => void)
             req.user.username = "hello user";
         }
         if (req.user.id) {
-            req.user.id = "123";
+            req.user.id = 123;
         }
     }
     next();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
* [deserializeUser](https://github.com/jaredhanson/passport/blob/1fd591d5cdcf6516d9eb446216843223c0e020c4/lib/strategies/session.js#L60-L67)
* [serializeUser](https://github.com/jaredhanson/passport/blob/1fd591d5cdcf6516d9eb446216843223c0e020c4/lib/sessionmanager.js#L14-L25)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This is of course a breaking change, but as far as I can see the current situation (introduced in #12446) does not make sense (anymore). @RandScullard could you shine some light on your rationale for these generics?