### PR TITLE
[ratelimiter] add ioredis support

### DIFF
--- a/types/ratelimiter/index.d.ts
+++ b/types/ratelimiter/index.d.ts
@@ -3,8 +3,10 @@
 // Definitions by: Aya Morisawa <https://github.com/AyaMorisawa>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-import { RedisClient } from 'redis';
-import { Redis as IORedisClient } from 'ioredis';
+
+interface RedisClient {
+    multi(operations: any[][]): { exec(cb: (err: any, res: any) => unknown): void };
+}
 
 declare class Limiter {
     constructor(opts: Limiter.LimiterOption);
@@ -30,7 +32,7 @@ declare namespace Limiter {
         /**
          * Redis connection instance
          */
-        db: RedisClient | IORedisClient;
+        db: RedisClient;
 
         /**
          * Max requests within duration

--- a/types/ratelimiter/index.d.ts
+++ b/types/ratelimiter/index.d.ts
@@ -4,6 +4,7 @@
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 import { RedisClient } from 'redis';
+import { Redis as IORedisClient } from 'ioredis';
 
 declare class Limiter {
     constructor(opts: Limiter.LimiterOption);
@@ -29,7 +30,7 @@ declare namespace Limiter {
         /**
          * Redis connection instance
          */
-        db: RedisClient;
+        db: RedisClient | IORedisClient;
 
         /**
          * Max requests within duration

--- a/types/ratelimiter/ratelimiter-tests.ts
+++ b/types/ratelimiter/ratelimiter-tests.ts
@@ -1,10 +1,13 @@
 import * as redis from 'redis';
+import * as ioredis from 'ioredis';
 import Limiter = require('ratelimiter');
 
 declare let id: string;
 declare let db: redis.RedisClient;
+declare let iodb: ioredis.Redis;
 
 const limit = new Limiter({ id, db, duration: 3_600, max: 1_000 });
+const ioLimit = new Limiter({ id, db: iodb });
 
 limit.inspect(); // $ExpectType string
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tj/node-ratelimiter/pull/12
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

--- 

`ratelimiter` supports both the `redis` NPM package as well as `ioredis` – this PR updates the type definitions to match.