### PR TITLE
(googlemaps) Update map.d.ts with browser domEvent types

### DIFF
--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -113,6 +113,7 @@ new google.maps.Data({ map });
 let latLng = new google.maps.LatLng(52.201203, -1.72437);
 let feature = new google.maps.Data.Feature();
 let geometry = new google.maps.Data.Geometry();
+let domEvent = new MouseEvent('click');
 
 let data = map.data;
 
@@ -199,6 +200,7 @@ data.toGeoJson(feature => {});
 let dataMouseEvent: google.maps.Data.MouseEvent = {
     feature,
     latLng,
+    domEvent,
     stop: (): void => {},
 };
 

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Google Maps JavaScript API 3.43.3
+// Type definitions for Google Maps JavaScript API 3.43
 // Project: https://developers.google.com/maps/
 // Definitions by: Chris Wrench <https://github.com/cgwrench>,
 //                 Kiarash Ghiaseddin <https://github.com/Silver-Connection>,

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Google Maps JavaScript API 3.40
+// Type definitions for Google Maps JavaScript API 3.43.3
 // Project: https://developers.google.com/maps/
 // Definitions by: Chris Wrench <https://github.com/cgwrench>,
 //                 Kiarash Ghiaseddin <https://github.com/Silver-Connection>,

--- a/types/googlemaps/reference/data.d.ts
+++ b/types/googlemaps/reference/data.d.ts
@@ -137,7 +137,7 @@ declare namespace google.maps {
         }
 
         // tslint:disable-next-line:no-unnecessary-qualifier
