### PR TITLE
[streamx] initial type definitions

### DIFF
--- a/types/streamx/index.d.ts
+++ b/types/streamx/index.d.ts
@@ -36,7 +36,7 @@ export interface StreamOptions<TStream extends Stream<TByteType>, TByteType = an
     signal?: AbortSignalLike;
 }
 
-/* tslint:disable-next-line interface-over-type-literal */
+/* tslint:disable-next-line interface-over-type-literal - cause: https://github.com/microsoft/TypeScript/issues/15300 */
 export type StreamEvents = {
     open: () => void;
     close: () => void;

--- a/types/streamx/index.d.ts
+++ b/types/streamx/index.d.ts
@@ -5,12 +5,12 @@
 
 /// <reference types="node" />
 
+import { EventEmitter } from 'events';
+import { Writable as NodeJSWritable, Readable as NodeJSReadable, Stream as NodeJSStream } from 'stream';
+
 export interface AbortSignalLike {
     addEventListener: (type: 'abort', listener: (this: AbortSignalLike, event: any) => any) => void;
 }
-
-import { EventEmitter } from 'events';
-import { Writable as NodeJSWritable, Readable as NodeJSReadable, Stream as NodeJSStream } from 'stream';
 
 export type AnyStream = NodeJSStream | Stream;
 export type AnyWritable<TType = any, TMap = TType, TByte = TMap> =

--- a/types/streamx/index.d.ts
+++ b/types/streamx/index.d.ts
@@ -123,7 +123,6 @@ export type ReadableOptions<
           }
     );
 
-/* tslint:disable-next-line strict-export-declare-modifiers */
 type FromType<TData> = TData extends Readable
     ? TData
     : TData extends Iterable<infer TType>
@@ -307,3 +306,5 @@ export class PassThrough<TRead = any, TWrite = any> extends Transform<TRead, TWr
 
 export function isStream(input: object): input is AnyStream;
 export function isStreamx(input: object): input is Stream;
+
+export {};

