### PR TITLE
@types/firefox-webext-browser: Adds specific types to `browser.devtools.network`.

### DIFF
--- a/types/firefox-webext-browser/firefox-webext-browser-tests.ts
+++ b/types/firefox-webext-browser/firefox-webext-browser-tests.ts
@@ -98,3 +98,15 @@ filter.write(new Uint8Array(32));
 filter.close();
 filter.disconnect();
 console.log(filter.status);
+
+/* Test Request */
+browser.devtools.network.onRequestFinished.addListener(async (request) => {
+  request; // $ExpectType Request
+  const har: HAREntry = request; // Extends HAR entry.
+  const [content, encodingOrMimeType] = await request.getContent();
+  content; // $ExpectType string
+  encodingOrMimeType; // $ExpectType string
+});
+
+/* Test getHAR() */
+browser.devtools.network.getHAR(); // $ExpectType Promise<Log>

--- a/types/firefox-webext-browser/har-format.d.ts
+++ b/types/firefox-webext-browser/har-format.d.ts
@@ -1,0 +1,6 @@
+import { Entry, Log } from 'har-format';
+
+declare global {
+  type HAREntry = Entry;
+  type HARLog = Log;
+}

--- a/types/firefox-webext-browser/index.d.ts
+++ b/types/firefox-webext-browser/index.d.ts
@@ -5,6 +5,8 @@
 // TypeScript Version: 3.4
 // Generated using script at github.com/jsmnbom/definitelytyped-firefox-webext-browser
 
+/// <reference path="har-format.d.ts" />
+
 interface WebExtEvent<TCallback extends (...args: any[]) => any> {
     addListener(cb: TCallback): void;
     removeListener(cb: TCallback): void;
@@ -5887,14 +5889,14 @@ declare namespace browser.devtools.network {
     /**
      * Represents a network request for a document resource (script, image and so on). See HAR Specification for reference.
      */
-    interface Request {
-        /** Returns content of the response body. */
-        getContent(): Promise<object>;
+    interface Request extends HAREntry {
+        /** Returns content of the response body. The first value is the body of the HTTP response, while the second is the encoding of body (Chrome) or the MIME type of the response (Firefox). */
+        getContent(): Promise<[string /* content */, string /* encodingOrMimeType */]>;
     }
 
     /* devtools.network functions */
     /** Returns HAR log that contains all known network requests. */
-    function getHAR(): Promise<{ [key: string]: any }>;
+    function getHAR(): Promise<HARLog>;
 
     /* devtools.network events */
     /**


### PR DESCRIPTION
This uses `@types/har-format` to bring these definitions in line with those from `@types/chrome`.

Updates `browser.devtools.network.Request` to extend `HAREntry` as defined [on MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools.network/onRequestFinished).

Also updates `getHAR()` and `getContent()` to be more specific about
their return values. `getContent()` is a little weird because the second
value has different semantics between Chrome and Firefox. For Chrome it
will be [either empty string or `'base64'`](https://developer.chrome.com/docs/extensions/reference/devtools_network/#type-Request) based on whether the first
HTTP response body in the first value was encoded. For Firefox it is the
MIME type of the HTTP response. This distinction is called out in a
comment.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [ ] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:

[MDN `browser.devtools.network.onRequestFinished()`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools.network/onRequestFinished)
[Firefox implementation of `getContent()`](https://searchfox.org/mozilla-central/rev/1843375acbbca68127713e402be222350ac99301/browser/components/extensions/parent/ext-devtools-network.js#65)
[Firefox unit test of `getContent()`](https://searchfox.org/mozilla-central/rev/1843375acbbca68127713e402be222350ac99301/browser/components/extensions/test/browser/browser_ext_devtools_network.js#253,258,263,268)

- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

These types aren't directly associated with a library, however Mozilla's Web Extensions polyfill is currently being updated to promisify `getContent()` in https://github.com/mozilla/webextension-polyfill/pull/250.

- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
