### PR TITLE
@wordpress/data-controls: Remove unneeded test.

### DIFF
--- a/types/wordpress__data-controls/wordpress__data-controls-tests.ts
+++ b/types/wordpress__data-controls/wordpress__data-controls-tests.ts
@@ -18,17 +18,6 @@ select('core/edit-post', 'isEditorPanelEnabled', 'foo');
 // $ExpectType void
 select('core/edit-post', 'isEditorPanelEnabled', 'foo', 123, true, 'bar');
 
-/* tslint:disable:no-void-expression */
-function* generator() {
-    // $ExpectType any
-    const apiFetchValue = yield apiFetch({ path: '/wp/v2/posts' });
-    // $ExpectType any
-    const dispatchValue = yield dispatch('core/edit-post', 'togglePublishSidebar');
-    // $ExpectType any
-    const selectValue = yield select('core/edit-post', 'isEditorPanelEnabled', 'foo');
-}
-/* tslint:enable:no-void-expression */
-
 const myExistingControls = {
     FOO: () => Promise.resolve('foo'),
     BAR: () => 'bar',


### PR DESCRIPTION
This removes a test from `@wordpress/data-controls` that doesn't test anything useful and is broken by https://github.com/microsoft/TypeScript/pull/41348 because all of the variables created are now considered "implicitly `any`".

All of the functions tested are covered on the lines above this removed section, and all it is verifying is that the result of `yield` is `any`, which isn't very useful.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

