### PR TITLE
[office-js, office-js-preview] Correcting Word.ContentControl.placeholderText behavior for Word on the web

### DIFF
--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -70840,7 +70840,7 @@ declare namespace Word {
          *
          * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
          * 
-         * **Note**: This API is not supported in Word on the web.
+         * **Note**: The set operation for this property is not supported in Word on the web.
          *
          * [Api set: WordApi 1.1]
          */
@@ -77109,7 +77109,7 @@ declare namespace Word {
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported in Word on the web.
+             * **Note**: The set operation for this property is not supported in Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -78038,7 +78038,7 @@ declare namespace Word {
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported in Word on the web.
+             * **Note**: The set operation for this property is not supported in Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -79398,7 +79398,7 @@ declare namespace Word {
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported in Word on the web.
+             * **Note**: The set operation for this property is not supported in Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -79566,7 +79566,7 @@ declare namespace Word {
              *
              * For EACH ITEM in the collection: Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported in Word on the web.
+             * **Note**: The set operation for this property is not supported in Word on the web.
              *
              * [Api set: WordApi 1.1]
              */

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -66246,7 +66246,7 @@ declare namespace Word {
          *
          * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
          * 
-         * **Note**: This API is not supported in Word on the web.
+         * **Note**: The set operation for this property is not supported in Word on the web.
          *
          * [Api set: WordApi 1.1]
          */
@@ -71761,7 +71761,7 @@ declare namespace Word {
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported in Word on the web.
+             * **Note**: The set operation for this property is not supported in Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -72667,7 +72667,7 @@ declare namespace Word {
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported in Word on the web.
+             * **Note**: The set operation for this property is not supported in Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -73937,7 +73937,7 @@ declare namespace Word {
              *
              * Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported in Word on the web.
+             * **Note**: The set operation for this property is not supported in Word on the web.
              *
              * [Api set: WordApi 1.1]
              */
@@ -74105,7 +74105,7 @@ declare namespace Word {
              *
              * For EACH ITEM in the collection: Gets or sets the placeholder text of the content control. Dimmed text will be displayed when the content control is empty.
              * 
-             * **Note**: This API is not supported in Word on the web.
+             * **Note**: The set operation for this property is not supported in Word on the web.
              *
              * [Api set: WordApi 1.1]
              */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

