### PR TITLE
Update equalTo: Definitions for Parse Platform to support Array Types

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -676,7 +676,7 @@ namespace Parse {
         reduce<U>(callback: (accumulator: U, currentObject: T, index: number) => PromiseLike<U> | U, initialValue: U, options?: Query.BatchOptions): Promise<U>;
         filter(callback: (currentObject: T, index: number, query: Query) => PromiseLike<boolean> | boolean, options?: Query.BatchOptions): Promise<T[]>;
         endsWith<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, suffix: string): this;
-        equalTo<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, value: (T['attributes'][K] extends Array ? T['attributes'][K][0] : T['attributes'][K]) | (T['attributes'][K] extends Object ? Pointer : never)): this;
+        equalTo<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, value: (T['attributes'][K] extends any[] ? T['attributes'][K][0] : T['attributes'][K]) | (T['attributes'][K] extends Object ? Pointer : never)): this;
         exclude<K extends (keyof T['attributes'] | keyof BaseAttributes)>(...keys: K[]): this;
         exists<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K): this;
         find(options?: Query.FindOptions): Promise<T[]>;
@@ -701,7 +701,7 @@ namespace Parse {
         matchesQuery<U extends Object, K extends keyof T['attributes']>(key: K, query: Query<U>): this;
         near<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, point: GeoPoint): this;
         notContainedIn<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, values: Array<T['attributes'][K]>): this;
-        notEqualTo<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, value: (T['attributes'][K] extends Array ? T['attributes'][K][0] : T['attributes'][K])): this;
+        notEqualTo<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, value: (T['attributes'][K] extends any[] ? T['attributes'][K][0] : T['attributes'][K])): this;
         polygonContains<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, point: GeoPoint): this;
         select<K extends (keyof T['attributes'] | keyof BaseAttributes)>(...keys: K[]): this;
         skip(n: number): Query<T>;

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -678,7 +678,14 @@ namespace Parse {
         endsWith<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, suffix: string): this;
         equalTo<K extends (keyof T['attributes'] | keyof BaseAttributes)>(
             key: K,
-            value: (T['attributes'][K] extends any[] ? T['attributes'][K][0] : T['attributes'][K]) | (T['attributes'][K] extends Object ? Pointer : never)
+            value: T['attributes'][K] | (
+                T['attributes'][K] extends Object
+                ? Pointer
+                : (T['attributes'][K] extends Array<infer E>
+                    ? E
+                    : never
+                )
+            )
         ): this;
         exclude<K extends (keyof T['attributes'] | keyof BaseAttributes)>(...keys: K[]): this;
         exists<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K): this;
@@ -704,7 +711,17 @@ namespace Parse {
         matchesQuery<U extends Object, K extends keyof T['attributes']>(key: K, query: Query<U>): this;
         near<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, point: GeoPoint): this;
         notContainedIn<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, values: Array<T['attributes'][K]>): this;
-        notEqualTo<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, value: (T['attributes'][K] extends any[] ? T['attributes'][K][0] : T['attributes'][K])): this;
+        notEqualTo<K extends (keyof T['attributes'] | keyof BaseAttributes)>(
+            key: K,
+            value: T['attributes'][K] | (
+                T['attributes'][K] extends Object
+                ? Pointer
+                : (T['attributes'][K] extends Array<infer E>
+                    ? E
+                    : never
+                )
+            )
+        ): this;
         polygonContains<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, point: GeoPoint): this;
         select<K extends (keyof T['attributes'] | keyof BaseAttributes)>(...keys: K[]): this;
         skip(n: number): Query<T>;

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -677,7 +677,7 @@ namespace Parse {
         filter(callback: (currentObject: T, index: number, query: Query) => PromiseLike<boolean> | boolean, options?: Query.BatchOptions): Promise<T[]>;
         endsWith<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, suffix: string): this;
         equalTo<K extends (keyof T['attributes'] | keyof BaseAttributes)>(
-            key: K, 
+            key: K,
             value: (T['attributes'][K] extends any[] ? T['attributes'][K][0] : T['attributes'][K]) | (T['attributes'][K] extends Object ? Pointer : never)
         ): this;
         exclude<K extends (keyof T['attributes'] | keyof BaseAttributes)>(...keys: K[]): this;

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -676,7 +676,10 @@ namespace Parse {
         reduce<U>(callback: (accumulator: U, currentObject: T, index: number) => PromiseLike<U> | U, initialValue: U, options?: Query.BatchOptions): Promise<U>;
         filter(callback: (currentObject: T, index: number, query: Query) => PromiseLike<boolean> | boolean, options?: Query.BatchOptions): Promise<T[]>;
         endsWith<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, suffix: string): this;
-        equalTo<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, value: (T['attributes'][K] extends any[] ? T['attributes'][K][0] : T['attributes'][K]) | (T['attributes'][K] extends Object ? Pointer : never)): this;
+        equalTo<K extends (keyof T['attributes'] | keyof BaseAttributes)>(
+            key: K, 
+            value: (T['attributes'][K] extends any[] ? T['attributes'][K][0] : T['attributes'][K]) | (T['attributes'][K] extends Object ? Pointer : never)
+        ): this;
         exclude<K extends (keyof T['attributes'] | keyof BaseAttributes)>(...keys: K[]): this;
         exists<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K): this;
         find(options?: Query.FindOptions): Promise<T[]>;

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -21,6 +21,7 @@
 //                  Jerome De Leon <https://github.com/JeromeDeLeon>
 //                  Kent Robin Haugen <https://github.com/kentrh>
 //                  Asen Lekov <https://github.com/L3K0V>
+//                  Switt Kongdachalert <https://github.com/swittk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.5
 
