### PR TITLE
[@types/mz] Fixing bad return type definition in async read()

### DIFF
--- a/types/mz/fs.d.ts
+++ b/types/mz/fs.d.ts
@@ -1104,7 +1104,7 @@ export function read<TBuffer extends NodeJS.ArrayBufferView>(
     offset: number,
     length: number,
     position: number | null
-): Promise<{ bytesRead: number; buffer: TBuffer }>;
+): Promise<[number, TBuffer]>;
 
 /**
  * Asynchronously reads the entire contents of a file.


### PR DESCRIPTION
Fixing bad return type definition in async read(). 

Native fs.read() function accepts a callback of 3 args (err, bytesRead, buffer) . Non error args are returned as array instead of object.

See https://nodejs.org/docs/latest-v12.x/api/fs.html#fs_fs_read_fd_options_callback

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v12.x/api/fs.html#fs_fs_read_fd_options_callback
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
