### PR TITLE
Allow mismatch in jest toStrictEqual matcher

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1028,7 +1028,7 @@ declare namespace jest {
          * This is particularly useful for ensuring expected objects have the right structure.
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        toStrictEqual<E extends T>(expected: E): R;
+        toStrictEqual<E = T>(expected: E): R;
         /**
          * Used to test that a function throws when it is called.
          */

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1083,6 +1083,12 @@ describe('', () => {
         interface Dog extends Animal { breed: string; }
         const dog: Dog = { type: 'dog', breed: 'chihuahua' };
         expect(dog as Animal).toStrictEqual({ type: 'dog', breed: 'chihuahua' });
+        class Cat {
+            type: 'cat';
+            constructor() { this.type = 'cat'; }
+            speak() { return 'meow'; }
+        }
+        expect(new Cat()).toStrictEqual({ type: 'cat' });
         // $ExpectError
         expect('abc').toStrictEqual(2);
 

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1089,8 +1089,6 @@ describe('', () => {
             speak() { return 'meow'; }
         }
         expect(new Cat()).toStrictEqual({ type: 'cat' });
-        // $ExpectError
-        expect('abc').toStrictEqual(2);
 
         const errInstance = new Error();
         const willThrow = () => {
@@ -1132,8 +1130,6 @@ describe('', () => {
 
         expect(Promise.resolve('jest')).resolves.toStrictEqual('jest').then(() => {});
         expect(Promise.resolve('jest')).resolves.not.toStrictEqual('other').then(() => {});
-        // $ExpectError
-        expect(Promise.resolve('jest')).resolves.toStrictEqual(123).then(() => {});
 
         /* type matchers */
 


### PR DESCRIPTION
Jest tests for strict equality for own properties. TypeScript equality also takes the prototype chain into account. This
means the type of the expected value doesn’t have to match the actual value as far as TypeScript is concerned.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.