### PR TITLE
@hapi__yar allow CookieOptions.isSameSite to be 'None'

### DIFF
--- a/types/hapi__yar/index.d.ts
+++ b/types/hapi__yar/index.d.ts
@@ -84,7 +84,7 @@ declare namespace yar {
              * enables the same-site cookie parameter.
              * Default to 'Lax'.
              */
-            isSameSite?: 'Lax' | 'Strict' | false;
+            isSameSite?: 'Lax' | 'Strict' | 'None' | false;
             /**
              * determines whether or not to transfer using TLS/SSL.
              * Defaults to true.


### PR DESCRIPTION
The docs for @hapi/yar (https://github.com/hapijs/yar/blob/master/API.md#options) say that the isSameSite field can be set to 'None'.

`isSameSite - enables the same-site cookie parameter. Default to 'Lax'. Can be 'Strict'|'Lax'|'None'|false.`

However, currently doing that results in a type error. This change adds 'None' as an option.

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/hapijs/yar/blob/master/API.md#options>>

