### PR TITLE
node: ChildProcess "close" event can have null code/signal

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -44,42 +44,42 @@ declare module "child_process" {
          */
 
         addListener(event: string, listener: (...args: any[]) => void): this;
-        addListener(event: "close", listener: (code: number, signal: NodeJS.Signals) => void): this;
+        addListener(event: "close", listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
         addListener(event: "disconnect", listener: () => void): this;
         addListener(event: "error", listener: (err: Error) => void): this;
         addListener(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
         addListener(event: "message", listener: (message: Serializable, sendHandle: SendHandle) => void): this;
 
         emit(event: string | symbol, ...args: any[]): boolean;
-        emit(event: "close", code: number, signal: NodeJS.Signals): boolean;
+        emit(event: "close", code: number | null, signal: NodeJS.Signals | null): boolean;
         emit(event: "disconnect"): boolean;
         emit(event: "error", err: Error): boolean;
         emit(event: "exit", code: number | null, signal: NodeJS.Signals | null): boolean;
         emit(event: "message", message: Serializable, sendHandle: SendHandle): boolean;
 
         on(event: string, listener: (...args: any[]) => void): this;
-        on(event: "close", listener: (code: number, signal: NodeJS.Signals) => void): this;
+        on(event: "close", listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
         on(event: "disconnect", listener: () => void): this;
         on(event: "error", listener: (err: Error) => void): this;
         on(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
         on(event: "message", listener: (message: Serializable, sendHandle: SendHandle) => void): this;
 
         once(event: string, listener: (...args: any[]) => void): this;
-        once(event: "close", listener: (code: number, signal: NodeJS.Signals) => void): this;
+        once(event: "close", listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
         once(event: "disconnect", listener: () => void): this;
         once(event: "error", listener: (err: Error) => void): this;
         once(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
         once(event: "message", listener: (message: Serializable, sendHandle: SendHandle) => void): this;
 
         prependListener(event: string, listener: (...args: any[]) => void): this;
-        prependListener(event: "close", listener: (code: number, signal: NodeJS.Signals) => void): this;
+        prependListener(event: "close", listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
         prependListener(event: "disconnect", listener: () => void): this;
         prependListener(event: "error", listener: (err: Error) => void): this;
         prependListener(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
         prependListener(event: "message", listener: (message: Serializable, sendHandle: SendHandle) => void): this;
 
         prependOnceListener(event: string, listener: (...args: any[]) => void): this;
-        prependOnceListener(event: "close", listener: (code: number, signal: NodeJS.Signals) => void): this;
+        prependOnceListener(event: "close", listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
         prependOnceListener(event: "disconnect", listener: () => void): this;
         prependOnceListener(event: "error", listener: (err: Error) => void): this;
         prependOnceListener(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;

--- a/types/node/test/child_process.ts
+++ b/types/node/test/child_process.ts
@@ -217,8 +217,8 @@ async function testPromisify() {
     const fd5: Readable | Writable | null = cp.stdio[4]!;
 
     cp = cp.addListener("close", (code, signal) => {
-        const _code: number = code;
-        const _signal: NodeJS.Signals = signal;
+        const _code: number | null = code;
+        const _signal: NodeJS.Signals | null = signal;
     });
     cp = cp.addListener("disconnect", () => { });
     cp = cp.addListener("error", (err) => {
@@ -226,7 +226,7 @@ async function testPromisify() {
     });
     cp = cp.addListener("exit", (code, signal) => {
         const _code: number | null = code;
-        const _signal: NodeJS.Signals | null  = signal;
+        const _signal: NodeJS.Signals | null = signal;
     });
     cp = cp.addListener("message", (message, sendHandle) => {
         const _message: any = message;
@@ -240,16 +240,16 @@ async function testPromisify() {
     _boolean = cp.emit("message", () => { });
 
     cp = cp.on("close", (code, signal) => {
-        const _code: number = code;
-        const _signal: NodeJS.Signals = signal;
+        const _code: number | null = code;
+        const _signal: NodeJS.Signals | null = signal;
     });
     cp = cp.on("disconnect", () => { });
     cp = cp.on("error", (err) => {
         const _err: Error = err;
     });
     cp = cp.on("exit", (code, signal) => {
-        const _code: number | null  = code;
-        const _signal: NodeJS.Signals | null  = signal;
+        const _code: number | null = code;
+        const _signal: NodeJS.Signals | null = signal;
     });
     cp = cp.on("message", (message, sendHandle) => {
         const _message: any = message;
@@ -257,16 +257,16 @@ async function testPromisify() {
     });
 
     cp = cp.once("close", (code, signal) => {
-        const _code: number = code;
-        const _signal: NodeJS.Signals = signal;
+        const _code: number | null = code;
+        const _signal: NodeJS.Signals | null = signal;
     });
     cp = cp.once("disconnect", () => { });
     cp = cp.once("error", (err) => {
         const _err: Error = err;
     });
     cp = cp.once("exit", (code, signal) => {
-        const _code: number | null  = code;
-        const _signal: NodeJS.Signals | null  = signal;
+        const _code: number | null = code;
+        const _signal: NodeJS.Signals | null = signal;
     });
     cp = cp.once("message", (message, sendHandle) => {
         const _message: any = message;
@@ -274,16 +274,16 @@ async function testPromisify() {
     });
 
     cp = cp.prependListener("close", (code, signal) => {
-        const _code: number = code;
-        const _signal: NodeJS.Signals = signal;
+        const _code: number | null = code;
+        const _signal: NodeJS.Signals | null = signal;
     });
     cp = cp.prependListener("disconnect", () => { });
     cp = cp.prependListener("error", (err) => {
         const _err: Error = err;
     });
     cp = cp.prependListener("exit", (code, signal) => {
-        const _code: number | null  = code;
-        const _signal: NodeJS.Signals | null  = signal;
+        const _code: number | null = code;
+        const _signal: NodeJS.Signals | null = signal;
     });
     cp = cp.prependListener("message", (message, sendHandle) => {
         const _message: any = message;
@@ -291,16 +291,16 @@ async function testPromisify() {
     });
 
     cp = cp.prependOnceListener("close", (code, signal) => {
-        const _code: number = code;
-        const _signal: NodeJS.Signals = signal;
+        const _code: number | null = code;
+        const _signal: NodeJS.Signals | null = signal;
     });
     cp = cp.prependOnceListener("disconnect", () => { });
     cp = cp.prependOnceListener("error", (err) => {
         const _err: Error = err;
     });
     cp = cp.prependOnceListener("exit", (code, signal) => {
-        const _code: number | null  = code;
-        const _signal: NodeJS.Signals | null  = signal;
+        const _code: number | null = code;
+        const _signal: NodeJS.Signals | null = signal;
     });
     cp = cp.prependOnceListener("message", (message, sendHandle) => {
         const _message: any = message;


### PR DESCRIPTION

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v15.x/docs/api/child_process.html#child_process_event_close documents the `"close"` event, saying that it has the same arguments as the `"exit"` event. The [documentation for `"exit"`](https://nodejs.org/dist/latest-v15.x/docs/api/child_process.html#child_process_event_exit) says that `code` is `null` if the process terminates due to a signal, and `signal` is `null` if the process exits normally. The following code illustrates this behavior:
  ```js
  const child_process = require('child_process')

  // Exit with code
  child_process.spawn('ls').on('close', console.log)
  // Prints `0 null`

  // Terminate with signal
  child_process.spawn('sh').on('close', console.log).kill()
  // Prints `null SIGTERM`
  ```
  This could potentially break existing code due to the wider types.

Also removes some extraneous whitespace in the tests
