### PR TITLE
[Node FS] Update fs types to include lstat options

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -579,12 +579,17 @@ declare module "fs" {
      * @param fd A file descriptor.
      */
     export function fstatSync(fd: number): Stats;
+        
+    export type lstatOptions = {
+        bigint?: boolean;
+    };
 
     /**
      * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
     export function lstat(path: PathLike, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+    export function lstat(path: PathLike, options: lstatOptions, callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     export namespace lstat {
@@ -599,7 +604,9 @@ declare module "fs" {
      * Synchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function lstatSync(path: PathLike): Stats;
+    export function lstatSync(path: PathLike, options?: lstatOptions & {
+      throwIfNoEntry?: boolean
+    }): Stats;
 
     /**
      * Asynchronous link(2) - Create a new link (also known as a hard link) to an existing file.


### PR DESCRIPTION
Both lstat and lstat sync include options which you can pass (https://nodejs.org/api/fs.html#fs_fs_lstatsync_path_options); this is my first time committing a type PR for node-functions, if there is a better way to do this please let me know!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [Not sure how to do this, any guidance is appreciated] Test the change in your own code. (Compile and run.)
- [Is this relevant for node-defined packages?] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/fs.html#fs_fs_lstatsync_path_options
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.