### PR TITLE
[mustache] Add `.render()` options parameter introduced in v4.1.0

### DIFF
--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Mustache 4.0.0
+// Type definitions for Mustache 4.1.0
 // Project: https://github.com/janl/mustache.js
 // Definitions by: Mark Ashley Bell <https://github.com/markashleybell>,
 //                 Manuel Thalmann <https://github.com/manuth>,
@@ -49,7 +49,8 @@ interface MustacheStatic {
     Writer: typeof MustacheWriter;
 
     /**
-     * HTML escaping by default, can be overriden by setting Mustache.escape explicitly.
+     * HTML escaping by default, can be overriden by setting Mustache.escape explicitly or providing the `options`
+     * argument with an `escape` function when invoking Mustache.render().
      *
      * Escaping can be avoided when needed by using `{{{ value }}}` or `{{& value }}` in templates.
      *
@@ -103,10 +104,15 @@ interface MustacheStatic {
      *
      * A function that is used to load partial template on the fly that takes a single argument: the name of the partial.
      *
-     * @param tags
-     * The tags to use.
+     * @param tagsOrOptions
+     * The delimeter tags to use or options overriding global defaults.
      */
-    render(template: string, view: any | MustacheContext, partials?: PartialsOrLookupFn, tags?: OpeningAndClosingTags): string;
+    render(
+        template: string,
+        view: any | MustacheContext,
+        partials?: PartialsOrLookupFn,
+        tagsOrOptions?: OpeningAndClosingTags | RenderOptions,
+    ): string;
 }
 
 /**
@@ -225,7 +231,12 @@ declare class MustacheWriter {
      * @param tags
      * The tags to use.
      */
-    render(template: string, view: any | MustacheContext, partials?: PartialsOrLookupFn, tags?: OpeningAndClosingTags): string;
+    render(
+        template: string,
+        view: any | MustacheContext,
+        partials?: PartialsOrLookupFn,
+        tags?: OpeningAndClosingTags,
+    ): string;
 
     /**
      * Low-level method that renders the given array of `tokens` using the given `context` and `partials`.
@@ -244,7 +255,12 @@ declare class MustacheWriter {
      *
      * If the template doesn't use higher-order sections, this argument may be omitted.
      */
-    renderTokens(tokens: string[][], context: MustacheContext, partials?: PartialsOrLookupFn, originalTemplate?: string): string;
+    renderTokens(
+        tokens: string[][],
+        context: MustacheContext,
+        partials?: PartialsOrLookupFn,
+        originalTemplate?: string,
+    ): string;
 
     /**
      * Renders a section block.
@@ -261,7 +277,12 @@ declare class MustacheWriter {
      * @param originalTemplate
      * An object used to extract the portion of the original template that was contained in a higher-order section.
      */
-    renderSection(token: string[], context: MustacheContext, partials?: PartialsOrLookupFn, originalTemplate?: string): string;
+    renderSection(
+        token: string[],
+        context: MustacheContext,
+        partials?: PartialsOrLookupFn,
+        originalTemplate?: string,
+    ): string;
 
     /**
      * Renders an inverted section block.
@@ -278,7 +299,12 @@ declare class MustacheWriter {
      * @param originalTemplate
      * An object used to extract the portion of the original template that was contained in a higher-order section.
      */
-    renderInverted(token: string[], context: MustacheContext, partials?: PartialsOrLookupFn, originalTemplate?: string): string;
+    renderInverted(
+        token: string[],
+        context: MustacheContext,
+        partials?: PartialsOrLookupFn,
+        originalTemplate?: string,
+    ): string;
 
     /**
      * Adds indentation to each line of the given partial.
@@ -309,7 +335,12 @@ declare class MustacheWriter {
      * @param tags
      * The tags to use.
      */
