### PR TITLE
[google.visualization] Add google.charts.safeLoad

### DIFF
--- a/types/google.visualization/google.visualization-tests.ts
+++ b/types/google.visualization/google.visualization-tests.ts
@@ -600,6 +600,12 @@ function test_ChartsLoadWithPromise() {
     google.charts.load('current', {packages: ['corechart', 'table', 'sankey']}).then(drawChart);
 }
 
+function test_ChartsSafeLoad() {
+    google.charts.safeLoad({packages: ['corechart']}).then(() => {
+        // Draw a chart.
+    });
+}
+
 function test_ChartAnnotations() {
     var annotations:google.visualization.ChartAnnotations = {
         boxStyle: {

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -12,6 +12,8 @@ declare namespace google {
     // https://developers.google.com/chart/interactive/docs/basic_load_libs
     namespace charts {
         function load(version: string | number, packages: Object, mapsApiKey?: string): Promise<void>;
+        /** Loads with `safeMode` enabled. */
+        function safeLoad(packages: Object): Promise<void>;
         function setOnLoadCallback(handler: Function): void;
     }
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/chart/interactive/docs/basic_load_libs
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

---

The definition types are consistent with `google.charts.load`.

[Demo](https://jsbin.com/tikohavayi/edit?html,output)
