### PR TITLE
[@types/express-serve-static-core] Update IRouterHandler to allow request generics

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -71,8 +71,10 @@ export interface IRouterMatcher<T, Method extends 'all' | 'get' | 'post' | 'put'
 }
 
 export interface IRouterHandler<T> {
-    (...handlers: RequestHandler[]): T;
-    (...handlers: RequestHandlerParams[]): T;
+  // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
+  <P = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = ParsedQs>(...handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery>>): T;
+  // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
+  <P = ParamsDictionary, ResBody = any, ReqBody = any, ReqQuery = ParsedQs>(...handlers: Array<RequestHandlerParams<P, ResBody, ReqBody, ReqQuery>>): T;
 }
 
 export interface IRouter extends RequestHandler {


### PR DESCRIPTION
`IRouterHandler` is not currently correctly allowing generics to be passed. Based on my understanding it should be similarly typed as `IRouterMatcher`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Leithal3/DefinitelyTyped/blob/bef3e060cebe3f8f99f192b2cbdd3bd11b2d44cf/types/express-serve-static-core/index.d.ts#L67
https://github.com/Leithal3/DefinitelyTyped/blob/bef3e060cebe3f8f99f192b2cbdd3bd11b2d44cf/types/express-serve-static-core/index.d.ts#L75
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
