### PR TITLE
braintree_node v3.1.0: SubscriptionRequest - paymentMethodToken

### DIFF
--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -1105,7 +1105,7 @@ declare namespace braintree {
             startImmediately?: boolean;
         };
         paymentMethodNonce?: string;
-        paymentMethodToken: string;
+        paymentMethodToken?: string;
         planId: string;
         price?: string;
         trialDuration?: number;


### PR DESCRIPTION
When updating a subscription using the dropIn wit a clientId, a paymentMethodToken should not be required; otherwise the subscription does not get updated. This is really an issue with the TypeScript definition for the SubscriptionRequest interface.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Subscription Update](https://developers.braintreepayments.com/reference/request/subscription/update/node)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

