### PR TITLE
Add types for mongoose-aggregate-paginate-v2 (modified from mongoose-paginate-v2)

### DIFF
--- a/types/mongoose-aggregate-paginate-v2/index.d.ts
+++ b/types/mongoose-aggregate-paginate-v2/index.d.ts
@@ -1,0 +1,97 @@
+// Type definitions for mongoose-paginate-v2 1.3
+// Project: https://github.com/webgangster/mongoose-paginate-v2
+// Definitions by: Linus Brolin <https://github.com/linusbrolin>
+//                 simonxca <https://github.com/simonxca>
+//                 woutgg <https://github.com/woutgg>
+//                 oktapodia <https://github.com/oktapodia>
+//                 Dongjun Lee <https://github.com/ChazEpps>
+//                 gamsterX <https://github.com/gamsterx>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.2
+//
+// Based on type declarations for mongoose-paginate 5.0.0.
+
+declare module 'mongoose' {
+    interface CustomLabels {
+        totalDocs?: string;
+        limit?: string;
+        page?: string;
+        totalPages?: string;
+        docs?: string;
+        nextPage?: string;
+        prevPage?: string;
+    }
+
+    interface ReadOptions {
+        pref: string;
+        tags?: any[];
+    }
+
+    interface PaginateOptions {
+        /* tslint:disable-next-line: ban-types */
+        select?: Object | string;
+        /* tslint:disable-next-line: ban-types */
+        sort?: Object | string;
+        customLabels?: CustomLabels;
+        collation?: CollationOptions;
+        /* tslint:disable-next-line: ban-types */
+        populate?: Object[] | string[] | Object | string | QueryPopulateOptions;
+        lean?: boolean;
+        leanWithId?: boolean;
+        offset?: number;
+        page?: number;
+        limit?: number;
+        read?: ReadOptions;
+        /* If pagination is set to `false`, it will return all docs without adding limit condition. (Default: `true`) */
+        pagination?: boolean;
+        projection?: any;
+        options?: QueryFindOptions;
+    }
+
+    interface QueryPopulateOptions {
+        /** space delimited path(s) to populate */
+        path: string;
+        /** optional fields to select */
+        select?: any;
+        /** optional query conditions to match */
+        match?: any;
+        /** optional model to use for population */
+        model?: string | Model<any>;
+        /** optional query options like sort, limit, etc */
+        options?: any;
+        /** deep populate */
+        populate?: QueryPopulateOptions | QueryPopulateOptions[];
+    }
+
+    interface PaginateResult<T> {
+        docs: T[];
+        totalDocs: number;
+        limit: number;
+        page?: number;
+        totalPages: number;
+        nextPage?: number | null;
+        prevPage?: number | null;
+        pagingCounter: number;
+        hasPrevPage: boolean;
+        hasNextPage: boolean;
+        meta?: any;
+        [customLabel: string]: T[] | number | boolean | null | undefined;
+    }
+
+    interface PaginateModel<T extends Document> extends Model<T> {
+        paginate(
+            query?: FilterQuery<T>,
+            options?: PaginateOptions,
+            callback?: (err: any, result: PaginateResult<T>) => void,
+        ): Promise<PaginateResult<T>>;
+    }
+
+    function model(name: string, schema?: Schema, collection?: string, skipInit?: boolean): PaginateModel<any>;
+}
+
+import mongoose = require('mongoose');
+declare function _(schema: mongoose.Schema): void;
+export = _;
+declare namespace _ {
+    const paginate: { options: mongoose.PaginateOptions };
+}

--- a/types/mongoose-aggregate-paginate-v2/index.d.ts
+++ b/types/mongoose-aggregate-paginate-v2/index.d.ts
@@ -1,18 +1,13 @@
 // Type definitions for mongoose-aggregate-paginate-v2 1.0
 // Project: https://github.com/webgangster/mongoose-aggregate-paginate-v2
-// Definitions by: Linus Brolin <https://github.com/linusbrolin>
-//                 simonxca <https://github.com/simonxca>
-//                 woutgg <https://github.com/woutgg>
-//                 oktapodia <https://github.com/oktapodia>
-//                 Dongjun Lee <https://github.com/ChazEpps>
-//                 gamsterX <https://github.com/gamsterx>
-//                 knyuwork <https://github.com/knyuwork>
-//                 LiRen Tu <https://github.com/tuliren>
-//                 Alexandre Croteau <https://github.com/acrilex1>
+// Definitions by: Alexandre Croteau <https://github.com/acrilex1>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.2
 //
 // Based on type declarations for mongoose-paginate-v2 1.3.
