### PR TITLE
[module-deps] fix 'options.transform' and 'options.resolve' with new types

### DIFF
--- a/types/module-deps/index.d.ts
+++ b/types/module-deps/index.d.ts
@@ -1,11 +1,9 @@
-// Type definitions for module-deps 6.1
+// Type definitions for module-deps 6.2
 // Project: https://github.com/browserify/module-deps
 // Definitions by: TeamworkGuy2 <https://github.com/TeamworkGuy2>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
-
-import * as browserResolve from "browser-resolve";
 
 /**
  * Return an object transform stream 'd' that expects entry filenames or '{ id: ..., file: ... }' objects
@@ -24,7 +22,7 @@ declare namespace moduleDeps {
         /**
          * A string or array of string transforms
          */
-        transform?: string | string[];
+        transform?: Transform | Transform[];
 
         /**
          * An array path of strings showing where to look in the package.json
@@ -35,7 +33,7 @@ declare namespace moduleDeps {
         /**
          * Custom resolve function using the opts.resolve(id, parent, cb) signature that browser-resolve has
          */
-        resolve?: (id: string, opts: browserResolve.SyncOpts, cb: (err?: Error | null, file?: string, pkg?: PackageObject, fakePath?: any) => void) => void;
+        resolve?: (id: string, opts: ParentObject, cb: (err?: Error | null, file?: string, pkg?: PackageObject, fakePath?: any) => void) => void;
 
         /**
          * A custom dependency detection function. opts.detect(source) should return an array of dependency module names. By default detective is used
@@ -99,7 +97,7 @@ declare namespace moduleDeps {
 
         // un-documented options used by module-deps
         basedir?: string;
-        globalTransform?: any[];
+        globalTransform?: Transform | Transform[];
         extensions?: string[];
         modules?: { [name: string]: any };
         expose?: { [name: string]: string };
@@ -108,7 +106,7 @@ declare namespace moduleDeps {
     }
 
     interface ModuleDepsObject extends NodeJS.ReadWriteStream {
-        resolve(id: string, parent: { id: string }, cb: (err: Error | null, file?: string, pkg?: PackageObject, fakePath?: any) => any): any;
+        resolve(id: string, parent: Partial<ParentObject> & { id: string; [name: string]: any }, cb: (err: Error | null, file?: string, pkg?: PackageObject, fakePath?: any) => any): any;
 
         readFile(file: string, id?: any, pkg?: PackageObject): NodeJS.ReadableStream;
 
@@ -129,11 +127,15 @@ declare namespace moduleDeps {
         /**
          * Every time a transform is applied to a file, a 'transform' event fires with the instantiated transform stream tr.
          */
-        on(event: "transform", listener: (tr: any, file: string) => any): this;
+        on(event: "transform", listener: (tr: NodeJS.ReadableStream, file: string) => any): this;
         /**
          * Every time a file is read, this event fires with the file path.
          */
         on(event: "file", listener: (file: string, id: string) => any): this;
+        /**
+         * When a transform stream emits an error it is passed along to this stream an an 'error' event.
+         */
+        on(event: "error", listener: (err: any) => any): this;
         /**
          * When opts.ignoreMissing is enabled, this event fires for each missing package.
          */
@@ -147,6 +149,8 @@ declare namespace moduleDeps {
 
     type CacheCallback = (err: Error | null, res?: { source: string; package: any; deps: { [dep: string]: boolean } }) => void;
 
+    type Transform = string | ((file: string, opts: { basedir?: string }) => NodeJS.ReadWriteStream);
+
     interface InputRow {
         file: string;
         id: string;
@@ -159,6 +163,19 @@ declare namespace moduleDeps {
         transform: string | (() => any);
         options: any;
         global?: boolean;
+    }
+
+    interface ParentObject {
+        id: string;
+        filename: string;
+        basedir: string;
+        paths: string[];
+        package?: any;
+        packageFilter?: (p: PackageObject, x: string) => PackageObject & { __dirname: string };
+        inNodeModules?: boolean;
+        // undocumented, see 'Options' interface
+        extensions?: string[];
+        modules?: { [name: string]: any };
     }
 
     interface TransformObject {

--- a/types/module-deps/module-deps-tests.ts
+++ b/types/module-deps/module-deps-tests.ts
@@ -11,7 +11,8 @@ function coreDepsTest() {
     const opts = {
         resolve: () => { },
         modules: coreModules,
-        extensions: [".js", ".json"]
+        extensions: [".js", ".json"],
+        transform: []
     };
 
     const s = moduleDeps(opts);
@@ -23,14 +24,20 @@ function coreDepsTest() {
             }
         }
     });
+
+    s.resolve("id", { id: "id" }, (err, file, pkg) => {
+        const errMsg: string | null = err != null ? err.message : null;
+        const ext: string = file != null ? file.substr(file.indexOf(".")) : "js";
+    });
 }
 
 function rifiTest() {
     const md = moduleDeps({
         resolve: (id, parent, cb) => {
+            const parentDependency = parent.id.substr(1);
             const dependency = id.substr(1);
         },
-        transform: [],
+        transform: ["transformer", (file, opts) => <NodeJS.ReadWriteStream> <any> null],
         globalTransform: [],
         cache: {}
     });


### PR DESCRIPTION
Add ParentObject interface for `options.resolve(..., "opts", ....)` parameter type.
Add Transform type of `options.transform` and `options.globalTransform` types.
Based on this code: https://github.com/browserify/module-deps/blob/ac7e85e330d636b87674fbf33ac537395e2f296e/index.js#L226
Also bump the definition version to [module-deps@6.2](https://github.com/browserify/module-deps/blob/master/CHANGELOG.md). Mostly just dependency updates since 6.1, this type change is backward compatible with 6.1.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test module-deps`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/browserify/module-deps/blob/ac7e85e330d636b87674fbf33ac537395e2f296e/index.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.