### PR TITLE
[sitemap-generator]add type definition

### DIFF
--- a/types/sitemap-generator/index.d.ts
+++ b/types/sitemap-generator/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/lgraubner/sitemap-generator
 // Definitions by: grgr-dkrk <https://github.com/grgr-dkrk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 2.8
 
 import Crawler = require('simplecrawler');
 

--- a/types/sitemap-generator/index.d.ts
+++ b/types/sitemap-generator/index.d.ts
@@ -1,0 +1,47 @@
+// Type definitions for sitemap-generator 8.5
+// Project: https://github.com/lgraubner/sitemap-generator
+// Definitions by: grgr-dkrk <https://github.com/grgr-dkrk>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.9
+
+import Crawler = require('simplecrawler');
+
+type PriorityValues = 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 | 1.0;
+type FreqValues = 'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
+type EventTypes = 'add' | 'done' | 'error' | 'ignore';
+type ExcludeFunctionProps<T> = Pick<T, { [K in keyof T]: T[K] extends (...args: any) => void ? never : K }[keyof T]>;
+
+type Options = Partial<ExcludeFunctionProps<Crawler>> & {
+    changeFreq?: FreqValues;
+    filepath?: string | null;
+    ignore?: (url: string) => boolean;
+    ignoreAMP?: boolean;
+    lastMod?: boolean;
+    maxEntriesPerFile?: number;
+    priorityMap?: PriorityValues[];
+};
+
+interface ErrorMessage {
+    code: string;
+    message: string;
+    url: string;
+}
+
+interface SiteMapRotator {
+    getPaths: () => string[];
+    addURL: (url: string, depth?: number, lastMod?: string) => void;
+    finish: () => void;
+}
+
+interface Methods {
+    start: () => void;
+    stop: () => void;
+    getCrawler: () => Crawler;
+    getSitemap: () => SiteMapRotator;
+    queueURL: (url: string) => void;
+    on: <T extends EventTypes>(events: T, cb: T extends 'error' ? (error: ErrorMessage) => void : () => void) => void;
+}
+
+declare function SitemapGenerator(url: string, options?: Options): Methods;
+
+export = SitemapGenerator;

--- a/types/sitemap-generator/index.d.ts
+++ b/types/sitemap-generator/index.d.ts
@@ -9,7 +9,7 @@ import Crawler = require('simplecrawler');
 type PriorityValues = 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 | 1.0;
 type FreqValues = 'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
 type EventTypes = 'add' | 'done' | 'error' | 'ignore';
-type ExcludeFunctionProps<T> = Pick<T, { [K in keyof T]: T[K] extends (...args: any) => void ? never : K }[keyof T]>;
+type ExcludeFunctionProps<T> = Pick<T, { [K in keyof T]: T[K] extends (...args: any[]) => void ? never : K }[keyof T]>;
 
 type Options = Partial<ExcludeFunctionProps<Crawler>> & {
     changeFreq?: FreqValues;

--- a/types/sitemap-generator/index.d.ts
+++ b/types/sitemap-generator/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/lgraubner/sitemap-generator
 // Definitions by: grgr-dkrk <https://github.com/grgr-dkrk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.9
+// Minimum TypeScript Version: 2.8
 
 import Crawler = require('simplecrawler');
 

--- a/types/sitemap-generator/package.json
+++ b/types/sitemap-generator/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "simplecrawler": "^1.1.9"
+    }
+}

--- a/types/sitemap-generator/package.json
+++ b/types/sitemap-generator/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "simplecrawler": "^1.1.9"
-    }
-}

--- a/types/sitemap-generator/sitemap-generator-tests.ts
+++ b/types/sitemap-generator/sitemap-generator-tests.ts
@@ -1,9 +1,9 @@
-import SitemapGenerator from 'sitemap-generator';
+import SitemapGenerator = require('sitemap-generator');
 
 // $ExpectError
 SitemapGenerator();
 
