### PR TITLE
Add optional refreshToken to RefreshTokenResponse for when refresh token rotation is on

### DIFF
--- a/types/react-native-auth0/index.d.ts
+++ b/types/react-native-auth0/index.d.ts
@@ -74,6 +74,7 @@ export interface RefreshTokenResponse {
     accessToken: string;
     expiresIn: number;
     idToken: string;
+    refreshToken?: string;
     scope?: string;
     tokenType: string;
 }


### PR DESCRIPTION
**Notable Changes**
* If refresh token rotation is on then calling `auth0.webAuth.refreshToken(refreshToken)` should include a new `refreshToken` in the response