### PR TITLE
Work around uncalled function errors in chrome-apps tests

### DIFF
--- a/types/chrome-apps/test/index.ts
+++ b/types/chrome-apps/test/index.ts
@@ -799,6 +799,10 @@ const deviceAttr = chrome.enterprise.deviceAttributes;
 
 if (deviceAttr.getDirectoryDeviceId && deviceAttr.getDeviceAssetId) {
     if (deviceAttr.getDeviceSerialNumber && deviceAttr.getDeviceAnnotatedLocation) {
+        void deviceAttr.getDirectoryDeviceId;
+        void deviceAttr.getDeviceAssetId;
+        void deviceAttr.getDeviceSerialNumber;
+        void deviceAttr.getDeviceAnnotatedLocation;
         console.log('API OK :)');
     }
 }
@@ -1210,6 +1214,8 @@ if (chrome.platformKeys.subtleCrypto &&
     chrome.platformKeys.subtleCrypto() &&
     chrome.platformKeys.subtleCrypto().sign &&
     chrome.platformKeys.subtleCrypto().exportKey) {
+    void chrome.platformKeys.subtleCrypto().sign;
+    void chrome.platformKeys.subtleCrypto().exportKey;
     console.log('Subtle crypto working (Y)')
 }
 


### PR DESCRIPTION
Typescript issues an error if a function is tested without subsequently being used. So I added some obviously-ignored uses of the tested functions in the chrome-apps tests.