### PR TITLE
[mssql] add typing for connect function

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -391,3 +391,8 @@ export declare class PreparedStatement extends events.EventEmitter {
 }
 
 export declare class PreparedStatementError extends MSSQLError {}
+
+export declare function connect(config: config, callback: (err?: any, pool?: ConnectionPool) => void): void;
+export declare function connect(config: config): Promise<ConnectionPool>;
+export declare function connect(connectionString: string, callback: (err?: any, pool?: ConnectionPool) => void): void;
+export declare function connect(connectionString: string): Promise<ConnectionPool>;

--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -392,7 +392,7 @@ export declare class PreparedStatement extends events.EventEmitter {
 
 export declare class PreparedStatementError extends MSSQLError {}
 
-export declare function connect(config: config, callback: (err?: any, pool?: ConnectionPool) => void): void;
-export declare function connect(config: config): Promise<ConnectionPool>;
-export declare function connect(connectionString: string, callback: (err?: any, pool?: ConnectionPool) => void): void;
-export declare function connect(connectionString: string): Promise<ConnectionPool>;
+export declare function connect(config?: config, callback: (err?: any, pool?: ConnectionPool) => void): void;
+export declare function connect(config?: config): Promise<ConnectionPool>;
+export declare function connect(connectionString?: string, callback: (err?: any, pool?: ConnectionPool) => void): void;
+export declare function connect(connectionString?: string): Promise<ConnectionPool>;

--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -392,7 +392,5 @@ export declare class PreparedStatement extends events.EventEmitter {
 
 export declare class PreparedStatementError extends MSSQLError {}
 
-export declare function connect(config?: config, callback: (err?: any, pool?: ConnectionPool) => void): void;
-export declare function connect(config?: config): Promise<ConnectionPool>;
-export declare function connect(connectionString?: string, callback: (err?: any, pool?: ConnectionPool) => void): void;
-export declare function connect(connectionString?: string): Promise<ConnectionPool>;
+export declare function connect(config: string | config | null | undefined, callback: (err?: any, pool?: ConnectionPool) => void): void;
+export declare function connect(config?: string | config): Promise<ConnectionPool>;

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -34,7 +34,8 @@ var connectionStringTest: sql.ConnectionPool = new sql.ConnectionPool("connectio
 
 sql.connect(config, (err, pool) => {
     if (err) {
-        return console.error(err);
+        console.error(err);
+        return;
     }
     pool.close();
 });
@@ -47,7 +48,8 @@ sql.connect(config).then((pool) => {
 
 sql.connect(config, (err, pool) => {
     if (err) {
-        return console.error(err);
+        console.error(err);
+        return;
     }
     pool.close();
 });

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -32,6 +32,32 @@ var connectionStringTest: sql.ConnectionPool = new sql.ConnectionPool("connectio
     }
 });
 
+sql.connect(config, (err, pool) => {
+    if (err) {
+        return console.error(err);
+    }
+    pool.close();
+});
+
+sql.connect(config).then((pool) => {
+    pool.close();
+}).catch((err) => {
+    console.log(err);
+});
+
+sql.connect(config, (err, pool) => {
+    if (err) {
+        return console.error(err);
+    }
+    pool.close();
+});
+
+sql.connect('mssql://username:password@localhost/database').then((pool) => {
+    pool.close();
+}).catch((err) => {
+    console.log(err);
+})
+
 var connection: sql.ConnectionPool = new sql.ConnectionPool(config, function (err: any) {
     if (err != null) {
         console.warn("Issue with connecting to SQL Server!");

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -51,14 +51,14 @@ sql.connect(config, (err, pool) => {
         console.error(err);
         return;
     }
-    pool.close();
 });
 
-sql.connect('mssql://username:password@localhost/database').then((pool) => {
+sql.connect('mssql://username:password@localhost/database').then(async (pool) => {
+    await sql.connect();
     pool.close();
 }).catch((err) => {
     console.log(err);
-})
+});
 
 var connection: sql.ConnectionPool = new sql.ConnectionPool(config, function (err: any) {
     if (err != null) {


### PR DESCRIPTION
Signed-off-by: Matthew Peveler <matt.peveler@gmail.com>

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
The export of connection function happens in https://github.com/tediousjs/node-mssql/blob/master/lib/global-connection.js#L8-L63, which is picked up and re-exported in https://github.com/tediousjs/node-mssql/blob/master/lib/base/index.js#L37, and then surfaced in https://github.com/tediousjs/node-mssql/blob/master/lib/tedious/index.js#L13, and finally to general consumption in https://github.com/tediousjs/node-mssql/blob/master/index.js#L1. This looks to be added in the 6.0 release.

The first example on the README uses this `connect` function: https://github.com/tediousjs/node-mssql#quick-example