### PR TITLE
[react-select] Fix defaultValue type in stateManager

### DIFF
--- a/types/react-select/src/stateManager.d.ts
+++ b/types/react-select/src/stateManager.d.ts
@@ -3,16 +3,16 @@ import { Component, ComponentType, Ref as ElementRef } from 'react';
 import SelectBase, { Props as SelectProps } from './Select';
 import { ActionMeta, InputActionMeta, OptionTypeBase, ValueType } from './types';
 
-export interface DefaultProps<OptionType extends OptionTypeBase> {
+export interface DefaultProps {
   defaultInputValue: string;
   defaultMenuIsOpen: boolean;
-  defaultValue: ValueType<OptionType, boolean>;
+  defaultValue: ValueType<OptionTypeBase, boolean>;
 }
 
 export interface Props<OptionType extends OptionTypeBase, IsMulti extends boolean> {
   defaultInputValue?: string;
   defaultMenuIsOpen?: boolean;
-  defaultValue?: ValueType<OptionType, boolean>;
+  defaultValue?: IsMulti extends true ? ValueType<OptionType, boolean> : ValueType<OptionType, false>;
   inputValue?: string;
   menuIsOpen?: boolean;
   value?: ValueType<OptionType, IsMulti>;
@@ -42,7 +42,7 @@ export class StateManager<
   IsMulti extends boolean = false,
   T extends SelectBase<OptionType, IsMulti> = SelectBase<OptionType, IsMulti>
 > extends Component<StateProps<SelectProps<OptionType, IsMulti>> & Props<OptionType, IsMulti> & SelectProps<OptionType, IsMulti>, State<OptionType, IsMulti>> {
-  static defaultProps: DefaultProps<any>;
+  static defaultProps: DefaultProps;
 
   select: T;
 

--- a/types/react-select/test/CustomSelect.tsx
+++ b/types/react-select/test/CustomSelect.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import Select, { OptionTypeBase, Props } from 'react-select';
+
+// tslint:disable-next-line:no-unnecessary-generics
+export function CustomSelect<IsMultiType extends boolean>(props: Props<OptionTypeBase, IsMultiType>) {
+    return <Select {...props} />;
+}

--- a/types/react-select/tsconfig.json
+++ b/types/react-select/tsconfig.json
@@ -25,6 +25,7 @@
         "test/styled-components.tsx",
         "test/AtlaskitDummy.ts",
         "test/ChronoNodeDummy.ts",
+        "test/CustomSelect.tsx",
         "test/Header.tsx",
         "test/Placeholder.tsx",
         "test/examples/AccessingInternals.tsx",


### PR DESCRIPTION
This PR fixes the type of `defaultValue` in `stateManager.d.ts` so that it matches the type of `defaultValue` in the `Props` type in `Select.d.ts`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
