### PR TITLE
[tmi.js] remove specific typing for badges

### DIFF
--- a/types/tmi.js/index.d.ts
+++ b/types/tmi.js/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for tmi.js 1.4
 // Project: https://github.com/tmijs/tmi.js
 // Definitions by: William Papsco <https://github.com/wpapsco>
+//                 Corbin Crutchley <https://github.com/crutchcorn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.3
 

--- a/types/tmi.js/index.d.ts
+++ b/types/tmi.js/index.d.ts
@@ -108,20 +108,7 @@ export interface ClientBase {
     listenerCount(event: keyof Events): number;
 }
 
-export interface Badges {
-    admin?: string;
-    bits?: string;
-    broadcaster?: string;
-    partner?: string;
-    global_mod?: string;
-    moderator?: string;
-    vip?: string;
-    subscriber?: string;
-    staff?: string;
-    turbo?: string;
-    premium?: string;
-    founder?: string;
-}
+export type Badges = Record<string, string>;
 
 export interface SubMethods {
     prime?: boolean;

--- a/types/tmi.js/index.d.ts
+++ b/types/tmi.js/index.d.ts
@@ -109,7 +109,23 @@ export interface ClientBase {
     listenerCount(event: keyof Events): number;
 }
 
-export type Badges = Record<string, string>;
+export interface Badges {
+    admin?: string;
+    bits?: string;
+    broadcaster?: string;
+    partner?: string;
+    global_mod?: string;
+    moderator?: string;
+    vip?: string;
+    subscriber?: string;
+    staff?: string;
+    turbo?: string;
+    premium?: string;
+    founder?: string;
+    ['bits-leader']?: string;
+    ['sub-gifter']?: string;
+    [other: string]: string | undefined;
+}
 
 export interface SubMethods {
     prime?: boolean;

--- a/types/tmi.js/tmi.js-tests.ts
+++ b/types/tmi.js/tmi.js-tests.ts
@@ -69,6 +69,9 @@ client.connect().then(() => {
         }
         if (badges) {
             const { admin, turbo, subscriber, bits, broadcaster, global_mod, moderator, premium, staff, vip, partner, founder } = badges;
+            badges['bits-leader'];
+            const test = 'hello';
+            badges[test];
         }
         userstate["display-name"];
         userstate["emotes-raw"];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Could not find docs, see explanation below
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

While working with TMI.JS in my Twitch chat, I noticed that there were 2 badges that were missing from the `Badges` interface:

- `bits-leader`
- `sub-gifter`

I also suspect that there are many other badges that are missing as a result of poor documentation from Twitch.js themselves on just how many badges there are and what they reflect

However, while working with this API, I also discovered that it's relatively unpleasant to do string indexing on the object, as it's `const` typed (so I couldn't do `badges[string]` without type coercion). This seems like a fairly common use-case and is even utilized by `tmi.js` author, Alca, themselves in a codepen demonstrating the project:

https://codepen.io/Alca/pen/zzomog

(line 233)

While yes, this is less strict, it is more consumer-friendly and removes inaccuracies due to being overly strict