### PR TITLE
[photoswipe] fix wrong types

### DIFF
--- a/types/photoswipe/index.d.ts
+++ b/types/photoswipe/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://photoswipe.com/
 // Definitions by: Xiaohan Zhang <https://github.com/hellochar>
 //                 PikachuEXE <https://github.com/PikachuEXE>
+//                 RazDva122 <https://github.com/Razdva122>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace PhotoSwipe {
@@ -61,6 +62,11 @@ declare namespace PhotoSwipe {
          * Internal property added by PhotoSwipe.
          */
         initialPosition?: any;
+
+        /**
+         * Custom IDs for each slide object that are used when forming URL
+         */
+        pid?: string | number;
     }
 
     /**
@@ -140,7 +146,7 @@ declare namespace PhotoSwipe {
          *
          * Default true.
          */
-        allowNoPanText?: boolean;
+        allowPanToNext?: boolean;
 
         /**
          * Maximum zoom level when performing spread (zoom) gesture. 2 means that image can be zoomed 2x from original size.
@@ -256,6 +262,14 @@ declare namespace PhotoSwipe {
         galleryUID?: number;
 
         /**
+         * Enables custom IDs for each slide object that are used when forming URL.
+         * If option set set to true, slide objects must have pid (picture identifier) property that can be a string or an integer.
+         *
+         * Default false.
+         */
+        galleryPIDs?: boolean;
+
+        /**
          * Error message when image was not loaded. %url% will be replaced by URL of image.
          *
          * Default is:
@@ -277,20 +291,6 @@ declare namespace PhotoSwipe {
          * String with name of class that will be added to root element of PhotoSwipe (.pswp). Can contain multiple classes separated by space.
          */
         mainClass?: string;
-
-        /**
-         * NOTE: this property will be ignored in future versions of PhotoSwipe.
-         *
-         * @deprecated
-         */
-        mainScrollEndFriction?: number;
-
-        /**
-         * NOTE: this property will be ignored in future versions of PhotoSwipe.
-         *
-         * @deprecated
-         */
-        panEndFriction?: number;
 
         /**
          * Function that should return total number of items in gallery. Don't put very complex code here, function is executed very often.

--- a/types/photoswipe/photoswipe-tests.ts
+++ b/types/photoswipe/photoswipe-tests.ts
@@ -7,16 +7,19 @@ function test_defaultUI() {
             src: "path/to/image.jpg",
             w: 100,
             h: 200,
+            pid: 'image-one',
         },
         {
             src: "path/to/image2.jpg",
             w: 1000,
             h: 2000,
+            pid: 'image-two',
         },
         {
             src: "path/to/image3.jpg",
             w: 1000,
             h: 2000,
+            pid: 'image-three',
 
             msrc: "path/to/image3-thumb.jpg"
         },
@@ -35,7 +38,7 @@ function test_defaultUI() {
         showHideOpacity: false,
         bgOpacity: 1,
         spacing: 0.12,
-        allowNoPanText: true,
+        allowPanToNext: true,
         maxSpreadZoom: 2,
         getDoubleTapZoom: function(isMouseClick, item) {
             if (isMouseClick) {
@@ -53,6 +56,7 @@ function test_defaultUI() {
         arrowKeys: true,
         history: true,
         galleryUID: 3,
+        galleryPIDs: true,
         errorMsg: '<div class="pswp__error-msg"><a href="%url%" target="_blank">The image</a> could not be loaded.</div>',
         preload: [1, 1],
         mainClass: "",
@@ -61,8 +65,6 @@ function test_defaultUI() {
         isClickableElement: function(el) {
             return el.tagName === 'A';
         },
-        mainScrollEndFriction: 0.35,
-        panEndFriction: 0.35,
         modal: true
     };
 


### PR DESCRIPTION
Was added prop pid for Item gallery.
Added `galleryPIDs` prop to options.
Fixed wrong name of prop from `allowNoPanText` to `allowPanToNext`.
Deleted deprecated props what not supported `mainScrollEndFriction`, `panEndFriction`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://photoswipe.com/documentation/options.html, https://photoswipe.com/documentation/faq.html#custom-pid-in-url
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
