### PR TITLE
Revert "🤖 Merge PR #49581 [tweenjs] - Add inference of Tween target t…

### DIFF
--- a/types/tweenjs/index.d.ts
+++ b/types/tweenjs/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for TweenJS 1.0.3
+// Type definitions for TweenJS 1.0.2
 // Project: http://www.createjs.com/#!/TweenJS
-// Definitions by: Pedro Ferreira <https://bitbucket.org/drk4>, Chris Smith <https://github.com/evilangelist>, J.C <https://github.com/jcyuan>, Lloyd Evans <https://github.com/lloydevans>
+// Definitions by: Pedro Ferreira <https://bitbucket.org/drk4>, Chris Smith <https://github.com/evilangelist>, J.C <https://github.com/jcyuan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /*
@@ -168,31 +168,31 @@ declare namespace createjs {
         toString():string;
     }
 
-    export class Tween<T = any> extends AbstractTween {
-        constructor(target: T, props?: TweenProps);
+    export class Tween extends AbstractTween {
+        constructor(target: any, props?: TweenProps);
 
         static IGNORE:any;
 
         // properties
-        target: T;
+        target: any;
         pluginData: any;
         passive: boolean;
 
         // methods
-        static get<T>(target:T, props?:TweenProps):Tween<T>;
+        static get(target:any, props?:TweenProps):Tween;
         static tick(delta:number, paused:boolean):void;
         static handleEvent(e:Event):void;
         static removeTweens(target:any):void;
         static removeAllTweens():void;
         static hasActiveTweens(target:any):boolean;
 
-        wait(duration:number, passive?:boolean):this;
-        to(props:Partial<T>, duration?:number, ease?:Function):this;
-        label(name:string):this;
-        call(callback:(...params:any[]) => void, params?:Partial<T>, scope?:any):this;
-        set(props:any, target?:any):this;
-        play(tween?:Tween):this;
-        pause(tween?:Tween):this;
+        wait(duration:number, passive?:boolean):Tween;
+        to(props:any, duration?:number, ease?:Function):Tween;
+        label(name:string):Tween;
+        call(callback:(...params:any[]) => void, params?:any[], scope?:any):Tween;
+        set(props:any, target?:any):Tween;
+        play(tween?:Tween):Tween;
+        pause(tween?:Tween):Tween;
     }
 
     export class TweenJS {

--- a/types/tweenjs/tweenjs-tests.ts
+++ b/types/tweenjs/tweenjs-tests.ts
@@ -9,6 +9,3 @@ createjs.Tween.get(target).wait(500, false).to({ alpha: 0, visible: false }, 100
 function onComplete() {
     //Tween complete
 }
-
-// $ExpectError
-createjs.Tween.get(target).wait(500, false).to({ unknown: 0 }, 1000);


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#49581

I believe this change should have gone in a minor version up and be included in a new patch version of the createjs types due to potentially introducing new type errors on existing projects.

On a separate issue, the PR also didn't merge properly and now has incorrect types so this should be merged ASAP to prevent peoples projects from breaking 😬

I see createjs is migrating to a new @createjs package scope and updating these libs to be modular, so perhaps this improvement can be made there, and this package left as is.

I'm also not sure what to do with the version number, I guess it needs to go up to 1.0.4 and 1.0.3 is a broken version?