### PR TITLE
Types for procurios.resizesensor 0.2

### DIFF
--- a/types/procurios.resizesensor/index.d.ts
+++ b/types/procurios.resizesensor/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for procurios.resizesensor 0.2
+// Project: https://github.com/procurios/ResizeSensor
+// Definitions by: Taylor Clark <https://github.com/DefinitelyTyped>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace resizeSensor;
+
+export function create(targetElement: HTMLElement, callback: (dimensions: Dimensions) => void): ResizeSensor;
+
+export interface Dimensions {
+    width: number;
+    height: number;
+}
+
+export interface ResizeSensor {
+    destroy(): void;
+}

--- a/types/procurios.resizesensor/test/procurios.resizesensor-tests.cjs.ts
+++ b/types/procurios.resizesensor/test/procurios.resizesensor-tests.cjs.ts
@@ -1,0 +1,12 @@
+import resizeSensor = require('procurios.resizesensor');
+
+const element = document.createElement('div');
+
+// $ExpectType ResizeSensor
+const sensor = resizeSensor.create(element, dimensions => {
+    // $ExpectType Dimensions
+    dimensions;
+});
+
+// $ExpectType void
+sensor.destroy();

--- a/types/procurios.resizesensor/test/procurios.resizesensor-tests.global.ts
+++ b/types/procurios.resizesensor/test/procurios.resizesensor-tests.global.ts
@@ -1,0 +1,10 @@
+const element = document.createElement('div');
+
+// $ExpectType ResizeSensor
+const sensor = resizeSensor.create(element, dimensions => {
+    // $ExpectType Dimensions
+    dimensions;
+});
+
+// $ExpectType void
+sensor.destroy();

--- a/types/procurios.resizesensor/tsconfig.json
+++ b/types/procurios.resizesensor/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "DOM"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "test/procurios.resizesensor-tests.cjs.ts",
+        "test/procurios.resizesensor-tests.global.ts"
+    ]
+}

--- a/types/procurios.resizesensor/tslint.json
+++ b/types/procurios.resizesensor/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
dts-gen fails for this package:
```
dts-gen -m procurios.resizesensor
Unexpected crash! Please log a bug with the commandline you specified.
%AppData%\Roaming\npm\node_modules\dts-gen\bin\lib\run.js:125
        throw e;
        ^

TypeError: Cannot use 'in' operator to search for 'attachEvent' in undefined
    at %AppData%\Roaming\npm\node_modules\procurios.resizesensor\dist\resizeSensor.min.js:1:7887
    at Object.5../css (%AppData%\Roaming\npm\node_modules\procurios.resizesensor\dist\resizeSensor.min.js:1:8051)
    at r (%AppData%\Roaming\npm\node_modules\procurios.resizesensor\dist\resizeSensor.min.js:1:572)
    at e (%AppData%\Roaming\npm\node_modules\procurios.resizesensor\dist\resizeSensor.min.js:1:739)
    at %AppData%\Roaming\npm\node_modules\procurios.resizesensor\dist\resizeSensor.min.js:1:756
    at %AppData%\Roaming\npm\node_modules\procurios.resizesensor\dist\resizeSensor.min.js:1:85
    at Object.<anonymous> (%AppData%\Roaming\npm\node_modules\procurios.resizesensor\dist\resizeSensor.min.js:1:301)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
```
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
