### PR TITLE
'timeoutAfter' for react-native-push-notification

### DIFF
--- a/types/react-native-push-notification/index.d.ts
+++ b/types/react-native-push-notification/index.d.ts
@@ -62,7 +62,7 @@ export class PushNotificationObject {
     channelId?: string;
     onlyAlertOnce?: boolean;
     allowWhileIdle?: boolean;
-    timeoutAfter?: number;
+    timeoutAfter?: number | null;
     messageId?: string;
 
     actions?: string;

--- a/types/react-native-push-notification/index.d.ts
+++ b/types/react-native-push-notification/index.d.ts
@@ -63,7 +63,6 @@ export class PushNotificationObject {
     onlyAlertOnce?: boolean;
     allowWhileIdle?: boolean;
     timeoutAfter?: number;
-    
     messageId?: string;
 
     actions?: string;

--- a/types/react-native-push-notification/index.d.ts
+++ b/types/react-native-push-notification/index.d.ts
@@ -62,7 +62,8 @@ export class PushNotificationObject {
     channelId?: string;
     onlyAlertOnce?: boolean;
     allowWhileIdle?: boolean;
-
+    timeoutAfter?: number;
+    
     messageId?: string;
 
     actions?: string;


### PR DESCRIPTION
added 'timeoutAfter' for local notifications to react-native-push-notification
This property was missing from definition.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zo0r/react-native-push-notification#local-notifications and https://github.com/zo0r/react-native-push-notification/blob/64e2a67ec3bb4c0b54ac653ed5fddd4acd935a1d/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
