### PR TITLE
Fix conflicting PaginateOptions in mongoose-paginate-v2 and mongoos…

### DIFF
--- a/types/mongoose-aggregate-paginate-v2/index.d.ts
+++ b/types/mongoose-aggregate-paginate-v2/index.d.ts
@@ -24,7 +24,7 @@ declare module 'mongoose' {
     }
 
     interface PaginateOptions {
-        sort?: any;
+        sort?: object | string;
         offset?: number;
         page?: number;
         limit?: number;

--- a/types/mongoose-paginate-v2/index.d.ts
+++ b/types/mongoose-paginate-v2/index.d.ts
@@ -30,8 +30,7 @@ declare module 'mongoose' {
     interface PaginateOptions {
         /* tslint:disable-next-line: ban-types */
         select?: Object | string;
-        /* tslint:disable-next-line: ban-types */
-        sort?: Object | string;
+        sort?: object | string;
         customLabels?: CustomLabels;
         collation?: CollationOptions;
         /* tslint:disable-next-line: ban-types */

--- a/types/mongoose-paginate-v2/index.d.ts
+++ b/types/mongoose-paginate-v2/index.d.ts
@@ -28,13 +28,11 @@ declare module 'mongoose' {
     }
 
     interface PaginateOptions {
-        /* tslint:disable-next-line: ban-types */
-        select?: Object | string;
+        select?: object | string;
         sort?: object | string;
         customLabels?: CustomLabels;
         collation?: CollationOptions;
-        /* tslint:disable-next-line: ban-types */
-        populate?: Object[] | string[] | Object | string | QueryPopulateOptions;
+        populate?: object[] | string[] | object | string | QueryPopulateOptions;
         lean?: boolean;
         leanWithId?: boolean;
         offset?: number;


### PR DESCRIPTION
…e-aggregate-paginate-v2

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://mongoosejs.com/docs/api.html#query_Query-sort
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Following a [comment](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49839#discussion_r533624966) by @amcasey in the pull request creating the types for mongoose-aggregate-paginate-v2, I changed PaginateOptions['sort']'s type to use `any` instead of `Object | string`. However, it is conflicting with mongoose-paginate-v2, so the packages cannot be used both at the same time.

The two packages use mongoose's sorting in the background, so using `object|string` for both is not a breaking change and will fix the conflicting types.

For reference, the error showing the conflict was `TS2717: Subsequent property declarations must have the same type.  Property 'sort' must be of type 'any', but here has type 'string | Object'.`