### PR TITLE
Update webpack-manifest-plugin for Webpack 5

### DIFF
--- a/types/webpack-manifest-plugin/index.d.ts
+++ b/types/webpack-manifest-plugin/index.d.ts
@@ -3,12 +3,12 @@
 // Definitions by: Andrew Makarov <https://github.com/r3nya>, Jeremy Monson <https://github.com/monsonjeremy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Plugin, compilation, Compiler } from 'webpack';
+import { WebpackPluginInstance, compilation, Compiler } from 'webpack';
 import { SyncWaterfallHook } from 'tapable';
 
-export class WebpackManifestPlugin extends Plugin {
-    constructor(options?: Options);
-}
+export const WebpackManifestPlugin: {
+    new (options?: Options): WebpackPluginInstance;
+};
 
 export interface FileDescriptor {
     /** Only available if isChunk is true. */

--- a/types/webpack-manifest-plugin/webpack-manifest-plugin-tests.ts
+++ b/types/webpack-manifest-plugin/webpack-manifest-plugin-tests.ts
@@ -3,32 +3,34 @@ import path = require('path');
 import { WebpackManifestPlugin, Options } from 'webpack-manifest-plugin';
 
 const options: Options = {
-    fileName: 'manifest.json',
     basePath: '/src/',
-    seed: {
-        name: 'Hello world',
-    },
-    publicPath: 'prod',
-    writeToFileEmit: false,
+    fileName: 'manifest.json',
     filter: file => file.isInitial,
+    generate: (seed, files, entries) =>
+        files.reduce((manifest, { name, path }) => (name ? { ...manifest, [name]: path } : manifest), seed),
     map: file => {
         if (file.name) {
             file.name = path.join(path.dirname(file.path), file.name);
         }
         return file;
     },
-    sort: (a, b) => a.path.localeCompare(b.path),
-    generate: (seed, files) =>
-        files.reduce((manifest, { name, path }) => (name ? { ...manifest, [name]: path } : manifest), seed),
+    publicPath: 'prod',
+    removeKeyHash: /[a-Z0-9]/g,
+    seed: {
+        name: 'Hello world',
+    },
     serialize: manifest => JSON.stringify(manifest, null, 2),
+    sort: (a, b) => a.path.localeCompare(b.path),
+    useEntryKeys: true,
+    writeToFileEmit: false,
 };
 
 const c: Configuration = {
     plugins: [
         new WebpackManifestPlugin(),
         new WebpackManifestPlugin({
-            fileName: 'my-manifest.json',
             basePath: '/app/',
+            fileName: 'my-manifest.json',
             seed: {
                 name: 'My Manifest',
             },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test webpack-manifest-plugin`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - <https://github.com/webpack/webpack/blob/e855a24ea04ea054b440e595112dfc38ebe162d8/types.d.ts#L1805-L1811>
  - <https://github.com/webpack/webpack/blob/e855a24ea04ea054b440e595112dfc38ebe162d8/types.d.ts#L9568-L9578>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

Description:
- Follow up to #50071
- Unfortunately, the old `Plugin` no longer works in Webpack 5:
> Type 'WebpackManifestPlugin' is not assignable to type 'WebpackPluginInstance | ((this: Compiler, compiler: Compiler) => void)'.
- This issue was also raised in #48806 for `terser-webpack-plugin`. The fix follows the approach taken in [copy-webpack-plugin](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/17c58280ed20c6b1949b62a32901dc1080ed85a2/types/copy-webpack-plugin/index.d.ts#L117). Tested with webpack v5.10.0
- Also adds the new options from v3.0 to the test file for coverage