### PR TITLE
codemirror: simple-mode: allow additional states in defineSimpleMode

### DIFF
--- a/types/codemirror/addon/mode/simple.d.ts
+++ b/types/codemirror/addon/mode/simple.d.ts
@@ -1,22 +1,22 @@
-import "codemirror";
+import 'codemirror';
 
-declare module "codemirror" {
-  // Based on https://codemirror.net/demo/simplemode.html
-  interface Rule {
-    regex?: string | RegExp;
-    token?: string | Array<string> | null;
-    sol?: boolean;
-    next?: string;
-    push?: string;
-    pop?: boolean;
-    mode?: any;
-    indent?: boolean;
-    dedent?: boolean;
-    dedentIfLineStart?: boolean;
-  }
+declare module 'codemirror' {
+    // Based on https://codemirror.net/demo/simplemode.html
+    interface Rule {
+        regex?: string | RegExp;
+        token?: string | Array<string> | null;
+        sol?: boolean;
+        next?: string;
+        push?: string;
+        pop?: boolean;
+        mode?: any;
+        indent?: boolean;
+        dedent?: boolean;
+        dedentIfLineStart?: boolean;
+    }
 
-  function defineSimpleMode<K extends string>(
-    name: string,
-    mode: {[P in K]: P extends "meta" ? Record<string, any> : Array<Rule>} & {start: Array<Rule>}
-  ): void;
+    function defineSimpleMode<K extends string>(
+        name: string,
+        mode: { [P in K]: P extends 'meta' ? Record<string, any> : Array<Rule> } & { start: Array<Rule> },
+    ): void;
 }

--- a/types/codemirror/addon/mode/simple.d.ts
+++ b/types/codemirror/addon/mode/simple.d.ts
@@ -1,4 +1,4 @@
-import * as CodeMirror from "codemirror";
+import "codemirror";
 
 declare module "codemirror" {
   // Based on https://codemirror.net/demo/simplemode.html
@@ -15,8 +15,8 @@ declare module "codemirror" {
     dedentIfLineStart?: boolean;
   }
 
-  function defineSimpleMode(
+  function defineSimpleMode<K extends string>(
     name: string,
-    mode: { start: Array<Rule>; comment?: Array<Rule>; meta?: any }
+    mode: {[P in K]: P extends "meta" ? Record<string, any> : Array<Rule>} & {start: Array<Rule>}
   ): void;
 }

--- a/types/codemirror/test/addon/simple/simple.ts
+++ b/types/codemirror/test/addon/simple/simple.ts
@@ -1,6 +1,83 @@
 import * as CodeMirror from 'codemirror';
 import 'codemirror/addon/mode/simple';
 
+const value = /([^&!|*><~:=*()\\/\x00]|\\[0-9a-f]{2})+/;
+
+// $ExpectError
+CodeMirror.defineSimpleMode('property-start-is-required', {
+});
+
 CodeMirror.defineSimpleMode('foobar', {
     start: [],
+});
+
+CodeMirror.defineSimpleMode("rfc2254", {
+    meta: {
+        dontIndentStates: ["prop"],
+    },
+    prop: [
+        { regex: /\s+/, token: "space" },
+        { regex: /\*/, token: "qualifier" },
+        { regex: /:/, token: "qualifier" },
+        { regex: /[&!|]/, token: "operator" },
+        { regex: /=/, token: "operator" },
+        { regex: /~=/, token: "operator" },
+        { regex: />=/, token: "operator" },
+        { regex: /<=/, token: "operator" },
+        { indent: true, regex: /\(/, token: "bracket" },
+        { dedent: true, next: "start", regex: /\)/, token: "bracket" },
+        { regex: value, token: "string" },
+    ],
+    start: [
+        {
+            regex: /\s+/,
+            token: "space",
+        },
+        {
+            regex: /\*/,
+            token: "qualifier",
+        },
+        {
+            regex: /:/,
+            token: "qualifier",
+        },
+        {
+            regex: /[&!|]/,
+            token: "operator",
+        },
+        {
+            next: "prop",
+            regex: /=/,
+            token: "operator",
+        },
+        {
+            next: "prop",
+            regex: /~=/,
+            token: "operator",
+        },
+        {
+            next: "prop",
+            regex: />=/,
+            token: "operator",
+        },
+        {
+            next: "prop",
+            regex: /<=/,
+            token: "operator",
+        },
+        {
+            indent: true,
+            regex: /\(/,
+            token: "bracket",
+        },
+        {
+            dedent: true,
+            regex: /\)/,
+            token: "bracket",
+        },
+        {
+            regex: value,
+            token: "attribute",
+        },
+    ],
 });

--- a/types/codemirror/test/addon/simple/simple.ts
+++ b/types/codemirror/test/addon/simple/simple.ts
@@ -4,80 +4,79 @@ import 'codemirror/addon/mode/simple';
 const value = /([^&!|*><~:=*()\\/\x00]|\\[0-9a-f]{2})+/;
 
 // $ExpectError
-CodeMirror.defineSimpleMode('property-start-is-required', {
-});
+CodeMirror.defineSimpleMode('property-start-is-required', {});
 
 CodeMirror.defineSimpleMode('foobar', {
     start: [],
 });
 
-CodeMirror.defineSimpleMode("rfc2254", {
+CodeMirror.defineSimpleMode('rfc2254', {
     meta: {
-        dontIndentStates: ["prop"],
+        dontIndentStates: ['prop'],
     },
     prop: [
-        { regex: /\s+/, token: "space" },
-        { regex: /\*/, token: "qualifier" },
-        { regex: /:/, token: "qualifier" },
-        { regex: /[&!|]/, token: "operator" },
-        { regex: /=/, token: "operator" },
-        { regex: /~=/, token: "operator" },
-        { regex: />=/, token: "operator" },
-        { regex: /<=/, token: "operator" },
-        { indent: true, regex: /\(/, token: "bracket" },
-        { dedent: true, next: "start", regex: /\)/, token: "bracket" },
-        { regex: value, token: "string" },
+        { regex: /\s+/, token: 'space' },
+        { regex: /\*/, token: 'qualifier' },
+        { regex: /:/, token: 'qualifier' },
+        { regex: /[&!|]/, token: 'operator' },
+        { regex: /=/, token: 'operator' },
+        { regex: /~=/, token: 'operator' },
+        { regex: />=/, token: 'operator' },
+        { regex: /<=/, token: 'operator' },
+        { indent: true, regex: /\(/, token: 'bracket' },
+        { dedent: true, next: 'start', regex: /\)/, token: 'bracket' },
+        { regex: value, token: 'string' },
     ],
     start: [
         {
             regex: /\s+/,
-            token: "space",
+            token: 'space',
         },
         {
             regex: /\*/,
-            token: "qualifier",
+            token: 'qualifier',
         },
         {
             regex: /:/,
-            token: "qualifier",
+            token: 'qualifier',
         },
         {
             regex: /[&!|]/,
-            token: "operator",
+            token: 'operator',
         },
         {
-            next: "prop",
+            next: 'prop',
             regex: /=/,
-            token: "operator",
+            token: 'operator',
         },
         {
-            next: "prop",
+            next: 'prop',
             regex: /~=/,
-            token: "operator",
+            token: 'operator',
         },
         {
-            next: "prop",
+            next: 'prop',
             regex: />=/,
-            token: "operator",
+            token: 'operator',
         },
         {
-            next: "prop",
+            next: 'prop',
             regex: /<=/,
-            token: "operator",
+            token: 'operator',
         },
         {
             indent: true,
             regex: /\(/,
-            token: "bracket",
+            token: 'bracket',
         },
         {
             dedent: true,
             regex: /\)/,
-            token: "bracket",
+            token: 'bracket',
         },
         {
             regex: value,
-            token: "attribute",
+            token: 'attribute',
         },
     ],
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://codemirror.net/demo/simplemode.html
- The `defineSimpleMode` function takes an object where the key is the state and the value the rules for that state. The comment state is just on particular state in that example and does not have to be present. According to the docs: `the meta property of the states object is special, and will not be interpreted as a state.` 