--- a/types/streamx/index.d.ts
+++ b/types/streamx/index.d.ts
@@ -1,0 +1,309 @@
+// Type definitions for streamx 2.9
+// Project: https://github.com/streamxorg/streamx
+// Definitions by: Martin Heidegger <https://github.com/martinheidegger>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+export interface AbortSignalLike {
+    addEventListener: (type: 'abort', listener: (this: AbortSignalLike, event: any) => any) => void;
+}
+
+import { EventEmitter } from 'events';
+import { Writable as NodeJSWritable, Readable as NodeJSReadable, Stream as NodeJSStream } from 'stream';
+
+export type AnyStream = NodeJSStream | Stream;
+export type AnyWritable<TType = any, TMap = TType, TByte = TMap> =
+    | NodeJSWritable
+    | Writable<TType, TMap, TByte>
+    | Duplex<TType, TByte, TMap, TByte>;
+export type AnyReadable<TType = any, TMap = TType, TByte = TMap> = NodeJSReadable | Readable<TType, TMap, TByte>;
+
+export interface Callback {
+    (err?: Error | null): void;
+}
+
+export interface ResultCallback<T> {
+    (err?: Error | null, result?: T): void;
+}
+
+export interface StreamOptions<TStream extends Stream<TByteType>, TByteType = any> {
+    highWaterMark?: number;
+    byteLength?: ByteLengthFunction<TStream, TByteType>;
+    open?: (this: TStream, cb: Callback) => void;
+    destroy?: (this: TStream, cb: Callback) => void;
+    predestroy?: (this: TStream, cb: Callback) => void;
+    signal?: AbortSignalLike;
+}
+
+/* tslint:disable-next-line interface-over-type-literal */
+export type StreamEvents = {
+    open: () => void;
+    close: () => void;
+    error: (error: Error) => void;
+};
+
+export type Events = { [event: string]: (...args: any[]) => void } | undefined;
+export type EventName<TEvents extends Events> = TEvents extends undefined ? string | symbol : keyof TEvents;
+export type EventListener<TEvents extends Events, TEvent extends string | symbol | number> = TEvents extends undefined
+    ? (...args: any[]) => void
+    : TEvent extends keyof TEvents
+    ? TEvents[TEvent]
+    : (...args: any[]) => void;
+
+export class Stream<
+    TByteType = any,
+    TReadable extends boolean = false,
+    TWritable extends boolean = false,
+    TEvents extends StreamEvents = StreamEvents
+> extends EventEmitter {
+    constructor(opts?: StreamOptions<Stream<TByteType>, TByteType>);
+    _open(cb: Callback): void;
+    _destroy(cb: Callback): void;
+    _predestroy(cb: Callback): void;
+    readonly readable: TReadable;
+    readonly writable: TWritable;
+    readonly destroyed: boolean;
+    readonly destroying: boolean;
+    destroy(error?: Error | null): void;
+
+    addListener<TEvent extends EventName<TEvents>>(event: TEvent, listener: EventListener<TEvents, TEvent>): this;
+    on<TEvent extends EventName<TEvents>>(event: TEvent, listener: EventListener<TEvents, TEvent>): this;
+    once<TEvent extends EventName<TEvents>>(event: TEvent, listener: EventListener<TEvents, TEvent>): this;
+    removeListener<TEvent extends EventName<TEvents>>(event: TEvent, listener: EventListener<TEvents, TEvent>): this;
+    off<TEvent extends EventName<TEvents>>(event: TEvent, listener: EventListener<TEvents, TEvent>): this;
+    removeAllListeners(event?: EventName<TEvents>): this;
+    setMaxListeners(n: number): this;
+    getMaxListeners(): number;
+    listeners<TEvent extends EventName<TEvents>>(event: TEvent): Array<EventListener<TEvents, TEvent>>;
+    rawListeners<TEvent extends EventName<TEvents>>(event: TEvent): Array<EventListener<TEvents, TEvent>>;
+    emit<TEvent extends EventName<TEvents>>(
+        event: TEvent,
+        ...rest: Parameters<EventListener<TEvents, TEvent>>
+    ): boolean;
+    listenerCount(event: EventName<TEvents>): number;
+
+    // Added in Node 6...
+    prependListener<TEvent extends EventName<TEvents>>(event: TEvent, listener: EventListener<TEvents, TEvent>): this;
+    prependOnceListener<TEvent extends EventName<TEvents>>(
+        event: TEvent,
+        listener: EventListener<TEvents, TEvent>,
+    ): this;
+    eventNames(): Array<string | symbol>;
+}
+
+export type MapFunction<TThis, TIn, TOut> = ((this: TThis, input: TIn) => TOut) | null | undefined;
+export type ByteLengthFunction<TThis, TData> = ((this: TThis, data: TData) => number) | null | undefined;
+
+export interface BaseReadableOptions<
+    TStream extends Readable<TType, TMapType, TByteType, any, any>,
+    TType,
+    TMapType,
+    TByteType
+> extends StreamOptions<TStream, TByteType> {
+    read?: (this: TStream, cb: ResultCallback<TType>) => void;
+    byteLengthReadable?: ByteLengthFunction<TStream, TByteType>;
+}
+
+export type ReadableOptions<
+    TStream extends Readable<TType, TMapType, TByteType, any, any>,
+    TType,
+    TMapType,
+    TByteType,
+    TMapFallback = any
+> = BaseReadableOptions<TStream, TType, TMapType, TByteType> &
+    (
+        | {}
+        | {
+              map?: TMapFallback;
+              mapReadable: MapFunction<TStream, TType, TMapType>;
+          }
+        | {
+              map: MapFunction<TStream, TType, TMapType>;
+          }
+    );
+
+/* tslint:disable-next-line strict-export-declare-modifiers */
+type FromType<TData> = TData extends Readable
+    ? TData
+    : TData extends Iterable<infer TType>
+    ? Readable<TType>
+    : TData extends AsyncIterable<infer TType>
+    ? Readable<TType>
+    : Readable<TData>;
+
+export type ReadableEvents<TMapType> = StreamEvents & {
+    piping: (writable: Writable<TMapType>) => void;
+    readable: () => void;
+    data: (data: TMapType) => void;
+    end: () => void;
+};
+
+export class Readable<
+    TType = any,
+    TMapType = TType,
+    TByteType = TMapType,
+    TReadable extends boolean = true,
+    TWritable extends boolean = false,
+    TEvents extends ReadableEvents<TMapType> = ReadableEvents<TMapType>
+> extends Stream<TByteType, TReadable, TWritable, TEvents> {
+    constructor(opts?: ReadableOptions<Readable<TType, TMapType>, TType, TMapType, TByteType>);
+    _read(cb: ResultCallback<TType>): void;
+    pipe<TTarget extends AnyWritable<TMapType, any, any> = AnyWritable<TMapType, any, any>>(
+        dest: TTarget,
+        cb?: Callback,
+    ): TTarget;
+    read(): TMapType;
+    push(data: TType | null): boolean;
+    unshift(data: TType | null): void;
+    resume(): this;
+    pause(): this;
+
+    static from<TInput = any>(input?: TInput): FromType<TInput>;
+    static isPaused(rs: Readable): boolean;
+    static isBackpressured(rs: Readable): boolean;
+    [Symbol.asyncIterator]: () => AsyncIterator<TType>;
+}
+
+export interface BaseWritableOptions<
+    TStream extends Writable<TType, TMapType, TByteType, any, any>,
+    TType,
+    TMapType,
+    TByteType
+> extends StreamOptions<TStream, TByteType> {
+    writev?: (this: TStream, batch: TMapType[], cb: Callback) => void;
+    write?: (this: TStream, data: TMapType, cb: Callback) => void;
+    final?: (this: TStream, cb: Callback) => void;
+    byteLengthWritable?: ByteLengthFunction<TStream, TByteType>;
+}
+
+export type WritableOptions<
+    TStream extends Writable<TType, TMapType, TByteType, any, any>,
+    TType,
+    TMapType,
+    TByteType,
+    TMapFallback = any
+> = BaseWritableOptions<TStream, TType, TMapType, TByteType> &
+    (
+        | {}
+        | {
+              map?: TMapFallback;
+              mapWritable: MapFunction<TStream, TType, TMapType>;
+          }
+        | {
+              map: MapFunction<TStream, TType, TMapType>;
+          }
+    );
+
+export type WritableEvents<TType> = StreamEvents & {
+    /* tslint:disable-next-line use-default-type-parameter */
+    pipe: (readable: Readable<any, TType>) => void;
+    finish: () => void;
+    drain: () => void;
+};
+
+export class Writable<
+    TType = any,
+    TMapType = TType,
+    TByteType = TType,
+    TReadable extends boolean = false,
+    TWritable extends boolean = true,
+    TEvents extends WritableEvents<TType> = WritableEvents<TType>
+> extends Stream<TByteType, TReadable, TWritable, TEvents> {
+    constructor(opts?: WritableOptions<Writable<TType, TMapType, TByteType>, TType, TMapType, TByteType>);
+    _writev(batch: TMapType[], cb: Callback): void;
+    _write(data: TMapType, cb: Callback): void;
+    _final(cb: Callback): void;
+    write(data: TType): boolean;
+    end(data?: TType | Callback): void;
+    static isBackpressured(ws: Writable): boolean;
+}
+
+export type DuplexOptions<
+    TStream extends Duplex<TWriteType, TReadType, TInternal, TByteType, TReadable, TWritable>,
+    TWriteType = any,
+    TReadType = TWriteType,
+    TInternal = TWriteType,
+    TByteType = TWriteType | TReadType,
+    TReadable extends boolean = boolean,
+    TWritable extends boolean = boolean
+> = BaseReadableOptions<TStream, TInternal, TReadType, TByteType> &
+    BaseWritableOptions<TStream, TWriteType, TInternal, TInternal> & {
+        map?: MapFunction<TStream, TByteType, TByteType>;
+        mapReadable?: MapFunction<TStream, TInternal, TReadType>;
+        mapWritable?: MapFunction<TStream, TWriteType, TInternal>;
+    };
+
+export type DuplexEvents<TWriteType, TReadType> = ReadableEvents<TReadType> & WritableEvents<TWriteType>;
+
+export class Duplex<
+        TWriteType = any,
+        TReadType = TWriteType,
+        TInternal = TWriteType,
+        TByteType = TWriteType | TReadType,
+        TReadable extends boolean = true,
+        TWritable extends boolean = true,
+        TEvents extends DuplexEvents<TWriteType, TReadType> = DuplexEvents<TWriteType, TReadType>
+    >
+    extends Readable<TInternal, TReadType, TByteType, TReadable, TWritable, TEvents>
+    implements Writable<TWriteType, TInternal, TByteType, TReadable, TWritable, TEvents> {
+    constructor(
+        opts?: DuplexOptions<
+            Duplex<TWriteType, TReadType, TInternal, TByteType, TReadable, TWritable>,
+            TWriteType,
+            TReadType,
+            TInternal,
+            TByteType,
+            TReadable,
+            TWritable
+        >,
+    );
+    _writev(batch: TInternal[], cb: Callback): void;
+    _write(data: TInternal, cb: Callback): void;
+    _final(cb: Callback): void;
+    write(data: TWriteType): boolean;
+    end(data?: TWriteType | Callback): void;
+}
+
+export interface TransformOptions<
+    TStream extends Transform<TWriteType, TReadType, TInternal, TByteType, TReadable, TWritable>,
+    TWriteType = any,
+    TReadType = TWriteType,
+    TInternal = TWriteType,
+    TByteType = TWriteType | TReadType,
+    TReadable extends boolean = true,
+    TWritable extends boolean = true
+> extends DuplexOptions<TStream, TWriteType, TReadType, TInternal, TByteType, TReadable, TWritable> {
+    transform?: (this: TStream, data: TWriteType, cb: ResultCallback<TReadType>) => void;
+    flush?: (this: TStream, cb: Callback) => void;
+}
+
+export class Transform<
+    TWriteType = any,
+    TReadType = TWriteType,
+    TInternal = TWriteType,
+    TByteType = TWriteType | TReadType,
+    TReadable extends boolean = true,
+    TWritable extends boolean = true
+> extends Duplex<TWriteType, TReadType, TInternal, TByteType, TReadable, TWritable> {
+    constructor(
+        opts?: TransformOptions<
+            Transform<TWriteType, TReadType, TInternal, TByteType, TReadable, TWritable>,
+            TWriteType,
+            TReadType,
+            TInternal,
+            TByteType,
+            TReadable,
+            TWritable
+        >,
+    );
+    _transform(data: TWriteType, cb: ResultCallback<TReadType>): void;
+    _flush(cb: Callback): void;
+}
+
+export class PassThrough<TRead = any, TWrite = any> extends Transform<TRead, TWrite> {
+    constructor(opts?: TransformOptions<Transform<TRead, TWrite>, TRead, TWrite>);
+}
+
+export function isStream(input: object): input is AnyStream;
+export function isStreamx(input: object): input is Stream;

