### PR TITLE
update(connect): improve argument inference for app.use

### DIFF
--- a/types/connect/connect-tests.ts
+++ b/types/connect/connect-tests.ts
@@ -40,8 +40,21 @@ app.use((req: connect.IncomingMessage, res: http.ServerResponse) => {
 
 // Allow http.IncomingMessage as the type for req
 app.use((req: http.IncomingMessage, res: http.ServerResponse) => {
-  console.log(req, res);
-  res.end();
+    console.log(req, res);
+    res.end();
+});
+
+// Infer arguments for simple handler usage
+app.use((req, res) => {
+    console.log(req.originalUrl);
+    res.end();
+});
+
+// Infer arguments for next handler usage
+app.use((req, res, next) => {
+    console.log(req.originalUrl);
+    res.setHeader('foo', 'bar');
+    next();
 });
 
 //create node.js http server and listen on port

--- a/types/connect/index.d.ts
+++ b/types/connect/index.d.ts
@@ -11,7 +11,6 @@ import * as http from "http";
 
 /**
  * Create a new connect server.
- * @public
  */
 declare function createServer(): createServer.Server;
 
@@ -24,10 +23,9 @@ declare namespace createServer {
 
     type NextFunction = (err?: any) => void;
 
-    export type SimpleHandleFunction = (req: IncomingMessage, res: http.ServerResponse) => void;
     export type NextHandleFunction = (req: IncomingMessage, res: http.ServerResponse, next: NextFunction) => void;
     export type ErrorHandleFunction = (err: any, req: IncomingMessage, res: http.ServerResponse, next: NextFunction) => void;
-    export type HandleFunction = SimpleHandleFunction | NextHandleFunction | ErrorHandleFunction;
+    export type HandleFunction = NextHandleFunction | ErrorHandleFunction;
 
     export interface ServerStackItem {
         route: string;
@@ -50,17 +48,15 @@ declare namespace createServer {
         * For example if we were to mount a function at _/admin_, it would
         * be invoked on _/admin_, and _/admin/settings_, however it would
         * not be invoked for _/_, or _/posts_.
-        *
-        * @public
         */
-        use(fn: HandleFunction): Server;
-        use(route: string, fn: HandleFunction): Server;
+        use(fn: NextHandleFunction): Server;
+        use(fn: ErrorHandleFunction): Server;
+        use(route: string, fn: NextHandleFunction): Server;
+        use(route: string, fn: ErrorHandleFunction): Server;
 
         /**
         * Handle server requests, punting them down
         * the middleware stack.
-        *
-        * @private
         */
         handle(req: http.IncomingMessage, res: http.ServerResponse, next: Function): void;
 
@@ -85,8 +81,6 @@ declare namespace createServer {
         *
         *      http.createServer(app).listen(80);
         *      https.createServer(options, app).listen(443);
-        *
-        * @api public
         */
         listen(port: number, hostname?: string, backlog?: number, callback?: Function): http.Server;
         listen(port: number, hostname?: string, callback?: Function): http.Server;

--- a/types/connect/index.d.ts
+++ b/types/connect/index.d.ts
@@ -23,9 +23,10 @@ declare namespace createServer {
 
     type NextFunction = (err?: any) => void;
 
+    export type SimpleHandleFunction = (req: IncomingMessage, res: http.ServerResponse) => void;
     export type NextHandleFunction = (req: IncomingMessage, res: http.ServerResponse, next: NextFunction) => void;
     export type ErrorHandleFunction = (err: any, req: IncomingMessage, res: http.ServerResponse, next: NextFunction) => void;
-    export type HandleFunction = NextHandleFunction | ErrorHandleFunction;
+    export type HandleFunction = SimpleHandleFunction | NextHandleFunction | ErrorHandleFunction;
 
     export interface ServerStackItem {
         route: string;
@@ -50,9 +51,9 @@ declare namespace createServer {
         * not be invoked for _/_, or _/posts_.
         */
         use(fn: NextHandleFunction): Server;
-        use(fn: ErrorHandleFunction): Server;
+        use(fn: HandleFunction): Server;
         use(route: string, fn: NextHandleFunction): Server;
-        use(route: string, fn: ErrorHandleFunction): Server;
+        use(route: string, fn: HandleFunction): Server;
 
         /**
         * Handle server requests, punting them down


### PR DESCRIPTION
Currently the definition always requires manual argument annotation even for the most simple cases:

```ts
app.use((req, res) => {
  // req and res are implicitly any
})
```

This is due to the difference between the several handlers types are purely in arity, and used as a union type in a single overload.

This PR:

- adds an overload for `app.use` so it can infer the arguments for `NextHandleFunction`
- removes redundant JSDoc tags (enforced by tslint during tests)
- adjusts formatting (spaces) of one existing test case

Note the error handler case still requires manual argument annotations - I don't think there is a way in TypeScript to make it differentiate between function types based on runtime arity. However this should still be a nice improvement to the next handler usage which is by far the most common use case.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/senchalabs/connect#use-middleware
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
