### PR TITLE
feat(aws-lambda): use interfaces for key-value object properties to allow merging

### DIFF
--- a/types/aws-lambda/test/alb-tests.ts
+++ b/types/aws-lambda/test/alb-tests.ts
@@ -3,10 +3,12 @@ import { ALBHandler, ALBResult } from "aws-lambda";
 const handler: ALBHandler = async (event, context, callback) => {
     str = event.httpMethod;
     str = event.path;
-    str = event.queryStringParameters![str];
-    str = event.headers![str];
-    str = event.multiValueQueryStringParameters![str][num];
-    str = event.multiValueHeaders![str][num];
+    strOrUndefined = event.queryStringParameters![str];
+    strOrUndefined = event.headers![str];
+    strArrayOrUndefined = event.multiValueQueryStringParameters![str];
+    str = event.multiValueQueryStringParameters![str]![num];
+    strArrayOrUndefined = event.multiValueHeaders![str];
+    str = event.multiValueHeaders![str]![num];
     strOrNull = event.body;
     bool = event.isBase64Encoded;
     str = event.requestContext.elb.targetGroupArn;

--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -72,15 +72,17 @@ type ProbablyInvalidCustomProxyHandler = APIGatewayProxyWithLambdaAuthorizerHand
 let proxyHandler: APIGatewayProxyHandler = async (event, context, callback) => {
     strOrNull = event.body;
     const headers = event.headers; // $ExpectType APIGatewayProxyEventHeaders
-    str = event.headers['example'];
-    str = event.multiValueHeaders['example'][0];
+    strOrUndefined = event.headers['example'];
+    strArrayOrUndefined = event.multiValueHeaders['example'];
+    str = event.multiValueHeaders['example']![0];
     str = event.httpMethod;
     bool = event.isBase64Encoded;
     str = event.path;
-    str = event.pathParameters!['example'];
-    str = event.queryStringParameters!['example'];
-    str = event.multiValueQueryStringParameters!['example'][0];
-    str = event.stageVariables!['example'];
+    strOrUndefined = event.pathParameters!['example'];
+    strOrUndefined = event.queryStringParameters!['example'];
+    strArrayOrUndefined = event.multiValueQueryStringParameters!['example'];
+    str = event.multiValueQueryStringParameters!['example']![0];
+    strOrUndefined = event.stageVariables!['example'];
     let requestContext: APIGatewayEventRequestContext;
     requestContext = event.requestContext;
     let requestContextWithCustomAuthorizer: APIGatewayEventRequestContextWithAuthorizer<CustomAuthorizerContext>;
@@ -139,7 +141,7 @@ let proxyHandler: APIGatewayProxyHandler = async (event, context, callback) => {
 
 const proxyHandlerV2: APIGatewayProxyHandlerV2 = async (event, context, callback) => {
     strOrUndefined = event.body;
-    str = event.headers['example'];
+    str = event.headers['example']!;
     str = event.routeKey;
     bool = event.isBase64Encoded;
     str = event.rawPath;
@@ -172,8 +174,9 @@ const proxyHandlerV2: APIGatewayProxyHandlerV2 = async (event, context, callback
 const proxyHandlerWithCustomAuthorizer: APIGatewayProxyWithLambdaAuthorizerHandler<CustomAuthorizerContext> = async (event, context, callback) => {
     // standard fields...
     strOrNull = event.body;
-    str = event.headers['example'];
-    str = event.multiValueHeaders['example'][0];
+    strOrUndefined = event.headers['example'];
+    strArrayOrUndefined = event.multiValueHeaders['example'];
+    str = event.multiValueHeaders['example']![0];
 
     // It seems like it would be easy to make this mistake, but it's still a useful type.
     let requestContextWithAuthorizerDirectly: APIGatewayEventRequestContextWithAuthorizer<CustomAuthorizerContext>;
@@ -386,17 +389,17 @@ const requestAuthorizer: APIGatewayRequestAuthorizerHandler = async (event, cont
     str = event.path;
     str = event.httpMethod;
     if (event.headers !== null)
-        str = event.headers[str];
+        strOrUndefined = event.headers[str];
     if (event.multiValueHeaders !== null)
-        str = event.multiValueHeaders[str][num];
+        str = event.multiValueHeaders[str]![num];
     if (event.pathParameters !== null)
-        str = event.pathParameters[str];
+        strOrUndefined = event.pathParameters[str];
     if (event.queryStringParameters !== null)
-        str = event.queryStringParameters[str];
+        strOrUndefined = event.queryStringParameters[str];
     if (event.multiValueQueryStringParameters !== null)
-        str = event.multiValueQueryStringParameters[str][num];
+        str = event.multiValueQueryStringParameters[str]![num];
     if (event.stageVariables !== null)
-        str = event.stageVariables[str];
+        strOrUndefined = event.stageVariables[str];
     const requestContext: APIGatewayEventRequestContext = event.requestContext;
     if (requestContext.domainName != null) {
         str = requestContext.domainName;

--- a/types/aws-lambda/test/appsync-resolver-tests.ts
+++ b/types/aws-lambda/test/appsync-resolver-tests.ts
@@ -31,7 +31,7 @@ const handler: AppSyncResolverHandler<TestArguments, TestEntity> = async (event,
     str = (event.identity as AppSyncIdentityCognito).username;
     anyObj = (event.identity as AppSyncIdentityCognito).claims;
 
-    str = event.request.headers.host;
+    strOrUndefined = event.request.headers.host;
 
     str = event.info.fieldName;
     str = event.info.parentTypeName;

--- a/types/aws-lambda/test/cloudwatch-tests.ts
+++ b/types/aws-lambda/test/cloudwatch-tests.ts
@@ -24,7 +24,7 @@ const logsHandler: CloudWatchLogsHandler = async (event, context, callback) => {
     str = logEvent.id;
     num = logEvent.timestamp;
     str = logEvent.message;
-    str = logEvent.extractedFields!['example'];
+    strOrUndefined = logEvent.extractedFields!['example'];
 
     callback();
     callback(new Error());

--- a/types/aws-lambda/trigger/alb.d.ts
+++ b/types/aws-lambda/trigger/alb.d.ts
@@ -10,14 +10,30 @@ export interface ALBEventRequestContext {
     };
 }
 
+export interface ALBEventQueryStringParameters {
+    [name: string]: string | undefined;
+}
+
+export interface ALBEventHeaders {
+    [name: string]: string | undefined;
+}
+
+export interface ALBEventMultiValueHeaders {
+    [name: string]: string[] | undefined;
+}
+
+export interface ALBEventMultiValueQueryStringParameters {
+    [name: string]: string[] | undefined;
+}
+
 export interface ALBEvent {
     requestContext: ALBEventRequestContext;
     httpMethod: string;
     path: string;
-    queryStringParameters?: { [parameter: string]: string }; // URL encoded
-    headers?: { [header: string]: string };
-    multiValueQueryStringParameters?: { [parameter: string]: string[] }; // URL encoded
-    multiValueHeaders?: { [header: string]: string[] };
+    queryStringParameters?: ALBEventQueryStringParameters; // URL encoded
+    headers?: ALBEventHeaders;
+    multiValueQueryStringParameters?: ALBEventMultiValueQueryStringParameters; // URL encoded
+    multiValueHeaders?: ALBEventMultiValueHeaders;
     body: string | null;
     isBase64Encoded: boolean;
 }

--- a/types/aws-lambda/trigger/api-gateway-authorizer.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-authorizer.d.ts
@@ -31,6 +31,30 @@ export interface APIGatewayTokenAuthorizerEvent {
     authorizationToken: string;
 }
 
+export interface APIGatewayRequestAuthorizerEventHeaders {
+    [name: string]: string | undefined;
+}
+
+export interface APIGatewayRequestAuthorizerEventMultiValueHeaders {
+    [name: string]: string[] | undefined;
+}
+
+export interface APIGatewayRequestAuthorizerEventPathParameters {
+    [name: string]: string | undefined;
+}
+
+export interface APIGatewayRequestAuthorizerEventQueryStringParameters {
+    [name: string]: string | undefined;
+}
+
+export interface APIGatewayRequestAuthorizerEventMultiValueQueryStringParameters {
+    [name: string]: string[] | undefined;
+}
+
+export interface APIGatewayRequestAuthorizerEventStageVariables {
+    [name: string]: string | undefined;
+}
+
 // Note, when invoked by the tester in the AWS web console, the map values can be null,
 // but they will be empty objects in the real object.
 // Worse, it will include "body" and "isBase64Encoded" properties, unlike the real call!
@@ -42,12 +66,12 @@ export interface APIGatewayRequestAuthorizerEvent {
     resource: string;
     path: string;
     httpMethod: string;
-    headers: { [name: string]: string } | null;
-    multiValueHeaders: { [name: string]: string[] } | null;
-    pathParameters: { [name: string]: string } | null;
-    queryStringParameters: { [name: string]: string } | null;
-    multiValueQueryStringParameters: { [name: string]: string[] } | null;
-    stageVariables: { [name: string]: string } | null;
+    headers: APIGatewayRequestAuthorizerEventHeaders | null;
+    multiValueHeaders: APIGatewayRequestAuthorizerEventMultiValueHeaders | null;
+    pathParameters: APIGatewayRequestAuthorizerEventPathParameters | null;
+    queryStringParameters: APIGatewayRequestAuthorizerEventQueryStringParameters | null;
+    multiValueQueryStringParameters: APIGatewayRequestAuthorizerEventMultiValueQueryStringParameters | null;
+    stageVariables: APIGatewayRequestAuthorizerEventStageVariables | null;
     requestContext: APIGatewayEventRequestContextWithAuthorizer<undefined>;
 }
 

--- a/types/aws-lambda/trigger/api-gateway-proxy.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-proxy.d.ts
@@ -63,31 +63,39 @@ export interface APIGatewayProxyCognitoAuthorizer {
 }
 
 export interface APIGatewayProxyEventHeaders {
-    [name: string]: string;
+    [name: string]: string | undefined;
+}
+
+export interface APIGatewayProxyEventMultiValueHeaders {
+    [name: string]: string[] | undefined;
 }
 
 export interface APIGatewayProxyEventPathParameters {
-    [name: string]: string;
+    [name: string]: string | undefined;
 }
 
 export interface APIGatewayProxyEventQueryStringParameters {
-    [name: string]: string;
+    [name: string]: string | undefined;
+}
+
+export interface APIGatewayProxyEventMultiValueQueryStringParameters {
+    [name: string]: string[] | undefined;
 }
 
 export interface APIGatewayProxyEventStageVariables {
-    [name: string]: string;
+    [name: string]: string | undefined;
 }
 
 export interface APIGatewayProxyEventBase<TAuthorizerContext> {
     body: string | null;
     headers: APIGatewayProxyEventHeaders;
-    multiValueHeaders: { [name: string]: string[] };
+    multiValueHeaders: APIGatewayProxyEventMultiValueHeaders;
     httpMethod: string;
     isBase64Encoded: boolean;
     path: string;
     pathParameters: APIGatewayProxyEventPathParameters | null;
     queryStringParameters: APIGatewayProxyEventQueryStringParameters | null;
-    multiValueQueryStringParameters: { [name: string]: string[] } | null;
+    multiValueQueryStringParameters: APIGatewayProxyEventMultiValueQueryStringParameters | null;
     stageVariables: APIGatewayProxyEventStageVariables | null;
     requestContext: APIGatewayEventRequestContextWithAuthorizer<TAuthorizerContext>;
     resource: string;

--- a/types/aws-lambda/trigger/appsync-resolver.d.ts
+++ b/types/aws-lambda/trigger/appsync-resolver.d.ts
@@ -2,6 +2,10 @@ import { Handler } from '../handler';
 
 export type AppSyncResolverHandler<T, V> = Handler<AppSyncResolverEvent<T>, V | V[]>;
 
+export interface AppSyncResolverEventHeaders {
+    [name: string]: string | undefined;
+}
+
 /**
  * See https://docs.aws.amazon.com/appsync/latest/devguide/resolver-context-reference.html
  *
@@ -12,7 +16,7 @@ export interface AppSyncResolverEvent<T> {
     identity?: AppSyncIdentityIAM | AppSyncIdentityCognito;
     source?: { [key: string]: any };
     request: {
-        headers: { [key: string]: string };
+        headers: AppSyncResolverEventHeaders;
     };
     info: {
         selectionSetList: string[];

--- a/types/aws-lambda/trigger/cloudwatch-logs.d.ts
+++ b/types/aws-lambda/trigger/cloudwatch-logs.d.ts
@@ -22,6 +22,10 @@ export interface CloudWatchLogsDecodedData {
     logEvents: CloudWatchLogsLogEvent[];
 }
 
+export interface CloudWatchLogsLogEventExtractedFields {
+    [name: string]: string | undefined;
+}
+
 /**
  * See http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html#LambdaFunctionExample
  */
@@ -29,5 +33,5 @@ export interface CloudWatchLogsLogEvent {
     id: string;
     timestamp: number;
     message: string;
-    extractedFields?: { [key: string]: string };
+    extractedFields?: CloudWatchLogsLogEventExtractedFields;
 }

--- a/types/aws-lambda/trigger/lex.d.ts
+++ b/types/aws-lambda/trigger/lex.d.ts
@@ -3,12 +3,24 @@ import { Callback, Handler } from "../handler";
 export type LexHandler = Handler<LexEvent, LexResult>;
 export type LexCallback = Callback<LexResult>;
 
+export interface LexEventSlots {
+    [name: string]: string | undefined | null;
+}
+
+export interface LexEventSessionAttributes {
+    [key: string]: string | undefined;
+}
+
+export interface LexEventRequestAttributes {
+    [key: string]: string | undefined;
+}
+
 // Lex
 // https://docs.aws.amazon.com/lambda/latest/dg/invoking-lambda-function.html#supported-event-source-lex
 export interface LexEvent {
     currentIntent: {
         name: string;
-        slots: { [name: string]: string | null };
+        slots: LexEventSlots;
         slotDetails: LexSlotDetails;
         confirmationStatus: 'None' | 'Confirmed' | 'Denied';
     };
@@ -22,8 +34,8 @@ export interface LexEvent {
     invocationSource: 'DialogCodeHook' | 'FulfillmentCodeHook';
     outputDialogMode: 'Text' | 'Voice';
     messageVersion: '1.0';
-    sessionAttributes: { [key: string]: string };
-    requestAttributes: { [key: string]: string } | null;
+    sessionAttributes: LexEventSessionAttributes;
+    requestAttributes: LexEventRequestAttributes | null;
 }
 
 export interface LexSlotResolution {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

----

This is a more aggressive version of #49973, for more properties.

I also realised that its best if the properties have `| undefined` as otherwise there's not a lot of point.
This should be fine as now any properties that are known to exist for an interface should be defined as such using declaration merging:

```
declare module 'aws-lambda/trigger/api-gateway-proxy' {
  export interface APIGatewayProxyEventHeaders {
    'X-GitHub-Event': WebhookEvents;
  }
}
```

For now I've focused on just primitive & array maps - i.e I've not marked `SQSMessageAttributes`  as `| undefined` - as that'd require importing in more types and so are a bit more effort downstream. Ideally they should also be updated to have `| undefined` at some point.