### PR TITLE
[codecs] fixing lookup to match the actually exported codecs

### DIFF
--- a/types/codecs/codecs-tests.ts
+++ b/types/codecs/codecs-tests.ts
@@ -86,10 +86,7 @@ import codecs = require('codecs');
 }
 {
   const codec = 'ucs-2';
-  codecs[codec].name; // $ExpectType "ucs2"
   codecs(codec).name; // $ExpectType "ucs2"
-  codecs[codec].encode('hello'); // $ExpectType Buffer
-  codecs[codec].decode(new Uint8Array()); // $ExpectType string
   const set: [Codec<'ucs-2'>, InType<'ucs-2'>, OutType<'ucs-2'>, CodecName<'ucs-2'>] = [] as any;
   set; // $ExpectType [Ucs2Codec, string, string, "ucs2"]
 }
@@ -104,10 +101,7 @@ import codecs = require('codecs');
 }
 {
   const codec = 'utf-8';
-  codecs[codec].name; // $ExpectType "utf-8"
   codecs(codec).name; // $ExpectType "utf-8"
-  codecs[codec].encode('hello'); // $ExpectType Buffer
-  codecs[codec].decode(new Uint8Array()); // $ExpectType string
   const set: [Codec<'utf-8'>, InType<'utf-8'>, OutType<'utf-8'>, CodecName<'utf-8'>] = [] as any;
   set; // $ExpectType [Utf8Codec, string, string, "utf-8"]
 }
@@ -122,10 +116,7 @@ import codecs = require('codecs');
 }
 {
   const codec = 'utf16-le';
-  codecs[codec].name; // $ExpectType "utf16le"
   codecs(codec).name; // $ExpectType "utf16le"
-  codecs[codec].encode('hello'); // $ExpectType Buffer
-  codecs[codec].decode(new Uint8Array()); // $ExpectType string
   const set: [Codec<'utf16-le'>, InType<'utf16-le'>, OutType<'utf16-le'>, CodecName<'utf16-le'>] = [] as any;
   set; // $ExpectType [Utf16leCodec, string, string, "utf16le"]
 }

--- a/types/codecs/index.d.ts
+++ b/types/codecs/index.d.ts
@@ -17,17 +17,32 @@ declare namespace codecs {
         name: TName;
     }
 
+    type AsciiCodec = NamedCodec<'ascii', string>;
+    type Base64Codec = NamedCodec<'base64', string>;
     type BinaryCodec = NamedCodec<'binary', string | Uint8Array, Buffer>;
+    type HexCodec = NamedCodec<'hex', string>;
     type JsonCodec = NamedCodec<'json', any, JsonValue>;
     type NDJsonCodec = NamedCodec<'ndjson', any, JsonValue>;
-    type AsciiCodec = NamedCodec<'ascii', string>;
-    type Utf8Codec = NamedCodec<'utf-8', string>;
-    type HexCodec = NamedCodec<'hex', string>;
-    type Base64Codec = NamedCodec<'base64', string>;
     type Ucs2Codec = NamedCodec<'ucs2', string>;
+    type Utf8Codec = NamedCodec<'utf-8', string>;
     type Utf16leCodec = NamedCodec<'utf16le', string>;
 
-    type CodecNames = keyof Codecs;
+    interface CodecLookup {
+        ascii: AsciiCodec;
+        base64: Base64Codec;
+        binary: BinaryCodec;
+        hex: HexCodec;
+        json: JsonCodec;
+        ndjson: NDJsonCodec;
+        ucs2: Ucs2Codec;
+        ['ucs-2']: Ucs2Codec;
+        utf8: Utf8Codec;
+        ['utf-8']: Utf8Codec;
+        utf16le: Utf16leCodec;
+        ['utf16-le']: Utf16leCodec;
+    }
+
+    type CodecNames = keyof CodecLookup;
 
     type CodecInput = BaseCodec | CodecNames;
     type MaybeCodecInput = CodecInput | string | null | undefined;
