### PR TITLE
[undertaker] remove 'any' from TaskFunctionBase's return type union

### DIFF
--- a/types/glob-watcher/glob-watcher-tests.ts
+++ b/types/glob-watcher/glob-watcher-tests.ts
@@ -18,9 +18,9 @@ function test() {
     optionsTypeTest(opts1);
     optionsTypeTest(opts2);
 
-    const taskFunc: Undertaker.TaskFunction = () => "";
+    const taskFunc: Undertaker.TaskFunction = async () => "";
 
-    const cb = () => {
+    const cb = async () => {
         console.log("watch change!");
     };
 

--- a/types/undertaker/index.d.ts
+++ b/types/undertaker/index.d.ts
@@ -7,7 +7,7 @@
 
 /// <reference types="node" />
 import * as Registry from "undertaker-registry";
-import { Duplex } from "stream";
+import { AsyncTask } from "async-done";
 import { EventEmitter } from "events";
 
 declare namespace Undertaker {
@@ -23,7 +23,7 @@ declare namespace Undertaker {
     }
 
     interface TaskFunctionBase {
-        (done: (error?: Error | null) => void): void | Duplex | NodeJS.Process | Promise<never> | any;
+        (done: (error?: Error | null) => void): ReturnType<AsyncTask>;
     }
 
     interface TaskFunction extends TaskFunctionBase, TaskFunctionParams {}

--- a/types/undertaker/package.json
+++ b/types/undertaker/package.json
@@ -1,7 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "async-done": "^1.3.2",
-        "rxjs": "^6.6.3"
+        "async-done": "^1.3.2"
     }
 }

--- a/types/undertaker/package.json
+++ b/types/undertaker/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "dependencies": {
+        "async-done": "^1.3.2",
+        "rxjs": "^6.6.3"
+    }
+}

--- a/types/undertaker/package.json
+++ b/types/undertaker/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "async-done": "^1.3.2"
+        "async-done": "~1.3.2"
     }
 }

--- a/types/undertaker/undertaker-tests.ts
+++ b/types/undertaker/undertaker-tests.ts
@@ -1,4 +1,7 @@
+import { exec } from "child_process";
+import { EventEmitter } from "events";
 import * as fs from "fs";
+import { fromEvent } from "rxjs";
 import Undertaker = require("undertaker");
 import Registry = require("undertaker-registry");
 
@@ -33,6 +36,19 @@ const {
     description,
     flags,
 } = taker.task("task4").unwrap();
+
+taker.task("task5", () => {
+    const emitter = new EventEmitter();
+    setTimeout(() => emitter.emit("done"), 1000);
+    return emitter;
+});
+
+taker.task("task6", () => exec("ls"));
+
+taker.task("task7", () => {
+    const lsProcess = exec("ls");
+    return fromEvent(lsProcess, "exit");
+});
 
 taker.task("combined", taker.series("task1", "task2"));
 

--- a/types/undertaker/undertaker-tests.ts
+++ b/types/undertaker/undertaker-tests.ts
@@ -1,7 +1,6 @@
 import { exec } from "child_process";
 import { EventEmitter } from "events";
 import * as fs from "fs";
-import { fromEvent } from "rxjs";
 import Undertaker = require("undertaker");
 import Registry = require("undertaker-registry");
 

--- a/types/undertaker/undertaker-tests.ts
+++ b/types/undertaker/undertaker-tests.ts
@@ -45,11 +45,10 @@ taker.task("task5", () => {
 
 taker.task("task6", () => exec("ls"));
 
-taker.task("task7", () => {
-    const lsProcess = exec("ls");
-    return fromEvent(lsProcess, "exit");
-});
-
+declare const task7: () => {
+    subscribe(next?: (v: any) => void, error?: (e: any) => void, complete?: () => void);
+};
+taker.task("task7", task7);
 taker.task("combined", taker.series("task1", "task2"));
 
 taker.task("all", taker.parallel("combined", "task3"));

--- a/types/undertaker/undertaker-tests.ts
+++ b/types/undertaker/undertaker-tests.ts
@@ -45,7 +45,7 @@ taker.task("task5", () => {
 taker.task("task6", () => exec("ls"));
 
 declare const task7: () => {
-    subscribe(next?: (v: any) => void, error?: (e: any) => void, complete?: () => void);
+    subscribe(next?: (v: any) => void, error?: (e: any) => void, complete?: () => void): any;
 };
 taker.task("task7", task7);
 taker.task("combined", taker.series("task1", "task2"));


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
- https://github.com/gulpjs/async-done#completion-and-error-resolution, linked from https://github.com/gulpjs/undertaker#api (first sentence)
- https://github.com/gulpjs/async-done/blob/35260ae27874e88e11f9a9e3942a3516534cc510/index.d.ts#L90
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

A note:

1. Gulp documentation regarding accepted return types from task functions is at https://gulpjs.com/docs/en/getting-started/async-completion/#signal-task-completion.