### PR TITLE
@types/react-native add missing props to TouchableNativeFeedback statics

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -5407,7 +5407,7 @@ export class TouchableNativeFeedback extends TouchableNativeFeedbackBase {
      * @param borderless If the ripple can render outside it's bounds
      * @param radius The radius of ripple effect
      */
-    static Ripple(color: ColorValue, borderless: boolean, radius?: number): RippleBackgroundPropType;
+    static Ripple(color: ColorValue, borderless: boolean, radius?: number | null): RippleBackgroundPropType;
     static canUseNativeForeground(): boolean;
 }
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -5332,13 +5332,13 @@ export class TouchableOpacity extends TouchableOpacityBase {
 
 interface BaseBackgroundPropType {
     type: string;
+    rippleRadius?: number | null;
 }
 
 interface RippleBackgroundPropType extends BaseBackgroundPropType {
-    type: 'RippleAndroid';
-    color?: ColorValue;
-    borderless?: boolean;
-    radius?: number;
+    type: 'RippleAndroid',
+    borderless: boolean,
+    color?: number | null,
 }
 
 interface ThemeAttributeBackgroundPropType extends BaseBackgroundPropType {
@@ -5386,15 +5386,19 @@ export class TouchableNativeFeedback extends TouchableNativeFeedbackBase {
     /**
      * Creates an object that represents android theme's default background for
      * selectable elements (?android:attr/selectableItemBackground).
+     *
+     * @param rippleRadius The radius of ripple effect
      */
-    static SelectableBackground(): ThemeAttributeBackgroundPropType;
+    static SelectableBackground(rippleRadius?: number | null): ThemeAttributeBackgroundPropType;
 
     /**
      * Creates an object that represent android theme's default background for borderless
      * selectable elements (?android:attr/selectableItemBackgroundBorderless).
      * Available on android API level 21+.
+     *
+     * @param rippleRadius The radius of ripple effect
      */
-    static SelectableBackgroundBorderless(): ThemeAttributeBackgroundPropType;
+    static SelectableBackgroundBorderless(rippleRadius?: number | null): ThemeAttributeBackgroundPropType;
 
     /**
      * Creates an object that represents ripple drawable with specified color (as a
@@ -5405,9 +5409,9 @@ export class TouchableNativeFeedback extends TouchableNativeFeedbackBase {
      *
      * @param color The ripple color
      * @param borderless If the ripple can render outside it's bounds
-     * @param radius The radius of ripple effect
+     * @param rippleRadius The radius of ripple effect
      */
-    static Ripple(color: ColorValue, borderless: boolean, radius?: number | null): RippleBackgroundPropType;
+    static Ripple(color: ColorValue, borderless: boolean, rippleRadius?: number | null): RippleBackgroundPropType;
     static canUseNativeForeground(): boolean;
 }
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -5407,7 +5407,7 @@ export class TouchableNativeFeedback extends TouchableNativeFeedbackBase {
      * @param borderless If the ripple can render outside it's bounds
      * @param radius The radius of ripple effect
      */
-    static Ripple(color: ColorValue, borderless: boolean, radius?: number | null): RippleBackgroundPropType;
+    static Ripple(color: ColorValue, borderless?: boolean, radius?: number): RippleBackgroundPropType;
     static canUseNativeForeground(): boolean;
 }
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -5407,7 +5407,7 @@ export class TouchableNativeFeedback extends TouchableNativeFeedbackBase {
      * @param borderless If the ripple can render outside it's bounds
      * @param radius The radius of ripple effect
      */
-    static Ripple(color: ColorValue, borderless?: boolean, radius?: number): RippleBackgroundPropType;
+    static Ripple(color: ColorValue, borderless: boolean, radius?: number): RippleBackgroundPropType;
     static canUseNativeForeground(): boolean;
 }
 

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -403,6 +403,21 @@ export class TouchableNativeFeedbackTest extends React.Component {
                         <Text style={{ margin: 30 }}>Button</Text>
                     </View>
                 </TouchableNativeFeedback>
+                <TouchableNativeFeedback background={TouchableNativeFeedback.SelectableBackgroundBorderless(30)}>
+                    <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
+                        <Text style={{ margin: 30 }}>Button</Text>
+                    </View>
+                </TouchableNativeFeedback>
+                <TouchableNativeFeedback background={TouchableNativeFeedback.SelectableBackground()}>
+                    <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
+                        <Text style={{ margin: 30 }}>Button</Text>
+                    </View>
+                </TouchableNativeFeedback>
+                <TouchableNativeFeedback background={TouchableNativeFeedback.SelectableBackground(30)}>
+                    <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
+                        <Text style={{ margin: 30 }}>Button</Text>
+                    </View>
+                </TouchableNativeFeedback>
             </>
         );
     }

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -393,7 +393,7 @@ export class TouchableNativeFeedbackTest extends React.Component {
                         <Text style={{ margin: 30 }}>Button</Text>
                     </View>
                 </TouchableNativeFeedback>
-                <TouchableNativeFeedback background={TouchableNativeFeedback.SelectableBackground()}>
+                <TouchableNativeFeedback background={TouchableNativeFeedback.SelectableBackground(30)}>
                     <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
                         <Text style={{ margin: 30 }}>Button</Text>
                     </View>
@@ -404,16 +404,6 @@ export class TouchableNativeFeedbackTest extends React.Component {
                     </View>
                 </TouchableNativeFeedback>
                 <TouchableNativeFeedback background={TouchableNativeFeedback.SelectableBackgroundBorderless(30)}>
-                    <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
-                        <Text style={{ margin: 30 }}>Button</Text>
-                    </View>
-                </TouchableNativeFeedback>
-                <TouchableNativeFeedback background={TouchableNativeFeedback.SelectableBackground()}>
-                    <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
-                        <Text style={{ margin: 30 }}>Button</Text>
-                    </View>
-                </TouchableNativeFeedback>
-                <TouchableNativeFeedback background={TouchableNativeFeedback.SelectableBackground(30)}>
                     <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
                         <Text style={{ margin: 30 }}>Button</Text>
                     </View>

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -393,6 +393,11 @@ export class TouchableNativeFeedbackTest extends React.Component {
                         <Text style={{ margin: 30 }}>Button</Text>
                     </View>
                 </TouchableNativeFeedback>
+                <TouchableNativeFeedback background={TouchableNativeFeedback.SelectableBackground()}>
+                    <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
+                        <Text style={{ margin: 30 }}>Button</Text>
+                    </View>
+                </TouchableNativeFeedback>
                 <TouchableNativeFeedback background={TouchableNativeFeedback.SelectableBackgroundBorderless()}>
                     <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
                         <Text style={{ margin: 30 }}>Button</Text>


### PR DESCRIPTION
Updated following props of `TouchableNativeFeedback`:
- Changed the prop `radius` to `rippleRadius` in `Ripple` to match https://github.com/facebook/react-native/blob/216037757494edf990ecb5a3dfdf6f75bab818a1/Libraries/Components/Touchable/TouchableNativeFeedback.js#L137
- Added `rippleRadius` to `BaseBackgroundPropType` since all options return it: https://github.com/facebook/react-native/blob/216037757494edf990ecb5a3dfdf6f75bab818a1/Libraries/Components/Touchable/TouchableNativeFeedback.js#L109, https://github.com/facebook/react-native/blob/216037757494edf990ecb5a3dfdf6f75bab818a1/Libraries/Components/Touchable/TouchableNativeFeedback.js#L125, https://github.com/facebook/react-native/blob/216037757494edf990ecb5a3dfdf6f75bab818a1/Libraries/Components/Touchable/TouchableNativeFeedback.js#L144
- Added `rippleRadius` to `SelectableBackground`: https://github.com/facebook/react-native/blob/216037757494edf990ecb5a3dfdf6f75bab818a1/Libraries/Components/Touchable/TouchableNativeFeedback.js#L105 and `SelectableBackgroundBorderless`: https://github.com/facebook/react-native/blob/216037757494edf990ecb5a3dfdf6f75bab818a1/Libraries/Components/Touchable/TouchableNativeFeedback.js#L121. You can see they are used in tests: https://github.com/facebook/react-native/blob/6e6443afd04a847ef23fb6254a84e48c70b45896/packages/rn-tester/js/examples/Touchable/TouchableExample.js#L456
- Added tests for the changes

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/facebook/react-native/blob/216037757494edf990ecb5a3dfdf6f75bab818a1/Libraries/Components/Touchable/TouchableNativeFeedback.js#L137>

