### PR TITLE
[node] bigint options for fstat and lstat

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -563,6 +563,8 @@ declare module "fs" {
      * Asynchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
+    export function fstat(fd: number, options: BigIntOptions, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    export function fstat(fd: number, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     export function fstat(fd: number, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
@@ -571,6 +573,8 @@ declare module "fs" {
          * Asynchronous fstat(2) - Get file status.
          * @param fd A file descriptor.
          */
+        function __promisify__(fd: number, options: BigIntOptions): Promise<BigIntStats>;
+        function __promisify__(fd: number, options: StatOptions): Promise<Stats | BigIntStats>;
         function __promisify__(fd: number): Promise<Stats>;
     }
 
@@ -578,12 +582,16 @@ declare module "fs" {
      * Synchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
+    export function fstatSync(fd: number, options: BigIntOptions): BigIntStats;
+    export function fstatSync(fd: number, options: StatOptions): Stats | BigIntStats;
     export function fstatSync(fd: number): Stats;
 
     /**
      * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
+    export function lstat(path: PathLike, options: BigIntOptions, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    export function lstat(path: PathLike, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     export function lstat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
@@ -592,6 +600,8 @@ declare module "fs" {
          * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
+        function __promisify__(path: PathLike, options: BigIntOptions): Promise<BigIntStats>;
+        function __promisify__(path: PathLike, options: StatOptions): Promise<Stats | BigIntStats>;
         function __promisify__(path: PathLike): Promise<Stats>;
     }
 
@@ -599,6 +609,8 @@ declare module "fs" {
      * Synchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
+    export function lstatSync(path: PathLike, options: BigIntOptions): BigIntStats;
+    export function lstatSync(path: PathLike, options: StatOptions): Stats | BigIntStats;
     export function lstatSync(path: PathLike): Stats;
 
     /**

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -536,7 +536,8 @@ declare module "fs" {
      * Asynchronous stat(2) - Get file status.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function stat(path: PathLike, options: BigIntOptions, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    export function stat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    export function stat(path: PathLike, options: undefined | (StatOptions & { bigint?: false }), callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
     export function stat(path: PathLike, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     export function stat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
 
@@ -546,16 +547,17 @@ declare module "fs" {
          * Asynchronous stat(2) - Get file status.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function __promisify__(path: PathLike, options: BigIntOptions): Promise<BigIntStats>;
+        function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function __promisify__(path: PathLike, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function __promisify__(path: PathLike, options: StatOptions): Promise<Stats | BigIntStats>;
-        function __promisify__(path: PathLike): Promise<Stats>;
     }
 
     /**
      * Synchronous stat(2) - Get file status.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function statSync(path: PathLike, options: BigIntOptions): BigIntStats;
+    export function statSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
+    export function statSync(path: PathLike, options?: StatOptions & { bigint?: false }): Stats;
     export function statSync(path: PathLike, options: StatOptions): Stats | BigIntStats;
     export function statSync(path: PathLike): Stats;
 
@@ -563,7 +565,8 @@ declare module "fs" {
      * Asynchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
-    export function fstat(fd: number, options: BigIntOptions, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    export function fstat(fd: number, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    export function fstat(fd: number, options: undefined | (StatOptions & { bigint?: false }), callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
     export function fstat(fd: number, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     export function fstat(fd: number, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
 
@@ -573,16 +576,17 @@ declare module "fs" {
          * Asynchronous fstat(2) - Get file status.
          * @param fd A file descriptor.
          */
-        function __promisify__(fd: number, options: BigIntOptions): Promise<BigIntStats>;
+        function __promisify__(fd: number, options?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function __promisify__(fd: number, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function __promisify__(fd: number, options: StatOptions): Promise<Stats | BigIntStats>;
-        function __promisify__(fd: number): Promise<Stats>;
     }
 
     /**
      * Synchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
-    export function fstatSync(fd: number, options: BigIntOptions): BigIntStats;
+    export function fstatSync(fd: number, options: StatOptions & { bigint: true }): BigIntStats;
+    export function fstatSync(fd: number, options?: StatOptions & { bigint?: false }): Stats;
     export function fstatSync(fd: number, options: StatOptions): Stats | BigIntStats;
     export function fstatSync(fd: number): Stats;
 
@@ -590,7 +594,8 @@ declare module "fs" {
      * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function lstat(path: PathLike, options: BigIntOptions, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    export function lstat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    export function lstat(path: PathLike, options: undefined | (StatOptions & { bigint?: false }), callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
     export function lstat(path: PathLike, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     export function lstat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
 
@@ -600,16 +605,17 @@ declare module "fs" {
          * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function __promisify__(path: PathLike, options: BigIntOptions): Promise<BigIntStats>;
+        function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function __promisify__(path: PathLike, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function __promisify__(path: PathLike, options: StatOptions): Promise<Stats | BigIntStats>;
-        function __promisify__(path: PathLike): Promise<Stats>;
     }
 
     /**
      * Synchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function lstatSync(path: PathLike, options: BigIntOptions): BigIntStats;
+    export function lstatSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
+    export function lstatSync(path: PathLike, options?: StatOptions & { bigint?: false }): Stats;
     export function lstatSync(path: PathLike, options: StatOptions): Stats | BigIntStats;
     export function lstatSync(path: PathLike): Stats;
 
@@ -2246,6 +2252,6 @@ declare module "fs" {
     }
 
     export interface StatOptions {
-        bigint: boolean;
+        bigint?: boolean;
     }
 }

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -536,10 +536,10 @@ declare module "fs" {
      * Asynchronous stat(2) - Get file status.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function stat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
-    export function stat(path: PathLike, options: undefined | (StatOptions & { bigint?: false }), callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
-    export function stat(path: PathLike, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     export function stat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    export function stat(path: PathLike, options: StatOptions & { bigint?: false } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    export function stat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    export function stat(path: PathLike, options: StatOptions | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     export namespace stat {
@@ -549,26 +549,25 @@ declare module "fs" {
          */
         function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false }): Promise<Stats>;
         function __promisify__(path: PathLike, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
-        function __promisify__(path: PathLike, options: StatOptions): Promise<Stats | BigIntStats>;
+        function __promisify__(path: PathLike, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
 
     /**
      * Synchronous stat(2) - Get file status.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function statSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
     export function statSync(path: PathLike, options?: StatOptions & { bigint?: false }): Stats;
-    export function statSync(path: PathLike, options: StatOptions): Stats | BigIntStats;
-    export function statSync(path: PathLike): Stats;
+    export function statSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
+    export function statSync(path: PathLike, options?: StatOptions): Stats | BigIntStats;
 
     /**
      * Asynchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
-    export function fstat(fd: number, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
-    export function fstat(fd: number, options: undefined | (StatOptions & { bigint?: false }), callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
-    export function fstat(fd: number, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     export function fstat(fd: number, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    export function fstat(fd: number, options: StatOptions & { bigint?: false } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    export function fstat(fd: number, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    export function fstat(fd: number, options: StatOptions | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     export namespace fstat {
@@ -578,26 +577,25 @@ declare module "fs" {
          */
         function __promisify__(fd: number, options?: StatOptions & { bigint?: false }): Promise<Stats>;
         function __promisify__(fd: number, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
-        function __promisify__(fd: number, options: StatOptions): Promise<Stats | BigIntStats>;
+        function __promisify__(fd: number, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
 
     /**
      * Synchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
-    export function fstatSync(fd: number, options: StatOptions & { bigint: true }): BigIntStats;
     export function fstatSync(fd: number, options?: StatOptions & { bigint?: false }): Stats;
-    export function fstatSync(fd: number, options: StatOptions): Stats | BigIntStats;
-    export function fstatSync(fd: number): Stats;
+    export function fstatSync(fd: number, options: StatOptions & { bigint: true }): BigIntStats;
+    export function fstatSync(fd: number, options?: StatOptions): Stats | BigIntStats;
 
     /**
      * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function lstat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
-    export function lstat(path: PathLike, options: undefined | (StatOptions & { bigint?: false }), callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
-    export function lstat(path: PathLike, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     export function lstat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    export function lstat(path: PathLike, options: StatOptions & { bigint?: false } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    export function lstat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    export function lstat(path: PathLike, options: StatOptions | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     export namespace lstat {
@@ -607,17 +605,16 @@ declare module "fs" {
          */
         function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false }): Promise<Stats>;
         function __promisify__(path: PathLike, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
-        function __promisify__(path: PathLike, options: StatOptions): Promise<Stats | BigIntStats>;
+        function __promisify__(path: PathLike, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
 
     /**
      * Synchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function lstatSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
     export function lstatSync(path: PathLike, options?: StatOptions & { bigint?: false }): Stats;
-    export function lstatSync(path: PathLike, options: StatOptions): Stats | BigIntStats;
-    export function lstatSync(path: PathLike): Stats;
+    export function lstatSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
+    export function lstatSync(path: PathLike, options?: StatOptions): Stats | BigIntStats;
 
     /**
      * Asynchronous link(2) - Create a new link (also known as a hard link) to an existing file.

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -1,6 +1,8 @@
 declare module 'fs/promises' {
     import {
         Stats,
+        BigIntStats,
+        StatOptions,
         WriteVResult,
         ReadVResult,
         PathLike,
@@ -92,7 +94,9 @@ declare module 'fs/promises' {
         /**
          * Asynchronous fstat(2) - Get file status.
          */
-        stat(): Promise<Stats>;
+        stat(opts?: StatOptions & { bigint?: false }): Promise<Stats>;
+        stat(opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
+        stat(opts: StatOptions): Promise<Stats | BigIntStats>;
 
         /**
          * Asynchronous ftruncate(2) - Truncate a file to a specified length.
@@ -358,22 +362,20 @@ declare module 'fs/promises' {
     function symlink(target: PathLike, path: PathLike, type?: string | null): Promise<void>;
 
     /**
-     * Asynchronous fstat(2) - Get file status.
-     * @param handle A `FileHandle`.
-     */
-    function fstat(handle: FileHandle): Promise<Stats>;
-
-    /**
      * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function lstat(path: PathLike): Promise<Stats>;
+    function lstat(path: PathLike, opts?: StatOptions & { bigint?: false }): Promise<Stats>;
+    function lstat(path: PathLike, opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
+    function lstat(path: PathLike, opts: StatOptions): Promise<Stats | BigIntStats>;
 
     /**
      * Asynchronous stat(2) - Get file status.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function stat(path: PathLike): Promise<Stats>;
+    function stat(path: PathLike, opts?: StatOptions & { bigint?: false }): Promise<Stats>;
+    function stat(path: PathLike, opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
+    function stat(path: PathLike, opts: StatOptions): Promise<Stats | BigIntStats>;
 
     /**
      * Asynchronous link(2) - Create a new link (also known as a hard link) to an existing file.

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -96,7 +96,7 @@ declare module 'fs/promises' {
          */
         stat(opts?: StatOptions & { bigint?: false }): Promise<Stats>;
         stat(opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
-        stat(opts: StatOptions): Promise<Stats | BigIntStats>;
+        stat(opts?: StatOptions): Promise<Stats | BigIntStats>;
 
         /**
          * Asynchronous ftruncate(2) - Truncate a file to a specified length.
@@ -367,7 +367,7 @@ declare module 'fs/promises' {
      */
     function lstat(path: PathLike, opts?: StatOptions & { bigint?: false }): Promise<Stats>;
     function lstat(path: PathLike, opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
-    function lstat(path: PathLike, opts: StatOptions): Promise<Stats | BigIntStats>;
+    function lstat(path: PathLike, opts?: StatOptions): Promise<Stats | BigIntStats>;
 
     /**
      * Asynchronous stat(2) - Get file status.
@@ -375,7 +375,7 @@ declare module 'fs/promises' {
      */
     function stat(path: PathLike, opts?: StatOptions & { bigint?: false }): Promise<Stats>;
     function stat(path: PathLike, opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
-    function stat(path: PathLike, opts: StatOptions): Promise<Stats | BigIntStats>;
+    function stat(path: PathLike, opts?: StatOptions): Promise<Stats | BigIntStats>;
 
     /**
      * Asynchronous link(2) - Create a new link (also known as a hard link) to an existing file.

--- a/types/node/v12/fs.d.ts
+++ b/types/node/v12/fs.d.ts
@@ -482,6 +482,8 @@ declare module "fs" {
      * Asynchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
+    function fstat(fd: number, options: BigIntOptions, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function fstat(fd: number, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     function fstat(fd: number, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
@@ -490,6 +492,8 @@ declare module "fs" {
          * Asynchronous fstat(2) - Get file status.
          * @param fd A file descriptor.
          */
+        function __promisify__(fd: number, options: BigIntOptions): Promise<BigIntStats>;
+        function __promisify__(fd: number, options: StatOptions): Promise<Stats | BigIntStats>;
         function __promisify__(fd: number): Promise<Stats>;
     }
 
@@ -497,12 +501,16 @@ declare module "fs" {
      * Synchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
+    function fstatSync(fd: number, options: BigIntOptions): BigIntStats;
+    function fstatSync(fd: number, options: StatOptions): Stats | BigIntStats;
     function fstatSync(fd: number): Stats;
 
     /**
      * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
+    function lstat(path: PathLike, options: BigIntOptions, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function lstat(path: PathLike, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     function lstat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
@@ -511,6 +519,8 @@ declare module "fs" {
          * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
+        function __promisify__(path: PathLike, options: BigIntOptions): Promise<BigIntStats>;
+        function __promisify__(path: PathLike, options: StatOptions): Promise<Stats | BigIntStats>;
         function __promisify__(path: PathLike): Promise<Stats>;
     }
 
@@ -518,6 +528,8 @@ declare module "fs" {
      * Synchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
+    function lstatSync(path: PathLike, options: BigIntOptions): BigIntStats;
+    function lstatSync(path: PathLike, options: StatOptions): Stats | BigIntStats;
     function lstatSync(path: PathLike): Stats;
 
     /**

--- a/types/node/v12/fs.d.ts
+++ b/types/node/v12/fs.d.ts
@@ -455,10 +455,10 @@ declare module "fs" {
      * Asynchronous stat(2) - Get file status.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function stat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
-    function stat(path: PathLike, options: undefined | (StatOptions & { bigint?: false }), callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
-    function stat(path: PathLike, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     function stat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    function stat(path: PathLike, options: StatOptions & { bigint?: false } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    function stat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function stat(path: PathLike, options: StatOptions | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     namespace stat {
@@ -468,26 +468,24 @@ declare module "fs" {
          */
         function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false }): Promise<Stats>;
         function __promisify__(path: PathLike, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
-        function __promisify__(path: PathLike, options: StatOptions): Promise<Stats | BigIntStats>;
+        function __promisify__(path: PathLike, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
 
     /**
      * Synchronous stat(2) - Get file status.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function statSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
     function statSync(path: PathLike, options?: StatOptions & { bigint?: false }): Stats;
-    function statSync(path: PathLike, options: StatOptions): Stats | BigIntStats;
-    function statSync(path: PathLike): Stats;
+    function statSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
+    function statSync(path: PathLike, options?: StatOptions): Stats | BigIntStats;
 
     /**
      * Asynchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
-    function fstat(fd: number, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
-    function fstat(fd: number, options: undefined | (StatOptions & { bigint?: false }), callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
-    function fstat(fd: number, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
-    function fstat(fd: number, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    stat(opts?: StatOptions & { bigint?: false }): Promise<Stats>;
+    stat(opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
+    stat(opts?: StatOptions): Promise<Stats | BigIntStats>;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     namespace fstat {
@@ -497,46 +495,44 @@ declare module "fs" {
          */
         function __promisify__(fd: number, options?: StatOptions & { bigint?: false }): Promise<Stats>;
         function __promisify__(fd: number, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
-        function __promisify__(fd: number, options: StatOptions): Promise<Stats | BigIntStats>;
+        function __promisify__(fd: number, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
 
     /**
      * Synchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
-    function fstatSync(fd: number, options: StatOptions & { bigint: true }): BigIntStats;
     function fstatSync(fd: number, options?: StatOptions & { bigint?: false }): Stats;
-    function fstatSync(fd: number, options: StatOptions): Stats | BigIntStats;
-    function fstatSync(fd: number): Stats;
+    function fstatSync(fd: number, options: StatOptions & { bigint: true }): BigIntStats;
+    function fstatSync(fd: number, options?: StatOptions): Stats | BigIntStats;
 
     /**
      * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function lstat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
-    function lstat(path: PathLike, options: undefined | (StatOptions & { bigint?: false }), callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
-    function lstat(path: PathLike, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     function lstat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    function lstat(path: PathLike, options: StatOptions & { bigint?: false } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    function lstat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function lstat(path: PathLike, options: StatOptions | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     namespace lstat {
         /**
-         * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
+        * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
         function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false }): Promise<Stats>;
         function __promisify__(path: PathLike, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
-        function __promisify__(path: PathLike, options: StatOptions): Promise<Stats | BigIntStats>;
+        function __promisify__(path: PathLike, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
 
     /**
      * Synchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function lstatSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
     function lstatSync(path: PathLike, options?: StatOptions & { bigint?: false }): Stats;
-    function lstatSync(path: PathLike, options: StatOptions): Stats | BigIntStats;
-    function lstatSync(path: PathLike): Stats;
+    function lstatSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
+    function lstatSync(path: PathLike, options?: StatOptions): Stats | BigIntStats;
 
     /**
      * Asynchronous link(2) - Create a new link (also known as a hard link) to an existing file.
@@ -2325,7 +2321,7 @@ declare module "fs" {
          */
         function lstat(path: PathLike, opts?: StatOptions & { bigint?: false }): Promise<Stats>;
         function lstat(path: PathLike, opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
-        function lstat(path: PathLike, opts: StatOptions): Promise<Stats | BigIntStats>;
+        function lstat(path: PathLike, opts?: StatOptions): Promise<Stats | BigIntStats>;
 
         /**
          * Asynchronous stat(2) - Get file status.
@@ -2333,7 +2329,7 @@ declare module "fs" {
          */
         function stat(path: PathLike, opts?: StatOptions & { bigint?: false }): Promise<Stats>;
         function stat(path: PathLike, opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
-        function stat(path: PathLike, opts: StatOptions): Promise<Stats | BigIntStats>;
+        function stat(path: PathLike, opts?: StatOptions): Promise<Stats | BigIntStats>;
 
         /**
          * Asynchronous link(2) - Create a new link (also known as a hard link) to an existing file.

--- a/types/node/v12/fs.d.ts
+++ b/types/node/v12/fs.d.ts
@@ -455,7 +455,8 @@ declare module "fs" {
      * Asynchronous stat(2) - Get file status.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function stat(path: PathLike, options: BigIntOptions, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function stat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function stat(path: PathLike, options: undefined | (StatOptions & { bigint?: false }), callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
     function stat(path: PathLike, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     function stat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
 
@@ -465,16 +466,17 @@ declare module "fs" {
          * Asynchronous stat(2) - Get file status.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function __promisify__(path: PathLike, options: BigIntOptions): Promise<BigIntStats>;
+        function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function __promisify__(path: PathLike, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function __promisify__(path: PathLike, options: StatOptions): Promise<Stats | BigIntStats>;
-        function __promisify__(path: PathLike): Promise<Stats>;
     }
 
     /**
      * Synchronous stat(2) - Get file status.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function statSync(path: PathLike, options: BigIntOptions): BigIntStats;
+    function statSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
+    function statSync(path: PathLike, options?: StatOptions & { bigint?: false }): Stats;
     function statSync(path: PathLike, options: StatOptions): Stats | BigIntStats;
     function statSync(path: PathLike): Stats;
 
@@ -482,7 +484,8 @@ declare module "fs" {
      * Asynchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
-    function fstat(fd: number, options: BigIntOptions, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function fstat(fd: number, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function fstat(fd: number, options: undefined | (StatOptions & { bigint?: false }), callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
     function fstat(fd: number, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     function fstat(fd: number, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
 
@@ -492,16 +495,17 @@ declare module "fs" {
          * Asynchronous fstat(2) - Get file status.
          * @param fd A file descriptor.
          */
-        function __promisify__(fd: number, options: BigIntOptions): Promise<BigIntStats>;
+        function __promisify__(fd: number, options?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function __promisify__(fd: number, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function __promisify__(fd: number, options: StatOptions): Promise<Stats | BigIntStats>;
-        function __promisify__(fd: number): Promise<Stats>;
     }
 
     /**
      * Synchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
-    function fstatSync(fd: number, options: BigIntOptions): BigIntStats;
+    function fstatSync(fd: number, options: StatOptions & { bigint: true }): BigIntStats;
+    function fstatSync(fd: number, options?: StatOptions & { bigint?: false }): Stats;
     function fstatSync(fd: number, options: StatOptions): Stats | BigIntStats;
     function fstatSync(fd: number): Stats;
 
@@ -509,7 +513,8 @@ declare module "fs" {
      * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function lstat(path: PathLike, options: BigIntOptions, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function lstat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function lstat(path: PathLike, options: undefined | (StatOptions & { bigint?: false }), callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
     function lstat(path: PathLike, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     function lstat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
 
@@ -519,16 +524,17 @@ declare module "fs" {
          * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function __promisify__(path: PathLike, options: BigIntOptions): Promise<BigIntStats>;
+        function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function __promisify__(path: PathLike, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function __promisify__(path: PathLike, options: StatOptions): Promise<Stats | BigIntStats>;
-        function __promisify__(path: PathLike): Promise<Stats>;
     }
 
     /**
      * Synchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function lstatSync(path: PathLike, options: BigIntOptions): BigIntStats;
+    function lstatSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
+    function lstatSync(path: PathLike, options?: StatOptions & { bigint?: false }): Stats;
     function lstatSync(path: PathLike, options: StatOptions): Stats | BigIntStats;
     function lstatSync(path: PathLike): Stats;
 
@@ -2072,7 +2078,9 @@ declare module "fs" {
             /**
              * Asynchronous fstat(2) - Get file status.
              */
-            stat(): Promise<Stats>;
+            stat(opts?: StatOptions & { bigint?: false }): Promise<Stats>;
+            stat(opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
+            stat(opts: StatOptions): Promise<Stats | BigIntStats>;
 
             /**
              * Asynchronous ftruncate(2) - Truncate a file to a specified length.
@@ -2312,22 +2320,20 @@ declare module "fs" {
         function symlink(target: PathLike, path: PathLike, type?: string | null): Promise<void>;
 
         /**
-         * Asynchronous fstat(2) - Get file status.
-         * @param handle A `FileHandle`.
-         */
-        function fstat(handle: FileHandle): Promise<Stats>;
-
-        /**
          * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function lstat(path: PathLike): Promise<Stats>;
+        function lstat(path: PathLike, opts?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function lstat(path: PathLike, opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
+        function lstat(path: PathLike, opts: StatOptions): Promise<Stats | BigIntStats>;
 
         /**
          * Asynchronous stat(2) - Get file status.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function stat(path: PathLike): Promise<Stats>;
+        function stat(path: PathLike, opts?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function stat(path: PathLike, opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
+        function stat(path: PathLike, opts: StatOptions): Promise<Stats | BigIntStats>;
 
         /**
          * Asynchronous link(2) - Create a new link (also known as a hard link) to an existing file.

--- a/types/node/v12/fs.d.ts
+++ b/types/node/v12/fs.d.ts
@@ -479,14 +479,6 @@ declare module "fs" {
     function statSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
     function statSync(path: PathLike, options?: StatOptions): Stats | BigIntStats;
 
-    /**
-     * Asynchronous fstat(2) - Get file status.
-     * @param fd A file descriptor.
-     */
-    stat(opts?: StatOptions & { bigint?: false }): Promise<Stats>;
-    stat(opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
-    stat(opts?: StatOptions): Promise<Stats | BigIntStats>;
-
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     namespace fstat {
         /**
@@ -518,7 +510,7 @@ declare module "fs" {
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     namespace lstat {
         /**
-        * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
+         * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
         function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false }): Promise<Stats>;

--- a/types/node/v13/fs.d.ts
+++ b/types/node/v13/fs.d.ts
@@ -491,7 +491,8 @@ declare module "fs" {
      * Asynchronous stat(2) - Get file status.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function stat(path: PathLike, options: BigIntOptions, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function stat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function stat(path: PathLike, options: undefined | (StatOptions & { bigint?: false }), callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
     function stat(path: PathLike, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     function stat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
 
@@ -501,16 +502,17 @@ declare module "fs" {
          * Asynchronous stat(2) - Get file status.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function __promisify__(path: PathLike, options: BigIntOptions): Promise<BigIntStats>;
+        function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function __promisify__(path: PathLike, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function __promisify__(path: PathLike, options: StatOptions): Promise<Stats | BigIntStats>;
-        function __promisify__(path: PathLike): Promise<Stats>;
     }
 
     /**
      * Synchronous stat(2) - Get file status.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function statSync(path: PathLike, options: BigIntOptions): BigIntStats;
+    function statSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
+    function statSync(path: PathLike, options?: StatOptions & { bigint?: false }): Stats;
     function statSync(path: PathLike, options: StatOptions): Stats | BigIntStats;
     function statSync(path: PathLike): Stats;
 
@@ -518,7 +520,8 @@ declare module "fs" {
      * Asynchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
-    function fstat(fd: number, options: BigIntOptions, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function fstat(fd: number, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function fstat(fd: number, options: undefined | (StatOptions & { bigint?: false }), callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
     function fstat(fd: number, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     function fstat(fd: number, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
 
@@ -528,16 +531,17 @@ declare module "fs" {
          * Asynchronous fstat(2) - Get file status.
          * @param fd A file descriptor.
          */
-        function __promisify__(fd: number, options: BigIntOptions): Promise<BigIntStats>;
+        function __promisify__(fd: number, options?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function __promisify__(fd: number, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function __promisify__(fd: number, options: StatOptions): Promise<Stats | BigIntStats>;
-        function __promisify__(fd: number): Promise<Stats>;
     }
 
     /**
      * Synchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
-    function fstatSync(fd: number, options: BigIntOptions): BigIntStats;
+    function fstatSync(fd: number, options: StatOptions & { bigint: true }): BigIntStats;
+    function fstatSync(fd: number, options?: StatOptions & { bigint?: false }): Stats;
     function fstatSync(fd: number, options: StatOptions): Stats | BigIntStats;
     function fstatSync(fd: number): Stats;
 
@@ -545,7 +549,8 @@ declare module "fs" {
      * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function lstat(path: PathLike, options: BigIntOptions, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function lstat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function lstat(path: PathLike, options: undefined | (StatOptions & { bigint?: false }), callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
     function lstat(path: PathLike, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     function lstat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
 
@@ -555,16 +560,17 @@ declare module "fs" {
          * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function __promisify__(path: PathLike, options: BigIntOptions): Promise<BigIntStats>;
+        function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function __promisify__(path: PathLike, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
         function __promisify__(path: PathLike, options: StatOptions): Promise<Stats | BigIntStats>;
-        function __promisify__(path: PathLike): Promise<Stats>;
     }
 
     /**
      * Synchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function lstatSync(path: PathLike, options: BigIntOptions): BigIntStats;
+    function lstatSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
+    function lstatSync(path: PathLike, options?: StatOptions & { bigint?: false }): Stats;
     function lstatSync(path: PathLike, options: StatOptions): Stats | BigIntStats;
     function lstatSync(path: PathLike): Stats;
 
@@ -2210,7 +2216,9 @@ declare module "fs" {
             /**
              * Asynchronous fstat(2) - Get file status.
              */
-            stat(): Promise<Stats>;
+            stat(opts?: StatOptions & { bigint?: false }): Promise<Stats>;
+            stat(opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
+            stat(opts: StatOptions): Promise<Stats | BigIntStats>;
 
             /**
              * Asynchronous ftruncate(2) - Truncate a file to a specified length.
@@ -2471,22 +2479,20 @@ declare module "fs" {
         function symlink(target: PathLike, path: PathLike, type?: string | null): Promise<void>;
 
         /**
-         * Asynchronous fstat(2) - Get file status.
-         * @param handle A `FileHandle`.
-         */
-        function fstat(handle: FileHandle): Promise<Stats>;
-
-        /**
          * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function lstat(path: PathLike): Promise<Stats>;
+        function lstat(path: PathLike, opts?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function lstat(path: PathLike, opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
+        function lstat(path: PathLike, opts: StatOptions): Promise<Stats | BigIntStats>;
 
         /**
          * Asynchronous stat(2) - Get file status.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        function stat(path: PathLike): Promise<Stats>;
+        function stat(path: PathLike, opts?: StatOptions & { bigint?: false }): Promise<Stats>;
+        function stat(path: PathLike, opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
+        function stat(path: PathLike, opts: StatOptions): Promise<Stats | BigIntStats>;
 
         /**
          * Asynchronous link(2) - Create a new link (also known as a hard link) to an existing file.

--- a/types/node/v13/fs.d.ts
+++ b/types/node/v13/fs.d.ts
@@ -491,10 +491,10 @@ declare module "fs" {
      * Asynchronous stat(2) - Get file status.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function stat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
-    function stat(path: PathLike, options: undefined | (StatOptions & { bigint?: false }), callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
-    function stat(path: PathLike, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     function stat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    function stat(path: PathLike, options: StatOptions & { bigint?: false } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    function stat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function stat(path: PathLike, options: StatOptions | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     namespace stat {
@@ -504,26 +504,25 @@ declare module "fs" {
          */
         function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false }): Promise<Stats>;
         function __promisify__(path: PathLike, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
-        function __promisify__(path: PathLike, options: StatOptions): Promise<Stats | BigIntStats>;
+        function __promisify__(path: PathLike, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
 
     /**
      * Synchronous stat(2) - Get file status.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function statSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
     function statSync(path: PathLike, options?: StatOptions & { bigint?: false }): Stats;
-    function statSync(path: PathLike, options: StatOptions): Stats | BigIntStats;
-    function statSync(path: PathLike): Stats;
+    function statSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
+    function statSync(path: PathLike, options?: StatOptions): Stats | BigIntStats;
 
     /**
      * Asynchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
-    function fstat(fd: number, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
-    function fstat(fd: number, options: undefined | (StatOptions & { bigint?: false }), callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
-    function fstat(fd: number, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     function fstat(fd: number, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    function fstat(fd: number, options: StatOptions & { bigint?: false } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    function fstat(fd: number, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function fstat(fd: number, options: StatOptions | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     namespace fstat {
@@ -533,26 +532,25 @@ declare module "fs" {
          */
         function __promisify__(fd: number, options?: StatOptions & { bigint?: false }): Promise<Stats>;
         function __promisify__(fd: number, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
-        function __promisify__(fd: number, options: StatOptions): Promise<Stats | BigIntStats>;
+        function __promisify__(fd: number, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
 
     /**
      * Synchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
-    function fstatSync(fd: number, options: StatOptions & { bigint: true }): BigIntStats;
     function fstatSync(fd: number, options?: StatOptions & { bigint?: false }): Stats;
-    function fstatSync(fd: number, options: StatOptions): Stats | BigIntStats;
-    function fstatSync(fd: number): Stats;
+    function fstatSync(fd: number, options: StatOptions & { bigint: true }): BigIntStats;
+    function fstatSync(fd: number, options?: StatOptions): Stats | BigIntStats;
 
     /**
      * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function lstat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
-    function lstat(path: PathLike, options: undefined | (StatOptions & { bigint?: false }), callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
-    function lstat(path: PathLike, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     function lstat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    function lstat(path: PathLike, options: StatOptions & { bigint?: false } | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    function lstat(path: PathLike, options: StatOptions & { bigint: true }, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function lstat(path: PathLike, options: StatOptions | undefined, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     namespace lstat {
@@ -562,17 +560,16 @@ declare module "fs" {
          */
         function __promisify__(path: PathLike, options?: StatOptions & { bigint?: false }): Promise<Stats>;
         function __promisify__(path: PathLike, options: StatOptions & { bigint: true }): Promise<BigIntStats>;
-        function __promisify__(path: PathLike, options: StatOptions): Promise<Stats | BigIntStats>;
+        function __promisify__(path: PathLike, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
 
     /**
      * Synchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function lstatSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
     function lstatSync(path: PathLike, options?: StatOptions & { bigint?: false }): Stats;
-    function lstatSync(path: PathLike, options: StatOptions): Stats | BigIntStats;
-    function lstatSync(path: PathLike): Stats;
+    function lstatSync(path: PathLike, options: StatOptions & { bigint: true }): BigIntStats;
+    function lstatSync(path: PathLike, options?: StatOptions): Stats | BigIntStats;
 
     /**
      * Asynchronous link(2) - Create a new link (also known as a hard link) to an existing file.
@@ -2218,7 +2215,7 @@ declare module "fs" {
              */
             stat(opts?: StatOptions & { bigint?: false }): Promise<Stats>;
             stat(opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
-            stat(opts: StatOptions): Promise<Stats | BigIntStats>;
+            stat(opts?: StatOptions): Promise<Stats | BigIntStats>;
 
             /**
              * Asynchronous ftruncate(2) - Truncate a file to a specified length.
@@ -2484,7 +2481,7 @@ declare module "fs" {
          */
         function lstat(path: PathLike, opts?: StatOptions & { bigint?: false }): Promise<Stats>;
         function lstat(path: PathLike, opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
-        function lstat(path: PathLike, opts: StatOptions): Promise<Stats | BigIntStats>;
+        function lstat(path: PathLike, opts?: StatOptions): Promise<Stats | BigIntStats>;
 
         /**
          * Asynchronous stat(2) - Get file status.
@@ -2492,7 +2489,7 @@ declare module "fs" {
          */
         function stat(path: PathLike, opts?: StatOptions & { bigint?: false }): Promise<Stats>;
         function stat(path: PathLike, opts: StatOptions & { bigint: true }): Promise<BigIntStats>;
-        function stat(path: PathLike, opts: StatOptions): Promise<Stats | BigIntStats>;
+        function stat(path: PathLike, opts?: StatOptions): Promise<Stats | BigIntStats>;
 
         /**
          * Asynchronous link(2) - Create a new link (also known as a hard link) to an existing file.

--- a/types/node/v13/fs.d.ts
+++ b/types/node/v13/fs.d.ts
@@ -518,6 +518,8 @@ declare module "fs" {
      * Asynchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
+    function fstat(fd: number, options: BigIntOptions, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function fstat(fd: number, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     function fstat(fd: number, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
@@ -526,6 +528,8 @@ declare module "fs" {
          * Asynchronous fstat(2) - Get file status.
          * @param fd A file descriptor.
          */
+        function __promisify__(fd: number, options: BigIntOptions): Promise<BigIntStats>;
+        function __promisify__(fd: number, options: StatOptions): Promise<Stats | BigIntStats>;
         function __promisify__(fd: number): Promise<Stats>;
     }
 
@@ -533,12 +537,16 @@ declare module "fs" {
      * Synchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
+    function fstatSync(fd: number, options: BigIntOptions): BigIntStats;
+    function fstatSync(fd: number, options: StatOptions): Stats | BigIntStats;
     function fstatSync(fd: number): Stats;
 
     /**
      * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
+    function lstat(path: PathLike, options: BigIntOptions, callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void): void;
+    function lstat(path: PathLike, options: StatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void): void;
     function lstat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
@@ -547,6 +555,8 @@ declare module "fs" {
          * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
+        function __promisify__(path: PathLike, options: BigIntOptions): Promise<BigIntStats>;
+        function __promisify__(path: PathLike, options: StatOptions): Promise<Stats | BigIntStats>;
         function __promisify__(path: PathLike): Promise<Stats>;
     }
 
@@ -554,6 +564,8 @@ declare module "fs" {
      * Synchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
+    function lstatSync(path: PathLike, options: BigIntOptions): BigIntStats;
+    function lstatSync(path: PathLike, options: StatOptions): Stats | BigIntStats;
     function lstatSync(path: PathLike): Stats;
 
     /**


### PR DESCRIPTION
According to the [Node Filesystem API](https://nodejs.org/docs/latest-v14.x/api/fs.html), these methods all support an `opts` parameter that allows it to return `bigint` stats:

* `stat`
* `lstat`
* `fstat`

They support the `bigint` option in the following modes:

* Callback
* Synchronous
* `util.promisify`
* `fs.promises`

Each call signature can handle these arguments:

* No extra argument yields `Stats`
* Passing undefined yields `Stats`
* Passing an empty object yields `Stats`
* Passing `{ bigint: false }` yields `Stats`
* Passing `{ bigint: true }` yields `BigIntStats`

The work was already done for `stat` and `statSync`, so this PR just extends that to `lstat` and `fstat` async and sync variants and makes the call signatures a bit more liberal.

I switched the call signatures from using the `BigIntOptions` type to using types like `StatOptions & { bigint: true }` where needed. This is the approach already taken by `mkdir` to handle the `recursive` option, for example. Also, it's acceptable to pass in an empty options object, so I made `StatOptions.bigint` optional.

`fs.promises.fstat` doesn't appear to have ever existed. (I looked at all the Node JS API documents going back to version 10.) This PR removes it. This functionality is implemented by `FileHandle.stat`.

These definitions go back to Node 10, but the `v10` and `v11` variants didn't have the other definitions for bigint stats, so I didn't touch those.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v14.x/api/fs.html#fs_fs_fstatsync_fd_options