### PR TITLE
Update contributing guidelines for when using npm v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ then follow the instructions to [edit an existing package](#edit-an-existing-pac
 
 Once you've tested your package, you can share it on Definitely Typed.
 
-First, [fork](https://guides.github.com/activities/forking/) this repository, install [node](https://nodejs.org/), and run `npm install`.
+First, [fork](https://guides.github.com/activities/forking/) this repository, install [node](https://nodejs.org/), and run `npm install`. If using `npm` v7 you need to add the `--legacy-peer-deps` flag to the command.
 
 We use a bot to let a large number of pull requests to DefinitelyTyped be handled entirely in a self-service manner. You can read more about [why and how here](https://devblogs.microsoft.com/typescript/changes-to-how-we-manage-definitelytyped/). Here is a handy reference showing the life-cycle of a pull request to DT:
 


### PR DESCRIPTION
Running `npm install` when using npm v7 results in the following error:

```js
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: definitely-typed@0.0.3
npm ERR! Found: typescript@4.2.0-dev.20201208
npm ERR! node_modules/typescript
npm ERR!   dev typescript@"next" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer typescript@">= 3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.7.0-dev || >= 3.8.0-dev || >= 3.9.0-dev || >= 4.0.0-dev" from dtslint@4.0.6
npm ERR! node_modules/dtslint
npm ERR!   dev dtslint@"latest" from the root project
npm ERR!   peer dtslint@"*" from @definitelytyped/dtslint-runner@0.0.64
npm ERR!   node_modules/@definitelytyped/dtslint-runner
npm ERR!     dev @definitelytyped/dtslint-runner@"latest" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

One must either downgrade to npm v6 or specify `--legacy-peer-deps` when running `npm install`