### PR TITLE
[@types/snowpack-env] remove readonly flag for `ImportMeta.url`

### DIFF
--- a/types/snowpack-env/index.d.ts
+++ b/types/snowpack-env/index.d.ts
@@ -36,7 +36,7 @@ interface ImportMetaHot {
 }
 
 interface ImportMeta {
-    readonly url: string;
+    url: string;
     // TypeScript Bug: https://github.com/microsoft/TypeScript/issues/41468
     // When TS bug is fixed and ecosystem has upgraded, then it will be safe
     // to change `hot` to the more correct "possibly undefined" (hot?: ...).

--- a/types/snowpack-env/snowpack-env-tests.ts
+++ b/types/snowpack-env/snowpack-env-tests.ts
@@ -1,6 +1,7 @@
 // Testing import.meta is not yet possible!
 // Does not work with "module": "commonjs", but linter requires it.
 
+// import.meta.url;
 // import.meta.env.NODE_ENV;
 // import.meta.env.FOO;
 // import.meta.hot.accept(update => update.module);


### PR DESCRIPTION
make `ImportMeta.url` compatible w/ WHATWG spec and `@types/node` typedef

References:
- https://github.com/snowpackjs/snowpack/discussions/1869
- https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/snowpackjs/snowpack/discussions/1869
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.