### PR TITLE
[lqip-modern] it should not error when passing only part of `LqipOptions`

### DIFF
--- a/types/lqip-modern/index.d.ts
+++ b/types/lqip-modern/index.d.ts
@@ -23,7 +23,7 @@ declare namespace lqip {
 
     type OutputFormat = WebpOptions['outputFormat'] | JpegOptions['outputFormat'] | JpgOptions['outputFormat'];
 
-    type LqipOptions = WebpOptions | JpegOptions | JpgOptions;
+    type LqipOptions = WebpOptions | JpegOptions | JpgOptions | DefaultOptions;
 
     interface DefaultOptions {
         concurrency?: number;
@@ -31,16 +31,16 @@ declare namespace lqip {
     }
 
     interface WebpOptions extends DefaultOptions {
-        readonly outputFormat: 'webp';
-        readonly outputOptions: sharp.WebpOptions;
+        readonly outputFormat?: 'webp';
+        readonly outputOptions?: sharp.WebpOptions;
     }
     interface JpegOptions extends DefaultOptions {
         readonly outputFormat: 'jpeg';
-        readonly outputOptions: sharp.JpegOptions;
+        readonly outputOptions?: sharp.JpegOptions;
     }
     interface JpgOptions extends DefaultOptions {
         readonly outputFormat: 'jpg';
-        readonly outputOptions: sharp.JpegOptions;
+        readonly outputOptions?: sharp.JpegOptions;
     }
 }
 

--- a/types/lqip-modern/lqip-modern-tests.ts
+++ b/types/lqip-modern/lqip-modern-tests.ts
@@ -9,13 +9,13 @@ lqip(['tst']); // $ExpectType Promise<LqipResult[]>
 // it should not error when passing only part of `LqipOptions`
 lqip('tst', { resize: 32 });
 lqip('tst', { outputFormat: 'webp' });
-lqip('tst', { outputOptions: { loop: 10 } });
+lqip(['tst'], { resize: 32, outputOptions: { lossless: true } });
 
 // it should validate `outputOptions` depending on `outputFormat`
-lqip('tst', { outputFormat: 'jpg', outputOptions: { loop: 10 } }); // $ExpectError
-lqip('tst', { outputFormat: 'jpeg', outputOptions: { loop: 10 } }); // $ExpectError
-lqip('tst', { outputFormat: 'webp', outputOptions: { loop: 10 } });
+lqip('tst', { outputFormat: 'jpg', outputOptions: { lossless: true } }); // $ExpectError
+lqip('tst', { outputFormat: 'jpeg', outputOptions: { lossless: true } }); // $ExpectError
+lqip('tst', { outputFormat: 'webp', outputOptions: { lossless: true } });
 
-lqip('tst', { outputFormat: 'jpg', outputOptions: { quantisationTable: 1 } });
-lqip('tst', { outputFormat: 'jpeg', outputOptions: { quantisationTable: 1 } });
-lqip('tst', { outputFormat: 'webp', outputOptions: { quantisationTable: 1 } }); // $ExpectError
+lqip('tst', { outputFormat: 'jpg', outputOptions: { progressive: true } });
+lqip('tst', { outputFormat: 'jpeg', outputOptions: { progressive: true } });
+lqip('tst', { outputFormat: 'webp', outputOptions: { progressive: true } }); // $ExpectError

--- a/types/lqip-modern/lqip-modern-tests.ts
+++ b/types/lqip-modern/lqip-modern-tests.ts
@@ -9,7 +9,7 @@ lqip(['tst']); // $ExpectType Promise<LqipResult[]>
 // it should not error when passing only part of `LqipOptions`
 lqip('tst', { resize: 32 });
 lqip('tst', { outputFormat: 'webp' });
-lqip(['tst'], { resize: 32, outputOptions: { lossless: true } });
+lqip('tst', { outputOptions: { lossless: true } });
 
 // it should validate `outputOptions` depending on `outputFormat`
 lqip('tst', { outputFormat: 'jpg', outputOptions: { lossless: true } }); // $ExpectError

--- a/types/lqip-modern/lqip-modern-tests.ts
+++ b/types/lqip-modern/lqip-modern-tests.ts
@@ -1,10 +1,17 @@
 import lqip = require('lqip-modern');
 
+// it should return the necessary type depending on `input`
 lqip(Buffer.from('')); // $ExpectType Promise<LqipResult>
 lqip('tst'); // $ExpectType Promise<LqipResult>
 lqip([Buffer.from('')]); // $ExpectType Promise<LqipResult[]>
 lqip(['tst']); // $ExpectType Promise<LqipResult[]>
 
+// it should not error when passing only part of `LqipOptions`
+lqip('tst', { resize: 32 });
+lqip('tst', { outputFormat: 'webp' });
+lqip('tst', { outputOptions: { loop: 10 } });
+
+// it should validate `outputOptions` depending on `outputFormat`
 lqip('tst', { outputFormat: 'jpg', outputOptions: { loop: 10 } }); // $ExpectError
 lqip('tst', { outputFormat: 'jpeg', outputOptions: { loop: 10 } }); // $ExpectError
 lqip('tst', { outputFormat: 'webp', outputOptions: { loop: 10 } });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/transitive-bullshit/lqip-modern>


Turns out that I made some mistakes in #49980, hopefully, this PR fixes all of the bugs or at least most of them.
