### PR TITLE
Mocha: Add global setup/teardown methods

### DIFF
--- a/types/mocha/index.d.ts
+++ b/types/mocha/index.d.ts
@@ -667,6 +667,62 @@ declare namespace Mocha {
     let test: TestFunction;
 
     /**
+     * Configures one or more global setup fixtures.
+     * If given no parameters, unsets any previously-set fixtures.
+     *
+     * - _Only available when invoked via the mocha CLI._
+     *
+     * @see https://mochajs.org/api/mocha#globalSetup
+     */
+    let globalSetup: Mocha.HookFunction;
+
+    /**
+     * Configures one or more global teardown fixtures.
+     * If given no parameters, unsets any previously-set fixtures.
+     *
+     * - _Only available when invoked via the mocha CLI._
+     *
+     * @see https://mochajs.org/api/mocha#globalTeardown
+     */
+    let globalTeardown: Mocha.HookFunction;
+
+    /**
+     * Returns `true` if one or more global setup fixtures have been supplied
+     *
+     * - _Only available when invoked via the mocha CLI._
+     *
+     * @see https://mochajs.org/api/mocha#hasGlobalSetupFixtures
+     */
+    let hasGlobalSetupFixtures: () => boolean;
+
+    /**
+     * Returns `true` if one or more global teardown fixtures have been supplied
+     *
+     * - _Only available when invoked via the mocha CLI._
+     *
+     * @see https://mochajs.org/api/mocha#hasGlobalTeardownFixtures
+     */
+    let hasGlobalTeardownFixtures: () => boolean;
+
+    /**
+     * Toggle execution of any global setup fixture(s)
+     *
+     * - _Only available when invoked via the mocha CLI._
+     *
+     * @see https://mochajs.org/api/mocha#enableGlobalSetup
+     */
+    let enableGlobalSetup: (enabled: boolean) => void;
+
+    /**
+     * Toggle execution of any global teardown fixture(s)
+     *
+     * - _Only available when invoked via the mocha CLI._
+     *
+     * @see https://mochajs.org/api/mocha#enableGlobalTeardown
+     */
+    let enableGlobalTeardown: (enabled: boolean) => void;
+
+    /**
      * Triggers root suite execution.
      *
      * - _Only available if flag --delay is passed into Mocha._


### PR DESCRIPTION
These methods were introduced in v8.2.0 See the changelog:

https://github.com/mochajs/mocha/blob/master/CHANGELOG.md

And also the documentation: https://mochajs.org/api/module-interfaces_common.html

This PR is not quite ready to be merged. I need to tick the rest of the boxes.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
