### PR TITLE
[sharp] specifies format type

### DIFF
--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -720,8 +720,8 @@ declare namespace sharp {
         width?: number;
         /** Number of pixels high (EXIF orientation is not taken into consideration) */
         height?: number;
-        /** Name of colour space interpretation e.g. srgb, rgb, cmyk, lab, b-w ... */
-        space?: string;
+        /** Name of colour space interpretation */
+        space?: keyof ColourspaceEnum;
         /** Number of bands e.g. 3 for sRGB, 4 for CMYK */
         channels?: Channels;
         /** Name of pixel depth format e.g. uchar, char, ushort, float ... */

--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -431,7 +431,7 @@ declare namespace sharp {
          * Write output image data to a file.
          * @param fileOut The path to write the image data to.
          * @throws {Error} Invalid parameters
-         * @returns A promise that fulfills with an object containing informations on the resulting file
+         * @returns A promise that fulfills with an object containing information on the resulting file
          */
         toFile(fileOut: string): Promise<OutputInfo>;
 

--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -536,7 +536,7 @@ declare namespace sharp {
          * @returns A sharp instance that can be used to chain operations
          */
         toFormat(
-            format: string | AvailableFormatInfo,
+            format: keyof FormatEnum | AvailableFormatInfo,
             options?:
                 | OutputOptions
                 | JpegOptions
@@ -713,7 +713,7 @@ declare namespace sharp {
 
     interface Metadata extends WriteableMetadata {
         /** Name of decoder used to decompress image data e.g. jpeg, png, webp, gif, svg */
-        format?: string;
+        format?: keyof FormatEnum;
         /** Total size of image in bytes, for Stream and Buffer input only */
         size?: number;
         /** Number of pixels wide (EXIF orientation is not taken into consideration) */
@@ -1138,23 +1138,23 @@ declare namespace sharp {
     }
 
     interface FormatEnum {
-        jpeg: AvailableFormatInfo;
-        png: AvailableFormatInfo;
-        webp: AvailableFormatInfo;
         avif: AvailableFormatInfo;
-        heif: AvailableFormatInfo;
-        raw: AvailableFormatInfo;
-        tiff: AvailableFormatInfo;
         dz: AvailableFormatInfo;
-        input: AvailableFormatInfo;
-        magick: AvailableFormatInfo;
-        openslide: AvailableFormatInfo;
-        ppm: AvailableFormatInfo;
         fits: AvailableFormatInfo;
         gif: AvailableFormatInfo;
-        svg: AvailableFormatInfo;
+        heif: AvailableFormatInfo;
+        input: AvailableFormatInfo;
+        jpeg: AvailableFormatInfo;
+        magick: AvailableFormatInfo;
+        openslide: AvailableFormatInfo;
         pdf: AvailableFormatInfo;
+        png: AvailableFormatInfo;
+        ppm: AvailableFormatInfo;
+        raw: AvailableFormatInfo;
+        svg: AvailableFormatInfo;
+        tiff: AvailableFormatInfo;
         v: AvailableFormatInfo;
+        webp: AvailableFormatInfo;
     }
 
     interface CacheResult {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [] ~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change~.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: `the types themselves`
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


The result of this PR is that instead of `format` being typed as `string`, it's typed as to provide the real options.

![Screenshot_20201222_094021](https://user-images.githubusercontent.com/15232461/102902158-9399f880-443c-11eb-9d9a-c1f7ee6398e2.png)
