### PR TITLE
[react-slider] Update react-slider types to 1.1

### DIFF
--- a/types/react-slider/index.d.ts
+++ b/types/react-slider/index.d.ts
@@ -1,12 +1,12 @@
-// Type definitions for react-slider 1.0
+// Type definitions for react-slider 1.1
 // Project: https://github.com/zillow/react-slider
 // Definitions by: Jason Unger <https://github.com/jsonunger>
 //                 Björgvin Bæhrenz Þórðarson <https://github.com/bjorgvin>
+//                 Loïc Huder <https://github.com/loichuder>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 import * as React from 'react';
-import * as motion from 'react-motion';
 
 declare namespace ReactSlider {
     interface ReactSliderProps {
@@ -124,19 +124,42 @@ declare namespace ReactSlider {
          * aria-valuetext for screen-readers.
          * Can be a static string, or a function that returns a string.
          */
-        ariaValuetext?: string | ((value: {index: number, value: number | number[], valueNow: number }) => string);
+        ariaValuetext?: string | ((value: { index: number; value: number | number[]; valueNow: number }) => string);
         /**
          * Provide a custom render function for the track node.
          * The render function will be passed two arguments. The first is
          * an object that should be added to your handle node.
          */
-        renderTrack?: (props: object, state: {index: number, value: number | number[] }) => JSX.Element;
+        renderTrack?: (
+            props: React.HTMLProps<HTMLDivElement>,
+            state: { index: number; value: number | number[] },
+        ) => JSX.Element;
         /**
          * Provide a custom render function for dynamic thumb content.
-         * The render function will be passed two arguments.The first is
-         * an object that should be added to your thumb node,
+         * The render function will be passed two arguments. The first is
+         * an object that should be added to your thumb node.
          */
-        renderThumb?: (props: object, state: {index: number, value: number | number[], valueNow: number }) => JSX.Element;
+        renderThumb?: (
+            props: React.HTMLProps<HTMLDivElement>,
+            state: { index: number; value: number | number[]; valueNow: number },
+        ) => JSX.Element;
+        /**
+         * Shows passed marks on the track, if true it shows all the marks,
+         * if an array of numbers it shows just the passed marks, if a number
+         * is passed it shows just the marks in that steps: like passing 3
+         * shows the marks 3, 6, 9.
+         */
+        marks?: boolean | number | number[];
+        /**
+         * The CSS class set on the marks
+         */
+        markClassName?: string;
+        /**
+         * Provide a custom render function for the mark node.
+         * The render function will be passed one argument,
+         * an object with props that should be added to your handle node.
+         */
+        renderMark?: (props: React.HTMLProps<HTMLSpanElement>) => JSX.Element;
     }
 }
 

--- a/types/react-slider/index.d.ts
+++ b/types/react-slider/index.d.ts
@@ -11,32 +11,23 @@ import * as React from 'react';
 declare namespace ReactSlider {
     interface ReactSliderProps {
         /**
-         * The minimum value of the slider.
+         * aria-label for screen-readers to apply to the thumbs.
+         * Use an array for more than one thumb.
+         * The length of the array must match the number of thumbs in the value array.
          */
-        min?: number;
+        ariaLabel?: string | string[];
+
         /**
-         * The maximum value of the slider.
+         * aria-valuetext for screen-readers.
+         * Can be a static string, or a function that returns a string.
          */
-        max?: number;
+        ariaValuetext?: string | ((value: { index: number; value: number | number[]; valueNow: number }) => string);
+
         /**
-         * Value to be added or subtracted on each step the slider makes.
-         * Must be greater than zero.
-         * `max - min` should be evenly divisible by the step value.
+         * The css class set on the slider node.
          */
-        step?: number;
-        /**
-         * The result of the function is the value to be added or subtracted
-         * when the `Page Up` or `Page Down` keys are pressed.
-         *
-         * The current `step` value will be passed as the only argument.
-         * By default, paging will modify `step` by a factor of 10.
-         */
-        pageFn?: (step: number) => number;
-        /**
-         * The minimal distance between any pair of thumbs.
-         * Must be positive, but zero means they can sit on top of each other.
-         */
-        minDistance?: number;
+        className?: string;
+
         /**
          * Determines the initial positions of the thumbs and the number of thumbs.
          *
@@ -45,95 +36,100 @@ declare namespace ReactSlider {
          * The values in the array must be sorted.
          */
         defaultValue?: number | number[];
-        /**
-         * Like `defaultValue` but for
-         * [controlled components](http://facebook.github.io/react/docs/forms.html#controlled-components).
-         */
-        value?: number | number[];
-        /**
-         * Determines whether the slider moves horizontally (from left to right)
-         * or vertically (from top to bottom).
-         */
-        orientation?: 'horizontal' | 'vertical';
-        /**
-         * The css class set on the slider node.
-         */
-        className?: string;
-        /**
-         * The css class set on each thumb node.
-         *
-         * In addition each thumb will receive a numbered css class of the form
-         * `${thumbClassName}-${i}`, e.g. `thumb-0`, `thumb-1`, ...
-         */
-        thumbClassName?: string;
-        /**
-         * The css class set on the thumb that is currently being moved.
-         */
-        thumbActiveClassName?: string;
-        /**
-         * The css class set on the tracks between the thumbs.
-         * In addition track fragment will receive a numbered css class of the form
-         * `${trackClassName}-${i}`, e.g. `track-0`, `track-1`, ...
-         */
-        trackClassName?: string;
-        /**
-         * If `true` tracks between the thumbs will be rendered.
-         */
-        withTracks?: boolean;
-        /**
-         * If `true` the active thumb will push other thumbs
-         * within the constraints of `min`, `max`, `step` and `minDistance`.
-         */
-        pearling?: boolean;
+
         /**
          * If `true` the thumbs can't be moved.
          */
         disabled?: boolean;
-        /**
-         * Disables thumb move when clicking the slider track
-         */
-        snapDragDisabled?: boolean;
+
         /**
          * Inverts the slider.
          */
         invert?: boolean;
+
         /**
-         * Callback called before starting to move a thumb.
+         * The CSS class set on the marks.
          */
-        onBeforeChange?: (value: number | number[] | undefined | null) => void;
+        markClassName?: string;
+
         /**
-         * Callback called on every value change.
+         * Shows passed marks on the track, if true it shows all the marks,
+         * if an array of numbers it shows just the passed marks, if a number
+         * is passed it shows just the marks in that steps: like passing 3
+         * shows the marks 3, 6, 9.
          */
-        onChange?: (value: number | number[] | undefined | null) => void;
+        marks?: boolean | number | number[];
+
         /**
-         * Callback called only after moving a thumb has ended.
+         * The maximum value of the slider.
+         */
+        max?: number;
+
+        /**
+         * The minimum value of the slider.
+         */
+        min?: number;
+
+        /**
+         * The minimal distance between any pair of thumbs.
+         * Must be positive, but zero means they can sit on top of each other.
+         */
+        minDistance?: number;
+
+        /**
+         * Callback called only after moving a thumb has ended. The callback
+         * will only be called if the action resulted in a change. The
+         * function will be called with one argument,  the result value(s).
          */
         onAfterChange?: (value: number | number[] | undefined | null) => void;
+
+        /**
+         * Callback called before starting to move a thumb. The callback will
+         * only be called if the action will result in a change. The function
+         * will be called with one argument, the initial value(s).
+         */
+        onBeforeChange?: (value: number | number[] | undefined | null) => void;
+
+        /**
+         * Callback called on every value change. The function will be called
+         * with one argument, the new value(s).
+         */
+        onChange?: (value: number | number[] | undefined | null) => void;
+
         /**
          * Callback called when the the slider is clicked (thumb or tracks).
          * Receives the value at the clicked position as argument.
          */
         onSliderClick?: (value: number) => void;
+
         /**
-         * aria-label for screen-readers to apply to the thumbs.
-         * Use an array for more than one thumb.
-         * The length of the array must match the number of thumbs in the value array.
+         * Determines whether the slider moves horizontally (from left to right)
+         * or vertically (from top to bottom).
          */
-        ariaLabel?: string | string[];
+        orientation?: 'horizontal' | 'vertical';
+
         /**
-         * aria-valuetext for screen-readers.
-         * Can be a static string, or a function that returns a string.
+         * The result of the function is the value to be added or subtracted
+         * when the `Page Up` or `Page Down` keys are pressed.
+         *
+         * The current `step` value will be passed as the only argument.
+         * By default, paging will modify `step` by a factor of 10.
          */
-        ariaValuetext?: string | ((value: { index: number; value: number | number[]; valueNow: number }) => string);
+        pageFn?: (step: number) => number;
+
         /**
-         * Provide a custom render function for the track node.
-         * The render function will be passed two arguments. The first is
-         * an object that should be added to your handle node.
+         * If `true` the active thumb will push other thumbs
+         * within the constraints of `min`, `max`, `step` and `minDistance`.
          */
-        renderTrack?: (
-            props: React.HTMLProps<HTMLDivElement>,
-            state: { index: number; value: number | number[] },
-        ) => JSX.Element;
+        pearling?: boolean;
+
+        /**
+         * Provide a custom render function for the mark node.
+         * The render function will be passed one argument,
+         * an object with props that should be added to your handle node.
+         */
+        renderMark?: (props: React.HTMLProps<HTMLSpanElement>) => JSX.Element;
+
         /**
          * Provide a custom render function for dynamic thumb content.
          * The render function will be passed two arguments. The first is
@@ -143,23 +139,59 @@ declare namespace ReactSlider {
             props: React.HTMLProps<HTMLDivElement>,
             state: { index: number; value: number | number[]; valueNow: number },
         ) => JSX.Element;
+
         /**
-         * Shows passed marks on the track, if true it shows all the marks,
-         * if an array of numbers it shows just the passed marks, if a number
-         * is passed it shows just the marks in that steps: like passing 3
-         * shows the marks 3, 6, 9.
+         * Provide a custom render function for the track node.
+         * The render function will be passed two arguments. The first is
+         * an object that should be added to your handle node.
          */
-        marks?: boolean | number | number[];
+        renderTrack?: (
+            props: React.HTMLProps<HTMLDivElement>,
+            state: { index: number; value: number | number[] },
+        ) => JSX.Element;
+
         /**
-         * The CSS class set on the marks
+         * Disables thumb move when clicking the slider track
          */
-        markClassName?: string;
+        snapDragDisabled?: boolean;
+
         /**
-         * Provide a custom render function for the mark node.
-         * The render function will be passed one argument,
-         * an object with props that should be added to your handle node.
+         * Value to be added or subtracted on each step the slider makes.
+         * Must be greater than zero.
+         * `max - min` should be evenly divisible by the step value.
          */
-        renderMark?: (props: React.HTMLProps<HTMLSpanElement>) => JSX.Element;
+        step?: number;
+
+        /**
+         * The css class set on the thumb that is currently being moved.
+         */
+        thumbActiveClassName?: string;
+
+        /**
+         * The css class set on each thumb node.
+         *
+         * In addition each thumb will receive a numbered css class of the form
+         * `${thumbClassName}-${i}`, e.g. `thumb-0`, `thumb-1`, ...
+         */
+        thumbClassName?: string;
+
+        /**
+         * The css class set on the tracks between the thumbs.
+         * In addition track fragment will receive a numbered css class of the form
+         * `${trackClassName}-${i}`, e.g. `track-0`, `track-1`, ...
+         */
+        trackClassName?: string;
+
+        /**
+         * Like `defaultValue` but for
+         * [controlled components](http://facebook.github.io/react/docs/forms.html#controlled-components).
+         */
+        value?: number | number[];
+
+        /**
+         * If `true` tracks between the thumbs will be rendered.
+         */
+        withTracks?: boolean;
     }
 }
 

--- a/types/react-slider/react-slider-tests.tsx
+++ b/types/react-slider/react-slider-tests.tsx
@@ -8,6 +8,8 @@ class Slider extends React.Component<ReactSlider.ReactSliderProps> {
                 snapDragDisabled
                 trackClassName="classnameForBar"
                 withTracks={false}
+                marks={5}
+                renderMark={props => <span {...props} />}
                 {...this.props}
             />
         );


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see https://github.com/zillow/react-slider/blob/master/CHANGELOG.md#110-2020-11-03 and https://zillow.github.io/react-slider/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The full diff is messy as I reorganized the types to match the order of https://zillow.github.io/react-slider/ in a separate commit. The "real" update to 1.1 is in the first commit.