### PR TITLE
StyledComponent: More accurate component constraint for TS 4.2

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -158,7 +158,7 @@ export type AnyStyledComponent =
     | StyledComponent<any, any, any>;
 
 export type StyledComponent<
-    C extends string | React.ComponentType<any>,
+    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
     T extends object,
     O extends object = {},
     A extends keyof any = never


### PR DESCRIPTION
This change makes styled-components pass compilation on Typescript 4.2, which correctly propagates type parameter constraints through certain
complex conditional types. Old versions of typescript just dropped the constraint by mistake, so this inconsistency was just not checked before.

I'm not certain this is the right solution; in particular, it may be a lot slower. I hope not, because I have no idea what the right fix is otherwise!

Edit: 

1. performance looks OK.
2. I haven't tried it, but changing all `keyof JSX.Intrinsic` to `string` might also fix the error, at the cost of some type accuracy.