### PR TITLE
undo react-redux deprecation of TypedUseSelectorHook type

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -18,6 +18,7 @@
 //                 Kazuma Ebina <https://github.com/kazuma1989>
 //                 Michael Lebedev <https://github.com/megazazik>
 //                 jun-sheaf <https://github.com/jun-sheaf>
+//                 Lenz Weber <https://github.com/phryneas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -577,8 +578,6 @@ export function useSelector<TState = DefaultRootState, TSelected = unknown>(
  * }
  *
  * const useTypedSelector: TypedUseSelectorHook<RootState> = useSelector;
- *
- * @deprecated Use `createSelectorHook<State, Action>()`
  */
 export interface TypedUseSelectorHook<TState> {
     <TSelected>(


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react-redux.js.org/using-react-redux/static-typing#typing-the-useselector-hook
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

Hi there. 

I'm a maintainer over at https://github.com/reduxjs/. It was brought to my attention that recently a `@deprecated` tag was added to the `TypedUseSelectorHook` type with the suggestion to use `createSelectorHook` instead. (in #46446) 

This should not be the case. 

Our [documentation shows that type](https://react-redux.js.org/using-react-redux/static-typing#typing-the-useselector-hook) and this change was made without opening a PR against the documentation or starting a discussion in our issues. I've had a short conversation with @markerikson on this and we agree that we want to stick to the current recommendation of doing a type assertion instead of introducing runtime code to really just achieve the same result. 
`createSelectorHook` is an advanced API that the average consumer of react-redux should never be incentivized to touch.

In addition to undoing the mentioned deprecation, with this PR I'm adding myself as a code owner so that I'm going to be notified about future PRs against the react-redux types and have a chance to review them.

Greetings,
Lenz