### PR TITLE
[module-deps] fix 'options.resolve' 'opts' parameter type

### DIFF
--- a/types/module-deps/index.d.ts
+++ b/types/module-deps/index.d.ts
@@ -1,11 +1,9 @@
-// Type definitions for module-deps 6.1
+// Type definitions for module-deps 6.2
 // Project: https://github.com/browserify/module-deps
 // Definitions by: TeamworkGuy2 <https://github.com/TeamworkGuy2>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
-
-import * as browserResolve from "browser-resolve";
 
 /**
  * Return an object transform stream 'd' that expects entry filenames or '{ id: ..., file: ... }' objects
@@ -35,7 +33,7 @@ declare namespace moduleDeps {
         /**
          * Custom resolve function using the opts.resolve(id, parent, cb) signature that browser-resolve has
          */
-        resolve?: (id: string, opts: browserResolve.SyncOpts, cb: (err?: Error | null, file?: string, pkg?: PackageObject, fakePath?: any) => void) => void;
+        resolve?: (id: string, opts: ParentObject, cb: (err?: Error | null, file?: string, pkg?: PackageObject, fakePath?: any) => void) => void;
 
         /**
          * A custom dependency detection function. opts.detect(source) should return an array of dependency module names. By default detective is used
@@ -108,7 +106,7 @@ declare namespace moduleDeps {
     }
 
     interface ModuleDepsObject extends NodeJS.ReadWriteStream {
-        resolve(id: string, parent: { id: string }, cb: (err: Error | null, file?: string, pkg?: PackageObject, fakePath?: any) => any): any;
+        resolve(id: string, parent: Partial<ParentObject> & { id: string; [name: string]: any }, cb: (err: Error | null, file?: string, pkg?: PackageObject, fakePath?: any) => any): any;
 
         readFile(file: string, id?: any, pkg?: PackageObject): NodeJS.ReadableStream;
 
@@ -159,6 +157,19 @@ declare namespace moduleDeps {
         transform: string | (() => any);
         options: any;
         global?: boolean;
+    }
+
+    interface ParentObject {
+        id: string;
+        filename: string;
+        basedir: string;
+        paths: string[];
+        package?: any;
+        packageFilter?: (p: PackageObject, x: string) => PackageObject & { __dirname: string };
+        inNodeModules?: boolean;
+        // undocumented, see 'Options' interface
+        extensions?: string[];
+        modules?: { [name: string]: any };
     }
 
     interface TransformObject {

--- a/types/module-deps/module-deps-tests.ts
+++ b/types/module-deps/module-deps-tests.ts
@@ -23,11 +23,17 @@ function coreDepsTest() {
             }
         }
     });
+
+    s.resolve("id", { id: "id" }, (err, file, pkg) => {
+        const errMsg: string | null = err != null ? err.message : null;
+        const ext: string = file != null ? file.substr(file.indexOf(".")) : "js";
+    });
 }
 
 function rifiTest() {
     const md = moduleDeps({
         resolve: (id, parent, cb) => {
+            const parentDependency = parent.id.substr(1);
             const dependency = id.substr(1);
         },
         transform: [],


### PR DESCRIPTION
Add ParentObject interface for options.resolve(..., "opts", ....) parameter type.
Also bump the definition version to [module-deps@6.2](https://github.com/browserify/module-deps/blob/master/CHANGELOG.md). Mostly just dependency updates since 6.1, this type change is backward compatible with 6.1.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test module-deps`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/browserify/module-deps/blob/ac7e85e330d636b87674fbf33ac537395e2f296e/index.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.