### PR TITLE
[bootstrap] fix options for bootstrap's tooltip/popover

### DIFF
--- a/types/bootstrap/bootstrap-tests.ts
+++ b/types/bootstrap/bootstrap-tests.ts
@@ -228,7 +228,7 @@ element.addEventListener(Toast.Events.shown, event => {
  */
 
 // $ExpectType Tooltip
-const tooltip = new Tooltip(element);
+const tooltip = new Tooltip(element, { delay: 0.5, title: () => "foo" });
 
 // $ExpectType Tooltip
 const instanceTooltip = Tooltip.getInstance(element);

--- a/types/bootstrap/js/dist/popover.d.ts
+++ b/types/bootstrap/js/dist/popover.d.ts
@@ -122,7 +122,7 @@ declare namespace Popover {
          *
          * @default ''
          */
-        content: string | Element | (() => void);
+        content: string | Element | ((this: HTMLElement) => string);
 
         /**
          * Delay showing and hiding the popover (ms) - does not apply to manual
@@ -188,7 +188,7 @@ declare namespace Popover {
          *
          * @default ''
          */
-        title: string | Element | (() => void);
+        title: string | Element | ((this: HTMLElement) => string);
 
         /**
          * How popover is triggered - click | hover | focus | manual. You may

--- a/types/bootstrap/js/dist/tooltip.d.ts
+++ b/types/bootstrap/js/dist/tooltip.d.ts
@@ -1,7 +1,7 @@
 import * as Popper from 'popper.js';
 
 declare class Tooltip {
-    constructor(element: Element);
+    constructor(element: Element, options?: Partial<Tooltip.Options>);
 
     /**
      * Reveals an element’s tooltip. Returns to the caller before the
@@ -180,7 +180,7 @@ declare namespace Tooltip {
          *
          * @default ''
          */
-        title: string | Element | (() => void);
+        title: string | Element | ((this: HTMLElement) => string);
 
         /**
          * How tooltip is triggered - click | hover | focus | manual. You may


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see https://getbootstrap.com/docs/4.5/components/popovers/#options and https://getbootstrap.com/docs/4.5/components/tooltips/#options or for the source https://github.com/twbs/bootstrap/blob/04674f88b0a2f7ad21bbe36a8d18b08357c8eafa/js/src/tooltip.js#L128
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. This is a bug fix.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
