### PR TITLE
node-imap: ConnectionOptions instead of TlsOptions for tls.connect(...)

### DIFF
--- a/types/imap/index.d.ts
+++ b/types/imap/index.d.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="node" />
 import { EventEmitter } from 'events';
-import { TlsOptions } from 'tls';
+import { ConnectionOptions } from 'tls';
 
 declare namespace Connection {
 
@@ -27,7 +27,7 @@ declare namespace Connection {
         /** Perform implicit TLS connection? Default: false */
         tls?: boolean;
         /** Options object to pass to tls.connect() Default: (none) */
-        tlsOptions?: TlsOptions;
+        tlsOptions?: ConnectionOptions;
         /** Set to 'always' to always attempt connection upgrades via STARTTLS, 'required' only if upgrading is required, or 'never' to never attempt upgrading. Default: 'never' */
         autotls?: string;
         /** Number of milliseconds to wait for a connection to be established. Default: 10000 */


### PR DESCRIPTION
`TlsOptions` type doesn't have `servername` property (needed as suggested here https://github.com/mscdex/node-imap/issues/705#issuecomment-546738438).

Looking at @types/node tls.d.ts file, the right type to be passed to `connect` function seems to be `ConnectionOptions` (https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/tls.d.ts#L736):

```(typescript)
function connect(options: ConnectionOptions, secureConnectListener?: () => void): TLSSocket;
```

