### PR TITLE
@types/node: stream.pipeline() should accept iterators since Node 13.10

### DIFF
--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -302,7 +302,11 @@ declare module 'stream' {
             function __promisify__(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, options?: FinishedOptions): Promise<void>;
         }
 
-        function pipeline<T extends NodeJS.WritableStream>(stream1: NodeJS.ReadableStream, stream2: T, callback?: (err: NodeJS.ErrnoException | null) => void): T;
+        function pipeline<T extends NodeJS.WritableStream>(
+            stream1: NodeJS.ReadableStream | Iterable<any> | AsyncIterable<any>,
+            stream2: T,
+            callback?: (err: NodeJS.ErrnoException | null) => void
+        ): T;
         function pipeline<T extends NodeJS.WritableStream>(stream1: NodeJS.ReadableStream, stream2: NodeJS.ReadWriteStream, stream3: T, callback?: (err: NodeJS.ErrnoException | null) => void): T;
         function pipeline<T extends NodeJS.WritableStream>(
             stream1: NodeJS.ReadableStream,

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -173,6 +173,19 @@ function streamPipelineFinished() {
     pipeline(process.stdin, process.stdout, (err?: Error | null) => {});
 }
 
+function pipelineIterator() {
+    const iterator = ['foo', 'bar'];
+    pipeline(iterator, process.stdout, (err?: Error | null) => {});
+}
+
+function pipelineAsyncIterator() {
+    const asyncGenerator = async function*() {
+        yield 'foo';
+        yield 'bar';
+    };
+    pipeline(asyncGenerator(), process.stdout, (err?: Error | null) => {});
+}
+
 async function asyncStreamPipelineFinished() {
     const fin = promisify(finished);
     await fin(process.stdin);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/stream.html#stream_stream_pipeline_source_transforms_destination_callback
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
- [x] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.~~