+//
+// Thanks to knyuwork <https://github.com/knyuwork>
+// and LiRen Tu <https://github.com/tuliren> for their contribution
 
 declare module 'mongoose' {
     interface CustomLabels {
@@ -29,8 +24,7 @@ declare module 'mongoose' {
     }
 
     interface PaginateOptions {
-        /* tslint:disable-next-line: ban-types */
-        sort?: Object | string;
+        sort?: any;
         offset?: number;
         page?: number;
         limit?: number;
@@ -83,8 +77,8 @@ declare module 'mongoose' {
 }
 
 import mongoose = require('mongoose');
-declare function _(schema: mongoose.Schema): void;
-export = _;
+declare function mongooseAggregatePaginate(schema: mongoose.Schema): void;
+export = mongooseAggregatePaginate;
 declare namespace _ {
     const aggregatePaginate: { options: mongoose.PaginateOptions };
 }

--- a/types/mongoose-aggregate-paginate-v2/index.d.ts
+++ b/types/mongoose-aggregate-paginate-v2/index.d.ts
@@ -1,15 +1,18 @@
-// Type definitions for mongoose-paginate-v2 1.3
-// Project: https://github.com/webgangster/mongoose-paginate-v2
+// Type definitions for mongoose-aggregate-paginate-v2 1.0
+// Project: https://github.com/webgangster/mongoose-aggregate-paginate-v2
 // Definitions by: Linus Brolin <https://github.com/linusbrolin>
 //                 simonxca <https://github.com/simonxca>
 //                 woutgg <https://github.com/woutgg>
 //                 oktapodia <https://github.com/oktapodia>
 //                 Dongjun Lee <https://github.com/ChazEpps>
 //                 gamsterX <https://github.com/gamsterx>
+//                 knyuwork <https://github.com/knyuwork>
+//                 LiRen Tu <https://github.com/tuliren>
+//                 Alexandre Croteau <https://github.com/acrilex1>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.2
 //
-// Based on type declarations for mongoose-paginate 5.0.0.
+// Based on type declarations for mongoose-paginate-v2 1.3.
 
 declare module 'mongoose' {
     interface CustomLabels {
@@ -20,32 +23,22 @@ declare module 'mongoose' {
         docs?: string;
         nextPage?: string;
         prevPage?: string;
-    }
-
-    interface ReadOptions {
-        pref: string;
-        tags?: any[];
+        pagingCounter?: string;
+        hasPrevPage?: string;
+        hasNextPage?: string;
     }
 
     interface PaginateOptions {
         /* tslint:disable-next-line: ban-types */
-        select?: Object | string;
-        /* tslint:disable-next-line: ban-types */
         sort?: Object | string;
-        customLabels?: CustomLabels;
-        collation?: CollationOptions;
-        /* tslint:disable-next-line: ban-types */
-        populate?: Object[] | string[] | Object | string | QueryPopulateOptions;
-        lean?: boolean;
-        leanWithId?: boolean;
         offset?: number;
         page?: number;
         limit?: number;
-        read?: ReadOptions;
+        customLabels?: CustomLabels;
         /* If pagination is set to `false`, it will return all docs without adding limit condition. (Default: `true`) */
         pagination?: boolean;
-        projection?: any;
-        options?: QueryFindOptions;
+        allowDiskUse?: boolean;
+        countQuery?: object;
     }
 
     interface QueryPopulateOptions {
@@ -63,7 +56,7 @@ declare module 'mongoose' {
         populate?: QueryPopulateOptions | QueryPopulateOptions[];
     }
 
-    interface PaginateResult<T> {
+    interface AggregatePaginateResult<T> {
         docs: T[];
         totalDocs: number;
         limit: number;
@@ -78,20 +71,20 @@ declare module 'mongoose' {
         [customLabel: string]: T[] | number | boolean | null | undefined;
     }
 
-    interface PaginateModel<T extends Document> extends Model<T> {
-        paginate(
-            query?: FilterQuery<T>,
+    interface AggregatePaginateModel<T extends Document> extends Model<T> {
+        aggregatePaginate(
+            query?: Aggregate<T[]>,
             options?: PaginateOptions,
-            callback?: (err: any, result: PaginateResult<T>) => void,
-        ): Promise<PaginateResult<T>>;
+            callback?: (err: any, result: AggregatePaginateResult<T>) => void,
+        ): Promise<AggregatePaginateResult<T>>;
     }
 
-    function model(name: string, schema?: Schema, collection?: string, skipInit?: boolean): PaginateModel<any>;
+    function model(name: string, schema?: Schema, collection?: string, skipInit?: boolean): AggregatePaginateModel<any>;
 }
 
 import mongoose = require('mongoose');
 declare function _(schema: mongoose.Schema): void;
 export = _;
 declare namespace _ {
-    const paginate: { options: mongoose.PaginateOptions };
+    const aggregatePaginate: { options: mongoose.PaginateOptions };
 }

--- a/types/mongoose-aggregate-paginate-v2/mongoose-paginate-v2-tests.ts
+++ b/types/mongoose-aggregate-paginate-v2/mongoose-paginate-v2-tests.ts
@@ -1,0 +1,78 @@
+/**
+ * Created by Linus Brolin <https://github.com/linusbrolin/>.
+ */
+
+import { Schema, model, PaginateModel, PaginateOptions, PaginateResult, Document } from 'mongoose';
+import mongoosePaginate = require('mongoose-paginate-v2');
+import { Router, Request, Response } from 'express';
+
+//#region Test Models
+interface User extends Document {
+    email: string;
+    username: string;
+    password: string;
+}
+
+const UserSchema: Schema = new Schema({
+    email: String,
+    username: String,
+    password: String,
+});
+
+UserSchema.plugin(mongoosePaginate);
+
+interface UserModel<T extends Document> extends PaginateModel<T> { }
+
+const UserModel: UserModel<User> = model<User>('User', UserSchema) as UserModel<User>;
+//#endregion
+
+//#region Test Paginate
+const router: Router = Router();
+
+router.get('/users.json', (req: Request, res: Response) => {
+    const descending = true;
+    const options: PaginateOptions = {};
+    options.select = 'email username';
+    options.sort = { username: descending ? -1 : 1 };
+    options.collation = { locale: 'en_US', strength: 1 };
+    options.pagination = false;
+    options.populate = '';
+    options.populate = {
+        path: '',
+    };
+    options.lean = true;
+    options.leanWithId = false;
+    options.offset = 0;
+    options.page = 1;
+    options.limit = 10;
+    options.customLabels = {
+        totalDocs: 'totalDocsCustom',
+        limit: 'limitCustom',
+        page: 'pageCustom',
+        totalPages: 'totalPagesCustom',
+        docs: 'docsCustom',
+        nextPage: 'nextPageCustom',
+        prevPage: 'prevPageCustom',
+    };
+    options.projection = { _id: 0 };
+    options.options = { batchSize: 200 };
+
+    UserModel.paginate({}, options, (err: any, value: PaginateResult<User>) => {
+        if (err) {
+            console.log(err);
+            return res.status(500).send(err);
+        }
+
+        console.log('totalDocs: ' + value.totalDocsCustom);
+        console.log('limit: ' + value.limitCustom);
+        console.log('page: ' + value.pageCustom);
+        console.log('nextPage: ' + value.nextPageCustom);
+        console.log('prevPage: ' + value.prevPageCustom);
+        console.log('totalPages: ' + value.totalPagesCustom);
+        console.log('offset: ' + value.offset);
+        console.log('docs: ');
+        console.dir(value.docsCustom);
+        return res.json(value);
+    });
+});
+//#endregion

--- a/types/mongoose-aggregate-paginate-v2/tsconfig.json
+++ b/types/mongoose-aggregate-paginate-v2/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mongoose-paginate-v2-tests.ts"
+    ]
+}

--- a/types/mongoose-aggregate-paginate-v2/tsconfig.json
+++ b/types/mongoose-aggregate-paginate-v2/tsconfig.json
@@ -18,6 +18,6 @@
     },
     "files": [
         "index.d.ts",
-        "mongoose-paginate-v2-tests.ts"
+        "mongoose-aggregate-paginate-v2-tests.ts"
     ]
 }

--- a/types/mongoose-aggregate-paginate-v2/tslint.json
+++ b/types/mongoose-aggregate-paginate-v2/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
…paginate-v2)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Because the two plugins are similar, I copied the definition from mongoose-paginate-v2 in a seperate commit to keep track of the changes. I used a suggested file found in an issue in the package at https://github.com/aravindnc/mongoose-aggregate-paginate-v2/issues/15 (Credits to @knyuwork and @tuliren for the suggestions), but I also did compare the changes with mongoose-paginate-v2's definition and the current state of the package.