### PR TITLE
@types/react-native add missing prop to Ripple

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -5437,7 +5437,7 @@ export class TouchableNativeFeedback extends TouchableNativeFeedbackBase {
      * @param borderless If the ripple can render outside it's bounds
      * @param radius The radius of ripple effect
      */
-    static Ripple(color: ColorValue, borderless: boolean, radius?: number): RippleBackgroundPropType;
+    static Ripple(color: ColorValue, borderless: boolean, radius?: number | null): RippleBackgroundPropType;
     static canUseNativeForeground(): boolean;
 }
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -5435,8 +5435,9 @@ export class TouchableNativeFeedback extends TouchableNativeFeedbackBase {
      *
      * @param color The ripple color
      * @param borderless If the ripple can render outside it's bounds
+     * @param radius The radius of ripple effect
      */
-    static Ripple(color: ColorValue, borderless?: boolean): RippleBackgroundPropType;
+    static Ripple(color: ColorValue, borderless?: boolean, radius?: number): RippleBackgroundPropType;
     static canUseNativeForeground(): boolean;
 }
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -5437,7 +5437,7 @@ export class TouchableNativeFeedback extends TouchableNativeFeedbackBase {
      * @param borderless If the ripple can render outside it's bounds
      * @param radius The radius of ripple effect
      */
-    static Ripple(color: ColorValue, borderless?: boolean, radius?: number): RippleBackgroundPropType;
+    static Ripple(color: ColorValue, borderless: boolean, radius?: number): RippleBackgroundPropType;
     static canUseNativeForeground(): boolean;
 }
 

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -372,11 +372,28 @@ export class TouchableNativeFeedbackTest extends React.Component {
 
     render() {
         return (
-            <TouchableNativeFeedback onPress={this.onPressButton}>
-                <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
-                    <Text style={{ margin: 30 }}>Button</Text>
-                </View>
-            </TouchableNativeFeedback>
+            <>
+                <TouchableNativeFeedback onPress={this.onPressButton}>
+                    <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
+                        <Text style={{ margin: 30 }}>Button</Text>
+                    </View>
+                </TouchableNativeFeedback>
+                <TouchableNativeFeedback background={TouchableNativeFeedback.Ripple('red', true)}>
+                    <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
+                        <Text style={{ margin: 30 }}>Button</Text>
+                    </View>
+                </TouchableNativeFeedback>
+                <TouchableNativeFeedback background={TouchableNativeFeedback.Ripple('red', true, 30)}>
+                    <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
+                        <Text style={{ margin: 30 }}>Button</Text>
+                    </View>
+                </TouchableNativeFeedback>
+                <TouchableNativeFeedback background={TouchableNativeFeedback.SelectableBackgroundBorderless()}>
+                    <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
+                        <Text style={{ margin: 30 }}>Button</Text>
+                    </View>
+                </TouchableNativeFeedback>
+            </>
         );
     }
 }

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -388,6 +388,11 @@ export class TouchableNativeFeedbackTest extends React.Component {
                         <Text style={{ margin: 30 }}>Button</Text>
                     </View>
                 </TouchableNativeFeedback>
+                <TouchableNativeFeedback background={TouchableNativeFeedback.SelectableBackground()}>
+                    <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
+                        <Text style={{ margin: 30 }}>Button</Text>
+                    </View>
+                </TouchableNativeFeedback>
                 <TouchableNativeFeedback background={TouchableNativeFeedback.SelectableBackgroundBorderless()}>
                     <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
                         <Text style={{ margin: 30 }}>Button</Text>


### PR DESCRIPTION
Added missing property `ripple?: number` for `TouchableNativeFeedback.Ripple`, the type `RippleBackgroundPropType` has this property, but the `Ripple` does not, probably due to a mistake. You can also check https://github.com/facebook/react-native/blob/216037757494edf990ecb5a3dfdf6f75bab818a1/Libraries/Components/Touchable/TouchableNativeFeedback.js#L137 where it is used and is available in the flow definition.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. - no tests for this
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests). - it doesn't work even without my change.


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/facebook/react-native/blob/216037757494edf990ecb5a3dfdf6f75bab818a1/Libraries/Components/Touchable/TouchableNativeFeedback.js#L137>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

