### PR TITLE
[iobroker] infer object type where possible

### DIFF
--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ioBroker/ioBroker, http://iobroker.net
 // Definitions by: AlCalzone <https://github.com/AlCalzone>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.9
+// TypeScript Version: 4.1
 
 // Note: This is not the definition for the package `iobroker`,
 // which is just an installer, not a library.
@@ -517,6 +517,7 @@ declare global {
             getObject(id: string, options: unknown, callback: GetObjectCallback): void;
             /** Reads an object from the object db */
             getObjectAsync(id: string, options?: unknown): GetObjectPromise;
+
             /** Creates or overwrites an object in the object db */
             setObject(id: string, obj: ioBroker.SettableObject, callback?: SetObjectCallback): void;
             setObject(id: string, obj: ioBroker.SettableObject, options: unknown, callback?: SetObjectCallback): void;
@@ -526,6 +527,7 @@ declare global {
                 obj: ioBroker.SettableObject,
                 options?: unknown,
             ): SetObjectPromise;
+
             /** Creates an object in the object db. Existing objects are not overwritten. */
             setObjectNotExists(id: string, obj: ioBroker.SettableObject, callback?: SetObjectCallback): void;
             setObjectNotExists(
@@ -540,10 +542,12 @@ declare global {
                 obj: ioBroker.SettableObject,
                 options?: unknown,
             ): SetObjectPromise;
-            /** Get all states, channels and devices of this adapter */
-            getAdapterObjects(callback: (objects: Record<string, ioBroker.Object>) => void): void;
-            /** Get all states, channels and devices of this adapter */
-            getAdapterObjectsAsync(): Promise<Record<string, ioBroker.Object>>;
+
+            /** Get all states, channels, devices and folders of this adapter */
+            getAdapterObjects(callback: (objects: Record<string, AdapterScopedObject>) => void): void;
+            /** Get all states, channels, devices and folders of this adapter */
+            getAdapterObjectsAsync(): Promise<Record<string, AdapterScopedObject>>;
+
             /** Extend an object and create it if it might not exist */
             extendObject(id: string, objPart: PartialObject, callback?: SetObjectCallback): void;
             extendObject(id: string, objPart: PartialObject, options: unknown, callback?: SetObjectCallback): void;
@@ -569,81 +573,84 @@ declare global {
             // foreign objects
 
             /** Reads an object (which might not belong to this adapter) from the object db */
-            getForeignObject(id: string, callback: GetObjectCallback): void;
-            getForeignObject(id: string, options: unknown, callback: GetObjectCallback): void;
+            getForeignObject<T extends string>(id: T, callback: GetObjectCallback<T>): void;
+            getForeignObject<T extends string>(id: T, options: unknown, callback: GetObjectCallback<T>): void;
             /** Reads an object (which might not belong to this adapter) from the object db */
-            getForeignObjectAsync(id: string, options?: unknown): GetObjectPromise;
+            getForeignObjectAsync<T extends string>(id: T, options?: unknown): GetObjectPromise<T>;
+
             /** Get foreign objects by pattern, by specific type and resolve their enums. */
             // tslint:disable:unified-signatures
             getForeignObjects(pattern: string, callback: GetObjectsCallback): void;
             getForeignObjects(pattern: string, options: unknown, callback: GetObjectsCallback): void;
-            getForeignObjects(pattern: string, type: ObjectType, callback: GetObjectsCallback): void;
-            getForeignObjects(pattern: string, type: ObjectType, enums: EnumList, callback: GetObjectsCallback): void;
-            getForeignObjects(pattern: string, type: ObjectType, options: unknown, callback: GetObjectsCallback): void;
-            getForeignObjects(
+            getForeignObjects<T extends ObjectType>(pattern: string, type: T, callback: GetObjectsCallbackTyped<T>): void;
+            getForeignObjects<T extends ObjectType>(pattern: string, type: T, enums: EnumList, callback: GetObjectsCallbackTyped<T>): void;
+            getForeignObjects<T extends ObjectType>(pattern: string, type: T, options: unknown, callback: GetObjectsCallbackTyped<T>): void;
+            getForeignObjects<T extends ObjectType>(
                 pattern: string,
-                type: ObjectType,
+                type: T,
                 enums: EnumList,
                 options: unknown,
-                callback: GetObjectsCallback,
+                callback: GetObjectsCallbackTyped<T>,
             ): void;
             // tslint:enable:unified-signatures
             /** Get foreign objects by pattern, by specific type and resolve their enums. */
-            getForeignObjectsAsync(
+            getForeignObjectsAsync<T extends ObjectType>(
                 pattern: string,
-                options?: unknown,
-            ): GetObjectsPromise;
-            getForeignObjectsAsync(
-                pattern: string,
-                type: ObjectType,
-                options?: unknown,
-            ): GetObjectsPromise;
-            getForeignObjectsAsync(
-                pattern: string,
-                type: ObjectType,
+                type: T,
                 enums: EnumList,
                 options?: unknown,
+            ): GetObjectsPromiseTyped<T>;
+            getForeignObjectsAsync<T extends ObjectType>(
+                pattern: string,
+                type: T,
+                options?: unknown,
+            ): GetObjectsPromiseTyped<T>;
+            getForeignObjectsAsync(
+                pattern: string,
+                options?: unknown,
             ): GetObjectsPromise;
+
             /** Creates or overwrites an object (which might not belong to this adapter) in the object db */
-            setForeignObject(id: string, obj: ioBroker.SettableObject, callback?: SetObjectCallback): void;
-            setForeignObject(
-                id: string,
-                obj: ioBroker.SettableObject,
+            setForeignObject<T extends string>(id: T, obj: ioBroker.SettableObject<ObjectIdToObjectType<T, "write">>, callback?: SetObjectCallback): void;
+            setForeignObject<T extends string>(
+                id: T,
+                obj: ioBroker.SettableObject<ObjectIdToObjectType<T, "write">>,
                 options: unknown,
                 callback?: SetObjectCallback,
             ): void;
             /** Creates or overwrites an object (which might not belong to this adapter) in the object db */
-            setForeignObjectAsync(
-                id: string,
-                obj: ioBroker.SettableObject,
+            setForeignObjectAsync<T extends string>(
+                id: T,
+                obj: ioBroker.SettableObject<ObjectIdToObjectType<T, "write">>,
                 options?: unknown,
             ): SetObjectPromise;
             /** Creates an object (which might not belong to this adapter) in the object db. Existing objects are not overwritten. */
-            setForeignObjectNotExists(id: string, obj: ioBroker.SettableObject, callback?: SetObjectCallback): void;
-            setForeignObjectNotExists(
-                id: string,
-                obj: ioBroker.SettableObject,
+            setForeignObjectNotExists<T extends string>(id: T, obj: ioBroker.SettableObject<ObjectIdToObjectType<T, "write">>, callback?: SetObjectCallback): void;
+            setForeignObjectNotExists<T extends string>(
+                id: T,
+                obj: ioBroker.SettableObject<ObjectIdToObjectType<T, "write">>,
                 options: unknown,
                 callback?: SetObjectCallback,
             ): void;
             /** Creates an object (which might not belong to this adapter) in the object db. Existing objects are not overwritten. */
-            setForeignObjectNotExistsAsync(
-                id: string,
-                obj: ioBroker.SettableObject,
+            setForeignObjectNotExistsAsync<T extends string>(
+                id: T,
+                obj: ioBroker.SettableObject<ObjectIdToObjectType<T, "write">>,
                 options?: unknown,
             ): SetObjectPromise;
+
             /** Extend an object (which might not belong to this adapter) and create it if it might not exist */
-            extendForeignObject(id: string, objPart: PartialObject, callback?: SetObjectCallback): void;
-            extendForeignObject(
-                id: string,
-                objPart: PartialObject,
+            extendForeignObject<T extends string>(id: T, objPart: PartialObject<ObjectIdToObjectType<T, "write">>, callback?: SetObjectCallback): void;
+            extendForeignObject<T extends string>(
+                id: T,
+                objPart: PartialObject<ObjectIdToObjectType<T, "write">>,
                 options: unknown,
                 callback?: SetObjectCallback,
             ): void;
             /** Extend an object (which might not belong to this adapter) and create it if it might not exist */
-            extendForeignObjectAsync(
-                id: string,
-                objPart: PartialObject,
+            extendForeignObjectAsync<T extends string>(
+                id: T,
+                objPart: PartialObject<ObjectIdToObjectType<T, "write">>,
                 options?: unknown,
             ): SetObjectPromise;
             /**
@@ -1162,18 +1169,18 @@ declare global {
             createDevice(deviceName: string, callback?: SetObjectCallback): void;
             createDevice(
                 deviceName: string,
-                common: Partial<ioBroker.ObjectCommon>,
+                common: Partial<ioBroker.DeviceCommon>,
                 callback?: SetObjectCallback,
             ): void;
             createDevice(
                 deviceName: string,
-                common: Partial<ioBroker.ObjectCommon>,
+                common: Partial<ioBroker.DeviceCommon>,
                 native: Record<string, any>,
                 callback?: SetObjectCallback,
             ): void;
             createDevice(
                 deviceName: string,
-                common: Partial<ioBroker.ObjectCommon>,
+                common: Partial<ioBroker.DeviceCommon>,
                 native: Record<string, any>,
                 options: unknown,
                 callback?: SetObjectCallback,
@@ -1181,16 +1188,16 @@ declare global {
             /** creates an object with type device */
             createDeviceAsync(
                 deviceName: string,
-                common?: Partial<ioBroker.ObjectCommon>,
+                common?: Partial<ioBroker.DeviceCommon>,
             ): SetObjectPromise;
             createDeviceAsync(
                 deviceName: string,
-                common: Partial<ioBroker.ObjectCommon>,
+                common: Partial<ioBroker.DeviceCommon>,
                 native?: Record<string, any>,
             ): SetObjectPromise;
             createDeviceAsync(
                 deviceName: string,
-                common: Partial<ioBroker.ObjectCommon>,
+                common: Partial<ioBroker.DeviceCommon>,
                 native: Record<string, any>,
                 options?: unknown,
             ): SetObjectPromise;
@@ -1588,8 +1595,8 @@ declare global {
         type SetObjectCallback = (err?: Error | null, obj?: { id: string }) => void;
         type SetObjectPromise = Promise<NonNullCallbackReturnTypeOf<SetObjectCallback>>;
 
-        type GetObjectCallback = (err?: Error | null, obj?: ioBroker.Object | null) => void;
-        type GetObjectPromise = Promise<CallbackReturnTypeOf<GetObjectCallback>>;
+        type GetObjectCallback<T extends string = string> = (err?: Error | null, obj?: ObjectIdToObjectType<T> | null) => void;
+        type GetObjectPromise<T extends string = string> = Promise<CallbackReturnTypeOf<GetObjectCallback<T>>>;
 
         type GetEnumCallback = (err?: Error | null, enums?: Record<string, Enum>, requestedEnum?: string) => void;
         type GetEnumsCallback = (
@@ -1603,6 +1610,9 @@ declare global {
         type GetObjectsCallback = (err?: Error | null, objects?: Record<string, ioBroker.Object>) => void;
         type GetObjectsPromise = Promise<NonNullCallbackReturnTypeOf<GetObjectsCallback>>;
 
+        type GetObjectsCallbackTyped<T extends ObjectType> = (err?: Error | null, objects?: Record<string, ioBroker.AnyObject & {type: T}>) => void;
+        type GetObjectsPromiseTyped<T extends ObjectType> = Promise<NonNullCallbackReturnTypeOf<GetObjectsCallbackTyped<T>>>;
+
         type FindObjectCallback = (
             /** If an error happened, this contains the message */
             err?: Error | null,
@@ -1612,12 +1622,6 @@ declare global {
             name?: string,
         ) => void;
 
-        interface GetObjectsItem<T extends BaseObject> {
-            /** The ID of this object */
-            id: string;
-            /** A copy of the object from the DB */
-            value: T;
-        }
         // This is a version used by GetDevices/GetChannelsOf/GetStatesOf
         type GetObjectsCallback3<T extends BaseObject> = (err?: Error | null, result?: T[]) => void;
 

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -205,6 +205,10 @@ adapter.getForeignObjectAsync('obj.id').then(obj => obj && obj._id.toLowerCase()
 adapter.getForeignObjects('*', (err, objs) => objs!['foo']._id.toLowerCase());
 // getForeignObjectsAsync always returns a Record when it doesn't throw
 adapter.getForeignObjectsAsync('*').then(objs => objs['foo']._id.toLowerCase());
+// If an object type was specified, the returned objects have the correct type
+adapter.getForeignObjectsAsync('*', "adapter").then(objs => {
+    objs[0].type; // $ExpectType "adapter"
+});
 
 // Check that required properties are enforced
 // OK:
@@ -639,3 +643,82 @@ const userObject: ioBroker.UserObject = {
     common: { name: 'me', password: '*****', enabled: true },
     native: {},
 };
+
+// Ensure that getForeignObject tries to resolve a specific object type
+(async () => {
+    let inst: ioBroker.InstanceObject | null | undefined;
+    inst = await adapter.getForeignObjectAsync("system.adapter.admin.0");
+
+    let adptr: ioBroker.AdapterObject | null | undefined;
+    adptr = await adapter.getForeignObjectAsync("system.adapter.admin");
+
+    let meta: ioBroker.MetaObject | null | undefined;
+    meta = await adapter.getForeignObjectAsync("admin.0");
+    meta = await adapter.getForeignObjectAsync("admin.admin");
+    meta = await adapter.getForeignObjectAsync("admin.meta");
+    meta = await adapter.getForeignObjectAsync("admin.meta.foobar");
+    meta = await adapter.getForeignObjectAsync("admin.0.meta.blub");
+
+    let chnl: ioBroker.ChannelObject | null | undefined;
+    chnl = await adapter.getForeignObjectAsync("script.js.common");
+    chnl = await adapter.getForeignObjectAsync("script.js.global");
+    chnl = await adapter.getForeignObjectAsync("admin.777.info");
+
+    let state: ioBroker.StateObject | null | undefined;
+    state = await adapter.getForeignObjectAsync("system.adapter.admin.0.foobar");
+
+    let scrChnl: ioBroker.ChannelObject | ioBroker.ScriptObject | null | undefined;
+    scrChnl = await adapter.getForeignObjectAsync("script.js.my-script");
+    scrChnl = await adapter.getForeignObjectAsync("script.js.my-script.foobar");
+
+    let enm: ioBroker.EnumObject | null | undefined;
+    enm = await adapter.getForeignObjectAsync("enum.functions");
+    enm = await adapter.getForeignObjectAsync("enum.functions.light");
+
+    let group: ioBroker.GroupObject | null | undefined;
+    group = await adapter.getForeignObjectAsync("system.group.admin.faz");
+
+    let user: ioBroker.UserObject | null | undefined;
+    user = await adapter.getForeignObjectAsync("system.user.admin.faz");
+
+    let host: ioBroker.HostObject | null | undefined;
+    host = await adapter.getForeignObjectAsync("system.host.my-hostname");
+
+    let config: ioBroker.OtherObject & {type: "config"} | null | undefined;
+    config = await adapter.getForeignObjectAsync("system.repositories");
+    config = await adapter.getForeignObjectAsync("system.config");
+    config = await adapter.getForeignObjectAsync("system.certificates");
+
+    let misc: ioBroker.FolderObject | ioBroker.DeviceObject | ioBroker.ChannelObject | ioBroker.StateObject | null | undefined;
+    misc = await adapter.getForeignObjectAsync("system.host.hostname.foobar");
+    misc = await adapter.getForeignObjectAsync("adapter-name.0.foo");
+    misc = await adapter.getForeignObjectAsync("adapter-name.0.foo.bar");
+    misc = await adapter.getForeignObjectAsync("adapter-name.0.foo.bar.baz");
+
+    // combined
+    const idCombined = "" as "enum.functions" | "script.js.global";
+    let combined: ioBroker.ChannelObject | ioBroker.EnumObject | null | undefined;
+    combined = await adapter.getForeignObjectAsync(idCombined);
+
+    // unknown id
+    let unknown: ioBroker.Object | null | undefined;
+    unknown = await adapter.getForeignObjectAsync("");
+});
+
+// Ensure that setForeignObject tries to resolve a specific object type
+(async () => {
+    adapter.setForeignObject("system.host.my-hostname", {
+        // $ExpectError
+        type: "not-host"
+    });
+
+    adapter.setForeignObject("admin.0.maybe-channel", {
+        type: "channel",
+        common: {
+            name: "A channel"
+        },
+        native: {}
+    });
+
+    adapter.setForeignObject(null! as string, null! as ioBroker.Object);
+});

--- a/types/iobroker/objects.d.ts
+++ b/types/iobroker/objects.d.ts
@@ -52,10 +52,89 @@ declare global {
             | 'user'
             | 'chart';
 
-        type CommonType = 'number' | 'string' | 'boolean' | 'array' | 'object' | 'mixed' | 'file';
+        // Define the naming schemes for objects so we can provide more specific types for get/setObject
+
+        namespace ObjectIDs {
+            // Guaranteed meta objects
+            type Meta =
+                | `${string}.${number}`
+                | `${string}.${"meta" | "admin"}`
+                | `${string}.meta.${string}`
+                | `${string}.${number}.meta.${string}`;
+
+            // Unsure, can be folder, device, channel or state
+            // --> We need this match to avoid matching the more specific types below
+            type Misc =
+                | `system.host.${string}.${string}`
+                | `0_userdata.0.${string}`;
+
+                // Guaranteed channel objects
+            type Channel =
+                | `script.js.${"common" | "global"}`
+                | `${string}.${number}.info`;
+            // Either script or channel object
+            type ScriptOrChannel = `script.js.${string}`;
+            // Guaranteed state objects
+            type State =
+                | `system.adapter.${string}.${number}.${string}`;
+            // Guaranteed enum objects
+            type Enum = `enum.${string}`;
+            // Guaranteed instance objects
+            type Instance = `system.adapter.${string}.${number}`;
+            // Guaranteed adapter objects
+            type Adapter = `system.adapter.${string}`;
+            // Guaranteed group objects
+            type Group = `system.group.${string}`;
+            // Guaranteed user objects
+            type User = `system.user.${string}`;
+            // Guaranteed host objects
+            type Host = `system.host.${string}`;
+            // Guaranteed config objects
+            type Config = `system.${"certificates" | "config" | "repositories"}`;
+
+            // Unsure, can be folder, device, channel or state (or whatever an adapter does)
+            type AdapterScoped =
+                | `${string}.${number}.${string}`;
+
+            /** All possible typed object IDs */
+            type Any =
+                | Meta
+                | Misc
+                | Channel
+                | ScriptOrChannel
+                | State
+                | Enum
+                | Instance
+                | Adapter
+                | Group
+                | User
+                | Host
+                | Config
+                | AdapterScoped;
+        }
+
+        type ObjectIdToObjectType<T extends string, Read extends "read" | "write" = "read"> =
+            // State must come before Adapter or system.adapter.admin.0.foobar will resolve to AdapterObject
+            T extends ObjectIDs.State ? StateObject :
+            // Instance and Adapter must come before meta or `system.adapter.admin` will resolve to MetaObject
+            T extends ObjectIDs.Instance ? InstanceObject :
+            T extends ObjectIDs.Adapter ? AdapterObject :
+            T extends ObjectIDs.Channel ? ChannelObject :
+            T extends ObjectIDs.Meta ? MetaObject :
+            T extends ObjectIDs.Misc ? AdapterScopedObject :
+            T extends ObjectIDs.ScriptOrChannel ? (ScriptObject | ChannelObject) :
+            T extends ObjectIDs.Enum ? EnumObject :
+            T extends ObjectIDs.Group ? GroupObject :
+            T extends ObjectIDs.User ? UserObject :
+            T extends ObjectIDs.Host ? HostObject :
+            T extends ObjectIDs.Config ? OtherObject & {type: "config"} :
+            T extends ObjectIDs.AdapterScoped ? AdapterScopedObject :
+            Read extends "read" ? ioBroker.Object : AnyObject;
 
         type Languages = 'en' | 'de' | 'ru' | 'pt' | 'nl' | 'fr' | 'it' | 'es' | 'pl' | 'zh-cn';
         type StringOrTranslated = string | { [lang in Languages]?: string; };
+
+        type CommonType = 'number' | 'string' | 'boolean' | 'array' | 'object' | 'mixed' | 'file';
 
         interface ObjectCommon {
             /** The name of this object as a simple string or an object with translations */
@@ -425,6 +504,7 @@ declare global {
             custom?: undefined;
         }
 
+        /* Base type for Objects. Should not be used directly */
         interface BaseObject {
             /** The ID of this object */
             _id: string;
@@ -548,14 +628,13 @@ declare global {
         }
 
         interface OtherObject extends BaseObject {
-            type: 'adapter' | 'config' | 'info' | 'chart';
+            type: 'config' | 'info' | 'chart';
             common: OtherCommon;
         }
         interface PartialOtherObject extends Partial<Omit<OtherObject, 'common'>> {
             common?: Partial<OtherCommon>;
         }
 
-        // Base type for Objects. Should not be used directly
         type AnyObject =
             | StateObject
             | ChannelObject
@@ -571,22 +650,7 @@ declare global {
             | ScriptObject
             | OtherObject;
 
-        // For all objects that are exposed to the user we need to tone the strictness down.
-        // Otherwise, every operation on objects becomes a pain to work with
-        type Object = AnyObject & {
-            common: Record<string, any>;
-            native: Record<string, any>;
-        };
-
-        type SettableObjectWorker<T> = T extends AnyObject ? Omit<T, '_id' | 'acl'> & {
-            _id?: T['_id'];
-            acl?: T['acl'];
-        } : never;
-
-        // In set[Foreign]Object[NotExists] methods, the ID and acl of the object is optional
-
-        type SettableObject = SettableObjectWorker<AnyObject>;
-        type PartialObject =
+        type AnyPartialObject =
             | PartialStateObject
             | PartialChannelObject
             | PartialDeviceObject
@@ -600,5 +664,26 @@ declare global {
             | PartialGroupObject
             | PartialScriptObject
             | PartialOtherObject;
+
+        /** All objects that usually appear in an adapter scope */
+        type AdapterScopedObject = FolderObject | DeviceObject | ChannelObject | StateObject;
+
+        // For all objects that are exposed to the user we need to tone the strictness down.
+        // Otherwise, every operation on objects becomes a pain to work with
+        type Object = AnyObject & {
+            common: Record<string, any>;
+            native: Record<string, any>;
+        };
+
+        // In set[Foreign]Object[NotExists] methods, the ID and acl of the object is optional
+        type SettableObjectWorker<T> = T extends AnyObject ? Omit<T, '_id' | 'acl'> & {
+            _id?: T['_id'];
+            acl?: T['acl'];
+        } : never;
+        // in extend[Foreign]Object, most properties are optional
+        type PartialObjectWorker<T> = T extends AnyObject ? AnyPartialObject & {type?: T["type"]} : never;
+
+        type SettableObject<T extends AnyObject = AnyObject> = SettableObjectWorker<T>;
+        type PartialObject<T extends AnyObject = AnyObject> = PartialObjectWorker<T>;
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **TypeScript 4.1 provided us with the possibility to do this**
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

With this PR (and based on #49618) we have the ability to infer the correct object types in method signatures. If we cannot infer it we fall back to the unspecified type like before.
This makes it easier and safer for users to work with the `{get,set,extend}ForeignObject` methods if the object IDs are known literals. Additionally, `getForeignObjects` now infers the object type from the `type` argument.