### PR TITLE
Fix return types and adds debug function call

### DIFF
--- a/types/wkhtmltopdf/index.d.ts
+++ b/types/wkhtmltopdf/index.d.ts
@@ -10,35 +10,29 @@
 /// <reference types="node"/>
 
 /**
- * Call wkhtmltopdf with a callback
- * If options.output is defined the file will be returned in the stream
- *
- * @param html HTML that needs to be compiled to PDF
- * @param options Options
- * @param callback Callback function to handle the incoming PDF
- */
-declare function wkhtmltopdf(html: string, options: Options, callback: (err: Error, stream: NodeJS.ReadWriteStream) => void): NodeJS.ReadWriteStream;
-/**
  * Call wkhtmltopdf and write PDF
  * If options.output is defined the file will be returned in the stream
  *
  * @param html HTML to convert to PDF
  * @param [options] Options
  */
-declare function wkhtmltopdf(html: string, options?: Options): NodeJS.ReadWriteStream;
+declare function wkhtmltopdf(html: string, options?: Options, callback?: (err: Error, stream: NodeJS.ReadWriteStream) => void): NodeJS.ReadWriteStream;
 /**
  * Call wkhtmltopdf and write PDF
  * If options.output is defined the file will be returned in the stream
  *
  * @param url URL to convert to PDF
  * @param [options] Options
+ * @param [callback] Callback
  */
-declare function wkhtmltopdf(url: string, options?: Options): NodeJS.ReadWriteStream;/**
+declare function wkhtmltopdf(url: string, options?: Options, callback?: (err: Error, stream: NodeJS.ReadWriteStream) => void): NodeJS.ReadWriteStream;
+/**
  * Call wkhtmltopdf and write PDF
  * If options.output is defined the file will be returned in the stream
  *
  * @param inputStream Input stream of html
  * @param [options] Options
+ * @param [callback] Callback
  */
 declare function wkhtmltopdf(inputStream: NodeJS.ReadStream, options?: Options): NodeJS.ReadWriteStream;
 

--- a/types/wkhtmltopdf/index.d.ts
+++ b/types/wkhtmltopdf/index.d.ts
@@ -11,40 +11,36 @@
 
 /**
  * Call wkhtmltopdf with a callback
+ * If options.output is defined the file will be returned in the stream
  *
  * @param html HTML that needs to be compiled to PDF
- * @param options Options without the output parameter
+ * @param options Options
  * @param callback Callback function to handle the incoming PDF
  */
-declare function wkhtmltopdf(html: string, options: Options, callback: (err: Error, stream: NodeJS.ReadWriteStream) => void): void;
+declare function wkhtmltopdf(html: string, options: Options, callback: (err: Error, stream: NodeJS.ReadWriteStream) => void): NodeJS.ReadWriteStream;
 /**
- * Call wkhtmltopdf and write PDF directly to specified file
- *
- * @param url URL to convert to PDF
- * @param options Options with the output parameter
- */
-declare function wkhtmltopdf(url: string, options: OptionsOutfile): void;
-/**
- * Call wkhtmltopdf and write PDF directly to specified file
+ * Call wkhtmltopdf and write PDF
+ * If options.output is defined the file will be returned in the stream
  *
  * @param html HTML to convert to PDF
- * @param options Options with the output parameter
- */
-declare function wkhtmltopdf(html: string, options: OptionsOutfile): void;
-/**
- * Call wkhtmltopdf and write PDF directly to specified file
- *
- * @param html HTML to convert to PDF
- * @param [options] Options without the output parameter
+ * @param [options] Options
  */
 declare function wkhtmltopdf(html: string, options?: Options): NodeJS.ReadWriteStream;
 /**
- * Call wkhtmltopdf and write PDF directly to specified file
+ * Call wkhtmltopdf and write PDF
+ * If options.output is defined the file will be returned in the stream
  *
  * @param url URL to convert to PDF
- * @param [options] Options without the output parameter
+ * @param [options] Options
  */
