### PR TITLE
Fix the type of `_`

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -632,7 +632,7 @@ declare namespace yargs {
 
     type Arguments<T = {}> = T & {
         /** Non-option arguments */
-        _: string[];
+        _: Array<string | number>;
         /** The script name or node command */
         $0: string;
         /** All remaining options */

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -131,19 +131,19 @@ function Argv$parsing() {
     const argv4 = yargs();
     console.log(argv1.x, argv2.x, argv3.x, argv4.x);
 
-    // $ExpectType { [x: string]: unknown; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; _: (string | number)[]; $0: string; }
     yargs.parse();
 
-    // $ExpectType { [x: string]: unknown; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; _: (string | number)[]; $0: string; }
     yargs([]).argv;
 
-    // $ExpectType { [x: string]: unknown; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; _: (string | number)[]; $0: string; }
     yargs.argv;
 
-    // $ExpectType { [x: string]: unknown; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; _: (string | number)[]; $0: string; }
     yargs();
 
-    // $ExpectType { [x: string]: unknown; update: boolean | undefined; extern: boolean | undefined; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; update: boolean | undefined; extern: boolean | undefined; _: (string | number)[]; $0: string; }
     yargs(['--update'])
         .boolean('update')
         .boolean('extern')
@@ -440,7 +440,7 @@ function Argv$commandModule() {
 
     const commandArgs = builder(yargs).argv;
 
-    // $ExpectType: { [x: string]: unknown; file: unknown; cleanDestination: boolean | undefined; _: string[]; $0: string; }
+    // $ExpectType: { [x: string]: unknown; file: unknown; cleanDestination: boolean | undefined; _: (string | number)[]; $0: string; }
     commandArgs;
 
     // Backwards compatibility with older types
@@ -931,7 +931,7 @@ type Stage = 1 | 2 | 3 | 4;
 const stages: ReadonlyArray<Stage> = [1, 2, 3, 4];
 
 function Argv$inferOptionTypes() {
-    // $ExpectType { [x: string]: unknown; a: (string | number)[] | undefined; b: boolean | undefined; c: number; n: number | undefined; s: string | undefined; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; a: (string | number)[] | undefined; b: boolean | undefined; c: number; n: number | undefined; s: string | undefined; _: (string | number)[]; $0: string; }
     yargs
         .option("a", { type: "array" })
         .option("b", { type: "boolean" })
@@ -940,14 +940,14 @@ function Argv$inferOptionTypes() {
         .option("s", { type: "string" })
         .argv;
 
-    // $ExpectType { [x: string]: unknown; a: number; b: boolean; c: string; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; a: number; b: boolean; c: string; _: (string | number)[]; $0: string; }
     yargs
         .option("a", { default: 42 })
         .option("b", { default: false })
         .option("c", { default: "tmp" })
         .argv;
 
-    // $ExpectType { [x: string]: unknown; a: (string | number)[] | undefined; b: boolean | undefined; n: number | undefined; s: string | undefined; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; a: (string | number)[] | undefined; b: boolean | undefined; n: number | undefined; s: string | undefined; _: (string | number)[]; $0: string; }
     yargs
         .option("a", { array: true })
         .option("b", { boolean: true })
@@ -955,7 +955,7 @@ function Argv$inferOptionTypes() {
         .option("s", { string: true })
         .argv;
 
-    // $ExpectType { [x: string]: unknown; choices: Color; numberChoices: Stage; coerce: Date | undefined; count: number; normalize: string | undefined; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; choices: Color; numberChoices: Stage; coerce: Date | undefined; count: number; normalize: string | undefined; _: (string | number)[]; $0: string; }
     yargs
         .option("choices", { choices: colors, required: true })
         .option("numberChoices", { choices: stages, demandOption: true })
@@ -1008,22 +1008,22 @@ function Argv$inferRequiredOptionTypes() {
     // $ExpectType string | undefined
     yargs.string("x").demandOption("x", false).argv.x;
 
-    // $ExpectType { [x: string]: unknown; x: string; y: number; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; x: string; y: number; _: (string | number)[]; $0: string; }
     yargs.string("x").number("y").demandOption(["x", "y"]).argv;
 
-    // $ExpectType { [x: string]: unknown; x: string; y: number; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; x: string; y: number; _: (string | number)[]; $0: string; }
     yargs.string("x").number("y").demandOption(["x", "y"], true).argv;
 
-    // $ExpectType { [x: string]: unknown; x: string | undefined; y: number | undefined; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; x: string | undefined; y: number | undefined; _: (string | number)[]; $0: string; }
     yargs.string("x").number("y").demandOption(["x", "y"], false).argv;
 
-    // $ExpectType { [x: string]: unknown; x: string; y: number; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; x: string; y: number; _: (string | number)[]; $0: string; }
     yargs.demandOption(["x", "y"]).string("x").number("y").argv;
 
-    // $ExpectType { [x: string]: unknown; x: string; y: number; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; x: string; y: number; _: (string | number)[]; $0: string; }
     yargs.demandOption(["x", "y"], true).string("x").number("y").argv;
 
-    // $ExpectType { [x: string]: unknown; x: string | undefined; y: number | undefined; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; x: string | undefined; y: number | undefined; _: (string | number)[]; $0: string; }
     yargs.demandOption(["x", "y"], false).string("x").number("y").argv;
 
     // $ExpectType string
@@ -1052,32 +1052,32 @@ function Argv$inferRequiredOptionTypes() {
 }
 
 function Argv$inferMultipleOptionTypes() {
-    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; }
     yargs
         .option({ a: { default: "a" }, b: { default: false } })
         .number(["c", "d", "e"])
         .demandOption(["c", "d", "e"])
         .argv;
 
-    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; }
     yargs
         .options({ a: { default: "a" }, b: { default: false } })
         .number(["c", "d", "e"])
         .demandOption(["c", "d", "e"])
         .argv;
 
-    // $ExpectType { [x: string]: unknown; a: number; b: string; c: boolean; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; a: number; b: string; c: boolean; _: (string | number)[]; $0: string; }
     yargs
         .default({ a: 42, b: "b", c: false })
         .argv;
 
-    // $ExpectType { [x: string]: unknown; a: number; b: string; c: Date; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; a: number; b: string; c: Date; _: (string | number)[]; $0: string; }
     yargs
         .coerce({ a: Date.parse, b: String.prototype.toLowerCase, c: (s: string) => new Date(s) })
         .demandOption(["a", "b", "c"])
         .argv;
 
-    // $ExpectType { [x: string]: unknown; a: number; b: string[]; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; a: number; b: string[]; _: (string | number)[]; $0: string; }
     yargs
         .options({
             a: {
@@ -1091,7 +1091,7 @@ function Argv$inferMultipleOptionTypes() {
         })
         .argv;
 
-    // $ExpectType { [x: string]: unknown; a: number | undefined; b: string | undefined; c: Color; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; a: number | undefined; b: string | undefined; c: Color; _: (string | number)[]; $0: string; }
     yargs
         .choices({ a: [1, 2, 3], b: ["black", "white"], c: colors })
         .demandOption("c")
@@ -1099,20 +1099,20 @@ function Argv$inferMultipleOptionTypes() {
 }
 
 function Argv$inferOptionTypesForAliases() {
-    // $ExpectType { [x: string]: unknown; u: string | undefined; url: string | undefined; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; u: string | undefined; url: string | undefined; _: (string | number)[]; $0: string; }
     yargs
         .option("u", { type: "string" })
         .alias("u", "url")
         .argv;
 
-    // $ExpectType { [x: string]: unknown; v: boolean; loud: boolean; noisy: boolean; verbose: boolean; n: boolean; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; v: boolean; loud: boolean; noisy: boolean; verbose: boolean; n: boolean; _: (string | number)[]; $0: string; }
     yargs
         .option("v", { default: false })
         .alias("v", ["loud", "noisy", "verbose"])
         .alias("n", "noisy")
         .argv;
 
-    // $ExpectType { [x: string]: unknown; n: number; count: number; num: number; _: string[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; n: number; count: number; num: number; _: (string | number)[]; $0: string; }
     yargs
         .option("n", { number: true, demandOption: true })
         .alias("n", "count")


### PR DESCRIPTION
The default converts number-looking arguments to numbers.

(It would be nice if yargs' `.string("_")` would just throw an error rather than getting a bogus type, but that's not for here.)
