### PR TITLE
[express] Add ability to parameterize Response['locals']

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -57,14 +57,14 @@ app.post("/", (req, res) => {
     req.params[0]; // $ExpectType string
 
     req.body; // $ExpectType any
-    res.send("ok"); // $ExpectType Response<any, number>
+    res.send("ok"); // $ExpectType Response<any, number, Record<string, any>>
 });
 
 // No params, only response body type
 app.get<never, { foo: string; }>("/", (req, res) => {
     req.params.baz; // $ExpectError
 
-    res.send({ foo: "ok" }); // $ExpectType Response<{ foo: string; }, number>
+    res.send({ foo: "ok" }); // $ExpectType Response<{ foo: string; }, number, Record<string, any>>
     req.body; // $ExpectType any
 });
 
@@ -72,11 +72,17 @@ app.get<never, { foo: string; }>("/", (req, res) => {
 app.post<never, { foo: string }, { bar: number }>('/', (req, res) => {
     req.params.baz; // $ExpectError
 
-    res.send({ foo: "ok" }); // $ExpectType Response<{ foo: string; }, number>
+    res.send({ foo: "ok" }); // $ExpectType Response<{ foo: string; }, number, Record<string, any>>
     req.body.bar; // $ExpectType number
 
     res.json({ baz: "fail" }); // $ExpectError
     req.body.baz; // $ExpectError
+});
+
+// Response locals custom type
+app.get<{}, any, any, {}, {userId: number}>('/', (req, res) => {
+  res.locals.userId; // $ExpectType number
+  res.locals.invalid; // $ExpectError
 });
 
 app.engine('ntl', (_filePath, _options, callback) => {

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -17,7 +17,7 @@ namespace express_tests {
     });
     app.use('/static', express.static(__dirname + '/public', {
         setHeaders: res => {
-            // $ExpectType Response<any>
+            // $ExpectType Response<any, number, Record<string, any>>
             res;
             res.set("foo", "bar");
         }
@@ -196,6 +196,12 @@ namespace express_tests {
         res.json();
         res.json(1); // $ExpectError
         res.send(1); // $ExpectError
+    });
+
+    // Response locals custom type
+    router.get<{}, any, any, {}, {userId: number}>('/', (req, res) => {
+      res.locals.userId; // $ExpectType number
+      res.locals.invalid; // $ExpectError
     });
 
     app.use((req, res, next) => {

--- a/types/express/index.d.ts
+++ b/types/express/index.d.ts
@@ -95,8 +95,13 @@ declare namespace e {
     interface Application extends core.Application { }
     interface CookieOptions extends core.CookieOptions { }
     interface Errback extends core.Errback { }
-    interface ErrorRequestHandler<P = core.ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = core.Query>
-        extends core.ErrorRequestHandler<P, ResBody, ReqBody, ReqQuery> { }
+    interface ErrorRequestHandler<
+        P = core.ParamsDictionary,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = core.Query,
+        Locals extends core.LocalsBase = core.LocalsDefault,
+    > extends core.ErrorRequestHandler<P, ResBody, ReqBody, ReqQuery, Locals> { }
     interface Express extends core.Express { }
     interface Handler extends core.Handler { }
     interface IRoute extends core.IRoute { }
@@ -105,10 +110,26 @@ declare namespace e {
     interface IRouterMatcher<T> extends core.IRouterMatcher<T> { }
     interface MediaType extends core.MediaType { }
     interface NextFunction extends core.NextFunction { }
-    interface Request<P = core.ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = core.Query> extends core.Request<P, ResBody, ReqBody, ReqQuery> { }
-    interface RequestHandler<P = core.ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = core.Query> extends core.RequestHandler<P, ResBody, ReqBody, ReqQuery> { }
+    interface Request<
+        P = core.ParamsDictionary,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = core.Query,
+        Locals extends core.LocalsBase = core.LocalsDefault,
+    > extends core.Request<P, ResBody, ReqBody, ReqQuery, Locals> { }
+    interface RequestHandler<
+        P = core.ParamsDictionary,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = core.Query,
+        Locals extends core.LocalsBase = core.LocalsDefault,
+    > extends core.RequestHandler<P, ResBody, ReqBody, ReqQuery, Locals> { }
     interface RequestParamHandler extends core.RequestParamHandler { }
-    export interface Response<ResBody = any> extends core.Response<ResBody> { }
+    export interface Response<
+        ResBody = any,
+        StatusCode extends number = number,
+        Locals extends core.LocalsBase = core.LocalsDefault,
+    > extends core.Response<ResBody, StatusCode, Locals> { }
     interface Router extends core.Router { }
     interface Send extends core.Send { }
 }


### PR DESCRIPTION
With new version of type definitions for express, it is possible to specify the type for `req.params`, `req.query`, `req.body` and `res.body`. I think `res.locals` also requires a static typing based on express documentation: https://expressjs.com/en/5x/api.html#res.locals 


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://expressjs.com/en/5x/api.html#res.locals

