### PR TITLE
parsimmon: sepBy1 should return a non-empty array

### DIFF
--- a/types/parsimmon/index.d.ts
+++ b/types/parsimmon/index.d.ts
@@ -250,9 +250,9 @@ declare namespace Parsimmon {
         /**
          * Equivalent to Parsimmon.sepBy(parser, separator).
          *
-         * Expects one or more matches for parser, separated by the parser separator, yielding an array.
+         * Expects one or more matches for parser, separated by the parser separator, yielding a non-empty array.
          */
-        sepBy1<U>(separator: Parser<U>): Parser<T[]>;
+        sepBy1<U>(separator: Parser<U>): Parser<[T, ...T[]]>;
         /**
          * Equivalent to Parsimmon.of(result).
          */
@@ -472,7 +472,7 @@ declare namespace Parsimmon {
     /**
      * This is the same as Parsimmon.sepBy, but matches the content parser at least once.
      */
-    function sepBy1<T, U>(content: Parser<T>, separator: Parser<U>): Parser<T[]>;
+    function sepBy1<T, U>(content: Parser<T>, separator: Parser<U>): Parser<[T, ...T[]]>;
 
     /**
      * accepts a function that returns a parser, which is evaluated the first time the parser is used.

--- a/types/parsimmon/parsimmon-tests.ts
+++ b/types/parsimmon/parsimmon-tests.ts
@@ -39,7 +39,9 @@ let fooOrBarPar: Parser<Foo | Bar>;
 // --  --  --  --  --  --  --  --  --  --  --  --  --
 
 let strArrPar: Parser<string[]>;
+let str1ArrPar: Parser<[string, ...string[]]>;
 let fooArrPar: Parser<Foo[]>;
+let foo1ArrPar: Parser<[Foo, ...Foo[]]>;
 
 // --  --  --  --  --  --  --  --  --  --  --  --  --
 
@@ -284,6 +286,9 @@ strPar = P.seqMap(
 
 strArrPar = P.sepBy(P.string('foo'), P.string('bar'));
 strArrPar = P.sepBy1(P.string('foo'), P.string('bar'));
+str1ArrPar = P.sepBy1(P.string('foo'), P.string('bar'));
+function flattenMultiple(first: string, ...rest: string[]): number { return rest.length; }
+numPar = str1ArrPar.map(arr => flattenMultiple(...arr));
 
 strPar = P.test((a: string) => false);
 
@@ -324,6 +329,7 @@ numPar = P.digit
 
 fooArrPar = fooPar.sepBy(barPar);
 fooArrPar = fooPar.sepBy1(barPar);
+foo1ArrPar = fooPar.sepBy1(barPar);
 
 fooPar = barPar.of(foo);
 


### PR DESCRIPTION
The type `[T, ...T[]]` describes non-empty arrays of `T`. In particular, this means you can now safely write

```typescript
const parser = P.sepBy1(P.string('foo'), P.string('bar'));

function flattenStrings(first: string, ...rest: string[]) {
    return first + " rest = " + rest.join("/");
}

const flattenedParser = parser.map(arr => flattenStrings(...arr));
```

if `sepBy1` just returned a `T[]`, then you'd get a complaint when calling `flattenStrings`:

> Expected at least 1 arguments, but got 0 or more.(2557)

This is (roughly) how I originally encountered this issue.

Similarly, with `--noUncheckedIndexedAccess`, you can now safely access `arr[0]` without getting an `undefined` value added in.

This change is reverse-compatible, since TypeScript recognizes `[T, ...T[]]` as a subtype of `T[]`. Some tests in the PR demonstrate this (using a parser declared with type `Parser<Something[]>` but holding a `sepBy1` parser).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/jneen/parsimmon/blob/master/src/parsimmon.js#L852
  - returned array is guaranteed to be non-empty (also, from the name of the function)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header
  - (no corresponding change in JS)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed
  -(only minor change)
