### PR TITLE
[react-router-config] Allow custom route config type

### DIFF
--- a/types/react-router-config/index.d.ts
+++ b/types/react-router-config/index.d.ts
@@ -27,12 +27,15 @@ export interface RouteConfig {
     [propName: string]: any;
 }
 
-export interface MatchedRoute<Params extends { [K in keyof Params]?: string }> {
-    route: RouteConfig;
+export interface MatchedRoute<Params extends { [K in keyof Params]?: string }, TRouteConfig extends RouteConfig = RouteConfig> {
+    route: TRouteConfig;
     match: match<Params>;
 }
 
-export function matchRoutes<Params extends { [K in keyof Params]?: string }>(routes: RouteConfig[], pathname: string): Array<MatchedRoute<Params>>;
+export function matchRoutes<Params extends { [K in keyof Params]?: string }, TRouteConfig extends RouteConfig = RouteConfig>(
+    routes: TRouteConfig[],
+    pathname: string,
+): Array<MatchedRoute<Params, TRouteConfig>>;
 
 export function renderRoutes(
     routes: RouteConfig[] | undefined,

--- a/types/react-router-config/index.d.ts
+++ b/types/react-router-config/index.d.ts
@@ -7,11 +7,12 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as React from "react";
-import { RouteComponentProps, SwitchProps, match } from "react-router";
-import { Location } from "history";
+import * as React from 'react';
+import { RouteComponentProps, SwitchProps, match } from 'react-router';
+import { Location } from 'history';
 
-export interface RouteConfigComponentProps<Params extends { [K in keyof Params]?: string } = {}> extends RouteComponentProps<Params> {
+export interface RouteConfigComponentProps<Params extends { [K in keyof Params]?: string } = {}>
+    extends RouteComponentProps<Params> {
     route?: RouteConfig;
 }
 
@@ -27,15 +28,18 @@ export interface RouteConfig {
     [propName: string]: any;
 }
 
-export interface MatchedRoute<Params extends { [K in keyof Params]?: string }, TRouteConfig extends RouteConfig = RouteConfig> {
+export interface MatchedRoute<
+    Params extends { [K in keyof Params]?: string },
+    TRouteConfig extends RouteConfig = RouteConfig
+> {
     route: TRouteConfig;
     match: match<Params>;
 }
 
-export function matchRoutes<Params extends { [K in keyof Params]?: string }, TRouteConfig extends RouteConfig = RouteConfig>(
-    routes: TRouteConfig[],
-    pathname: string,
-): Array<MatchedRoute<Params, TRouteConfig>>;
+export function matchRoutes<
+    Params extends { [K in keyof Params]?: string },
+    TRouteConfig extends RouteConfig = RouteConfig
+>(routes: TRouteConfig[], pathname: string): Array<MatchedRoute<Params, TRouteConfig>>;
 
 export function renderRoutes(
     routes: RouteConfig[] | undefined,

--- a/types/react-router-config/react-router-config-tests.tsx
+++ b/types/react-router-config/react-router-config-tests.tsx
@@ -62,3 +62,30 @@ const branch: Array<MatchedRoute<{}>> = matchRoutes<{}>(routes, "/child/23");
 
 // pass this into ReactDOM.render
 <BrowserRouter>{renderRoutes(routes)}</BrowserRouter>;
+
+interface CustomRouteConfig extends RouteConfig {
+    customProperty: string;
+}
+
+const routesWithCustomConfig: CustomRouteConfig[] = [
+    {
+        component: Root,
+        customProperty: 'hello',
+        routes: [
+            {
+                path: "/",
+                exact: true,
+                component: Home,
+            },
+        ]
+    }
+];
+
+// $ExpectType MatchedRoute<{}, CustomRouteConfig>[]
+const branchWithCustomRoutes = matchRoutes(routesWithCustomConfig, "/child/23");
+// $ExpectType MatchedRoute<{}, CustomRouteConfig>
+const customRoute = branchWithCustomRoutes[0];
+// $ExpectType string
+const customProperty = customRoute.route.customProperty;
+
+<BrowserRouter>{renderRoutes(routesWithCustomConfig)}</BrowserRouter>;

--- a/types/react-router-config/react-router-config-tests.tsx
+++ b/types/react-router-config/react-router-config-tests.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
-import { RouteConfig, matchRoutes, MatchedRoute, renderRoutes, RouteConfigComponentProps } from "react-router-config";
-import { BrowserRouter } from "react-router-dom";
+import * as React from 'react';
+import { RouteConfig, matchRoutes, MatchedRoute, renderRoutes, RouteConfigComponentProps } from 'react-router-config';
+import { BrowserRouter } from 'react-router-dom';
 
 const Root = ({ route }: RouteConfigComponentProps) => (
     <div>
@@ -36,24 +36,26 @@ const routes: RouteConfig[] = [
         component: Root,
         routes: [
             {
-                path: "/",
+                path: '/',
                 exact: true,
-                component: Home
+                component: Home,
             },
             {
-                path: "/child/:id",
+                path: '/child/:id',
                 component: Child,
-                routes: [{
-                    path: "/child/:id/grand-child",
-                    component: GrandChild
-                }],
-                loadData: () => Promise.resolve({})
-            }
-        ]
-    }
+                routes: [
+                    {
+                        path: '/child/:id/grand-child',
+                        component: GrandChild,
+                    },
+                ],
+                loadData: () => Promise.resolve({}),
+            },
+        ],
+    },
 ];
 
-const branch: Array<MatchedRoute<{}>> = matchRoutes<{}>(routes, "/child/23");
+const branch: Array<MatchedRoute<{}>> = matchRoutes<{}>(routes, '/child/23');
 // using the routes shown earlier, this returns
 // [
 //   routes[0],
@@ -73,16 +75,16 @@ const routesWithCustomConfig: CustomRouteConfig[] = [
         customProperty: 'hello',
         routes: [
             {
-                path: "/",
+                path: '/',
                 exact: true,
                 component: Home,
             },
-        ]
-    }
+        ],
+    },
 ];
 
 // $ExpectType MatchedRoute<{}, CustomRouteConfig>[]
-const branchWithCustomRoutes = matchRoutes(routesWithCustomConfig, "/child/23");
+const branchWithCustomRoutes = matchRoutes(routesWithCustomConfig, '/child/23');
 // $ExpectType MatchedRoute<{}, CustomRouteConfig>
 const customRoute = branchWithCustomRoutes[0];
 // $ExpectType string


### PR DESCRIPTION
I am working in a codebase where we extend the route object with
some custom properties. This works because react-router-config just
passes the route objects directly through.

To make this work with TypeScript, we need  to be able to specify a 
custom route config type. This commit expands the generics here to
allow this to be threaded through the types in a backwards-compatible
way.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ReactTraining/react-router/blob/085d0a862c33f9cfbbf825fddb643cbc0ed44243/packages/react-router-config/modules/matchRoutes.js#L3-L23
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
