### PR TITLE
[dygraphs] fix resize() method type

### DIFF
--- a/types/dygraphs/index.d.ts
+++ b/types/dygraphs/index.d.ts
@@ -1235,7 +1235,7 @@ declare class Dygraph {
      * @param {number} width Width (in pixels)
      * @param {number} height Height (in pixels)
      */
-    resize(width: number, height: number): void;
+    resize(width?: number, height?: number): void;
 
     /**
      * Adjusts the number of points in the rolling average. Updates the graph to


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://dygraphs.com/jsdoc/symbols/Dygraph.html#resize

```
Resizes the dygraph. If no parameters are specified, resizes to fill the containing div (which has presumably changed size since the dygraph was instantiated. 
```

So, the parameters of resize method are optional.

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
