### PR TITLE
amqplib: Fix serverProperties location

### DIFF
--- a/types/amqplib/amqplib-tests.ts
+++ b/types/amqplib/amqplib-tests.ts
@@ -14,13 +14,13 @@ amqp.connect('amqp://localhost')
 
 amqp.connect('amqp://localhost')
     .then(connection => {
-        connection.serverProperties.copyright; // $ExpectType string | undefined
-        connection.serverProperties.platform; // $ExpectType string
-        connection.serverProperties.information; // $ExpectType string
-        connection.serverProperties.host; // $ExpectType string
-        connection.serverProperties.product; // $ExpectType string
-        connection.serverProperties.version; // $ExpectType string
-        connection.serverProperties.customField; // $ExpectType string | undefined
+        connection.connection.serverProperties.copyright; // $ExpectType string | undefined
+        connection.connection.serverProperties.platform; // $ExpectType string
+        connection.connection.serverProperties.information; // $ExpectType string
+        connection.connection.serverProperties.host; // $ExpectType string
+        connection.connection.serverProperties.product; // $ExpectType string
+        connection.connection.serverProperties.version; // $ExpectType string
+        connection.connection.serverProperties.customField; // $ExpectType string | undefined
 
         return connection.createChannel()
             .tap(channel => channel.checkQueue('myQueue'))
@@ -45,22 +45,22 @@ import amqpcb = require('amqplib/callback_api');
 
 amqpcb.connect('amqp://localhost', (err, connection) => {
     if (!err) {
-        connection.serverProperties.copyright; // $ExpectType string | undefined
-        connection.serverProperties.platform; // $ExpectType string
-        connection.serverProperties.information; // $ExpectType string
-        connection.serverProperties.host; // $ExpectType string
-        connection.serverProperties.product; // $ExpectType string
-        connection.serverProperties.version; // $ExpectType string
-        connection.serverProperties.customField; // $ExpectType string | undefined
+        connection.connection.serverProperties.copyright; // $ExpectType string | undefined
+        connection.connection.serverProperties.platform; // $ExpectType string
+        connection.connection.serverProperties.information; // $ExpectType string
+        connection.connection.serverProperties.host; // $ExpectType string
+        connection.connection.serverProperties.product; // $ExpectType string
+        connection.connection.serverProperties.version; // $ExpectType string
+        connection.connection.serverProperties.customField; // $ExpectType string | undefined
 
         connection.createChannel((err, channel) => {
-          if (!err) {
-              channel.assertQueue('myQueue', {}, (err, ok) => {
-                  if (!err) {
-                      channel.sendToQueue('myQueue', new Buffer(msg));
-                  }
-              });
-          }
+            if (!err) {
+                channel.assertQueue('myQueue', {}, (err, ok) => {
+                    if (!err) {
+                        channel.sendToQueue('myQueue', new Buffer(msg));
+                    }
+                });
+            }
         });
     }
 });
@@ -68,20 +68,20 @@ amqpcb.connect('amqp://localhost', (err, connection) => {
 amqpcb.connect('amqp://localhost', (err, connection) => {
     if (!err) {
         connection.createChannel((err, channel) => {
-          if (!err) {
-              channel.assertQueue('myQueue', {}, (err, ok) => {
-                  if (!err) {
-                      channel.consume('myQueue', newMsg => {
-                          if (newMsg != null) {
-                              // test callback api properties
-                              if (newMsg.properties.contentType === 'application/json') {
-                                  console.log('New Message: ' + newMsg.content.toString());
-                              }
-                          }
-                      });
-                  }
-              });
-          }
+            if (!err) {
+                channel.assertQueue('myQueue', {}, (err, ok) => {
+                    if (!err) {
+                        channel.consume('myQueue', newMsg => {
+                            if (newMsg != null) {
+                                // test callback api properties
+                                if (newMsg.properties.contentType === 'application/json') {
+                                    console.log('New Message: ' + newMsg.content.toString());
+                                }
+                            }
+                        });
+                    }
+                });
+            }
         });
     }
 });

--- a/types/amqplib/callback_api.d.ts
+++ b/types/amqplib/callback_api.d.ts
@@ -2,14 +2,13 @@ import events = require('events');
 import { Replies, Options, Message, ServerProperties } from './properties';
 export * from './properties';
 
-export interface Connection {
-    serverProperties: ServerProperties;
-}
-export interface CallbackModel extends events.EventEmitter {
+export interface Connection extends events.EventEmitter {
     close(callback?: (err: any) => void): void;
     createChannel(callback: (err: any, channel: Channel) => void): void;
     createConfirmChannel(callback: (err: any, confirmChannel: ConfirmChannel) => void): void;
-    connection: Connection;
+    connection: {
+        serverProperties: ServerProperties;
+    };
 }
 
 export interface Channel extends events.EventEmitter {
@@ -71,6 +70,6 @@ export const credentials: {
     };
 };
 
-export function connect(callback: (err: any, connection: CallbackModel) => void): void;
-export function connect(url: string | Options.Connect, callback: (err: any, connection: CallbackModel) => void): void;
-export function connect(url: string | Options.Connect, socketOptions: any, callback: (err: any, connection: CallbackModel) => void): void;
+export function connect(callback: (err: any, connection: Connection) => void): void;
+export function connect(url: string | Options.Connect, callback: (err: any, connection: Connection) => void): void;
+export function connect(url: string | Options.Connect, socketOptions: any, callback: (err: any, connection: Connection) => void): void;

--- a/types/amqplib/callback_api.d.ts
+++ b/types/amqplib/callback_api.d.ts
@@ -2,11 +2,14 @@ import events = require('events');
 import { Replies, Options, Message, ServerProperties } from './properties';
 export * from './properties';
 
-export interface Connection extends events.EventEmitter {
+export interface Connection {
+    serverProperties: ServerProperties;
+}
+export interface CallbackModel extends events.EventEmitter {
     close(callback?: (err: any) => void): void;
     createChannel(callback: (err: any, channel: Channel) => void): void;
     createConfirmChannel(callback: (err: any, confirmChannel: ConfirmChannel) => void): void;
-    serverProperties: ServerProperties;
+    connection: Connection;
 }
 
 export interface Channel extends events.EventEmitter {
@@ -57,17 +60,17 @@ export interface ConfirmChannel extends Channel {
 
 export const credentials: {
     external(): {
-      mechanism: string;
-      response(): Buffer;
+        mechanism: string;
+        response(): Buffer;
     };
     plain(username: string, password: string): {
-      mechanism: string;
-      response(): Buffer;
-      username: string;
-      password: string;
+        mechanism: string;
+        response(): Buffer;
+        username: string;
+        password: string;
     };
 };
 
-export function connect(callback: (err: any, connection: Connection) => void): void;
-export function connect(url: string | Options.Connect, callback: (err: any, connection: Connection) => void): void;
-export function connect(url: string | Options.Connect, socketOptions: any, callback: (err: any, connection: Connection) => void): void;
+export function connect(callback: (err: any, connection: CallbackModel) => void): void;
+export function connect(url: string | Options.Connect, callback: (err: any, connection: CallbackModel) => void): void;
+export function connect(url: string | Options.Connect, socketOptions: any, callback: (err: any, connection: CallbackModel) => void): void;

--- a/types/amqplib/index.d.ts
+++ b/types/amqplib/index.d.ts
@@ -15,11 +15,14 @@ import * as events from 'events';
 import { Replies, Options, Message, GetMessage, ConsumeMessage, ServerProperties } from './properties';
 export * from './properties';
 
-export interface Connection extends events.EventEmitter {
+export interface Connection {
+    serverProperties: ServerProperties;
+}
+export interface ChannelModel extends events.EventEmitter {
     close(): Promise<void>;
     createChannel(): Promise<Channel>;
     createConfirmChannel(): Promise<ConfirmChannel>;
-    serverProperties: ServerProperties;
+    connection: Connection;
 }
 
 export interface Channel extends events.EventEmitter {
@@ -70,15 +73,15 @@ export interface ConfirmChannel extends Channel {
 
 export const credentials: {
     external(): {
-      mechanism: string;
-      response(): Buffer;
+        mechanism: string;
+        response(): Buffer;
     };
     plain(username: string, password: string): {
-      mechanism: string;
-      response(): Buffer;
-      username: string;
-      password: string;
+        mechanism: string;
+        response(): Buffer;
+        username: string;
+        password: string;
     };
 };
 
-export function connect(url: string | Options.Connect, socketOptions?: any): Promise<Connection>;
+export function connect(url: string | Options.Connect, socketOptions?: any): Promise<ChannelModel>;

--- a/types/amqplib/index.d.ts
+++ b/types/amqplib/index.d.ts
@@ -15,14 +15,13 @@ import * as events from 'events';
 import { Replies, Options, Message, GetMessage, ConsumeMessage, ServerProperties } from './properties';
 export * from './properties';
 
-export interface Connection {
-    serverProperties: ServerProperties;
-}
-export interface ChannelModel extends events.EventEmitter {
+export interface Connection extends events.EventEmitter {
     close(): Promise<void>;
     createChannel(): Promise<Channel>;
     createConfirmChannel(): Promise<ConfirmChannel>;
-    connection: Connection;
+    connection: {
+        serverProperties: ServerProperties;
+    };
 }
 
 export interface Channel extends events.EventEmitter {
@@ -84,4 +83,4 @@ export const credentials: {
     };
 };
 
-export function connect(url: string | Options.Connect, socketOptions?: any): Promise<ChannelModel>;
+export function connect(url: string | Options.Connect, socketOptions?: any): Promise<Connection>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - Amqplib doesn't expose `serverProperties` at the model level (`Connection` in the Typescript type). It exposes the property on the internal connection object
   - https://github.com/squaremo/amqp.node/blob/e3e10167d3f498f632a5a50dc7fac62b314400c8/lib/channel_model.js#L19
   - https://github.com/squaremo/amqp.node/blob/e3e10167d3f498f632a5a50dc7fac62b314400c8/lib/connection.js#L208

