### PR TITLE
[undertaker] first param of task function callback is Error | null, not any

### DIFF
--- a/types/undertaker/index.d.ts
+++ b/types/undertaker/index.d.ts
@@ -23,7 +23,7 @@ declare namespace Undertaker {
     }
 
     interface TaskFunctionBase {
-        (done: (error?: any) => void): void | Duplex | NodeJS.Process | Promise<never> | any;
+        (done: (error?: Error | null) => void): void | Duplex | NodeJS.Process | Promise<never> | any;
     }
 
     interface TaskFunction extends TaskFunctionBase, TaskFunctionParams {}

--- a/types/undertaker/undertaker-tests.ts
+++ b/types/undertaker/undertaker-tests.ts
@@ -42,6 +42,17 @@ taker.task("all-parallel-array", taker.parallel(["combined", "task3"]));
 
 taker.task("all-series-array", taker.series(["combined", "task3"]));
 
+const version = 7;
+taker.task("checkVersion", (cb: Parameters<Undertaker.TaskFunction>[0]) => {
+    if (version < 7) {
+        cb(new Error("version < 7!"));
+    } else if (version < 9) {
+        cb(null);
+    } else {
+        cb();
+    }
+});
+
 const registry = new Registry();
 const CommonRegistry = (options: { buildDir: string }): Registry => {
     return registry;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
        https://github.com/gulpjs/async-done#completion-and-error-resolution, linked from https://github.com/gulpjs/undertaker#api (first sentence)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Some notes:
1. https://github.com/gulpjs/async-done#completion-and-error-resolution states that the callback can be called with a null/non-null error. After examining https://github.com/gulpjs/async-done#usage, it appears that "error" here means `Error`.
1. This first parameter is optional, as shown in https://gulpjs.com/docs/en/getting-started/async-completion/#using-an-error-first-callback (i.e. callback can be invoked with 0 arguments).
1. There actually appears to be a second parameter (https://github.com/gulpjs/async-done#successful-completion) but that parameter isn't apparently used for gulp task functions.