### PR TITLE
Use ReadonlyArray for InitOptions["providers"] in `next-auth`

### DIFF
--- a/types/next-auth/index.d.ts
+++ b/types/next-auth/index.d.ts
@@ -16,7 +16,7 @@ import { SessionProvider } from './client';
 import { JWTEncodeParams, JWTDecodeParams } from './jwt';
 
 interface InitOptions {
-    providers: Array<ReturnType<PossibleProviders>>;
+    providers: ReadonlyArray<ReturnType<PossibleProviders>>;
     database?: string | ConnectionOptions;
     secret?: string;
     session?: Session;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [the default exported function doesn't write to `userSuppliedOptions.providers` parameter](https://github.com/nextauthjs/next-auth/blob/main/src/server/index.js)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
