### PR TITLE
node: add setLocalWindowSize to node/http2

### DIFF
--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -281,6 +281,7 @@ declare module "http2" {
         ping(callback: (err: Error | null, duration: number, payload: Buffer) => void): boolean;
         ping(payload: NodeJS.ArrayBufferView, callback: (err: Error | null, duration: number, payload: Buffer) => void): boolean;
         ref(): void;
+        setLocalWindowSize(windowSize: number): void;
         setTimeout(msecs: number, callback?: () => void): void;
         settings(settings: Settings): void;
         unref(): void;

--- a/types/node/test/http2.ts
+++ b/types/node/test/http2.ts
@@ -102,6 +102,7 @@ import { URL } from 'url';
     (http2Session as ClientHttp2Session).request(headers, options);
 
     const stream: Http2Stream = {} as any;
+    http2Session.setLocalWindowSize(2 ** 20);
     http2Session.setTimeout(100, () => {});
     http2Session.close(() => {});
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://nodejs.org/dist/latest-v15.x/docs/api/http2.html#http2_http2session_setlocalwindowsize_windowsize>

A new API [`http2session.setLocalWindowSize(windowSize)`](https://nodejs.org/dist/latest-v15.x/docs/api/http2.html#http2_http2session_setlocalwindowsize_windowsize) was introduced in node `v15.3.0`.
