### PR TITLE
fix method name updateLineItems() for shopify-buy >= v1

### DIFF
--- a/types/shopify-buy/index.d.ts
+++ b/types/shopify-buy/index.d.ts
@@ -95,7 +95,7 @@ declare namespace ShopifyBuy {
         /**
          * Update a line item quantity based on line item id
          */
-        updateLineItem(checkoutId: string | number, lineItems: AttributeInput[]): Promise<Cart>;
+        updateLineItems(checkoutId: string | number, lineItems: AttributeInput[]): Promise<Cart>;
     }
 
     export interface ShopResource {

--- a/types/shopify-buy/shopify-buy-tests.ts
+++ b/types/shopify-buy/shopify-buy-tests.ts
@@ -285,7 +285,7 @@ function updateVariantInCart(cartLineItem : ShopifyBuy.LineItem, quantity : numb
         id: cartLineItem.id,
         quantity
     };
-    client.checkout.updateLineItem(cartLineItem.id, [lineItemVariant]).then(function(updatedCart : ShopifyBuy.Cart) {
+    client.checkout.updateLineItems(cartLineItem.id, [lineItemVariant]).then(function(updatedCart : ShopifyBuy.Cart) {
         var $cartItem = $('.cart').find('.cart-item[data-variant-id="' + variantId + '"]');
         if (updatedCart.lineItems.length >= cartLength) {
             $cartItem.find('.cart-item__quantity').val(cartLineItem.quantity);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/47742, https://github.com/Shopify/js-buy-sdk#updating-line-items, https://github.com/Shopify/js-buy-sdk/blob/master/tutorials/MIGRATION_GUIDE.md#updating-line-items
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

I don't know all types are correct for latest version. So I didn't update version.