### PR TITLE
feat(aws-lambda): use interfaces for proxy event properties to allow merging

### DIFF
--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -71,6 +71,7 @@ type ProbablyInvalidCustomProxyHandler = APIGatewayProxyWithLambdaAuthorizerHand
 
 let proxyHandler: APIGatewayProxyHandler = async (event, context, callback) => {
     strOrNull = event.body;
+    const headers = event.headers; // $ExpectType APIGatewayProxyEventHeaders
     str = event.headers['example'];
     str = event.multiValueHeaders['example'][0];
     str = event.httpMethod;

--- a/types/aws-lambda/trigger/api-gateway-proxy.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-proxy.d.ts
@@ -62,17 +62,33 @@ export interface APIGatewayProxyCognitoAuthorizer {
     };
 }
 
+export interface APIGatewayProxyEventHeaders {
+    [name: string]: string;
+}
+
+export interface APIGatewayProxyEventPathParameters {
+    [name: string]: string;
+}
+
+export interface APIGatewayProxyEventQueryStringParameters {
+    [name: string]: string;
+}
+
+export interface APIGatewayProxyEventStageVariables {
+    [name: string]: string;
+}
+
 export interface APIGatewayProxyEventBase<TAuthorizerContext> {
     body: string | null;
-    headers: { [name: string]: string };
+    headers: APIGatewayProxyEventHeaders;
     multiValueHeaders: { [name: string]: string[] };
     httpMethod: string;
     isBase64Encoded: boolean;
     path: string;
-    pathParameters: { [name: string]: string } | null;
-    queryStringParameters: { [name: string]: string } | null;
+    pathParameters: APIGatewayProxyEventPathParameters | null;
+    queryStringParameters: APIGatewayProxyEventQueryStringParameters | null;
     multiValueQueryStringParameters: { [name: string]: string[] } | null;
-    stageVariables: { [name: string]: string } | null;
+    stageVariables: APIGatewayProxyEventStageVariables | null;
     requestContext: APIGatewayEventRequestContextWithAuthorizer<TAuthorizerContext>;
     resource: string;
 }
@@ -103,8 +119,8 @@ export interface APIGatewayProxyEventV2 {
     rawPath: string;
     rawQueryString: string;
     cookies?: string[];
-    headers: { [name: string]: string };
-    queryStringParameters?: { [name: string]: string };
+    headers: APIGatewayProxyEventHeaders;
+    queryStringParameters?: APIGatewayProxyEventQueryStringParameters;
     requestContext: {
         accountId: string;
         apiId: string;
@@ -130,9 +146,9 @@ export interface APIGatewayProxyEventV2 {
         timeEpoch: number;
     };
     body?: string;
-    pathParameters?: { [name: string]: string };
+    pathParameters?: APIGatewayProxyEventPathParameters;
     isBase64Encoded: boolean;
-    stageVariables?: { [name: string]: string };
+    stageVariables?: APIGatewayProxyEventStageVariables;
 }
 
 /**


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

----

This lets you do declaration merging, like so:

```
declare module 'aws-lambda/trigger/api-gateway-proxy' {
  export interface APIGatewayProxyEventHeaders {
    'X-GitHub-Event': WebhookEvents;
  }
}
```

I've applied it to all four properties that are in this situation.