### PR TITLE
[sharedb] Update types for Backend and Connection

### DIFF
--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -8,7 +8,9 @@
 
 /// <reference path="lib/sharedb.d.ts" />
 
+import { Duplex } from 'stream';
 import Agent = require('./lib/agent');
+import { Connection } from './lib/client';
 import * as ShareDB from './lib/sharedb';
 
 interface PubSubOptions {
@@ -32,7 +34,17 @@ declare class sharedb {
         disableDocAction?: boolean,
         disableSpaceDelimitedActions?: boolean
     });
-    connect: (connection?: any, req?: any) => sharedb.Connection;
+    /**
+     * Creates a server-side connection to ShareDB.
+     *
+     * This is almost always called with no arguments.
+     *
+     * @param connection optional existing connection to re-bind to this `Backend`.
+     * @param req optional request context for the new connection. See `#listen` for details.
+     *
+     * @see https://github.com/share/sharedb#client-api
+     */
+    connect(connection?: Connection, req?: any): Connection;
     /**
      * Registers a projection that can be used from clients just like a normal collection.
      *
@@ -41,7 +53,16 @@ declare class sharedb {
      * @param fields field whitelist for the projection
      */
     addProjection(name: string, collection: string, fields: ProjectionFields): void;
-    listen(stream: any): void;
+    /**
+     * Registers a new `Duplex` stream with the backend. This should be called when the server
+     * receives a new connection from a client.
+     *
+     * @param stream duplex stream for exchanging data with the new client
+     * @param request optional request that initiated the new connection, e.g. a HTTP request. This
+     *   is passed to any "connect" middleware listeners, which can use it for inspecting cookies
+     *   or session info.
+     */
+    listen(stream: Duplex, request?: any): Agent;
     close(callback?: BasicCallback): void;
     /**
      * Registers a server middleware function.
@@ -109,6 +130,10 @@ declare namespace sharedb {
         private _removeStream(channel, stream): void;
     }
 
+    /**
+     * @deprecated Use the `Connection` type from 'sharedb/lib/client' instead, as that's where it
+     *   lives in the actual source code.
+     */
     class Connection {
         constructor(ws: WebSocket);
         get(collectionName: string, documentID: string): ShareDB.Doc;

--- a/types/sharedb/lib/client.d.ts
+++ b/types/sharedb/lib/client.d.ts
@@ -10,6 +10,7 @@ export class Connection {
     // ShareDB, but it is handy for server-side only user code that may cache
     // state on the agent and read it in middleware
     agent: Agent | null;
+    close(): void;
     get(collectionName: string, documentID: string): Doc;
     createFetchQuery(collectionName: string, query: any, options: {results?: Query[]}, callback: (err: Error, results: any[]) => void): Query;
     createSubscribeQuery(collectionName: string, query: any, options: {results?: Query[]}, callback: (err: Error, results: any[]) => void): Query;

--- a/types/sharedb/lib/client.d.ts
+++ b/types/sharedb/lib/client.d.ts
@@ -12,8 +12,8 @@ export class Connection {
     agent: Agent | null;
     close(): void;
     get(collectionName: string, documentID: string): Doc;
-    createFetchQuery(collectionName: string, query: any, options: {results?: Query[]}, callback: (err: Error, results: any[]) => void): Query;
-    createSubscribeQuery(collectionName: string, query: any, options: {results?: Query[]}, callback: (err: Error, results: any[]) => void): Query;
+    createFetchQuery(collectionName: string, query: any, options: {results?: Query[]} | null, callback: (err: Error, results: any[]) => void): Query;
+    createSubscribeQuery(collectionName: string, query: any, options: {results?: Query[]} | null, callback: (err: Error, results: any[]) => void): Query;
 }
 export type Doc = ShareDB.Doc;
 export type Query = ShareDB.Query;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -191,6 +191,8 @@ function startServer() {
     wss.on('connection', (ws, req) => {
       const stream = new WebSocketJSONStream(ws);
       backend.listen(stream);
+      // Test type definition for 2-argument version
+      backend.listen(stream, req);
     });
 
     server.listen(8080);
@@ -245,4 +247,6 @@ function startClient(callback) {
     if (anotherDoc.version !== null) {
       Math.round(anotherDoc.version);
     }
+
+    connection.close();
 }


### PR DESCRIPTION
# Changes

This makes some updates to `@types/sharedb` to better reflect the JS source code.
1. Add second optional `request` param in `Backend#listen(stream, request?)`, and narrow type of `stream` param from `any` to `Duplex`
    - [Source code for `Backend#listen`](https://github.com/share/sharedb/blob/eadd9bc9754280007fac920cea20d42214c8e6cc/lib/backend.js#L129)
2. Narrow first param in `Backend#connect(connection?: Connection, req?: any)` from `connection: any` to `Connection`
    - [Source code for `Backend#connnect`](https://github.com/share/sharedb/blob/eadd9bc9754280007fac920cea20d42214c8e6cc/lib/backend.js#L106)
3. Add `Connection#close()` method
    - [Source code for `Connection#close`](https://github.com/share/sharedb/blob/eadd9bc9754280007fac920cea20d42214c8e6cc/lib/client/connection.js#L480)
4. Update `Connection#createFetchQuery` and `createSubscribeQuery` to allow null `options` param
    - [A test in sharedb that exercises a null `options` param](https://github.com/share/sharedb/blob/eadd9bc9754280007fac920cea20d42214c8e6cc/test/client/query.js#L14-L17)

# PR template

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (linked above under changes)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (not applicable for this PR)
