### PR TITLE
[office-js, office-js-preview] Update ContentControl.placeholderText to note Word for the web support

### DIFF
--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -70833,6 +70833,8 @@ declare namespace Word {
         /**
          *
          * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
+         * 
+         * **Note**: This API is not supported by Word for the web.
          *
          * [Api set: WordApi 1.1]
          */
@@ -77100,6 +77102,8 @@ declare namespace Word {
             /**
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
+             * 
+             * **Note**: This API is not supported by Word for the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -78027,6 +78031,8 @@ declare namespace Word {
             /**
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
+             * 
+             * **Note**: This API is not supported by Word for the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -79385,6 +79391,8 @@ declare namespace Word {
             /**
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
+             * 
+             * **Note**: This API is not supported by Word for the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -79551,6 +79559,8 @@ declare namespace Word {
             /**
              *
              * For EACH ITEM in the collection: Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
+             * 
+             * **Note**: This API is not supported by Word for the web.
              *
              * [Api set: WordApi 1.1]
              */

--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -70834,7 +70834,7 @@ declare namespace Word {
          *
          * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
          * 
-         * **Note**: This API is not supported by Word on the web.
+         * **Note**: This API is not supported in Word on the web.
          *
          * [Api set: WordApi 1.1]
          */
@@ -77103,7 +77103,7 @@ declare namespace Word {
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported by Word on the web.
+             * **Note**: This API is not supported in Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -78032,7 +78032,7 @@ declare namespace Word {
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported by Word on the web.
+             * **Note**: This API is not supported in Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -79392,7 +79392,7 @@ declare namespace Word {
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported by Word on the web.
+             * **Note**: This API is not supported in Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -79560,7 +79560,7 @@ declare namespace Word {
              *
              * For EACH ITEM in the collection: Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported by Word on the web.
+             * **Note**: This API is not supported in Word on the web.
              *
              * [Api set: WordApi 1.1]
              */

--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -70446,7 +70446,7 @@ declare namespace Word {
          */
         clear(): void;
         /**
-         * Gets an HTML representation of the body object. When rendered in a web page or HTML viewer, the formatting will be a close, but not exact, match for of the formatting of the document. This method does not return the exact same HTML for the same document on different platforms (Windows, Mac, Word for the web, etc.). If you need exact fidelity, or consistency across platforms, use `Body.getOoxml()` and convert the returned XML to HTML.
+         * Gets an HTML representation of the body object. When rendered in a web page or HTML viewer, the formatting will be a close, but not exact, match for of the formatting of the document. This method does not return the exact same HTML for the same document on different platforms (Windows, Mac, Word on the web, etc.). If you need exact fidelity, or consistency across platforms, use `Body.getOoxml()` and convert the returned XML to HTML.
          *
          * [Api set: WordApi 1.1]
          */
@@ -70834,7 +70834,7 @@ declare namespace Word {
          *
          * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
          * 
-         * **Note**: This API is not supported by Word for the web.
+         * **Note**: This API is not supported by Word on the web.
          *
          * [Api set: WordApi 1.1]
          */
@@ -70924,7 +70924,7 @@ declare namespace Word {
          */
         delete(keepContent: boolean): void;
         /**
-         * Gets an HTML representation of the content control object. When rendered in a web page or HTML viewer, the formatting will be a close, but not exact, match for of the formatting of the document. This method does not return the exact same HTML for the same document on different platforms (Windows, Mac, Word for the web, etc.). If you need exact fidelity, or consistency across platforms, use `ContentControl.getOoxml()` and convert the returned XML to HTML.
+         * Gets an HTML representation of the content control object. When rendered in a web page or HTML viewer, the formatting will be a close, but not exact, match for of the formatting of the document. This method does not return the exact same HTML for the same document on different platforms (Windows, Mac, Word on the web, etc.). If you need exact fidelity, or consistency across platforms, use `ContentControl.getOoxml()` and convert the returned XML to HTML.
          *
          * [Api set: WordApi 1.1]
          */
@@ -71345,7 +71345,7 @@ declare namespace Word {
         readonly type: Word.DocumentPropertyType | "String" | "Number" | "Date" | "Boolean";
         /**
          *
-         * Gets or sets the value of the custom property. Note that even though Word for the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
+         * Gets or sets the value of the custom property. Note that even though Word on the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
          *
          * [Api set: WordApi 1.3]
          */
@@ -73510,7 +73510,7 @@ declare namespace Word {
          */
         detachFromList(): void;
         /**
-         * Gets an HTML representation of the paragraph object. When rendered in a web page or HTML viewer, the formatting will be a close, but not exact, match for of the formatting of the document. This method does not return the exact same HTML for the same document on different platforms (Windows, Mac, Word for the web, etc.). If you need exact fidelity, or consistency across platforms, use `Paragraph.getOoxml()` and convert the returned XML to HTML.
+         * Gets an HTML representation of the paragraph object. When rendered in a web page or HTML viewer, the formatting will be a close, but not exact, match for of the formatting of the document. This method does not return the exact same HTML for the same document on different platforms (Windows, Mac, Word on the web, etc.). If you need exact fidelity, or consistency across platforms, use `Paragraph.getOoxml()` and convert the returned XML to HTML.
          *
          * [Api set: WordApi 1.1]
          */
@@ -74071,7 +74071,7 @@ declare namespace Word {
          */
         getBookmarks(includeHidden?: boolean, includeAdjacent?: boolean): OfficeExtension.ClientResult<string[]>;
         /**
-         * Gets an HTML representation of the range object. When rendered in a web page or HTML viewer, the formatting will be a close, but not exact, match for of the formatting of the document. This method does not return the exact same HTML for the same document on different platforms (Windows, Mac, Word for the web, etc.). If you need exact fidelity, or consistency across platforms, use `Range.getOoxml()` and convert the returned XML to HTML.
+         * Gets an HTML representation of the range object. When rendered in a web page or HTML viewer, the formatting will be a close, but not exact, match for of the formatting of the document. This method does not return the exact same HTML for the same document on different platforms (Windows, Mac, Word on the web, etc.). If you need exact fidelity, or consistency across platforms, use `Range.getOoxml()` and convert the returned XML to HTML.
          *
          * [Api set: WordApi 1.1]
          */
@@ -77103,7 +77103,7 @@ declare namespace Word {
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported by Word for the web.
+             * **Note**: This API is not supported by Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -77152,7 +77152,7 @@ declare namespace Word {
         interface CustomPropertyUpdateData {
             /**
              *
-             * Gets or sets the value of the custom property. Note that even though Word for the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
+             * Gets or sets the value of the custom property. Note that even though Word on the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
              *
              * [Api set: WordApi 1.3]
              */
@@ -78032,7 +78032,7 @@ declare namespace Word {
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported by Word for the web.
+             * **Note**: This API is not supported by Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -78116,7 +78116,7 @@ declare namespace Word {
             type?: Word.DocumentPropertyType | "String" | "Number" | "Date" | "Boolean";
             /**
              *
-             * Gets or sets the value of the custom property. Note that even though Word for the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
+             * Gets or sets the value of the custom property. Note that even though Word on the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
              *
              * [Api set: WordApi 1.3]
              */
@@ -79392,7 +79392,7 @@ declare namespace Word {
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported by Word for the web.
+             * **Note**: This API is not supported by Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -79560,7 +79560,7 @@ declare namespace Word {
              *
              * For EACH ITEM in the collection: Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported by Word for the web.
+             * **Note**: This API is not supported by Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -79649,7 +79649,7 @@ declare namespace Word {
             type?: boolean;
             /**
              *
-             * Gets or sets the value of the custom property. Note that even though Word for the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
+             * Gets or sets the value of the custom property. Note that even though Word on the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
              *
              * [Api set: WordApi 1.3]
              */
@@ -79682,7 +79682,7 @@ declare namespace Word {
             type?: boolean;
             /**
              *
-             * For EACH ITEM in the collection: Gets or sets the value of the custom property. Note that even though Word for the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
+             * For EACH ITEM in the collection: Gets or sets the value of the custom property. Note that even though Word on the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
              *
              * [Api set: WordApi 1.3]
              */

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -66240,7 +66240,7 @@ declare namespace Word {
          *
          * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
          * 
-         * **Note**: This API is not supported by Word on the web.
+         * **Note**: This API is not supported in Word on the web.
          *
          * [Api set: WordApi 1.1]
          */
@@ -71755,7 +71755,7 @@ declare namespace Word {
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported by Word on the web.
+             * **Note**: This API is not supported in Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -72661,7 +72661,7 @@ declare namespace Word {
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported by Word on the web.
+             * **Note**: This API is not supported in Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -73931,7 +73931,7 @@ declare namespace Word {
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported by Word on the web.
+             * **Note**: This API is not supported in Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -74099,7 +74099,7 @@ declare namespace Word {
              *
              * For EACH ITEM in the collection: Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported by Word on the web.
+             * **Note**: This API is not supported in Word on the web.
              *
              * [Api set: WordApi 1.1]
              */

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -66239,6 +66239,8 @@ declare namespace Word {
         /**
          *
          * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
+         * 
+         * **Note**: This API is not supported by Word for the web.
          *
          * [Api set: WordApi 1.1]
          */
@@ -71752,6 +71754,8 @@ declare namespace Word {
             /**
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
+             * 
+             * **Note**: This API is not supported by Word for the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -72656,6 +72660,8 @@ declare namespace Word {
             /**
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
+             * 
+             * **Note**: This API is not supported by Word for the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -73924,6 +73930,8 @@ declare namespace Word {
             /**
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
+             * 
+             * **Note**: This API is not supported by Word for the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -74090,6 +74098,8 @@ declare namespace Word {
             /**
              *
              * For EACH ITEM in the collection: Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
+             * 
+             * **Note**: This API is not supported by Word for the web.
              *
              * [Api set: WordApi 1.1]
              */

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -65852,7 +65852,7 @@ declare namespace Word {
          */
         clear(): void;
         /**
-         * Gets an HTML representation of the body object. When rendered in a web page or HTML viewer, the formatting will be a close, but not exact, match for of the formatting of the document. This method does not return the exact same HTML for the same document on different platforms (Windows, Mac, Word for the web, etc.). If you need exact fidelity, or consistency across platforms, use `Body.getOoxml()` and convert the returned XML to HTML.
+         * Gets an HTML representation of the body object. When rendered in a web page or HTML viewer, the formatting will be a close, but not exact, match for of the formatting of the document. This method does not return the exact same HTML for the same document on different platforms (Windows, Mac, Word on the web, etc.). If you need exact fidelity, or consistency across platforms, use `Body.getOoxml()` and convert the returned XML to HTML.
          *
          * [Api set: WordApi 1.1]
          */
@@ -66240,7 +66240,7 @@ declare namespace Word {
          *
          * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
          * 
-         * **Note**: This API is not supported by Word for the web.
+         * **Note**: This API is not supported by Word on the web.
          *
          * [Api set: WordApi 1.1]
          */
@@ -66330,7 +66330,7 @@ declare namespace Word {
          */
         delete(keepContent: boolean): void;
         /**
-         * Gets an HTML representation of the content control object. When rendered in a web page or HTML viewer, the formatting will be a close, but not exact, match for of the formatting of the document. This method does not return the exact same HTML for the same document on different platforms (Windows, Mac, Word for the web, etc.). If you need exact fidelity, or consistency across platforms, use `ContentControl.getOoxml()` and convert the returned XML to HTML.
+         * Gets an HTML representation of the content control object. When rendered in a web page or HTML viewer, the formatting will be a close, but not exact, match for of the formatting of the document. This method does not return the exact same HTML for the same document on different platforms (Windows, Mac, Word on the web, etc.). If you need exact fidelity, or consistency across platforms, use `ContentControl.getOoxml()` and convert the returned XML to HTML.
          *
          * [Api set: WordApi 1.1]
          */
@@ -66721,7 +66721,7 @@ declare namespace Word {
         readonly type: Word.DocumentPropertyType | "String" | "Number" | "Date" | "Boolean";
         /**
          *
-         * Gets or sets the value of the custom property. Note that even though Word for the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
+         * Gets or sets the value of the custom property. Note that even though Word on the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
          *
          * [Api set: WordApi 1.3]
          */
@@ -68411,7 +68411,7 @@ declare namespace Word {
          */
         detachFromList(): void;
         /**
-         * Gets an HTML representation of the paragraph object. When rendered in a web page or HTML viewer, the formatting will be a close, but not exact, match for of the formatting of the document. This method does not return the exact same HTML for the same document on different platforms (Windows, Mac, Word for the web, etc.). If you need exact fidelity, or consistency across platforms, use `Paragraph.getOoxml()` and convert the returned XML to HTML.
+         * Gets an HTML representation of the paragraph object. When rendered in a web page or HTML viewer, the formatting will be a close, but not exact, match for of the formatting of the document. This method does not return the exact same HTML for the same document on different platforms (Windows, Mac, Word on the web, etc.). If you need exact fidelity, or consistency across platforms, use `Paragraph.getOoxml()` and convert the returned XML to HTML.
          *
          * [Api set: WordApi 1.1]
          */
@@ -68962,7 +68962,7 @@ declare namespace Word {
          */
         expandToOrNullObject(range: Word.Range): Word.Range;
         /**
-         * Gets an HTML representation of the range object. When rendered in a web page or HTML viewer, the formatting will be a close, but not exact, match for of the formatting of the document. This method does not return the exact same HTML for the same document on different platforms (Windows, Mac, Word for the web, etc.). If you need exact fidelity, or consistency across platforms, use `Range.getOoxml()` and convert the returned XML to HTML.
+         * Gets an HTML representation of the range object. When rendered in a web page or HTML viewer, the formatting will be a close, but not exact, match for of the formatting of the document. This method does not return the exact same HTML for the same document on different platforms (Windows, Mac, Word on the web, etc.). If you need exact fidelity, or consistency across platforms, use `Range.getOoxml()` and convert the returned XML to HTML.
          *
          * [Api set: WordApi 1.1]
          */
@@ -71755,7 +71755,7 @@ declare namespace Word {
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported by Word for the web.
+             * **Note**: This API is not supported by Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -71804,7 +71804,7 @@ declare namespace Word {
         interface CustomPropertyUpdateData {
             /**
              *
-             * Gets or sets the value of the custom property. Note that even though Word for the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
+             * Gets or sets the value of the custom property. Note that even though Word on the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
              *
              * [Api set: WordApi 1.3]
              */
@@ -72661,7 +72661,7 @@ declare namespace Word {
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported by Word for the web.
+             * **Note**: This API is not supported by Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -72745,7 +72745,7 @@ declare namespace Word {
             type?: Word.DocumentPropertyType | "String" | "Number" | "Date" | "Boolean";
             /**
              *
-             * Gets or sets the value of the custom property. Note that even though Word for the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
+             * Gets or sets the value of the custom property. Note that even though Word on the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
              *
              * [Api set: WordApi 1.3]
              */
@@ -73931,7 +73931,7 @@ declare namespace Word {
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported by Word for the web.
+             * **Note**: This API is not supported by Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -74099,7 +74099,7 @@ declare namespace Word {
              *
              * For EACH ITEM in the collection: Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported by Word for the web.
+             * **Note**: This API is not supported by Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -74188,7 +74188,7 @@ declare namespace Word {
             type?: boolean;
             /**
              *
-             * Gets or sets the value of the custom property. Note that even though Word for the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
+             * Gets or sets the value of the custom property. Note that even though Word on the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
              *
              * [Api set: WordApi 1.3]
              */
@@ -74221,7 +74221,7 @@ declare namespace Word {
             type?: boolean;
             /**
              *
-             * For EACH ITEM in the collection: Gets or sets the value of the custom property. Note that even though Word for the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
+             * For EACH ITEM in the collection: Gets or sets the value of the custom property. Note that even though Word on the web and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).
              *
              * [Api set: WordApi 1.3]
              */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/OfficeDev/office-js/issues/1515
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

