### PR TITLE
[@types/styled-components] fix intersection type error when use hoist-non-react-statics@2.x in project

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -11,6 +11,7 @@
 //                 Yuki Ito <https://github.com/Lazyuki>
 //                 Maciej Goszczycki <https://github.com/mgoszcz2>
 //                 Danilo Fuchs <https://github.com/danilofuchs>
+//                 Jeason <https://github.com/jeasonstudio>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // forward declarations
@@ -23,7 +24,30 @@ declare global {
 
 import * as CSS from "csstype";
 import * as React from "react";
-import * as hoistNonReactStatics from 'hoist-non-react-statics';
+
+type MEMO_STATICS_KEY = '$$typeof' | 'compare' | 'defaultProps' | 'displayName' | 'propTypes' | 'type';
+
+type FORWARD_REF_STATICS_KEY = '$$typeof' | "render" | "defaultProps" | "displayName" | "propTypes";
+
+type REACT_STATICS_KEY = "childContextTypes" | "contextType" | "contextTypes" | "defaultProps" | "displayName" | "getDefaultProps" | "getDerivedStateFromError" | "getDerivedStateFromProps" | "mixins" | "propTypes" | "type";
+
+type KNOWN_STATICS_KEY = 'name' | 'length' | 'prototype' | 'caller' | 'callee' | 'arguments' | 'arity';
+
+type NonReactStatics<
+    S extends React.ComponentType<any>,
+    C extends {
+        [key: string]: true
+    } = {}
+> = {
+    [key in Exclude<
+        keyof S,
+        S extends React.MemoExoticComponent<any>
+            ? MEMO_STATICS_KEY | keyof C
+            : S extends React.ForwardRefExoticComponent<any>
+            ? FORWARD_REF_STATICS_KEY | keyof C
+            : REACT_STATICS_KEY | KNOWN_STATICS_KEY | keyof C
+    >]: S[key]
+};
 
 export type CSSProperties = CSS.Properties<string | number>;
 
@@ -164,7 +188,7 @@ export type StyledComponent<
     A extends keyof any = never
 > = // the "string" allows this to be used as an object key
     // I really want to avoid this if possible but it's the only way to use nesting with object styles...
-    string & StyledComponentBase<C, T, O, A> & hoistNonReactStatics.NonReactStatics<C extends React.ComponentType<any> ? C : never>;
+    string & StyledComponentBase<C, T, O, A> & NonReactStatics<C extends React.ComponentType<any> ? C : never>;
 
 export interface StyledComponentBase<
     C extends string | React.ComponentType<any>,

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -22,14 +22,25 @@ declare global {
     }
 }
 
-import * as CSS from "csstype";
-import * as React from "react";
+import * as CSS from 'csstype';
+import * as React from 'react';
 
 type MEMO_STATICS_KEY = '$$typeof' | 'compare' | 'defaultProps' | 'displayName' | 'propTypes' | 'type';
 
-type FORWARD_REF_STATICS_KEY = '$$typeof' | "render" | "defaultProps" | "displayName" | "propTypes";
+type FORWARD_REF_STATICS_KEY = '$$typeof' | 'render' | 'defaultProps' | 'displayName' | 'propTypes';
 
-type REACT_STATICS_KEY = "childContextTypes" | "contextType" | "contextTypes" | "defaultProps" | "displayName" | "getDefaultProps" | "getDerivedStateFromError" | "getDerivedStateFromProps" | "mixins" | "propTypes" | "type";
+type REACT_STATICS_KEY =
+    'childContextTypes'
+    | 'contextType'
+    | 'contextTypes'
+    | 'defaultProps'
+    | 'displayName'
+    | 'getDefaultProps'
+    | 'getDerivedStateFromError'
+    | 'getDerivedStateFromProps'
+    | 'mixins'
+    | 'propTypes'
+    | 'type';
 
 type KNOWN_STATICS_KEY = 'name' | 'length' | 'prototype' | 'caller' | 'callee' | 'arguments' | 'arity';
 

--- a/types/styled-components/ts3.6/index.d.ts
+++ b/types/styled-components/ts3.6/index.d.ts
@@ -6,14 +6,25 @@ declare global {
     }
 }
 
-import * as CSS from "csstype";
-import * as React from "react";
+import * as CSS from 'csstype';
+import * as React from 'react';
 
 type MEMO_STATICS_KEY = '$$typeof' | 'compare' | 'defaultProps' | 'displayName' | 'propTypes' | 'type';
 
