### PR TITLE
Change the definition of Omit<T, K> so that it preserves discriminated unions

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -779,7 +779,10 @@ export class Db extends EventEmitter {
     collections(callback: MongoCallback<Array<Collection<Default>>>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Db.html#command */
     command(command: object, callback: MongoCallback<any>): void;
-    command(command: object, options?: { readPreference?: ReadPreferenceOrMode; session?: ClientSession }): Promise<any>;
+    command(
+        command: object,
+        options?: { readPreference?: ReadPreferenceOrMode; session?: ClientSession },
+    ): Promise<any>;
     command(
         command: object,
         options: { readPreference: ReadPreferenceOrMode; session?: ClientSession },
@@ -1070,10 +1073,9 @@ export interface FSyncOptions extends CommonOptions {
 // TypeScript Omit (Exclude to be specific) does not work for objects with an "any" indexed type, and breaks discriminated unions
 type EnhancedOmit<T, K> = string | number extends keyof T
     ? T // T has indexed type e.g. { _id: string; [k: string]: any; } or it is "any"
-    : (T extends any
-        ? Pick<T, Exclude<keyof T, K>> // discriminated unions
-        : never
-    );
+    : T extends any
+    ? Pick<T, Exclude<keyof T, K>> // discriminated unions
+    : never;
 
 type ExtractIdType<TSchema> = TSchema extends { _id: infer U } // user has defined a type for _id
     ? {} extends U
@@ -2153,8 +2155,8 @@ export interface BulkWriteOpResultObject {
     modifiedCount?: number;
     deletedCount?: number;
     upsertedCount?: number;
-    insertedIds?: {[index: number]: any};
-    upsertedIds?: {[index: number]: any};
+    insertedIds?: { [index: number]: any };
+    upsertedIds?: { [index: number]: any };
     result?: any;
 }
 
@@ -2725,7 +2727,9 @@ export class AggregationCursor<T = Default> extends Cursor<T> {
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/AggregationCursor.html#unshift */
     unshift(stream: Buffer | string): void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/AggregationCursor.html#unwind */
-    unwind<U = T>(field: string | { path: string; includeArrayIndex?: string; preserveNullAndEmptyArrays?: boolean; }): AggregationCursor<U>;
+    unwind<U = T>(
+        field: string | { path: string; includeArrayIndex?: string; preserveNullAndEmptyArrays?: boolean },
+    ): AggregationCursor<U>;
 }
 
 /** http://mongodb.github.io/node-mongodb-native/3.1/api/CommandCursor.html#~resultCallback */

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -45,9 +45,6 @@ import { EventEmitter } from 'events';
 import { Readable, Writable } from 'stream';
 import { checkServerIdentity } from 'tls';
 
-// We can use TypeScript Omit once minimum required TypeScript Version is above 3.5
-type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
-
 type FlattenIfArray<T> = T extends ReadonlyArray<infer R> ? R : T;
 
 export function connect(uri: string, options?: MongoClientOptions): Promise<MongoClient>;
@@ -1070,10 +1067,13 @@ export interface FSyncOptions extends CommonOptions {
     fsync?: boolean;
 }
 
-// TypeScript Omit (Exclude to be specific) does not work for objects with an "any" indexed type
+// TypeScript Omit (Exclude to be specific) does not work for objects with an "any" indexed type, and breaks discriminated unions
 type EnhancedOmit<T, K> = string | number extends keyof T
     ? T // T has indexed type e.g. { _id: string; [k: string]: any; } or it is "any"
-    : Omit<T, K>;
+    : (T extends any
+        ? Pick<T, Exclude<keyof T, K>> // discriminated unions
+        : never
+    );
 
 type ExtractIdType<TSchema> = TSchema extends { _id: infer U } // user has defined a type for _id
     ? {} extends U

--- a/types/mongodb/test/collection/findX.ts
+++ b/types/mongodb/test/collection/findX.ts
@@ -20,7 +20,7 @@ async function run() {
         readonlyFruitTags: ReadonlyArray<string>;
     }
     const collectionT = db.collection<TestModel>('testCollection');
-    collectionT.find({
+    await collectionT.find({
         $and: [{ numberField: { $gt: 0 } }, { numberField: { $lt: 100 } }],
         readonlyFruitTags: { $all: ['apple', 'pear'] },
     });
@@ -45,6 +45,21 @@ async function run() {
             sort: { stringField: -1, text: { $meta: 'textScore' }, notExistingField: -1 },
         },
     );
+
+    // test with discriminated union type
+    interface DUModelEmpty {
+        type: 'empty';
+    }
+    interface DUModelString {
+        type: 'string';
+        value: string;
+    }
+    type DUModel = DUModelEmpty | DUModelString;
+    const collectionDU = db.collection<DUModel>('testDU');
+    const duValue = await collectionDU.findOne({});
+    if (duValue && duValue.type === 'string') {
+        const value: string = duValue.value;
+    }
 
     // collection.findX<T>() generic tests
     interface Bag {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/TypeScript/issues/31501
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
