### PR TITLE
k6/http CookieJar.set() has wrong arguments

### DIFF
--- a/types/k6/http.d.ts
+++ b/types/k6/http.d.ts
@@ -668,11 +668,12 @@ export class CookieJar {
     /**
      * Set cookie.
      * https://k6.io/docs/javascript-api/k6-http/cookiejar-k6-http/cookiejar-set-name-value-options
+     * @param url - Cookie URL.
      * @param name - Cookie name.
      * @param value - Cookie value.
      * @param options - Optional settings.
      */
-    set(name: string, value: string, options?: CookieOptions | null): void;
+    set(url: string, name: string, value: string, options?: CookieOptions | null): void;
 }
 
 /**

--- a/types/k6/test/http.ts
+++ b/types/k6/test/http.ts
@@ -320,13 +320,17 @@ jar.set(); // $ExpectError
 jar.set(5); // $ExpectError
 jar.set('session'); // $ExpectError
 jar.set('session', 5); // $ExpectError
-jar.set('session', 'abc123'); // $ExpectType void
-jar.set('session', 'abc123', null); // $ExpectType void
-jar.set('session', 'abc123', {}); // $ExpectType void
-jar.set('session', 'abc123', { badoption: true }); // $ExpectError
-jar.set('session', 'abc123', { domain: 'example.com' }); // $ExpectType void
+jar.set('session', 'abc123'); // $ExpectError
+jar.set('session', 'abc123', null); // $ExpectError
+jar.set('session', 'abc123', {}); // $ExpectError
+jar.set('session', 'abc123', { domain: 'example.com' }); // $ExpectError
+jar.set(address, 'session', 'abc123'); // $ExpectType void
+jar.set(address, 'session', 'abc123', null); // $ExpectType void
+jar.set(address, 'session', 'abc123', {}); // $ExpectType void
+jar.set(address, 'session', 'abc123', { badoption: true }); // $ExpectError
+jar.set(address, 'session', 'abc123', { domain: 'example.com' }); // $ExpectType void
 // $ExpectType void
-jar.set('session', 'abc123', {
+jar.set(address, 'session', 'abc123', {
     domain: address,
     path: '/index.html',
     expires: '2019-06-23T18:04:45Z',
@@ -335,3 +339,4 @@ jar.set('session', 'abc123', {
     http_only: true,
 });
 jar.set('session', 'abc123', {}, 5); // $ExpectError
+jar.set(address, 'session', 'abc123', {}, 5); // $ExpectError


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [CookieJar.set(url, name, value, [options])](https://k6.io/docs/javascript-api/k6-http/cookiejar/cookiejar-set-url-name-value-options)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. --> in [Release Page](https://github.com/loadimpact/k6/releases) I could not find any hint that this is a new Api. Instead I guess it just a wrong definition of the function here in the types.
