### PR TITLE
create typings for tiny-json-http module

### DIFF
--- a/types/tiny-json-http/index.d.ts
+++ b/types/tiny-json-http/index.d.ts
@@ -1,0 +1,46 @@
+// Type definitions for tiny-json-http 7.3
+// Project: https://github.com/brianleroux/tiny-json-http
+// Definitions by: Levi Bostian <https://github.com/levibostian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface Options {
+  url: string;
+  data?: any;
+  headers?: any;
+  /**
+   * Set to true the response body is returned as a buffer
+   */
+  buffer?: boolean;
+  timeout?: number;
+}
+
+export interface Result {
+  body: any;
+  headers: any;
+}
+export type Callback = (err: Error | null, res?: Result) => void;
+
+export function get(options: Options): Promise<Result>;
+export function get(options: Options, callback: Callback): void;
+
+export function head(options: Options): Promise<Result>;
+export function head(options: Options, callback: Callback): void;
+
+export function options(options: Options): Promise<Result>;
+export function options(options: Options, callback: Callback): void;
+
+export function post(options: Options): Promise<Result>;
+export function post(options: Options, callback: Callback): void;
+
+export function put(options: Options): Promise<Result>;
+export function put(options: Options, callback: Callback): void;
+
+export function patch(options: Options): Promise<Result>;
+export function patch(options: Options, callback: Callback): void;
+
+export function del(options: Options): Promise<Result>;
+export function del(options: Options, callback: Callback): void;
+
+// delete is a function option, but typescript has reserved that word
+// export function delete(options: Options): Promise<Result>;
+// export function delete(options: Options, callback: Callback): void;

--- a/types/tiny-json-http/index.d.ts
+++ b/types/tiny-json-http/index.d.ts
@@ -3,44 +3,48 @@
 // Definitions by: Levi Bostian <https://github.com/levibostian>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export interface Options {
-  url: string;
-  data?: any;
-  headers?: any;
-  /**
-   * Set to true the response body is returned as a buffer
-   */
-  buffer?: boolean;
-  timeout?: number;
+declare namespace TinyJsonHttp {
+  interface Options {
+    url: string;
+    data?: any;
+    headers?: any;
+    /**
+     * Set to true the response body is returned as a buffer
+     */
+    buffer?: boolean;
+    timeout?: number;
+  }
+
+  interface Result {
+    body: any;
+    headers: any;
+  }
+  type Callback = (err: Error | null, res?: Result) => void;
+
+  interface Api {
+    get(options: Options): Promise<Result>;
+    get(options: Options, callback: Callback): void;
+
+    head(options: Options): Promise<Result>;
+    head(options: Options, callback: Callback): void;
+
+    options(options: Options): Promise<Result>;
+    options(options: Options, callback: Callback): void;
+
+    post(options: Options): Promise<Result>;
+    post(options: Options, callback: Callback): void;
+
+    put(options: Options): Promise<Result>;
+    put(options: Options, callback: Callback): void;
+
+    patch(options: Options): Promise<Result>;
+    patch(options: Options, callback: Callback): void;
+
+    del(options: Options): Promise<Result>;
+    del(options: Options, callback: Callback): void;
+  }
 }
 
-export interface Result {
-  body: any;
-  headers: any;
-}
-export type Callback = (err: Error | null, res?: Result) => void;
+declare const http: TinyJsonHttp.Api;
 
-export function get(options: Options): Promise<Result>;
-export function get(options: Options, callback: Callback): void;
-
-export function head(options: Options): Promise<Result>;
-export function head(options: Options, callback: Callback): void;
-
-export function options(options: Options): Promise<Result>;
-export function options(options: Options, callback: Callback): void;
-
-export function post(options: Options): Promise<Result>;
-export function post(options: Options, callback: Callback): void;
-
-export function put(options: Options): Promise<Result>;
-export function put(options: Options, callback: Callback): void;
-
-export function patch(options: Options): Promise<Result>;
-export function patch(options: Options, callback: Callback): void;
-
-export function del(options: Options): Promise<Result>;
-export function del(options: Options, callback: Callback): void;
-
-// delete is a function option, but typescript has reserved that word
-// export function delete(options: Options): Promise<Result>;
-// export function delete(options: Options, callback: Callback): void;
+export = http;

--- a/types/tiny-json-http/tiny-json-http-tests.ts
+++ b/types/tiny-json-http/tiny-json-http-tests.ts
@@ -1,41 +1,39 @@
 import http = require("tiny-json-http");
 
-const callback: http.Callback = (err, res) => {};
-
 // $ExpectType void
 http.get({
   url: "https://github.com"
-}, callback);
+}, (err, res) => {});
 
 // $ExpectType void
 http.head({
   url: "https://github.com"
-}, callback);
+}, (err, res) => {});
 
 // $ExpectType void
 http.options({
   url: "https://github.com"
-}, callback);
+}, (err, res) => {});
 
 // $ExpectType void
 http.post({
   url: "https://github.com"
-}, callback);
+}, (err, res) => {});
 
 // $ExpectType void
 http.put({
   url: "https://github.com"
-}, callback);
+}, (err, res) => {});
 
 // $ExpectType void
 http.patch({
   url: "https://github.com"
-}, callback);
+}, (err, res) => {});
 
 // $ExpectType void
 http.del({
   url: "https://github.com"
-}, callback);
+}, (err, res) => {});
 
 // Promise alternatives
 Promise.resolve()

--- a/types/tiny-json-http/tiny-json-http-tests.ts
+++ b/types/tiny-json-http/tiny-json-http-tests.ts
@@ -1,0 +1,82 @@
+import http = require("tiny-json-http");
+
+const callback: http.Callback = (err, res) => {};
+
+// $ExpectType void
+http.get({
+  url: "https://github.com"
+}, callback);
+
+// $ExpectType void
+http.head({
+  url: "https://github.com"
+}, callback);
+
+// $ExpectType void
+http.options({
+  url: "https://github.com"
+}, callback);
+
+// $ExpectType void
+http.post({
+  url: "https://github.com"
+}, callback);
+
+// $ExpectType void
+http.put({
+  url: "https://github.com"
+}, callback);
+
+// $ExpectType void
+http.patch({
+  url: "https://github.com"
+}, callback);
+
+// $ExpectType void
+http.del({
+  url: "https://github.com"
+}, callback);
+
+// Promise alternatives
+Promise.resolve()
+.then(async () => {
+  // $ExpectType Result
+  await http.get({
+    url: "https://github.com"
+  });
+
+  // $ExpectType Result
+  await http.get({
+    url: "https://github.com"
+  });
+
+  // $ExpectType Result
+  await http.head({
+    url: "https://github.com"
+  });
+
+  // $ExpectType Result
+  await http.options({
+    url: "https://github.com"
+  });
+
+  // $ExpectType Result
+  await http.post({
+    url: "https://github.com"
+  });
+
+  // $ExpectType Result
+  await http.put({
+    url: "https://github.com"
+  });
+
+  // $ExpectType Result
+  await http.patch({
+    url: "https://github.com"
+  });
+
+  // $ExpectType Result
+  await http.del({
+    url: "https://github.com"
+  });
+});

--- a/types/tiny-json-http/tsconfig.json
+++ b/types/tiny-json-http/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "tiny-json-http-tests.ts"
+    ]
+}

--- a/types/tiny-json-http/tslint.json
+++ b/types/tiny-json-http/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
