### PR TITLE
react-native: Make keyboard event better usable for both platforms

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -9355,23 +9355,28 @@ type ScreenRect = {
     height: number;
 };
 
-type BaseKeyboardEvent = {
+interface IOSKeyboardEvent {
+    /**
+     * @platform ios
+     */
+    startCoordinates: ScreenRect;
+    /**
+     * @platform ios
+     */
+    isEventFromThisApp: boolean;
+}
+
+export interface KeyboardEvent extends IOSKeyboardEvent {
+    /**
+     * Always set to 0 on Android.
+     */
     duration: number;
+    /**
+     * Always set to "keyboard" on Android.
+     */
     easing: KeyboardEventEasing;
     endCoordinates: ScreenRect;
-};
-
-type AndroidKeyboardEvent = BaseKeyboardEvent & {
-    duration: 0;
-    easing: 'keyboard';
-};
-
-type IOSKeyboardEvent = BaseKeyboardEvent & {
-    startCoordinates: ScreenRect;
-    isEventFromThisApp: boolean;
-};
-
-export type KeyboardEvent = AndroidKeyboardEvent | IOSKeyboardEvent;
+}
 
 type KeyboardEventListener = (event: KeyboardEvent) => void;
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -9355,7 +9355,7 @@ type ScreenRect = {
     height: number;
 };
 
-interface IOSKeyboardEvent {
+interface KeyboardEventIOS {
     /**
      * @platform ios
      */
@@ -9366,7 +9366,7 @@ interface IOSKeyboardEvent {
     isEventFromThisApp: boolean;
 }
 
-export interface KeyboardEvent extends IOSKeyboardEvent {
+export interface KeyboardEvent extends Partial<KeyboardEventIOS> {
     /**
      * Always set to 0 on Android.
      */


### PR DESCRIPTION
Following up the discussion with @yfunk on https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49716, this should make the keyboard event easier to use when working with adding/removing event listeners.

The types still match the original ones from the react-native repo: https://github.com/facebook/react-native/blob/6e6443afd04a847ef23fb6254a84e48c70b45896/Libraries/Components/Keyboard/Keyboard.js#L44

As I can’t extend the `KeyboardEvent` from a more specific `KeyboardEventAndroid` which has e.g. `duration` set to `0`, I decided to mention these specific values in the doc-string and only extract the iOS specific types. I made them optional when creating the main interface, as otherwise they would have to be defined always even though they won’t be defined on Android. I hope this makes sense.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49716
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.