### PR TITLE
[@types/carbon-components-react] Fix ContentSwitcher & Switcher types.

### DIFF
--- a/types/carbon-components-react/lib/components/ContentSwitcher/ContentSwitcher.d.ts
+++ b/types/carbon-components-react/lib/components/ContentSwitcher/ContentSwitcher.d.ts
@@ -1,8 +1,12 @@
 import * as React from "react";
 import { ReactDivAttr } from "../../../typings/shared";
+import { SwitchOnKeyDownData } from "../Switch";
 
-export interface ContentSwitcherProps extends Omit<ReactDivAttr, "role"> {
+export type ContentSwitcherOnChangeData = Omit<SwitchOnKeyDownData, "key"> & Partial<Pick<SwitchOnKeyDownData, "key">>;
+
+export interface ContentSwitcherProps extends Omit<ReactDivAttr, "onChange" | "role"> {
     light?: boolean,
+    onChange?(data: ContentSwitcherOnChangeData): void,
     selectedIndex?: number,
     selectionMode?: "automatic" | "manual";
     size?: "sm" | "xl";

--- a/types/carbon-components-react/lib/components/Switch/Switch.d.ts
+++ b/types/carbon-components-react/lib/components/Switch/Switch.d.ts
@@ -1,16 +1,18 @@
 import * as React from "react";
 import { ReactButtonAttr, ForwardRefReturn } from "../../../typings/shared";
 
+export interface SwitchOnKeyDownData {
+    index: SwitchProps["index"],
+    key: React.KeyboardEvent["key"] | React.KeyboardEvent["which"]
+    name: SwitchProps["name"],
+    text: SwitchProps["text"],
+}
+
 export interface SwitchProps extends Omit<ReactButtonAttr, "onClick" | "onKeyDown" | "name"> {
     index?: number,
     name?: string | number;
-    onClick(data: { index: SwitchProps["index"], name: SwitchProps["name"], text: SwitchProps["text"] }): void,
-    onKeyDown(data: {
-        index: SwitchProps["index"],
-        name: SwitchProps["name"],
-        text: SwitchProps["text"],
-        key: React.KeyboardEvent["key"] | React.KeyboardEvent["which"]
-    }): void,
+    onClick?(data: { index: SwitchProps["index"], name: SwitchProps["name"], text: SwitchProps["text"] }): void, // required but has default value
+    onKeyDown?(data: SwitchOnKeyDownData): void, // required but had default value
     selected?: boolean,
     text: string,
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/carbon-design-system/carbon/blob/v10.24.0/packages/react/src/components/ContentSwitcher/ContentSwitcher.js
https://github.com/carbon-design-system/carbon/blob/v10.24.0/packages/react/src/components/Switch/Switch.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
