### PR TITLE
Added type definitions for flowchart-vue

### DIFF
--- a/types/flowchart-vue/flowchart-vue-tests.ts
+++ b/types/flowchart-vue/flowchart-vue-tests.ts
@@ -9,6 +9,6 @@ new Vue({
     },
     data: {
         nodes: [],
-        connections: []
-    }
+        connections: [],
+    },
 });

--- a/types/flowchart-vue/flowchart-vue-tests.ts
+++ b/types/flowchart-vue/flowchart-vue-tests.ts
@@ -1,0 +1,14 @@
+import Vue from 'vue';
+import flowchart from 'flowchart-vue';
+
+new Vue({
+    el: '#app',
+    template: `<flowchart v-model="list"></flowchart>`,
+    components: {
+        flowchart,
+    },
+    data: {
+        nodes: [],
+        connections: []
+    }
+});

--- a/types/flowchart-vue/index.d.ts
+++ b/types/flowchart-vue/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for flowchart-vue 0.15
+// Project: https://github.com/joyceworks/flowchart-vue
+// Definitions by: Nikolay Moskvin <https://github.com/moskvin/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.7
+
+import { VueConstructor } from 'vue';
+
+interface FlowChartVueConstructor extends VueConstructor {
+    props: any;
+    data: () => any;
+    watch: any;
+    methods: any;
+}
+
+export default flowchart;
+export const flowchart: FlowChartVueConstructor;

--- a/types/flowchart-vue/package.json
+++ b/types/flowchart-vue/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "vue": "^2.0.0"
+  }
+}

--- a/types/flowchart-vue/tsconfig.json
+++ b/types/flowchart-vue/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6", "dom"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "flowchart-vue-tests.ts"]
+}

--- a/types/flowchart-vue/tslint.json
+++ b/types/flowchart-vue/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
