### PR TITLE
fix(ua-parser-js): export alias for backward compatibility

### DIFF
--- a/types/ua-parser-js/index.d.ts
+++ b/types/ua-parser-js/index.d.ts
@@ -140,7 +140,13 @@ declare namespace UAParser {
         NAME: string;
         VERSION: string;
     }
+
+    // alias for older syntax
+    const UAParser: typeof UAParserAlias;
 }
+
+// support re-export
+declare const UAParserAlias: typeof UAParser;
 
 declare class UAParser {
     static VERSION: string;

--- a/types/ua-parser-js/ua-parser-js-tests.ts
+++ b/types/ua-parser-js/ua-parser-js-tests.ts
@@ -1,4 +1,7 @@
 import UAParser = require('ua-parser-js');
+// tslint:disable-next-line:no-duplicate-imports testing imports
+import { UAParser as UAParserAlias } from 'ua-parser-js';
+// tslint:disable-next-line:no-duplicate-imports testing imports
 import { IBrowser, ICPU, IDevice, IEngine, IOS, IResult, BROWSER, CPU, DEVICE, ENGINE, OS } from 'ua-parser-js';
 
 const ua = 'Mozilla/5.0 (Windows NT 6.2) AppleWebKit/536.6 (KHTML, like Gecko) Chrome/20.0.1090.0 Safari/536.6';
@@ -45,3 +48,6 @@ parser.getCPU().architecture; // $ExpectType string | undefined
 const uaString = 'ownbrowser/1.3';
 const ownBrowser = [[/(ownbrowser)\/([\w\.]+)/i], [UAParser.BROWSER.NAME, UAParser.BROWSER.VERSION]];
 parser = new UAParser(uaString, { browser: ownBrowser }); // $ExpectType UAParser
+
+// alias
+parser = new UAParserAlias(uaString, { browser: ownBrowser }); // $ExpectType UAParser


### PR DESCRIPTION
This commit restores support for older syntax imports, sorry for the
trouble caused.

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48764#issuecomment-739548080
/cc @karfau

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).