### PR TITLE
(react-native-material-ripple) remove deprecated prop from test case

### DIFF
--- a/types/react-native-material-ripple/react-native-material-ripple-tests.tsx
+++ b/types/react-native-material-ripple/react-native-material-ripple-tests.tsx
@@ -39,7 +39,6 @@ const RippleTest: React.FC = () => {
             disabled={false}
             onRippleAnimation={callback}
             accessibilityActions={[{ name: 'activate' }]}
-            accessibilityComponentType="radiobutton_checked"
             accessibilityElementsHidden
             accessibilityHint="string"
             accessibilityIgnoresInvertColors
@@ -47,7 +46,6 @@ const RippleTest: React.FC = () => {
             accessibilityLiveRegion="none"
             accessibilityRole="button"
             accessibilityState={{ disabled: false }}
-            accessibilityTraits="header"
             accessibilityValue={{
                 min: aNumber,
                 max: aNumber,
@@ -123,5 +121,5 @@ const RippleTest: React.FC = () => {
 };
 
 const styles = StyleSheet.create({
-    wrapper: {} as any as ViewStyle,
+    wrapper: ({} as any) as ViewStyle,
 });


### PR DESCRIPTION
Follow-up for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49983

Removing deprecated props from test case so that typings can be removed for future release

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49983
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

