### PR TITLE
Add definitions for cleasby-vigfusson-dictionary package

### DIFF
--- a/types/cleasby-vigfusson-dictionary/cleasby-vigfusson-dictionary-tests.ts
+++ b/types/cleasby-vigfusson-dictionary/cleasby-vigfusson-dictionary-tests.ts
@@ -1,0 +1,7 @@
+import { getDictionary, getNoMarkupDictionary } from 'cleasby-vigfusson-dictionary';
+
+// $ExpectType DictionaryEntry[]
+const result = getDictionary();
+
+// $ExpectType DictionaryEntry[]
+const result2 = getNoMarkupDictionary();

--- a/types/cleasby-vigfusson-dictionary/index.d.ts
+++ b/types/cleasby-vigfusson-dictionary/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for cleasby-vigfusson-dictionary 1.0
+// Project: https://github.com/stscoundrel/cleasby-vigfusson-dictionary
+// Definitions by: StScoundrel <https://github.com/stscoundrel>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface DictionaryEntry {
+    word: string;
+    definitions: string[];
+}
+
+export function getDictionary(): DictionaryEntry[];
+export function getNoMarkupDictionary(): DictionaryEntry[];

--- a/types/cleasby-vigfusson-dictionary/tsconfig.json
+++ b/types/cleasby-vigfusson-dictionary/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "cleasby-vigfusson-dictionary-tests.ts"
+    ]
+}

--- a/types/cleasby-vigfusson-dictionary/tslint.json
+++ b/types/cleasby-vigfusson-dictionary/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Adds types for cleasby-vigfusson-dictionary NPM package.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` [should contain `{ "extends": "dtslint/dt.json" }`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson), and no additional rules.
- [X] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

