### PR TITLE
Update prosemirror-markdown add const schema,defaultMarkdownParser

### DIFF
--- a/types/prosemirror-markdown/index.d.ts
+++ b/types/prosemirror-markdown/index.d.ts
@@ -5,6 +5,7 @@
 //                 Tim Baumann <https://github.com/timjb>
 //                 Patrick Simmelbauer <https://github.com/patsimm>
 //                 Ifiokj Jr. <https://github.com/ifiokjr>
+//                 Hayashi Takuya <https://github.com/howyi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -119,7 +120,9 @@ export class MarkdownParser<S extends Schema = any> {
  * A parser parsing unextended [CommonMark](http://commonmark.org/),
  * without inline HTML, and producing a document in the basic schema.
  */
-export let defaultMarkdownParser: MarkdownParser;
+export const defaultMarkdownParser: MarkdownParser;
+
+export const schema: Schema;
 
 export type MarkSerializerMethod<S extends Schema = any> = (
     state: MarkdownSerializerState<S>,


### PR DESCRIPTION
This PR keeps the type definition of prosemirror-markdown up to date.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/ProseMirror/prosemirror-markdown/blob/master/src/index.js#L3
https://github.com/ProseMirror/prosemirror-markdown/blob/master/src/from_markdown.js#L228
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
