### PR TITLE
gtag.js - Support extended 'set' interface

### DIFF
--- a/types/gtag.js/gtag.js-tests.ts
+++ b/types/gtag.js/gtag.js-tests.ts
@@ -5,6 +5,11 @@ gtag('event', 'login', {
   method: 'Google'
 });
 
+gtag('set', 'user_properties', {
+  favorite_composer: 'Mahler',
+  favorite_instrument: 'double bass',
+  season_ticketholder: 'true'
+});
 gtag('set', {currency: 'USD'});
 gtag('js', new Date());
 gtag('set', {

--- a/types/gtag.js/index.d.ts
+++ b/types/gtag.js/index.d.ts
@@ -7,6 +7,7 @@ declare var gtag: Gtag.Gtag;
 declare namespace Gtag {
   interface Gtag {
     (command: 'config', targetId: string, config?: ControlParams | EventParams | CustomParams): void;
+    (command: 'set', targetId: string, config: CustomParams): void;
     (command: 'set', config: CustomParams): void;
     (command: 'js', config: Date): void;
     (command: 'event', eventName: EventNames | string, eventParams?: ControlParams |  EventParams | CustomParams): void;


### PR DESCRIPTION
According to https://developers.google.com/analytics/devguides/collection/ga4/user-properties, the 'set' command takes another string property.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.