### PR TITLE
[undertaker] refactor out task callback definition

### DIFF
--- a/types/undertaker/index.d.ts
+++ b/types/undertaker/index.d.ts
@@ -22,8 +22,12 @@ declare namespace Undertaker {
         [arg: string]: string;
     }
 
+    interface TaskCallback {
+        (error?: Error | null): void;
+    }
+
     interface TaskFunctionBase {
-        (done: (error?: Error | null) => void): ReturnType<AsyncTask>;
+        (done: TaskCallback): ReturnType<AsyncTask>;
     }
 
     interface TaskFunction extends TaskFunctionBase, TaskFunctionParams {}

--- a/types/undertaker/undertaker-tests.ts
+++ b/types/undertaker/undertaker-tests.ts
@@ -67,6 +67,14 @@ taker.task("checkVersion", (cb: Parameters<Undertaker.TaskFunction>[0]) => {
     }
 });
 
+taker.task("mixed", async (cb: Undertaker.TaskCallback, args?: number) => {
+    if (!args) {
+        cb(new Error("Undefined args!"));
+        return;
+    }
+    return args + 2;
+});
+
 const registry = new Registry();
 const CommonRegistry = (options: { buildDir: string }): Registry => {
     return registry;

--- a/types/undertaker/undertaker-tests.ts
+++ b/types/undertaker/undertaker-tests.ts
@@ -67,12 +67,12 @@ taker.task("checkVersion", (cb: Parameters<Undertaker.TaskFunction>[0]) => {
     }
 });
 
-taker.task("mixed", async (cb: Undertaker.TaskCallback, args?: number) => {
+taker.task("mixed", (cb: Undertaker.TaskCallback, args?: number) => {
     if (!args) {
         cb(new Error("Undefined args!"));
         return;
     }
-    return args + 2;
+    return Promise.resolve(args + 2);
 });
 
 const registry = new Registry();


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/95a05b8a7e244cda68c35bc784f37242b5518310/types/undertaker/index.d.ts#L25-L27
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.

This makes it slightly more convenient to type annotate a callback parameter.