### PR TITLE
multer: fix type of callback for custom storage

### DIFF
--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -270,7 +270,7 @@ declare namespace multer {
         _removeFile(
             req: Request,
             file: Express.Multer.File,
-            callback: (error: Error) => void
+            callback: (error?: Error) => void
         ): void;
     }
 

--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -270,7 +270,7 @@ declare namespace multer {
         _removeFile(
             req: Request,
             file: Express.Multer.File,
-            callback: (error?: Error) => void
+            callback: (error: Error | null) => void
         ): void;
     }
 

--- a/types/multer/multer-tests.ts
+++ b/types/multer/multer-tests.ts
@@ -46,3 +46,22 @@ const diskUpload: Multer = multer({ storage: diskStorage });
 
 const memoryStorage = multer.memoryStorage();
 const memoryUpload: Multer = multer({ storage: memoryStorage });
+
+const customStorage = {
+    _handleFile: (
+            req: Request,
+            file: Express.Multer.File,
+            callback: (error?: any, info?: Partial<Express.Multer.File>) => void
+        ): void => {
+        callback();
+    },
+    _removeFile: (
+        req: Request,
+        file: Express.Multer.File,
+        callback: (error?: Error) => void
+    ): void => {
+        callback();
+    }
+};
+
+const customUpload: Multer = multer({ storage: customStorage });

--- a/types/multer/multer-tests.ts
+++ b/types/multer/multer-tests.ts
@@ -58,7 +58,7 @@ const customStorage = {
     _removeFile: (
         req: express.Request,
         file: Express.Multer.File,
-        callback: (error?: Error) => void
+        callback: (error: Error | null) => void
     ): void => {
         callback();
     }

--- a/types/multer/multer-tests.ts
+++ b/types/multer/multer-tests.ts
@@ -60,7 +60,7 @@ const customStorage = {
         file: Express.Multer.File,
         callback: (error: Error | null) => void
     ): void => {
-        callback();
+        callback(null);
     }
 };
 

--- a/types/multer/multer-tests.ts
+++ b/types/multer/multer-tests.ts
@@ -49,14 +49,14 @@ const memoryUpload: Multer = multer({ storage: memoryStorage });
 
 const customStorage = {
     _handleFile: (
-            req: Request,
+            req: express.Request,
             file: Express.Multer.File,
             callback: (error?: any, info?: Partial<Express.Multer.File>) => void
         ): void => {
         callback();
     },
     _removeFile: (
-        req: Request,
+        req: express.Request,
         file: Express.Multer.File,
         callback: (error?: Error) => void
     ): void => {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>


The interface `StorageEngine` could implement as such:
```js
class CustomStorage {
  _handleFile(
    req: Request,
    file: Express.Multer.File,
    callback: (error?: any, info?: Partial<Express.Multer.File>) => void
  ): void {
    // just callback
    callback();
  }

  _removeFile(
      req: Request,
      file: Express.Multer.File,
      callback: (error: Error) => void
  ): void {
    // do something successfully
    // then callback
    callback();
  }
}
```

but the parameter `error` is not optional, so we get a type error here.
I checked the source code and the error should be optional, see:
https://github.com/expressjs/multer/blob/master/lib/remove-uploaded-files.js#L11