### PR TITLE
fs-extra: define missing overload for `ensureDir`

### DIFF
--- a/types/fs-extra/fs-extra-tests.ts
+++ b/types/fs-extra/fs-extra-tests.ts
@@ -173,6 +173,7 @@ fs.ensureDir(path, ensureNum).then(() => {
 });
 fs.ensureDir(path, ensureObj, errorCallback);
 fs.ensureDir(path, ensureNum, errorCallback);
+fs.ensureDir(path, errorCallback);
 fs.ensureDirSync(path);
 fs.ensureDirSync(path, ensureObj);
 fs.ensureDirSync(path, ensureNum);

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -42,6 +42,7 @@ export function createSymlink(src: string, dest: string, type: SymlinkType, call
 export function createSymlinkSync(src: string, dest: string, type: SymlinkType): void;
 
 export function ensureDir(path: string, options?: EnsureOptions | number): Promise<void>;
+export function ensureDir(path: string, callback?: (err: Error) => void): void;
 export function ensureDir(path: string, options?: EnsureOptions | number, callback?: (err: Error) => void): void;
 export function ensureDirSync(path: string, options?: EnsureOptions | number): void;
 


### PR DESCRIPTION
For some reason, this overload's definition was removed in this [commit](https://github.com/stagefright5/DefinitelyTyped/commit/4d830a5c954c55c5a3c5cb714597e2f1a5cadf4b#diff-cfd53b4251aad7f2ff6407d866c5f581f741a7458cbe9f15c90814642f4a27c4L148)

This PR brings it up-to-date with the official [docs](https://github.com/jprichardson/node-fs-extra/blob/1680dff87f1faeb62c4eddf45c66bc4f549a879d/docs/ensureDir.md#example)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jprichardson/node-fs-extra/blob/1680dff87f1faeb62c4eddf45c66bc4f549a879d/docs/ensureDir.md#example
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