-SitemapGenerator('https://example.com/');
+SitemapGenerator('https://example.com/', {});
 
 const generator = SitemapGenerator('https://example.com/', {
     changeFreq: 'always',

--- a/types/sitemap-generator/sitemap-generator-tests.ts
+++ b/types/sitemap-generator/sitemap-generator-tests.ts
@@ -3,7 +3,7 @@ import SitemapGenerator = require('sitemap-generator');
 // $ExpectError
 SitemapGenerator();
 
-SitemapGenerator('https://example.com/', {});
+SitemapGenerator('https://example.com/');
 
 SitemapGenerator('https://example.com/', {});
 

--- a/types/sitemap-generator/sitemap-generator-tests.ts
+++ b/types/sitemap-generator/sitemap-generator-tests.ts
@@ -1,6 +1,6 @@
 import SitemapGenerator from 'sitemap-generator';
 
-// @ts-expect-error - no url
+// $ExpectError
 SitemapGenerator();
 
 SitemapGenerator('https://example.com/');
@@ -16,7 +16,7 @@ const generator = SitemapGenerator('https://example.com/', {
     // simplecrawler props
     userAgent: 'Node/SitemapGenerator',
     stripQuerystring: false,
-    // @ts-expect-error - exclude simplecrawler methods
+    // $ExpectError
     wait: () => {},
 });
 
@@ -26,9 +26,9 @@ generator.on('ignore', () => {});
 generator.on('error', error => {
     error.message;
 });
-// @ts-expect-error - invalid event
+// $ExpectError
 generator.on('bar', () => {});
-// @ts-expect-error - invalid arg
+// $ExpectError
 generator.on('add', error => {
     error.message;
 });

--- a/types/sitemap-generator/sitemap-generator-tests.ts
+++ b/types/sitemap-generator/sitemap-generator-tests.ts
@@ -5,6 +5,8 @@ SitemapGenerator();
 
 SitemapGenerator('https://example.com/', {});
 
+SitemapGenerator('https://example.com/', {});
+
 const generator = SitemapGenerator('https://example.com/', {
     changeFreq: 'always',
     filepath: './sitemap.xml',

--- a/types/sitemap-generator/sitemap-generator-tests.ts
+++ b/types/sitemap-generator/sitemap-generator-tests.ts
@@ -1,0 +1,46 @@
+import SitemapGenerator from 'sitemap-generator';
+
+// @ts-expect-error - no url
+SitemapGenerator();
+
+SitemapGenerator('https://example.com/');
+
+const generator = SitemapGenerator('https://example.com/', {
+    changeFreq: 'always',
+    filepath: './sitemap.xml',
+    ignore: url => /foo/g.test(url),
+    ignoreAMP: true,
+    lastMod: false,
+    maxEntriesPerFile: 1000,
+    priorityMap: [0.0, 0.4, 1.0],
+    // simplecrawler props
+    userAgent: 'Node/SitemapGenerator',
+    stripQuerystring: false,
+    // @ts-expect-error - exclude simplecrawler methods
+    wait: () => {},
+});
+
+generator.on('add', () => {});
+generator.on('done', () => {});
+generator.on('ignore', () => {});
+generator.on('error', error => {
+    error.message;
+});
+// @ts-expect-error - invalid event
+generator.on('bar', () => {});
+// @ts-expect-error - invalid arg
+generator.on('add', error => {
+    error.message;
+});
+
+generator.start();
+generator.stop();
+
+const crawler = generator.getCrawler();
+const sitemap = generator.getSitemap();
+
+crawler.on('crawlstart', () => {
+    sitemap.addURL('/my/static/url');
+});
+
+generator.queueURL('https://example.com/');

--- a/types/sitemap-generator/tsconfig.json
+++ b/types/sitemap-generator/tsconfig.json
@@ -13,14 +13,8 @@
             "../"
         ],
         "types": [],
-        "paths": {
-            "@simplecrawler/*": [
-                "simplecrawler__*"
-            ]
-        },
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "esModuleInterop": true
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/sitemap-generator/tsconfig.json
+++ b/types/sitemap-generator/tsconfig.json
@@ -13,6 +13,11 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "@simplecrawler/*": [
+                "simplecrawler__*"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,
         "esModuleInterop": true

--- a/types/sitemap-generator/tsconfig.json
+++ b/types/sitemap-generator/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "sitemap-generator-tests.ts"
+    ]
+}

--- a/types/sitemap-generator/tslint.json
+++ b/types/sitemap-generator/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

NPM Package: https://www.npmjs.com/package/sitemap-generator
GitHub Repository: https://github.com/lgraubner/sitemap-generator