### PR TITLE
[mobile-messaging-cordova] Lists and date time for customAttributes, in-app chat, notification primary button actions

### DIFF
--- a/types/mobile-messaging-cordova/index.d.ts
+++ b/types/mobile-messaging-cordova/index.d.ts
@@ -77,7 +77,7 @@ declare namespace MobileMessagingCordova {
         phones?: string[];
         emails?: string[];
         tags?: string[];
-        customAttributes?: Record<string, string | number | boolean | any[]>;
+        customAttributes?: Record<string, string | number | boolean | object[]>;
     }
 
     interface Installation {
@@ -107,7 +107,7 @@ declare namespace MobileMessagingCordova {
 
     interface PersonalizeContext {
         userIdentity: UserIdentity;
-        userAttributes?: Record<string, string | number | boolean | any[]>;
+        userAttributes?: Record<string, string | number | boolean | object[]>;
         forceDepersonalize?: boolean;
     }
 

--- a/types/mobile-messaging-cordova/index.d.ts
+++ b/types/mobile-messaging-cordova/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package mobile-messaging-cordova-plugin 1.3
+// Type definitions for non-npm package mobile-messaging-cordova-plugin 1.7
 // Project: https://github.com/infobip/mobile-messaging-cordova-plugin
 // Definitions by: kostap13 <https://github.com/kostap13>,
 //                 tjuric <https://github.com/tjuric>

--- a/types/mobile-messaging-cordova/index.d.ts
+++ b/types/mobile-messaging-cordova/index.d.ts
@@ -18,7 +18,8 @@ declare namespace MobileMessagingCordova {
         'installationUpdated' |
         'userUpdated' |
         'personalized' |
-        'depersonalized';
+        'depersonalized'|
+        'deeplink';
 
     interface Configuration {
         /**
@@ -26,6 +27,7 @@ declare namespace MobileMessagingCordova {
          */
         applicationCode: string;
         geofencingEnabled?: boolean;
+        inAppChatEnabled?: boolean;
         /**
          * Message storage save callback
          */
@@ -71,11 +73,11 @@ declare namespace MobileMessagingCordova {
         lastName?: string;
         middleName?: string;
         gender?: Gender;
-        birthday?: Date;
+        birthday?: string;
         phones?: string[];
         emails?: string[];
         tags?: string[];
-        customAttributes?: Record<string, string>;
+        customAttributes?: Record<string, string | number | boolean | any[]>;
     }
 
     interface Installation {
@@ -94,7 +96,7 @@ declare namespace MobileMessagingCordova {
         deviceTimezoneId?: string;
         applicationUserId?: string;
         deviceName?: string;
-        customAttributes?: Record<string, string>;
+        customAttributes?: Record<string, string | number | boolean>;
     }
 
     interface UserIdentity {
@@ -105,7 +107,7 @@ declare namespace MobileMessagingCordova {
 
     interface PersonalizeContext {
         userIdentity: UserIdentity;
-        userAttributes?: Record<string, string>;
+        userAttributes?: Record<string, string | number | boolean | any[]>;
         forceDepersonalize?: boolean;
     }
 
@@ -114,16 +116,34 @@ declare namespace MobileMessagingCordova {
         title?: string;
         body?: string;
         sound?: string;
-        vibrate?: string;
         silent?: string;
-        category?: string;
         customPayload?: Record<string, string>;
         internalData?: string;
+        receivedTimestamp?: number;
+        seenDate?: number;
+        contentUrl?: string;
+        seen?: boolean;
+        geo?: boolean;
+        originalPayload?: Record<string, string>; // iOS only
+        vibrate?: boolean; // Android only
+        icon?: string; // Android only
+        category?: string; // Android only
+        chat?: string;
+        browserUrl?: string;
+        deeplink?: string;
+        webViewUrl?: string;
+        inAppDismissTitle?: string;
     }
 
     interface MobileMessagingError {
         code: string;
         message: string;
+    }
+
+    interface ChatConfig {
+        ios?: {
+            showModally: boolean;
+        };
     }
 
     interface DefaultMessageStorage {
@@ -324,6 +344,12 @@ declare namespace MobileMessagingCordova {
                            errorCallback: (error: MobileMessagingError) => void): void;
 
         defaultMessageStorage(): DefaultMessageStorage | undefined;
+
+        /**
+         * Displays chat view
+         * @param config
+         */
+        showChat(config?: ChatConfig): void;
     }
 }
 

--- a/types/mobile-messaging-cordova/mobile-messaging-cordova-tests.ts
+++ b/types/mobile-messaging-cordova/mobile-messaging-cordova-tests.ts
@@ -33,7 +33,7 @@ MobileMessaging.saveUser({
     lastName: 'Lastname',
     middleName: 'Middle',
     gender: 'Male',
-    birthday: new Date(1987, 6, 5),
+    birthday: '1987-11-23',
     phones: ['+12345677890'],
     emails: ['some@ema.il'],
     tags: ['TestIonic'],
@@ -164,4 +164,10 @@ MobileMessaging.showDialogForError(1, () => {
     console.log("Dialog opened");
 }, () => {
     console.error("Error opening dialog");
+});
+
+MobileMessaging.showChat({
+    ios: {
+        showModally: false,
+    },
 });


### PR DESCRIPTION
Added support of following features:

- [Lists and date type for customAttributes](https://github.com/infobip/mobile-messaging-cordova-plugin/wiki/Users-and-installations#custom-attributes-1)
- [In-app chat](https://github.com/infobip/mobile-messaging-cordova-plugin/wiki/In%E2%80%90app-chat)
- [notification primary button actions](https://github.com/infobip/mobile-messaging-cordova-plugin/wiki/How-to-define-specific-action-on-notification-or-in-app-primary-button-tap(open-url,-deeplink)%3F)