### PR TITLE
Parse Push notification SendOptions type updated

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -1433,7 +1433,7 @@ namespace Parse {
             sound?: string;
             title?: string;
             notification?: any;
-            content_available?: any;
+            contentAvailable?: boolean;
         }
 
         interface SendOptions extends UseMasterKeyOption {

--- a/types/parse/package.json
+++ b/types/parse/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "types": "index",
     "typesVersions": {
-        "<=3.6": {
+        ">=3.6.0-0": {
             "*": [
                 "ts3.6/*"
             ]

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -745,6 +745,41 @@ function test_push() {
             },
         },
     );
+
+    Parse.Push.send(
+        {
+            data: {
+                alert: 'Willie Hayes injured by own pop fly.',
+            },
+            contentAvailable: true
+        },
+        {
+            success() {
+                // Push was successful
+            },
+            error(error: any) {
+                // Handle error
+            },
+        },
+    );
+
+    Parse.Push.send(
+        {
+            data: {
+                alert: 'Willie Hayes injured by own pop fly.',
+            },
+            // $ExpectError
+            contentAvailable: 'true'
+        },
+        {
+            success() {
+                // Push was successful
+            },
+            error(error: any) {
+                // Handle error
+            },
+        },
+    );
 }
 
 function test_batch_operations() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/parse-community/parse-server-push-adapter/pull/165
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The tests do not run, but as far as I understand it, the whole package is quite outdated? 