### PR TITLE
markdown-it: remove dependency `highlight.js` (and only keep `@types/highlight.js`) to resolve vulnerability GHSA-7wwv-vh3v-89cq

### DIFF
--- a/types/markdown-it/index.d.ts
+++ b/types/markdown-it/index.d.ts
@@ -1,10 +1,10 @@
-// Type definitions for markdown-it v10.0.0
+// Type definitions for markdown-it v12.0.2
 // Project: https://github.com/markdown-it/markdown-it
 // Definitions by: York Yao <https://github.com/plantain-00>
 //                 Robert Coie <https://github.com/rapropos>
 //                 duduluu <https://github.com/duduluu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.0
+// TypeScript Version: 3.6
 
 import MarkdownIt = require('./lib');
 

--- a/types/markdown-it/index.d.ts
+++ b/types/markdown-it/index.d.ts
@@ -4,7 +4,7 @@
 //                 Robert Coie <https://github.com/rapropos>
 //                 duduluu <https://github.com/duduluu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.6
+// TypeScript Version: 2.0
 
 import MarkdownIt = require('./lib');
 

--- a/types/markdown-it/lib/index.d.ts
+++ b/types/markdown-it/lib/index.d.ts
@@ -82,12 +82,12 @@ declare namespace MarkdownIt {
 
         /**
          * Highlighter function for fenced code blocks.
-         * Highlighter `function (str, lang)` should return escaped HTML. It can also
-         * return empty string if the source was not changed and should be escaped
-         * externaly. If result starts with <pre... internal wrapper is skipped.
+         * Highlighter `function (str, lang, attrs)` should return escaped HTML. It can
+         * also return empty string if the source was not changed and should be escaped
+         * externally. If result starts with <pre... internal wrapper is skipped.
          * @default null
          */
-        highlight?: ((str: string, lang: string) => string) | null;
+        highlight?: ((str: string, lang: string, attrs: string) => string) | null;
     }
 
     type PluginSimple = (md: MarkdownIt) => void;

--- a/types/markdown-it/package.json
+++ b/types/markdown-it/package.json
@@ -1,7 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "highlight.js": "^9.7.0",
-        "@types/highlight.js": "^9.7.0"
+        "highlight.js": "10.4.1"
     }
 }

--- a/types/markdown-it/package.json
+++ b/types/markdown-it/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "highlight.js": "10.4.1"
+        "@types/highlight.js": "^9.7.0"
     }
 }

--- a/types/markdown-it/test/index.ts
+++ b/types/markdown-it/test/index.ts
@@ -44,7 +44,7 @@ import LinkifyIt = require('linkify-it');
         linkify: false,
         typographer: false,
         quotes: '\u201c\u201d\u2018\u2019' /* “”‘’ */,
-        highlight: null,
+        highlight: function(str, lang, attrs) { return ""; },
     };
 }
 

--- a/types/markdown-it/test/index.ts
+++ b/types/markdown-it/test/index.ts
@@ -44,6 +44,18 @@ import LinkifyIt = require('linkify-it');
         linkify: false,
         typographer: false,
         quotes: '\u201c\u201d\u2018\u2019' /* “”‘’ */,
+        highlight: null,
+    };
+
+    // highlight
+    options = {
+        html: false,
+        xhtmlOut: false,
+        breaks: false,
+        langPrefix: 'language-',
+        linkify: false,
+        typographer: false,
+        quotes: '\u201c\u201d\u2018\u2019' /* “”‘’ */,
         highlight: function(str, lang, attrs) { return ""; },
     };
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/advisories/GHSA-7wwv-vh3v-89cq
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Note: besides, adjustments have been made in line with the changed API: https://github.com/markdown-it/markdown-it/issues/626