### PR TITLE
[kurento-client] Adding callback to kurento-client constructor and getSingleton methods

### DIFF
--- a/types/kurento-client/index.d.ts
+++ b/types/kurento-client/index.d.ts
@@ -11,9 +11,9 @@
 
 declare namespace kurento {
     interface Constructor {
-        (ws_uri: string, options?: Options): Promise<ClientInstance>;
+        (ws_uri: string, options?: Options, callback?: Callback<ClientInstance>): Promise<ClientInstance>;
         getComplexType: (complex: 'IceCandidate') => (value: any) => any;
-        getSingleton(ws_uri: string, options?: Options): Promise<ClientInstance>;
+        getSingleton(ws_uri: string, options?: Options, callback?: Callback<ClientInstance>): Promise<ClientInstance>;
         register: (module: string | ReturnType<NodeRequire>) => void;
         on: undefined;
     }

--- a/types/kurento-client/kurento-client-tests.ts
+++ b/types/kurento-client/kurento-client-tests.ts
@@ -37,7 +37,7 @@ async () => {
 };
 
 async () => {
-    const client = await kurento('//server', { failAfter: 500, useImplicitTransactions: true });
+    const client = await kurento('//server', { failAfter: 500, useImplicitTransactions: true }, () => {});
     const pipeline = await client.create('MediaPipeline');
 
     await pipeline.release();
@@ -47,7 +47,7 @@ async () => {
     const endpointId = 'endpointId';
     const candidate = new RTCIceCandidate();
 
-    const client = await kurento.getSingleton('//server', {});
+    const client = await kurento.getSingleton('//server', {}, () => {});
     const endpoint = ((await client.getMediaobjectById(endpointId)) as any) as WebRtcEndpoint;
     const server = await client.getServerManager();
 


### PR DESCRIPTION
KurentoClient has support for callback on the constructor and `getSingleton` method which are not reflected in the typings. This adds them as optional parameters. 

I wasn't able to determine which version of kurento-client added this functionality, as their repo version tags don't seem to be maintained.

--- 
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [KurentoClient.js](https://github.com/Kurento/kurento-client-js/blob/master/lib/KurentoClient.js#L194)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
