### PR TITLE
[fs-extra] Add missing mkdir argument

### DIFF
--- a/types/fs-extra/fs-extra-tests.ts
+++ b/types/fs-extra/fs-extra-tests.ts
@@ -73,6 +73,22 @@ fs.createFile(file).then(() => {
 fs.createFile(file, errorCallback);
 fs.createFileSync(file);
 
+fs.mkdir(dir).then(() => {
+    // stub
+});
+fs.mkdir(dir, errorCallback);
+fs.mkdirSync(dir);
+fs.mkdir(dir, modeNum).then(() => {
+    // stub
+});
+fs.mkdir(dir, modeNum, errorCallback);
+fs.mkdirSync(dir, modeNum);
+fs.mkdir(dir, {mode: modeNum}).then(() => {
+    // stub
+});
+fs.mkdir(dir, {mode: modeNum}, errorCallback);
+fs.mkdirSync(dir, {mode: modeNum});
+
 fs.mkdirs(dir).then(() => {
     // stub
 });

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -184,7 +184,7 @@ export function mkdir(path: PathLike, callback: (err: NodeJS.ErrnoException) => 
  * @param callback No arguments other than a possible exception are given to the completion callback.
  */
 export function mkdir(path: PathLike, options: Mode | fs.MakeDirectoryOptions | null, callback: (err: NodeJS.ErrnoException) => void): void;
-export function mkdir(path: PathLike): Promise<void>;
+export function mkdir(path: PathLike, options?: Mode | fs.MakeDirectoryOptions | null): Promise<void>;
 
 export function open(path: PathLike, flags: string | number, callback: (err: NodeJS.ErrnoException, fd: number) => void): void;
 export function open(path: PathLike, flags: string | number, mode: Mode, callback: (err: NodeJS.ErrnoException, fd: number) => void): void;

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -185,6 +185,7 @@ export function mkdir(path: PathLike, callback: (err: NodeJS.ErrnoException) => 
  */
 export function mkdir(path: PathLike, options: Mode | fs.MakeDirectoryOptions | null, callback: (err: NodeJS.ErrnoException) => void): void;
 export function mkdir(path: PathLike, options?: Mode | fs.MakeDirectoryOptions | null): Promise<void>;
+export function mkdirSync(path: PathLike, options?: Mode | fs.MakeDirectoryOptions | null): void;
 
 export function open(path: PathLike, flags: string | number, callback: (err: NodeJS.ErrnoException, fd: number) => void): void;
 export function open(path: PathLike, flags: string | number, mode: Mode, callback: (err: NodeJS.ErrnoException, fd: number) => void): void;


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jprichardson/node-fs-extra/blob/6bffcd81881ae474d3d1765be7dd389b5edfd0e0/lib/fs/index.js / https://nodejs.org/api/fs.html#fs_fs_mkdir_path_options_callback
  Note: this `options` argument is missing from the promised definition but present in the callback definition above.

Edit: I also added the missing mkdirSync definition.