### PR TITLE
chore(jest): remove unneeded `Parameters` definition

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1052,8 +1052,6 @@ declare namespace jest {
     T['length'] extends 0 ? [] :
         (((...b: T) => void) extends (a: any, ...b: infer I) => void ? I : []);
 
-    type Parameters<T extends (...args: any[]) => any> = T extends (...args: infer P) => any ? P : never;
-
     interface AsymmetricMatcher {
         asymmetricMatch(other: unknown): boolean;
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

------

We don't need this one either - I've done it in its own PR because unlike `Omit`, this definition is slightly different to the built-in, but I think we should ideally be using the built-in or else name ours differently.