### PR TITLE
[svgicons2svgfont]: add definition for nfroidure/svgicons2svgfont

### DIFF
--- a/types/svgicons2svgfont/index.d.ts
+++ b/types/svgicons2svgfont/index.d.ts
@@ -22,7 +22,7 @@ declare namespace SVGIcons2SVGFont {
         /**
          * The font id you want (Default value: the options.fontName)
          *
-         * Default value: the options.fontName value
+         * @default the options.fontName value
          */
         fontId?: string;
         /**

--- a/types/svgicons2svgfont/index.d.ts
+++ b/types/svgicons2svgfont/index.d.ts
@@ -16,7 +16,7 @@ declare namespace SVGIcons2SVGFont {
         /**
          * The font family name you want
          *
-         * Default value: 'iconfont'
+         * @default 'iconfont'
          */
         fontName?: string;
         /**

--- a/types/svgicons2svgfont/index.d.ts
+++ b/types/svgicons2svgfont/index.d.ts
@@ -52,7 +52,7 @@ declare namespace SVGIcons2SVGFont {
         /**
          * Setup SVG path rounding.
          *
-         * Default value: 10e12
+         * @default 10e12
          */
         round?: number;
         /**

--- a/types/svgicons2svgfont/index.d.ts
+++ b/types/svgicons2svgfont/index.d.ts
@@ -1,0 +1,90 @@
+// Type definitions for svgicons2svgfont 9.1
+// Project: https://github.com/nfroidure/svgicons2svgfont
+// Definitions by: Kaspar Vollenweider <https://github.com/casaper>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import { Stream } from 'stream';
+
+declare class SVGIcons2SVGFont extends Stream.Transform {
+    constructor(options?: SVGIcons2SVGFont.SvgIcons2FontOptions);
+}
+
+declare namespace SVGIcons2SVGFont {
+    interface SvgIcons2FontOptions {
+        /**
+         * The font family name you want
+         *
+         * Default value: 'iconfont'
+         */
+        fontName?: string;
+        /**
+         * The font id you want (Default value: the options.fontName)
+         *
+         * Default value: the options.fontName value
+         */
+        fontId?: string;
+        /**
+         * The font style you want.
+         */
+        fontStyle?: string;
+        /**
+         * The font weight
+         */
+        fontWeight?: string;
+        /**
+         * Creates a monospace font of the width of the largest input icon.
+         */
+        fixedWidth?: boolean;
+        /**
+         * Calculate the bounds of a glyph and center it horizontally.
+         */
+        centerHorizontally?: boolean;
+        /**
+         * Normalize icons by scaling them to the height of the highest icon.
+         */
+        normalize?: boolean;
+        /**
+         * The outputted font height (defaults to the height of the highest input icon).
+         */
+        fontHeight?: number;
+        /**
+         * Setup SVG path rounding.
+         *
+         * Default value: 10e12
+         */
+        round?: number;
+        /**
+         * The font descent. It is usefull to fix the font baseline yourself.
+         *
+         * Warning: The descent is a positive value!
+         */
+        descent?: number;
+        /**
+         * The font ascent.
+         *
+         * Default value: fontHeight - descent
+         *
+         * Use this options only if you know what you're doing.
+         * A suitable value for this is computed for you.
+         */
+        ascent?: number;
+        /**
+         * The font [metadata](http://www.w3.org/TR/SVG/metadata.html).
+         *
+         * You can set any character data in but it is the be suited place for a copyright mention.
+         */
+        metadata?: string;
+        /**
+         * Allows you to provide your own logging function.
+         *
+         * Set to function(){} to disable logging.
+         *
+         * Defaults to console.log()
+         */
+        log?: (message?: any) => void;
+    }
+}
+
+export = SVGIcons2SVGFont;

--- a/types/svgicons2svgfont/index.d.ts
+++ b/types/svgicons2svgfont/index.d.ts
@@ -81,7 +81,7 @@ declare namespace SVGIcons2SVGFont {
          *
          * Set to function(){} to disable logging.
          *
-         * Defaults to console.log()
+         * @default console.log()
          */
         log?: (message?: any) => void;
     }

--- a/types/svgicons2svgfont/svgicons2svgfont-tests.ts
+++ b/types/svgicons2svgfont/svgicons2svgfont-tests.ts
@@ -1,4 +1,4 @@
-import SVGIcons2SVGFont from 'svgicons2svgfont';
+import SVGIcons2SVGFont = require('svgicons2svgfont');
 
 let svgIcons2SvgFont = new SVGIcons2SVGFont();
 svgIcons2SvgFont = new SVGIcons2SVGFont({});

--- a/types/svgicons2svgfont/svgicons2svgfont-tests.ts
+++ b/types/svgicons2svgfont/svgicons2svgfont-tests.ts
@@ -1,0 +1,16 @@
+import SVGIcons2SVGFont from 'svgicons2svgfont';
+
+let svgIcons2SvgFont = new SVGIcons2SVGFont();
+svgIcons2SvgFont = new SVGIcons2SVGFont({});
+svgIcons2SvgFont = new SVGIcons2SVGFont({ fontName: 'testfont' });
+svgIcons2SvgFont = new SVGIcons2SVGFont({ fontName: 'testfont', fontId: 'testId' });
+svgIcons2SvgFont = new SVGIcons2SVGFont({ fontStyle: 'italic' });
+svgIcons2SvgFont = new SVGIcons2SVGFont({ fontWeight: 'normal' });
+svgIcons2SvgFont = new SVGIcons2SVGFont({ fixedWidth: true });
+svgIcons2SvgFont = new SVGIcons2SVGFont({ centerHorizontally: true });
+svgIcons2SvgFont = new SVGIcons2SVGFont({ normalize: true });
+svgIcons2SvgFont = new SVGIcons2SVGFont({ fontHeight: 100 });
+svgIcons2SvgFont = new SVGIcons2SVGFont({ round: 10e13 });
+svgIcons2SvgFont = new SVGIcons2SVGFont({ descent: 10 });
+svgIcons2SvgFont = new SVGIcons2SVGFont({ ascent: 10 });
+svgIcons2SvgFont = new SVGIcons2SVGFont({ metadata: 'test metadata' });

--- a/types/svgicons2svgfont/tsconfig.json
+++ b/types/svgicons2svgfont/tsconfig.json
@@ -14,8 +14,7 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "allowSyntheticDefaultImports": true
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/svgicons2svgfont/tsconfig.json
+++ b/types/svgicons2svgfont/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "allowSyntheticDefaultImports": true
+    },
+    "files": [
+        "index.d.ts",
+        "svgicons2svgfont-tests.ts"
+    ]
+}

--- a/types/svgicons2svgfont/tslint.json
+++ b/types/svgicons2svgfont/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
https://github.com/nfroidure/svgicons2svgfont

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

~~If changing an existing definition:~~

~~If removing a declaration:~~
