### PR TITLE
fix(@hapi/joi): missing error report return type of custom validator

### DIFF
--- a/types/hapi__joi/index.d.ts
+++ b/types/hapi__joi/index.d.ts
@@ -693,7 +693,7 @@ declare namespace Joi {
         message: (messages: LanguageMessages, local?: Context) => ErrorReport;
     }
 
-    type CustomValidator<V = any> = (value: V, helpers: CustomHelpers) => V;
+    type CustomValidator<V = any> = (value: V, helpers: CustomHelpers) => V|ErrorReport;
 
     type ExternalValidationFunction = (value: any) => any;
 


### PR DESCRIPTION
Ref: https://github.com/sideway/joi/blob/f5f6e6284df8077b08e3da043343b4695f5ba19c/lib/index.d.ts#L682

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sideway/joi/blob/f5f6e6284df8077b08e3da043343b4695f5ba19c/lib/index.d.ts#L682