-declare function wkhtmltopdf(url: string, options?: Options): NodeJS.ReadWriteStream;
+declare function wkhtmltopdf(url: string, options?: Options): NodeJS.ReadWriteStream;/**
+ * Call wkhtmltopdf and write PDF
+ * If options.output is defined the file will be returned in the stream
+ *
+ * @param inputStream Input stream of html
+ * @param [options] Options
+ */
+declare function wkhtmltopdf(inputStream: NodeJS.ReadStream, options?: Options): NodeJS.ReadWriteStream;
 
 declare namespace wkhtmltopdf {
     /**
@@ -103,13 +99,15 @@ interface Options {
     /** Do not use lossless compression on pdf objects */
     noPdfCompression?: boolean;
     /** Debug prints stderr messages */
-    debug?: boolean;
+    debug?: boolean|((data: Buffer) => void);
     /** debugStdOut prints any stdout warning messages */
     debugStdOut?: boolean;
     /** The title of the generated pdf file (The title of the first document is used if not specified) */
     title?: string;
     /** Ignore warnings */
     ignore?: ReadonlyArray<string|RegExp>;
+    /** If defined only output to this path */
+    output?: string;
 
     /*******************
      * Outline options *
@@ -331,11 +329,6 @@ interface Options {
     toc?: string;
     /** Page object */
     page?: string;
-}
-
-interface OptionsOutfile extends Options {
-    /** If defined only output to this path */
-    output: string;
 }
 
 export = wkhtmltopdf;

--- a/types/wkhtmltopdf/wkhtmltopdf-tests.ts
+++ b/types/wkhtmltopdf/wkhtmltopdf-tests.ts
@@ -7,10 +7,10 @@ wkhtmltopdf("http://google.com/", { pageSize: "Letter" }); // $ExpectType NodeJS
 wkhtmltopdf("<h1>Test</h1><p>Hello world</p>"); // $ExpectType ReadWriteStream
 
 // output to a file directly
-wkhtmltopdf("http://apple.com/", { output: "out.pdf" }); // $ExpectType void
+wkhtmltopdf("http://apple.com/", { output: "out.pdf" }); // $ExpectType ReadWriteStream
 
 // Optional callback
-wkhtmltopdf("http://google.com/", { pageSize: "Letter" }, (err, stream) => { }); // $ExpectType void
+wkhtmltopdf("http://google.com/", { pageSize: "Letter" }, (err: Error, stream: NodeJS.ReadWriteStream) => { }); // $ExpectType void
 
 // Repeatable options
 wkhtmltopdf("http://google.com/", { // $ExpectType NodeJS.ReadWriteStream
@@ -22,15 +22,34 @@ wkhtmltopdf("http://google.com/", { // $ExpectType NodeJS.ReadWriteStream
 });
 
 // Ignore warning strings
-wkhtmltopdf("http://apple.com/", { // $ExpectType void
+wkhtmltopdf("http://apple.com/", { // $ExpectType ReadWriteStream
   output: "out.pdf",
   ignore: ["QFont::setPixelSize: Pixel size <= 0 (0)"]
 });
 
 // RegExp also acceptable
-wkhtmltopdf("http://apple.com/", { // $ExpectType void
+wkhtmltopdf("http://apple.com/", { // $ExpectType ReadWriteStream
   output: "out.pdf",
   ignore: [/QFont::setPixelSize/]
+});
+
+// Test debug types
+wkhtmltopdf("http://apple.com/", { // $ExpectType ReadWriteStream
+  debug: true
+});
+
+wkhtmltopdf("http://apple.com/", { // $ExpectType ReadWriteStream
+  output: "test.pdf",
+  debug: (data: Buffer) => {
+    const dataString = data.toString();
+    const stageMatch = dataString.match(/\((\d*)\/(\d*)\)/);
+    const percentMatch = dataString.match(/(\d*)%/);
+    if (stageMatch) {
+        console.log(`Pdf at ${stageMatch[1]} out of ${stageMatch[2]} stages`);
+    } else if (percentMatch) {
+        console.log(`Pdf at ${percentMatch[1]}%`);
+    }
+  }
 });
 
 wkhtmltopdf.shell; // $ExpectType string


### PR DESCRIPTION
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Undocumented debug function](https://github.com/devongovett/node-wkhtmltopdf/blob/master/index.js#L179)

- Realised that the library always returns a stream so i changed the return values to ReadWriteStream when wkhtmltopdf is called with the `output` option.
- [Adds streaming input type](https://github.com/devongovett/node-wkhtmltopdf/blob/master/index.js#L191)
