### PR TITLE
[google.visualization] Add typing for load options

### DIFF
--- a/types/google.visualization/google.visualization-tests.ts
+++ b/types/google.visualization/google.visualization-tests.ts
@@ -606,6 +606,28 @@ function test_ChartsSafeLoad() {
     });
 }
 
+function test_ChartsLoadLegacy() {
+    google.load("visualization", "1", {packages:["corechart"]});
+    google.charts.load("visualization", "1", {packages:["corechart"]});
+}
+
+function test_ChartsLoadWithVersion() {
+    google.charts.load('current', {packages: ['corechart']});
+}
+
+function test_ChartsLoadOptions() {
+    google.charts.load({
+        packages: ['corechart'],
+        callback: drawChart,
+        mapsApiKey: 'mapsApiKey',
+        safeMode: true,
+        language: 'ja'
+    });
+
+    function drawChart(){}
+}
+
+
 function test_ChartAnnotations() {
     var annotations:google.visualization.ChartAnnotations = {
         boxStyle: {

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -5,16 +5,35 @@
 
 declare namespace google {
 
-    function load(visualization: string, version: string, packages: any): void;
+    /** Legacy https://developers.google.com/chart/interactive/docs/basic_load_libs#updateloader */
+    function load(visualization: 'visualization', version: string | number, options: LoadOptions): void;
     function setOnLoadCallback(handler: Function): void;
     function setOnLoadCallback(handler: () => void): void;
 
     // https://developers.google.com/chart/interactive/docs/basic_load_libs
     namespace charts {
-        function load(version: string | number, packages: Object, mapsApiKey?: string): Promise<void>;
         /** Loads with `safeMode` enabled. */
-        function safeLoad(packages: Object): Promise<void>;
+        function safeLoad(options: LoadOptions): Promise<void>;
+        function load(options: LoadOptions): Promise<void>;
+        function load(version: string | number, options: LoadOptions): Promise<void>;
+        /** Legacy https://developers.google.com/chart/interactive/docs/basic_load_libs#updateloader */
+        function load(visualization: 'visualization', version: string | number, options: LoadOptions): Promise<void>;
+
         function setOnLoadCallback(handler: Function): void;
+    }
+
+    export interface LoadOptions {
+        packages?: string | string[];
+        language?: string;
+        callback?: Function;
+        mapsApiKey?: string;
+        safeMode?: boolean;
+        /** not documented */
+        debug?: boolean;
+        /** not documented */
+        pseudo?: boolean;
+        /** not documented, looks for charts-version in url query params */
+        enableUrlSettings?: boolean;
     }
 
     // https://developers.google.com/chart/interactive/docs/reference


### PR DESCRIPTION
The load signature was missing types for a while now, as mentioned [here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49750#issuecomment-732808481).
This brings the load API up to date with the [docs](https://developers.google.com/chart/interactive/docs/basic_load_libs) and the [existing sources](https://www.gstatic.com/charts/loader.js) (which I had to manually inspect to figure out all the optional parameters)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/chart/interactive/docs/basic_load_libs
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

