### PR TITLE
Create package @types/truncate-utf8-bytes

### DIFF
--- a/types/truncate-utf8-bytes/index.d.ts
+++ b/types/truncate-utf8-bytes/index.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for truncate-utf8-bytes 1.0
+// Project: https://github.com/parshap/truncate-utf8-bytes#readme
+// Definitions by: Ben Limmer <https://github.com/blimmer>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace truncateUtf8Bytes;
+
+/** Returns string truncated to at most length bytes in length. */
+declare function truncate(string: string, byteLength: number): string;
+
+export = truncate;

--- a/types/truncate-utf8-bytes/index.d.ts
+++ b/types/truncate-utf8-bytes/index.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: Ben Limmer <https://github.com/blimmer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export as namespace truncateUtf8Bytes;
-
 /** Returns string truncated to at most length bytes in length. */
 declare function truncate(string: string, byteLength: number): string;
 

--- a/types/truncate-utf8-bytes/truncate-utf8-bytes-tests.ts
+++ b/types/truncate-utf8-bytes/truncate-utf8-bytes-tests.ts
@@ -1,0 +1,3 @@
+import truncate = require('truncate-utf8-bytes');
+
+truncate('foo', 123); // $ExpectType string

--- a/types/truncate-utf8-bytes/tsconfig.json
+++ b/types/truncate-utf8-bytes/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "truncate-utf8-bytes-tests.ts"
+    ]
+}

--- a/types/truncate-utf8-bytes/tslint.json
+++ b/types/truncate-utf8-bytes/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
