### PR TITLE
[redux-form] fix type for registeredFields

### DIFF
--- a/types/redux-form/lib/reducer.d.ts
+++ b/types/redux-form/lib/reducer.d.ts
@@ -18,7 +18,7 @@ export interface FormStateMap {
 }
 
 export interface FormState {
-    registeredFields: RegisteredFieldState[];
+    registeredFields: { [name: string]: RegisteredFieldState };
     fields?: { [name: string]: FieldState };
     values?: { [fieldName: string]: any };
     active?: string;


### PR DESCRIPTION
Hi all! :wave: 

The `registeredFields` property on `FormState` seems to have the wrong type. Since it represents what's in the redux store it shouldn't be a list of `RegisteredFieldState`; instead it should be an nested object where the path for the field is the key for each `RegisteredFieldState` object.

I think [this](https://github.com/redux-form/redux-form/blob/ed62498c8af7624ec3446ca4935deef2c89092ec/src/createReduxForm.js#L231) might be the cause of the confusion here and where the list type is coming from. But this type isn't used in the actual `FormState` as far as I can tell. And I've verified manually that it's not the type that actually gets passed for instance when using `reduxForm.onSubmit` in the third `prop` type.

The tests for redux-form seems to support this, e.g. [looking here](https://github.com/redux-form/redux-form/blob/0c4a04777d812b4f6769bbcb26e3d7eef359a586/src/__tests__/reduxForm.spec.js#L774).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
