### PR TITLE
Fix: node http METHODS should list knows methods

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -395,7 +395,13 @@ declare module "http" {
         destroy(): void;
     }
 
-    const METHODS: string[];
+    const METHODS: Array<
+        | 'ACL' | 'BIND' | 'CHECKOUT' | 'CONNECT' | 'COPY' | 'DELETE' | 'GET'
+        | 'HEAD' | 'LINK' | 'LOCK' | 'M-SEARCH' | 'MERGE' | 'MKACTIVITY' | 'MKCALENDAR'
+        | 'MKCOL' | 'MOVE' | 'NOTIFY' | 'OPTIONS' | 'PATCH' | 'POST' | 'PRI'
+        | 'PROPFIND' | 'PROPPATCH' | 'PURGE' | 'PUT' | 'REBIND' | 'REPORT' | 'SEARCH'
+        | 'SOURCE' | 'SUBSCRIBE' | 'TRACE' | 'UNBIND' | 'UNLINK' | 'UNLOCK' | 'UNSUBSCRIBE'
+    >;
 
     const STATUS_CODES: {
         [errorCode: number]: string | undefined;

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -133,10 +133,13 @@ import * as net from 'net';
     const method: string = req.method;
 }
 
+// HTTP Methods
 {
-    // Status codes
-    let codeMessage: string = http.STATUS_CODES['400']!;
-    codeMessage = http.STATUS_CODES[400]!;
+    http.METHODS.length;
+
+    let method: typeof http.METHODS[number] = http.METHODS[7];
+    method = 'any_string'; // $ExpectError
+    method = http.METHODS[42];
 }
 
 {

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -142,6 +142,12 @@ import * as net from 'net';
     method = http.METHODS[42];
 }
 
+// HTTP status codes
+{
+    let codeMessage: string = http.STATUS_CODES['400']!;
+    codeMessage = http.STATUS_CODES[400]!;
+}
+
 {
     let agent: http.Agent = new http.Agent({
         keepAlive: true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - ~[STATUS_CODES](https://github.com/nodejs/node/blob/8154e47e2b407a906f2c1270e5fc76fe466cc886/lib/_http_server.js#L94)~
  - METHODS I could not find, so I just logged ones in node14
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Changed these because they are pretty much constant anyway and for a better autocomplete support and to be able to do things like
```ts
type HTTPMethod = typeof http.METHODS[number];
type HTTPStatusCode = keyof typeof http.STATUS_CODES; // not implemented due to back-compat concerns
```
Very handy in cases where you expect not just any string, but an HTTP method. ~Same for HTTP status codes.~
