### PR TITLE
Mongoose: Added flag for Optimistic Concurrency option in SchemaType

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -1194,6 +1194,8 @@ declare module "mongoose" {
     _id?: boolean;
     /** controls document#toObject behavior when called manually - defaults to true */
     minimize?: boolean;
+    /** When true mongoose will throw a Version Error if a document has change before saving - defaults to false */
+    optimisticConcurrency?: boolean;
     read?: string;
     writeConcern?: WriteConcern;
     /** defaults to true. */

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -42,6 +42,7 @@
 //                 Andrei Alecu <https://github.com/andreialecu>
 //                 The Half Blood Prince <https://github.com/tHBp>
 //                 Pirasis Leelatanon <https://github.com/1pete>
+//                 Guillem Gelabert Sunyer <https://github.com/guillem-gelabert>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.2
 

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -1195,7 +1195,7 @@ declare module "mongoose" {
     _id?: boolean;
     /** controls document#toObject behavior when called manually - defaults to true */
     minimize?: boolean;
-    /** When true mongoose will throw a Version Error if a document has change before saving - defaults to false */
+    /** When true, mongoose will throw a Version Error if a document has changed before saving - defaults to false */
     optimisticConcurrency?: boolean;
     read?: string;
     writeConcern?: WriteConcern;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Automattic/mongoose/blob/master/History.md#5100--2020-08-14
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.