### PR TITLE
[selenium-webdriver] Fix typo in IPerfLoggingPrefs 

### DIFF
--- a/types/selenium-webdriver/chrome.d.ts
+++ b/types/selenium-webdriver/chrome.d.ts
@@ -35,11 +35,11 @@ export interface IOptionsValues {
 }
 
 export interface IPerfLoggingPrefs {
-  enableNetwork: boolean;
-  enablePage: boolean;
-  enableTimeline: boolean;
-  tracingCategories: string;
-  bufferUsageReportingInterval: number;
+  enableNetwork?: boolean;
+  enablePage?: boolean;
+  enableTimeline?: boolean;
+  traceCategories?: string;
+  bufferUsageReportingInterval?: number;
 }
 
 /**

--- a/types/selenium-webdriver/test/chrome.ts
+++ b/types/selenium-webdriver/test/chrome.ts
@@ -28,8 +28,8 @@ function TestChromeOptions() {
     options = options.androidProcess('com.android.chrome');
     options = options.androidUseRunningApp(true);
     options = options.setPerfLoggingPrefs({
-        enableNetwork: true, enablePage: true, enableTimeline: true,
-        tracingCategories: 'category', bufferUsageReportingInterval: 1000 });
+        enableNetwork: true, enablePage: true,
+        traceCategories: 'category', bufferUsageReportingInterval: 1000 });
     options = options.setUserPreferences('preferences');
 }
 


### PR DESCRIPTION
According the [ChromeDriver docs](https://chromedriver.chromium.org/capabilities#TOC-perfLoggingPrefs-object) this field is called `traceCategories` not `tracingCategories`. Further I'm getting an error in ChromeDriver when trying to use `tracingCategories`. Using `traceCategories` fixes it. Also see SeleniumHQ/selenium#8976.

I've also made the properties optional since ChromeDriver uses defaults if partial options are provided.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/SeleniumHQ/selenium/pull/8976
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
