### PR TITLE
[node] clarify typings of Buffer.from in implicit coercion case

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -73,6 +73,8 @@ declare var exports: any;
 // Buffer class
 type BufferEncoding = "ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" | "ucs-2" | "base64" | "latin1" | "binary" | "hex";
 
+type WithImplicitCoercion<T> = T | { valueOf(): T };
+
 /**
  * Raw data is stored in instances of the Buffer class.
  * A Buffer is similar to an array of integers but corresponds to a raw memory allocation outside the V8 heap.  A Buffer cannot be resized.
@@ -132,25 +134,19 @@ declare class Buffer extends Uint8Array {
      *
      * @param arrayBuffer The .buffer property of any TypedArray or a new ArrayBuffer()
      */
-    static from(arrayBuffer: ArrayBuffer | SharedArrayBuffer, byteOffset?: number, length?: number): Buffer;
+    static from(arrayBuffer: WithImplicitCoercion<ArrayBuffer | SharedArrayBuffer>, byteOffset?: number, length?: number): Buffer;
     /**
      * Creates a new Buffer using the passed {data}
      * @param data data to create a new Buffer
      */
-    static from(data: ReadonlyArray<number>): Buffer;
-    static from(data: Uint8Array): Buffer;
-    /**
-     * Creates a new buffer containing the coerced value of an object
-     * A `TypeError` will be thrown if {obj} has not mentioned methods or is not of other type appropriate for `Buffer.from()` variants.
-     * @param obj An object supporting `Symbol.toPrimitive` or `valueOf()`.
-     */
-    static from(obj: { valueOf(): string | object } | { [Symbol.toPrimitive](hint: 'string'): string }, byteOffset?: number, length?: number): Buffer;
+    static from(data: Uint8Array | ReadonlyArray<number>): Buffer;
+    static from(data: WithImplicitCoercion<Uint8Array | ReadonlyArray<number> | string>): Buffer;
     /**
      * Creates a new Buffer containing the given JavaScript string {str}.
      * If provided, the {encoding} parameter identifies the character encoding.
      * If not provided, {encoding} defaults to 'utf8'.
      */
-    static from(str: string, encoding?: BufferEncoding): Buffer;
+    static from(str: WithImplicitCoercion<string> | { [Symbol.toPrimitive](hint: 'string'): string }, encoding?: BufferEncoding): Buffer;
     /**
      * Creates a new Buffer using the passed {data}
      * @param values to create a new Buffer

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -43,7 +43,7 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     // Array
     const buf1: Buffer = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72] as ReadonlyArray<number>);
     // Buffer
-    const buf2: Buffer = Buffer.from(buf1);
+    const buf2: Buffer = Buffer.from(buf1, 1, 2);
     // String
     const buf3: Buffer = Buffer.from('this is a tést');
     // ArrayBuffer
@@ -56,6 +56,8 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     const buf6: Buffer = Buffer.from(buf1);
     const sb: SharedArrayBuffer = {} as any;
     const buf7: Buffer = Buffer.from(sb);
+    // $ExpectError
+    Buffer.from({});
 }
 
 // Class Method: Buffer.from(arrayBuffer[, byteOffset[, length]])
@@ -67,11 +69,31 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     let buf: Buffer;
     buf = Buffer.from(arr.buffer, 1);
     buf = Buffer.from(arr.buffer, 0, 1);
+
+    // $ExpectError
+    Buffer.from("this is a test", 1, 1);
+    // Ideally passing a normal Buffer would be a type error too, but it's not
+    //  since Buffer is assignable to ArrayBuffer currently
 }
 
 // Class Method: Buffer.from(str[, encoding])
 {
     const buf2: Buffer = Buffer.from('7468697320697320612074c3a97374', 'hex');
+    // $ExpectError
+    Buffer.from(buf2, 'hex');
+}
+
+// Class Method: Buffer.from(object, [, byteOffset[, length]])  (Implicit coercion)
+{
+    const pseudoBuf = { valueOf() { return Buffer.from([1, 2, 3]); } };
+    let buf: Buffer = Buffer.from(pseudoBuf);
+    const pseudoString = { valueOf() { return "Hello"; }};
+    buf = Buffer.from(pseudoString);
+    buf = Buffer.from(pseudoString, "utf-8");
+    // $ExpectError
+    Buffer.from(pseudoString, 1, 2);
+    const pseudoArrayBuf = { valueOf() { return new Uint16Array(2); } };
+    buf = Buffer.from(pseudoArrayBuf, 1, 1);
 }
 
 // Class Method: Buffer.alloc(size[, fill[, encoding]])

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -79,6 +79,8 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
 // Class Method: Buffer.from(str[, encoding])
 {
     const buf2: Buffer = Buffer.from('7468697320697320612074c3a97374', 'hex');
+    /* tslint:disable-next-line no-construct */
+    Buffer.from(new String("DEADBEEF"), "hex");
     // $ExpectError
     Buffer.from(buf2, 'hex');
 }


### PR DESCRIPTION
#42111 added an overload corresponding to the `Buffer.from(object, [offsetOrEncoding, [length]])` [signature for constructing buffers](https://nodejs.org/dist/latest-v15.x/docs/api/buffer.html#buffer_static_method_buffer_from_object_offsetorencoding_length).  I think the implementation of this signature leaves a little to be desired, particularly, it allowed for invalid/useless arguments:

```ts
Buffer.from("foo", 1, 1); // The offset and length arguments are meaningless when the first argument isn't an ArrayBuffer
Buffer.from({}); // Allowed because the type accepts { valueOf(): object }... which seems to be `object` with extra steps.
```

And disallowed valid (if weird) calls, like:

```ts
Buffer.from(new String("DEADBEEF"), "hex");
```

To fix this, rather than having the implicit coercion case be its own signature, I added implicit coercion options to all the other signatures.  

---

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v15.x/docs/api/buffer.html#buffer_static_method_buffer_from_object_offsetorencoding_length
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.