### PR TITLE
Add 'search' method to connection.js

### DIFF
--- a/types/jsforce/connection.d.ts
+++ b/types/jsforce/connection.d.ts
@@ -153,6 +153,10 @@ export interface ExecuteAnonymousResult {
 
 export type ConnectionEvent = "refresh";
 
+export interface SearchResult<T> {
+    searchRecords: Record<T>[];
+}
+
 /**
  * the methods exposed here are done so that a client can use 'declaration augmentation' to get intellisense on their own projects.
  * for example, given a type
@@ -217,6 +221,7 @@ export abstract class BaseConnection extends EventEmitter {
     recent(callback?: (err: Error, result: RecordResult[]) => void): Promise<(RecordResult[])>;
     recent(param: number | string, callback?: (err: Error, result: RecordResult[]) => void): Promise<(RecordResult[])>;
     recent(type: string, limit: number, callback?: (err: Error, result: RecordResult[]) => void): Promise<(RecordResult[])>;
+    search<T>(sosl: string, callback?: (err: Error, result: SearchResult<T>) => void): Promise<(SearchResult<T>)>;
 }
 
 export class Connection extends BaseConnection {

--- a/types/jsforce/jsforce-tests.ts
+++ b/types/jsforce/jsforce-tests.ts
@@ -8,6 +8,7 @@ import { RecordReference, Record } from 'jsforce/record';
 import { SObject } from 'jsforce/salesforce-object';
 import { RecordResult } from 'jsforce/record-result';
 import { BatchDescribeSObjectOptions, DescribeSObjectOptions, DescribeSObjectResult } from 'jsforce/describe-result';
+import { SearchResult } from 'jsforce/connection';
 
 const salesforceConnection: sf.Connection = new sf.Connection({
     instanceUrl: '',
@@ -467,6 +468,10 @@ const requestInfo: sf.RequestInfo = {
 interface MyFoo {
     anything: string;
 }
+interface MyBar {
+    something: string;
+}
+
 salesforceConnection.request<MyFoo>(requestInfo).then((myFoo: MyFoo) => {
     console.log(myFoo.anything)
 });
@@ -500,6 +505,20 @@ salesforceConnection.query('SELECT Id FROM Account')
         console.log('Error returned from query:', error);
     })
     .run({ autoFetch: true, maxFetch: 25 });
+
+salesforceConnection.search<MyFoo|MyBar>('FIND {my} IN ALL FIELDS RETURNING Foo__c(Id, Name), Bar__c(Id, Name)', (err: Error, result: SearchResult<MyFoo|MyBar>) => {
+    console.error(err);
+    for (const record of result.searchRecords) {
+        if (record && record.attributes && record.attributes.type === 'Foo__c') {
+            const foo = record as MyFoo;
+            console.log(foo.anything);
+        }
+        if (record && record.attributes && record.attributes.type === 'Bar__c') {
+            const bar = record as MyBar;
+            console.log(bar.something);
+        }
+    }
+});
 
 salesforceConnection.sobject<any>('Coverage__c')
     .select(['Id', 'Name']).del(() => { });

--- a/types/jsforce/record.d.ts
+++ b/types/jsforce/record.d.ts
@@ -15,4 +15,12 @@ export class RecordReference<T = any> {
     update(record: Partial<T>, options?: Object, callback?: (err: Error, result: RecordResult) => void): Promise<RecordResult>;
 }
 
-export type Record<T = any> = { Id?: SalesforceId } & T;
+export interface RecordAttributes {
+    type: string;
+    url: string;
+}
+
+export type Record<T = any> = {
+    Id?: SalesforceId;
+    attributes?: RecordAttributes
+} & T;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jsforce/jsforce/blob/master/build/jsforce-core.js
  * Line 1910
  * Also note, the jsdocs for the method in the jsforce library are wrong. What is returned is NOT an array of RecordResult; it's the SearchResult type included in this pull request.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

### SOSL Response
```typescript
jsforceClient.search(
    'FIND {my} IN ALL FIELDS RETURNING Foo__c(Id, Name), Bar__c(Id, Name)',
    (err: Error, results: SearchResult) => {
        console.log(results);
    },
);
```
```json
{
    "searchRecords": [
        {
            "attributes": {
                "type": "Foo__c",
                "url": "/services/data/v49.0/sobjects/Foo__c/a7hB0000000GpeuIAC"
            },
            "Id": "a7hB0000000GpeuIAC",
            "Name": "My Foo"
        },
        {
            "attributes": {
                "type": "Bar__c",
                "url": "/services/data/v49.0/sobjects/Bar__c/a7vB000000006VWIAY"
            },
            "Id": "a7vB000000006VWIAY",
            "Name": "My Bar"
        }
    ]
}

```