### PR TITLE
[socket.io] add parser option to server constructor

### DIFF
--- a/types/socket.io/index.d.ts
+++ b/types/socket.io/index.d.ts
@@ -16,7 +16,7 @@ declare const SocketIO: SocketIOStatic;
 import engine = require('engine.io');
 import { Server as HttpServer, IncomingMessage } from 'http';
 import { Server as HttpsServer } from 'https';
-import SocketIoParser = require('socket.io-parser');
+import { Encoder as ParserEncoder, Decoder as ParserDecoder } from 'socket.io-parser';
 export = SocketIO;
 /** @deprecated Available as a global for backwards-compatibility. */
 export as namespace SocketIO;
@@ -485,7 +485,10 @@ declare namespace SocketIO {
          * ships with socket.io which is memory-based. See `socket.io-parser`.
          * @default require('socket.io-parser')
          */
-        parser?: typeof SocketIoParser;
+        parser?: {
+            Encoder: ParserEncoder,
+            Decoder: ParserDecoder,
+        };
     }
 
     /**

--- a/types/socket.io/index.d.ts
+++ b/types/socket.io/index.d.ts
@@ -11,6 +11,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 ///<reference types="node" />
+///<reference lib="dom" />
 
 declare const SocketIO: SocketIOStatic;
 import engine = require('engine.io');

--- a/types/socket.io/index.d.ts
+++ b/types/socket.io/index.d.ts
@@ -11,12 +11,13 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 ///<reference types="node" />
+///<reference lib="dom" /> required by socket.io-parser.
 
 declare const SocketIO: SocketIOStatic;
 import engine = require('engine.io');
 import { Server as HttpServer, IncomingMessage } from 'http';
 import { Server as HttpsServer } from 'https';
-import { EventEmitter } from 'events';
+import SocketIoParser = require('socket.io-parser');
 export = SocketIO;
 /** @deprecated Available as a global for backwards-compatibility. */
 export as namespace SocketIO;
@@ -456,7 +457,7 @@ declare namespace SocketIO {
      */
     interface ServerOptions extends engine.ServerAttachOptions {
         /**
-         * The path to server the client file to
+         * The path to server the client file to.
          * @default '/socket.io'
          */
         path?: string;
@@ -469,16 +470,23 @@ declare namespace SocketIO {
 
         /**
          * The adapter to use for handling rooms. NOTE: this should be a class,
-         * not an object
+         * not an object.
          * @default typeof Adapter
          */
         adapter?: Adapter;
 
         /**
-         * Accepted origins
+         * Accepted origins.
          * @default '*:*'
          */
         origins?: string | string[];
+
+        /**
+         * The parser to use. Defaults to an instance of the `Parser` that
+         * ships with socket.io which is memory-based. See `socket.io-parser`.
+         * @default require('socket.io-parser')
+         */
+        parser?: typeof SocketIoParser;
     }
 
     /**

--- a/types/socket.io/index.d.ts
+++ b/types/socket.io/index.d.ts
@@ -11,7 +11,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 ///<reference types="node" />
-///<reference lib="dom" /> required by socket.io-parser.
 
 declare const SocketIO: SocketIOStatic;
 import engine = require('engine.io');

--- a/types/socket.io/socket.io-tests.ts
+++ b/types/socket.io/socket.io-tests.ts
@@ -67,7 +67,13 @@ function testUsingWithExpress() {
 function testUsingWithOptions() {
     var app = require('express')();
     var server = require('http').Server(app);
-    var io = socketIO(server, { wsEngine: 'ws' });
+    var io = socketIO(server, {
+        path: "/hello",
+        serveClient: false,
+        origins: "*/*",
+        wsEngine: 'ws',
+        parser: require("socket.io-parser"),
+    });
 }
 
 function testUsingWithTheExpressFramework() {

--- a/types/socket.io/tsconfig.json
+++ b/types/socket.io/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6", "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/socket.io/tsconfig.json
+++ b/types/socket.io/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6", "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://socket.io/docs/v2/server-api/index.html#new-Server-httpServer-options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This PR is related to #35469. I will make a separate PR adding the `parser` option for socket.io-client.