### PR TITLE
Add types for package resx

### DIFF
--- a/types/resx/index.d.ts
+++ b/types/resx/index.d.ts
@@ -1,0 +1,36 @@
+// Type definitions for resx 2.0
+// Project: http://locize.com
+// Definitions by: Daniel Sousa <https://github.com/danielb7390>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface ObjectOfStrings {
+    [key: string]: string;
+}
+
+export interface Js2ResxOptions {
+    pretty?: boolean;
+    indent?: string;
+    newline?: string;
+}
+
+// resx2js: promise version
+export function resx2js(str: string, withComments?: boolean): Promise<ObjectOfStrings>;
+
+// resx2js: callback version
+export function resx2js(str: string, cb: (error: Error, result: ObjectOfStrings) => void): void;
+
+// resx2js: callback version with option
+export function resx2js(str: string, withComments: boolean, cb: (error: Error, result: ObjectOfStrings) => void): void;
+
+// js2resx: promise version
+export function js2resx(resources: ObjectOfStrings, opt?: Js2ResxOptions): Promise<string>;
+
+// js2resx: callback version
+export function js2resx(resources: ObjectOfStrings, cb: (error: Error, result: string) => void): void;
+
+// js2resx: callback version with options
+export function js2resx(
+    resources: ObjectOfStrings,
+    opt: Js2ResxOptions,
+    cb: (error: Error, result: string) => void,
+): void;

--- a/types/resx/resx-tests.ts
+++ b/types/resx/resx-tests.ts
@@ -1,0 +1,65 @@
+import resx = require('resx');
+
+// resx2js promise version
+// $ExpectType Promise<ObjectOfStrings>
+resx.resx2js('dummyResx');
+
+// resx2js promise version with option
+// $ExpectType Promise<ObjectOfStrings>
+resx.resx2js('dummyResx', false);
+
+// resx2js callback version
+// $ExpectType void
+resx.resx2js('dummyResx', (error: Error, result: resx.ObjectOfStrings) => {
+    // $ExpectType Error
+    error;
+    // $ExpectType ObjectOfStrings
+    result;
+});
+
+// resx2js callback version with option
+// $ExpectType void
+resx.resx2js('dummyResx', false, (error: Error, result: resx.ObjectOfStrings) => {
+    // $ExpectType Error
+    error;
+    // $ExpectType ObjectOfStrings
+    result;
+});
+
+// Test phrases object to use in the next tests
+const dummyPhrases: resx.ObjectOfStrings = {
+    'some phrase key': 'some phrase value',
+};
+
+// Test options object to use in the next tests
+const dummyOptions: resx.Js2ResxOptions = {
+    indent: '    ',
+    newline: '\n',
+    pretty: true,
+};
+
+// js2resx promise version
+// $ExpectType Promise<string>
+resx.js2resx(dummyPhrases);
+
+// js2resx promise version with options
+// $ExpectType Promise<string>
+resx.js2resx(dummyPhrases, dummyOptions);
+
+// js2resx callback version
+// $ExpectType void
+resx.js2resx(dummyPhrases, (error: Error, result: string) => {
+    // $ExpectType Error
+    error;
+    // $ExpectType string
+    result;
+});
+
+// js2resx callback version with options
+// $ExpectType void
+resx.js2resx(dummyPhrases, dummyOptions, (error: Error, result: string) => {
+    // $ExpectType Error
+    error;
+    // $ExpectType string
+    result;
+});

--- a/types/resx/tsconfig.json
+++ b/types/resx/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "resx-tests.ts"
+    ]
+}

--- a/types/resx/tslint.json
+++ b/types/resx/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This is my first attempt at creating types. Let me know if i screwed up something! 😄 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
