### PR TITLE
feat(aws-lambda): use tuple for property type in `LexSlotDetail` interface

### DIFF
--- a/types/aws-lambda/test/lex-tests.ts
+++ b/types/aws-lambda/test/lex-tests.ts
@@ -10,6 +10,7 @@ import {
     LexGenericAttachment,
     LexHandler,
     LexResult,
+    LexSlotDetail
 } from "aws-lambda";
 
 // TODO: Update test to read all event properties, and write all result
@@ -120,3 +121,29 @@ lexDialogActionElicitSlot.type === 'ElicitSlot';
 strOrNull = lexDialogActionElicitSlot.slots['example'];
 str = lexDialogActionElicitSlot.slotToElicit;
 str = lexDialogActionElicitSlot.intentName;
+
+declare let lexSlotDetail: LexSlotDetail;
+lexSlotDetail = {
+    resolutions: [{ value: 'value1' }],
+    originalValue: 'originalValue',
+};
+
+lexSlotDetail.resolutions[0];
+lexSlotDetail.resolutions[1];
+lexSlotDetail.resolutions[2];
+lexSlotDetail.resolutions[3];
+lexSlotDetail.resolutions[4];
+lexSlotDetail.resolutions[5]; // $ExpectError
+
+lexSlotDetail = {
+    // $ExpectError
+    resolutions: [
+        { value: 'value0' },
+        { value: 'value1' },
+        { value: 'value2' },
+        { value: 'value3' },
+        { value: 'value4' },
+        { value: 'value5' },
+    ],
+    originalValue: 'originalValue',
+};

--- a/types/aws-lambda/trigger/lex.d.ts
+++ b/types/aws-lambda/trigger/lex.d.ts
@@ -30,13 +30,14 @@ export interface LexSlotResolution {
     value: string;
 }
 
+export interface LexSlotDetail {
+    // "at least 1 but no more than 5 items"
+    resolutions: [LexSlotResolution, LexSlotResolution?, LexSlotResolution?, LexSlotResolution?, LexSlotResolution?];
+    originalValue: string;
+}
+
 export interface LexSlotDetails {
-    [name: string]: {
-        // The following line only works in TypeScript Version: 3.0, The array should have at least 1 and no more than 5 items
-        // resolutions: [LexSlotResolution, LexSlotResolution?, LexSlotResolution?, LexSlotResolution?, LexSlotResolution?];
-        resolutions: LexSlotResolution[];
-        originalValue: string;
-    };
+    [name: string]: LexSlotDetail;
 }
 
 export interface LexGenericAttachment {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

----

We're using TypeScript 3+ now, so this can be shipped. Also made the type an `interface` so it can be imported and used on its own.