### PR TITLE
[relay-runtime]: Removed old execute events from log

### DIFF
--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -434,30 +434,6 @@ type LogEvent =
           info: any;
       }>
     | Readonly<{
-          name: 'execute.start';
-          transactionID: number;
-          params: RequestParameters;
-          variables: Variables;
-      }>
-    | Readonly<{
-          name: 'execute.next';
-          transactionID: number;
-          response: GraphQLResponse;
-      }>
-    | Readonly<{
-          name: 'execute.error';
-          transactionID: number;
-          error: Error;
-      }>
-    | Readonly<{
-          name: 'execute.complete';
-          transactionID: number;
-      }>
-    | Readonly<{
-          name: 'execute.unsubscribe';
-          transactionID: number;
-      }>
-    | Readonly<{
         name: 'network.info',
         transactionID: number,
         info: unknown,

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -115,12 +115,12 @@ const environment = new Environment({
     ],
     log: logEvent => {
         switch (logEvent.name) {
-            case 'execute.start':
-            case 'execute.next':
-            case 'execute.error':
+            case 'network.start':
+            case 'network.complete':
+            case 'network.error':
+            case 'network.info':
+            case 'network.unsubscribe':
             case 'execute.info':
-            case 'execute.complete':
-            case 'execute.unsubscribe':
             case 'queryresource.fetch':
             default:
                 break;


### PR DESCRIPTION
Removes the _old_ execute events: https://github.com/facebook/relay/commit/5075851cb99a5293638b358d4d882779363d8b71