-        interface MouseEvent extends google.maps.MouseEvent {
+        interface MouseEvent extends google.maps.MapMouseEvent {
             feature: Feature;
         }
 

--- a/types/googlemaps/reference/map.d.ts
+++ b/types/googlemaps/reference/map.d.ts
@@ -612,6 +612,13 @@ declare namespace google.maps {
          * occurred.
          */
         latLng: LatLng;
+        /**
+         * The corresponding native DOM event.  Developres hsould not rely on target,
+         * currentTarget, relatedTarget and path properties being defined and 
+         * consistent.  Developres should not also rely on DOM structure of hte internal
+         * implementation of Maps API.
+         */
+        domEvent: lib.dom.MouseEvent  | lib.dom.TouchEvent | lib.dom.PointerEvent | lib.dom.Event;                                                  
     }
 
     /**

--- a/types/googlemaps/reference/map.d.ts
+++ b/types/googlemaps/reference/map.d.ts
@@ -603,7 +603,7 @@ declare namespace google.maps {
     /**
      * This object is returned from various mouse events on the map and overlays,
      * and contains all the fields shown below.
-     * https://developers.google.com/maps/documentation/javascript/reference/map#MapMouseEvent
+     * @see {@link https://developers.google.com/maps/documentation/javascript/reference/map#MapMouseEvent Maps JavaScript API}
      */
     interface MapMouseEvent {
         /** Prevents this event from propagating further. */

--- a/types/googlemaps/reference/map.d.ts
+++ b/types/googlemaps/reference/map.d.ts
@@ -614,10 +614,11 @@ declare namespace google.maps {
          */
         latLng: LatLng;
         /**
-         * The corresponding native DOM event. Developers should not rely on target,
-         * currentTarget, relatedTarget and path properties being defined and consistent.
-         *  Developers should not also rely on the DOM structure of the internal
+         * The corresponding native DOM event. Developers should not rely on `target`,
+         * `currentTarget`, `relatedTarget` and `path` properties being defined and consistent.
+         * Developers should not also rely on the DOM structure of the internal
          * implementation of the Maps API.
+         * @see {@link https://developers.google.com/maps/documentation/javascript/reference/map#MapMouseEvent.domEvent Maps JavaScript API}
          */
         domEvent: MouseEvent | TouchEvent | PointerEvent | Event;
     }

--- a/types/googlemaps/reference/map.d.ts
+++ b/types/googlemaps/reference/map.d.ts
@@ -26,13 +26,13 @@ declare namespace google.maps {
          * The click event is not fired if a marker or infowindow was clicked.
          * @see {@link https://developers.google.com/maps/documentation/javascript/reference/map#Map.click Maps JavaScript API}
          */
-        click: (this: T, event: MouseEvent | IconMouseEvent) => void;
+        click: (this: T, event: MapMouseEvent | IconMouseEvent) => void;
 
         /**
          * This event is fired when the user double-clicks on the map. Note that the click event will also fire, right before this one.
          * @see {@link https://developers.google.com/maps/documentation/javascript/reference/map#Map.dblclick Maps JavaScript API}
          */
-        dblclick: (this: T, event: MouseEvent) => void;
+        dblclick: (this: T, event: MapMouseEvent) => void;
 
         /**
          * This event is repeatedly fired while the user drags the map.
@@ -80,19 +80,19 @@ declare namespace google.maps {
          * This event is fired whenever the user's mouse moves over the map container.
          * @see {@link https://developers.google.com/maps/documentation/javascript/reference/map#Map.mousemove Maps JavaScript API}
          */
-        mousemove: (this: T, event: MouseEvent) => void;
+        mousemove: (this: T, event: MapMouseEvent) => void;
 
         /**
          * This event is fired when the user's mouse exits the map container.
          * @see {@link https://developers.google.com/maps/documentation/javascript/reference/map#Map.mouseout Maps JavaScript API}
          */
-        mouseout: (this: T, event: MouseEvent) => void;
+        mouseout: (this: T, event: MapMouseEvent) => void;
 
         /**
          * This event is fired when the user's mouse enters the map container.
          * @see {@link https://developers.google.com/maps/documentation/javascript/reference/map#Map.mouseover Maps JavaScript API}
          */
-        mouseover: (this: T, event: MouseEvent) => void;
+        mouseover: (this: T, event: MapMouseEvent) => void;
 
         /**
          * This event is fired when the projection has changed.
@@ -105,7 +105,7 @@ declare namespace google.maps {
          * This event is fired when the DOM contextmenu event is fired on the map container.
          * @see {@link https://developers.google.com/maps/documentation/javascript/reference/map#Map.rightclick Maps JavaScript API}
          */
-        rightclick: (this: T, event: MouseEvent) => void;
+        rightclick: (this: T, event: MapMouseEvent) => void;
 
         /**
          * This event is fired when the visible tiles have finished loading.
@@ -603,8 +603,9 @@ declare namespace google.maps {
     /**
      * This object is returned from various mouse events on the map and overlays,
      * and contains all the fields shown below.
+     * https://developers.google.com/maps/documentation/javascript/reference/map#MapMouseEvent
      */
-    interface MouseEvent {
+    interface MapMouseEvent {
         /** Prevents this event from propagating further. */
         stop(): void;
         /**
@@ -613,12 +614,12 @@ declare namespace google.maps {
          */
         latLng: LatLng;
         /**
-         * The corresponding native DOM event.  Developres hsould not rely on target,
-         * currentTarget, relatedTarget and path properties being defined and 
-         * consistent.  Developres should not also rely on DOM structure of hte internal
-         * implementation of Maps API.
+         * The corresponding native DOM event. Developers should not rely on target,
+         * currentTarget, relatedTarget and path properties being defined and consistent.
+         *  Developers should not also rely on the DOM structure of the internal
+         * implementation of the Maps API.
          */
-        domEvent: lib.dom.MouseEvent  | lib.dom.TouchEvent | lib.dom.PointerEvent | lib.dom.Event;                                                  
+        domEvent: MouseEvent | TouchEvent | PointerEvent | Event;
     }
 
     /**
@@ -628,7 +629,7 @@ declare namespace google.maps {
      * on this event to prevent it being propagated. Learn more about place IDs in
      * the Places API developer guide.
      */
-    interface IconMouseEvent extends MouseEvent {
+    interface IconMouseEvent extends MapMouseEvent {
         /**
          * The place ID of the place that was clicked.
          * This place ID can be used to query more information about the feature

--- a/types/googlemaps/reference/polygon.d.ts
+++ b/types/googlemaps/reference/polygon.d.ts
@@ -170,7 +170,7 @@ declare namespace google.maps {
     }
 
     /**
-     * https://developers.google.com/maps/documentation/javascript/reference/polygon?hl=en#PolyMouseEvent
+     * @see {@link https://developers.google.com/maps/documentation/javascript/reference/polygon#PolyMouseEvent Maps JavaScript API}
      */
     interface PolyMouseEvent extends MapMouseEvent {
         /**

--- a/types/googlemaps/reference/polygon.d.ts
+++ b/types/googlemaps/reference/polygon.d.ts
@@ -169,9 +169,25 @@ declare namespace google.maps {
         zIndex?: number;
     }
 
-    interface PolyMouseEvent extends MouseEvent {
+    /**
+     * https://developers.google.com/maps/documentation/javascript/reference/polygon?hl=en#PolyMouseEvent
+     */
+    interface PolyMouseEvent extends MapMouseEvent {
+        /**
+         * The index of the edge within the path beneath the cursor when the event occurred, if the
+         *  event occurred on a mid-point on an editable polygon.
+         */
         edge?: number;
+        /**
+         * The index of the path beneath the cursor when the event occurred, if the event occurred on
+         *  a vertex and the polygon is editable. Otherwise undefined.
+         */
         path?: number;
+        /**
+         * The index of the vertex beneath the cursor when the event occurred, if the event occurred on
+         *  a vertex and the polyline or polygon is editable. If the event does not occur on a vertex,
+         *  the value is undefined.
+         */
         vertex?: number;
     }
 

--- a/types/googlemaps/test/reference/map-tests.ts
+++ b/types/googlemaps/test/reference/map-tests.ts
@@ -9,10 +9,10 @@ map.addListener('bounds_changed', (event) => {}); // $ExpectError
 map.addListener('center_changed', () => {});
 map.addListener('center_changed', (event) => {}); // $ExpectError
 map.addListener('click', event => {
-    event; // $ExpectType MouseEvent | IconMouseEvent
+    event; // $ExpectType MapMouseEvent | IconMouseEvent
 });
 map.addListener('dblclick', event => {
-    event; // $ExpectType MouseEvent
+    event; // $ExpectType MapMouseEvent
 });
 map.addListener('drag', () => {});
 map.addListener('drag', (event) => {}); // $ExpectError
@@ -27,18 +27,18 @@ map.addListener('idle', (event) => {}); // $ExpectError
 map.addListener('maptypeid_changed', () => {});
 map.addListener('maptypeid_changed', (event) => {}); // $ExpectError
 map.addListener('mousemove', event => {
-    event; // $ExpectType MouseEvent
+    event; // $ExpectType MapMouseEvent
 });
 map.addListener('mouseout', event => {
-    event; // $ExpectType MouseEvent
+    event; // $ExpectType MapMouseEvent
 });
 map.addListener('mouseover', event => {
-    event; // $ExpectType MouseEvent
+    event; // $ExpectType MapMouseEvent
 });
 map.addListener('projection_changed', () => {});
 map.addListener('projection_changed', (event) => {}); // $ExpectError
 map.addListener('rightclick', event => {
-    event; // $ExpectType MouseEvent
+    event; // $ExpectType MapMouseEvent
 });
 map.addListener('tilesloaded', () => {});
 map.addListener('tilesloaded', (event) => {}); // $ExpectError


### PR DESCRIPTION
Updated with `domEvent` matching the current documentation [https://developers.google.com/maps/documentation/javascript/reference/map#MapMouseEvent](https://developers.google.com/maps/documentation/javascript/reference/map#MapMouseEvent).

I've been using this change locally on a couple of my machines by changing locally.  Figured I'd submit this so I could maybe stop doing it manually each time.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
