### PR TITLE
Revert incorrect fix to FileArray type in @types/express-fileupload

### DIFF
--- a/types/express-fileupload/express-fileupload-tests.ts
+++ b/types/express-fileupload/express-fileupload-tests.ts
@@ -6,16 +6,29 @@ type UploadedFile = fileUpload.UploadedFile;
 
 const app: express.Express = express();
 
-function isUploadedFile(file: UploadedFile | UploadedFile[]): file is UploadedFile {
+function isSingleFile(file: UploadedFile | UploadedFile[]): file is UploadedFile {
     return typeof file === 'object' && (file as UploadedFile).name !== undefined;
+}
+
+function isFileArray(file: UploadedFile | UploadedFile[]): file is UploadedFile[] {
+    return Array.isArray(file);
 }
 
 const uploadHandler: RequestHandler = (req: Request, res: Response, next: NextFunction) => {
     if (typeof req.files === 'object') {
         const fileField = req.files.field;
-        if (isUploadedFile(fileField)) {
+        if (isSingleFile(fileField)) {
             console.log(fileField.name);
             fileField.mv('/tmp/test', err => {
+                if (err) {
+                    console.log('Error while copying file to target location');
+                }
+            });
+        }
+
+        if (isFileArray(fileField)) {
+            console.log(fileField[0].name);
+            fileField[0].mv('/tmp/test', err => {
                 if (err) {
                     console.log('Error while copying file to target location');
                 }
@@ -62,8 +75,11 @@ app.use(
     fileUpload({
         limitHandler: (req, res, next) => {
             if (req.files) {
-                if (isUploadedFile(req.files.field)) {
+                if (isSingleFile(req.files.field)) {
                     console.log(req.files.field.name);
+                }
+                if (isFileArray(req.files.field)) {
+                    console.log(req.files.field[0].name);
                 }
             }
             next();

--- a/types/express-fileupload/index.d.ts
+++ b/types/express-fileupload/index.d.ts
@@ -20,7 +20,7 @@ declare function fileUpload(options?: fileUpload.Options): express.RequestHandle
 
 declare namespace fileUpload {
     class FileArray {
-        [index: string]: UploadedFile;
+        [index: string]: UploadedFile | UploadedFile[];
     }
 
     interface UploadedFile {


### PR DESCRIPTION
In #47418 , FileArray's values, which can be either a single UploadedFile object or an array of UploadedFiles, were incorrectly changed to reflect just the single object case. The same incorrect change had been attempted in both #40915 and #45572 , and rejected both times because it did not match the actual behavior of the library. Somehow #47418 got merged, though.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/richardgirges/express-fileupload/blob/1216f4f0685caca7f1ece47f52c6119dc956b07d/lib/utilities.js#L88-L91
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.