### PR TITLE
Update Node.js scrypt options

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -431,6 +431,9 @@ declare module 'crypto' {
     ): void;
 
     interface ScryptOptions {
+        cost?: number;
+        blockSize?: number;
+        parallelization?: number;
         N?: number;
         r?: number;
         p?: number;

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -1,5 +1,5 @@
-declare module "crypto" {
-    import * as stream from "stream";
+declare module 'crypto' {
+    import * as stream from 'stream';
 
     interface Certificate {
         exportChallenge(spkac: BinaryLike): Buffer;
@@ -7,11 +7,12 @@ declare module "crypto" {
         verifySpkac(spkac: NodeJS.ArrayBufferView): boolean;
     }
     const Certificate: {
-        new(): Certificate;
+        new (): Certificate;
         (): Certificate;
     };
 
-    namespace constants { // https://nodejs.org/dist/latest-v10.x/docs/api/crypto.html#crypto_crypto_constants
+    namespace constants {
+        // https://nodejs.org/dist/latest-v10.x/docs/api/crypto.html#crypto_crypto_constants
         const OPENSSL_VERSION_NUMBER: number;
 
         /** Applies multiple bug workarounds within OpenSSL. See https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_options.html for detail. */
@@ -121,13 +122,13 @@ declare module "crypto" {
     function createHmac(algorithm: string, key: BinaryLike | KeyObject, options?: stream.TransformOptions): Hmac;
 
     // https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings
-    type BinaryToTextEncoding = "base64" | "hex";
-    type CharacterEncoding = "utf8" | "utf-8" | "utf16le" | "latin1";
-    type LegacyCharacterEncoding = "ascii" | "binary" | "ucs2" | "ucs-2";
+    type BinaryToTextEncoding = 'base64' | 'hex';
+    type CharacterEncoding = 'utf8' | 'utf-8' | 'utf16le' | 'latin1';
+    type LegacyCharacterEncoding = 'ascii' | 'binary' | 'ucs2' | 'ucs-2';
 
     type Encoding = BinaryToTextEncoding | CharacterEncoding | LegacyCharacterEncoding;
 
-    type ECDHKeyFormat = "compressed" | "uncompressed" | "hybrid";
+    type ECDHKeyFormat = 'compressed' | 'uncompressed' | 'hybrid';
 
     class Hash extends stream.Transform {
         private constructor();
@@ -192,16 +193,19 @@ declare module "crypto" {
         algorithm: CipherCCMTypes,
         key: CipherKey,
         iv: BinaryLike | null,
-        options: CipherCCMOptions
+        options: CipherCCMOptions,
     ): CipherCCM;
     function createCipheriv(
         algorithm: CipherGCMTypes,
         key: CipherKey,
         iv: BinaryLike | null,
-        options?: CipherGCMOptions
+        options?: CipherGCMOptions,
     ): CipherGCM;
     function createCipheriv(
-        algorithm: string, key: CipherKey, iv: BinaryLike | null, options?: stream.TransformOptions
+        algorithm: string,
+        key: CipherKey,
+        iv: BinaryLike | null,
+        options?: stream.TransformOptions,
     ): Cipher;
 
     class Cipher extends stream.Transform {
@@ -243,7 +247,12 @@ declare module "crypto" {
         iv: BinaryLike | null,
         options?: CipherGCMOptions,
     ): DecipherGCM;
-    function createDecipheriv(algorithm: string, key: CipherKey, iv: BinaryLike | null, options?: stream.TransformOptions): Decipher;
+    function createDecipheriv(
+        algorithm: string,
+        key: CipherKey,
+        iv: BinaryLike | null,
+        options?: stream.TransformOptions,
+    ): Decipher;
 
     class Decipher extends stream.Transform {
         private constructor();
@@ -296,13 +305,11 @@ declare module "crypto" {
         dsaEncoding?: DSAEncoding;
     }
 
-    interface SignPrivateKeyInput extends PrivateKeyInput, SigningOptions {
-    }
+    interface SignPrivateKeyInput extends PrivateKeyInput, SigningOptions {}
     interface SignKeyObjectInput extends SigningOptions {
         key: KeyObject;
     }
-    interface VerifyPublicKeyInput extends PublicKeyInput, SigningOptions {
-    }
+    interface VerifyPublicKeyInput extends PublicKeyInput, SigningOptions {}
     interface VerifyKeyObjectInput extends SigningOptions {
         key: KeyObject;
     }
@@ -315,7 +322,10 @@ declare module "crypto" {
         update(data: BinaryLike): Signer;
         update(data: string, input_encoding: Encoding): Signer;
         sign(private_key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput): Buffer;
-        sign(private_key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput, output_format: BinaryToTextEncoding): string;
+        sign(
+            private_key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput,
+            output_format: BinaryToTextEncoding,
+        ): string;
     }
 
     function createVerify(algorithm: string, options?: stream.WritableOptions): Verify;
@@ -324,16 +334,32 @@ declare module "crypto" {
 
         update(data: BinaryLike): Verify;
         update(data: string, input_encoding: Encoding): Verify;
-        verify(object: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput, signature: NodeJS.ArrayBufferView): boolean;
-        verify(object: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput, signature: string, signature_format?: BinaryToTextEncoding): boolean;
+        verify(
+            object: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput,
+            signature: NodeJS.ArrayBufferView,
+        ): boolean;
+        verify(
+            object: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput,
+            signature: string,
+            signature_format?: BinaryToTextEncoding,
+        ): boolean;
         // https://nodejs.org/api/crypto.html#crypto_verifier_verify_object_signature_signature_format
         // The signature field accepts a TypedArray type, but it is only available starting ES2017
     }
     function createDiffieHellman(prime_length: number, generator?: number | NodeJS.ArrayBufferView): DiffieHellman;
     function createDiffieHellman(prime: NodeJS.ArrayBufferView): DiffieHellman;
     function createDiffieHellman(prime: string, prime_encoding: BinaryToTextEncoding): DiffieHellman;
-    function createDiffieHellman(prime: string, prime_encoding: BinaryToTextEncoding, generator: number | NodeJS.ArrayBufferView): DiffieHellman;
-    function createDiffieHellman(prime: string, prime_encoding: BinaryToTextEncoding, generator: string, generator_encoding: BinaryToTextEncoding): DiffieHellman;
+    function createDiffieHellman(
+        prime: string,
+        prime_encoding: BinaryToTextEncoding,
+        generator: number | NodeJS.ArrayBufferView,
+    ): DiffieHellman;
+    function createDiffieHellman(
+        prime: string,
+        prime_encoding: BinaryToTextEncoding,
+        generator: string,
+        generator_encoding: BinaryToTextEncoding,
+    ): DiffieHellman;
     class DiffieHellman {
         private constructor();
         generateKeys(): Buffer;
@@ -341,7 +367,11 @@ declare module "crypto" {
         computeSecret(other_public_key: NodeJS.ArrayBufferView): Buffer;
         computeSecret(other_public_key: string, input_encoding: BinaryToTextEncoding): Buffer;
         computeSecret(other_public_key: NodeJS.ArrayBufferView, output_encoding: BinaryToTextEncoding): string;
-        computeSecret(other_public_key: string, input_encoding: BinaryToTextEncoding, output_encoding: BinaryToTextEncoding): string;
+        computeSecret(
+            other_public_key: string,
+            input_encoding: BinaryToTextEncoding,
+            output_encoding: BinaryToTextEncoding,
+        ): string;
         getPrime(): Buffer;
         getPrime(encoding: BinaryToTextEncoding): string;
         getGenerator(): Buffer;
@@ -365,7 +395,13 @@ declare module "crypto" {
         digest: string,
         callback: (err: Error | null, derivedKey: Buffer) => any,
     ): void;
-    function pbkdf2Sync(password: BinaryLike, salt: BinaryLike, iterations: number, keylen: number, digest: string): Buffer;
+    function pbkdf2Sync(
+        password: BinaryLike,
+        salt: BinaryLike,
+        iterations: number,
+        keylen: number,
+        digest: string,
+    ): Buffer;
 
     function randomBytes(size: number): Buffer;
     function randomBytes(size: number, callback: (err: Error | null, buf: Buffer) => void): void;
@@ -378,9 +414,21 @@ declare module "crypto" {
     function randomInt(min: number, max: number, callback: (err: Error | null, value: number) => void): void;
 
     function randomFillSync<T extends NodeJS.ArrayBufferView>(buffer: T, offset?: number, size?: number): T;
-    function randomFill<T extends NodeJS.ArrayBufferView>(buffer: T, callback: (err: Error | null, buf: T) => void): void;
-    function randomFill<T extends NodeJS.ArrayBufferView>(buffer: T, offset: number, callback: (err: Error | null, buf: T) => void): void;
-    function randomFill<T extends NodeJS.ArrayBufferView>(buffer: T, offset: number, size: number, callback: (err: Error | null, buf: T) => void): void;
+    function randomFill<T extends NodeJS.ArrayBufferView>(
+        buffer: T,
+        callback: (err: Error | null, buf: T) => void,
+    ): void;
+    function randomFill<T extends NodeJS.ArrayBufferView>(
+        buffer: T,
+        offset: number,
+        callback: (err: Error | null, buf: T) => void,
+    ): void;
+    function randomFill<T extends NodeJS.ArrayBufferView>(
+        buffer: T,
+        offset: number,
+        size: number,
+        callback: (err: Error | null, buf: T) => void,
+    ): void;
 
     interface ScryptOptions {
         N?: number;
@@ -391,7 +439,8 @@ declare module "crypto" {
     function scrypt(
         password: BinaryLike,
         salt: BinaryLike,
-        keylen: number, callback: (err: Error | null, derivedKey: Buffer) => void,
+        keylen: number,
+        callback: (err: Error | null, derivedKey: Buffer) => void,
     ): void;
     function scrypt(
         password: BinaryLike,
@@ -430,15 +479,19 @@ declare module "crypto" {
             key: BinaryLike,
             curve: string,
             inputEncoding?: BinaryToTextEncoding,
-            outputEncoding?: "latin1" | "hex" | "base64",
-            format?: "uncompressed" | "compressed" | "hybrid",
+            outputEncoding?: 'latin1' | 'hex' | 'base64',
+            format?: 'uncompressed' | 'compressed' | 'hybrid',
         ): Buffer | string;
         generateKeys(): Buffer;
         generateKeys(encoding: BinaryToTextEncoding, format?: ECDHKeyFormat): string;
         computeSecret(other_public_key: NodeJS.ArrayBufferView): Buffer;
         computeSecret(other_public_key: string, input_encoding: BinaryToTextEncoding): Buffer;
         computeSecret(other_public_key: NodeJS.ArrayBufferView, output_encoding: BinaryToTextEncoding): string;
-        computeSecret(other_public_key: string, input_encoding: BinaryToTextEncoding, output_encoding: BinaryToTextEncoding): string;
+        computeSecret(
+            other_public_key: string,
+            input_encoding: BinaryToTextEncoding,
+            output_encoding: BinaryToTextEncoding,
+        ): string;
         getPrivateKey(): Buffer;
         getPrivateKey(encoding: BinaryToTextEncoding): string;
         getPublicKey(): Buffer;
@@ -478,15 +531,15 @@ declare module "crypto" {
     }
 
     interface X25519KeyPairKeyObjectOptions {
-       /**
-        * No options.
-        */
+        /**
+         * No options.
+         */
     }
 
     interface X448KeyPairKeyObjectOptions {
-       /**
-        * No options.
-        */
+        /**
+         * No options.
+         */
     }
 
     interface ECKeyPairKeyObjectOptions {
@@ -618,132 +671,446 @@ declare module "crypto" {
         privateKey: T2;
     }
 
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'rsa', options: RSAKeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'dsa', options: DSAKeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'ec', options: ECKeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPairSync(type: 'ed25519', options: ED25519KeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'ed25519', options: ED25519KeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'ed25519', options: ED25519KeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'ed25519', options: ED25519KeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'ed25519',
+        options: ED25519KeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'ed25519',
+        options: ED25519KeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'ed25519',
+        options: ED25519KeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'ed25519',
+        options: ED25519KeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'ed25519', options?: ED25519KeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPairSync(type: 'ed448', options: ED448KeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'ed448', options: ED448KeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'ed448', options: ED448KeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'ed448', options: ED448KeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'ed448',
+        options: ED448KeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'ed448',
+        options: ED448KeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'ed448',
+        options: ED448KeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'ed448',
+        options: ED448KeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'ed448', options?: ED448KeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPairSync(type: 'x25519', options: X25519KeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'x25519', options: X25519KeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'x25519', options: X25519KeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'x25519', options: X25519KeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'x25519',
+        options: X25519KeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'x25519',
+        options: X25519KeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'x25519',
+        options: X25519KeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'x25519',
+        options: X25519KeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'x25519', options?: X25519KeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPairSync(type: 'x448', options: X448KeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'x448', options: X448KeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'x448', options: X448KeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'x448', options: X448KeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'x448',
+        options: X448KeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'x448',
+        options: X448KeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'x448',
+        options: X448KeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'x448',
+        options: X448KeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'x448', options?: X448KeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairKeyObjectOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairKeyObjectOptions,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairKeyObjectOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairKeyObjectOptions,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairKeyObjectOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairKeyObjectOptions,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
-    function generateKeyPair(type: 'ed25519', options: ED25519KeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ed25519', options: ED25519KeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'ed25519', options: ED25519KeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ed25519', options: ED25519KeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'ed25519', options: ED25519KeyPairKeyObjectOptions | undefined, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'ed25519',
+        options: ED25519KeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ed25519',
+        options: ED25519KeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ed25519',
+        options: ED25519KeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ed25519',
+        options: ED25519KeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ed25519',
+        options: ED25519KeyPairKeyObjectOptions | undefined,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
-    function generateKeyPair(type: 'ed448', options: ED448KeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ed448', options: ED448KeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'ed448', options: ED448KeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ed448', options: ED448KeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'ed448', options: ED448KeyPairKeyObjectOptions | undefined, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'ed448',
+        options: ED448KeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ed448',
+        options: ED448KeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ed448',
+        options: ED448KeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ed448',
+        options: ED448KeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ed448',
+        options: ED448KeyPairKeyObjectOptions | undefined,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
-    function generateKeyPair(type: 'x25519', options: X25519KeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'x25519', options: X25519KeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'x25519', options: X25519KeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'x25519', options: X25519KeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'x25519', options: X25519KeyPairKeyObjectOptions | undefined, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'x25519',
+        options: X25519KeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'x25519',
+        options: X25519KeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'x25519',
+        options: X25519KeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'x25519',
+        options: X25519KeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'x25519',
+        options: X25519KeyPairKeyObjectOptions | undefined,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
-    function generateKeyPair(type: 'x448', options: X448KeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'x448', options: X448KeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'x448', options: X448KeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'x448', options: X448KeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'x448', options: X448KeyPairKeyObjectOptions | undefined, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'x448',
+        options: X448KeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'x448',
+        options: X448KeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'x448',
+        options: X448KeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'x448',
+        options: X448KeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'x448',
+        options: X448KeyPairKeyObjectOptions | undefined,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
     namespace generateKeyPair {
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(type: 'rsa', options: RSAKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
 
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(type: 'dsa', options: DSAKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
 
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "ec", options: ECKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(type: 'ec', options: ECKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
 
-        function __promisify__(type: "ed25519", options: ED25519KeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "ed25519", options: ED25519KeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "ed25519", options: ED25519KeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "ed25519", options: ED25519KeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "ed25519", options?: ED25519KeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'ed25519',
+            options: ED25519KeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'ed25519',
+            options: ED25519KeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'ed25519',
+            options: ED25519KeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'ed25519',
+            options: ED25519KeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'ed25519',
+            options?: ED25519KeyPairKeyObjectOptions,
+        ): Promise<KeyPairKeyObjectResult>;
 
-        function __promisify__(type: "ed448", options: ED448KeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "ed448", options: ED448KeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "ed448", options: ED448KeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "ed448", options: ED448KeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "ed448", options?: ED448KeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'ed448',
+            options: ED448KeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'ed448',
+            options: ED448KeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'ed448',
+            options: ED448KeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'ed448',
+            options: ED448KeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(type: 'ed448', options?: ED448KeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
 
-        function __promisify__(type: "x25519", options: X25519KeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "x25519", options: X25519KeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "x25519", options: X25519KeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "x25519", options: X25519KeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "x25519", options?: X25519KeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'x25519',
+            options: X25519KeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'x25519',
+            options: X25519KeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'x25519',
+            options: X25519KeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'x25519',
+            options: X25519KeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'x25519',
+            options?: X25519KeyPairKeyObjectOptions,
+        ): Promise<KeyPairKeyObjectResult>;
 
-        function __promisify__(type: "x448", options: X448KeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "x448", options: X448KeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "x448", options: X448KeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "x448", options: X448KeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "x448", options?: X448KeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'x448',
+            options: X448KeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'x448',
+            options: X448KeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'x448',
+            options: X448KeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'x448',
+            options: X448KeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(type: 'x448', options?: X448KeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
     }
 
     /**
@@ -754,7 +1121,11 @@ declare module "crypto" {
      * If `key` is not a [`KeyObject`][], this function behaves as if `key` had been
      * passed to [`crypto.createPrivateKey()`][].
      */
-    function sign(algorithm: string | null | undefined, data: NodeJS.ArrayBufferView, key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput): Buffer;
+    function sign(
+        algorithm: string | null | undefined,
+        data: NodeJS.ArrayBufferView,
+        key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput,
+    ): Buffer;
 
     /**
      * Calculates and returns the signature for `data` using the given private key and
@@ -764,15 +1135,17 @@ declare module "crypto" {
      * If `key` is not a [`KeyObject`][], this function behaves as if `key` had been
      * passed to [`crypto.createPublicKey()`][].
      */
-    function verify(algorithm: string | null | undefined, data: NodeJS.ArrayBufferView, key: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput, signature: NodeJS.ArrayBufferView): boolean;
+    function verify(
+        algorithm: string | null | undefined,
+        data: NodeJS.ArrayBufferView,
+        key: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput,
+        signature: NodeJS.ArrayBufferView,
+    ): boolean;
 
     /**
      * Computes the Diffie-Hellman secret based on a privateKey and a publicKey.
      * Both keys must have the same asymmetricKeyType, which must be one of
      * 'dh' (for Diffie-Hellman), 'ec' (for ECDH), 'x448', or 'x25519' (for ECDH-ES).
      */
-    function diffieHellman(options: {
-        privateKey: KeyObject;
-        publicKey: KeyObject
-    }): Buffer;
+    function diffieHellman(options: { privateKey: KeyObject; publicKey: KeyObject }): Buffer;
 }

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -14,20 +14,23 @@ import { promisify } from 'util';
 
 {
     // crypto_hash_buffer_test
-    const hashResult: string = crypto.createHash('md5')
-        .update(new Buffer('world')).digest('hex');
+    const hashResult: string = crypto.createHash('md5').update(new Buffer('world')).digest('hex');
 }
 
 {
     // crypto_hash_dataview_test
-    const hashResult: string = crypto.createHash('md5')
-        .update(new DataView(new Buffer('world').buffer)).digest('hex');
+    const hashResult: string = crypto
+        .createHash('md5')
+        .update(new DataView(new Buffer('world').buffer))
+        .digest('hex');
 }
 
 {
     // crypto_hash_int8array_test
-    const hashResult: string = crypto.createHash('md5')
-        .update(new Int8Array(new Buffer('world').buffer)).digest('hex');
+    const hashResult: string = crypto
+        .createHash('md5')
+        .update(new Int8Array(new Buffer('world').buffer))
+        .digest('hex');
 }
 
 {
@@ -37,20 +40,23 @@ import { promisify } from 'util';
 
 {
     // crypto_hmac_buffer_test
-    const hmacResult: string = crypto.createHmac('md5', 'hello')
-        .update(new Buffer('world')).digest('hex');
+    const hmacResult: string = crypto.createHmac('md5', 'hello').update(new Buffer('world')).digest('hex');
 }
 
 {
     // crypto_hmac_dataview_test
-    const hmacResult: string = crypto.createHmac('md5', 'hello')
-        .update(new DataView(new Buffer('world').buffer)).digest('hex');
+    const hmacResult: string = crypto
+        .createHmac('md5', 'hello')
+        .update(new DataView(new Buffer('world').buffer))
+        .digest('hex');
 }
 
 {
     // crypto_hmac_int8array_test
-    const hmacResult: string = crypto.createHmac('md5', 'hello')
-        .update(new Int8Array(new Buffer('world').buffer)).digest('hex');
+    const hmacResult: string = crypto
+        .createHmac('md5', 'hello')
+        .update(new Int8Array(new Buffer('world').buffer))
+        .digest('hex');
 }
 
 {
@@ -69,14 +75,14 @@ import { promisify } from 'util';
 {
     // crypto_cipher_decipher_string_test
     const key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
-    const clearText = "This is the clear text.";
-    const cipher: crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
-    let cipherText: string = cipher.update(clearText, "utf8", "hex");
-    cipherText += cipher.final("hex");
+    const clearText = 'This is the clear text.';
+    const cipher: crypto.Cipher = crypto.createCipher('aes-128-ecb', key);
+    let cipherText: string = cipher.update(clearText, 'utf8', 'hex');
+    cipherText += cipher.final('hex');
 
-    const decipher: crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
-    let clearText2: string = decipher.update(cipherText, "hex", "utf8");
-    clearText2 += decipher.final("utf8");
+    const decipher: crypto.Decipher = crypto.createDecipher('aes-128-ecb', key);
+    let clearText2: string = decipher.update(cipherText, 'hex', 'utf8');
+    clearText2 += decipher.final('utf8');
 
     assert.equal(clearText2, clearText);
 }
@@ -85,14 +91,14 @@ import { promisify } from 'util';
     // crypto_cipher_decipher_buffer_test
     const key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
     const clearText: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4]);
-    const cipher: crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
+    const cipher: crypto.Cipher = crypto.createCipher('aes-128-ecb', key);
     const cipherBuffers: Buffer[] = [];
     cipherBuffers.push(cipher.update(clearText));
     cipherBuffers.push(cipher.final());
 
     const cipherText: Buffer = Buffer.concat(cipherBuffers);
 
-    const decipher: crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
+    const decipher: crypto.Decipher = crypto.createDecipher('aes-128-ecb', key);
     const decipherBuffers: Buffer[] = [];
     decipherBuffers.push(decipher.update(cipherText));
     decipherBuffers.push(decipher.final());
@@ -106,14 +112,14 @@ import { promisify } from 'util';
     // crypto_cipher_decipher_dataview_test
     const key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
     const clearText: DataView = new DataView(new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4]).buffer);
-    const cipher: crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
+    const cipher: crypto.Cipher = crypto.createCipher('aes-128-ecb', key);
     const cipherBuffers: Buffer[] = [];
     cipherBuffers.push(cipher.update(clearText));
     cipherBuffers.push(cipher.final());
 
     const cipherText: DataView = new DataView(Buffer.concat(cipherBuffers).buffer);
 
-    const decipher: crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
+    const decipher: crypto.Decipher = crypto.createDecipher('aes-128-ecb', key);
     const decipherBuffers: Buffer[] = [];
     decipherBuffers.push(decipher.update(cipherText));
     decipherBuffers.push(decipher.final());
@@ -129,22 +135,22 @@ import { promisify } from 'util';
     const aad = Buffer.from('0123456789', 'hex');
 
     const cipher = crypto.createCipheriv('aes-192-ccm', key, nonce, {
-        authTagLength: 16
+        authTagLength: 16,
     });
     const plaintext = 'Hello world';
     cipher.setAAD(aad, {
-        plaintextLength: Buffer.byteLength(plaintext)
+        plaintextLength: Buffer.byteLength(plaintext),
     });
     const ciphertext = cipher.update(plaintext, 'utf8');
     cipher.final();
     const tag = cipher.getAuthTag();
 
     const decipher = crypto.createDecipheriv('aes-192-ccm', key, nonce, {
-        authTagLength: 16
+        authTagLength: 16,
     });
     decipher.setAuthTag(tag);
     decipher.setAAD(aad, {
-        plaintextLength: ciphertext.length
+        plaintextLength: ciphertext.length,
     });
     const receivedPlaintext: string = decipher.update(ciphertext, undefined, 'utf8');
     decipher.final();
@@ -158,7 +164,7 @@ import { promisify } from 'util';
     const cipher = crypto.createCipheriv('aes-192-gcm', key, nonce);
     const plaintext = 'Hello world';
     cipher.setAAD(aad, {
-        plaintextLength: Buffer.byteLength(plaintext)
+        plaintextLength: Buffer.byteLength(plaintext),
     });
     const ciphertext = cipher.update(plaintext, 'utf8');
     cipher.final();
@@ -167,7 +173,7 @@ import { promisify } from 'util';
     const decipher = crypto.createDecipheriv('aes-192-gcm', key, nonce);
     decipher.setAuthTag(tag);
     decipher.setAAD(aad, {
-        plaintextLength: ciphertext.length
+        plaintextLength: ciphertext.length,
     });
     const receivedPlaintext: string = decipher.update(ciphertext, undefined, 'utf8');
     decipher.final();
@@ -179,22 +185,22 @@ import { promisify } from 'util';
     const aad = Buffer.from('0123456789', 'hex');
 
     const cipher = crypto.createCipheriv('aes-192-ccm', key, nonce, {
-        authTagLength: 16
+        authTagLength: 16,
     });
     const plaintext = 'Hello world';
     cipher.setAAD(aad, {
-        plaintextLength: Buffer.byteLength(plaintext)
+        plaintextLength: Buffer.byteLength(plaintext),
     });
     const ciphertext = cipher.update(plaintext, 'utf8');
     cipher.final();
     const tag = cipher.getAuthTag();
 
     const decipher = crypto.createDecipheriv('aes-192-ccm', key, nonce, {
-        authTagLength: 16
+        authTagLength: 16,
     });
     decipher.setAuthTag(tag);
     decipher.setAAD(aad, {
-        plaintextLength: ciphertext.length
+        plaintextLength: ciphertext.length,
     });
     const receivedPlaintext: string = decipher.update(ciphertext, undefined, 'utf8');
     decipher.final();
@@ -246,7 +252,6 @@ import { promisify } from 'util';
     // let arr1: Uint8Array = Uint8Array.of(1, 0, 2, 0, 3, 0, 4, 0);
     // let arr2: Uint16Array = Uint16Array.of(1, 2, 3, 4);
     // let arr3: Uint32Array = Uint8ClampedArray.of(131073, 262147);
-
     // assert(crypto.timingSafeEqual(arr1, arr2)); // binary same
     // assert(crypto.timingSafeEqual(arr1, arr3)); // binary same
 }
@@ -257,7 +262,6 @@ import { promisify } from 'util';
     // let arr1: Uint8Array = Uint8Array.of(1, 2, 3, 4);
     // let arr2: Uint16Array = Uint16Array.of(1, 2, 3, 4);
     // let arr3: Uint32Array = Uint8ClampedArray.of(1, 2, 3, 4);
-
     // assert(!crypto.timingSafeEqual(arr1, arr2)); // dumps core
     // assert(!crypto.timingSafeEqual(arr1, arr3)); // dumps core
 }
@@ -335,7 +339,7 @@ import { promisify } from 'util';
         N: 16384,
         r: 8,
         p: 1,
-        maxmem: 32 * 1024 * 1024
+        maxmem: 32 * 1024 * 1024,
     };
     crypto.scrypt(pwd, salt, 64, opts, (err: Error | null, derivedKey: Buffer): void => {});
     crypto.scrypt(pwd, salt, 64, { maxmem: 16 * 1024 * 1024 }, (err: Error | null, derivedKey: Buffer): void => {});
@@ -345,16 +349,16 @@ import { promisify } from 'util';
 }
 
 {
-    let key: string | Buffer = Buffer.from("buf");
-    const curve = "secp256k1";
+    let key: string | Buffer = Buffer.from('buf');
+    const curve = 'secp256k1';
     let ret: string | Buffer = crypto.ECDH.convertKey(key, curve);
-    key = "0xfff";
+    key = '0xfff';
     ret = crypto.ECDH.convertKey(key, curve);
-    ret = crypto.ECDH.convertKey(key, curve, "hex");
-    ret = crypto.ECDH.convertKey(key, curve, "hex", "hex");
-    ret = crypto.ECDH.convertKey(key, curve, "hex", "hex", "uncompressed");
-    ret = crypto.ECDH.convertKey(key, curve, "hex", "hex", "compressed");
-    ret = crypto.ECDH.convertKey(key, curve, "hex", "hex", "hybrid");
+    ret = crypto.ECDH.convertKey(key, curve, 'hex');
+    ret = crypto.ECDH.convertKey(key, curve, 'hex', 'hex');
+    ret = crypto.ECDH.convertKey(key, curve, 'hex', 'hex', 'uncompressed');
+    ret = crypto.ECDH.convertKey(key, curve, 'hex', 'hex', 'compressed');
+    ret = crypto.ECDH.convertKey(key, curve, 'hex', 'hex', 'hybrid');
 }
 
 {
@@ -458,70 +462,90 @@ import { promisify } from 'util';
 }
 
 {
-    crypto.generateKeyPair('rsa', {
-        modulusLength: 123,
-        publicKeyEncoding: {
-            format: 'der',
-            type: 'pkcs1',
+    crypto.generateKeyPair(
+        'rsa',
+        {
+            modulusLength: 123,
+            publicKeyEncoding: {
+                format: 'der',
+                type: 'pkcs1',
+            },
+            privateKeyEncoding: {
+                cipher: 'some-cipher',
+                format: 'pem',
+                passphrase: 'secret',
+                type: 'pkcs8',
+            },
         },
-        privateKeyEncoding: {
-            cipher: 'some-cipher',
-            format: 'pem',
-            passphrase: 'secret',
-            type: 'pkcs8',
-        },
-    }, (err: NodeJS.ErrnoException | null, publicKey: Buffer, privateKey: string) => {});
+        (err: NodeJS.ErrnoException | null, publicKey: Buffer, privateKey: string) => {},
+    );
 
-    crypto.generateKeyPair('dsa', {
-        modulusLength: 123,
-        divisorLength: 123,
-        publicKeyEncoding: {
-            format: 'pem',
-            type: 'spki',
+    crypto.generateKeyPair(
+        'dsa',
+        {
+            modulusLength: 123,
+            divisorLength: 123,
+            publicKeyEncoding: {
+                format: 'pem',
+                type: 'spki',
+            },
+            privateKeyEncoding: {
+                cipher: 'some-cipher',
+                format: 'der',
+                passphrase: 'secret',
+                type: 'pkcs8',
+            },
         },
-        privateKeyEncoding: {
-            cipher: 'some-cipher',
-            format: 'der',
-            passphrase: 'secret',
-            type: 'pkcs8',
-        },
-    }, (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: Buffer) => {});
+        (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: Buffer) => {},
+    );
 
-    crypto.generateKeyPair('ec', {
-        namedCurve: 'curve',
-        publicKeyEncoding: {
-            format: 'pem',
-            type: 'pkcs1',
+    crypto.generateKeyPair(
+        'ec',
+        {
+            namedCurve: 'curve',
+            publicKeyEncoding: {
+                format: 'pem',
+                type: 'pkcs1',
+            },
+            privateKeyEncoding: {
+                cipher: 'some-cipher',
+                format: 'pem',
+                passphrase: 'secret',
+                type: 'pkcs8',
+            },
         },
-        privateKeyEncoding: {
-            cipher: 'some-cipher',
-            format: 'pem',
-            passphrase: 'secret',
-            type: 'pkcs8',
-        },
-    }, (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {});
+        (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {},
+    );
 
-    crypto.generateKeyPair('ed25519', {
-        publicKeyEncoding: {
-            format: 'pem',
-            type: 'spki',
+    crypto.generateKeyPair(
+        'ed25519',
+        {
+            publicKeyEncoding: {
+                format: 'pem',
+                type: 'spki',
+            },
+            privateKeyEncoding: {
+                format: 'pem',
+                type: 'pkcs8',
+            },
         },
-        privateKeyEncoding: {
-            format: 'pem',
-            type: 'pkcs8',
-        },
-    }, (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {});
+        (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {},
+    );
 
-    crypto.generateKeyPair('x25519', {
-        publicKeyEncoding: {
-            format: 'pem',
-            type: 'spki',
+    crypto.generateKeyPair(
+        'x25519',
+        {
+            publicKeyEncoding: {
+                format: 'pem',
+                type: 'spki',
+            },
+            privateKeyEncoding: {
+                format: 'pem',
+                type: 'pkcs8',
+            },
         },
-        privateKeyEncoding: {
-            format: 'pem',
-            type: 'pkcs8',
-        },
-    }, (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {});
+        (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {},
+    );
 }
 
 {
@@ -624,12 +648,12 @@ import { promisify } from 'util';
     const keyObject = crypto.createSecretKey(Buffer.from('asdf')); // $ExpectType KeyObject
     keyObject instanceof crypto.KeyObject;
     assert.equal(keyObject.symmetricKeySize, 4);
-    assert.equal(keyObject.type, "secret");
+    assert.equal(keyObject.type, 'secret');
 }
 
 {
     const { privateKey, publicKey } = crypto.generateKeyPairSync('ec', {
-        namedCurve: 'sect239k1'
+        namedCurve: 'sect239k1',
     });
 
     const sign: crypto.Signer = crypto.createSign('SHA256');
@@ -640,7 +664,7 @@ import { promisify } from 'util';
     const verify: crypto.Verify = crypto.createVerify('SHA256');
     verify.write('some data to sign');
     verify.end();
-    verify.verify(publicKey, signature);    // $ExpectType boolean
+    verify.verify(publicKey, signature); // $ExpectType boolean
 
     // ensure that instanceof works
     verify instanceof crypto.Verify;
@@ -660,7 +684,7 @@ import { promisify } from 'util';
     const verify: crypto.Verify = crypto.createVerify('SHA256');
     verify.update('some data to sign');
     verify.end();
-    verify.verify(publicKey, signature);    // $ExpectType boolean
+    verify.verify(publicKey, signature); // $ExpectType boolean
 }
 
 {
@@ -789,7 +813,7 @@ import { promisify } from 'util';
 
 // crypto.randomInt
 {
-    const callback = (error: Error|null, value: number): void => {};
+    const callback = (error: Error | null, value: number): void => {};
 
     const a: number = crypto.randomInt(10);
     const b: number = crypto.randomInt(1, 10);
@@ -801,48 +825,62 @@ import { promisify } from 'util';
     const key = crypto.createPrivateKey('pkey');
     crypto.sign('sha256', Buffer.from('asd'), {
         key: Buffer.from('keylike'),
-        dsaEncoding: 'der'
+        dsaEncoding: 'der',
     });
-    crypto.createSign('sha256')
+    crypto
+        .createSign('sha256')
         .update(Buffer.from('asd'))
         .sign({
             key: Buffer.from('keylike'),
-            dsaEncoding: 'der'
+            dsaEncoding: 'der',
         });
     crypto.sign('sha256', Buffer.from('asd'), {
         key,
-        dsaEncoding: 'der'
+        dsaEncoding: 'der',
     });
-    crypto.createSign('sha256')
-        .update(Buffer.from('asd'))
-        .sign({
-            key,
-            dsaEncoding: 'der'
-        });
+    crypto.createSign('sha256').update(Buffer.from('asd')).sign({
+        key,
+        dsaEncoding: 'der',
+    });
 }
 
 {
     const key = crypto.createPublicKey('pkey');
-    crypto.verify('sha256', Buffer.from('asd'), {
-        key: Buffer.from('keylike'),
-        dsaEncoding: 'der'
-    }, Buffer.from('sig'));
-    crypto.createVerify('sha256')
-        .update(Buffer.from('asd'))
-        .verify({
+    crypto.verify(
+        'sha256',
+        Buffer.from('asd'),
+        {
             key: Buffer.from('keylike'),
-            dsaEncoding: 'der'
-        }, Buffer.from('sig'));
-    crypto.verify('sha256', Buffer.from('asd'), {
-        key,
-        dsaEncoding: 'der'
-    }, Buffer.from('sig'));
-    crypto.createVerify('sha256')
+            dsaEncoding: 'der',
+        },
+        Buffer.from('sig'),
+    );
+    crypto
+        .createVerify('sha256')
         .update(Buffer.from('asd'))
-        .verify({
+        .verify(
+            {
+                key: Buffer.from('keylike'),
+                dsaEncoding: 'der',
+            },
+            Buffer.from('sig'),
+        );
+    crypto.verify(
+        'sha256',
+        Buffer.from('asd'),
+        {
             key,
-            dsaEncoding: 'der'
-        }, Buffer.from('sig'));
+            dsaEncoding: 'der',
+        },
+        Buffer.from('sig'),
+    );
+    crypto.createVerify('sha256').update(Buffer.from('asd')).verify(
+        {
+            key,
+            dsaEncoding: 'der',
+        },
+        Buffer.from('sig'),
+    );
 }
 
 {
@@ -857,7 +895,7 @@ import { promisify } from 'util';
     crypto.generateKeyPairSync('ed25519').privateKey; // $ExpectType KeyObject
     crypto.generateKeyPairSync('ed448').privateKey; // $ExpectType KeyObject
 
-    [undefined, {}].forEach((opts) => {
+    [undefined, {}].forEach(opts => {
         crypto.generateKeyPair('x25519', opts, (err, publicKey, privateKey) => {
             privateKey; // $ExpectType KeyObject
             publicKey; // $ExpectType KeyObject
@@ -877,7 +915,7 @@ import { promisify } from 'util';
     });
 
     const pGenerateKeyPair = promisify(crypto.generateKeyPair);
-    [undefined, {}].forEach(async (opts) => {
+    [undefined, {}].forEach(async opts => {
         (await pGenerateKeyPair('x25519', opts)).privateKey; // $ExpectType KeyObject
         (await pGenerateKeyPair('x448', opts)).privateKey; // $ExpectType KeyObject
         (await pGenerateKeyPair('ed25519', opts)).privateKey; // $ExpectType KeyObject

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -336,16 +336,24 @@ import { promisify } from 'util';
     const salt: string | Buffer | Int32Array | DataView = Buffer.alloc(16);
     crypto.scrypt(pwd, salt, 64, (err: Error | null, derivedKey: Buffer): void => {});
     const opts: crypto.ScryptOptions = {
-        N: 16384,
-        r: 8,
-        p: 1,
+        cost: 16384,
+        blockSize: 8,
+        parallelization: 1,
         maxmem: 32 * 1024 * 1024,
     };
     crypto.scrypt(pwd, salt, 64, opts, (err: Error | null, derivedKey: Buffer): void => {});
     crypto.scrypt(pwd, salt, 64, { maxmem: 16 * 1024 * 1024 }, (err: Error | null, derivedKey: Buffer): void => {});
-    let buf: Buffer = crypto.scryptSync(pwd, salt, 64);
-    buf = crypto.scryptSync(pwd, salt, 64, opts);
-    buf = crypto.scryptSync(pwd, salt, 64, { N: 1024 });
+    crypto.scryptSync(pwd, salt, 64);
+    crypto.scryptSync(pwd, salt, 64, opts);
+    crypto.scryptSync(pwd, salt, 64, { N: 1024 });
+    const optsWithAliases: crypto.ScryptOptions = {
+        N: opts.cost,
+        r: opts.blockSize,
+        p: opts.parallelization,
+        maxmem: opts.maxmem,
+    };
+    crypto.scrypt(pwd, salt, 64, optsWithAliases, (err: Error | null, derivedKey: Buffer): void => {});
+    crypto.scryptSync(pwd, salt, 64, optsWithAliases);
 }
 
 {

--- a/types/node/v10/crypto.d.ts
+++ b/types/node/v10/crypto.d.ts
@@ -296,6 +296,9 @@ declare module 'crypto' {
     ): void;
 
     interface ScryptOptions {
+        cost?: number;
+        blockSize?: number;
+        parallelization?: number;
         N?: number;
         r?: number;
         p?: number;

--- a/types/node/v10/crypto.d.ts
+++ b/types/node/v10/crypto.d.ts
@@ -1,5 +1,5 @@
-declare module "crypto" {
-    import * as stream from "stream";
+declare module 'crypto' {
+    import * as stream from 'stream';
 
     interface Certificate {
         exportChallenge(spkac: string | Buffer | NodeJS.TypedArray | DataView): Buffer;
@@ -7,7 +7,7 @@ declare module "crypto" {
         verifySpkac(spkac: Buffer | NodeJS.TypedArray | DataView): boolean;
     }
     const Certificate: {
-        new(): Certificate;
+        new (): Certificate;
         (): Certificate;
     };
 
@@ -24,17 +24,23 @@ declare module "crypto" {
         ciphers: string;
     }
     /** @deprecated since v0.11.13 - use tls.SecureContext instead. */
-    interface Credentials { context?: any; }
+    interface Credentials {
+        context?: any;
+    }
     /** @deprecated since v0.11.13 - use tls.createSecureContext instead. */
     function createCredentials(details: CredentialDetails): Credentials;
     function createHash(algorithm: string, options?: stream.TransformOptions): Hash;
-    function createHmac(algorithm: string, key: string | Buffer | NodeJS.TypedArray | DataView, options?: stream.TransformOptions): Hmac;
+    function createHmac(
+        algorithm: string,
+        key: string | Buffer | NodeJS.TypedArray | DataView,
+        options?: stream.TransformOptions,
+    ): Hmac;
 
-    type Utf8AsciiLatin1Encoding = "utf8" | "ascii" | "latin1";
-    type HexBase64Latin1Encoding = "latin1" | "hex" | "base64";
-    type Utf8AsciiBinaryEncoding = "utf8" | "ascii" | "binary";
-    type HexBase64BinaryEncoding = "binary" | "base64" | "hex";
-    type ECDHKeyFormat = "compressed" | "uncompressed" | "hybrid";
+    type Utf8AsciiLatin1Encoding = 'utf8' | 'ascii' | 'latin1';
+    type HexBase64Latin1Encoding = 'latin1' | 'hex' | 'base64';
+    type Utf8AsciiBinaryEncoding = 'utf8' | 'ascii' | 'binary';
+    type HexBase64BinaryEncoding = 'binary' | 'base64' | 'hex';
+    type ECDHKeyFormat = 'compressed' | 'uncompressed' | 'hybrid';
 
     interface Hash extends stream.Transform {
         update(data: string | Buffer | NodeJS.TypedArray | DataView): Hash;
@@ -57,21 +63,52 @@ declare module "crypto" {
         authTagLength?: number;
     }
     /** @deprecated since v10.0.0 use createCipheriv() */
-    function createCipher(algorithm: CipherCCMTypes, password: string | Buffer | NodeJS.TypedArray | DataView, options: CipherCCMOptions): CipherCCM;
+    function createCipher(
+        algorithm: CipherCCMTypes,
+        password: string | Buffer | NodeJS.TypedArray | DataView,
+        options: CipherCCMOptions,
+    ): CipherCCM;
     /** @deprecated since v10.0.0 use createCipheriv() */
-    function createCipher(algorithm: CipherGCMTypes, password: string | Buffer | NodeJS.TypedArray | DataView, options?: CipherGCMOptions): CipherGCM;
+    function createCipher(
+        algorithm: CipherGCMTypes,
+        password: string | Buffer | NodeJS.TypedArray | DataView,
+        options?: CipherGCMOptions,
+    ): CipherGCM;
     /** @deprecated since v10.0.0 use createCipheriv() */
-    function createCipher(algorithm: string, password: string | Buffer | NodeJS.TypedArray | DataView, options?: stream.TransformOptions): Cipher;
+    function createCipher(
+        algorithm: string,
+        password: string | Buffer | NodeJS.TypedArray | DataView,
+        options?: stream.TransformOptions,
+    ): Cipher;
 
-    function createCipheriv(algorithm: CipherCCMTypes, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options: CipherCCMOptions): CipherCCM;
-    function createCipheriv(algorithm: CipherGCMTypes, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options?: CipherGCMOptions): CipherGCM;
-    function createCipheriv(algorithm: string, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options?: stream.TransformOptions): Cipher;
+    function createCipheriv(
+        algorithm: CipherCCMTypes,
+        key: string | Buffer | NodeJS.TypedArray | DataView,
+        iv: string | Buffer | NodeJS.TypedArray | DataView,
+        options: CipherCCMOptions,
+    ): CipherCCM;
+    function createCipheriv(
+        algorithm: CipherGCMTypes,
+        key: string | Buffer | NodeJS.TypedArray | DataView,
+        iv: string | Buffer | NodeJS.TypedArray | DataView,
+        options?: CipherGCMOptions,
+    ): CipherGCM;
+    function createCipheriv(
+        algorithm: string,
+        key: string | Buffer | NodeJS.TypedArray | DataView,
+        iv: string | Buffer | NodeJS.TypedArray | DataView,
+        options?: stream.TransformOptions,
+    ): Cipher;
 
     interface Cipher extends stream.Transform {
         update(data: string | Buffer | NodeJS.TypedArray | DataView): Buffer;
         update(data: string, input_encoding: Utf8AsciiBinaryEncoding): Buffer;
         update(data: Buffer | NodeJS.TypedArray | DataView, output_encoding: HexBase64BinaryEncoding): string;
-        update(data: Buffer | NodeJS.TypedArray | DataView, input_encoding: any, output_encoding: HexBase64BinaryEncoding): string;
+        update(
+            data: Buffer | NodeJS.TypedArray | DataView,
+            input_encoding: any,
+            output_encoding: HexBase64BinaryEncoding,
+        ): string;
         // second arg ignored
         update(data: string, input_encoding: Utf8AsciiBinaryEncoding, output_encoding: HexBase64BinaryEncoding): string;
         final(): Buffer;
@@ -89,11 +126,23 @@ declare module "crypto" {
         getAuthTag(): Buffer;
     }
     /** @deprecated since v10.0.0 use createDecipheriv() */
-    function createDecipher(algorithm: CipherCCMTypes, password: string | Buffer | NodeJS.TypedArray | DataView, options: CipherCCMOptions): DecipherCCM;
+    function createDecipher(
+        algorithm: CipherCCMTypes,
+        password: string | Buffer | NodeJS.TypedArray | DataView,
+        options: CipherCCMOptions,
+    ): DecipherCCM;
     /** @deprecated since v10.0.0 use createDecipheriv() */
-    function createDecipher(algorithm: CipherGCMTypes, password: string | Buffer | NodeJS.TypedArray | DataView, options?: CipherGCMOptions): DecipherGCM;
+    function createDecipher(
+        algorithm: CipherGCMTypes,
+        password: string | Buffer | NodeJS.TypedArray | DataView,
+        options?: CipherGCMOptions,
+    ): DecipherGCM;
     /** @deprecated since v10.0.0 use createDecipheriv() */
-    function createDecipher(algorithm: string, password: string | Buffer | NodeJS.TypedArray | DataView, options?: stream.TransformOptions): Decipher;
+    function createDecipher(
+        algorithm: string,
+        password: string | Buffer | NodeJS.TypedArray | DataView,
+        options?: stream.TransformOptions,
+    ): Decipher;
 
     function createDecipheriv(
         algorithm: CipherCCMTypes,
@@ -107,12 +156,21 @@ declare module "crypto" {
         iv: string | Buffer | NodeJS.TypedArray | DataView,
         options?: CipherGCMOptions,
     ): DecipherGCM;
-    function createDecipheriv(algorithm: string, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options?: stream.TransformOptions): Decipher;
+    function createDecipheriv(
+        algorithm: string,
+        key: string | Buffer | NodeJS.TypedArray | DataView,
+        iv: string | Buffer | NodeJS.TypedArray | DataView,
+        options?: stream.TransformOptions,
+    ): Decipher;
 
     interface Decipher extends stream.Transform {
         update(data: Buffer | NodeJS.TypedArray | DataView): Buffer;
         update(data: string, input_encoding: HexBase64BinaryEncoding): Buffer;
-        update(data: Buffer | NodeJS.TypedArray | DataView, input_encoding: HexBase64BinaryEncoding | undefined, output_encoding: Utf8AsciiBinaryEncoding): string;
+        update(
+            data: Buffer | NodeJS.TypedArray | DataView,
+            input_encoding: HexBase64BinaryEncoding | undefined,
+            output_encoding: Utf8AsciiBinaryEncoding,
+        ): string;
         // second arg is ignored
         update(data: string, input_encoding: HexBase64BinaryEncoding, output_encoding: Utf8AsciiBinaryEncoding): string;
         final(): Buffer;
@@ -134,8 +192,11 @@ declare module "crypto" {
     interface Signer extends NodeJS.WritableStream {
         update(data: string | Buffer | NodeJS.TypedArray | DataView): Signer;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Signer;
-        sign(private_key: string | { key: string; passphrase?: string, padding?: number, saltLength?: number }): Buffer;
-        sign(private_key: string | { key: string; passphrase?: string, padding?: number, saltLength?: number }, output_format: HexBase64Latin1Encoding): string;
+        sign(private_key: string | { key: string; passphrase?: string; padding?: number; saltLength?: number }): Buffer;
+        sign(
+            private_key: string | { key: string; passphrase?: string; padding?: number; saltLength?: number },
+            output_format: HexBase64Latin1Encoding,
+        ): string;
     }
     function createVerify(algorith: string, options?: stream.WritableOptions): Verify;
     interface Verify extends NodeJS.WritableStream {
@@ -146,18 +207,37 @@ declare module "crypto" {
         // https://nodejs.org/api/crypto.html#crypto_verifier_verify_object_signature_signature_format
         // The signature field accepts a TypedArray type, but it is only available starting ES2017
     }
-    function createDiffieHellman(prime_length: number, generator?: number | Buffer | NodeJS.TypedArray | DataView): DiffieHellman;
+    function createDiffieHellman(
+        prime_length: number,
+        generator?: number | Buffer | NodeJS.TypedArray | DataView,
+    ): DiffieHellman;
     function createDiffieHellman(prime: Buffer | NodeJS.TypedArray | DataView): DiffieHellman;
     function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding): DiffieHellman;
-    function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding, generator: number | Buffer | NodeJS.TypedArray | DataView): DiffieHellman;
-    function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding, generator: string, generator_encoding: HexBase64Latin1Encoding): DiffieHellman;
+    function createDiffieHellman(
+        prime: string,
+        prime_encoding: HexBase64Latin1Encoding,
+        generator: number | Buffer | NodeJS.TypedArray | DataView,
+    ): DiffieHellman;
+    function createDiffieHellman(
+        prime: string,
+        prime_encoding: HexBase64Latin1Encoding,
+        generator: string,
+        generator_encoding: HexBase64Latin1Encoding,
+    ): DiffieHellman;
     interface DiffieHellman {
         generateKeys(): Buffer;
         generateKeys(encoding: HexBase64Latin1Encoding): string;
         computeSecret(other_public_key: Buffer | NodeJS.TypedArray | DataView): Buffer;
         computeSecret(other_public_key: string, input_encoding: HexBase64Latin1Encoding): Buffer;
-        computeSecret(other_public_key: Buffer | NodeJS.TypedArray | DataView, output_encoding: HexBase64Latin1Encoding): string;
-        computeSecret(other_public_key: string, input_encoding: HexBase64Latin1Encoding, output_encoding: HexBase64Latin1Encoding): string;
+        computeSecret(
+            other_public_key: Buffer | NodeJS.TypedArray | DataView,
+            output_encoding: HexBase64Latin1Encoding,
+        ): string;
+        computeSecret(
+            other_public_key: string,
+            input_encoding: HexBase64Latin1Encoding,
+            output_encoding: HexBase64Latin1Encoding,
+        ): string;
         getPrime(): Buffer;
         getPrime(encoding: HexBase64Latin1Encoding): string;
         getGenerator(): Buffer;
@@ -181,17 +261,39 @@ declare module "crypto" {
         digest: string,
         callback: (err: Error | null, derivedKey: Buffer) => any,
     ): void;
-    function pbkdf2Sync(password: string | Buffer | NodeJS.TypedArray | DataView, salt: string | Buffer | NodeJS.TypedArray | DataView, iterations: number, keylen: number, digest: string): Buffer;
+    function pbkdf2Sync(
+        password: string | Buffer | NodeJS.TypedArray | DataView,
+        salt: string | Buffer | NodeJS.TypedArray | DataView,
+        iterations: number,
+        keylen: number,
+        digest: string,
+    ): Buffer;
 
     function randomBytes(size: number): Buffer;
     function randomBytes(size: number, callback: (err: Error | null, buf: Buffer) => void): void;
     function pseudoRandomBytes(size: number): Buffer;
     function pseudoRandomBytes(size: number, callback: (err: Error | null, buf: Buffer) => void): void;
 
-    function randomFillSync<T extends Buffer | NodeJS.TypedArray | DataView>(buffer: T, offset?: number, size?: number): T;
-    function randomFill<T extends Buffer | NodeJS.TypedArray | DataView>(buffer: T, callback: (err: Error | null, buf: T) => void): void;
-    function randomFill<T extends Buffer | NodeJS.TypedArray | DataView>(buffer: T, offset: number, callback: (err: Error | null, buf: T) => void): void;
-    function randomFill<T extends Buffer | NodeJS.TypedArray | DataView>(buffer: T, offset: number, size: number, callback: (err: Error | null, buf: T) => void): void;
+    function randomFillSync<T extends Buffer | NodeJS.TypedArray | DataView>(
+        buffer: T,
+        offset?: number,
+        size?: number,
+    ): T;
+    function randomFill<T extends Buffer | NodeJS.TypedArray | DataView>(
+        buffer: T,
+        callback: (err: Error | null, buf: T) => void,
+    ): void;
+    function randomFill<T extends Buffer | NodeJS.TypedArray | DataView>(
+        buffer: T,
+        offset: number,
+        callback: (err: Error | null, buf: T) => void,
+    ): void;
+    function randomFill<T extends Buffer | NodeJS.TypedArray | DataView>(
+        buffer: T,
+        offset: number,
+        size: number,
+        callback: (err: Error | null, buf: T) => void,
+    ): void;
 
     interface ScryptOptions {
         N?: number;
@@ -202,7 +304,8 @@ declare module "crypto" {
     function scrypt(
         password: string | Buffer | NodeJS.TypedArray | DataView,
         salt: string | Buffer | NodeJS.TypedArray | DataView,
-        keylen: number, callback: (err: Error | null, derivedKey: Buffer) => void,
+        keylen: number,
+        callback: (err: Error | null, derivedKey: Buffer) => void,
     ): void;
     function scrypt(
         password: string | Buffer | NodeJS.TypedArray | DataView,
@@ -211,7 +314,12 @@ declare module "crypto" {
         options: ScryptOptions,
         callback: (err: Error | null, derivedKey: Buffer) => void,
     ): void;
-    function scryptSync(password: string | Buffer | NodeJS.TypedArray | DataView, salt: string | Buffer | NodeJS.TypedArray | DataView, keylen: number, options?: ScryptOptions): Buffer;
+    function scryptSync(
+        password: string | Buffer | NodeJS.TypedArray | DataView,
+        salt: string | Buffer | NodeJS.TypedArray | DataView,
+        keylen: number,
+        options?: ScryptOptions,
+    ): Buffer;
 
     interface RsaPublicKey {
         key: string;
@@ -235,15 +343,22 @@ declare module "crypto" {
             key: string | Buffer | NodeJS.TypedArray | DataView,
             curve: string,
             inputEncoding?: HexBase64Latin1Encoding,
-            outputEncoding?: "latin1" | "hex" | "base64",
-            format?: "uncompressed" | "compressed" | "hybrid",
+            outputEncoding?: 'latin1' | 'hex' | 'base64',
+            format?: 'uncompressed' | 'compressed' | 'hybrid',
         ): Buffer | string;
         generateKeys(): Buffer;
         generateKeys(encoding: HexBase64Latin1Encoding, format?: ECDHKeyFormat): string;
         computeSecret(other_public_key: Buffer | NodeJS.TypedArray | DataView): Buffer;
         computeSecret(other_public_key: string, input_encoding: HexBase64Latin1Encoding): Buffer;
-        computeSecret(other_public_key: Buffer | NodeJS.TypedArray | DataView, output_encoding: HexBase64Latin1Encoding): string;
-        computeSecret(other_public_key: string, input_encoding: HexBase64Latin1Encoding, output_encoding: HexBase64Latin1Encoding): string;
+        computeSecret(
+            other_public_key: Buffer | NodeJS.TypedArray | DataView,
+            output_encoding: HexBase64Latin1Encoding,
+        ): string;
+        computeSecret(
+            other_public_key: string,
+            input_encoding: HexBase64Latin1Encoding,
+            output_encoding: HexBase64Latin1Encoding,
+        ): string;
         getPrivateKey(): Buffer;
         getPrivateKey(encoding: HexBase64Latin1Encoding): string;
         getPublicKey(): Buffer;
@@ -252,7 +367,10 @@ declare module "crypto" {
         setPrivateKey(private_key: string, encoding: HexBase64Latin1Encoding): void;
     }
     function createECDH(curve_name: string): ECDH;
-    function timingSafeEqual(a: Buffer | NodeJS.TypedArray | DataView, b: Buffer | NodeJS.TypedArray | DataView): boolean;
+    function timingSafeEqual(
+        a: Buffer | NodeJS.TypedArray | DataView,
+        b: Buffer | NodeJS.TypedArray | DataView,
+    ): boolean;
     /** @deprecated since v10.0.0 */
     const DEFAULT_ENCODING: string;
 
@@ -323,50 +441,170 @@ declare module "crypto" {
         privateKey: T2;
     }
 
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
 
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
 
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
 
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
 
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
 
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
 
     namespace generateKeyPair {
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
 
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
 
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
     }
 }

--- a/types/node/v11/crypto.d.ts
+++ b/types/node/v11/crypto.d.ts
@@ -390,6 +390,9 @@ declare module 'crypto' {
     ): void;
 
     interface ScryptOptions {
+        cost?: number;
+        blockSize?: number;
+        parallelization?: number;
         N?: number;
         r?: number;
         p?: number;

--- a/types/node/v11/crypto.d.ts
+++ b/types/node/v11/crypto.d.ts
@@ -1,5 +1,5 @@
-declare module "crypto" {
-    import * as stream from "stream";
+declare module 'crypto' {
+    import * as stream from 'stream';
 
     interface Certificate {
         exportChallenge(spkac: BinaryLike): Buffer;
@@ -7,11 +7,12 @@ declare module "crypto" {
         verifySpkac(spkac: Binary): boolean;
     }
     const Certificate: {
-        new(): Certificate;
+        new (): Certificate;
         (): Certificate;
     };
 
-    namespace constants { // https://nodejs.org/dist/latest-v10.x/docs/api/crypto.html#crypto_crypto_constants
+    namespace constants {
+        // https://nodejs.org/dist/latest-v10.x/docs/api/crypto.html#crypto_crypto_constants
         const OPENSSL_VERSION_NUMBER: number;
 
         /** Applies multiple bug workarounds within OpenSSL. See https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_options.html for detail. */
@@ -112,11 +113,11 @@ declare module "crypto" {
     function createHash(algorithm: string, options?: stream.TransformOptions): Hash;
     function createHmac(algorithm: string, key: BinaryLike, options?: stream.TransformOptions): Hmac;
 
-    type Utf8AsciiLatin1Encoding = "utf8" | "ascii" | "latin1";
-    type HexBase64Latin1Encoding = "latin1" | "hex" | "base64";
-    type Utf8AsciiBinaryEncoding = "utf8" | "ascii" | "binary";
-    type HexBase64BinaryEncoding = "binary" | "base64" | "hex";
-    type ECDHKeyFormat = "compressed" | "uncompressed" | "hybrid";
+    type Utf8AsciiLatin1Encoding = 'utf8' | 'ascii' | 'latin1';
+    type HexBase64Latin1Encoding = 'latin1' | 'hex' | 'base64';
+    type Utf8AsciiBinaryEncoding = 'utf8' | 'ascii' | 'binary';
+    type HexBase64BinaryEncoding = 'binary' | 'base64' | 'hex';
+    type ECDHKeyFormat = 'compressed' | 'uncompressed' | 'hybrid';
 
     class Hash extends stream.Transform {
         private constructor();
@@ -176,16 +177,19 @@ declare module "crypto" {
         algorithm: CipherCCMTypes,
         key: CipherKey,
         iv: BinaryLike | null,
-        options: CipherCCMOptions
+        options: CipherCCMOptions,
     ): CipherCCM;
     function createCipheriv(
         algorithm: CipherGCMTypes,
         key: CipherKey,
         iv: BinaryLike | null,
-        options?: CipherGCMOptions
+        options?: CipherGCMOptions,
     ): CipherGCM;
     function createCipheriv(
-        algorithm: string, key: CipherKey, iv: BinaryLike | null, options?: stream.TransformOptions
+        algorithm: string,
+        key: CipherKey,
+        iv: BinaryLike | null,
+        options?: stream.TransformOptions,
     ): Cipher;
 
     class Cipher extends stream.Transform {
@@ -193,7 +197,11 @@ declare module "crypto" {
         update(data: BinaryLike): Buffer;
         update(data: string, input_encoding: Utf8AsciiBinaryEncoding): Buffer;
         update(data: Binary, input_encoding: undefined, output_encoding: HexBase64BinaryEncoding): string;
-        update(data: string, input_encoding: Utf8AsciiBinaryEncoding | undefined, output_encoding: HexBase64BinaryEncoding): string;
+        update(
+            data: string,
+            input_encoding: Utf8AsciiBinaryEncoding | undefined,
+            output_encoding: HexBase64BinaryEncoding,
+        ): string;
         final(): Buffer;
         final(output_encoding: string): string;
         setAutoPadding(auto_padding?: boolean): this;
@@ -227,14 +235,23 @@ declare module "crypto" {
         iv: BinaryLike | null,
         options?: CipherGCMOptions,
     ): DecipherGCM;
-    function createDecipheriv(algorithm: string, key: BinaryLike, iv: BinaryLike | null, options?: stream.TransformOptions): Decipher;
+    function createDecipheriv(
+        algorithm: string,
+        key: BinaryLike,
+        iv: BinaryLike | null,
+        options?: stream.TransformOptions,
+    ): Decipher;
 
     class Decipher extends stream.Transform {
         private constructor();
         update(data: Binary): Buffer;
         update(data: string, input_encoding: HexBase64BinaryEncoding): Buffer;
         update(data: Binary, input_encoding: undefined, output_encoding: Utf8AsciiBinaryEncoding): string;
-        update(data: string, input_encoding: HexBase64BinaryEncoding | undefined, output_encoding: Utf8AsciiBinaryEncoding): string;
+        update(
+            data: string,
+            input_encoding: HexBase64BinaryEncoding | undefined,
+            output_encoding: Utf8AsciiBinaryEncoding,
+        ): string;
         final(): Buffer;
         final(output_encoding: string): string;
         setAutoPadding(auto_padding?: boolean): this;
@@ -299,8 +316,17 @@ declare module "crypto" {
     function createDiffieHellman(prime_length: number, generator?: number | Binary): DiffieHellman;
     function createDiffieHellman(prime: Binary): DiffieHellman;
     function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding): DiffieHellman;
-    function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding, generator: number | Binary): DiffieHellman;
-    function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding, generator: string, generator_encoding: HexBase64Latin1Encoding): DiffieHellman;
+    function createDiffieHellman(
+        prime: string,
+        prime_encoding: HexBase64Latin1Encoding,
+        generator: number | Binary,
+    ): DiffieHellman;
+    function createDiffieHellman(
+        prime: string,
+        prime_encoding: HexBase64Latin1Encoding,
+        generator: string,
+        generator_encoding: HexBase64Latin1Encoding,
+    ): DiffieHellman;
     class DiffieHellman {
         private constructor();
         generateKeys(): Buffer;
@@ -308,7 +334,11 @@ declare module "crypto" {
         computeSecret(other_public_key: Binary): Buffer;
         computeSecret(other_public_key: string, input_encoding: HexBase64Latin1Encoding): Buffer;
         computeSecret(other_public_key: Binary, output_encoding: HexBase64Latin1Encoding): string;
-        computeSecret(other_public_key: string, input_encoding: HexBase64Latin1Encoding, output_encoding: HexBase64Latin1Encoding): string;
+        computeSecret(
+            other_public_key: string,
+            input_encoding: HexBase64Latin1Encoding,
+            output_encoding: HexBase64Latin1Encoding,
+        ): string;
         getPrime(): Buffer;
         getPrime(encoding: HexBase64Latin1Encoding): string;
         getGenerator(): Buffer;
@@ -332,7 +362,13 @@ declare module "crypto" {
         digest: string,
         callback: (err: Error | null, derivedKey: Buffer) => any,
     ): void;
-    function pbkdf2Sync(password: BinaryLike, salt: BinaryLike, iterations: number, keylen: number, digest: string): Buffer;
+    function pbkdf2Sync(
+        password: BinaryLike,
+        salt: BinaryLike,
+        iterations: number,
+        keylen: number,
+        digest: string,
+    ): Buffer;
 
     function randomBytes(size: number): Buffer;
     function randomBytes(size: number, callback: (err: Error | null, buf: Buffer) => void): void;
@@ -341,8 +377,17 @@ declare module "crypto" {
 
     function randomFillSync<T extends Binary>(buffer: T, offset?: number, size?: number): T;
     function randomFill<T extends Binary>(buffer: T, callback: (err: Error | null, buf: T) => void): void;
-    function randomFill<T extends Binary>(buffer: T, offset: number, callback: (err: Error | null, buf: T) => void): void;
-    function randomFill<T extends Binary>(buffer: T, offset: number, size: number, callback: (err: Error | null, buf: T) => void): void;
+    function randomFill<T extends Binary>(
+        buffer: T,
+        offset: number,
+        callback: (err: Error | null, buf: T) => void,
+    ): void;
+    function randomFill<T extends Binary>(
+        buffer: T,
+        offset: number,
+        size: number,
+        callback: (err: Error | null, buf: T) => void,
+    ): void;
 
     interface ScryptOptions {
         N?: number;
@@ -353,7 +398,8 @@ declare module "crypto" {
     function scrypt(
         password: BinaryLike,
         salt: BinaryLike,
-        keylen: number, callback: (err: Error | null, derivedKey: Buffer) => void,
+        keylen: number,
+        callback: (err: Error | null, derivedKey: Buffer) => void,
     ): void;
     function scrypt(
         password: BinaryLike,
@@ -387,15 +433,19 @@ declare module "crypto" {
             key: BinaryLike,
             curve: string,
             inputEncoding?: HexBase64Latin1Encoding,
-            outputEncoding?: "latin1" | "hex" | "base64",
-            format?: "uncompressed" | "compressed" | "hybrid",
+            outputEncoding?: 'latin1' | 'hex' | 'base64',
+            format?: 'uncompressed' | 'compressed' | 'hybrid',
         ): Buffer | string;
         generateKeys(): Buffer;
         generateKeys(encoding: HexBase64Latin1Encoding, format?: ECDHKeyFormat): string;
         computeSecret(other_public_key: Binary): Buffer;
         computeSecret(other_public_key: string, input_encoding: HexBase64Latin1Encoding): Buffer;
         computeSecret(other_public_key: Binary, output_encoding: HexBase64Latin1Encoding): string;
-        computeSecret(other_public_key: string, input_encoding: HexBase64Latin1Encoding, output_encoding: HexBase64Latin1Encoding): string;
+        computeSecret(
+            other_public_key: string,
+            input_encoding: HexBase64Latin1Encoding,
+            output_encoding: HexBase64Latin1Encoding,
+        ): string;
         getPrivateKey(): Buffer;
         getPrivateKey(encoding: HexBase64Latin1Encoding): string;
         getPublicKey(): Buffer;
@@ -511,59 +561,191 @@ declare module "crypto" {
         privateKey: T2;
     }
 
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'rsa', options: RSAKeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'dsa', options: DSAKeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'ec', options: ECKeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairKeyObjectOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairKeyObjectOptions,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairKeyObjectOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairKeyObjectOptions,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairKeyObjectOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairKeyObjectOptions,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
     namespace generateKeyPair {
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(type: 'rsa', options: RSAKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
 
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(type: 'dsa', options: DSAKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
 
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "ec", options: ECKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(type: 'ec', options: ECKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
     }
 }

--- a/types/node/v11/test/crypto.ts
+++ b/types/node/v11/test/crypto.ts
@@ -298,16 +298,24 @@ import { promisify } from 'util';
     const salt: string | Buffer | Int32Array | DataView = Buffer.alloc(16);
     crypto.scrypt(pwd, salt, 64, (err: Error | null, derivedKey: Buffer): void => {});
     const opts: crypto.ScryptOptions = {
-        N: 16384,
-        r: 8,
-        p: 1,
+        cost: 16384,
+        blockSize: 8,
+        parallelization: 1,
         maxmem: 32 * 1024 * 1024,
     };
     crypto.scrypt(pwd, salt, 64, opts, (err: Error | null, derivedKey: Buffer): void => {});
     crypto.scrypt(pwd, salt, 64, { maxmem: 16 * 1024 * 1024 }, (err: Error | null, derivedKey: Buffer): void => {});
-    let buf: Buffer = crypto.scryptSync(pwd, salt, 64);
-    buf = crypto.scryptSync(pwd, salt, 64, opts);
-    buf = crypto.scryptSync(pwd, salt, 64, { N: 1024 });
+    crypto.scryptSync(pwd, salt, 64);
+    crypto.scryptSync(pwd, salt, 64, opts);
+    crypto.scryptSync(pwd, salt, 64, { N: 1024 });
+    const optsWithAliases: crypto.ScryptOptions = {
+        N: opts.cost,
+        r: opts.blockSize,
+        p: opts.parallelization,
+        maxmem: opts.maxmem,
+    };
+    crypto.scrypt(pwd, salt, 64, optsWithAliases, (err: Error | null, derivedKey: Buffer): void => {});
+    crypto.scryptSync(pwd, salt, 64, optsWithAliases);
 }
 
 {

--- a/types/node/v11/test/crypto.ts
+++ b/types/node/v11/test/crypto.ts
@@ -9,20 +9,23 @@ import { promisify } from 'util';
 
 {
     // crypto_hash_buffer_test
-    const hashResult: string = crypto.createHash('md5')
-        .update(new Buffer('world')).digest('hex');
+    const hashResult: string = crypto.createHash('md5').update(new Buffer('world')).digest('hex');
 }
 
 {
     // crypto_hash_dataview_test
-    const hashResult: string = crypto.createHash('md5')
-        .update(new DataView(new Buffer('world').buffer)).digest('hex');
+    const hashResult: string = crypto
+        .createHash('md5')
+        .update(new DataView(new Buffer('world').buffer))
+        .digest('hex');
 }
 
 {
     // crypto_hash_int8array_test
-    const hashResult: string = crypto.createHash('md5')
-        .update(new Int8Array(new Buffer('world').buffer)).digest('hex');
+    const hashResult: string = crypto
+        .createHash('md5')
+        .update(new Int8Array(new Buffer('world').buffer))
+        .digest('hex');
 }
 
 {
@@ -32,20 +35,23 @@ import { promisify } from 'util';
 
 {
     // crypto_hmac_buffer_test
-    const hmacResult: string = crypto.createHmac('md5', 'hello')
-        .update(new Buffer('world')).digest('hex');
+    const hmacResult: string = crypto.createHmac('md5', 'hello').update(new Buffer('world')).digest('hex');
 }
 
 {
     // crypto_hmac_dataview_test
-    const hmacResult: string = crypto.createHmac('md5', 'hello')
-        .update(new DataView(new Buffer('world').buffer)).digest('hex');
+    const hmacResult: string = crypto
+        .createHmac('md5', 'hello')
+        .update(new DataView(new Buffer('world').buffer))
+        .digest('hex');
 }
 
 {
     // crypto_hmac_int8array_test
-    const hmacResult: string = crypto.createHmac('md5', 'hello')
-        .update(new Int8Array(new Buffer('world').buffer)).digest('hex');
+    const hmacResult: string = crypto
+        .createHmac('md5', 'hello')
+        .update(new Int8Array(new Buffer('world').buffer))
+        .digest('hex');
 }
 
 {
@@ -58,14 +64,14 @@ import { promisify } from 'util';
 {
     // crypto_cipher_decipher_string_test
     const key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
-    const clearText = "This is the clear text.";
-    const cipher: crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
-    let cipherText: string = cipher.update(clearText, "utf8", "hex");
-    cipherText += cipher.final("hex");
+    const clearText = 'This is the clear text.';
+    const cipher: crypto.Cipher = crypto.createCipher('aes-128-ecb', key);
+    let cipherText: string = cipher.update(clearText, 'utf8', 'hex');
+    cipherText += cipher.final('hex');
 
-    const decipher: crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
-    let clearText2: string = decipher.update(cipherText, "hex", "utf8");
-    clearText2 += decipher.final("utf8");
+    const decipher: crypto.Decipher = crypto.createDecipher('aes-128-ecb', key);
+    let clearText2: string = decipher.update(cipherText, 'hex', 'utf8');
+    clearText2 += decipher.final('utf8');
 
     assert.equal(clearText2, clearText);
 }
@@ -74,14 +80,14 @@ import { promisify } from 'util';
     // crypto_cipher_decipher_buffer_test
     const key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
     const clearText: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4]);
-    const cipher: crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
+    const cipher: crypto.Cipher = crypto.createCipher('aes-128-ecb', key);
     const cipherBuffers: Buffer[] = [];
     cipherBuffers.push(cipher.update(clearText));
     cipherBuffers.push(cipher.final());
 
     const cipherText: Buffer = Buffer.concat(cipherBuffers);
 
-    const decipher: crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
+    const decipher: crypto.Decipher = crypto.createDecipher('aes-128-ecb', key);
     const decipherBuffers: Buffer[] = [];
     decipherBuffers.push(decipher.update(cipherText));
     decipherBuffers.push(decipher.final());
@@ -95,14 +101,14 @@ import { promisify } from 'util';
     // crypto_cipher_decipher_dataview_test
     const key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
     const clearText: DataView = new DataView(new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4]).buffer);
-    const cipher: crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
+    const cipher: crypto.Cipher = crypto.createCipher('aes-128-ecb', key);
     const cipherBuffers: Buffer[] = [];
     cipherBuffers.push(cipher.update(clearText));
     cipherBuffers.push(cipher.final());
 
     const cipherText: DataView = new DataView(Buffer.concat(cipherBuffers).buffer);
 
-    const decipher: crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
+    const decipher: crypto.Decipher = crypto.createDecipher('aes-128-ecb', key);
     const decipherBuffers: Buffer[] = [];
     decipherBuffers.push(decipher.update(cipherText));
     decipherBuffers.push(decipher.final());
@@ -118,22 +124,22 @@ import { promisify } from 'util';
     const aad = Buffer.from('0123456789', 'hex');
 
     const cipher = crypto.createCipheriv('aes-192-ccm', key, nonce, {
-        authTagLength: 16
+        authTagLength: 16,
     });
     const plaintext = 'Hello world';
     cipher.setAAD(aad, {
-        plaintextLength: Buffer.byteLength(plaintext)
+        plaintextLength: Buffer.byteLength(plaintext),
     });
     const ciphertext = cipher.update(plaintext, 'utf8');
     cipher.final();
     const tag = cipher.getAuthTag();
 
     const decipher = crypto.createDecipheriv('aes-192-ccm', key, nonce, {
-        authTagLength: 16
+        authTagLength: 16,
     });
     decipher.setAuthTag(tag);
     decipher.setAAD(aad, {
-        plaintextLength: ciphertext.length
+        plaintextLength: ciphertext.length,
     });
     const receivedPlaintext: string = decipher.update(ciphertext, undefined, 'utf8');
     decipher.final();
@@ -147,7 +153,7 @@ import { promisify } from 'util';
     const cipher = crypto.createCipheriv('aes-192-gcm', key, nonce);
     const plaintext = 'Hello world';
     cipher.setAAD(aad, {
-        plaintextLength: Buffer.byteLength(plaintext)
+        plaintextLength: Buffer.byteLength(plaintext),
     });
     const ciphertext = cipher.update(plaintext, 'utf8');
     cipher.final();
@@ -156,7 +162,7 @@ import { promisify } from 'util';
     const decipher = crypto.createDecipheriv('aes-192-gcm', key, nonce);
     decipher.setAuthTag(tag);
     decipher.setAAD(aad, {
-        plaintextLength: ciphertext.length
+        plaintextLength: ciphertext.length,
     });
     const receivedPlaintext: string = decipher.update(ciphertext, undefined, 'utf8');
     decipher.final();
@@ -208,7 +214,6 @@ import { promisify } from 'util';
     // let arr1: Uint8Array = Uint8Array.of(1, 0, 2, 0, 3, 0, 4, 0);
     // let arr2: Uint16Array = Uint16Array.of(1, 2, 3, 4);
     // let arr3: Uint32Array = Uint8ClampedArray.of(131073, 262147);
-
     // assert(crypto.timingSafeEqual(arr1, arr2)); // binary same
     // assert(crypto.timingSafeEqual(arr1, arr3)); // binary same
 }
@@ -219,7 +224,6 @@ import { promisify } from 'util';
     // let arr1: Uint8Array = Uint8Array.of(1, 2, 3, 4);
     // let arr2: Uint16Array = Uint16Array.of(1, 2, 3, 4);
     // let arr3: Uint32Array = Uint8ClampedArray.of(1, 2, 3, 4);
-
     // assert(!crypto.timingSafeEqual(arr1, arr2)); // dumps core
     // assert(!crypto.timingSafeEqual(arr1, arr3)); // dumps core
 }
@@ -297,7 +301,7 @@ import { promisify } from 'util';
         N: 16384,
         r: 8,
         p: 1,
-        maxmem: 32 * 1024 * 1024
+        maxmem: 32 * 1024 * 1024,
     };
     crypto.scrypt(pwd, salt, 64, opts, (err: Error | null, derivedKey: Buffer): void => {});
     crypto.scrypt(pwd, salt, 64, { maxmem: 16 * 1024 * 1024 }, (err: Error | null, derivedKey: Buffer): void => {});
@@ -307,16 +311,16 @@ import { promisify } from 'util';
 }
 
 {
-    let key: string | Buffer = Buffer.from("buf");
-    const curve = "secp256k1";
+    let key: string | Buffer = Buffer.from('buf');
+    const curve = 'secp256k1';
     let ret: string | Buffer = crypto.ECDH.convertKey(key, curve);
-    key = "0xfff";
+    key = '0xfff';
     ret = crypto.ECDH.convertKey(key, curve);
-    ret = crypto.ECDH.convertKey(key, curve, "hex");
-    ret = crypto.ECDH.convertKey(key, curve, "hex", "hex");
-    ret = crypto.ECDH.convertKey(key, curve, "hex", "hex", "uncompressed");
-    ret = crypto.ECDH.convertKey(key, curve, "hex", "hex", "compressed");
-    ret = crypto.ECDH.convertKey(key, curve, "hex", "hex", "hybrid");
+    ret = crypto.ECDH.convertKey(key, curve, 'hex');
+    ret = crypto.ECDH.convertKey(key, curve, 'hex', 'hex');
+    ret = crypto.ECDH.convertKey(key, curve, 'hex', 'hex', 'uncompressed');
+    ret = crypto.ECDH.convertKey(key, curve, 'hex', 'hex', 'compressed');
+    ret = crypto.ECDH.convertKey(key, curve, 'hex', 'hex', 'hybrid');
 }
 
 {
@@ -374,48 +378,60 @@ import { promisify } from 'util';
 }
 
 {
-    crypto.generateKeyPair('rsa', {
-        modulusLength: 123,
-        publicKeyEncoding: {
-            format: 'der',
-            type: 'pkcs1',
+    crypto.generateKeyPair(
+        'rsa',
+        {
+            modulusLength: 123,
+            publicKeyEncoding: {
+                format: 'der',
+                type: 'pkcs1',
+            },
+            privateKeyEncoding: {
+                cipher: 'some-cipher',
+                format: 'pem',
+                passphrase: 'secret',
+                type: 'pkcs8',
+            },
         },
-        privateKeyEncoding: {
-            cipher: 'some-cipher',
-            format: 'pem',
-            passphrase: 'secret',
-            type: 'pkcs8',
-        },
-    }, (err: NodeJS.ErrnoException | null, publicKey: Buffer, privateKey: string) => {});
+        (err: NodeJS.ErrnoException | null, publicKey: Buffer, privateKey: string) => {},
+    );
 
-    crypto.generateKeyPair('dsa', {
-        modulusLength: 123,
-        divisorLength: 123,
-        publicKeyEncoding: {
-            format: 'pem',
-            type: 'spki',
+    crypto.generateKeyPair(
+        'dsa',
+        {
+            modulusLength: 123,
+            divisorLength: 123,
+            publicKeyEncoding: {
+                format: 'pem',
+                type: 'spki',
+            },
+            privateKeyEncoding: {
+                cipher: 'some-cipher',
+                format: 'der',
+                passphrase: 'secret',
+                type: 'pkcs8',
+            },
         },
-        privateKeyEncoding: {
-            cipher: 'some-cipher',
-            format: 'der',
-            passphrase: 'secret',
-            type: 'pkcs8',
-        },
-    }, (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: Buffer) => {});
+        (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: Buffer) => {},
+    );
 
-    crypto.generateKeyPair('ec', {
-        namedCurve: 'curve',
-        publicKeyEncoding: {
-            format: 'pem',
-            type: 'pkcs1',
+    crypto.generateKeyPair(
+        'ec',
+        {
+            namedCurve: 'curve',
+            publicKeyEncoding: {
+                format: 'pem',
+                type: 'pkcs1',
+            },
+            privateKeyEncoding: {
+                cipher: 'some-cipher',
+                format: 'pem',
+                passphrase: 'secret',
+                type: 'pkcs8',
+            },
         },
-        privateKeyEncoding: {
-            cipher: 'some-cipher',
-            format: 'pem',
-            passphrase: 'secret',
-            type: 'pkcs8',
-        },
-    }, (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {});
+        (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {},
+    );
 }
 
 {
@@ -488,7 +504,7 @@ import { promisify } from 'util';
 
 {
     const { privateKey, publicKey } = crypto.generateKeyPairSync('ec', {
-        namedCurve: 'sect239k1'
+        namedCurve: 'sect239k1',
     });
 
     const sign: crypto.Signer = crypto.createSign('SHA256');
@@ -499,7 +515,7 @@ import { promisify } from 'util';
     const verify: crypto.Verify = crypto.createVerify('SHA256');
     verify.write('some data to sign');
     verify.end();
-    verify.verify(publicKey, signature);    // $ExpectType boolean
+    verify.verify(publicKey, signature); // $ExpectType boolean
 
     // ensure that instanceof works
     verify instanceof crypto.Verify;
@@ -519,7 +535,7 @@ import { promisify } from 'util';
     const verify: crypto.Verify = crypto.createVerify('SHA256');
     verify.update('some data to sign');
     verify.end();
-    verify.verify(publicKey, signature);    // $ExpectType boolean
+    verify.verify(publicKey, signature); // $ExpectType boolean
 }
 
 {

--- a/types/node/v12/crypto.d.ts
+++ b/types/node/v12/crypto.d.ts
@@ -1,5 +1,5 @@
-declare module "crypto" {
-    import * as stream from "stream";
+declare module 'crypto' {
+    import * as stream from 'stream';
 
     interface Certificate {
         exportChallenge(spkac: BinaryLike): Buffer;
@@ -7,11 +7,12 @@ declare module "crypto" {
         verifySpkac(spkac: NodeJS.ArrayBufferView): boolean;
     }
     const Certificate: {
-        new(): Certificate;
+        new (): Certificate;
         (): Certificate;
     };
 
-    namespace constants { // https://nodejs.org/dist/latest-v10.x/docs/api/crypto.html#crypto_crypto_constants
+    namespace constants {
+        // https://nodejs.org/dist/latest-v10.x/docs/api/crypto.html#crypto_crypto_constants
         const OPENSSL_VERSION_NUMBER: number;
 
         /** Applies multiple bug workarounds within OpenSSL. See https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_options.html for detail. */
@@ -120,11 +121,11 @@ declare module "crypto" {
     function createHash(algorithm: string, options?: HashOptions): Hash;
     function createHmac(algorithm: string, key: BinaryLike, options?: stream.TransformOptions): Hmac;
 
-    type Utf8AsciiLatin1Encoding = "utf8" | "ascii" | "latin1";
-    type HexBase64Latin1Encoding = "latin1" | "hex" | "base64";
-    type Utf8AsciiBinaryEncoding = "utf8" | "ascii" | "binary";
-    type HexBase64BinaryEncoding = "binary" | "base64" | "hex";
-    type ECDHKeyFormat = "compressed" | "uncompressed" | "hybrid";
+    type Utf8AsciiLatin1Encoding = 'utf8' | 'ascii' | 'latin1';
+    type HexBase64Latin1Encoding = 'latin1' | 'hex' | 'base64';
+    type Utf8AsciiBinaryEncoding = 'utf8' | 'ascii' | 'binary';
+    type HexBase64BinaryEncoding = 'binary' | 'base64' | 'hex';
+    type ECDHKeyFormat = 'compressed' | 'uncompressed' | 'hybrid';
 
     class Hash extends stream.Transform {
         private constructor();
@@ -188,24 +189,35 @@ declare module "crypto" {
         algorithm: CipherCCMTypes,
         key: CipherKey,
         iv: BinaryLike | null,
-        options: CipherCCMOptions
+        options: CipherCCMOptions,
     ): CipherCCM;
     function createCipheriv(
         algorithm: CipherGCMTypes,
         key: CipherKey,
         iv: BinaryLike | null,
-        options?: CipherGCMOptions
+        options?: CipherGCMOptions,
     ): CipherGCM;
     function createCipheriv(
-        algorithm: string, key: CipherKey, iv: BinaryLike | null, options?: stream.TransformOptions
+        algorithm: string,
+        key: CipherKey,
+        iv: BinaryLike | null,
+        options?: stream.TransformOptions,
     ): Cipher;
 
     class Cipher extends stream.Transform {
         private constructor();
         update(data: BinaryLike): Buffer;
         update(data: string, input_encoding: Utf8AsciiBinaryEncoding): Buffer;
-        update(data: NodeJS.ArrayBufferView, input_encoding: undefined, output_encoding: HexBase64BinaryEncoding): string;
-        update(data: string, input_encoding: Utf8AsciiBinaryEncoding | undefined, output_encoding: HexBase64BinaryEncoding): string;
+        update(
+            data: NodeJS.ArrayBufferView,
+            input_encoding: undefined,
+            output_encoding: HexBase64BinaryEncoding,
+        ): string;
+        update(
+            data: string,
+            input_encoding: Utf8AsciiBinaryEncoding | undefined,
+            output_encoding: HexBase64BinaryEncoding,
+        ): string;
         final(): Buffer;
         final(output_encoding: string): string;
         setAutoPadding(auto_padding?: boolean): this;
@@ -239,14 +251,27 @@ declare module "crypto" {
         iv: BinaryLike | null,
         options?: CipherGCMOptions,
     ): DecipherGCM;
-    function createDecipheriv(algorithm: string, key: BinaryLike, iv: BinaryLike | null, options?: stream.TransformOptions): Decipher;
+    function createDecipheriv(
+        algorithm: string,
+        key: BinaryLike,
+        iv: BinaryLike | null,
+        options?: stream.TransformOptions,
+    ): Decipher;
 
     class Decipher extends stream.Transform {
         private constructor();
         update(data: NodeJS.ArrayBufferView): Buffer;
         update(data: string, input_encoding: HexBase64BinaryEncoding): Buffer;
-        update(data: NodeJS.ArrayBufferView, input_encoding: HexBase64BinaryEncoding | undefined, output_encoding: Utf8AsciiBinaryEncoding): string;
-        update(data: string, input_encoding: HexBase64BinaryEncoding | undefined, output_encoding: Utf8AsciiBinaryEncoding): string;
+        update(
+            data: NodeJS.ArrayBufferView,
+            input_encoding: HexBase64BinaryEncoding | undefined,
+            output_encoding: Utf8AsciiBinaryEncoding,
+        ): string;
+        update(
+            data: string,
+            input_encoding: HexBase64BinaryEncoding | undefined,
+            output_encoding: Utf8AsciiBinaryEncoding,
+        ): string;
         final(): Buffer;
         final(output_encoding: string): string;
         setAutoPadding(auto_padding?: boolean): this;
@@ -292,13 +317,11 @@ declare module "crypto" {
         dsaEncoding?: DSAEncoding;
     }
 
-    interface SignPrivateKeyInput extends PrivateKeyInput, SigningOptions {
-    }
+    interface SignPrivateKeyInput extends PrivateKeyInput, SigningOptions {}
     interface SignKeyObjectInput extends SigningOptions {
         key: KeyObject;
     }
-    interface VerifyPublicKeyInput extends PublicKeyInput, SigningOptions {
-    }
+    interface VerifyPublicKeyInput extends PublicKeyInput, SigningOptions {}
     interface VerifyKeyObjectInput extends SigningOptions {
         key: KeyObject;
     }
@@ -311,7 +334,10 @@ declare module "crypto" {
         update(data: BinaryLike): Signer;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Signer;
         sign(private_key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput): Buffer;
-        sign(private_key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput, output_format: HexBase64Latin1Encoding): string;
+        sign(
+            private_key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput,
+            output_format: HexBase64Latin1Encoding,
+        ): string;
     }
 
     function createVerify(algorithm: string, options?: stream.WritableOptions): Verify;
@@ -320,16 +346,32 @@ declare module "crypto" {
 
         update(data: BinaryLike): Verify;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Verify;
-        verify(object: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput, signature: NodeJS.ArrayBufferView): boolean;
-        verify(object: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput, signature: string, signature_format?: HexBase64Latin1Encoding): boolean;
+        verify(
+            object: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput,
+            signature: NodeJS.ArrayBufferView,
+        ): boolean;
+        verify(
+            object: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput,
+            signature: string,
+            signature_format?: HexBase64Latin1Encoding,
+        ): boolean;
         // https://nodejs.org/api/crypto.html#crypto_verifier_verify_object_signature_signature_format
         // The signature field accepts a TypedArray type, but it is only available starting ES2017
     }
     function createDiffieHellman(prime_length: number, generator?: number | NodeJS.ArrayBufferView): DiffieHellman;
     function createDiffieHellman(prime: NodeJS.ArrayBufferView): DiffieHellman;
     function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding): DiffieHellman;
-    function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding, generator: number | NodeJS.ArrayBufferView): DiffieHellman;
-    function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding, generator: string, generator_encoding: HexBase64Latin1Encoding): DiffieHellman;
+    function createDiffieHellman(
+        prime: string,
+        prime_encoding: HexBase64Latin1Encoding,
+        generator: number | NodeJS.ArrayBufferView,
+    ): DiffieHellman;
+    function createDiffieHellman(
+        prime: string,
+        prime_encoding: HexBase64Latin1Encoding,
+        generator: string,
+        generator_encoding: HexBase64Latin1Encoding,
+    ): DiffieHellman;
     class DiffieHellman {
         private constructor();
         generateKeys(): Buffer;
@@ -337,7 +379,11 @@ declare module "crypto" {
         computeSecret(other_public_key: NodeJS.ArrayBufferView): Buffer;
         computeSecret(other_public_key: string, input_encoding: HexBase64Latin1Encoding): Buffer;
         computeSecret(other_public_key: NodeJS.ArrayBufferView, output_encoding: HexBase64Latin1Encoding): string;
-        computeSecret(other_public_key: string, input_encoding: HexBase64Latin1Encoding, output_encoding: HexBase64Latin1Encoding): string;
+        computeSecret(
+            other_public_key: string,
+            input_encoding: HexBase64Latin1Encoding,
+            output_encoding: HexBase64Latin1Encoding,
+        ): string;
         getPrime(): Buffer;
         getPrime(encoding: HexBase64Latin1Encoding): string;
         getGenerator(): Buffer;
@@ -361,7 +407,13 @@ declare module "crypto" {
         digest: string,
         callback: (err: Error | null, derivedKey: Buffer) => any,
     ): void;
-    function pbkdf2Sync(password: BinaryLike, salt: BinaryLike, iterations: number, keylen: number, digest: string): Buffer;
+    function pbkdf2Sync(
+        password: BinaryLike,
+        salt: BinaryLike,
+        iterations: number,
+        keylen: number,
+        digest: string,
+    ): Buffer;
 
     function randomBytes(size: number): Buffer;
     function randomBytes(size: number, callback: (err: Error | null, buf: Buffer) => void): void;
@@ -374,9 +426,21 @@ declare module "crypto" {
     function randomInt(min: number, max: number, callback: (err: Error | null, value: number) => void): void;
 
     function randomFillSync<T extends NodeJS.ArrayBufferView>(buffer: T, offset?: number, size?: number): T;
-    function randomFill<T extends NodeJS.ArrayBufferView>(buffer: T, callback: (err: Error | null, buf: T) => void): void;
-    function randomFill<T extends NodeJS.ArrayBufferView>(buffer: T, offset: number, callback: (err: Error | null, buf: T) => void): void;
-    function randomFill<T extends NodeJS.ArrayBufferView>(buffer: T, offset: number, size: number, callback: (err: Error | null, buf: T) => void): void;
+    function randomFill<T extends NodeJS.ArrayBufferView>(
+        buffer: T,
+        callback: (err: Error | null, buf: T) => void,
+    ): void;
+    function randomFill<T extends NodeJS.ArrayBufferView>(
+        buffer: T,
+        offset: number,
+        callback: (err: Error | null, buf: T) => void,
+    ): void;
+    function randomFill<T extends NodeJS.ArrayBufferView>(
+        buffer: T,
+        offset: number,
+        size: number,
+        callback: (err: Error | null, buf: T) => void,
+    ): void;
 
     interface ScryptOptions {
         N?: number;
@@ -387,7 +451,8 @@ declare module "crypto" {
     function scrypt(
         password: BinaryLike,
         salt: BinaryLike,
-        keylen: number, callback: (err: Error | null, derivedKey: Buffer) => void,
+        keylen: number,
+        callback: (err: Error | null, derivedKey: Buffer) => void,
     ): void;
     function scrypt(
         password: BinaryLike,
@@ -426,15 +491,19 @@ declare module "crypto" {
             key: BinaryLike,
             curve: string,
             inputEncoding?: HexBase64Latin1Encoding,
-            outputEncoding?: "latin1" | "hex" | "base64",
-            format?: "uncompressed" | "compressed" | "hybrid",
+            outputEncoding?: 'latin1' | 'hex' | 'base64',
+            format?: 'uncompressed' | 'compressed' | 'hybrid',
         ): Buffer | string;
         generateKeys(): Buffer;
         generateKeys(encoding: HexBase64Latin1Encoding, format?: ECDHKeyFormat): string;
         computeSecret(other_public_key: NodeJS.ArrayBufferView): Buffer;
         computeSecret(other_public_key: string, input_encoding: HexBase64Latin1Encoding): Buffer;
         computeSecret(other_public_key: NodeJS.ArrayBufferView, output_encoding: HexBase64Latin1Encoding): string;
-        computeSecret(other_public_key: string, input_encoding: HexBase64Latin1Encoding, output_encoding: HexBase64Latin1Encoding): string;
+        computeSecret(
+            other_public_key: string,
+            input_encoding: HexBase64Latin1Encoding,
+            output_encoding: HexBase64Latin1Encoding,
+        ): string;
         getPrivateKey(): Buffer;
         getPrivateKey(encoding: HexBase64Latin1Encoding): string;
         getPublicKey(): Buffer;
@@ -474,15 +543,15 @@ declare module "crypto" {
     }
 
     interface X25519KeyPairKeyObjectOptions {
-       /**
-        * No options.
-        */
+        /**
+         * No options.
+         */
     }
 
     interface X448KeyPairKeyObjectOptions {
-       /**
-        * No options.
-        */
+        /**
+         * No options.
+         */
     }
 
     interface ECKeyPairKeyObjectOptions {
@@ -614,132 +683,446 @@ declare module "crypto" {
         privateKey: T2;
     }
 
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'rsa', options: RSAKeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'dsa', options: DSAKeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'ec', options: ECKeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPairSync(type: 'ed25519', options: ED25519KeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'ed25519', options: ED25519KeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'ed25519', options: ED25519KeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'ed25519', options: ED25519KeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'ed25519',
+        options: ED25519KeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'ed25519',
+        options: ED25519KeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'ed25519',
+        options: ED25519KeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'ed25519',
+        options: ED25519KeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'ed25519', options?: ED25519KeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPairSync(type: 'ed448', options: ED448KeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'ed448', options: ED448KeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'ed448', options: ED448KeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'ed448', options: ED448KeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'ed448',
+        options: ED448KeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'ed448',
+        options: ED448KeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'ed448',
+        options: ED448KeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'ed448',
+        options: ED448KeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'ed448', options?: ED448KeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPairSync(type: 'x25519', options: X25519KeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'x25519', options: X25519KeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'x25519', options: X25519KeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'x25519', options: X25519KeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'x25519',
+        options: X25519KeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'x25519',
+        options: X25519KeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'x25519',
+        options: X25519KeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'x25519',
+        options: X25519KeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'x25519', options?: X25519KeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPairSync(type: 'x448', options: X448KeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'x448', options: X448KeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'x448', options: X448KeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'x448', options: X448KeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'x448',
+        options: X448KeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'x448',
+        options: X448KeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'x448',
+        options: X448KeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'x448',
+        options: X448KeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'x448', options?: X448KeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairKeyObjectOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairKeyObjectOptions,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairKeyObjectOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairKeyObjectOptions,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairKeyObjectOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairKeyObjectOptions,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
-    function generateKeyPair(type: 'ed25519', options: ED25519KeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ed25519', options: ED25519KeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'ed25519', options: ED25519KeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ed25519', options: ED25519KeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'ed25519', options: ED25519KeyPairKeyObjectOptions | undefined, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'ed25519',
+        options: ED25519KeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ed25519',
+        options: ED25519KeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ed25519',
+        options: ED25519KeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ed25519',
+        options: ED25519KeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ed25519',
+        options: ED25519KeyPairKeyObjectOptions | undefined,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
-    function generateKeyPair(type: 'ed448', options: ED448KeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ed448', options: ED448KeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'ed448', options: ED448KeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ed448', options: ED448KeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'ed448', options: ED448KeyPairKeyObjectOptions | undefined, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'ed448',
+        options: ED448KeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ed448',
+        options: ED448KeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ed448',
+        options: ED448KeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ed448',
+        options: ED448KeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ed448',
+        options: ED448KeyPairKeyObjectOptions | undefined,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
-    function generateKeyPair(type: 'x25519', options: X25519KeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'x25519', options: X25519KeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'x25519', options: X25519KeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'x25519', options: X25519KeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'x25519', options: X25519KeyPairKeyObjectOptions | undefined, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'x25519',
+        options: X25519KeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'x25519',
+        options: X25519KeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'x25519',
+        options: X25519KeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'x25519',
+        options: X25519KeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'x25519',
+        options: X25519KeyPairKeyObjectOptions | undefined,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
-    function generateKeyPair(type: 'x448', options: X448KeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'x448', options: X448KeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'x448', options: X448KeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'x448', options: X448KeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'x448', options: X448KeyPairKeyObjectOptions | undefined, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'x448',
+        options: X448KeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'x448',
+        options: X448KeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'x448',
+        options: X448KeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'x448',
+        options: X448KeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'x448',
+        options: X448KeyPairKeyObjectOptions | undefined,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
     namespace generateKeyPair {
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(type: 'rsa', options: RSAKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
 
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(type: 'dsa', options: DSAKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
 
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "ec", options: ECKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(type: 'ec', options: ECKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
 
-        function __promisify__(type: "ed25519", options: ED25519KeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "ed25519", options: ED25519KeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "ed25519", options: ED25519KeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "ed25519", options: ED25519KeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "ed25519", options?: ED25519KeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'ed25519',
+            options: ED25519KeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'ed25519',
+            options: ED25519KeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'ed25519',
+            options: ED25519KeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'ed25519',
+            options: ED25519KeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'ed25519',
+            options?: ED25519KeyPairKeyObjectOptions,
+        ): Promise<KeyPairKeyObjectResult>;
 
-        function __promisify__(type: "ed448", options: ED448KeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "ed448", options: ED448KeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "ed448", options: ED448KeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "ed448", options: ED448KeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "ed448", options?: ED448KeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'ed448',
+            options: ED448KeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'ed448',
+            options: ED448KeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'ed448',
+            options: ED448KeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'ed448',
+            options: ED448KeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(type: 'ed448', options?: ED448KeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
 
-        function __promisify__(type: "x25519", options: X25519KeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "x25519", options: X25519KeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "x25519", options: X25519KeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "x25519", options: X25519KeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "x25519", options?: X25519KeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'x25519',
+            options: X25519KeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'x25519',
+            options: X25519KeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'x25519',
+            options: X25519KeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'x25519',
+            options: X25519KeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'x25519',
+            options?: X25519KeyPairKeyObjectOptions,
+        ): Promise<KeyPairKeyObjectResult>;
 
-        function __promisify__(type: "x448", options: X448KeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "x448", options: X448KeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "x448", options: X448KeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "x448", options: X448KeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "x448", options?: X448KeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'x448',
+            options: X448KeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'x448',
+            options: X448KeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'x448',
+            options: X448KeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'x448',
+            options: X448KeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(type: 'x448', options?: X448KeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
     }
 
     /**
@@ -750,7 +1133,11 @@ declare module "crypto" {
      * If `key` is not a [`KeyObject`][], this function behaves as if `key` had been
      * passed to [`crypto.createPrivateKey()`][].
      */
-    function sign(algorithm: string | null | undefined, data: NodeJS.ArrayBufferView, key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput): Buffer;
+    function sign(
+        algorithm: string | null | undefined,
+        data: NodeJS.ArrayBufferView,
+        key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput,
+    ): Buffer;
 
     /**
      * Calculates and returns the signature for `data` using the given private key and
@@ -760,5 +1147,10 @@ declare module "crypto" {
      * If `key` is not a [`KeyObject`][], this function behaves as if `key` had been
      * passed to [`crypto.createPublicKey()`][].
      */
-    function verify(algorithm: string | null | undefined, data: NodeJS.ArrayBufferView, key: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput, signature: NodeJS.ArrayBufferView): Buffer;
+    function verify(
+        algorithm: string | null | undefined,
+        data: NodeJS.ArrayBufferView,
+        key: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput,
+        signature: NodeJS.ArrayBufferView,
+    ): Buffer;
 }

--- a/types/node/v12/crypto.d.ts
+++ b/types/node/v12/crypto.d.ts
@@ -443,6 +443,9 @@ declare module 'crypto' {
     ): void;
 
     interface ScryptOptions {
+        cost?: number;
+        blockSize?: number;
+        parallelization?: number;
         N?: number;
         r?: number;
         p?: number;

--- a/types/node/v12/test/crypto.ts
+++ b/types/node/v12/test/crypto.ts
@@ -326,16 +326,24 @@ import { promisify } from 'util';
     const salt: string | Buffer | Int32Array | DataView = Buffer.alloc(16);
     crypto.scrypt(pwd, salt, 64, (err: Error | null, derivedKey: Buffer): void => {});
     const opts: crypto.ScryptOptions = {
-        N: 16384,
-        r: 8,
-        p: 1,
+        cost: 16384,
+        blockSize: 8,
+        parallelization: 1,
         maxmem: 32 * 1024 * 1024,
     };
     crypto.scrypt(pwd, salt, 64, opts, (err: Error | null, derivedKey: Buffer): void => {});
     crypto.scrypt(pwd, salt, 64, { maxmem: 16 * 1024 * 1024 }, (err: Error | null, derivedKey: Buffer): void => {});
-    let buf: Buffer = crypto.scryptSync(pwd, salt, 64);
-    buf = crypto.scryptSync(pwd, salt, 64, opts);
-    buf = crypto.scryptSync(pwd, salt, 64, { N: 1024 });
+    crypto.scryptSync(pwd, salt, 64);
+    crypto.scryptSync(pwd, salt, 64, opts);
+    crypto.scryptSync(pwd, salt, 64, { N: 1024 });
+    const optsWithAliases: crypto.ScryptOptions = {
+        N: opts.cost,
+        r: opts.blockSize,
+        p: opts.parallelization,
+        maxmem: opts.maxmem,
+    };
+    crypto.scrypt(pwd, salt, 64, optsWithAliases, (err: Error | null, derivedKey: Buffer): void => {});
+    crypto.scryptSync(pwd, salt, 64, optsWithAliases);
 }
 
 {

--- a/types/node/v12/test/crypto.ts
+++ b/types/node/v12/test/crypto.ts
@@ -10,20 +10,23 @@ import { promisify } from 'util';
 
 {
     // crypto_hash_buffer_test
-    const hashResult: string = crypto.createHash('md5')
-        .update(new Buffer('world')).digest('hex');
+    const hashResult: string = crypto.createHash('md5').update(new Buffer('world')).digest('hex');
 }
 
 {
     // crypto_hash_dataview_test
-    const hashResult: string = crypto.createHash('md5')
-        .update(new DataView(new Buffer('world').buffer)).digest('hex');
+    const hashResult: string = crypto
+        .createHash('md5')
+        .update(new DataView(new Buffer('world').buffer))
+        .digest('hex');
 }
 
 {
     // crypto_hash_int8array_test
-    const hashResult: string = crypto.createHash('md5')
-        .update(new Int8Array(new Buffer('world').buffer)).digest('hex');
+    const hashResult: string = crypto
+        .createHash('md5')
+        .update(new Int8Array(new Buffer('world').buffer))
+        .digest('hex');
 }
 
 {
@@ -33,20 +36,23 @@ import { promisify } from 'util';
 
 {
     // crypto_hmac_buffer_test
-    const hmacResult: string = crypto.createHmac('md5', 'hello')
-        .update(new Buffer('world')).digest('hex');
+    const hmacResult: string = crypto.createHmac('md5', 'hello').update(new Buffer('world')).digest('hex');
 }
 
 {
     // crypto_hmac_dataview_test
-    const hmacResult: string = crypto.createHmac('md5', 'hello')
-        .update(new DataView(new Buffer('world').buffer)).digest('hex');
+    const hmacResult: string = crypto
+        .createHmac('md5', 'hello')
+        .update(new DataView(new Buffer('world').buffer))
+        .digest('hex');
 }
 
 {
     // crypto_hmac_int8array_test
-    const hmacResult: string = crypto.createHmac('md5', 'hello')
-        .update(new Int8Array(new Buffer('world').buffer)).digest('hex');
+    const hmacResult: string = crypto
+        .createHmac('md5', 'hello')
+        .update(new Int8Array(new Buffer('world').buffer))
+        .digest('hex');
 }
 
 {
@@ -59,14 +65,14 @@ import { promisify } from 'util';
 {
     // crypto_cipher_decipher_string_test
     const key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
-    const clearText = "This is the clear text.";
-    const cipher: crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
-    let cipherText: string = cipher.update(clearText, "utf8", "hex");
-    cipherText += cipher.final("hex");
+    const clearText = 'This is the clear text.';
+    const cipher: crypto.Cipher = crypto.createCipher('aes-128-ecb', key);
+    let cipherText: string = cipher.update(clearText, 'utf8', 'hex');
+    cipherText += cipher.final('hex');
 
-    const decipher: crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
-    let clearText2: string = decipher.update(cipherText, "hex", "utf8");
-    clearText2 += decipher.final("utf8");
+    const decipher: crypto.Decipher = crypto.createDecipher('aes-128-ecb', key);
+    let clearText2: string = decipher.update(cipherText, 'hex', 'utf8');
+    clearText2 += decipher.final('utf8');
 
     assert.equal(clearText2, clearText);
 }
@@ -75,14 +81,14 @@ import { promisify } from 'util';
     // crypto_cipher_decipher_buffer_test
     const key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
     const clearText: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4]);
-    const cipher: crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
+    const cipher: crypto.Cipher = crypto.createCipher('aes-128-ecb', key);
     const cipherBuffers: Buffer[] = [];
     cipherBuffers.push(cipher.update(clearText));
     cipherBuffers.push(cipher.final());
 
     const cipherText: Buffer = Buffer.concat(cipherBuffers);
 
-    const decipher: crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
+    const decipher: crypto.Decipher = crypto.createDecipher('aes-128-ecb', key);
     const decipherBuffers: Buffer[] = [];
     decipherBuffers.push(decipher.update(cipherText));
     decipherBuffers.push(decipher.final());
@@ -96,14 +102,14 @@ import { promisify } from 'util';
     // crypto_cipher_decipher_dataview_test
     const key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
     const clearText: DataView = new DataView(new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4]).buffer);
-    const cipher: crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
+    const cipher: crypto.Cipher = crypto.createCipher('aes-128-ecb', key);
     const cipherBuffers: Buffer[] = [];
     cipherBuffers.push(cipher.update(clearText));
     cipherBuffers.push(cipher.final());
 
     const cipherText: DataView = new DataView(Buffer.concat(cipherBuffers).buffer);
 
-    const decipher: crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
+    const decipher: crypto.Decipher = crypto.createDecipher('aes-128-ecb', key);
     const decipherBuffers: Buffer[] = [];
     decipherBuffers.push(decipher.update(cipherText));
     decipherBuffers.push(decipher.final());
@@ -119,22 +125,22 @@ import { promisify } from 'util';
     const aad = Buffer.from('0123456789', 'hex');
 
     const cipher = crypto.createCipheriv('aes-192-ccm', key, nonce, {
-        authTagLength: 16
+        authTagLength: 16,
     });
     const plaintext = 'Hello world';
     cipher.setAAD(aad, {
-        plaintextLength: Buffer.byteLength(plaintext)
+        plaintextLength: Buffer.byteLength(plaintext),
     });
     const ciphertext = cipher.update(plaintext, 'utf8');
     cipher.final();
     const tag = cipher.getAuthTag();
 
     const decipher = crypto.createDecipheriv('aes-192-ccm', key, nonce, {
-        authTagLength: 16
+        authTagLength: 16,
     });
     decipher.setAuthTag(tag);
     decipher.setAAD(aad, {
-        plaintextLength: ciphertext.length
+        plaintextLength: ciphertext.length,
     });
     const receivedPlaintext: string = decipher.update(ciphertext, undefined, 'utf8');
     decipher.final();
@@ -148,7 +154,7 @@ import { promisify } from 'util';
     const cipher = crypto.createCipheriv('aes-192-gcm', key, nonce);
     const plaintext = 'Hello world';
     cipher.setAAD(aad, {
-        plaintextLength: Buffer.byteLength(plaintext)
+        plaintextLength: Buffer.byteLength(plaintext),
     });
     const ciphertext = cipher.update(plaintext, 'utf8');
     cipher.final();
@@ -157,7 +163,7 @@ import { promisify } from 'util';
     const decipher = crypto.createDecipheriv('aes-192-gcm', key, nonce);
     decipher.setAuthTag(tag);
     decipher.setAAD(aad, {
-        plaintextLength: ciphertext.length
+        plaintextLength: ciphertext.length,
     });
     const receivedPlaintext: string = decipher.update(ciphertext, undefined, 'utf8');
     decipher.final();
@@ -169,22 +175,22 @@ import { promisify } from 'util';
     const aad = Buffer.from('0123456789', 'hex');
 
     const cipher = crypto.createCipheriv('aes-192-ccm', key, nonce, {
-        authTagLength: 16
+        authTagLength: 16,
     });
     const plaintext = 'Hello world';
     cipher.setAAD(aad, {
-        plaintextLength: Buffer.byteLength(plaintext)
+        plaintextLength: Buffer.byteLength(plaintext),
     });
     const ciphertext = cipher.update(plaintext, 'utf8');
     cipher.final();
     const tag = cipher.getAuthTag();
 
     const decipher = crypto.createDecipheriv('aes-192-ccm', key, nonce, {
-        authTagLength: 16
+        authTagLength: 16,
     });
     decipher.setAuthTag(tag);
     decipher.setAAD(aad, {
-        plaintextLength: ciphertext.length
+        plaintextLength: ciphertext.length,
     });
     const receivedPlaintext: string = decipher.update(ciphertext, 'binary', 'utf8');
     decipher.final();
@@ -236,7 +242,6 @@ import { promisify } from 'util';
     // let arr1: Uint8Array = Uint8Array.of(1, 0, 2, 0, 3, 0, 4, 0);
     // let arr2: Uint16Array = Uint16Array.of(1, 2, 3, 4);
     // let arr3: Uint32Array = Uint8ClampedArray.of(131073, 262147);
-
     // assert(crypto.timingSafeEqual(arr1, arr2)); // binary same
     // assert(crypto.timingSafeEqual(arr1, arr3)); // binary same
 }
@@ -247,7 +252,6 @@ import { promisify } from 'util';
     // let arr1: Uint8Array = Uint8Array.of(1, 2, 3, 4);
     // let arr2: Uint16Array = Uint16Array.of(1, 2, 3, 4);
     // let arr3: Uint32Array = Uint8ClampedArray.of(1, 2, 3, 4);
-
     // assert(!crypto.timingSafeEqual(arr1, arr2)); // dumps core
     // assert(!crypto.timingSafeEqual(arr1, arr3)); // dumps core
 }
@@ -325,7 +329,7 @@ import { promisify } from 'util';
         N: 16384,
         r: 8,
         p: 1,
-        maxmem: 32 * 1024 * 1024
+        maxmem: 32 * 1024 * 1024,
     };
     crypto.scrypt(pwd, salt, 64, opts, (err: Error | null, derivedKey: Buffer): void => {});
     crypto.scrypt(pwd, salt, 64, { maxmem: 16 * 1024 * 1024 }, (err: Error | null, derivedKey: Buffer): void => {});
@@ -335,16 +339,16 @@ import { promisify } from 'util';
 }
 
 {
-    let key: string | Buffer = Buffer.from("buf");
-    const curve = "secp256k1";
+    let key: string | Buffer = Buffer.from('buf');
+    const curve = 'secp256k1';
     let ret: string | Buffer = crypto.ECDH.convertKey(key, curve);
-    key = "0xfff";
+    key = '0xfff';
     ret = crypto.ECDH.convertKey(key, curve);
-    ret = crypto.ECDH.convertKey(key, curve, "hex");
-    ret = crypto.ECDH.convertKey(key, curve, "hex", "hex");
-    ret = crypto.ECDH.convertKey(key, curve, "hex", "hex", "uncompressed");
-    ret = crypto.ECDH.convertKey(key, curve, "hex", "hex", "compressed");
-    ret = crypto.ECDH.convertKey(key, curve, "hex", "hex", "hybrid");
+    ret = crypto.ECDH.convertKey(key, curve, 'hex');
+    ret = crypto.ECDH.convertKey(key, curve, 'hex', 'hex');
+    ret = crypto.ECDH.convertKey(key, curve, 'hex', 'hex', 'uncompressed');
+    ret = crypto.ECDH.convertKey(key, curve, 'hex', 'hex', 'compressed');
+    ret = crypto.ECDH.convertKey(key, curve, 'hex', 'hex', 'hybrid');
 }
 
 {
@@ -448,48 +452,60 @@ import { promisify } from 'util';
 }
 
 {
-    crypto.generateKeyPair('rsa', {
-        modulusLength: 123,
-        publicKeyEncoding: {
-            format: 'der',
-            type: 'pkcs1',
+    crypto.generateKeyPair(
+        'rsa',
+        {
+            modulusLength: 123,
+            publicKeyEncoding: {
+                format: 'der',
+                type: 'pkcs1',
+            },
+            privateKeyEncoding: {
+                cipher: 'some-cipher',
+                format: 'pem',
+                passphrase: 'secret',
+                type: 'pkcs8',
+            },
         },
-        privateKeyEncoding: {
-            cipher: 'some-cipher',
-            format: 'pem',
-            passphrase: 'secret',
-            type: 'pkcs8',
-        },
-    }, (err: NodeJS.ErrnoException | null, publicKey: Buffer, privateKey: string) => {});
+        (err: NodeJS.ErrnoException | null, publicKey: Buffer, privateKey: string) => {},
+    );
 
-    crypto.generateKeyPair('dsa', {
-        modulusLength: 123,
-        divisorLength: 123,
-        publicKeyEncoding: {
-            format: 'pem',
-            type: 'spki',
+    crypto.generateKeyPair(
+        'dsa',
+        {
+            modulusLength: 123,
+            divisorLength: 123,
+            publicKeyEncoding: {
+                format: 'pem',
+                type: 'spki',
+            },
+            privateKeyEncoding: {
+                cipher: 'some-cipher',
+                format: 'der',
+                passphrase: 'secret',
+                type: 'pkcs8',
+            },
         },
-        privateKeyEncoding: {
-            cipher: 'some-cipher',
-            format: 'der',
-            passphrase: 'secret',
-            type: 'pkcs8',
-        },
-    }, (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: Buffer) => {});
+        (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: Buffer) => {},
+    );
 
-    crypto.generateKeyPair('ec', {
-        namedCurve: 'curve',
-        publicKeyEncoding: {
-            format: 'pem',
-            type: 'pkcs1',
+    crypto.generateKeyPair(
+        'ec',
+        {
+            namedCurve: 'curve',
+            publicKeyEncoding: {
+                format: 'pem',
+                type: 'pkcs1',
+            },
+            privateKeyEncoding: {
+                cipher: 'some-cipher',
+                format: 'pem',
+                passphrase: 'secret',
+                type: 'pkcs8',
+            },
         },
-        privateKeyEncoding: {
-            cipher: 'some-cipher',
-            format: 'pem',
-            passphrase: 'secret',
-            type: 'pkcs8',
-        },
-    }, (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {});
+        (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {},
+    );
 }
 
 {
@@ -560,12 +576,12 @@ import { promisify } from 'util';
     const keyObject = crypto.createSecretKey(Buffer.from('asdf')); // $ExpectType KeyObject
     keyObject instanceof crypto.KeyObject;
     assert.equal(keyObject.symmetricKeySize, 4);
-    assert.equal(keyObject.type, "secret");
+    assert.equal(keyObject.type, 'secret');
 }
 
 {
     const { privateKey, publicKey } = crypto.generateKeyPairSync('ec', {
-        namedCurve: 'sect239k1'
+        namedCurve: 'sect239k1',
     });
 
     const sign: crypto.Signer = crypto.createSign('SHA256');
@@ -576,7 +592,7 @@ import { promisify } from 'util';
     const verify: crypto.Verify = crypto.createVerify('SHA256');
     verify.write('some data to sign');
     verify.end();
-    verify.verify(publicKey, signature);    // $ExpectType boolean
+    verify.verify(publicKey, signature); // $ExpectType boolean
 
     // ensure that instanceof works
     verify instanceof crypto.Verify;
@@ -596,7 +612,7 @@ import { promisify } from 'util';
     const verify: crypto.Verify = crypto.createVerify('SHA256');
     verify.update('some data to sign');
     verify.end();
-    verify.verify(publicKey, signature);    // $ExpectType boolean
+    verify.verify(publicKey, signature); // $ExpectType boolean
 }
 
 {
@@ -692,7 +708,7 @@ import { promisify } from 'util';
 
 // crypto.randomInt
 {
-    const callback = (error: Error|null, value: number): void => {};
+    const callback = (error: Error | null, value: number): void => {};
 
     const a: number = crypto.randomInt(10);
     const b: number = crypto.randomInt(1, 10);
@@ -704,48 +720,62 @@ import { promisify } from 'util';
     const key = crypto.createPrivateKey('pkey');
     crypto.sign('sha256', Buffer.from('asd'), {
         key: Buffer.from('keylike'),
-        dsaEncoding: 'der'
+        dsaEncoding: 'der',
     });
-    crypto.createSign('sha256')
+    crypto
+        .createSign('sha256')
         .update(Buffer.from('asd'))
         .sign({
             key: Buffer.from('keylike'),
-            dsaEncoding: 'der'
+            dsaEncoding: 'der',
         });
     crypto.sign('sha256', Buffer.from('asd'), {
         key,
-        dsaEncoding: 'der'
+        dsaEncoding: 'der',
     });
-    crypto.createSign('sha256')
-        .update(Buffer.from('asd'))
-        .sign({
-            key,
-            dsaEncoding: 'der'
-        });
+    crypto.createSign('sha256').update(Buffer.from('asd')).sign({
+        key,
+        dsaEncoding: 'der',
+    });
 }
 
 {
     const key = crypto.createPublicKey('pkey');
-    crypto.verify('sha256', Buffer.from('asd'), {
-        key: Buffer.from('keylike'),
-        dsaEncoding: 'der'
-    }, Buffer.from('sig'));
-    crypto.createVerify('sha256')
-        .update(Buffer.from('asd'))
-        .verify({
+    crypto.verify(
+        'sha256',
+        Buffer.from('asd'),
+        {
             key: Buffer.from('keylike'),
-            dsaEncoding: 'der'
-        }, Buffer.from('sig'));
-    crypto.verify('sha256', Buffer.from('asd'), {
-        key,
-        dsaEncoding: 'der'
-    }, Buffer.from('sig'));
-    crypto.createVerify('sha256')
+            dsaEncoding: 'der',
+        },
+        Buffer.from('sig'),
+    );
+    crypto
+        .createVerify('sha256')
         .update(Buffer.from('asd'))
-        .verify({
+        .verify(
+            {
+                key: Buffer.from('keylike'),
+                dsaEncoding: 'der',
+            },
+            Buffer.from('sig'),
+        );
+    crypto.verify(
+        'sha256',
+        Buffer.from('asd'),
+        {
             key,
-            dsaEncoding: 'der'
-        }, Buffer.from('sig'));
+            dsaEncoding: 'der',
+        },
+        Buffer.from('sig'),
+    );
+    crypto.createVerify('sha256').update(Buffer.from('asd')).verify(
+        {
+            key,
+            dsaEncoding: 'der',
+        },
+        Buffer.from('sig'),
+    );
 }
 
 {
@@ -760,7 +790,7 @@ import { promisify } from 'util';
     crypto.generateKeyPairSync('ed25519').privateKey; // $ExpectType KeyObject
     crypto.generateKeyPairSync('ed448').privateKey; // $ExpectType KeyObject
 
-    [undefined, {}].forEach((opts) => {
+    [undefined, {}].forEach(opts => {
         crypto.generateKeyPair('x25519', opts, (err, publicKey, privateKey) => {
             privateKey; // $ExpectType KeyObject
             publicKey; // $ExpectType KeyObject
@@ -780,7 +810,7 @@ import { promisify } from 'util';
     });
 
     const pGenerateKeyPair = promisify(crypto.generateKeyPair);
-    [undefined, {}].forEach(async (opts) => {
+    [undefined, {}].forEach(async opts => {
         (await pGenerateKeyPair('x25519', opts)).privateKey; // $ExpectType KeyObject
         (await pGenerateKeyPair('x448', opts)).privateKey; // $ExpectType KeyObject
         (await pGenerateKeyPair('ed25519', opts)).privateKey; // $ExpectType KeyObject

--- a/types/node/v13/crypto.d.ts
+++ b/types/node/v13/crypto.d.ts
@@ -1,5 +1,5 @@
-declare module "crypto" {
-    import * as stream from "stream";
+declare module 'crypto' {
+    import * as stream from 'stream';
 
     interface Certificate {
         exportChallenge(spkac: BinaryLike): Buffer;
@@ -7,11 +7,12 @@ declare module "crypto" {
         verifySpkac(spkac: NodeJS.ArrayBufferView): boolean;
     }
     const Certificate: {
-        new(): Certificate;
+        new (): Certificate;
         (): Certificate;
     };
 
-    namespace constants { // https://nodejs.org/dist/latest-v10.x/docs/api/crypto.html#crypto_crypto_constants
+    namespace constants {
+        // https://nodejs.org/dist/latest-v10.x/docs/api/crypto.html#crypto_crypto_constants
         const OPENSSL_VERSION_NUMBER: number;
 
         /** Applies multiple bug workarounds within OpenSSL. See https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_options.html for detail. */
@@ -120,11 +121,11 @@ declare module "crypto" {
     function createHash(algorithm: string, options?: HashOptions): Hash;
     function createHmac(algorithm: string, key: BinaryLike | KeyObject, options?: stream.TransformOptions): Hmac;
 
-    type Utf8AsciiLatin1Encoding = "utf8" | "ascii" | "latin1";
-    type HexBase64Latin1Encoding = "latin1" | "hex" | "base64";
-    type Utf8AsciiBinaryEncoding = "utf8" | "ascii" | "binary";
-    type HexBase64BinaryEncoding = "binary" | "base64" | "hex";
-    type ECDHKeyFormat = "compressed" | "uncompressed" | "hybrid";
+    type Utf8AsciiLatin1Encoding = 'utf8' | 'ascii' | 'latin1';
+    type HexBase64Latin1Encoding = 'latin1' | 'hex' | 'base64';
+    type Utf8AsciiBinaryEncoding = 'utf8' | 'ascii' | 'binary';
+    type HexBase64BinaryEncoding = 'binary' | 'base64' | 'hex';
+    type ECDHKeyFormat = 'compressed' | 'uncompressed' | 'hybrid';
 
     class Hash extends stream.Transform {
         private constructor();
@@ -189,24 +190,35 @@ declare module "crypto" {
         algorithm: CipherCCMTypes,
         key: CipherKey,
         iv: BinaryLike | null,
-        options: CipherCCMOptions
+        options: CipherCCMOptions,
     ): CipherCCM;
     function createCipheriv(
         algorithm: CipherGCMTypes,
         key: CipherKey,
         iv: BinaryLike | null,
-        options?: CipherGCMOptions
+        options?: CipherGCMOptions,
     ): CipherGCM;
     function createCipheriv(
-        algorithm: string, key: CipherKey, iv: BinaryLike | null, options?: stream.TransformOptions
+        algorithm: string,
+        key: CipherKey,
+        iv: BinaryLike | null,
+        options?: stream.TransformOptions,
     ): Cipher;
 
     class Cipher extends stream.Transform {
         private constructor();
         update(data: BinaryLike): Buffer;
         update(data: string, input_encoding: Utf8AsciiBinaryEncoding): Buffer;
-        update(data: NodeJS.ArrayBufferView, input_encoding: undefined, output_encoding: HexBase64BinaryEncoding): string;
-        update(data: string, input_encoding: Utf8AsciiBinaryEncoding | undefined, output_encoding: HexBase64BinaryEncoding): string;
+        update(
+            data: NodeJS.ArrayBufferView,
+            input_encoding: undefined,
+            output_encoding: HexBase64BinaryEncoding,
+        ): string;
+        update(
+            data: string,
+            input_encoding: Utf8AsciiBinaryEncoding | undefined,
+            output_encoding: HexBase64BinaryEncoding,
+        ): string;
         final(): Buffer;
         final(output_encoding: string): string;
         setAutoPadding(auto_padding?: boolean): this;
@@ -240,14 +252,27 @@ declare module "crypto" {
         iv: BinaryLike | null,
         options?: CipherGCMOptions,
     ): DecipherGCM;
-    function createDecipheriv(algorithm: string, key: CipherKey, iv: BinaryLike | null, options?: stream.TransformOptions): Decipher;
+    function createDecipheriv(
+        algorithm: string,
+        key: CipherKey,
+        iv: BinaryLike | null,
+        options?: stream.TransformOptions,
+    ): Decipher;
 
     class Decipher extends stream.Transform {
         private constructor();
         update(data: NodeJS.ArrayBufferView): Buffer;
         update(data: string, input_encoding: HexBase64BinaryEncoding): Buffer;
-        update(data: NodeJS.ArrayBufferView, input_encoding: HexBase64BinaryEncoding | undefined, output_encoding: Utf8AsciiBinaryEncoding): string;
-        update(data: string, input_encoding: HexBase64BinaryEncoding | undefined, output_encoding: Utf8AsciiBinaryEncoding): string;
+        update(
+            data: NodeJS.ArrayBufferView,
+            input_encoding: HexBase64BinaryEncoding | undefined,
+            output_encoding: Utf8AsciiBinaryEncoding,
+        ): string;
+        update(
+            data: string,
+            input_encoding: HexBase64BinaryEncoding | undefined,
+            output_encoding: Utf8AsciiBinaryEncoding,
+        ): string;
         final(): Buffer;
         final(output_encoding: string): string;
         setAutoPadding(auto_padding?: boolean): this;
@@ -290,8 +315,7 @@ declare module "crypto" {
         saltLength?: number;
     }
 
-    interface SignPrivateKeyInput extends PrivateKeyInput, SigningOptions {
-    }
+    interface SignPrivateKeyInput extends PrivateKeyInput, SigningOptions {}
 
     type KeyLike = string | Buffer | KeyObject;
 
@@ -318,8 +342,17 @@ declare module "crypto" {
     function createDiffieHellman(prime_length: number, generator?: number | NodeJS.ArrayBufferView): DiffieHellman;
     function createDiffieHellman(prime: NodeJS.ArrayBufferView): DiffieHellman;
     function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding): DiffieHellman;
-    function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding, generator: number | NodeJS.ArrayBufferView): DiffieHellman;
-    function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding, generator: string, generator_encoding: HexBase64Latin1Encoding): DiffieHellman;
+    function createDiffieHellman(
+        prime: string,
+        prime_encoding: HexBase64Latin1Encoding,
+        generator: number | NodeJS.ArrayBufferView,
+    ): DiffieHellman;
+    function createDiffieHellman(
+        prime: string,
+        prime_encoding: HexBase64Latin1Encoding,
+        generator: string,
+        generator_encoding: HexBase64Latin1Encoding,
+    ): DiffieHellman;
     class DiffieHellman {
         private constructor();
         generateKeys(): Buffer;
@@ -327,7 +360,11 @@ declare module "crypto" {
         computeSecret(other_public_key: NodeJS.ArrayBufferView): Buffer;
         computeSecret(other_public_key: string, input_encoding: HexBase64Latin1Encoding): Buffer;
         computeSecret(other_public_key: NodeJS.ArrayBufferView, output_encoding: HexBase64Latin1Encoding): string;
-        computeSecret(other_public_key: string, input_encoding: HexBase64Latin1Encoding, output_encoding: HexBase64Latin1Encoding): string;
+        computeSecret(
+            other_public_key: string,
+            input_encoding: HexBase64Latin1Encoding,
+            output_encoding: HexBase64Latin1Encoding,
+        ): string;
         getPrime(): Buffer;
         getPrime(encoding: HexBase64Latin1Encoding): string;
         getGenerator(): Buffer;
@@ -351,7 +388,13 @@ declare module "crypto" {
         digest: string,
         callback: (err: Error | null, derivedKey: Buffer) => any,
     ): void;
-    function pbkdf2Sync(password: BinaryLike, salt: BinaryLike, iterations: number, keylen: number, digest: string): Buffer;
+    function pbkdf2Sync(
+        password: BinaryLike,
+        salt: BinaryLike,
+        iterations: number,
+        keylen: number,
+        digest: string,
+    ): Buffer;
 
     function randomBytes(size: number): Buffer;
     function randomBytes(size: number, callback: (err: Error | null, buf: Buffer) => void): void;
@@ -359,9 +402,21 @@ declare module "crypto" {
     function pseudoRandomBytes(size: number, callback: (err: Error | null, buf: Buffer) => void): void;
 
     function randomFillSync<T extends NodeJS.ArrayBufferView>(buffer: T, offset?: number, size?: number): T;
-    function randomFill<T extends NodeJS.ArrayBufferView>(buffer: T, callback: (err: Error | null, buf: T) => void): void;
-    function randomFill<T extends NodeJS.ArrayBufferView>(buffer: T, offset: number, callback: (err: Error | null, buf: T) => void): void;
-    function randomFill<T extends NodeJS.ArrayBufferView>(buffer: T, offset: number, size: number, callback: (err: Error | null, buf: T) => void): void;
+    function randomFill<T extends NodeJS.ArrayBufferView>(
+        buffer: T,
+        callback: (err: Error | null, buf: T) => void,
+    ): void;
+    function randomFill<T extends NodeJS.ArrayBufferView>(
+        buffer: T,
+        offset: number,
+        callback: (err: Error | null, buf: T) => void,
+    ): void;
+    function randomFill<T extends NodeJS.ArrayBufferView>(
+        buffer: T,
+        offset: number,
+        size: number,
+        callback: (err: Error | null, buf: T) => void,
+    ): void;
 
     interface ScryptOptions {
         N?: number;
@@ -372,7 +427,8 @@ declare module "crypto" {
     function scrypt(
         password: BinaryLike,
         salt: BinaryLike,
-        keylen: number, callback: (err: Error | null, derivedKey: Buffer) => void,
+        keylen: number,
+        callback: (err: Error | null, derivedKey: Buffer) => void,
     ): void;
     function scrypt(
         password: BinaryLike,
@@ -411,15 +467,19 @@ declare module "crypto" {
             key: BinaryLike,
             curve: string,
             inputEncoding?: HexBase64Latin1Encoding,
-            outputEncoding?: "latin1" | "hex" | "base64",
-            format?: "uncompressed" | "compressed" | "hybrid",
+            outputEncoding?: 'latin1' | 'hex' | 'base64',
+            format?: 'uncompressed' | 'compressed' | 'hybrid',
         ): Buffer | string;
         generateKeys(): Buffer;
         generateKeys(encoding: HexBase64Latin1Encoding, format?: ECDHKeyFormat): string;
         computeSecret(other_public_key: NodeJS.ArrayBufferView): Buffer;
         computeSecret(other_public_key: string, input_encoding: HexBase64Latin1Encoding): Buffer;
         computeSecret(other_public_key: NodeJS.ArrayBufferView, output_encoding: HexBase64Latin1Encoding): string;
-        computeSecret(other_public_key: string, input_encoding: HexBase64Latin1Encoding, output_encoding: HexBase64Latin1Encoding): string;
+        computeSecret(
+            other_public_key: string,
+            input_encoding: HexBase64Latin1Encoding,
+            output_encoding: HexBase64Latin1Encoding,
+        ): string;
         getPrivateKey(): Buffer;
         getPrivateKey(encoding: HexBase64Latin1Encoding): string;
         getPublicKey(): Buffer;
@@ -535,60 +595,192 @@ declare module "crypto" {
         privateKey: T2;
     }
 
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'rsa', options: RSAKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'rsa', options: RSAKeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'dsa', options: DSAKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'dsa', options: DSAKeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'pem', 'pem'>): KeyPairSyncResult<string, string>;
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'pem', 'der'>): KeyPairSyncResult<string, Buffer>;
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'der', 'pem'>): KeyPairSyncResult<Buffer, string>;
-    function generateKeyPairSync(type: 'ec', options: ECKeyPairOptions<'der', 'der'>): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'pem'>,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'der'>,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'pem'>,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'der'>,
+    ): KeyPairSyncResult<Buffer, Buffer>;
     function generateKeyPairSync(type: 'ec', options: ECKeyPairKeyObjectOptions): KeyPairKeyObjectResult;
 
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'rsa', options: RSAKeyPairKeyObjectOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'rsa',
+        options: RSAKeyPairKeyObjectOptions,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'dsa', options: DSAKeyPairKeyObjectOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'dsa',
+        options: DSAKeyPairKeyObjectOptions,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'pem', 'pem'>, callback: (err: Error | null, publicKey: string, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'pem', 'der'>, callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'der', 'pem'>, callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairOptions<'der', 'der'>, callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void): void;
-    function generateKeyPair(type: 'ec', options: ECKeyPairKeyObjectOptions, callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'pem'>,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'pem', 'der'>,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'pem'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairOptions<'der', 'der'>,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type: 'ec',
+        options: ECKeyPairKeyObjectOptions,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
 
     namespace generateKeyPair {
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "rsa", options: RSAKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'rsa',
+            options: RSAKeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(type: 'rsa', options: RSAKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
 
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "dsa", options: DSAKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'dsa',
+            options: DSAKeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(type: 'dsa', options: DSAKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
 
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'pem', 'pem'>): Promise<{ publicKey: string, privateKey: string }>;
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'pem', 'der'>): Promise<{ publicKey: string, privateKey: Buffer }>;
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'der', 'pem'>): Promise<{ publicKey: Buffer, privateKey: string }>;
-        function __promisify__(type: "ec", options: ECKeyPairOptions<'der', 'der'>): Promise<{ publicKey: Buffer, privateKey: Buffer }>;
-        function __promisify__(type: "ec", options: ECKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'pem', 'pem'>,
+        ): Promise<{ publicKey: string; privateKey: string }>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'pem', 'der'>,
+        ): Promise<{ publicKey: string; privateKey: Buffer }>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'der', 'pem'>,
+        ): Promise<{ publicKey: Buffer; privateKey: string }>;
+        function __promisify__(
+            type: 'ec',
+            options: ECKeyPairOptions<'der', 'der'>,
+        ): Promise<{ publicKey: Buffer; privateKey: Buffer }>;
+        function __promisify__(type: 'ec', options: ECKeyPairKeyObjectOptions): Promise<KeyPairKeyObjectResult>;
     }
 
     /**
@@ -599,10 +791,13 @@ declare module "crypto" {
      * If `key` is not a [`KeyObject`][], this function behaves as if `key` had been
      * passed to [`crypto.createPrivateKey()`][].
      */
-    function sign(algorithm: string | null | undefined, data: NodeJS.ArrayBufferView, key: KeyLike | SignPrivateKeyInput): Buffer;
+    function sign(
+        algorithm: string | null | undefined,
+        data: NodeJS.ArrayBufferView,
+        key: KeyLike | SignPrivateKeyInput,
+    ): Buffer;
 
-    interface VerifyKeyWithOptions extends KeyObject, SigningOptions {
-    }
+    interface VerifyKeyWithOptions extends KeyObject, SigningOptions {}
 
     /**
      * Calculates and returns the signature for `data` using the given private key and
@@ -612,5 +807,10 @@ declare module "crypto" {
      * If `key` is not a [`KeyObject`][], this function behaves as if `key` had been
      * passed to [`crypto.createPublicKey()`][].
      */
-    function verify(algorithm: string | null | undefined, data: NodeJS.ArrayBufferView, key: KeyLike | VerifyKeyWithOptions, signature: NodeJS.ArrayBufferView): boolean;
+    function verify(
+        algorithm: string | null | undefined,
+        data: NodeJS.ArrayBufferView,
+        key: KeyLike | VerifyKeyWithOptions,
+        signature: NodeJS.ArrayBufferView,
+    ): boolean;
 }

--- a/types/node/v13/crypto.d.ts
+++ b/types/node/v13/crypto.d.ts
@@ -419,6 +419,9 @@ declare module 'crypto' {
     ): void;
 
     interface ScryptOptions {
+        cost?: number;
+        blockSize?: number;
+        parallelization?: number;
         N?: number;
         r?: number;
         p?: number;

--- a/types/node/v13/test/crypto.ts
+++ b/types/node/v13/test/crypto.ts
@@ -14,20 +14,23 @@ import { promisify } from 'util';
 
 {
     // crypto_hash_buffer_test
-    const hashResult: string = crypto.createHash('md5')
-        .update(new Buffer('world')).digest('hex');
+    const hashResult: string = crypto.createHash('md5').update(new Buffer('world')).digest('hex');
 }
 
 {
     // crypto_hash_dataview_test
-    const hashResult: string = crypto.createHash('md5')
-        .update(new DataView(new Buffer('world').buffer)).digest('hex');
+    const hashResult: string = crypto
+        .createHash('md5')
+        .update(new DataView(new Buffer('world').buffer))
+        .digest('hex');
 }
 
 {
     // crypto_hash_int8array_test
-    const hashResult: string = crypto.createHash('md5')
-        .update(new Int8Array(new Buffer('world').buffer)).digest('hex');
+    const hashResult: string = crypto
+        .createHash('md5')
+        .update(new Int8Array(new Buffer('world').buffer))
+        .digest('hex');
 }
 
 {
@@ -37,20 +40,23 @@ import { promisify } from 'util';
 
 {
     // crypto_hmac_buffer_test
-    const hmacResult: string = crypto.createHmac('md5', 'hello')
-        .update(new Buffer('world')).digest('hex');
+    const hmacResult: string = crypto.createHmac('md5', 'hello').update(new Buffer('world')).digest('hex');
 }
 
 {
     // crypto_hmac_dataview_test
-    const hmacResult: string = crypto.createHmac('md5', 'hello')
-        .update(new DataView(new Buffer('world').buffer)).digest('hex');
+    const hmacResult: string = crypto
+        .createHmac('md5', 'hello')
+        .update(new DataView(new Buffer('world').buffer))
+        .digest('hex');
 }
 
 {
     // crypto_hmac_int8array_test
-    const hmacResult: string = crypto.createHmac('md5', 'hello')
-        .update(new Int8Array(new Buffer('world').buffer)).digest('hex');
+    const hmacResult: string = crypto
+        .createHmac('md5', 'hello')
+        .update(new Int8Array(new Buffer('world').buffer))
+        .digest('hex');
 }
 
 {
@@ -63,14 +69,14 @@ import { promisify } from 'util';
 {
     // crypto_cipher_decipher_string_test
     const key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
-    const clearText = "This is the clear text.";
-    const cipher: crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
-    let cipherText: string = cipher.update(clearText, "utf8", "hex");
-    cipherText += cipher.final("hex");
+    const clearText = 'This is the clear text.';
+    const cipher: crypto.Cipher = crypto.createCipher('aes-128-ecb', key);
+    let cipherText: string = cipher.update(clearText, 'utf8', 'hex');
+    cipherText += cipher.final('hex');
 
-    const decipher: crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
-    let clearText2: string = decipher.update(cipherText, "hex", "utf8");
-    clearText2 += decipher.final("utf8");
+    const decipher: crypto.Decipher = crypto.createDecipher('aes-128-ecb', key);
+    let clearText2: string = decipher.update(cipherText, 'hex', 'utf8');
+    clearText2 += decipher.final('utf8');
 
     assert.equal(clearText2, clearText);
 }
@@ -79,14 +85,14 @@ import { promisify } from 'util';
     // crypto_cipher_decipher_buffer_test
     const key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
     const clearText: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4]);
-    const cipher: crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
+    const cipher: crypto.Cipher = crypto.createCipher('aes-128-ecb', key);
     const cipherBuffers: Buffer[] = [];
     cipherBuffers.push(cipher.update(clearText));
     cipherBuffers.push(cipher.final());
 
     const cipherText: Buffer = Buffer.concat(cipherBuffers);
 
-    const decipher: crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
+    const decipher: crypto.Decipher = crypto.createDecipher('aes-128-ecb', key);
     const decipherBuffers: Buffer[] = [];
     decipherBuffers.push(decipher.update(cipherText));
     decipherBuffers.push(decipher.final());
@@ -100,14 +106,14 @@ import { promisify } from 'util';
     // crypto_cipher_decipher_dataview_test
     const key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
     const clearText: DataView = new DataView(new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4]).buffer);
-    const cipher: crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
+    const cipher: crypto.Cipher = crypto.createCipher('aes-128-ecb', key);
     const cipherBuffers: Buffer[] = [];
     cipherBuffers.push(cipher.update(clearText));
     cipherBuffers.push(cipher.final());
 
     const cipherText: DataView = new DataView(Buffer.concat(cipherBuffers).buffer);
 
-    const decipher: crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
+    const decipher: crypto.Decipher = crypto.createDecipher('aes-128-ecb', key);
     const decipherBuffers: Buffer[] = [];
     decipherBuffers.push(decipher.update(cipherText));
     decipherBuffers.push(decipher.final());
@@ -123,22 +129,22 @@ import { promisify } from 'util';
     const aad = Buffer.from('0123456789', 'hex');
 
     const cipher = crypto.createCipheriv('aes-192-ccm', key, nonce, {
-        authTagLength: 16
+        authTagLength: 16,
     });
     const plaintext = 'Hello world';
     cipher.setAAD(aad, {
-        plaintextLength: Buffer.byteLength(plaintext)
+        plaintextLength: Buffer.byteLength(plaintext),
     });
     const ciphertext = cipher.update(plaintext, 'utf8');
     cipher.final();
     const tag = cipher.getAuthTag();
 
     const decipher = crypto.createDecipheriv('aes-192-ccm', key, nonce, {
-        authTagLength: 16
+        authTagLength: 16,
     });
     decipher.setAuthTag(tag);
     decipher.setAAD(aad, {
-        plaintextLength: ciphertext.length
+        plaintextLength: ciphertext.length,
     });
     const receivedPlaintext: string = decipher.update(ciphertext, undefined, 'utf8');
     decipher.final();
@@ -152,7 +158,7 @@ import { promisify } from 'util';
     const cipher = crypto.createCipheriv('aes-192-gcm', key, nonce);
     const plaintext = 'Hello world';
     cipher.setAAD(aad, {
-        plaintextLength: Buffer.byteLength(plaintext)
+        plaintextLength: Buffer.byteLength(plaintext),
     });
     const ciphertext = cipher.update(plaintext, 'utf8');
     cipher.final();
@@ -161,7 +167,7 @@ import { promisify } from 'util';
     const decipher = crypto.createDecipheriv('aes-192-gcm', key, nonce);
     decipher.setAuthTag(tag);
     decipher.setAAD(aad, {
-        plaintextLength: ciphertext.length
+        plaintextLength: ciphertext.length,
     });
     const receivedPlaintext: string = decipher.update(ciphertext, undefined, 'utf8');
     decipher.final();
@@ -173,22 +179,22 @@ import { promisify } from 'util';
     const aad = Buffer.from('0123456789', 'hex');
 
     const cipher = crypto.createCipheriv('aes-192-ccm', key, nonce, {
-        authTagLength: 16
+        authTagLength: 16,
     });
     const plaintext = 'Hello world';
     cipher.setAAD(aad, {
-        plaintextLength: Buffer.byteLength(plaintext)
+        plaintextLength: Buffer.byteLength(plaintext),
     });
     const ciphertext = cipher.update(plaintext, 'utf8');
     cipher.final();
     const tag = cipher.getAuthTag();
 
     const decipher = crypto.createDecipheriv('aes-192-ccm', key, nonce, {
-        authTagLength: 16
+        authTagLength: 16,
     });
     decipher.setAuthTag(tag);
     decipher.setAAD(aad, {
-        plaintextLength: ciphertext.length
+        plaintextLength: ciphertext.length,
     });
     const receivedPlaintext: string = decipher.update(ciphertext, 'binary', 'utf8');
     decipher.final();
@@ -240,7 +246,6 @@ import { promisify } from 'util';
     // let arr1: Uint8Array = Uint8Array.of(1, 0, 2, 0, 3, 0, 4, 0);
     // let arr2: Uint16Array = Uint16Array.of(1, 2, 3, 4);
     // let arr3: Uint32Array = Uint8ClampedArray.of(131073, 262147);
-
     // assert(crypto.timingSafeEqual(arr1, arr2)); // binary same
     // assert(crypto.timingSafeEqual(arr1, arr3)); // binary same
 }
@@ -251,7 +256,6 @@ import { promisify } from 'util';
     // let arr1: Uint8Array = Uint8Array.of(1, 2, 3, 4);
     // let arr2: Uint16Array = Uint16Array.of(1, 2, 3, 4);
     // let arr3: Uint32Array = Uint8ClampedArray.of(1, 2, 3, 4);
-
     // assert(!crypto.timingSafeEqual(arr1, arr2)); // dumps core
     // assert(!crypto.timingSafeEqual(arr1, arr3)); // dumps core
 }
@@ -329,7 +333,7 @@ import { promisify } from 'util';
         N: 16384,
         r: 8,
         p: 1,
-        maxmem: 32 * 1024 * 1024
+        maxmem: 32 * 1024 * 1024,
     };
     crypto.scrypt(pwd, salt, 64, opts, (err: Error | null, derivedKey: Buffer): void => {});
     crypto.scrypt(pwd, salt, 64, { maxmem: 16 * 1024 * 1024 }, (err: Error | null, derivedKey: Buffer): void => {});
@@ -339,16 +343,16 @@ import { promisify } from 'util';
 }
 
 {
-    let key: string | Buffer = Buffer.from("buf");
-    const curve = "secp256k1";
+    let key: string | Buffer = Buffer.from('buf');
+    const curve = 'secp256k1';
     let ret: string | Buffer = crypto.ECDH.convertKey(key, curve);
-    key = "0xfff";
+    key = '0xfff';
     ret = crypto.ECDH.convertKey(key, curve);
-    ret = crypto.ECDH.convertKey(key, curve, "hex");
-    ret = crypto.ECDH.convertKey(key, curve, "hex", "hex");
-    ret = crypto.ECDH.convertKey(key, curve, "hex", "hex", "uncompressed");
-    ret = crypto.ECDH.convertKey(key, curve, "hex", "hex", "compressed");
-    ret = crypto.ECDH.convertKey(key, curve, "hex", "hex", "hybrid");
+    ret = crypto.ECDH.convertKey(key, curve, 'hex');
+    ret = crypto.ECDH.convertKey(key, curve, 'hex', 'hex');
+    ret = crypto.ECDH.convertKey(key, curve, 'hex', 'hex', 'uncompressed');
+    ret = crypto.ECDH.convertKey(key, curve, 'hex', 'hex', 'compressed');
+    ret = crypto.ECDH.convertKey(key, curve, 'hex', 'hex', 'hybrid');
 }
 
 {
@@ -452,48 +456,60 @@ import { promisify } from 'util';
 }
 
 {
-    crypto.generateKeyPair('rsa', {
-        modulusLength: 123,
-        publicKeyEncoding: {
-            format: 'der',
-            type: 'pkcs1',
+    crypto.generateKeyPair(
+        'rsa',
+        {
+            modulusLength: 123,
+            publicKeyEncoding: {
+                format: 'der',
+                type: 'pkcs1',
+            },
+            privateKeyEncoding: {
+                cipher: 'some-cipher',
+                format: 'pem',
+                passphrase: 'secret',
+                type: 'pkcs8',
+            },
         },
-        privateKeyEncoding: {
-            cipher: 'some-cipher',
-            format: 'pem',
-            passphrase: 'secret',
-            type: 'pkcs8',
-        },
-    }, (err: NodeJS.ErrnoException | null, publicKey: Buffer, privateKey: string) => {});
+        (err: NodeJS.ErrnoException | null, publicKey: Buffer, privateKey: string) => {},
+    );
 
-    crypto.generateKeyPair('dsa', {
-        modulusLength: 123,
-        divisorLength: 123,
-        publicKeyEncoding: {
-            format: 'pem',
-            type: 'spki',
+    crypto.generateKeyPair(
+        'dsa',
+        {
+            modulusLength: 123,
+            divisorLength: 123,
+            publicKeyEncoding: {
+                format: 'pem',
+                type: 'spki',
+            },
+            privateKeyEncoding: {
+                cipher: 'some-cipher',
+                format: 'der',
+                passphrase: 'secret',
+                type: 'pkcs8',
+            },
         },
-        privateKeyEncoding: {
-            cipher: 'some-cipher',
-            format: 'der',
-            passphrase: 'secret',
-            type: 'pkcs8',
-        },
-    }, (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: Buffer) => {});
+        (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: Buffer) => {},
+    );
 
-    crypto.generateKeyPair('ec', {
-        namedCurve: 'curve',
-        publicKeyEncoding: {
-            format: 'pem',
-            type: 'pkcs1',
+    crypto.generateKeyPair(
+        'ec',
+        {
+            namedCurve: 'curve',
+            publicKeyEncoding: {
+                format: 'pem',
+                type: 'pkcs1',
+            },
+            privateKeyEncoding: {
+                cipher: 'some-cipher',
+                format: 'pem',
+                passphrase: 'secret',
+                type: 'pkcs8',
+            },
         },
-        privateKeyEncoding: {
-            cipher: 'some-cipher',
-            format: 'pem',
-            passphrase: 'secret',
-            type: 'pkcs8',
-        },
-    }, (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {});
+        (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {},
+    );
 }
 
 {
@@ -564,12 +580,12 @@ import { promisify } from 'util';
     const keyObject = crypto.createSecretKey(Buffer.from('asdf')); // $ExpectType KeyObject
     keyObject instanceof crypto.KeyObject;
     assert.equal(keyObject.symmetricKeySize, 4);
-    assert.equal(keyObject.type, "secret");
+    assert.equal(keyObject.type, 'secret');
 }
 
 {
     const { privateKey, publicKey } = crypto.generateKeyPairSync('ec', {
-        namedCurve: 'sect239k1'
+        namedCurve: 'sect239k1',
     });
 
     const sign: crypto.Signer = crypto.createSign('SHA256');
@@ -580,7 +596,7 @@ import { promisify } from 'util';
     const verify: crypto.Verify = crypto.createVerify('SHA256');
     verify.write('some data to sign');
     verify.end();
-    verify.verify(publicKey, signature);    // $ExpectType boolean
+    verify.verify(publicKey, signature); // $ExpectType boolean
 
     // ensure that instanceof works
     verify instanceof crypto.Verify;
@@ -600,7 +616,7 @@ import { promisify } from 'util';
     const verify: crypto.Verify = crypto.createVerify('SHA256');
     verify.update('some data to sign');
     verify.end();
-    verify.verify(publicKey, signature);    // $ExpectType boolean
+    verify.verify(publicKey, signature); // $ExpectType boolean
 }
 
 {

--- a/types/node/v13/test/crypto.ts
+++ b/types/node/v13/test/crypto.ts
@@ -330,16 +330,24 @@ import { promisify } from 'util';
     const salt: string | Buffer | Int32Array | DataView = Buffer.alloc(16);
     crypto.scrypt(pwd, salt, 64, (err: Error | null, derivedKey: Buffer): void => {});
     const opts: crypto.ScryptOptions = {
-        N: 16384,
-        r: 8,
-        p: 1,
+        cost: 16384,
+        blockSize: 8,
+        parallelization: 1,
         maxmem: 32 * 1024 * 1024,
     };
     crypto.scrypt(pwd, salt, 64, opts, (err: Error | null, derivedKey: Buffer): void => {});
     crypto.scrypt(pwd, salt, 64, { maxmem: 16 * 1024 * 1024 }, (err: Error | null, derivedKey: Buffer): void => {});
-    let buf: Buffer = crypto.scryptSync(pwd, salt, 64);
-    buf = crypto.scryptSync(pwd, salt, 64, opts);
-    buf = crypto.scryptSync(pwd, salt, 64, { N: 1024 });
+    crypto.scryptSync(pwd, salt, 64);
+    crypto.scryptSync(pwd, salt, 64, opts);
+    crypto.scryptSync(pwd, salt, 64, { N: 1024 });
+    const optsWithAliases: crypto.ScryptOptions = {
+        N: opts.cost,
+        r: opts.blockSize,
+        p: opts.parallelization,
+        maxmem: opts.maxmem,
+    };
+    crypto.scrypt(pwd, salt, 64, optsWithAliases, (err: Error | null, derivedKey: Buffer): void => {});
+    crypto.scryptSync(pwd, salt, 64, optsWithAliases);
 }
 
 {


### PR DESCRIPTION
This change adds missing options for scrypt.

The change is in two commits. The first commit has only formatting changes so that formatting changes are not together with the actual changes.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/crypto.html#crypto_crypto_scrypt_password_salt_keylen_options_callback