### PR TITLE
fix: gulp-connect tests use gulp.task callback correctly

### DIFF
--- a/types/gulp-connect/gulp-connect-tests.ts
+++ b/types/gulp-connect/gulp-connect-tests.ts
@@ -91,12 +91,12 @@ gulp.task('connect', () => {
 // Validate gulp-connect typings allow express apps to be passed in as middleware
 import express = require("express");
 
-gulp.task('connect', async () => {
+gulp.task('connect', () => {
     const middleware = [
         express()
     ];
 
-    return connect.server({
+    connect.server({
         root: [__dirname],
         port: 8081,
         livereload: true,
@@ -106,13 +106,13 @@ gulp.task('connect', async () => {
 });
 
 // Validate using paths to restrict handler functions works
-gulp.task('connect', async () => {
+gulp.task('connect', () => {
     const middleware: connect.ConnectRouteHandler[] = [
         ["/path", express()],
         ["/path2", express()],
     ];
 
-    return connect.server({
+    connect.server({
         root: [__dirname],
         port: 8081,
         livereload: true,

--- a/types/gulp-connect/gulp-connect-tests.ts
+++ b/types/gulp-connect/gulp-connect-tests.ts
@@ -91,7 +91,7 @@ gulp.task('connect', () => {
 // Validate gulp-connect typings allow express apps to be passed in as middleware
 import express = require("express");
 
-gulp.task('connect', () => {
+gulp.task('connect', async () => {
     const middleware = [
         express()
     ];
@@ -106,7 +106,7 @@ gulp.task('connect', () => {
 });
 
 // Validate using paths to restrict handler functions works
-gulp.task('connect', () => {
+gulp.task('connect', async () => {
     const middleware: connect.ConnectRouteHandler[] = [
         ["/path", express()],
         ["/path2", express()],


### PR DESCRIPTION
Previously, `gulp.task` allowed a callback to return anything. Now it's based on the `async-done`'s `AsyncTask`. I'm pretty sure the correct change is to stop returning the result of `connect.server`, based on reading `gulp-connect`'s examples.