### PR TITLE
Added Promise-based API overload for blueimp-load-image.

### DIFF
--- a/types/blueimp-load-image/blueimp-load-image-tests.ts
+++ b/types/blueimp-load-image/blueimp-load-image-tests.ts
@@ -30,3 +30,13 @@ loadImage(imageUrlJPEG, (image: Event | HTMLCanvasElement | HTMLImageElement, da
     console.log(url);
   });
 }, {canvas: true, orientation: true, maxWidth: 100, maxHeight: 100, crop: true});
+
+loadImage(imageUrlJPEG, { canvas: true, orientation: true, maxWidth: 100, maxHeight: 100, crop: true }).then(data => {
+  const { image } = data;
+  const canvas = image as HTMLCanvasElement;
+  console.log(data);
+  canvas.toBlob((blob: Blob | null): void => {
+    const url = canvas.toDataURL('image/png');
+    console.log(url);
+  });
+});

--- a/types/blueimp-load-image/index.d.ts
+++ b/types/blueimp-load-image/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for blueimp-load-image 2.23
+// Type definitions for blueimp-load-image 5.14
 // Project: https://github.com/blueimp/JavaScript-Load-Image
 // Definitions by: Evan Kesten <https://github.com/ebk46>
 //                 Konstantin Lukaschenko <https://github.com/KonstantinLukaschenko>

--- a/types/blueimp-load-image/index.d.ts
+++ b/types/blueimp-load-image/index.d.ts
@@ -6,9 +6,12 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace loadImage {
-    type LoadImageCallback = (eventOrImage: Event | HTMLCanvasElement | HTMLImageElement, data?: MetaData) => void;
-
+    type EventOrImage = Event | HTMLCanvasElement | HTMLImageElement;
+    type LoadImageCallback = (eventOrImage: EventOrImage, data?: MetaData) => void;
     type ParseMetaDataCallback = (data: ImageHead) => void;
+    interface PromiseApiResolveArg extends MetaData {
+        image: EventOrImage;
+    }
 
     interface Exif {
         [tag: number]: number | string | string[];
@@ -99,11 +102,15 @@ declare namespace loadImage {
 }
 
 // loadImage is implemented as a callable object.
-interface LoadImage  {
+interface LoadImage {
     (file: File | Blob | string, callback: loadImage.LoadImageCallback, options: loadImage.LoadImageOptions):
         | HTMLImageElement
         | FileReader
         | false;
+
+    (file: File | Blob | string, options: loadImage.LoadImageOptions): Promise<
+        loadImage.PromiseApiResolveArg
+    >;
 
     // Parses image meta data and calls the callback with the image head
     parseMetaData: (


### PR DESCRIPTION
[`blueimp-load-image`](https://github.com/blueimp/JavaScript-Load-Image/#promise) has a Promise-based API that was [previously missing from its type definition](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/blueimp-load-image/index.d.ts#L103). I've gone ahead and added the definitions for that in this PR.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/blueimp/JavaScript-Load-Image/#promise
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.