@@ -35,7 +50,7 @@ declare namespace codecs {
     type OutType <
         TCodec extends MaybeCodecInput,
         TFallback extends NamedCodec = BinaryCodec,
-        TCodecs = Codecs
+        TCodecs = CodecLookup
     > = Codec<TCodec, TFallback, TCodecs> extends BaseCodec<any, infer T>
         ? T
         : unknown;
@@ -43,7 +58,7 @@ declare namespace codecs {
     type InType <
         TCodec extends MaybeCodecInput,
         TFallback extends NamedCodec = BinaryCodec,
-        TCodecs = Codecs
+        TCodecs = CodecLookup
     > = Codec<TCodec, TFallback, TCodecs> extends BaseCodec<infer T, any>
         ? T
         : unknown;
@@ -51,7 +66,7 @@ declare namespace codecs {
     type CodecName <
         TInput extends MaybeCodecInput,
         TFallback extends NamedCodec = BinaryCodec,
-        TCodecs = Codecs
+        TCodecs = CodecLookup
     > = TInput extends null | undefined
         ? TFallback['name']
         : TInput extends NamedCodec
@@ -64,7 +79,7 @@ declare namespace codecs {
                         : undefined
                     : TFallback['name'];
 
-    type Codec<TInput, TFallback = BinaryCodec, TCodecs = Codecs> = TInput extends BaseCodec
+    type Codec<TInput, TFallback = BinaryCodec, TCodecs = CodecLookup> = TInput extends BaseCodec
         ? TInput
         : TInput extends null | undefined
             ? TFallback
@@ -86,13 +101,10 @@ declare namespace codecs {
         ndjson: NDJsonCodec;
         json: JsonCodec;
         ascii: AsciiCodec;
-        'utf-8': Utf8Codec;
         utf8: Utf8Codec;
         hex: HexCodec;
         base64: Base64Codec;
-        'ucs-2': Ucs2Codec;
         ucs2: Ucs2Codec;
-        'utf16-le': Utf16leCodec;
         utf16le: Utf16leCodec;
     }
 }

--- a/types/codecs/ts3.6/codecs-tests.ts
+++ b/types/codecs/ts3.6/codecs-tests.ts
@@ -86,10 +86,7 @@ import codecs = require('codecs/ts3.6');
 }
 {
   const codec = 'ucs-2';
-  codecs[codec].name; // $ExpectType "ucs2"
   codecs(codec).name; // $ExpectType "ucs2"
-  codecs[codec].encode('hello'); // $ExpectType Buffer
-  codecs[codec].decode(new Uint8Array()); // $ExpectType string
   const set: [Codec<'ucs-2'>, InType<'ucs-2'>, OutType<'ucs-2'>, CodecName<'ucs-2'>] = [] as any;
   set; // $ExpectType [NamedCodec<"ucs2", string, string>, string, string, "ucs2"]
 }
@@ -104,10 +101,7 @@ import codecs = require('codecs/ts3.6');
 }
 {
   const codec = 'utf-8';
-  codecs[codec].name; // $ExpectType "utf-8"
   codecs(codec).name; // $ExpectType "utf-8"
-  codecs[codec].encode('hello'); // $ExpectType Buffer
-  codecs[codec].decode(new Uint8Array()); // $ExpectType string
   const set: [Codec<'utf-8'>, InType<'utf-8'>, OutType<'utf-8'>, CodecName<'utf-8'>] = [] as any;
   set; // $ExpectType [NamedCodec<"utf-8", string, string>, string, string, "utf-8"]
 }
@@ -122,10 +116,7 @@ import codecs = require('codecs/ts3.6');
 }
 {
   const codec = 'utf16-le';
-  codecs[codec].name; // $ExpectType "utf16le"
   codecs(codec).name; // $ExpectType "utf16le"
-  codecs[codec].encode('hello'); // $ExpectType Buffer
-  codecs[codec].decode(new Uint8Array()); // $ExpectType string
   const set: [Codec<'utf16-le'>, InType<'utf16-le'>, OutType<'utf16-le'>, CodecName<'utf16-le'>] = [] as any;
   set; // $ExpectType [NamedCodec<"utf16le", string, string>, string, string, "utf16le"]
 }

--- a/types/codecs/ts3.6/index.d.ts
+++ b/types/codecs/ts3.6/index.d.ts
@@ -12,17 +12,32 @@ declare namespace codecs {
         name: TName;
     }
 
