### PR TITLE
Add mjml-core package with initial typings

### DIFF
--- a/types/mjml-core/index.d.ts
+++ b/types/mjml-core/index.d.ts
@@ -1,49 +1,156 @@
-/**
- * An map of components available to be used in mjml
- */
-export const components: {[componentName: string]: Component | undefined};
+// Type definitions for mjml-core 4.7
+// Project: https://mjml.io
+// Definitions by: Ian Edington       <https://github.com/IanEdington>
+//                 aahoughton         <https://github.com/aahoughton>
+//                 marpstar           <https://github.com/marpstar>
+//                 eiskalteschatten   <https://github.com/eiskalteschatten>
+//                 emrah88            <https://github.com/emrah88>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-interface IInitialData {
-  attributes: IAttributes;
-  children: IInitialData[];
-  content: string;
-  context: {
-    add(attr: any, ...params: any[]): void;
-    addMediaQuery(className: any, unit: { parsedWidth: any; unit: any }): void;
-    addHeadStyle(identifier: any, headStyle: any): void;
-    addComponentHeadSyle(headStyle: any): void;
-    setBackgroundColor(color: string): void;
-    processing(node: any, context: any): void;
-  };
-  props: {};
-  globalAttributes: IAttributes;
+/**
+ * The main parser for MJML.
+ * This version doesn't contain any of the components registered in the 'mjml' package.
+ */
+export default function mjml2html(input: string | MJMLJsonObject, options?: MJMLParsingOptions): MJMLParseResults;
+
+/**
+ * Options passed as an object to the mjml2html function
+ * 
+ * https://documentation.mjml.io/#inside-node-js
+ */
+export interface MJMLParsingOptions {
+    /**
+     * Default fonts imported in the HTML rendered by HTML
+     * ie. { 'Open Sans': 'https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,700' }
+     * 
+     * default: @see https://github.com/mjmlio/mjml/blob/master/packages/mjml-core/src/index.js
+     */
+    fonts?: { [key: string]: string; };
+
+    /**
+     * Option to keep comments in the HTML output
+     * default: true
+     */
+    keepComments?: boolean;
+
+    /**
+     * @deprecated use js-beautify directly after processing the MJML
+     * 
+     * Option to beautify the HTML output
+     * default: false
+     */
+    beautify?: boolean;
+
+    /**
+     * @deprecated use html-minifier directly after processing the MJML
+     * 
+     * Option to minify the HTML output
+     * 
+     * default: false
+     */
+    minify?: boolean;
+    /**
+     * @deprecated @see minify
+     * 
+     * Options for html minifier, see mjml-cli documentation for more info
+     * Passed directly to html-minifier as options
+     * 
+     * default: @see htmlMinify usage in mjml-core/src/index.js
+     */
+    minifyOptions?: MJMLMinifyOptions;
+
+    /**
+     * How to validate your MJML
+     *
+     * skip: your document is rendered without going through validation
+     * soft: your document is going through validation and is rendered, even if it has errors
+     * strict: your document is going through validation and is not rendered if it has any error
+     *
+     * default: soft
+     */
+    validationLevel?: 'strict' | 'soft' | 'skip';
+
+    /**
+     * Full path of the specified file to use when resolving paths from mj-include components
+     * default: '.'
+     */
+    filePath?: string;
+    /**
+     * The path or directory of the .mjmlconfig file
+     * default: process.cwd()
+     **/
+    mjmlConfigPath?: string;
+
+    /**
+     * Use the config attribute defined in the .mjmlconfig file.
+     * The config passed into mjml2html overrides the .mjmlconfig.
+     * default: false
+     */
+    useMjmlConfigOptions?: boolean;
+
+    /**
+     * optional setting when inlining css, see mjml-cli documentation for more info
+     */
+    juicePreserveTags?: { [index: string]: { start: string; end: string } };
+    juiceOptions?: any;
+
+    /**
+     * undocumented
+     * a function returning html skeleton
+     * default: see mjml-core/src/helpers/skeleton.js
+     */
+    skeleton?: string | (() => string);
+
+    actualPath?: string;
+    /**
+     * undocumented
+     * ignore mj-include elements
+     * default: false
+     */
+    ignoreIncludes?: any;
+    /** see mjml-parser-xml */
+    preprocessors?: ((xml: string)=>string)[];
 }
 
