### PR TITLE
kurento-client: Added generic overload for getMediaobjectById()

### DIFF
--- a/types/kurento-client/index.d.ts
+++ b/types/kurento-client/index.d.ts
@@ -91,6 +91,7 @@ declare namespace kurento {
         ): Promise<PlayerEndpoint>;
         create(type: string, options?: Record<string, unknown>): Promise<MediaElement>;
         getMediaobjectById(objectId: string): Promise<MediaPipeline | WebRtcEndpoint | RecorderEndpoint>;
+        // tslint:disable-next-line
         getMediaobjectById<T extends MediaPipeline | WebRtcEndpoint | RecorderEndpoint>(objectId: string): Promise<T>;
         getServerManager: (callback?: Callback<ServerManager>) => Promise<ServerManager>;
         close(): void;

--- a/types/kurento-client/index.d.ts
+++ b/types/kurento-client/index.d.ts
@@ -91,6 +91,7 @@ declare namespace kurento {
         ): Promise<PlayerEndpoint>;
         create(type: string, options?: Record<string, unknown>): Promise<MediaElement>;
         getMediaobjectById(objectId: string): Promise<MediaPipeline | WebRtcEndpoint | RecorderEndpoint>;
+        getMediaobjectById<T extends MediaPipeline | WebRtcEndpoint | RecorderEndpoint>(objectId: string): Promise<T>;
         getServerManager: (callback?: Callback<ServerManager>) => Promise<ServerManager>;
         close(): void;
     }

--- a/types/kurento-client/index.d.ts
+++ b/types/kurento-client/index.d.ts
@@ -90,9 +90,8 @@ declare namespace kurento {
             },
         ): Promise<PlayerEndpoint>;
         create(type: string, options?: Record<string, unknown>): Promise<MediaElement>;
-        getMediaobjectById(objectId: string): Promise<MediaPipeline | WebRtcEndpoint | RecorderEndpoint>;
         // tslint:disable-next-line
-        getMediaobjectById<T extends MediaPipeline | WebRtcEndpoint | RecorderEndpoint>(objectId: string): Promise<T>;
+        getMediaobjectById<T extends MediaObject = MediaObject>(objectId: string): Promise<T>;
         getServerManager: (callback?: Callback<ServerManager>) => Promise<ServerManager>;
         close(): void;
     }

--- a/types/kurento-client/kurento-client-tests.ts
+++ b/types/kurento-client/kurento-client-tests.ts
@@ -57,6 +57,15 @@ async () => {
 };
 
 async () => {
+    const endpointId = 'endpointId';
+
+    const client = await kurento('//server', { failAfter: 500, useImplicitTransactions: true });
+    const endpoint = await client.getMediaobjectById<WebRtcEndpoint>(endpointId);
+
+    await endpoint.release();
+};
+
+async () => {
     const kurentoClient = await kurento('//server');
     const pipeline = await kurentoClient.create('MediaPipeline'); // $ExpectType MediaPipeline
     const webRtcEp = await pipeline.create('WebRtcEndpoint'); // $ExpectType WebRtcEndpoint

--- a/types/kurento-client/kurento-client-tests.ts
+++ b/types/kurento-client/kurento-client-tests.ts
@@ -60,7 +60,7 @@ async () => {
     const endpointId = 'endpointId';
 
     const client = await kurento('//server', { failAfter: 500, useImplicitTransactions: true });
-    const endpoint = await client.getMediaobjectById<WebRtcEndpoint>(endpointId);
+    const endpoint = await client.getMediaobjectById<WebRtcEndpoint>(endpointId); // $ExpectType WebRtcEndpoint
 
     await endpoint.release();
 };


### PR DESCRIPTION
This PR adds an overload to `getMediaobjectById` to allow for generic typing. This makes it much easier, and cleaner to work with this method. At the moment, we have to cast the method.

**Old**
```typescript
const pipeline = await (instance.getMediaobjectById('...')) as MediaPipeline;
```

**New**
```typescript
const pipeline = await instance.getMediaobjectById<MediaPipeline>('...');
```

I've just run into this failing the linter, I've added a disabled comment as I wanted to enquire about why this would fail. It seems cleaner, and allows a user to use either method of providing the relevant type.

Let me know! 

Thanks

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [getMediaobjectById documentation](https://doc-kurento.readthedocs.io/en/6.7.1/_static/client-jsdoc/module-kurentoClient.KurentoClient.html#getMediaobjectById)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
