### PR TITLE
Add Type defintions for Babar 0.2

### DIFF
--- a/types/babar/babar-tests.ts
+++ b/types/babar/babar-tests.ts
@@ -1,4 +1,4 @@
-import babar from "babar";
+import babar = require('babar');
 
 // $ExpectType string
 const graph = babar([[0, 1], [1, 5], [2, 5], [3, 1], [4, 6]]);

--- a/types/babar/babar-tests.ts
+++ b/types/babar/babar-tests.ts
@@ -1,0 +1,31 @@
+import babar from "babar";
+
+// $ExpectType string
+const graph = babar([[0, 1], [1, 5], [2, 5], [3, 1], [4, 6]]);
+
+// $ExpectType string
+const graphWithCaption = babar([[0, 1], [1, 5], [2, 5], [3, 1], [4, 6]], {caption: "Test"});
+
+// $ExpectType string
+const graphWithAllOptions = babar([[0, 1], [1, 5], [2, 5], [3, 1], [4, 6]], {
+    caption: 'Test',
+    color: 'green',
+    grid: 'black',
+    width: 80,
+    height: 15,
+    xFractions: 20,
+    yFractions: 10,
+    minX: 0,
+    maxX: 100,
+    minY: 0,
+    maxY: 100
+});
+
+// $ExpectError
+const invalidPoints = babar([["0", 1], ["1", 5]]);
+// $ExpectError
+const invalidOptions = babar([[0, 1], [1, 5]], {batman: 1});
+// $ExpectError
+const invalidOptionType = babar([[0, 1], [1, 5]], {caption: 1});
+// $ExpectError
+const invalidColor = babar([[0, 1], [1, 5]], {color: "pink"});

--- a/types/babar/babar-tests.ts
+++ b/types/babar/babar-tests.ts
@@ -20,6 +20,8 @@ const graphWithAllOptions = babar([[0, 1], [1, 5], [2, 5], [3, 1], [4, 6]], {
     minY: 0,
     maxY: 100
 });
+// $ExpectType string
+const asciiValidColor = babar([[0, 1], [1, 5]], {color: "ascii"});
 
 // $ExpectError
 const invalidPoints = babar([["0", 1], ["1", 5]]);
@@ -29,3 +31,5 @@ const invalidOptions = babar([[0, 1], [1, 5]], {batman: 1});
 const invalidOptionType = babar([[0, 1], [1, 5]], {caption: 1});
 // $ExpectError
 const invalidColor = babar([[0, 1], [1, 5]], {color: "pink"});
+// $ExpectError
+const asciiNotAllowedOnGrid = babar([[0, 1], [1, 5]], {grid: "ascii"});

--- a/types/babar/babar-tests.ts
+++ b/types/babar/babar-tests.ts
@@ -10,7 +10,7 @@ const graphWithCaption = babar([[0, 1], [1, 5], [2, 5], [3, 1], [4, 6]], {captio
 const graphWithAllOptions = babar([[0, 1], [1, 5], [2, 5], [3, 1], [4, 6]], {
     caption: 'Test',
     color: 'green',
-    grid: 'black',
+    grid: 'blue',
     width: 80,
     height: 15,
     xFractions: 20,

--- a/types/babar/index.d.ts
+++ b/types/babar/index.d.ts
@@ -3,11 +3,11 @@
 // Definitions by: Matt Bachmann <https://github.com/Bachmann1234>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-type color = 'yellow' | 'cyan' | 'white' | 'magenta' | 'green' | 'red' | 'grey' | 'blue' | 'ascii';
+type color = 'yellow' | 'cyan' | 'white' | 'magenta' | 'green' | 'red' | 'grey' | 'blue';
 
 interface Options {
     caption?: string;
-    color?: color;
+    color?: color | 'ascii';
     grid?: color;
     width?: number;
     height?: number;

--- a/types/babar/index.d.ts
+++ b/types/babar/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for babar 0.2
+// Project: https://github.com/stephan83/babar#readme
+// Definitions by: Matt Bachmann <https://github.com/Bachmann1234>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface Options {
+    caption?: string;
+    color?: 'yellow' | 'cyan' | 'white' | 'magenta' | 'green' | 'red' | 'grey' | 'blue' | 'ascii';
+    grid?: string;
+    width?: number;
+    height?: number;
+    xFractions?: number;
+    yFractions?: number;
+    minX?: number;
+    maxX?: number;
+    minY?: number;
+    maxY?: number;
+}
+
+declare function babar(points: ReadonlyArray<[number, number]>, options?: Options): string;
+
+export = babar;

--- a/types/babar/index.d.ts
+++ b/types/babar/index.d.ts
@@ -18,7 +18,6 @@ interface Options {
     minY?: number;
     maxY?: number;
 }
-
 declare function babar(points: ReadonlyArray<[number, number]>, options?: Options): string;
 
 export = babar;

--- a/types/babar/index.d.ts
+++ b/types/babar/index.d.ts
@@ -3,10 +3,12 @@
 // Definitions by: Matt Bachmann <https://github.com/Bachmann1234>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+type color = 'yellow' | 'cyan' | 'white' | 'magenta' | 'green' | 'red' | 'grey' | 'blue' | 'ascii';
+
 interface Options {
     caption?: string;
-    color?: 'yellow' | 'cyan' | 'white' | 'magenta' | 'green' | 'red' | 'grey' | 'blue' | 'ascii';
-    grid?: string;
+    color?: color;
+    grid?: color;
     width?: number;
     height?: number;
     xFractions?: number;

--- a/types/babar/tsconfig.json
+++ b/types/babar/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "esModuleInterop": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "babar-tests.ts"
+    ]
+}

--- a/types/babar/tslint.json
+++ b/types/babar/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
I used this package on a small toy project and wrote types for it. Thought I would add it

*Module*: https://www.npmjs.com/package/babar
*Module Source*: https://github.com/stephan83/babar/blob/master/src/babar.coffee
*Place I used this*: https://github.com/Bachmann1234/adventOfCodeDifficultyCurve/blob/main/src/index.ts

In my usage of the code I only used the caption option. The others I mapped based on the project readme and the code

#Template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.