### PR TITLE
Revert "[@types/jest] Infer matcher types based on expect (#47020)"

### DIFF
--- a/types/jest-in-case/jest-in-case-tests.ts
+++ b/types/jest-in-case/jest-in-case-tests.ts
@@ -48,9 +48,9 @@ test('array', () => {
     expect(global.test.mock.calls[0][1]).toHaveLength(0);
     expect(global.test.mock.calls[1][1]).toHaveLength(0);
     expect(global.test.mock.calls[2][1]).toHaveLength(0);
-    expect(tester).toHaveBeenCalledWith(testCases[0], expect.anything());
-    expect(tester).toHaveBeenCalledWith(testCases[1], expect.anything());
-    expect(tester).toHaveBeenCalledWith(testCases[2], expect.anything());
+    expect(tester).toHaveBeenCalledWith(testCases[0]);
+    expect(tester).toHaveBeenCalledWith(testCases[1]);
+    expect(tester).toHaveBeenCalledWith(testCases[2]);
 });
 
 test('object', () => {

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -333,10 +333,6 @@ declare namespace jest {
         string;
     type ConstructorPropertyNames<T> = { [K in keyof T]: T[K] extends new (...args: any[]) => any ? K : never }[keyof T] &
         string;
-    type Collection<T> = Iterable<T> | ArrayLike<T>;
-    type CollectionElementType<T> = T extends Collection<never> ? any : (T extends Collection<infer U> ? U : any);
-    type MockArgsType<T> = T extends MockInstance<any, infer TArgs> ? TArgs : any;
-    type MockReturnType<T> = T extends MockInstance<infer TReturn, any> ? TReturn : any;
 
     interface DoneCallback {
         (...args: any[]): any;
@@ -696,23 +692,19 @@ declare namespace jest {
         getState(): MatcherState & Record<string, any>;
     }
 
-    type JestMatchers<T> = JestMatchersShape<T, Matchers<void, T>, Matchers<Promise<void>, T>>;
+    type JestMatchers<T> = JestMatchersShape<Matchers<void, T>, Matchers<Promise<void>, T>>;
 
-    type JestMatchersShape<
-        TActual,
-        TNonPromise extends Matchers<void, TActual> = Matchers<void, TActual>,
-        TPromise extends Matchers<Promise<void>, TActual> = Matchers<Promise<void>, TActual>
-    > = {
+    type JestMatchersShape<TNonPromise extends {} = {}, TPromise extends {} = {}> = {
         /**
          * Use resolves to unwrap the value of a fulfilled promise so any other
          * matcher can be chained. If the promise is rejected the assertion fails.
          */
-        resolves: AndNot<TPromise extends Matchers<infer U, Promise<infer V>> ? TPromise & Matchers<U, V> : never>,
+        resolves: AndNot<TPromise>,
         /**
          * Unwraps the reason of a rejected promise so any other matcher can be chained.
          * If the promise is fulfilled the assertion fails.
          */
-        rejects: AndNot<TPromise extends Matchers<infer U, Promise<any>> ? TPromise & Matchers<U, any> : never>
+        rejects: AndNot<TPromise>
     } & AndNot<TNonPromise>;
     type AndNot<T> = T & {
         not: T
@@ -727,7 +719,7 @@ declare namespace jest {
          * Note that the type must be either an array or a tuple.
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        lastCalledWith<E extends MockArgsType<T>>(...args: E): R;
+        lastCalledWith<E extends any[]>(...args: E): R;
         /**
          * Ensure that the last call to a mock function has returned a specified value.
          *
@@ -735,7 +727,7 @@ declare namespace jest {
          * This is particularly useful for ensuring expected objects have the right structure.
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        lastReturnedWith<E extends MockReturnType<T>>(value: E): R;
+        lastReturnedWith<E = any>(value: E): R;
         /**
          * Ensure that a mock function is called with specific arguments on an Nth call.
          *
@@ -743,7 +735,7 @@ declare namespace jest {
          * Note that the type must be either an array or a tuple.
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        nthCalledWith<E extends MockArgsType<T>>(nthCall: number, ...params: E): R;
+        nthCalledWith<E extends any[]>(nthCall: number, ...params: E): R;
         /**
          * Ensure that the nth call to a mock function has returned a specified value.
          *
@@ -751,7 +743,7 @@ declare namespace jest {
          * This is particularly useful for ensuring expected objects have the right structure.
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        nthReturnedWith<E extends MockReturnType<T>>(n: number, value: E): R;
+        nthReturnedWith<E = any>(n: number, value: E): R;
         /**
          * Checks that a value is what you expect. It uses `Object.is` to check strict equality.
          * Don't use `toBe` with floating-point numbers.
@@ -760,7 +752,7 @@ declare namespace jest {
          * This is particularly useful for ensuring expected objects have the right structure.
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        toBe<E = T>(expected: E): R;
+        toBe<E = any>(expected: E): R;
         /**
          * Ensures that a mock function is called.
          */
@@ -776,7 +768,7 @@ declare namespace jest {
          * Note that the type must be either an array or a tuple.
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        toBeCalledWith<E extends MockArgsType<T>>(...args: E): R;
+        toBeCalledWith<E extends any[]>(...args: E): R;
         /**
          * Using exact equality with floating point numbers is a bad idea.
          * Rounding means that intuitive things fail.
@@ -845,7 +837,7 @@ declare namespace jest {
          * This is particularly useful for ensuring expected objects have the right structure.
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        toContain<E = T>(expected: E extends string ? string : CollectionElementType<E>): R;
+        toContain<E = any>(expected: E): R;
         /**
          * Used when you want to check that an item is in a list.
          * For testing the items in the list, this matcher recursively checks the
@@ -855,7 +847,7 @@ declare namespace jest {
          * This is particularly useful for ensuring expected objects have the right structure.
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        toContainEqual<E = T>(expected: CollectionElementType<E>): R;
+        toContainEqual<E = any>(expected: E): R;
         /**
          * Used when you want to check that two objects have the same value.
          * This matcher recursively checks the equality of all fields, rather than checking for object identity.
@@ -864,7 +856,7 @@ declare namespace jest {
          * This is particularly useful for ensuring expected objects have the right structure.
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        toEqual<E = T>(expected: E): R;
+        toEqual<E = any>(expected: E): R;
         /**
          * Ensures that a mock function is called.
          */
@@ -880,7 +872,7 @@ declare namespace jest {
          * Note that the type must be either an array or a tuple.
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        toHaveBeenCalledWith<E extends MockArgsType<T>>(...params: E): R;
+        toHaveBeenCalledWith<E extends any[]>(...params: E): R;
         /**
          * Ensure that a mock function is called with specific arguments on an Nth call.
          *
@@ -888,7 +880,7 @@ declare namespace jest {
          * Note that the type must be either an array or a tuple.
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        toHaveBeenNthCalledWith<E extends MockArgsType<T>>(nthCall: number, ...params: E): R;
+        toHaveBeenNthCalledWith<E extends any[]>(nthCall: number, ...params: E): R;
         /**
          * If you have a mock function, you can use `.toHaveBeenLastCalledWith`
          * to test what arguments it was last called with.
@@ -897,7 +889,7 @@ declare namespace jest {
          * Note that the type must be either an array or a tuple.
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        toHaveBeenLastCalledWith<E extends MockArgsType<T>>(...params: E): R;
+        toHaveBeenLastCalledWith<E extends any[]>(...params: E): R;
         /**
          * Use to test the specific value that a mock function last returned.
          * If the last call to the mock function threw an error, then this matcher will fail
@@ -907,7 +899,7 @@ declare namespace jest {
          * This is particularly useful for ensuring expected objects have the right structure.
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        toHaveLastReturnedWith<E extends MockReturnType<T>>(expected: E): R;
+        toHaveLastReturnedWith<E = any>(expected: E): R;
         /**
          * Used to check that an object has a `.length` property
          * and it is set to a certain numeric value.
@@ -922,7 +914,7 @@ declare namespace jest {
          * This is particularly useful for ensuring expected objects have the right structure.
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        toHaveNthReturnedWith<E extends MockReturnType<T>>(nthCall: number, expected: E): R;
+        toHaveNthReturnedWith<E = any>(nthCall: number, expected: E): R;
         /**
          * Use to check if property at provided reference keyPath exists for an object.
          * For checking deeply nested properties in an object you may use dot notation or an array containing
@@ -954,7 +946,7 @@ declare namespace jest {
          * This is particularly useful for ensuring expected objects have the right structure.
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        toHaveReturnedWith<E extends MockReturnType<T>>(expected: E): R;
+        toHaveReturnedWith<E = any>(expected: E): R;
         /**
          * Check that a string matches a regular expression.
          */
@@ -1028,7 +1020,7 @@ declare namespace jest {
          * This is particularly useful for ensuring expected objects have the right structure.
          */
         // tslint:disable-next-line: no-unnecessary-generics
-        toStrictEqual<E extends T>(expected: E): R;
+        toStrictEqual<E = any>(expected: E): R;
         /**
          * Used to test that a function throws when it is called.
          */
@@ -1071,7 +1063,7 @@ declare namespace jest {
     // Use the `void` type for return types only. Otherwise, use `undefined`. See: https://github.com/Microsoft/dtslint/blob/master/docs/void-return.md
     // have added issue https://github.com/microsoft/dtslint/issues/256 - Cannot have type union containing void ( to be used as return type only
     type ExtendedMatchers<TMatchers extends ExpectExtendMap, TMatcherReturn, TActual> = Matchers<TMatcherReturn, TActual> & {[K in keyof TMatchers]: CustomJestMatcher<TMatchers[K], TMatcherReturn>};
-    type JestExtendedMatchers<TMatchers extends ExpectExtendMap, TActual> = JestMatchersShape<TActual, ExtendedMatchers<TMatchers, void, TActual>, ExtendedMatchers<TMatchers, Promise<void>, TActual>>;
+    type JestExtendedMatchers<TMatchers extends ExpectExtendMap, TActual> = JestMatchersShape<ExtendedMatchers<TMatchers, void, TActual>, ExtendedMatchers<TMatchers, Promise<void>, TActual>>;
 
     // when have called expect.extend
     type ExtendedExpectFunction<TMatchers extends ExpectExtendMap> = <TActual>(actual: TActual) => JestExtendedMatchers<TMatchers, TActual>;
@@ -1080,9 +1072,12 @@ declare namespace jest {
     ExpectProperties &
     AndNot<CustomAsyncMatchers<TMatchers>> &
     ExtendedExpectFunction<TMatchers>;
-
+    /**
+     * Construct a type with the properties of T except for those in type K.
+     */
+    type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
     type NonPromiseMatchers<T extends JestMatchersShape<any>> = Omit<T, 'resolves' | 'rejects' | 'not'>;
-    type PromiseMatchers<T extends JestMatchersShape<any>> = Omit<T['resolves'], 'not'>;
+    type PromiseMatchers<T extends JestMatchersShape> = Omit<T['resolves'], 'not'>;
 
     interface Constructable {
         new (...args: any[]): any;

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -843,33 +843,15 @@ describe('', () => {
         expect(jest.fn()).lastCalledWith();
         expect(jest.fn()).lastCalledWith('jest');
         expect(jest.fn()).lastCalledWith({}, {});
-        expect(jest.fn<void, [string]>()).lastCalledWith('abc');
-        expect(jest.fn<void, [string, string?]>()).lastCalledWith('abc');
-        // $ExpectError
-        expect(jest.fn<void, [string]>()).lastCalledWith(123);
-        // $ExpectError
-        expect(jest.fn<void, [string, string]>()).lastCalledWith('abc');
 
         expect(jest.fn()).lastReturnedWith('jest');
         expect(jest.fn()).lastReturnedWith({});
-        expect(jest.fn<string, []>()).lastReturnedWith('abc');
-        // $ExpectError
-        expect(jest.fn<string, []>()).lastReturnedWith(123);
 
         expect(jest.fn()).nthCalledWith(0, 'jest');
         expect(jest.fn()).nthCalledWith(1, {});
-        expect(jest.fn<void, [string]>()).nthCalledWith(1, 'abc');
-        expect(jest.fn<void, [string, string?]>()).nthCalledWith(1, 'abc');
-        // $ExpectError
-        expect(jest.fn<void, [string]>()).nthCalledWith(1, 123);
-        // $ExpectError
-        expect(jest.fn<void, [string, string]>()).nthCalledWith(1, 'abc');
 
         expect(jest.fn()).nthReturnedWith(0, 'jest');
         expect(jest.fn()).nthReturnedWith(1, {});
-        expect(jest.fn<string, []>()).nthReturnedWith(1, 'abc');
-        // $ExpectError
-        expect(jest.fn<string, []>()).nthReturnedWith(1, 123);
 
         expect({}).toBe({});
         expect([]).toBe([]);
@@ -882,13 +864,6 @@ describe('', () => {
         expect(jest.fn()).toBeCalledWith();
         expect(jest.fn()).toBeCalledWith('jest');
         expect(jest.fn()).toBeCalledWith({}, {});
-
-        expect(jest.fn<void, [string]>()).toBeCalledWith('abc');
-        expect(jest.fn<void, [string, string?]>()).toBeCalledWith('abc');
-        // $ExpectError
-        expect(jest.fn<void, [string]>()).toBeCalledWith(123);
-        // $ExpectError
-        expect(jest.fn<void, [string, string]>()).toBeCalledWith('abc');
 
         // $ExpectError
         expect(jest.fn()).toBeCalledWith<[string, number]>(1, 'two');
@@ -931,29 +906,13 @@ describe('', () => {
         expect([]).toContain({});
         expect(['abc']).toContain('abc');
         expect(['abc']).toContain('def');
-        expect(new Set(['abc'])).toContain('abc');
         expect('abc').toContain('bc');
-        expect([1] as any).toContain(1);
-        expect('abc' as any).toContain('abc');
-        // $ExpectError
-        expect([1, 2, 3]).toContain('2');
-        // $ExpectError
-        expect({ 1: 1, 2: 2, length: 2 }).toContain('1');
-        // $ExpectError
-        expect('abc').toContain(2);
 
         expect([]).toContainEqual({});
         expect(['abc']).toContainEqual('def');
-        expect(new Set(['abc'])).toContainEqual('abc');
-        expect([1] as any).toContainEqual(1);
-        // $ExpectError
-        expect([1, 2, 3]).toContainEqual('2');
-        // $ExpectError
-        expect({ 1: 1, 2: 2, length: 2 }).toContainEqual('1');
 
         expect([]).toEqual([]);
         expect({}).toEqual({});
-        expect({a: 1}).toEqual({b: 'test'});
 
         expect(jest.fn()).toHaveBeenCalled();
 
@@ -968,40 +927,18 @@ describe('', () => {
         expect(jest.fn()).toHaveBeenCalledWith(1, 'jest');
         expect(jest.fn()).toHaveBeenCalledWith(2, {}, {});
 
-        expect(jest.fn<void, [string]>()).toHaveBeenCalledWith('abc');
-        expect(jest.fn<void, [string, string?]>()).toHaveBeenCalledWith('abc');
-        // $ExpectError
-        expect(jest.fn<void, [string]>()).toHaveBeenCalledWith(123);
-        // $ExpectError
-        expect(jest.fn<void, [string, string]>()).toHaveBeenCalledWith('abc');
-
         expect(jest.fn()).toHaveBeenLastCalledWith();
         expect(jest.fn()).toHaveBeenLastCalledWith('jest');
         expect(jest.fn()).toHaveBeenLastCalledWith({}, {});
 
-        expect(jest.fn<void, [string]>()).toHaveBeenLastCalledWith('abc');
-        expect(jest.fn<void, [string, string?]>()).toHaveBeenLastCalledWith('abc');
-        // $ExpectError
-        expect(jest.fn<void, [string]>()).toHaveBeenLastCalledWith(123);
-        // $ExpectError
-        expect(jest.fn<void, [string, string]>()).toHaveBeenLastCalledWith('abc');
-
         expect(jest.fn()).toHaveLastReturnedWith('jest');
         expect(jest.fn()).toHaveLastReturnedWith({});
-
-        expect(jest.fn<string, []>()).toHaveLastReturnedWith('abc');
-        // $ExpectError
-        expect(jest.fn<string, []>()).toHaveLastReturnedWith(123);
 
         expect([]).toHaveLength(0);
         expect('').toHaveLength(1);
 
         expect(jest.fn()).toHaveNthReturnedWith(0, 'jest');
         expect(jest.fn()).toHaveNthReturnedWith(1, {});
-
-        expect(jest.fn<string, []>()).toHaveNthReturnedWith(1, 'abc');
-        // $ExpectError
-        expect(jest.fn<string, []>()).toHaveNthReturnedWith(1, 123);
 
         expect({}).toHaveProperty('property');
         expect({}).toHaveProperty('property', {});
@@ -1017,10 +954,6 @@ describe('', () => {
 
         expect(jest.fn()).toHaveReturnedWith('jest');
         expect(jest.fn()).toHaveReturnedWith({});
-
-        expect(jest.fn<string, []>()).toHaveReturnedWith('abc');
-        // $ExpectError
-        expect(jest.fn<string, []>()).toHaveReturnedWith(123);
 
         expect('').toMatch('');
         expect('').toMatch(/foo/);
@@ -1079,12 +1012,6 @@ describe('', () => {
 
         expect(true).toStrictEqual(false);
         expect({}).toStrictEqual({});
-        interface Animal { type: string; }
-        interface Dog extends Animal { breed: string; }
-        const dog: Dog = { type: 'dog', breed: 'chihuahua' };
-        expect(dog as Animal).toStrictEqual({ type: 'dog', breed: 'chihuahua' });
-        // $ExpectError
-        expect('abc').toStrictEqual(2);
 
         const errInstance = new Error();
         const willThrow = () => {
@@ -1121,14 +1048,11 @@ describe('', () => {
 
         /* Promise matchers */
 
-        expect(Promise.reject('jest')).rejects.toStrictEqual('jest').then(() => {});
-        expect(Promise.reject('jest')).rejects.not.toStrictEqual('other').then(() => {});
+        expect(Promise.reject('jest')).rejects.toEqual('jest').then(() => {});
+        expect(Promise.reject('jest')).rejects.not.toEqual('other').then(() => {});
 
-        expect(Promise.resolve('jest')).resolves.toStrictEqual('jest').then(() => {});
-        expect(Promise.resolve('jest')).resolves.not.toStrictEqual('other').then(() => {});
-        // $ExpectError
-        expect(Promise.resolve('jest')).resolves.toStrictEqual(123).then(() => {});
-
+        expect(Promise.resolve('jest')).resolves.toEqual('jest').then(() => {});
+        expect(Promise.resolve('jest')).resolves.not.toEqual('other').then(() => {});
         /* type matchers */
 
         expect({}).toBe(expect.anything());
@@ -1141,11 +1065,6 @@ describe('', () => {
         expect(['abc']).toBe(expect.arrayContaining(['a', 'b']));
 
         expect.objectContaining({});
-        // $ExpectError
-        expect.objectContaining<{ a: string, b: string }>({ a: '123' });
-        // $ExpectError
-        expect.objectContaining<{ a: string, b: string }>({ a: 123 });
-
         expect.stringMatching('foo');
         expect.stringMatching(/foo/);
         expect.stringContaining('foo');
@@ -1159,21 +1078,6 @@ describe('', () => {
                 ghi: expect.stringMatching('foo'),
             })
         );
-
-        expect({ a: 2, b: 'abc' }).toEqual(expect.objectContaining({ a: 2 }));
-        expect({ a: 2, b: 'abc' }).toEqual(expect.anything());
-        expect([1, 2, 3]).toEqual(expect.arrayContaining([2]));
-
-        expect({ a: 2, b: 'abc' }).toStrictEqual(expect.objectContaining({ a: 2 }));
-        expect({ a: 2, b: 'abc' }).toStrictEqual(expect.anything());
-        expect([1, 2, 3]).toStrictEqual(expect.arrayContaining([2]));
-
-        expect([{ a: 2, b: 'abc' }]).toContain(expect.objectContaining({ a: 2 }));
-
-        const a = [{ a: "foo" }, { a: "bar" }, { b: "baz" }];
-        expect(a).toContain(expect.objectContaining({ a: "foo" }));
-
-        expect([{ a: 2, b: 'abc' }]).toContainEqual(expect.objectContaining({ a: 2 }));
 
         /* Inverse type matchers */
 


### PR DESCRIPTION
This reverts commit 13763cc7

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/pull/47020>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
