### PR TITLE
Update webpack-manifest-plugin definitions to v3

### DIFF
--- a/types/webpack-manifest-plugin/index.d.ts
+++ b/types/webpack-manifest-plugin/index.d.ts
@@ -1,92 +1,95 @@
-// Type definitions for webpack-manifest-plugin 2.1
-// Project: https://github.com/danethurber/webpack-manifest-plugin
+// Type definitions for webpack-manifest-plugin 3.0
+// Project: https://github.com/shellscape/webpack-manifest-plugin
 // Definitions by: Andrew Makarov <https://github.com/r3nya>, Jeremy Monson <https://github.com/monsonjeremy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
-import { Plugin } from 'webpack';
+import { Plugin, compilation, Compiler } from 'webpack';
+import { SyncWaterfallHook } from 'tapable';
 
-export = WebpackManifestPlugin;
-
-declare class WebpackManifestPlugin extends Plugin {
-    constructor(options?: WebpackManifestPlugin.Options);
+export class WebpackManifestPlugin extends Plugin {
+    constructor(options?: Options);
 }
 
-declare namespace WebpackManifestPlugin {
-    interface Chunk {
-        id: string;
-        parents: string[];
-        [propName: string]: any;
-    }
-
-    interface FileDescriptor {
-        path: string;
-        name: string | null;
-        /** Is required to run you app. Cannot be true if isChunk is false. */
-        isInitial: boolean;
-        isChunk: boolean;
-        /** Only available is isChunk is true. */
-        chunk?: Chunk;
-        isAsset: boolean;
-        /** Is required by a module. Cannot be true if isAsset is false. */
-        isModuleAsset: boolean;
-    }
-
-    interface Options {
-        /**
-         * The manifest filename in your output directory.
-         * Default: manifest.json
-         */
-        fileName?: string;
-
-        /**
-         * A path prefix that will be added to values of the manifest.
-         * Default: output.publicPath
-         */
-        publicPath?: string;
-
-        /**
-         * A path prefix for all keys. Useful for including your output path in the manifest.
-         */
-        basePath?: string;
-
-        /**
-         * If set to true will emit to build folder and memory in combination with webpack-dev-server
-         * Default: false
-         */
-        writeToFileEmit?: boolean;
-
-        /**
-         * A cache of key/value pairs to used to seed the manifest. This may include a set of custom key/value pairs to include in your manifest,
-         * or may be used to combine manifests across compilations in multi-compiler mode.
-         * To combine manifests, pass a shared seed object to each compiler's ManifestPlugin instance.
-         * Default: {}
-         */
-        seed?: object;
-
-        /**
-         * Filter out files.
-         */
-        filter?: (file: FileDescriptor) => boolean;
-
-        /**
-         * Modify files details before the manifest is created.
-         */
-        map?: (file: FileDescriptor) => FileDescriptor;
-
-        /**
-         * Sort files before they are passed to generate.
-         */
-        sort?: (a: FileDescriptor, b: FileDescriptor) => number;
-
-        /**
-         * Create the manifest. It can return anything as long as it's serialisable by JSON.stringify.
-         */
-        generate?: (seed: object, files: FileDescriptor[], entrypoints: { [key: string]: string[] }) => object;
-
-        /**
-         * Output manifest file in different format then json (i.e. yaml).
-         */
-        serialize?: (manifest: object) => string;
-    }
+export interface FileDescriptor {
+    /** Only available if isChunk is true. */
+    chunk?: compilation.Chunk;
+    isAsset: boolean;
+    isChunk: boolean;
+    /** Is required to run you app. Cannot be true if isChunk is false. */
+    isInitial: boolean;
+    /** Is required by a module. Cannot be true if isAsset is false. */
+    isModuleAsset: boolean;
+    name: string | null;
+    path: string;
 }
+
+export interface Options {
+    /**
+     * A path prefix for all keys. Useful for including your output path in the manifest.
+     * Default: ''
+     */
+    basePath?: string;
+
+    /**
+     * The manifest filename in your output directory.
+     * Default: 'manifest.json'
+     */
+    fileName?: string;
+
+    /**
+     * Filter out files which make up the manifest. Return true to keep the file, false to remove it.
+     */
+    filter?: (file: FileDescriptor) => boolean;
+
+    /**
+     * Create the manifest. It can return anything as long as it's serializable by JSON.stringify.
+     */
+    generate?: (seed: object, files: FileDescriptor[], entries: string[]) => object;
+
+    /**
+     * Modify file details before the manifest is created.
+     */
+    map?: (file: FileDescriptor) => FileDescriptor;
+
+    /**
+     * A path prefix that will be added to values of the manifest.
+     * Default: output.publicPath
+     */
+    publicPath?: string;
+
+    /**
+     * Remove hashes from manifest keys. Defaults to Webpack's md5 hash.
+     * Default: /([a-f0-9]{32}\.?)/gi
+     */
+    removeKeyHash?: RegExp | boolean;
+
+    /**
+     * A cache of key/value pairs to used to seed the manifest.
+     * Default: {}
+     */
+    seed?: object;
+
+    /**
+     * Output manifest file in different format then json (i.e. yaml).
+     */
+    serialize?: (manifest: object) => string;
+
+    /**
+     * Sort files before they are passed to generate.
+     */
+    sort?: (fileA: FileDescriptor, fileB: FileDescriptor) => number;
+
+    /**
+     * If true, the keys specified in the entry property will be used as keys in the manifest.
+     * Default: false
+     */
+    useEntryKeys?: boolean;
+
+    /**
+     * If set to true will emit to build folder and memory in combination with webpack-dev-server.
+     * Default: false
+     */
+    writeToFileEmit?: boolean;
+}
+
+export function getCompilerHooks(compiler: Compiler): { afterEmit: SyncWaterfallHook; beforeEmit: SyncWaterfallHook };

--- a/types/webpack-manifest-plugin/webpack-manifest-plugin-tests.ts
+++ b/types/webpack-manifest-plugin/webpack-manifest-plugin-tests.ts
@@ -1,8 +1,8 @@
 import { Configuration } from 'webpack';
 import path = require('path');
-import WebpackManifestPlugin = require('webpack-manifest-plugin');
+import { WebpackManifestPlugin, Options } from 'webpack-manifest-plugin';
 
-const options: WebpackManifestPlugin.Options = {
+const options: Options = {
     fileName: 'manifest.json',
     basePath: '/src/',
     seed: {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/shellscape/webpack-manifest-plugin#options>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Rationale:

- Bring the type definition up to speed with the latest v3.0 release of webpack-manifest-plugin which adds compatibility with Webpack 5.
- Namely, make `WebpackManifestPlugin` a named rather than default export, and add an export of `getCompilerHooks`.