### PR TITLE
Update react-bootstrap-typeahead typings to include shouldSelectHint …

### DIFF
--- a/types/react-bootstrap-typeahead/index.d.ts
+++ b/types/react-bootstrap-typeahead/index.d.ts
@@ -31,13 +31,13 @@ export type TypeaheadLabelKey<T extends TypeaheadModel> = T extends object
     : never;
 // don't allow onBlur, onChange, onFocus or onKeyDown as members of inputProps
 // those props should be supplied directly to <Typeahead /> or <AsyncTypeahead />
-export type InputProps = Omit<
+export interface InputProps extends Omit<
     React.InputHTMLAttributes<HTMLInputElement>,
     'onBlur' | 'onChange' | 'onFocus' | 'onKeyDown'
 > {
     /* Callback function that determines whether the hint should be selected. */
     shouldSelectHint?: ShouldSelect;
-};
+}
 
 /* ---------------------------------------------------------------------------
                             Typeahead Contexts

--- a/types/react-bootstrap-typeahead/index.d.ts
+++ b/types/react-bootstrap-typeahead/index.d.ts
@@ -34,7 +34,10 @@ export type TypeaheadLabelKey<T extends TypeaheadModel> = T extends object
 export type InputProps = Omit<
     React.InputHTMLAttributes<HTMLInputElement>,
     'onBlur' | 'onChange' | 'onFocus' | 'onKeyDown'
->;
+> {
+    /* Callback function that determines whether the hint should be selected. */
+    shouldSelectHint?: ShouldSelect;
+};
 
 /* ---------------------------------------------------------------------------
                             Typeahead Contexts


### PR DESCRIPTION
…property on InputProps type

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ericgio/react-bootstrap-typeahead/blob/master/docs/API.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.