### PR TITLE
[pino-http] fix: Declare support for the optional `next` parameter

### DIFF
--- a/types/pino-http/index.d.ts
+++ b/types/pino-http/index.d.ts
@@ -16,7 +16,7 @@ declare function PinoHttp(opts?: PinoHttp.Options, stream?: DestinationStream): 
 declare function PinoHttp(stream?: DestinationStream): PinoHttp.HttpLogger;
 
 declare namespace PinoHttp {
-    type HttpLogger = (req: IncomingMessage, res: ServerResponse) => void;
+    type HttpLogger = (req: IncomingMessage, res: ServerResponse, next?: () => void) => void;
     type ReqId = number | string | object;
 
     /**

--- a/types/pino-http/pino-http-tests.ts
+++ b/types/pino-http/pino-http-tests.ts
@@ -13,6 +13,13 @@ function handle(req: http.IncomingMessage, res: http.ServerResponse) {
     res[pinoHttp.startTime] = Date.now();
 }
 
+function handle_with_next(req: http.IncomingMessage, res: http.ServerResponse, next: () => void) {
+    pinoHttp()(req, res, () => {
+        // Do a thing.
+        next();
+    });
+}
+
 pinoHttp({ logger });
 pinoHttp({ genReqId: req => req.statusCode || 200 });
 pinoHttp({ genReqId: req => 'foo' });


### PR DESCRIPTION
The actual code handles it just fine, it looks like it was a simple omission.  The actual middleware function in pino-http has supported this since the first commit if my read of the blame is correct.

With this in place, as my locally patched edition has it, I can use AsyncLocalStorage to keep the logger context across the whole request.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pinojs/pino-http/blob/master/logger.js#L89
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
