### PR TITLE
[codemirror] add `configureMouse` to EditorConfiguration

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -1256,6 +1256,13 @@ declare namespace CodeMirror {
 
         /** Optional lint configuration to be used in conjunction with CodeMirror's linter addon. */
         lint?: boolean | LintStateOptions | Linter | AsyncLinter;
+
+        /** Allows you to configure the behavior of mouse selection and dragging. The function is called when the left mouse button is pressed. */
+        configureMouse?: (
+            cm: CodeMirror.Editor,
+            repeat: 'single' | 'double' | 'triple',
+            event: Event,
+        ) => MouseSelectionConfiguration;
     }
 
     interface TextMarkerOptions {
@@ -1887,5 +1894,33 @@ declare namespace CodeMirror {
              */
             setShowDifferences(showDifferences: boolean): void;
         }
+    }
+
+    interface MouseSelectionConfiguration {
+        /** The unit by which to select. May be one of the built-in units
+        or a function that takes a position and returns a range around
+        that, for a custom unit. The default is to return "word" for
+        double clicks, "line" for triple clicks, "rectangle" for alt-clicks
+        (or, on Chrome OS, meta-shift-clicks), and "single" otherwise. */
+        unit:
+            | 'char'
+            | 'word'
+            | 'line'
+            | 'rectangle'
+            | ((cm: CodeMirror.Editor, pos: Position) => { from: Position; to: Position });
+
+        /** Whether to extend the existing selection range or start
+        a new one. By default, this is enabled when shift clicking. */
+        extend: boolean;
+
+        /** When enabled, this adds a new range to the existing selection,
+        rather than replacing it. The default behavior is to enable this
+        for command-click on Mac OS, and control-click on other platforms. */
+        addNew: boolean;
+
+        /** When the mouse even drags content around inside the editor, this
+        controls whether it is copied (false) or moved (true). By default, this
+        is enabled by alt-clicking on Mac OS, and ctrl-clicking elsewhere. */
+        moveOnDrag: boolean;
     }
 }

--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -1092,6 +1092,13 @@ declare namespace CodeMirror {
         /** Can be used to specify extra keybindings for the editor, alongside the ones defined by keyMap. Should be either null, or a valid keymap value. */
         extraKeys?: string | KeyMap;
 
+        /** Allows you to configure the behavior of mouse selection and dragging. The function is called when the left mouse button is pressed. */
+        configureMouse?: (
+            cm: CodeMirror.Editor,
+            repeat: 'single' | 'double' | 'triple',
+            event: Event,
+        ) => MouseSelectionConfiguration;
+        
         /** Whether CodeMirror should scroll or wrap for long lines. Defaults to false (scroll). */
         lineWrapping?: boolean;
 
@@ -1256,13 +1263,6 @@ declare namespace CodeMirror {
 
         /** Optional lint configuration to be used in conjunction with CodeMirror's linter addon. */
         lint?: boolean | LintStateOptions | Linter | AsyncLinter;
-
-        /** Allows you to configure the behavior of mouse selection and dragging. The function is called when the left mouse button is pressed. */
-        configureMouse?: (
-            cm: CodeMirror.Editor,
-            repeat: 'single' | 'double' | 'triple',
-            event: Event,
-        ) => MouseSelectionConfiguration;
     }
 
     interface TextMarkerOptions {
@@ -1902,7 +1902,7 @@ declare namespace CodeMirror {
         that, for a custom unit. The default is to return "word" for
         double clicks, "line" for triple clicks, "rectangle" for alt-clicks
         (or, on Chrome OS, meta-shift-clicks), and "single" otherwise. */
-        unit:
+        unit?:
             | 'char'
             | 'word'
             | 'line'
@@ -1911,16 +1911,16 @@ declare namespace CodeMirror {
 
         /** Whether to extend the existing selection range or start
         a new one. By default, this is enabled when shift clicking. */
-        extend: boolean;
+        extend?: boolean;
 
         /** When enabled, this adds a new range to the existing selection,
         rather than replacing it. The default behavior is to enable this
         for command-click on Mac OS, and control-click on other platforms. */
-        addNew: boolean;
+        addNew?: boolean;
 
         /** When the mouse even drags content around inside the editor, this
         controls whether it is copied (false) or moved (true). By default, this
         is enabled by alt-clicking on Mac OS, and ctrl-clicking elsewhere. */
-        moveOnDrag: boolean;
+        moveOnDrag?: boolean;
     }
 }


### PR DESCRIPTION
Added type description for `EditorConfiguration.configureMouse` to types/codemirror/index.d.ts, which is available since CodeMirror [v5.27.0](https://github.com/codemirror/CodeMirror/blob/master/CHANGELOG.md#new-features-31).

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - Docs: https://codemirror.net/doc/manual.html#option_configureMouse
   - Code: https://github.com/codemirror/CodeMirror/blob/master/src/edit/mouse_events.js#L116
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

