### PR TITLE
[dom-parser] Fix signature for getElementsByAttribute

### DIFF
--- a/types/dom-parser/dom-parser-tests.ts
+++ b/types/dom-parser/dom-parser-tests.ts
@@ -11,7 +11,7 @@ const element = dom.getElementById('one'); // $ExpectType Node | null
 dom.getElementsByClassName('myclass'); // $ExpectType Node[] | null
 dom.getElementsByTagName('div'); // $ExpectType Node[] | null
 dom.getElementsByName('somenonexistentname'); // $ExpectType Node[] | null
-dom.getElementsByAttribute('nonexistentattr'); // $ExpectType Node[] | null
+dom.getElementsByAttribute('nonexistentattr', 'nonexistentvalue'); // $ExpectType Node[] | null
 
 if (element) {
     element.getAttribute('madeupattr'); // $ExpectType string | null

--- a/types/dom-parser/index.d.ts
+++ b/types/dom-parser/index.d.ts
@@ -16,7 +16,7 @@ declare namespace DomParser {
         getElementsByName(name: string): Node[] | null;
         getElementById(id: string): Node | null;
 
-        getElementsByAttribute(attribute: string): Node[] | null;
+        getElementsByAttribute(attr: string, value: string): Node[] | null;
     }
 
     interface Node extends DOMSearchable {


### PR DESCRIPTION
Adding to the great work from @gbidkar The signature for getElementsByAttribute was incorrect, have added the second parameter - see:
https://github.com/ershov-konst/dom-parser/blob/22fc84ab2c8958c4dd144c9b4c8b95e796cdb89a/lib/Dom.js#L135

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/ershov-konst/dom-parser/blob/22fc84ab2c8958c4dd144c9b4c8b95e796cdb89a/lib/Dom.js#L135
- [ ] **N/A** If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] **N/A** If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
