### PR TITLE
Add tapable as a dependency to webpack

### DIFF
--- a/types/webpack/package.json
+++ b/types/webpack/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "source-map": "^0.6.0"
+        "source-map": "^0.6.0",
+        "tapable": "1.1.3"
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/tapable/releases/tag/v2.0.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

`tapable@2.0.0` ships with built in typings which can conflict with using `tapable` as a core dependency in your project. This  adds `tapable` to the [last version](https://github.com/webpack/tapable/releases/tag/v1.1.3) that shipped without types in order to prevent any hoisting errors that happen when `tapable` > 2 exists as a top level dependency.

- [x] PR for adding tapable as an allowed dependency: microsoft/DefinitelyTyped-tools#178