### PR TITLE
node/dns: add setLocalAddress and cancel to dns promises resolver

### DIFF
--- a/types/node/dns.d.ts
+++ b/types/node/dns.d.ts
@@ -277,8 +277,8 @@ declare module "dns" {
     const CANCELLED: string;
 
     class Resolver {
+        cancel(): void;
         getServers: typeof getServers;
-        setServers: typeof setServers;
         resolve: typeof resolve;
         resolve4: typeof resolve4;
         resolve6: typeof resolve6;
@@ -292,7 +292,8 @@ declare module "dns" {
         resolveSrv: typeof resolveSrv;
         resolveTxt: typeof resolveTxt;
         reverse: typeof reverse;
-        cancel(): void;
+        setLocalAddress(ipv4?: string, ipv6?: string): void;
+        setServers: typeof setServers;
     }
 
     namespace promises {
@@ -351,6 +352,7 @@ declare module "dns" {
         function setServers(servers: ReadonlyArray<string>): void;
 
         class Resolver {
+            cancel(): void;
             getServers: typeof getServers;
             resolve: typeof resolve;
             resolve4: typeof resolve4;
@@ -365,6 +367,7 @@ declare module "dns" {
             resolveSrv: typeof resolveSrv;
             resolveTxt: typeof resolveTxt;
             reverse: typeof reverse;
+            setLocalAddress(ipv4?: string, ipv6?: string): void;
             setServers: typeof setServers;
         }
     }

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -44,6 +44,7 @@
 //                 Anna Henningsen <https://github.com/addaleax>
 //                 Jason Kwok <https://github.com/JasonHK>
 //                 Victor Perin <https://github.com/victorperin>
+//                 Yongsheng Zhang <https://github.com/ZYSzys>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // NOTE: These definitions support NodeJS and TypeScript 3.7.

--- a/types/node/test/dns.ts
+++ b/types/node/test/dns.ts
@@ -1,4 +1,4 @@
-import { lookup, ADDRCONFIG, V4MAPPED, LookupAddress, lookupService, resolve, AnyRecord, MxRecord, resolve4, RecordWithTtl, resolve6, Resolver, ALL } from 'dns';
+import { lookup, ADDRCONFIG, V4MAPPED, LookupAddress, lookupService, resolve, AnyRecord, MxRecord, resolve4, RecordWithTtl, resolve6, Resolver, ALL, promises } from 'dns';
 
 lookup("nodejs.org", (err, address, family) => {
     const _err: NodeJS.ErrnoException | null = err;
@@ -100,9 +100,19 @@ resolve6("nodejs.org", { ttl: true }, (err, addresses) => {
 }
 {
     const resolver = new Resolver();
+    resolver.setLocalAddress("4.4.4.4", "8.8.8.8");
     resolver.setServers(["4.4.4.4"] as ReadonlyArray<string>);
     resolver.resolve("nodejs.org", (err, addresses) => {
         const _addresses: string[] = addresses;
     });
+    resolver.cancel();
+}
+
+{
+    const resolver = new promises.Resolver();
+    resolver.setLocalAddress("4.4.4.4", "8.8.8.8");
+    resolver.setServers(["4.4.4.4"] as ReadonlyArray<string>);
+    // $ExpectType Promise<string[]>
+    resolver.resolve("nodejs.org");
     resolver.cancel();
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://nodejs.org/dist/latest-v15.x/docs/api/dns.html>

`setLocalAddress` was introduced in `v15.1.0` and `cancel` was added intor `dns.promises` in `v15.3.0`.

Refs: https://nodejs.org/dist/latest-v15.x/docs/api/dns.html