### PR TITLE
big.js: Remove googol from definition owners

### DIFF
--- a/types/big.js/index.d.ts
+++ b/types/big.js/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for big.js 6.0
 // Project: https://github.com/MikeMcl/big.js/
 // Definitions by: Steve Ognibene <https://github.com/nycdotnet>
-//                 Miika Hänninen <https://github.com/googol>
 //                 Roman Nuritdinov (Ky6uk) <https://github.com/Ky6uk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 


### PR DESCRIPTION
Removing myself from the definition owners of this package, as I haven't worked with the library in a couple of years