-    renderPartial(token: string[], context: MustacheContext, partials?: PartialsOrLookupFn, tags?: OpeningAndClosingTags): string;
+    renderPartial(
+        token: string[],
+        context: MustacheContext,
+        partials?: PartialsOrLookupFn,
+        tags?: OpeningAndClosingTags,
+    ): string;
 
     /**
      * Renders an unescaped value.
@@ -342,24 +373,16 @@ declare class MustacheWriter {
     rawValue(token: string[]): string;
 }
 
-type RAW_VALUE = "text";
-type ESCAPED_VALUE = "name";
-type UNESCAPED_VALUE = "&";
-type SECTION = "#";
-type INVERTED = "^";
-type COMMENT = "!";
-type PARTIAL = ">";
-type EQUAL = "=";
+type RAW_VALUE = 'text';
+type ESCAPED_VALUE = 'name';
+type UNESCAPED_VALUE = '&';
+type SECTION = '#';
+type INVERTED = '^';
+type COMMENT = '!';
+type PARTIAL = '>';
+type EQUAL = '=';
 
-type TemplateSpanType =
-    | RAW_VALUE
-    | ESCAPED_VALUE
-    | SECTION
-    | UNESCAPED_VALUE
-    | INVERTED
-    | COMMENT
-    | PARTIAL
-    | EQUAL;
+type TemplateSpanType = RAW_VALUE | ESCAPED_VALUE | SECTION | UNESCAPED_VALUE | INVERTED | COMMENT | PARTIAL | EQUAL;
 
 type TemplateSpans = Array<
     | [TemplateSpanType, string, number, number]
@@ -385,13 +408,18 @@ type OpeningAndClosingTags = [string, string];
  *
  * A function that is used to load partial template on the fly that takes a single argument: the name of the partial.
  */
-type PartialsOrLookupFn = Record<string, string> | PartialLookupFn
-type PartialLookupFn = (partialName: string) => string | undefined
+type PartialsOrLookupFn = Record<string, string> | PartialLookupFn;
+type PartialLookupFn = (partialName: string) => string | undefined;
+
+interface RenderOptions {
+    escape: EscapeFunction;
+    tags: OpeningAndClosingTags;
+}
 
 interface TemplateCache {
-    set(cacheKey: string, value: string): void
-    get(cacheKey: string): string | undefined
-    clear(): void
+    set(cacheKey: string, value: string): void;
+    get(cacheKey: string): string | undefined;
+    clear(): void;
 }
 
 /**

--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -49,12 +49,14 @@ interface MustacheStatic {
     Writer: typeof MustacheWriter;
 
     /**
-     * Escapes HTML-characters.
+     * HTML escaping by default, can be overriden by setting Mustache.escape explicitly.
+     *
+     * Escaping can be avoided when needed by using `{{{ value }}}` or `{{& value }}` in templates.
      *
      * @param value
-     * The string to escape.
+     * The value to escape into a string.
      */
-    escape: (value: string) => string;
+    escape: EscapeFunction;
 
     /**
      * Clears all cached templates in this writer.
@@ -364,6 +366,12 @@ type TemplateSpans = Array<
     | [TemplateSpanType, string, number, number, TemplateSpans, number]
     | [TemplateSpanType, string, number, number, string, number, boolean]
 >;
+
+/**
+ * Function responsible for escaping values from the view into the rendered output when templates
+ * has `{{ value }}` in them.
+ */
+type EscapeFunction = (value: any) => string;
 
 /**
  * An array of two strings, representing the opening and closing tags respectively, to be used in the templates being rendered.

--- a/types/mustache/mustache-tests.ts
+++ b/types/mustache/mustache-tests.ts
@@ -34,6 +34,11 @@ var output5 = Mustache.render(template5, view5, {}, ["[[", "]]"]);
 Mustache.render("{{>text}}", {}, {"text":"from partial"});
 Mustache.render("{{>text}}", {}, (partialName) => partialName === "text" ? "from partial" : undefined);
 
+Mustache.render("[[title]]", view1, undefined, {
+    escape: () => "Escape function overridden",
+    tags: ["[[", "]]"]
+});
+
 const defaultCache = Mustache.templateCache;
 Mustache.templateCache = undefined;
 Mustache.templateCache = new Map();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

These changes reflects mustache's recent adjustments to `mustache.render()` where an options object can be provided: https://github.com/janl/mustache.js/pull/764