### PR TITLE
update(email-templates): v8 update

### DIFF
--- a/types/email-templates/email-templates-tests.ts
+++ b/types/email-templates/email-templates-tests.ts
@@ -1,4 +1,4 @@
-import EmailTemplates = require('email-templates');
+import Email = require('email-templates');
 import { createTransport } from 'nodemailer';
 import path = require('path');
 
@@ -6,21 +6,23 @@ const locals = {
     locale: 'en',
     name: 'Elon',
 };
-const email = new EmailTemplates({
+
+let email = new Email();
+
+email = new Email({
     message: {
       from: 'Test@testing.com'
     },
     transport: {
         jsonTransport: true
     },
-    /** returns different template based on current locale */
     getPath: (type, template, locales) => {
         const locale = locales.locale;
         return path.join(template, locale, type);
     },
 });
 
-const emailNoTransporter = new EmailTemplates({
+const emailNoTransporter = new Email({
     message: {
       from: 'test@testing.com'
     },
@@ -41,7 +43,7 @@ interface Locals {
     firstName: string;
 }
 
-const withTransportInstance = new EmailTemplates<Locals>({
+const withTransportInstance = new Email<Locals>({
     message: {
         from: 'definitelytyped@example.org'
     },
@@ -52,7 +54,7 @@ const withTransportInstance = new EmailTemplates<Locals>({
 
 withTransportInstance.render('tmpl', { firstName: 'TypeScript' });
 
-const emailOptions: EmailTemplates.EmailOptions<Locals> = {
+const emailOptions: Email.EmailOptions<Locals> = {
     template: 'tmpl',
     locals: {
         firstName: 'TypeScript'
@@ -74,4 +76,20 @@ promise.then(value => {
     const subject: string | undefined = value.subject;
     const html: string | undefined = value.html;
     const text: string | undefined = value.text;
+});
+
+email = new Email({
+    message: {
+        from: 'definitelytyped@example.org',
+    },
+    juice: true,
+    juiceSettings: {
+        tableElements: ['TABLE'],
+    },
+    juiceResources: {
+        preserveImportant: true,
+        webResources: {
+            relativeTo: path.resolve('build'),
+        },
+    },
 });

--- a/types/email-templates/index.d.ts
+++ b/types/email-templates/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for node-email-templates 7.1
+// Type definitions for node-email-templates 8.0
 // Project: https://github.com/forwardemail/email-templates
 // Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>
 //                 Matus Gura <https://github.com/gurisko>
@@ -20,8 +20,9 @@ import SESTransport = require('nodemailer/lib/ses-transport');
 import SMTPPool = require('nodemailer/lib/smtp-pool');
 import SMTPTransport = require('nodemailer/lib/smtp-transport');
 import StreamTransport = require('nodemailer/lib/stream-transport');
+import juice = require('juice');
 
-declare namespace EmailTemplate {
+declare namespace Email {
     // email-templates accepts nodemailer.createTransport options directly
     // too and calls createTransport if given a non-function, thus a lot
     // of different types accepted for transport
@@ -92,69 +93,81 @@ declare namespace EmailTemplate {
     }
 
      interface EmailConfig<T = any> {
-        /**
-         * The message <Nodemailer.com/message/>
-         */
-        message: Mail.Options;
-        /**
-         * The nodemailer Transport created via nodemailer.createTransport
-         */
-        transport?: NodeMailerTransportOptions;
-        /**
-         * The email template directory and engine information
-         */
-        views?: View;
-        /**
-         * Do you really want to send, false for test or development
-         */
-        send?: boolean;
-        /**
-         * Preview the email
-         */
-        preview?: boolean | PreviewEmailOpts;
-        /**
-         * Set to object to configure and Enable <https://github.com/ladjs/il8n>
-         */
-        i18n?: any;
-        /**
-         * defaults to false, unless you pass your own render function,
-         * and in that case it will be automatically set to true.
-         * @default false
-         */
-        customRender?: boolean;
-        /**
-         * Pass a custom render function if necessary
-         */
-        render?: (view: string, locals?: T) => Promise<any>;
-        /**
-         * force text-only rendering of template (disregards template folder)
-         */
-        textOnly?: boolean;
-        /**
-         * <Https://github.com/werk85/node-html-to-text>
-         *
-         * configuration object for html-to-text
-         */
-        htmlToText?: HtmlToTextOptions | false;
-        /**
-         * You can pass an option to prefix subject lines with a string
-         * env === 'production' ? false : `[${env.toUpperCase()}] `; // <--- HERE
-         */
-        subjectPrefix?: string | false;
-        /**
-         * <https://github.com/Automattic/juice>
-         */
-        juice?: boolean;
-        /**
-         * <https://github.com/Automattic/juice>
-         */
-        juiceResources?: any;
-        /**
-         * a function that returns the path to a template file
-         * @default (path: string, template: string) => string
-         */
-        getPath?: (path: string, template: string, locals: any) => string;
-    }
+         /**
+          * The message <Nodemailer.com/message/>
+          */
+         message: Mail.Options;
+         /**
+          * The nodemailer Transport created via nodemailer.createTransport
+          */
+         transport?: NodeMailerTransportOptions;
+         /**
+          * The email template directory and engine information
+          */
+         views?: View;
+         /**
+          * Do you really want to send, false for test or development
+          */
+         send?: boolean;
+         /**
+          * Preview the email
+          */
+         preview?: boolean | PreviewEmailOpts;
+         /**
+          * Set to object to configure and Enable <https://github.com/ladjs/il8n>
+          */
+         i18n?: any;
+         /**
+          * defaults to false, unless you pass your own render function,
+          * and in that case it will be automatically set to true.
+          * @default false
+          */
+         customRender?: boolean;
+         /**
+          * Pass a custom render function if necessary
+          */
+         render?: (view: string, locals?: T) => Promise<any>;
+         /**
+          * force text-only rendering of template (disregards template folder)
+          */
+         textOnly?: boolean;
+         /**
+          * <Https://github.com/werk85/node-html-to-text>
+          *
+          * configuration object for html-to-text
+          */
+         htmlToText?: HtmlToTextOptions | false;
+         /**
+          * You can pass an option to prefix subject lines with a string
+          * env === 'production' ? false : `[${env.toUpperCase()}] `; // <--- HERE
+          */
+         subjectPrefix?: string | false;
+         /**
+          * <https://github.com/Automattic/juice>
+          */
+         juice?: boolean;
+         juiceSettings?: JuiceGlobalConfig;
+         /**
+          * <https://github.com/Automattic/juice>
+          */
+         juiceResources?: juice.Options;
+         /**
+          * a function that returns the path to a template file
+          * @default (path: string, template: string) => string
+          */
+         getPath?: (path: string, template: string, locals: any) => string;
+     }
+
+     type JuiceGlobalConfig = Partial<{
+        codeBlocks: typeof juice.codeBlocks;
+        excludedProperties: typeof juice.excludedProperties;
+        heightElements: string[];
+        ignoredPseudos: typeof juice.ignoredPseudos;
+        nonVisualElements: typeof juice.nonVisualElements;
+        styleToAttribute: typeof juice.styleToAttribute;
+        tableElements: string[];
+        widthElements: string[];
+     }>;
 
      interface EmailOptions<T = any> {
         /**
@@ -180,19 +193,22 @@ declare namespace EmailTemplate {
     }
 }
 
-declare class EmailTemplate<T = any> {
-    constructor(config: EmailTemplate.EmailConfig);
+declare class Email<T = any> {
+    constructor(config?: Email.EmailConfig);
+
     /**
      *   shorthand use of `juiceResources` with the config
      *   mainly for custom renders like from a database).
      */
-    juiceResources(html: string): Promise<string>;
+    juiceResources(html: string, options?: juice.Options): Promise<string>;
+
     /**
      *
      * @param view The Html pug to render
      * @param locals The template Variables
      */
     render(view: string, locals?: T): Promise<string>;
+
     /**
      * Render all available template files for a given email
      * template (e.g. `html.pug`, `text.pug`, and `subject.pug`)
@@ -200,11 +216,12 @@ declare class EmailTemplate<T = any> {
      * @param view Name of the template
      * @param locals The template variables
      */
-    renderAll(view: string, locals?: T): Promise<Partial<EmailTemplate.EmailMessage>>;
+    renderAll(view: string, locals?: T): Promise<Partial<Email.EmailMessage>>;
+
     /**
      * Send the Email
      */
-    send(options: EmailTemplate.EmailOptions<T>): Promise<any>;
+    send(options: Email.EmailOptions<T>): Promise<any>;
 }
 
-export = EmailTemplate;
+export = Email;

--- a/types/email-templates/package.json
+++ b/types/email-templates/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "juice": "^7.0.0"
+    }
+}

--- a/types/email-templates/tsconfig.json
+++ b/types/email-templates/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
- version 8 update
- paraterless constructor support
- Juice types support

https://github.com/forwardemail/email-templates/compare/v7.2.0...v8.0.0
https://github.com/forwardemail/email-templates/blob/master/src/index.js#L30

- naming convention aligned with source:
https://github.com/forwardemail/email-templates/blob/master/src/index.js#L29
https://github.com/forwardemail/email-templates#basic

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.