### PR TITLE
Added new type definitions for uncontrollable package

### DIFF
--- a/types/uncontrollable/index.d.ts
+++ b/types/uncontrollable/index.d.ts
@@ -1,0 +1,54 @@
+// Type definitions for uncontrollable 7.0
+// Project: https://github.com/jquense/uncontrollable
+// Definitions by: Alex Leon <https://github.com/alex-e-leon>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 4.1
+
+import * as React from 'react';
+
+export namespace Uncontrollable {
+    // Omit keys and values in TField, then converts a "prop" to "defaultProp"
+    type BuildDefaultType<T extends string> = `default${Capitalize<T>}`;
+
+    // Gets a union of the values in an object
+    type ValueOf<T> = T[keyof T];
+
+    // Here is where we build out the actual type pairs for controlled uncontrolled props
+    // For each controlled prop we create a {value, onChange} required pair and a {defaultValue, onChange} optional pair
+    type BuildSingleControlledProp<
+        TProps,
+        TControlled extends keyof TProps & string,
+        TControlledFunction extends keyof TProps
+    > =
+        | (Record<TControlled, TProps[TControlled]> & Record<TControlledFunction, TProps[TControlledFunction]>)
+        | (Partial<Record<BuildDefaultType<TControlled>, TProps[TControlled]>> &
+              Partial<Record<TControlledFunction, TProps[TControlledFunction]>>);
+
+    type BuildPropMap<TProps, TFields extends { [key: string]: keyof TProps }> = {
+        [P in keyof TFields]: BuildSingleControlledProp<
+            TProps,
+            P extends keyof TProps & string ? P : never,
+            TFields[P]
+        >;
+    };
+
+    // This builds a map of the controlled/uncontrolled type pairs and then unions them all together.
+    // Note that an intersection is actually the correct output here, but this seems impossible with typescript at this time
+    type BuildControlledProps<TProps, TFields extends { [key: string]: keyof TProps }> = BuildPropMap<
+        TProps,
+        TFields
+    >[keyof TFields];
+
+    // Gets all the props for the component that aren't being controlled/uncontrolled
+    type BaseProps<TProps, TFields extends { [key: string]: keyof TProps }> = Omit<
+        TProps,
+        keyof TFields | ValueOf<TFields>
+    >;
+}
+
+export function uncontrollable<TProps extends {}, TFields extends { [key: string]: keyof TProps }>(
+    Component: React.ComponentType<TProps>,
+    props: TFields,
+): React.ComponentType<
+    Uncontrollable.BaseProps<TProps, TFields> & Uncontrollable.BuildControlledProps<TProps, TFields>
+>;

--- a/types/uncontrollable/tsconfig.json
+++ b/types/uncontrollable/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "uncontrollable-tests.ts"
+    ]
+}

--- a/types/uncontrollable/tslint.json
+++ b/types/uncontrollable/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/uncontrollable/uncontrollable-tests.ts
+++ b/types/uncontrollable/uncontrollable-tests.ts
@@ -1,0 +1,29 @@
+/* tslint:disable:max-line-length */
+import * as React from 'react';
+import { uncontrollable } from 'uncontrollable';
+
+interface Props {
+    a: string;
+    b?: string;
+    value: string;
+    onChange: () => void;
+}
+const TestComponent = (props: Props) => null;
+
+// The following generated type is equivalent to the more concise
+// ComponentType<(Pick<Props, "a" | "b"> & ({value: string, onChange: () => void} | {defaultValue:? string, onChange?: () => void})
+
+// $ExpectType ComponentType<(Pick<Props, "a" | "b"> & Record<"value", string> & Record<"onChange", () => void>) | (Pick<Props, "a" | "b"> & Partial<Record<"defaultValue", string>> & Partial<Record<"onChange", () => void>>)>
+uncontrollable(TestComponent, { value: 'onChange' as 'onChange' });
+
+interface Props2 extends Props {
+    value2: string;
+    onChange2: () => void;
+}
+const TestComponent2 = (props: Props2) => null;
+
+// The following generated type is equivalent to the more concise
+// ComponentType<(Pick<Props, "a" | "b"> & ({value: string, onChange: () => void} | {defaultValue:? string, onChange?: () => void} | {value2: string, onChange2: () => void} | {defaultValue2:? string, onChange2?: () => void})
+
+// $ExpectType ComponentType<(Pick<Props2, "a" | "b"> & Record<"value", string> & Record<"onChange", () => void>) | (Pick<Props2, "a" | "b"> & Partial<Record<"defaultValue", string>> & Partial<Record<"onChange", () => void>>) | (Pick<Props2, "a" | "b"> & Record<"value2", string> & Record<"onChange2", () => void>) | (Pick<Props2, "a" | "b"> & Partial<Record<"defaultValue2", string>> & Partial<Record<"onChange2", () => void>>)>
+uncontrollable(TestComponent2, { value: 'onChange' as 'onChange', value2: 'onChange2' as 'onChange2' });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain `{ "extends": "dtslint/dt.json" }`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson), and no additional rules.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

I found this to be quite a tricky function to type, so could use some advice to clean it up or improve the types.

Note that this types just one of the 2 functions provided by uncontrollable - as useUncontrolled is already written in typescript and ships with it's own definitions