### PR TITLE
feat(tedious): set type for cryptoCredentialDetails

### DIFF
--- a/types/tedious/index.d.ts
+++ b/types/tedious/index.d.ts
@@ -12,6 +12,7 @@
 
 
 import events = require("events");
+import { SecureContextOptions } from 'tls';
 
 export interface ColumnType {
     /**
@@ -239,7 +240,7 @@ export interface ConnectionOptions {
     /**
      * When encryption is used, an object may be supplied that will be used for the first argument when calling tls.createSecurePair (default: {}).
      */
-    cryptoCredentialsDetails?: Object;
+    cryptoCredentialsDetails?: SecureContextOptions;
 
     /**
      * A boolean, that when true will expose received rows in Requests' done* events. See done, doneInProc and doneProc. (default: false)

--- a/types/tedious/tedious-tests.ts
+++ b/types/tedious/tedious-tests.ts
@@ -5,6 +5,9 @@ var config: tedious.ConnectionConfig = {
     options: {
         database: "somedb",
         instanceName: "someinstance",
+        cryptoCredentialsDetails: {
+            minVersion: "TLSv1"
+        }
     },
     authentication: {
         type: "default",


### PR DESCRIPTION
Change `Object` to `SecureContextOptions`

Inside tedious, `cryptoCredentialDetails` are eventually used when calling `tls.createSecureContext()`
In tedious' internal interface, it also defines it as `tls.SecureContextOptions`. (I have made a PR to tedious about exposing it in their external interface).

https://nodejs.org/docs/latest/api/tls.html#tls_tls_createsecurecontext_options
https://github.com/tediousjs/tedious/blob/69ad8243d400d19fb05230c027ff74648b91a2e8/src/connection.ts#L1669

Since tedious is written in TypeScript, it would be nice if they bundled definitions - but they don't.

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tediousjs/tedious/blob/69ad8243d400d19fb05230c027ff74648b91a2e8/src/connection.ts#L1669
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

