### PR TITLE
Ajv updated to 7.0 -- update the tests of dependents

### DIFF
--- a/types/ajv-async/ajv-async-tests.ts
+++ b/types/ajv-async/ajv-async-tests.ts
@@ -1,4 +1,4 @@
-import * as Ajv from 'ajv';
+import Ajv from 'ajv';
 import setupAsyncToAJV = require('ajv-async');
 
 const ajv = new Ajv();

--- a/types/ajv-async/index.d.ts
+++ b/types/ajv-async/index.d.ts
@@ -2,9 +2,9 @@
 // Project: https://github.com/epoberezkin/ajv-async#readme
 // Definitions by: es <https://github.com/dmitriismitnov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 3.8
 
-import { Ajv } from 'ajv';
+import Ajv from 'ajv';
 
 declare function ajvAsync(ajv: Ajv): Ajv;
 export = ajvAsync;

--- a/types/ajv-bsontype/ajv-bsontype-tests.ts
+++ b/types/ajv-bsontype/ajv-bsontype-tests.ts
@@ -1,4 +1,4 @@
-import * as Ajv from 'ajv';
+import Ajv from 'ajv';
 import ajvBsontype = require('ajv-bsontype');
 
 const ajv = new Ajv();

--- a/types/ajv-bsontype/index.d.ts
+++ b/types/ajv-bsontype/index.d.ts
@@ -2,8 +2,9 @@
 // Project: https://github.com/BoLaMN/ajv-bsontype#readme
 // Definitions by: Alex <https://github.com/adjerbetian>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.8
 
-import { Ajv } from 'ajv';
+import Ajv from 'ajv';
 
 declare function ajvBsontype(ajv: Ajv): Ajv;
 export = ajvBsontype;

--- a/types/ajv-errors/ajv-errors-tests.ts
+++ b/types/ajv-errors/ajv-errors-tests.ts
@@ -1,5 +1,5 @@
 import Ajv from "ajv";
 import AjvErrors = require("ajv-errors");
 
-const ajv = new Ajv({allErrors: true, jsonPointers: true});
+const ajv = new Ajv({ allErrors: true });
 AjvErrors(ajv);

--- a/types/ajv-errors/ajv-errors-tests.ts
+++ b/types/ajv-errors/ajv-errors-tests.ts
@@ -1,4 +1,4 @@
-import * as Ajv from "ajv";
+import Ajv from "ajv";
 import AjvErrors = require("ajv-errors");
 
 const ajv = new Ajv({allErrors: true, jsonPointers: true});

--- a/types/ajv-errors/index.d.ts
+++ b/types/ajv-errors/index.d.ts
@@ -2,9 +2,9 @@
 // Project: https://github.com/epoberezkin/ajv-errors
 // Definitions by: Afshawn Lotfi <https://github.com/afshawnlotfi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 3.8
 
-import { Ajv } from "ajv";
+import Ajv from "ajv";
 
 /**
  *

--- a/types/ajv-merge-patch/ajv-merge-patch-tests.ts
+++ b/types/ajv-merge-patch/ajv-merge-patch-tests.ts
@@ -1,4 +1,4 @@
-import * as Ajv from "ajv";
+import Ajv from "ajv";
 
 import ajvMergePatch = require("ajv-merge-patch");
 

--- a/types/ajv-merge-patch/index.d.ts
+++ b/types/ajv-merge-patch/index.d.ts
@@ -2,9 +2,9 @@
 // Project: https://github.com/epoberezkin/ajv-merge-patch#readme
 // Definitions by: Zhu Zijia <https://github.com/littlepiggy03>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 3.8
 
-import { Ajv } from "ajv";
+import Ajv from "ajv";
 
 declare function ajvMergePatch(ajv: Ajv): void;
 


### PR DESCRIPTION
It now needs to be imported with default imports.

Edit: ajv@7 requires TS 3.8, so I added that requirement to all these packages too.