+    type AsciiCodec = NamedCodec<'ascii', string>;
+    type Base64Codec = NamedCodec<'base64', string>;
     type BinaryCodec = NamedCodec<'binary', string | Uint8Array, Buffer>;
+    type HexCodec = NamedCodec<'hex', string>;
     type JsonCodec = NamedCodec<'json', any, JsonValue>;
     type NDJsonCodec = NamedCodec<'ndjson', any, JsonValue>;
-    type AsciiCodec = NamedCodec<'ascii', string>;
-    type Utf8Codec = NamedCodec<'utf-8', string>;
-    type HexCodec = NamedCodec<'hex', string>;
-    type Base64Codec = NamedCodec<'base64', string>;
     type Ucs2Codec = NamedCodec<'ucs2', string>;
+    type Utf8Codec = NamedCodec<'utf-8', string>;
     type Utf16leCodec = NamedCodec<'utf16le', string>;
 
-    type CodecNames = keyof Codecs;
+    interface CodecLookup {
+        ascii: AsciiCodec;
+        base64: Base64Codec;
+        binary: BinaryCodec;
+        hex: HexCodec;
+        json: JsonCodec;
+        ndjson: NDJsonCodec;
+        ucs2: Ucs2Codec;
+        ['ucs-2']: Ucs2Codec;
+        utf8: Utf8Codec;
+        ['utf-8']: Utf8Codec;
+        utf16le: Utf16leCodec;
+        ['utf16-le']: Utf16leCodec;
+    }
+
+    type CodecNames = keyof CodecLookup;
 
     type CodecInput = BaseCodec | CodecNames;
     type MaybeCodecInput = CodecInput | string | null | undefined;
@@ -30,7 +45,7 @@ declare namespace codecs {
     type OutType <
         TCodec extends MaybeCodecInput,
         TFallback extends NamedCodec = BinaryCodec,
-        TCodecs = Codecs
+        TCodecs = CodecLookup
     > = Codec<TCodec, TFallback, TCodecs> extends BaseCodec<any, infer T>
         ? T
         : unknown;
@@ -38,7 +53,7 @@ declare namespace codecs {
     type InType <
         TCodec extends MaybeCodecInput,
         TFallback extends NamedCodec = BinaryCodec,
-        TCodecs = Codecs
+        TCodecs = CodecLookup
     > = Codec<TCodec, TFallback, TCodecs> extends BaseCodec<infer T, any>
         ? T
         : unknown;
@@ -46,7 +61,7 @@ declare namespace codecs {
     type CodecName <
         TInput extends MaybeCodecInput,
         TFallback extends NamedCodec = BinaryCodec,
-        TCodecs = Codecs
+        TCodecs = CodecLookup
     > = TInput extends null | undefined
         ? TFallback['name']
         : TInput extends NamedCodec
@@ -59,7 +74,7 @@ declare namespace codecs {
                         : undefined
                     : TFallback['name'];
 
-    type Codec<TInput, TFallback = BinaryCodec, TCodecs = Codecs> = TInput extends BaseCodec
+    type Codec<TInput, TFallback = BinaryCodec, TCodecs = CodecLookup> = TInput extends BaseCodec
         ? TInput
         : TInput extends null | undefined
             ? TFallback
@@ -81,13 +96,10 @@ declare namespace codecs {
         ndjson: NDJsonCodec;
         json: JsonCodec;
         ascii: AsciiCodec;
-        'utf-8': Utf8Codec;
         utf8: Utf8Codec;
         hex: HexCodec;
         base64: Base64Codec;
-        'ucs-2': Ucs2Codec;
         ucs2: Ucs2Codec;
-        'utf16-le': Utf16leCodec;
         utf16le: Utf16leCodec;
     }
 }


### PR DESCRIPTION
The hyphenated codecs `ucs-2`, `utf-8`, `utf16-le` are supposed by `codecs` as input parameter but are not part of the `codecs` property access. _(`codecs('ucs-2')` works but `codecs['ucs-2']` doesn't)_. This PR removes those fields from the property definitions but allows it to be still used as arguments returning the correct codecs.