@@ -675,7 +676,7 @@ namespace Parse {
         reduce<U>(callback: (accumulator: U, currentObject: T, index: number) => PromiseLike<U> | U, initialValue: U, options?: Query.BatchOptions): Promise<U>;
         filter(callback: (currentObject: T, index: number, query: Query) => PromiseLike<boolean> | boolean, options?: Query.BatchOptions): Promise<T[]>;
         endsWith<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, suffix: string): this;
-        equalTo<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, value: T['attributes'][K] | (T['attributes'][K] extends Object ? Pointer : never)): this;
+        equalTo<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, value: (T['attributes'][K] extends Array ? T['attributes'][K][0] : T['attributes'][K]) | (T['attributes'][K] extends Object ? Pointer : never)): this;
         exclude<K extends (keyof T['attributes'] | keyof BaseAttributes)>(...keys: K[]): this;
         exists<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K): this;
         find(options?: Query.FindOptions): Promise<T[]>;
@@ -700,7 +701,7 @@ namespace Parse {
         matchesQuery<U extends Object, K extends keyof T['attributes']>(key: K, query: Query<U>): this;
         near<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, point: GeoPoint): this;
         notContainedIn<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, values: Array<T['attributes'][K]>): this;
-        notEqualTo<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, value: T['attributes'][K]): this;
+        notEqualTo<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, value: (T['attributes'][K] extends Array ? T['attributes'][K][0] : T['attributes'][K])): this;
         polygonContains<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, point: GeoPoint): this;
         select<K extends (keyof T['attributes'] | keyof BaseAttributes)>(...keys: K[]): this;
         skip(n: number): Query<T>;

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -1542,7 +1542,12 @@ function testQuery() {
                 super('Another', { x: 'example' });
             }
         }
-        class MySubClass extends Parse.Object<{attribute1: string, attribute2: number, attribute3: AnotherSubClass}> { }
+        class MySubClass extends Parse.Object<{
+            attribute1: string,
+            attribute2: number,
+            attribute3: AnotherSubClass,
+            attribute4: string[]
+        }> { }
         const query = new Parse.Query(MySubClass);
 
         // $ExpectType Query<MySubClass>
@@ -1640,6 +1645,26 @@ function testQuery() {
         query.equalTo('attribute2', 'a string value');
         // $ExpectError
         query.equalTo('nonexistentProp', 'any value');
+
+        // $ExpectType Query<MySubClass>
+        query.equalTo('attribute4', 'a_string_value'); // Can query contents of array
+        // Can query array itself if equal too (mongodb $eq matches the array exactly or the <field> contains an element that matches the array exactly)
+        // $ExpectType Query<MySubClass>
+        query.equalTo('attribute4', ['a_string_value']);
+
+        // $ExpectType Query<MySubClass>
+        query.notEqualTo('attribute4', 'a_string_value');
+        // $ExpectType Query<MySubClass>
+        query.notEqualTo('attribute4', ['a_string_value']);
+
+        // $ExpectError
+        query.equalTo('attribute4', 5);
+        // $ExpectError
+        query.notEqualTo('attribute4', 5);
+        // $ExpectError
+        query.equalTo('attribute4', [5]);
+        // $ExpectError
+        query.notEqualTo('attribute4', [5]);
 
         // $ExpectType Query<MySubClass>
         query.exists('attribute1');

--- a/types/parse/ts3.6/index.d.ts
+++ b/types/parse/ts3.6/index.d.ts
@@ -649,7 +649,17 @@ namespace Parse {
         reduce<U>(callback: (accumulator: U, currentObject: T, index: number) => PromiseLike<U> | U, initialValue: U, options?: Query.BatchOptions): Promise<U>;
         filter(callback: (currentObject: T, index: number, query: Query) => PromiseLike<boolean> | boolean, options?: Query.BatchOptions): Promise<T[]>;
         endsWith<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, suffix: string): this;
-        equalTo<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, value: T['attributes'][K] | (T['attributes'][K] extends Object ? Pointer : never)): this;
+        equalTo<K extends (keyof T['attributes'] | keyof BaseAttributes)>(
+            key: K,
+            value: T['attributes'][K] | (
+                T['attributes'][K] extends Object
+                ? Pointer
+                : (T['attributes'][K] extends Array<infer E>
+                    ? E
+                    : never
+                )
+            )
+        ): this;
         exclude<K extends (keyof T['attributes'] | keyof BaseAttributes)>(...keys: K[]): this;
         exists<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K): this;
         find(options?: Query.FindOptions): Promise<T[]>;
@@ -673,7 +683,17 @@ namespace Parse {
         matchesQuery<U extends Object, K extends keyof T['attributes']>(key: K, query: Query<U>): this;
         near<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, point: GeoPoint): this;
         notContainedIn<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, values: Array<T['attributes'][K]>): this;
-        notEqualTo<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, value: T['attributes'][K]): this;
+        notEqualTo<K extends (keyof T['attributes'] | keyof BaseAttributes)>(
+            key: K,
+            value: T['attributes'][K] | (
+                T['attributes'][K] extends Object
+                ? Pointer
+                : (T['attributes'][K] extends Array<infer E>
+                    ? E
+                    : never
+                )
+            )
+        ): this;
         polygonContains<K extends (keyof T['attributes'] | keyof BaseAttributes)>(key: K, point: GeoPoint): this;
         select<K extends (keyof T['attributes'] | keyof BaseAttributes)>(...keys: K[]): this;
         skip(n: number): Query<T>;


### PR DESCRIPTION
equalTo: and notEqualTo: both support values contained in arrays (finds if exist/not exist in them)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://docs.parseplatform.org/js/guide/#queries-on-array-values>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.