### PR TITLE
[resolve-bin] Add types for `resolve-bin` package

### DIFF
--- a/types/resolve-bin/index.d.ts
+++ b/types/resolve-bin/index.d.ts
@@ -1,0 +1,46 @@
+// Type definitions for resolve-bin 0.4
+// Project: https://github.com/thlorenz/resolve-bin
+// Definitions by: Cameron Hunter <https://github.com/cameronhunter>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+interface Options {
+    /**
+     * (default: @name) executable name (e.g. 'buster-test')
+     */
+    executable?: string;
+}
+
+interface ResolveBin {
+    /**
+     * Resolves the full path to the bin file of a given package by inspecting the "bin" field in its package.json.
+     *
+     * @param name module name, i.e. 'tap'
+     * @param cb called back with the full path to the bin file of the module or an error if it couldn't be resolved
+     */
+    (name: string, cb: (error: Error | null, path: string) => void): void;
+
+    /**
+     * Resolves the full path to the bin file of a given package by inspecting the "bin" field in its package.json.
+     *
+     * @param name module name, i.e. 'tap'
+     * @param opts options
+     * @param cb called back with the full path to the bin file of the module or an error if it couldn't be resolved
+     */
+    (name: string, opts: Options, cb: (error: Error | null, path: string) => void): void;
+
+    /**
+     * Synchronous version of resolveBin
+     *
+     * @param name module name, i.e. 'tap'
+     * @param opts options
+     */
+    sync(name: string, opts?: Options): string | never;
+}
+
+/**
+ * Resolves the full path to the bin file of a given package by inspecting the "bin" field in its package.json.
+ */
+declare const resolveBin: ResolveBin;
+
+export = resolveBin;

--- a/types/resolve-bin/resolve-bin-tests.ts
+++ b/types/resolve-bin/resolve-bin-tests.ts
@@ -1,0 +1,27 @@
+import resolveBin from 'resolve-bin';
+
+// Asynchronous
+(() => {
+    resolveBin('my-package', (error, path) => {
+        error; // $ExpectType Error | null
+        path; // $ExpectType string
+    });
+})();
+
+// Asynchronous with options
+(() => {
+    resolveBin('my-package', { executable: 'custom-package-name' }, (error, path) => {
+        error; // $ExpectType Error | null
+        path; // $ExpectType string
+    });
+})();
+
+// Synchronous
+(() => {
+    resolveBin.sync('my-package'); // $ExpectType string
+})();
+
+// Synchronous with options
+(() => {
+    resolveBin.sync('my-package', { executable: 'custom-package-name' }); // $ExpectType string
+})();

--- a/types/resolve-bin/tsconfig.json
+++ b/types/resolve-bin/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "target": "es6",
+        "noImplicitAny": true,
+        "esModuleInterop": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "resolve-bin-tests.ts"
+    ]
+}

--- a/types/resolve-bin/tslint.json
+++ b/types/resolve-bin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Adding TypeScript type definitions for [`resolve-bin`](https://github.com/thlorenz/resolve-bin) package.

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.