### PR TITLE
fix: type definition for set function in @types/cookies

### DIFF
--- a/types/cookies/cookies-tests.ts
+++ b/types/cookies/cookies-tests.ts
@@ -27,7 +27,11 @@ const server = http.createServer((req, res) => {
             .set("tampered.sig", "bogus")
 
             // delete cookie but pass options
-            .set("removed", { signed: true })
+            .set("removed", null, { signed: true })
+            .set("removed", "", { signed: true })
+
+            // delete cookie with no value or options
+            .set("removed")
 
             // sameSite option
             .set("samesite", "same", {sameSite: 'lax'})

--- a/types/cookies/index.d.ts
+++ b/types/cookies/index.d.ts
@@ -29,8 +29,7 @@ interface Cookies {
      * the current context to allow chaining.If the value is omitted,
      * an outbound header with an expired date is used to delete the cookie.
      */
-    set(name: string, value: string | null, opts?: Cookies.SetOption): this;
-    set(name: string, opts?: Cookies.SetOption): this;
+    set(name: string, value?: string | null, opts?: Cookies.SetOption): this;
 }
 
 declare namespace Cookies {

--- a/types/cookies/index.d.ts
+++ b/types/cookies/index.d.ts
@@ -29,7 +29,7 @@ interface Cookies {
      * the current context to allow chaining.If the value is omitted,
      * an outbound header with an expired date is used to delete the cookie.
      */
-    set(name: string, value: string, opts?: Cookies.SetOption): this;
+    set(name: string, value: string | null, opts?: Cookies.SetOption): this;
     set(name: string, opts?: Cookies.SetOption): this;
 }
 


### PR DESCRIPTION
The cookies [documentation](https://github.com/pillarjs/cookies/blob/master/README.md) explicitly states the omission of `value` will cause the deletion of a cookie. `null` is more explicitly an omission than `""` IMHO.

Further to that, I see no evidence in the package source code that an overload, providing config as the second argument, counts as an omission of `value`. In testing, providing config as the second argument causes an indefinite cookie to be created with a value of `[object Object]`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pillarjs/cookies/blob/master/README.md
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
