### PR TITLE
[agenda] fixing types for agenda.mongo() method to allow passing a db object directly

### DIFF
--- a/types/agenda/agenda-tests.ts
+++ b/types/agenda/agenda-tests.ts
@@ -115,3 +115,6 @@ class ExtendedAgenda extends Agenda {
 
 const extendedAgenda: ExtendedAgenda = new ExtendedAgenda()
     .mongo(new MongoClient(mongoConnectionString), "tes-collection");
+
+const extendedAgenda2: ExtendedAgenda = new ExtendedAgenda()
+    .mongo(new MongoClient(mongoConnectionString).db());

--- a/types/agenda/index.d.ts
+++ b/types/agenda/index.d.ts
@@ -51,7 +51,7 @@ declare class Agenda extends EventEmitter {
      * @param collection name collection we want to use ('agendaJobs')
      * @param cb called when MongoDB connection fails or passes
      */
-    mongo(mdb: MongoClient, collection: string, cb?: ResultCallback<Collection>): this;
+    mongo(mdb: MongoClient | Db, collection?: string, cb?: ResultCallback<Collection>): this;
 
     /**
      * Set name of queue


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/agenda/agenda#mongodbinstance
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

The most recent update to the agenda types broke the `.mongo()` method: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49377. The docs specify that you call `.mongo()` with either a `Db` or ` MongoClient`, however the most recent PR changed the types so passing a `Db` is no longer accepted. This PR fixes that so either is accepted. 
