### PR TITLE
feat: Add `is‑arguments`

### DIFF
--- a/types/is-arguments/index.d.ts
+++ b/types/is-arguments/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for is-arguments 1.0
+// Project: https://github.com/ljharb/is-arguments
+// Definitions by: Jordan Harband <https://github.com/ljharb>
+//                 ExE Boss <https://github.com/ExE-Boss>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = isArguments;
+
+/**
+ * This function determines whether `value` is an `arguments` object.
+ *
+ * **Caveats:** If you have modified an actual `arguments` object by giving
+ * it a `Symbol.toStringTag` property, then this function will return `false`.
+ */
+declare function isArguments(value: unknown): value is IArguments;

--- a/types/is-arguments/is-arguments-tests.ts
+++ b/types/is-arguments/is-arguments-tests.ts
@@ -1,0 +1,7 @@
+import isArguments = require('is-arguments');
+
+(value: unknown) => {
+    if (isArguments(value)) {
+        value; // $ExpectType IArguments
+    }
+};

--- a/types/is-arguments/tsconfig.json
+++ b/types/is-arguments/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["ES5"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "is-arguments-tests.ts",
+        "index.d.ts"
+    ]
+}

--- a/types/is-arguments/tslint.json
+++ b/types/is-arguments/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
