### PR TITLE
react-bootstrap-table2-filter: Filter factory after filter spec

### DIFF
--- a/types/react-bootstrap-table2-filter/index.d.ts
+++ b/types/react-bootstrap-table2-filter/index.d.ts
@@ -144,5 +144,10 @@ export function customFilter(props: CustomFilterProps): TableColumnFilterProps;
 /**
  * declaration for table filter sub module
  */
-declare function filterFactory(): unknown;
+export interface FilterFactoryProps<T extends object = any> {
+    // TODO newFilters is not tested not its type is validated since the author of this commit has no experience with this field
+    afterFilter?: (newResult: T[], newFilters?: unknown[]) => void;
+}
+
+declare function filterFactory(props?: FilterFactoryProps): unknown;
 export default filterFactory;

--- a/types/react-bootstrap-table2-filter/react-bootstrap-table2-filter-tests.tsx
+++ b/types/react-bootstrap-table2-filter/react-bootstrap-table2-filter-tests.tsx
@@ -265,3 +265,41 @@ const textColumns = [
 ];
 
 <BootstrapTable keyField="id" data={products} columns={textColumns} filter={filterFactory()} />;
+
+/**
+ * After filter test
+ */
+const afterFilterColumns = [
+    {
+        dataField: 'id',
+        text: 'Product ID',
+    },
+    {
+        dataField: 'name',
+        text: 'Product Name',
+        filter: textFilter({
+            placeholder: 'My Custom PlaceHolder', // custom the input placeholder
+            className: 'my-custom-text-filter', // custom classname on input
+            defaultValue: 'test', // default filtering value
+            comparator: Comparator.EQ, // default is Comparator.LIKE
+            caseSensitive: true, // default is false, and true will only work when comparator is LIKE
+            style: { backgroundColor: 'yellow' }, // your custom inline styles on input
+            delay: 1000, // how long will trigger filtering after user typing, default is 500 ms
+            onClick: e => console.log(e),
+        }),
+    },
+    {
+        dataField: 'price',
+        text: 'Product Price',
+        filter: textFilter(),
+    },
+];
+
+const afterFilter = (newResult: Product[]): void => {
+    console.log(newResult);
+};
+
+render(
+    <BootstrapTable keyField="id" data={products} columns={selectColumns} filter={filterFactory({ afterFilter })} />,
+    document.getElementById('app'),
+);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react-bootstrap-table.github.io/react-bootstrap-table2/docs/filter-props.html#afterfilter

Explanation of the changes: the `afterFilter` hook isn't included in the current definition of the `filterFactory`. The definition I'm providing is not complete and therefore improvable, but I only have experience with one of the two parameters, and therefore I'm leaving the other as `unknown` and a TODO comment for others to improve it. Hopefully this is enough.
