### PR TITLE
Parcel-Bundler: Add missing `autoInstall` property to ParcelOptions

### DIFF
--- a/types/parcel-bundler/index.d.ts
+++ b/types/parcel-bundler/index.d.ts
@@ -150,6 +150,13 @@ declare namespace ParcelBundler {
          * @default false
          */
         hmr?: true | false;
+
+        /**
+         * Enable or disable auto install of missing dependencies found during bundling
+         *
+         * @default true
+         */
+        autoInstall?: boolean;
     }
 
     type ParcelAsset = any;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] ~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~ The [tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/48b9a8ed5b55ba1535829c163c61de8e7553da53/types/parcel-bundler/parcel-bundler-tests.ts#L3) don't include the other options
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://parceljs.org/api.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **n/a**