### PR TITLE
Fix Legend payload with type = "plainline"

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -417,7 +417,9 @@ export interface LegendPayload {
     id: any;
     type: LegendType;
     color?: string;
-    payload?: Record<"strokeDasharray", string>;
+    payload?: {
+        strokeDasharray: string;
+    };
 }
 
 export type BBoxUpdateCallback = (box: { width: number; height: number; }) => void;

--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -417,6 +417,7 @@ export interface LegendPayload {
     id: any;
     type: LegendType;
     color?: string;
+    payload?: Record<"strokeDasharray", string>;
 }
 
 export type BBoxUpdateCallback = (box: { width: number; height: number; }) => void;


### PR DESCRIPTION
Adding missing property payload to LegendPayload, used to define the strokeDasharray when type = "plainline".
Related bug : 
https://github.com/recharts/recharts/issues/2141

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/recharts/recharts/issues/2141


