### PR TITLE
Changed faker.address.nearByGPSCoordinate() coordinate parameter type from string to ReadOnlyArray<string>

### DIFF
--- a/types/faker/faker-tests.ts
+++ b/types/faker/faker-tests.ts
@@ -42,7 +42,7 @@ resultStr = faker.address.cardinalDirection(true);
 resultStr = faker.address.ordinalDirection();
 resultStr = faker.address.ordinalDirection(true);
 resultStrArr = faker.address.nearbyGPSCoordinate();
-resultStrArr = faker.address.nearbyGPSCoordinate('foo', 0, true);
+resultStrArr = faker.address.nearbyGPSCoordinate(['0', '0'], 0, true);
 resultStr = faker.address.timeZone();
 
 resultStr = faker.commerce.color();

--- a/types/faker/index.d.ts
+++ b/types/faker/index.d.ts
@@ -36,7 +36,7 @@ declare namespace Faker {
             direction(useAbbr?: boolean): string;
             cardinalDirection(useAbbr?: boolean): string;
             ordinalDirection(useAbbr?: boolean): string;
-            nearbyGPSCoordinate(coordinate?: string[], radius?: number, isMetric?: boolean): string[];
+            nearbyGPSCoordinate(coordinate?: ReadonlyArray<string>, radius?: number, isMetric?: boolean): string[];
             timeZone(): string;
         };
 

--- a/types/faker/index.d.ts
+++ b/types/faker/index.d.ts
@@ -36,7 +36,7 @@ declare namespace Faker {
             direction(useAbbr?: boolean): string;
             cardinalDirection(useAbbr?: boolean): string;
             ordinalDirection(useAbbr?: boolean): string;
-            nearbyGPSCoordinate(coordinate?: string, radius?: number, isMetric?: boolean): string[];
+            nearbyGPSCoordinate(coordinate?: string[], radius?: number, isMetric?: boolean): string[];
             timeZone(): string;
         };
 


### PR DESCRIPTION
The nearbyGPSCoordinate function uses coordinate[0] and coordinate[1] as a string array, not a single string. The function worked when i used "["0", "0"] as unknown as string" as the input, which means it actually should have a string array. Hope this can be approved to fix this issue. As mentioned in the commit message, I also changed the test to reflect the usage.

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [x ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: [faker.js - address](https://github.com/Marak/faker.js/blob/master/lib/address.js)
- [x ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