--- a/types/streamx/test/failing-tests.ts
+++ b/types/streamx/test/failing-tests.ts
@@ -1,0 +1,30 @@
+import streamx = require('streamx');
+const { Readable, Writable } = streamx;
+
+{
+    const r = new Readable<string, number>({
+        read(cb) {
+            cb(null, 123); // $ExpectError
+        },
+    });
+    r.on('anyevent', () => {}); // $ExpectError
+    r.on('data', (data: string) => {}); // $ExpectError
+    r.on('error', (error: number) => {}); // $ExpectError
+    r.on('open', (hello: string) => {}); // $ExpectError
+    r.on('close', (hello: string) => {}); // $ExpectError
+    r.unshift(1); // $ExpectError
+    r.push(1); // $ExpectError
+    r.destroy('hi'); // $ExpectError
+    r.pipe(new Readable()); // $ExpectError
+    r.pipe(new Writable<string>()); // $ExpectError
+}
+
+{
+    const w = new Writable<number, string>({
+        write(data: string, cb) {
+            cb(null, 123); // $ExpectError
+        },
+    });
+    w.write('123'); // $ExpectError
+    w.end('123'); // $ExpectError
+}

--- a/types/streamx/test/passing-tests.ts
+++ b/types/streamx/test/passing-tests.ts
@@ -1,0 +1,191 @@
+import streamx = require('streamx');
+import { Writable as NodeJSWritable, Readable as NodeJSReadable } from 'stream';
+
+const { Readable, Writable, Duplex, Transform, PassThrough, Stream, isStream, isStreamx } = streamx;
+
+// All instances can be done without arguments
+new Readable();
+new Writable();
+new Duplex();
+new Transform();
+new PassThrough();
+
+// Or empty arguments
+new Readable({});
+new Writable({});
+new Duplex({});
+new Transform({});
+new PassThrough({});
+
+isStream({}); // $ExpectType boolean
+isStreamx(new Readable()); // $ExpectType boolean
+
+// Extending the stream class!
+{
+    class MyClass extends Stream<string, false, false> {
+        constructor() {
+            super({
+                highWaterMark: 1234,
+                byteLength(x: string) {
+                    return 1;
+                },
+            });
+        }
+        _open(cb: streamx.Callback) {
+            cb();
+        }
+        _predestroy(cb: streamx.Callback) {
+            cb();
+        }
+        _destroy(cb: streamx.Callback) {
+            cb();
+        }
+    }
+    const c = new MyClass();
+    c.destroyed; // $ExpectType boolean
+    c.destroying; // $ExpectType boolean
+}
+{
+    const r: streamx.Readable<string> = new Readable<string>({
+        read(cb) {
+            cb(null, 'hello');
+        },
+    });
+    r.on('open', () => {});
+    r.on('error', (_: Error) => {});
+    r.on('readable', () => {});
+    r.on('data', (_: string) => {});
+    r.on('piping', (_: streamx.Writable<string, any>) => {});
+    r.on('end', () => {});
+    r.on('close', () => {});
+    r.push('hello'); // $ExpectType boolean
+    r.unshift('holla'); // $ExpectType void
+    r.unshift(null); // $ExpectType void
+    r.push(null); // $ExpectType boolean
+    r.resume(); // $ExpectType Readable<string, string, string, true, false, ReadableEvents<string>>
+    r.pause(); // $ExpectType Readable<string, string, string, true, false, ReadableEvents<string>>
+    r.readable; // $ExpectType true
+    r.writable; // $ExpectType false
+    r.destroy();
+    Readable.isPaused(r); // $ExpectType boolean
+    Readable.isBackpressured(r); // $ExpectType boolean
+}
+{
+    const w = new Writable<string>({
+        write(data, cb) {
+            data; // $ExpectType string
+            cb();
+        },
+        writev(data, cb) {
+            data; // $ExpectType string[]
+            cb();
+        },
+        final(cb) {
+            cb();
+        },
+    });
+    w.on('open', () => {});
+    w.on('error', (_: Error) => {});
+    w.on('pipe', (_: streamx.Readable<string>) => {});
+    w.on('drain', () => {});
+    w.on('finish', () => {});
+    w.on('close', () => {});
+    w.write('hello'); // $ExpectType boolean
+    w.end(); // $ExpectType void
+    w.destroyed; // $ExpectType boolean
+    w.destroying; // $ExpectType boolean
+    w.readable; // $ExpectType false
+    w.writable; // $ExpectType true
+    w.destroy(null);
+}
+{
+    const d = new Duplex<string, number, Buffer>({
+        write(data, cb) {
+            data; // $ExpectType Buffer
+            this.push(data); // $ExpectType boolean
+            this.read(); // $ExpectType number
+            this.writable; // $ExpectType true
+            this.readable; // $ExpectType true
+            cb();
+        },
+        mapWritable: data => Buffer.from(data, 'base64'),
+        mapReadable: data => parseInt(data.toString('base64'), 10),
+    });
+    d.on('open', () => {});
+    d.on('error', (_: Error) => {});
+    d.on('pipe', (_: streamx.Readable<string>) => {});
+    d.on('drain', () => {});
+    d.on('finish', () => {});
+    d.on('readable', () => {});
+    d.on('data', (_: number) => {});
+    d.on('piping', (_: streamx.Writable<number, any>) => {});
+    d.on('end', () => {});
+    d.on('close', () => {});
+    d.write('1');
+    d.destroy(new Error('hi'));
+}
+
+// Various ways of ending a writable
+new Writable<string>().end((error?: Error | null) => {
+    // Callback variant
+});
+new Writable<{ hello: 'world' }>().end({ hello: 'world' });
+
+// Mapping functions
+new Readable<number, string>({
+    map: (input: number) => input.toString(),
+    byteLength: input => input.length,
+}).pipe(new Writable<string>());
+
+new Readable<number, string>({
+    map: (input: number) => input !== 0,
+    mapReadable: input => input.toString(),
+    byteLength: input => input.length,
+}).pipe(new Writable<string>());
+
+new Readable<string>().pipe(
+    new Writable<string, number>({
+        map: (input: string) => input.length,
+    }),
+);
+
+new Readable<string>().pipe(
+    new Writable<string, number>({
+        map: (input: string) => input !== '',
+        mapWritable: input => input.length,
+    }),
+);
+
+// Piping NodeJs.streams
+new Readable<string>().pipe(new NodeJSWritable());
+
+// Since the streams are technically not nodejs streams but they work, there needs to be a helping hand here.
+new NodeJSReadable({ read() {} }).pipe((new Writable<string>() as unknown) as NodeJSWritable);
+
+Readable.from(new Set(['a', 'b', 'c'])); // $ExpectType Readable<string, string, string, true, false, ReadableEvents<string>>
+Readable.from('string'); // $ExpectType Readable<string, string, string, true, false, ReadableEvents<string>>
+Readable.from(new Readable<number>()); // $ExpectType Readable<number, number, number, true, false, ReadableEvents<number>>
+const x: streamx.Readable<string> = Readable.from();
+
+Readable.from('hello')
+    .pipe(
+        new Transform<string, number>({
+            transform(input, cb) {
+                cb(null, input.length);
+            },
+        }),
+    )
+    .pipe(
+        new Writable<number>({
+            write(input, cb) {
+                input; // $ExpectType number
+                cb();
+            },
+        }),
+    );
+
+new Readable({
+    signal: {
+        addEventListener() {},
+    },
+});

--- a/types/streamx/tsconfig.json
+++ b/types/streamx/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es2017"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "target": "ES2017",
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "test/failing-tests.ts",
+        "test/passing-tests.ts"
+    ]
+}

--- a/types/streamx/tslint.json
+++ b/types/streamx/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