-type FORWARD_REF_STATICS_KEY = '$$typeof' | "render" | "defaultProps" | "displayName" | "propTypes";
+type FORWARD_REF_STATICS_KEY = '$$typeof' | 'render' | 'defaultProps' | 'displayName' | 'propTypes';
 
-type REACT_STATICS_KEY = "childContextTypes" | "contextType" | "contextTypes" | "defaultProps" | "displayName" | "getDefaultProps" | "getDerivedStateFromError" | "getDerivedStateFromProps" | "mixins" | "propTypes" | "type";
+type REACT_STATICS_KEY =
+    'childContextTypes'
+    | 'contextType'
+    | 'contextTypes'
+    | 'defaultProps'
+    | 'displayName'
+    | 'getDefaultProps'
+    | 'getDerivedStateFromError'
+    | 'getDerivedStateFromProps'
+    | 'mixins'
+    | 'propTypes'
+    | 'type';
 
 type KNOWN_STATICS_KEY = 'name' | 'length' | 'prototype' | 'caller' | 'callee' | 'arguments' | 'arity';
 

--- a/types/styled-components/ts3.6/index.d.ts
+++ b/types/styled-components/ts3.6/index.d.ts
@@ -8,7 +8,30 @@ declare global {
 
 import * as CSS from "csstype";
 import * as React from "react";
-import * as hoistNonReactStatics from 'hoist-non-react-statics';
+
+type MEMO_STATICS_KEY = '$$typeof' | 'compare' | 'defaultProps' | 'displayName' | 'propTypes' | 'type';
+
+type FORWARD_REF_STATICS_KEY = '$$typeof' | "render" | "defaultProps" | "displayName" | "propTypes";
+
+type REACT_STATICS_KEY = "childContextTypes" | "contextType" | "contextTypes" | "defaultProps" | "displayName" | "getDefaultProps" | "getDerivedStateFromError" | "getDerivedStateFromProps" | "mixins" | "propTypes" | "type";
+
+type KNOWN_STATICS_KEY = 'name' | 'length' | 'prototype' | 'caller' | 'callee' | 'arguments' | 'arity';
+
+type NonReactStatics<
+    S extends React.ComponentType<any>,
+    C extends {
+        [key: string]: true
+    } = {}
+> = {
+    [key in Exclude<
+        keyof S,
+        S extends React.MemoExoticComponent<any>
+            ? MEMO_STATICS_KEY | keyof C
+            : S extends React.ForwardRefExoticComponent<any>
+            ? FORWARD_REF_STATICS_KEY | keyof C
+            : REACT_STATICS_KEY | KNOWN_STATICS_KEY | keyof C
+    >]: S[key]
+};
 
 export type CSSProperties = CSS.Properties<string | number>;
 
@@ -150,7 +173,7 @@ export type StyledComponent<
     A extends keyof any = never
 > = // the "string" allows this to be used as an object key
     // I really want to avoid this if possible but it's the only way to use nesting with object styles...
-    string & StyledComponentBase<C, T, O, A> & hoistNonReactStatics.NonReactStatics<C extends React.ComponentType<any> ? C : never>;
+    string & StyledComponentBase<C, T, O, A> & NonReactStatics<C extends React.ComponentType<any> ? C : never>;
 
 export interface StyledComponentBase<
     C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://codesandbox.io/s/zealous-hooks-jph4o?file=/src/index.tsx>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

`@types/styled-components` depends on `@types/hoist-non-react-statics`, but `hoist-non-react-statics@2.x` contains the type declaration in pacakge([link](https://unpkg.com/browse/hoist-non-react-statics@2.5.5/index.d.ts)). So if I install `hoist-non-react-statics@2.x` in my project, the declaration of `HNRS` in package will have a higher priority than `@types/HNRS`, and break the type of styled components.

```tsx
// StyledContainer => any
const StyledContainer = styled.div`
  color: red;
`;

interface IMyButtonProps {
  className?: string;
  style?: React.CSSProperties;
}
const MyButton: React.FC<IMyButtonProps> = (props) => (
  <button {...props}>Click me</button>
);

// StyledButton => any
const StyledButton = styled(MyButton)`
  margin-left: 20px;
`;
```

Try in [CodeSandbox](https://codesandbox.io/s/zealous-hooks-jph4o?file=/src/index.tsx:109-448).