### PR TITLE
[@types/numeral] fix numeral.isNumeral() type

### DIFF
--- a/types/numeral/index.d.ts
+++ b/types/numeral/index.d.ts
@@ -55,7 +55,7 @@ type RegisterType = 'format' | 'locale';
 interface Numeral {
     (value?: any): Numeral;
     version: string;
-    isNumeral(value?: any): boolean;
+    isNumeral(value: any): boolean;
     options: NumeralJSOptions;
 
     /**

--- a/types/numeral/index.d.ts
+++ b/types/numeral/index.d.ts
@@ -55,7 +55,7 @@ type RegisterType = 'format' | 'locale';
 interface Numeral {
     (value?: any): Numeral;
     version: string;
-    isNumeral: boolean;
+    isNumeral(value?: any): boolean;
     options: NumeralJSOptions;
 
     /**

--- a/types/numeral/numeral-tests.ts
+++ b/types/numeral/numeral-tests.ts
@@ -109,6 +109,5 @@ numeral(50).format('0%')
 // '50%'
 
 // test isNumeral
-numeral.isNumeral();
 numeral.isNumeral(numeral(1000));
 numeral.isNumeral(1000);

--- a/types/numeral/numeral-tests.ts
+++ b/types/numeral/numeral-tests.ts
@@ -107,3 +107,8 @@ const ordinalResult = localeData.ordinal(2)
 numeral.options.scalePercentBy100 = false
 numeral(50).format('0%')
 // '50%'
+
+// test isNumeral
+numeral.isNumeral();
+numeral.isNumeral(numeral(1000));
+numeral.isNumeral(1000);


### PR DESCRIPTION
`numeral.isNumeral()` is wrongly typed a `boolean` while it's `(?: any): boolean`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  https://github.com/adamwdraper/Numeral-js/blob/7de892ffb438af6e63b9c4f6aff0c9bc3932f09f/src/numeral.js#L97
  https://github.com/adamwdraper/Numeral-js/blob/7de892ffb438af6e63b9c4f6aff0c9bc3932f09f/tests/numeral.js#L121
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.





