### PR TITLE
Add type definitions for videojs-hotkeys

### DIFF
--- a/types/videojs-hotkeys/index.d.ts
+++ b/types/videojs-hotkeys/index.d.ts
@@ -7,7 +7,7 @@ import { VideoJsPlayer } from 'video.js';
 
 declare module 'video.js' {
     interface VideoJsPlayer {
-        hotkeys(options: VideoJsHotkeysOptions): void;
+        hotkeys(options?: VideoJsHotkeysOptions): void;
     }
 }
 

--- a/types/videojs-hotkeys/index.d.ts
+++ b/types/videojs-hotkeys/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for videojs-hotkeys 0.1
+// Type definitions for videojs-hotkeys 0.2
 // Project: https://github.com/ctd1500/videojs-hotkeys
 // Definitions by: James Cote <https://github.com/Coteh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/videojs-hotkeys/index.d.ts
+++ b/types/videojs-hotkeys/index.d.ts
@@ -1,0 +1,46 @@
+// Type definitions for videojs-hotkeys 0.1
+// Project: https://github.com/ctd1500/videojs-hotkeys
+// Definitions by: James Cote <https://github.com/Coteh>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { VideoJsPlayer } from 'video.js';
+
+declare module 'video.js' {
+    interface VideoJsPlayer {
+        hotkeys(options: VideoJsHotkeysOptions): void;
+    }
+}
+
+export interface VideoJsHotkeysOptions {
+    volumeStep?: number;
+    seekStep?: number;
+    enableMute?: boolean;
+    enableVolumeScroll?: boolean;
+    enableHoverScroll?: boolean;
+    enableFullscreen?: boolean;
+    enableNumbers?: boolean;
+    enableModifiersForNumbers?: boolean;
+    alwaysCaptureHotkeys?: boolean;
+    enableInactiveFocus?: boolean;
+    skipInitialFocus?: boolean;
+    captureDocumentHotkeys?: boolean;
+    documentHotkeysFocusElementFilter?: (element: HTMLElement) => boolean;
+    enableJogStyle?: boolean;
+    playPauseKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
+    rewindKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
+    forwardKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
+    volumeUpKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
+    volumeDownKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
+    muteKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
+    fullscreenKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
+    customKeys?: VideoJsCustomHotkeyOptions;
+}
+
+export interface VideoJsCustomHotkeyOptions {
+    [key: string]: VideoJsCustomHotkey;
+}
+
+export interface VideoJsCustomHotkey {
+    key: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
+    handler: (player: VideoJsPlayer, options: VideoJsHotkeysOptions, event: KeyboardEvent) => void;
+}

--- a/types/videojs-hotkeys/tsconfig.json
+++ b/types/videojs-hotkeys/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "videojs-hotkeys-tests.ts"
+    ]
+}

--- a/types/videojs-hotkeys/tslint.json
+++ b/types/videojs-hotkeys/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/videojs-hotkeys/videojs-hotkeys-tests.ts
+++ b/types/videojs-hotkeys/videojs-hotkeys-tests.ts
@@ -1,0 +1,45 @@
+import videojs from 'video.js';
+
+const video = videojs('myvideo', {
+    autoplay: true,
+});
+
+video.ready(function () {
+    this.hotkeys({
+        volumeStep: 0.1,
+        seekStep: 1,
+        enableMute: false,
+        enableVolumeScroll: true,
+        enableHoverScroll: true,
+        enableFullscreen: true,
+        enableNumbers: false,
+        enableModifiersForNumbers: false,
+        alwaysCaptureHotkeys: false,
+        enableInactiveFocus: false,
+        skipInitialFocus: false,
+        captureDocumentHotkeys: false,
+        documentHotkeysFocusElementFilter: (e: HTMLElement) => e.tagName === 'main',
+        enableJogStyle: false,
+        playPauseKey: (e: KeyboardEvent) => e.key === 'f',
+        rewindKey: (e: KeyboardEvent) => e.key === 'f',
+        forwardKey: (e: KeyboardEvent) => e.key === 'f',
+        volumeUpKey: (e: KeyboardEvent) => e.key === 'f',
+        volumeDownKey: (e: KeyboardEvent) => e.key === 'f',
+        muteKey: (e: KeyboardEvent) => e.key === 'f',
+        fullscreenKey: (event, player) => {
+            return !player.isFullscreen() && (event.key === 'F' || (event.ctrlKey && event.key === 'Enter'));
+        },
+        customKeys: {
+            ctrldKey: {
+                key: event => {
+                    return event.ctrlKey && event.key === 'D';
+                },
+                handler: (player, options, event) => {
+                    if (options.enableMute && event.shiftKey) {
+                        player.muted(!player.muted());
+                    }
+                },
+            },
+        },
+    });
+});

--- a/types/videojs-hotkeys/videojs-hotkeys-tests.ts
+++ b/types/videojs-hotkeys/videojs-hotkeys-tests.ts
@@ -4,7 +4,7 @@ const video = videojs('myvideo', {
     autoplay: true,
 });
 
-video.ready(function () {
+video.ready(function() {
     this.hotkeys({
         volumeStep: 0.1,
         seekStep: 1,


### PR DESCRIPTION
https://github.com/ctd1500/videojs-hotkeys

This package is missing definitions which forces TypeScript users to cast videojs player as `any` when referring to the plugin. See https://joeflateau.net/posts/video-js-heart-typescript for more information.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
