### PR TITLE
[codecs] Extending codecs definitions for better developer comfort

### DIFF
--- a/types/codecs/codecs-tests.ts
+++ b/types/codecs/codecs-tests.ts
@@ -1,4 +1,3 @@
-/* tslint:disable:prefer-const */
 import { CodecName, InType, OutType, Codec, JsonCodec, NamedCodec } from 'codecs';
 import codecs = require('codecs');
 

--- a/types/codecs/index.d.ts
+++ b/types/codecs/index.d.ts
@@ -4,8 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
-type ArgsType<T> = T extends (...args: infer U) => any ? U : never;
-
 declare namespace codecs {
     type JsonObject = { [Key in string]?: JsonValue };
     interface JsonArray extends Array<JsonValue> {}

--- a/types/codecs/package.json
+++ b/types/codecs/package.json
@@ -1,0 +1,12 @@
+{
+   "private": true,
+   "types": "index",
+   "typesVersions": {
+      "<=3.6": {
+         "*": [
+            "ts3.6/*"
+         ]
+      }
+   },
+   "dependencies": {}
+}

--- a/types/codecs/ts3.6/codecs-tests.ts
+++ b/types/codecs/ts3.6/codecs-tests.ts
@@ -1,27 +1,27 @@
 /* tslint:disable:prefer-const */
-import { CodecName, InType, OutType, Codec, JsonCodec, NamedCodec } from 'codecs';
-import codecs = require('codecs');
+import { CodecName, InType, OutType, Codec, JsonCodec, NamedCodec } from 'codecs/ts3.6';
+import codecs = require('codecs/ts3.6');
 
 {
   codecs().name; // $ExpectType "binary"
   codecs(undefined).name; // $ExpectType "binary"
   const set: [Codec<undefined>, InType<undefined>, OutType<undefined>, CodecName<undefined>] = [] as any;
-  set; // $ExpectType [BinaryCodec, string | Uint8Array, Buffer, "binary"]
+  set; // $ExpectType [NamedCodec<"binary", string | Uint8Array, Buffer>, string | Uint8Array, Buffer, "binary"]
 }
 {
   codecs(null).name; // $ExpectType "binary"
   const set: [Codec<null>, InType<null>, OutType<null>, CodecName<null>] = [] as any;
-  set; // $ExpectType [BinaryCodec, string | Uint8Array, Buffer, "binary"]
+  set; // $ExpectType [NamedCodec<"binary", string | Uint8Array, Buffer>, string | Uint8Array, Buffer, "binary"]
 }
 {
   codecs('any').name; // $ExpectType "binary"
   const set: [Codec<'any'>, InType<'any'>, OutType<'any'>, CodecName<'any'>] = [] as any;
-  set; // $ExpectType [BinaryCodec, string | Uint8Array, Buffer, "binary"]
+  set; // $ExpectType [NamedCodec<"binary", string | Uint8Array, Buffer>, string | Uint8Array, Buffer, "binary"]
 }
 {
   codecs('any', codecs.json).name; // $ExpectType "json"
   const set: [Codec<'any', JsonCodec>, InType<'any', JsonCodec>, OutType<'any', JsonCodec>, CodecName<'any', JsonCodec>] = [] as any;
-  set; // $ExpectType [JsonCodec, any, JsonValue, "json"]
+  set; // $ExpectType [NamedCodec<"json", any, JsonValue>, any, JsonValue, "json"]
 }
 {
   interface custom {
@@ -38,7 +38,7 @@ import codecs = require('codecs');
   codecs[codec].encode('hello'); // $ExpectType Buffer
   codecs[codec].decode(new Uint8Array()); // $ExpectType string
   const set: [Codec<'ascii'>, InType<'ascii'>, OutType<'ascii'>, CodecName<'ascii'>] = [] as any;
-  set; // $ExpectType [AsciiCodec, string, string, "ascii"]
+  set; // $ExpectType [NamedCodec<"ascii", string, string>, string, string, "ascii"]
 }
 {
   const codec = 'base64';
@@ -47,7 +47,7 @@ import codecs = require('codecs');
   codecs[codec].encode('hello'); // $ExpectType Buffer
   codecs[codec].decode(new Uint8Array()); // $ExpectType string
   const set: [Codec<'base64'>, InType<'base64'>, OutType<'base64'>, CodecName<'base64'>] = [] as any;
-  set; // $ExpectType [Base64Codec, string, string, "base64"]
+  set; // $ExpectType [NamedCodec<"base64", string, string>, string, string, "base64"]
 }
 {
   const codec = 'binary';
@@ -56,7 +56,7 @@ import codecs = require('codecs');
   codecs[codec].encode('hello'); // $ExpectType Buffer
   codecs[codec].decode(new Uint8Array()); // $ExpectType Buffer
   const set: [Codec<'binary'>, InType<'binary'>, OutType<'binary'>, CodecName<'binary'>] = [] as any;
-  set; // $ExpectType [BinaryCodec, string | Uint8Array, Buffer, "binary"]
+  set; // $ExpectType [NamedCodec<"binary", string | Uint8Array, Buffer>, string | Uint8Array, Buffer, "binary"]
 }
 {
   const codec = 'hex';
@@ -65,7 +65,7 @@ import codecs = require('codecs');
   codecs[codec].encode('hello'); // $ExpectType Buffer
   codecs[codec].decode(new Uint8Array()); // $ExpectType string
   const set: [Codec<'hex'>, InType<'hex'>, OutType<'hex'>, CodecName<'hex'>] = [] as any;
-  set; // $ExpectType [HexCodec, string, string, "hex"]
+  set; // $ExpectType [NamedCodec<"hex", string, string>, string, string, "hex"]
 }
 {
   const codec = 'json';
@@ -74,7 +74,7 @@ import codecs = require('codecs');
   codecs[codec].encode({ hello: 'world' }); // $ExpectType Buffer
   codecs[codec].decode(new Uint8Array()); // $ExpectType JsonValue
   const set: [Codec<'json'>, InType<'json'>, OutType<'json'>, CodecName<'json'>] = [] as any;
-  set; // $ExpectType [JsonCodec, any, JsonValue, "json"]
+  set; // $ExpectType [NamedCodec<"json", any, JsonValue>, any, JsonValue, "json"]
 }
 {
   const codec = 'ndjson';
@@ -83,7 +83,7 @@ import codecs = require('codecs');
   codecs[codec].encode({ hello: 'world' }); // $ExpectType Buffer
   codecs[codec].decode(new Uint8Array()); // $ExpectType JsonValue
   const set: [Codec<'ndjson'>, InType<'ndjson'>, OutType<'ndjson'>, CodecName<'ndjson'>] = [] as any;
-  set; // $ExpectType [NDJsonCodec, any, JsonValue, "ndjson"]
+  set; // $ExpectType [NamedCodec<"ndjson", any, JsonValue>, any, JsonValue, "ndjson"]
 }
 {
   const codec = 'ucs-2';
@@ -92,7 +92,7 @@ import codecs = require('codecs');
   codecs[codec].encode('hello'); // $ExpectType Buffer
   codecs[codec].decode(new Uint8Array()); // $ExpectType string
   const set: [Codec<'ucs-2'>, InType<'ucs-2'>, OutType<'ucs-2'>, CodecName<'ucs-2'>] = [] as any;
-  set; // $ExpectType [Ucs2Codec, string, string, "ucs2"]
+  set; // $ExpectType [NamedCodec<"ucs2", string, string>, string, string, "ucs2"]
 }
 {
   const codec = 'ucs2';
@@ -101,7 +101,7 @@ import codecs = require('codecs');
   codecs[codec].encode('hello'); // $ExpectType Buffer
   codecs[codec].decode(new Uint8Array()); // $ExpectType string
   const set: [Codec<'ucs2'>, InType<'ucs2'>, OutType<'ucs2'>, CodecName<'ucs2'>] = [] as any;
-  set; // $ExpectType [Ucs2Codec, string, string, "ucs2"]
+  set; // $ExpectType [NamedCodec<"ucs2", string, string>, string, string, "ucs2"]
 }
 {
   const codec = 'utf-8';
@@ -110,7 +110,7 @@ import codecs = require('codecs');
   codecs[codec].encode('hello'); // $ExpectType Buffer
   codecs[codec].decode(new Uint8Array()); // $ExpectType string
   const set: [Codec<'utf-8'>, InType<'utf-8'>, OutType<'utf-8'>, CodecName<'utf-8'>] = [] as any;
-  set; // $ExpectType [Utf8Codec, string, string, "utf-8"]
+  set; // $ExpectType [NamedCodec<"utf-8", string, string>, string, string, "utf-8"]
 }
 {
   const codec = 'utf8';
@@ -119,7 +119,7 @@ import codecs = require('codecs');
   codecs[codec].encode('hello'); // $ExpectType Buffer
   codecs[codec].decode(new Uint8Array()); // $ExpectType string
   const set: [Codec<'utf8'>, InType<'utf8'>, OutType<'utf8'>, CodecName<'utf8'>] = [] as any;
-  set; // $ExpectType [Utf8Codec, string, string, "utf-8"]
+  set; // $ExpectType [NamedCodec<"utf-8", string, string>, string, string, "utf-8"]
 }
 {
   const codec = 'utf16-le';
@@ -128,7 +128,7 @@ import codecs = require('codecs');
   codecs[codec].encode('hello'); // $ExpectType Buffer
   codecs[codec].decode(new Uint8Array()); // $ExpectType string
   const set: [Codec<'utf16-le'>, InType<'utf16-le'>, OutType<'utf16-le'>, CodecName<'utf16-le'>] = [] as any;
-  set; // $ExpectType [Utf16leCodec, string, string, "utf16le"]
+  set; // $ExpectType [NamedCodec<"utf16le", string, string>, string, string, "utf16le"]
 }
 {
   const codec = 'utf16le';
@@ -137,5 +137,5 @@ import codecs = require('codecs');
   codecs[codec].encode('hello'); // $ExpectType Buffer
   codecs[codec].decode(new Uint8Array()); // $ExpectType string
   const set: [Codec<'utf16le'>, InType<'utf16le'>, OutType<'utf16le'>, CodecName<'utf16le'>] = [] as any;
-  set; // $ExpectType [Utf16leCodec, string, string, "utf16le"]
+  set; // $ExpectType [NamedCodec<"utf16le", string, string>, string, string, "utf16le"]
 }

--- a/types/codecs/ts3.6/codecs-tests.ts
+++ b/types/codecs/ts3.6/codecs-tests.ts
@@ -1,4 +1,3 @@
-/* tslint:disable:prefer-const */
 import { CodecName, InType, OutType, Codec, JsonCodec, NamedCodec } from 'codecs/ts3.6';
 import codecs = require('codecs/ts3.6');
 

--- a/types/codecs/ts3.6/index.d.ts
+++ b/types/codecs/ts3.6/index.d.ts
@@ -1,6 +1,4 @@
 /// <reference types="node" />
-type ArgsType<T> = T extends (...args: infer U) => any ? U : never;
-
 declare namespace codecs {
     type JsonObject = { [Key in string]?: JsonValue };
     interface JsonArray extends Array<JsonValue> {}

--- a/types/codecs/ts3.6/index.d.ts
+++ b/types/codecs/ts3.6/index.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for codecs 2.2
-// Project: https://github.com/mafintosh/codecs
-// Definitions by: Martin Heidegger <https://github.com/martinheidegger>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference types="node" />
 type ArgsType<T> = T extends (...args: infer U) => any ? U : never;
 

--- a/types/codecs/ts3.6/tsconfig.json
+++ b/types/codecs/ts3.6/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "codecs-tests.ts"
+    ]
+}

--- a/types/codecs/ts3.6/tslint.json
+++ b/types/codecs/ts3.6/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR updates the `codecs` type definitions with new util types that makes it easier to use `codecs` with other libraries.

When working with the recently added `codecs` definitions I noticed that they are kind of stressful to work that this solves:

1. `NamedCodec` always required a type so I had to do like `NamedCodec<string>`. Now it does have a default and I can just reference `NamedCodec` without setting the default.
2. When having a structure like `hypercore` that [accepts a codec as parameter](https://github.com/hypercore-protocol/hypercore/blob/0534b7a2b2b509880773814e7e72a8a01fd4c92f/index.js#L1294) then the `hypercore` instance is of the type of the input character. `HyperCode<InputType>` but since `codecs` has fallbacks, its rather tricky to evaluate this. This PR adds a `InType` and `OutType` helper that allows to easily derive what the output of a codec is:
    ```typescript
    import { OutType } = require('codecs')
    class Hypercore<ValueCodec> {
       constructor (options: HypercoreOptions<ValueCodec>)
       get (item: number, cb: Callback<OutType<ValueCodec>>): void
    }
    ```
3. Additionally this PR adds a `CodecName` helper that allows to get the name of a selected codec.
    ```typescript
    import { CodecName } = require('codecs')
    class ToBeSerialized<ValueCodec> {
       constructor (options: HypercoreOptions<ValueCodec>)
       get name (): CodecName<ValueCodec>
    }
    ```
4. When my code had a different default codec it was kind of annoying to see `NamedCodec<'json', any, JsonValue>` so this PR also named all the given codecs: `JsonCodec`, `AsciiCodec`, `Base64Codec`, ...; In combination with the new `MaybeCodecInput` this allows following update:
    ```typescript
    // old
    createThing <T extends BaseCodec | string  | null  | undefined>(codec: T): Codec<T, NamedCodec<'json', any, JsonValue>>
    // new
    createThing <T extends CodecInput>(codec: T): Codec<T, JsonCodec>
    ```
5. Unfortunately the current code missed a definition allowing an `undefined` value to be passed in to codecs:

     ```typescript
     codecs() // worked!
     codecs(undefined) // didn't work
     ```

     This PR also fixes that small issue.

     
Unfortunately there was some update `ExpectType` with Typescript 3.7 that resolves to different types (`JsonCodec` is `JsonCodec` from 3.7 but `NamedCodec<"json", any, JsonValue>` before that). In order to get the tests to pass I had to duplicate the whole definitions and add a `3.6` variant. 