-export function initComponent({ initialData, name }: { initialData: IInitialData; name: any }): any;
+export interface MJMLMinifyOptions {
+    collapseWhitespace?: boolean;
+    minifyCSS?: boolean;
+    removeEmptyAttributes?: boolean;
+}
+
+export interface MJMLParseResults {
+    html: string;
+    json: MJMLJsonObject;
+    errors: MJMLParseError[];
+}
+
+export interface MJMLParseError {
+    line: number;
+    message: string;
+    tagName: string;
+    formattedMessage: string;
+}
+
+export interface MJMLJsonObject {
+    tagName: string;
+    attributes: object;
+    children?: MJMLJsonObject[];
+    content?: string;
+}
+
+/**
+ * An map of elements to handling component available to be used in mjml
+ */
+export const components: {[componentName: string]: Component | undefined};
 
 /**
  * Registers a component for use in mjml
  */
-export function registerComponent(Component: Component): void;
-
-export function suffixCssClasses(classes: any, suffix: any): any;
-
-export function handleMjmlConfig(
-  configPathOrDir?: string,
-  registerCompFn?: typeof registerComponent
-):
-  | {
-      success: any[];
-      failures: any[];
-    }
-  | {
-      error: any;
-    };
-
-export function initializeType(typeConfig: any): any;
+export function registerComponent<T extends typeof Component>(Component: T): void;
 
 export abstract class BodyComponent extends Component {
-  constructor(initialData: IInitialData);
+
+  constructor(initialData: unknown);
 
   getStyles(): {};
 
@@ -71,23 +178,21 @@ export abstract class BodyComponent extends Component {
     options?: {
       props?: Component['props'];
       renderer?: (component: Component) => any;
-      attributes?: IAttributes;
+      attributes?: Record<string, string>;
       rawXML?: boolean;
     }
   ): string;
 }
 
 export abstract class HeadComponent extends Component {
-  constructor(initialData: IInitialData);
+  constructor(initialData: unknown);
 
   handlerChildren(): any;
+
+  render(): string;
 }
 
