### PR TITLE
[auth0-lock] v11.27.1 Add types for AuthResult & checkSession Options.

### DIFF
--- a/types/auth0-lock/auth0-lock-tests.ts
+++ b/types/auth0-lock/auth0-lock-tests.ts
@@ -21,6 +21,27 @@ lock.checkSession({}, function(error: auth0.Auth0Error, authResult: AuthResult):
   }
 });
 
+lock.checkSession({
+  access_token: undefined,
+  connection_scope: undefined,
+  device: undefined,
+  nonce: undefined,
+  protocol: undefined,
+  request_id: undefined,
+  scope: undefined,
+  state: undefined,
+  param: undefined
+}, function(error: auth0.Auth0Error, authResult: AuthResult): void {
+  if (error || !authResult) {
+    lock.show();
+  } else {
+    // user has an active session, so we can use the accessToken directly.
+    lock.getUserInfo(authResult.accessToken, function(error, profile) {
+      console.log(error, profile);
+    });
+  }
+});
+
 // Show supports UI arguments
 
 const showOptions : Auth0LockShowOptions = {
@@ -269,18 +290,48 @@ const avatarOptions : Auth0LockConstructorOptions = {
 
 new Auth0Lock(CLIENT_ID, DOMAIN, avatarOptions);
 
-const authResult : AuthResult = {
+const authResultWithUndefined : AuthResult = {
     accessToken: 'fake_access_token',
     expiresIn: 7200,
     idToken: 'fake_id_token',
     idTokenPayload: {
+      name: undefined,
+      nickname: undefined,
+      picture: undefined,
+      email: undefined,
+      email_verified: undefined,
       aud: "EaQzyHt1Dy57l-r5iHcMeT-lh1fFZntg",
       exp: 1494393724,
       iat: 1494357724,
       iss: "https://www.foo.com",
-      sub: "auth0|aksjfkladsf"
+      sub: "auth0|aksjfkladsf",
+      acr: undefined,
+      amr: undefined
     },
     refreshToken: undefined,
+    state: "923jf092j3.FFSDJFDSKLDF",
+    tokenType: 'Bearer'
+};
+
+const authResultFilled : AuthResult = {
+    accessToken: 'fake_access_token',
+    expiresIn: 7200,
+    idToken: 'fake_id_token',
+    idTokenPayload: {
+      name: "fake name",
+      nickname: "fake nickname",
+      picture: "https://www.fakeavatar.com/fake.png",
+      email: "fake@fake.com",
+      email_verified: true,
+      aud: "EaQzyHt1Dy57l-r5iHcMeT-lh1fFZntg",
+      exp: 1494393724,
+      iat: 1494357724,
+      iss: "https://www.foo.com",
+      sub: "auth0|aksjfkladsf",
+      acr: "http://schemas.openid.net/pape/policies/2007/06/multi-factor",
+      amr: ["mfa"]
+    },
+    refreshToken: "refresh_token",
     state: "923jf092j3.FFSDJFDSKLDF",
     tokenType: 'Bearer'
 };

--- a/types/auth0-lock/index.d.ts
+++ b/types/auth0-lock/index.d.ts
@@ -189,6 +189,7 @@ interface Auth0IdTokenPayload {
     sub: string;
     acr?: string;
     amr?: string[];
+    [key: string]: any;
 }
 
 interface AuthResult {

--- a/types/auth0-lock/index.d.ts
+++ b/types/auth0-lock/index.d.ts
@@ -4,6 +4,7 @@
 //                 Dan Caddigan <https://github.com/goldcaddy77>
 //                 Larry Faudree <https://github.com/lfaudreejr>
 //                 Will Caulfield <https://github.com/willcaul>
+//                 Thomas Pearson <https://github.com/xsv24>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
@@ -93,6 +94,7 @@ interface Auth0LockAuthParamsOptions {
     request_id?: any;
     scope?: string;
     state?: string;
+    [key: string]: any; // Auth0 rules can use custom params.
 }
 
 interface Auth0LockAuthOptions {
@@ -174,23 +176,32 @@ interface Auth0LockShowOptions {
     languageDictionary?: any;
 }
 
+interface Auth0IdTokenPayload {
+    name?: string;
+    nickname?: string;
+    picture?: string;
+    email?: string;
+    email_verified?: boolean;
+    aud: string;
+    exp: number;
+    iat: number;
+    iss: string;
+    sub: string;
+    acr?: string;
+    amr?: string[];
+}
+
 interface AuthResult {
     accessToken: string;
     appState?: any;
     expiresIn: number;
     idToken: string;
-    idTokenPayload: {
-        aud: string;
-        exp: number;
-        iat: number;
-        iss: string;
-        sub: string;
-    };
+    idTokenPayload: Auth0IdTokenPayload;
     refreshToken?: string;
     scope?: string;
     state: string;
     tokenType: string;
-  }
+}
 
 interface Auth0LockStatic {
     new (clientId: string, domain: string, options?: Auth0LockConstructorOptions): Auth0LockStatic;
@@ -198,7 +209,7 @@ interface Auth0LockStatic {
     // deprecated
     getProfile(token: string, callback: (error: auth0.Auth0Error, profile: auth0.Auth0UserProfile) => void): void;
     getUserInfo(token: string, callback: (error: auth0.Auth0Error, profile: auth0.Auth0UserProfile) => void): void;
-    checkSession(options: any, callback: (error: auth0.Auth0Error, authResult: AuthResult | undefined) => void): void;
+    checkSession(options: Auth0LockAuthParamsOptions, callback: (error: auth0.Auth0Error, authResult: AuthResult | undefined) => void): void;
     // https://github.com/auth0/lock#resumeauthhash-callback
     resumeAuth(hash: string, callback: (error: auth0.Auth0Error, authResult: AuthResult) => void): void;
     show(options?: Auth0LockShowOptions): void;


### PR DESCRIPTION
Update has no breaking API changes, added some additonal types for AuthResult to match up with return types of auth0.
- tests amended

v11.27.1

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:     https://github.com/auth0/lock
https://auth0.com/docs/tokens/id-tokens/id-token-structure
https://auth0.com/docs/libraries/lock/lock-api-reference#checksession-
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