-export interface IAttributes {
-  [attribute: string]: string;
-}
-
-abstract class Component {
+declare abstract class Component {
   static getTagName(): any;
 
   static isRawElement(): boolean;
@@ -105,10 +210,10 @@ abstract class Component {
     sibling: number;
     nonRawSiblings: number;
   };
-  attributes: IAttributes;
+  attributes: Record<string,string>;
   context: any;
 
-  constructor(initialData: IInitialData);
+  constructor(initialData: unknown);
 
   getChildContext(): any;
 
@@ -131,12 +236,19 @@ abstract class Component {
   componentHeadStyle(breakpoint: number): string;
 
   /**
-   * If you want to return mjml from a component, it needs to be processed first
+   * If you want to return mjml from a component, it needs to be processed first, ie.
+   * 
+   * render() {
+   *   return this.renderMJML('<mj-text>hello world</mj-text>');
+   * }
    */
   renderMJML(mjml: string, options?: {}): string;
 
   /**
    * Expected to return an html string
+   * @see renderMJML for returning an mjml string
    */
   abstract render(): string;
 }
+
+export function suffixCssClasses(classes: string, suffix: string): string;

--- a/types/mjml-core/index.d.ts
+++ b/types/mjml-core/index.d.ts
@@ -130,21 +130,21 @@ export interface MJMLParseError {
     formattedMessage: string;
 }
 
-export type MJMLJsonObject = MJMLJsonNonEndingTag | MJMLJsonEndingTag | MJMLJsonEndingTagWithoutContent;
+export type MJMLJsonObject = MJMLJsonWithChildren | MJMLJsonWithContent | MJMLJsonSelfClosingTag;
 
-export interface MJMLJsonNonEndingTag {
+export interface MJMLJsonWithChildren {
     tagName: string;
     attributes: object;
     children: MJMLJsonObject[];
 }
 
-export interface MJMLJsonEndingTag {
+export interface MJMLJsonWithContent {
     tagName: string;
     attributes: object;
     content: string;
 }
 
-export interface MJMLJsonEndingTagWithoutContent {
+export interface MJMLJsonSelfClosingTag {
     tagName: string;
     attributes: object;
 }

--- a/types/mjml-core/index.d.ts
+++ b/types/mjml-core/index.d.ts
@@ -78,7 +78,7 @@ export interface MJMLParsingOptions {
     /**
      * The path or directory of the .mjmlconfig file
      * default: process.cwd()
-     **/
+     */
     mjmlConfigPath?: string;
 
     /**
@@ -108,8 +108,10 @@ export interface MJMLParsingOptions {
      * default: false
      */
     ignoreIncludes?: any;
-    /** see mjml-parser-xml */
-    preprocessors?: ((xml: string) => string)[];
+    /**
+     * see mjml-parser-xml
+     */
+    preprocessors?: Array<((xml: string) => string)>;
 }
 
 export interface MJMLMinifyOptions {
@@ -146,17 +148,18 @@ export const components: { [componentName: string]: Component | undefined };
 /**
  * Registers a component for use in mjml
  */
-export function registerComponent<T extends typeof Component>(Component: T): void;
+export function registerComponent(ComponentClass: typeof Component): void;
 
 export abstract class BodyComponent extends Component {
     constructor(initialData: unknown);
 
     getStyles(): {};
 
-    /** takes a style attribute and tries to parse it's value
+    /**
+     * takes a style attribute and tries to parse it's value
      * ie. padding="1 2 3 4"
      * getShorthandAttrValue("padding","left") => 1
-     *  */
+     */
     getShorthandAttrValue(attribute: any, direction: any): number;
 
     getShorthandBorderValue(direction: any): number;
@@ -191,7 +194,7 @@ export abstract class HeadComponent extends Component {
     render(): string;
 }
 
-declare abstract class Component {
+export abstract class Component {
     static getTagName(): any;
 
     static isRawElement(): boolean;

--- a/types/mjml-core/index.d.ts
+++ b/types/mjml-core/index.d.ts
@@ -1,15 +1,12 @@
 // Type definitions for mjml-core 4.7
 // Project: https://mjml.io
 // Definitions by: Ian Edington       <https://github.com/IanEdington>
-//                 aahoughton         <https://github.com/aahoughton>
-//                 marpstar           <https://github.com/marpstar>
-//                 eiskalteschatten   <https://github.com/eiskalteschatten>
-//                 emrah88            <https://github.com/emrah88>
+//                 Ryan Burr          <https://github.com/ryanburr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**
  * The main parser for MJML.
- * This version doesn't contain any of the components registered in the 'mjml' package.
+ * This version doesn't contain any of the core components registered in the 'mjml' package.
  */
 export default function mjml2html(input: string | MJMLJsonObject, options?: MJMLParsingOptions): MJMLParseResults;
 
@@ -133,11 +130,23 @@ export interface MJMLParseError {
     formattedMessage: string;
 }
 
-export interface MJMLJsonObject {
+export type MJMLJsonObject = MJMLJsonNonEndingTag | MJMLJsonEndingTag | MJMLJsonEndingTagWithoutContent;
+
+export interface MJMLJsonNonEndingTag {
     tagName: string;
     attributes: object;
-    children?: MJMLJsonObject[];
-    content?: string;
+    children: MJMLJsonObject[];
+}
+
+export interface MJMLJsonEndingTag {
+    tagName: string;
+    attributes: object;
+    content: string;
+}
+
+export interface MJMLJsonEndingTagWithoutContent {
+    tagName: string;
+    attributes: object;
 }
 
 /**

--- a/types/mjml-core/index.d.ts
+++ b/types/mjml-core/index.d.ts
@@ -15,17 +15,17 @@ export default function mjml2html(input: string | MJMLJsonObject, options?: MJML
 
 /**
  * Options passed as an object to the mjml2html function
- * 
+ *
  * https://documentation.mjml.io/#inside-node-js
  */
 export interface MJMLParsingOptions {
     /**
      * Default fonts imported in the HTML rendered by HTML
      * ie. { 'Open Sans': 'https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,700' }
-     * 
+     *
      * default: @see https://github.com/mjmlio/mjml/blob/master/packages/mjml-core/src/index.js
      */
-    fonts?: { [key: string]: string; };
+    fonts?: { [key: string]: string };
 
     /**
      * Option to keep comments in the HTML output
@@ -35,7 +35,7 @@ export interface MJMLParsingOptions {
 
     /**
      * @deprecated use js-beautify directly after processing the MJML
-     * 
+     *
      * Option to beautify the HTML output
      * default: false
      */
@@ -43,18 +43,18 @@ export interface MJMLParsingOptions {
 
     /**
      * @deprecated use html-minifier directly after processing the MJML
-     * 
+     *
      * Option to minify the HTML output
-     * 
+     *
      * default: false
      */
     minify?: boolean;
     /**
      * @deprecated @see minify
-     * 
+     *
      * Options for html minifier, see mjml-cli documentation for more info
      * Passed directly to html-minifier as options
-     * 
+     *
      * default: @see htmlMinify usage in mjml-core/src/index.js
      */
     minifyOptions?: MJMLMinifyOptions;
@@ -109,7 +109,7 @@ export interface MJMLParsingOptions {
      */
     ignoreIncludes?: any;
     /** see mjml-parser-xml */
-    preprocessors?: ((xml: string)=>string)[];
+    preprocessors?: ((xml: string) => string)[];
 }
 
 export interface MJMLMinifyOptions {
@@ -141,7 +141,7 @@ export interface MJMLJsonObject {
 /**
  * An map of elements to handling component available to be used in mjml
  */
-export const components: {[componentName: string]: Component | undefined};
+export const components: { [componentName: string]: Component | undefined };
 
 /**
  * Registers a component for use in mjml
@@ -149,106 +149,105 @@ export const components: {[componentName: string]: Component | undefined};
 export function registerComponent<T extends typeof Component>(Component: T): void;
 
 export abstract class BodyComponent extends Component {
+    constructor(initialData: unknown);
 
-  constructor(initialData: unknown);
+    getStyles(): {};
 
-  getStyles(): {};
+    /** takes a style attribute and tries to parse it's value
+     * ie. padding="1 2 3 4"
+     * getShorthandAttrValue("padding","left") => 1
+     *  */
+    getShorthandAttrValue(attribute: any, direction: any): number;
 
-  /** takes a style attribute and tries to parse it's value
-   * ie. padding="1 2 3 4"
-   * getShorthandAttrValue("padding","left") => 1
-   *  */
-  getShorthandAttrValue(attribute: any, direction: any): number;
+    getShorthandBorderValue(direction: any): number;
 
-  getShorthandBorderValue(direction: any): number;
+    getBoxWidths(): {
+        totalWidth: number;
+        borders: number;
+        paddings: number;
+        box: number;
+    };
 
-  getBoxWidths(): {
-    totalWidth: number;
-    borders: number;
-    paddings: number;
-    box: number;
-  };
+    htmlAttributes(attributes: any): any;
 
-  htmlAttributes(attributes: any): any;
+    styles(styles: any): any;
 
-  styles(styles: any): any;
-
-  renderChildren(
-    children?: [],
-    options?: {
-      props?: Component['props'];
-      renderer?: (component: Component) => any;
-      attributes?: Record<string, string>;
-      rawXML?: boolean;
-    }
-  ): string;
+    renderChildren(
+        children?: [],
+        options?: {
+            props?: Component['props'];
+            renderer?: (component: Component) => any;
+            attributes?: Record<string, string>;
+            rawXML?: boolean;
+        },
+    ): string;
 }
 
 export abstract class HeadComponent extends Component {
-  constructor(initialData: unknown);
+    constructor(initialData: unknown);
 
-  handlerChildren(): any;
+    handlerChildren(): any;
 
-  render(): string;
+    render(): string;
 }
 
 declare abstract class Component {
-  static getTagName(): any;
+    static getTagName(): any;
 
-  static isRawElement(): boolean;
+    static isRawElement(): boolean;
 
-  static defaultAttributes: { [prop: string]: string | undefined };
+    static defaultAttributes: { [prop: string]: string | undefined };
 
-  props: {
-    children: any;
-    /** is first child */
-    first: boolean;
-    index: number;
-    /** is last child */
-    last: boolean;
-    /** number of sibling elements */
-    sibling: number;
-    nonRawSiblings: number;
-  };
-  attributes: Record<string,string>;
-  context: any;
+    props: {
+        children: any;
+        /** is first child */
+        first: boolean;
+        index: number;
+        /** is last child */
+        last: boolean;
+        /** number of sibling elements */
+        sibling: number;
+        nonRawSiblings: number;
+    };
+    attributes: Record<string, string>;
+    context: any;
 
-  constructor(initialData: unknown);
+    constructor(initialData: unknown);
 
-  getChildContext(): any;
+    getChildContext(): any;
 
-  getAttribute(name: any): any;
+    getAttribute(name: any): any;
 
-  getContent(): any;
+    getContent(): any;
 
-  /**
-   * Use if you want the CSS to be registered once
-   *
-   * @returns string css style string
-   */
-  headStyle(breakpoint: number): string;
+    /**
+     * Use if you want the CSS to be registered once
+     *
+     * @returns string css style string
+     */
+    headStyle(breakpoint: number): string;
 
-  /**
-   * Use if you need custom styles for every instance of a component
-   *
-   * @returns string css style string
-   */
-  componentHeadStyle(breakpoint: number): string;
+    /**
+     * Use if you need custom styles for every instance of a component
+     *
+     * @returns string css style string
+     */
+    componentHeadStyle(breakpoint: number): string;
 
-  /**
-   * If you want to return mjml from a component, it needs to be processed first, ie.
-   * 
-   * render() {
-   *   return this.renderMJML('<mj-text>hello world</mj-text>');
-   * }
-   */
-  renderMJML(mjml: string, options?: {}): string;
+    /**
+     * If you want to return mjml from a component, it needs to be processed first, ie.
+     *
+     * render() {
+     *   return this.renderMJML('<mj-text>hello world</mj-text>');
+     * }
+     */
+    renderMJML(mjml: string, options?: {}): string;
 
-  /**
-   * Expected to return an html string
-   * @see renderMJML for returning an mjml string
-   */
-  abstract render(): string;
+    /**
+     * Expected to return an html string
+     * @see renderMJML for returning an mjml string
+     */
+    abstract render(): string;
 }
 
 export function suffixCssClasses(classes: string, suffix: string): string;

--- a/types/mjml-core/index.d.ts
+++ b/types/mjml-core/index.d.ts
@@ -1,0 +1,142 @@
+/**
+ * An map of components available to be used in mjml
+ */
+export const components: {[componentName: string]: Component | undefined};
+
+interface IInitialData {
+  attributes: IAttributes;
+  children: IInitialData[];
+  content: string;
+  context: {
+    add(attr: any, ...params: any[]): void;
+    addMediaQuery(className: any, unit: { parsedWidth: any; unit: any }): void;
+    addHeadStyle(identifier: any, headStyle: any): void;
+    addComponentHeadSyle(headStyle: any): void;
+    setBackgroundColor(color: string): void;
+    processing(node: any, context: any): void;
+  };
+  props: {};
+  globalAttributes: IAttributes;
+}
+
+export function initComponent({ initialData, name }: { initialData: IInitialData; name: any }): any;
+
+/**
+ * Registers a component for use in mjml
+ */
+export function registerComponent(Component: Component): void;
+
+export function suffixCssClasses(classes: any, suffix: any): any;
+
+export function handleMjmlConfig(
+  configPathOrDir?: string,
+  registerCompFn?: typeof registerComponent
+):
+  | {
+      success: any[];
+      failures: any[];
+    }
+  | {
+      error: any;
+    };
+
+export function initializeType(typeConfig: any): any;
+
+export abstract class BodyComponent extends Component {
+  constructor(initialData: IInitialData);
+
+  getStyles(): {};
+
+  /** takes a style attribute and tries to parse it's value
+   * ie. padding="1 2 3 4"
+   * getShorthandAttrValue("padding","left") => 1
+   *  */
+  getShorthandAttrValue(attribute: any, direction: any): number;
+
+  getShorthandBorderValue(direction: any): number;
+
+  getBoxWidths(): {
+    totalWidth: number;
+    borders: number;
+    paddings: number;
+    box: number;
+  };
+
+  htmlAttributes(attributes: any): any;
+
+  styles(styles: any): any;
+
+  renderChildren(
+    children?: [],
+    options?: {
+      props?: Component['props'];
+      renderer?: (component: Component) => any;
+      attributes?: IAttributes;
+      rawXML?: boolean;
+    }
+  ): string;
+}
+
+export abstract class HeadComponent extends Component {
+  constructor(initialData: IInitialData);
+
+  handlerChildren(): any;
+}
+
+export interface IAttributes {
+  [attribute: string]: string;
+}
+
+abstract class Component {
+  static getTagName(): any;
+
+  static isRawElement(): boolean;
+
+  static defaultAttributes: { [prop: string]: string | undefined };
+
+  props: {
+    children: any;
+    /** is first child */
+    first: boolean;
+    index: number;
+    /** is last child */
+    last: boolean;
+    /** number of sibling elements */
+    sibling: number;
+    nonRawSiblings: number;
+  };
+  attributes: IAttributes;
+  context: any;
+
+  constructor(initialData: IInitialData);
+
+  getChildContext(): any;
+
+  getAttribute(name: any): any;
+
+  getContent(): any;
+
+  /**
+   * Use if you want the CSS to be registered once
+   *
+   * @returns string css style string
+   */
+  headStyle(breakpoint: number): string;
+
+  /**
+   * Use if you need custom styles for every instance of a component
+   *
+   * @returns string css style string
+   */
+  componentHeadStyle(breakpoint: number): string;
+
+  /**
+   * If you want to return mjml from a component, it needs to be processed first
+   */
+  renderMJML(mjml: string, options?: {}): string;
+
+  /**
+   * Expected to return an html string
+   */
+  abstract render(): string;
+}

--- a/types/mjml-core/mjml-core-tests.ts
+++ b/types/mjml-core/mjml-core-tests.ts
@@ -1,0 +1,45 @@
+import mjml2html, {
+    BodyComponent,
+     HeadComponent,
+      Component,
+      registerComponent
+} from "mjml-core";
+
+const simple_test = mjml2html("<mjml>");
+const html = simple_test.html;
+const errors = simple_test.errors;
+let formattedMessage = errors[0].formattedMessage;
+formattedMessage = "force string test";
+
+const minimal_opts_test = mjml2html("<mjml>", {beautify: true});
+const validation_level_test = mjml2html("<mjml>", {validationLevel: "strict"});
+const filePath_test = mjml2html("<mjml>", {filePath: "."});
+
+const jsonObject = {tagName: "mjml", attributes: {width: "100px"}, content: "test content"};
+const jsonObject_test = mjml2html(jsonObject);
+
+const minify_opts_test = mjml2html("<mjml", {minifyOptions: {minifyCSS: true}});
+const minify_opts_all_test = mjml2html("<mjml", {minifyOptions: {minifyCSS: true, collapseWhitespace: true, removeEmptyAttributes: true}});
+
+class NewBodyComponent extends BodyComponent {
+    render() {
+        return this.renderMJML('<mj-text>hello world</mj-text');
+    }
+}
+
+class MjBreakpoint extends HeadComponent {
+    static endingTag = true
+  
+    static allowedAttributes = {
+      width: 'unit(px)',
+    }
+  
+    handler() {
+      const { add } = this.context
+  
+      add('breakpoint', this.getAttribute('width'))
+    }
+}
+
+registerComponent(MjBreakpoint)
+registerComponent(NewBodyComponent)

--- a/types/mjml-core/mjml-core-tests.ts
+++ b/types/mjml-core/mjml-core-tests.ts
@@ -1,25 +1,22 @@
-import mjml2html, {
-    BodyComponent,
-     HeadComponent,
-      Component,
-      registerComponent
-} from "mjml-core";
+import mjml2html, { BodyComponent, HeadComponent, Component, registerComponent } from 'mjml-core';
 
-const simple_test = mjml2html("<mjml>");
+const simple_test = mjml2html('<mjml>');
 const html = simple_test.html;
 const errors = simple_test.errors;
 let formattedMessage = errors[0].formattedMessage;
-formattedMessage = "force string test";
+formattedMessage = 'force string test';
 
-const minimal_opts_test = mjml2html("<mjml>", {beautify: true});
-const validation_level_test = mjml2html("<mjml>", {validationLevel: "strict"});
-const filePath_test = mjml2html("<mjml>", {filePath: "."});
+const minimal_opts_test = mjml2html('<mjml>', { beautify: true });
+const validation_level_test = mjml2html('<mjml>', { validationLevel: 'strict' });
+const filePath_test = mjml2html('<mjml>', { filePath: '.' });
 
-const jsonObject = {tagName: "mjml", attributes: {width: "100px"}, content: "test content"};
+const jsonObject = { tagName: 'mjml', attributes: { width: '100px' }, content: 'test content' };
 const jsonObject_test = mjml2html(jsonObject);
 
-const minify_opts_test = mjml2html("<mjml", {minifyOptions: {minifyCSS: true}});
-const minify_opts_all_test = mjml2html("<mjml", {minifyOptions: {minifyCSS: true, collapseWhitespace: true, removeEmptyAttributes: true}});
+const minify_opts_test = mjml2html('<mjml', { minifyOptions: { minifyCSS: true } });
+const minify_opts_all_test = mjml2html('<mjml', {
+    minifyOptions: { minifyCSS: true, collapseWhitespace: true, removeEmptyAttributes: true },
+});
 
 class NewBodyComponent extends BodyComponent {
     render() {
@@ -28,18 +25,18 @@ class NewBodyComponent extends BodyComponent {
 }
 
 class MjBreakpoint extends HeadComponent {
-    static endingTag = true
-  
+    static endingTag = true;
+
     static allowedAttributes = {
-      width: 'unit(px)',
-    }
-  
+        width: 'unit(px)',
+    };
+
     handler() {
-      const { add } = this.context
-  
-      add('breakpoint', this.getAttribute('width'))
+        const { add } = this.context;
+
+        add('breakpoint', this.getAttribute('width'));
     }
 }
 
-registerComponent(MjBreakpoint)
-registerComponent(NewBodyComponent)
+registerComponent(MjBreakpoint);
+registerComponent(NewBodyComponent);

--- a/types/mjml-core/tsconfig.json
+++ b/types/mjml-core/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mjml-core-test.ts"
+    ]
+}

--- a/types/mjml-core/tsconfig.json
+++ b/types/mjml-core/tsconfig.json
@@ -6,8 +6,8 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": true,
         "strictFunctionTypes": true,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"
@@ -18,6 +18,6 @@
     },
     "files": [
         "index.d.ts",
-        "mjml-core-test.ts"
+        "mjml-core-tests.ts"
     ]
 }

--- a/types/mjml-core/tslint.json
+++ b/types/mjml-core/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/mjml/index.d.ts
+++ b/types/mjml/index.d.ts
@@ -7,6 +7,6 @@
 //                 IanEdington        <https://github.com/IanEdington>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import mjml2html from 'mjml-core'
+import mjml2html from 'mjml-core';
 
-export default mjml2html
+export default mjml2html;

--- a/types/mjml/index.d.ts
+++ b/types/mjml/index.d.ts
@@ -9,4 +9,4 @@
 
 import mjml2html from 'mjml-core';
 
-export default mjml2html;
+export = mjml2html;

--- a/types/mjml/index.d.ts
+++ b/types/mjml/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/mjmlio/mjml, https://mjml.io
 // Definitions by: aahoughton         <https://github.com/aahoughton>
 //                 marpstar           <https://github.com/marpstar>
-//                 eiskalteschatten   <https://github.com/eiskalteschatten>
 //                 emrah88            <https://github.com/emrah88>
 //                 IanEdington        <https://github.com/IanEdington>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/mjml/index.d.ts
+++ b/types/mjml/index.d.ts
@@ -1,46 +1,12 @@
-// Type definitions for mjml 4.0
+// Type definitions for mjml 4.7
 // Project: https://github.com/mjmlio/mjml, https://mjml.io
-// Definitions by: aahoughton <https://github.com/aahoughton>
-//                 marpstar   <https://github.com/marpstar>
+// Definitions by: aahoughton         <https://github.com/aahoughton>
+//                 marpstar           <https://github.com/marpstar>
 //                 eiskalteschatten   <https://github.com/eiskalteschatten>
-//                 emrah88    <https://github.com/emrah88>
+//                 emrah88            <https://github.com/emrah88>
+//                 IanEdington        <https://github.com/IanEdington>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-interface MJMLParsingOpts {
-    fonts?: { [key: string]: string; };
-    keepComments?: boolean;
-    beautify?: boolean;
-    minify?: boolean;
-    validationLevel?: 'strict' | 'soft' | 'skip';
-    filePath?: string;
-    minifyOptions?: MJMLMinifyOptions;
-}
+import mjml2html from 'mjml-core'
 
-interface MJMLParseError {
-    line: number;
-    message: string;
-    tagName: string;
-    formattedMessage: string;
-}
-
-interface MJMLParseResults {
-    html: string;
-    errors: MJMLParseError[];
-}
-
-interface MJMLJsonObject {
-    tagName: string;
-    attributes: object;
-    children?: MJMLJsonObject[];
-    content?: string;
-}
-
-interface MJMLMinifyOptions {
-    collapseWhitespace?: boolean;
-    minifyCSS?: boolean;
-    removeEmptyAttributes?: boolean;
-}
-
-declare function mjml2html(inp: string | MJMLJsonObject, opts?: MJMLParsingOpts): MJMLParseResults;
-
-export = mjml2html;
+export default mjml2html

--- a/types/mjml/mjml-tests.ts
+++ b/types/mjml/mjml-tests.ts
@@ -1,17 +1,19 @@
-import mjml2html from "mjml";
+import mjml2html from 'mjml';
 
-const simple_test = mjml2html("<mjml>");
+const simple_test = mjml2html('<mjml>');
 const html = simple_test.html;
 const errors = simple_test.errors;
 let formattedMessage = errors[0].formattedMessage;
-formattedMessage = "force string test";
+formattedMessage = 'force string test';
 
-const minimal_opts_test = mjml2html("<mjml>", {beautify: true});
-const validation_level_test = mjml2html("<mjml>", {validationLevel: "strict"});
-const filePath_test = mjml2html("<mjml>", {filePath: "."});
+const minimal_opts_test = mjml2html('<mjml>', { beautify: true });
+const validation_level_test = mjml2html('<mjml>', { validationLevel: 'strict' });
+const filePath_test = mjml2html('<mjml>', { filePath: '.' });
 
-const jsonObject = {tagName: "mjml", attributes: {width: "100px"}, content: "test content"};
+const jsonObject = { tagName: 'mjml', attributes: { width: '100px' }, content: 'test content' };
 const jsonObject_test = mjml2html(jsonObject);
 
-const minify_opts_test = mjml2html("<mjml", {minifyOptions: {minifyCSS: true}});
-const minify_opts_all_test = mjml2html("<mjml", {minifyOptions: {minifyCSS: true, collapseWhitespace: true, removeEmptyAttributes: true}});
+const minify_opts_test = mjml2html('<mjml', { minifyOptions: { minifyCSS: true } });
+const minify_opts_all_test = mjml2html('<mjml', {
+    minifyOptions: { minifyCSS: true, collapseWhitespace: true, removeEmptyAttributes: true },
+});

--- a/types/mjml/mjml-tests.ts
+++ b/types/mjml/mjml-tests.ts
@@ -1,4 +1,4 @@
-import mjml2html from 'mjml';
+import mjml2html = require('mjml');
 
 const simple_test = mjml2html('<mjml>');
 const html = simple_test.html;

--- a/types/mjml/mjml-tests.ts
+++ b/types/mjml/mjml-tests.ts
@@ -1,4 +1,4 @@
-import mjml2html = require("mjml");
+import mjml2html from "mjml";
 
 const simple_test = mjml2html("<mjml>");
 const html = simple_test.html;


### PR DESCRIPTION
- Adds more details about the options for `mjml2html`
- Adds the types for MJML custom components
- rearrange types to more accurately describe interaction between `mjml` and `mjml-core`

## ✅ mjml re-export mjml-core or mjml-core re-export mjml
Based on the implementation, mjml re-exports `mjml2html` from mjml-core. However, most users only use mjml. This change will require both @types/mjml and @types/mjml-core to be added when most users just need @types/mjml.

I'm looking for an opinion from a maintainer on the best way to handle this. The technically more correct way or the way that's better for the end user.

Decision: have mjml re-export mjml-core the way the JS behaves
Based on conversation in discord

## Excluded functions
These three functions don't seem to be useful outside the MJML packages and so weren't included here. I'm happy to include them if they should be included.
- initComponent
- initializeType
- handleMjmlConfig