### PR TITLE
Add typings for ahoy.js

### DIFF
--- a/types/ahoy.js/index.d.ts
+++ b/types/ahoy.js/index.d.ts
@@ -1,0 +1,154 @@
+// Type definitions for ahoy.js 0.3
+// Project: https://github.com/ankane/ahoy.js
+// Definitions by: Timothy Gu <https://github.com/TimothyGu>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * ahoy.js supports two import styles:
+ *
+ * - UMD
+ *   - In Node.js, require('ahoy.js') is a namespace containing the individual exports.
+ *   - If neither CJS nor AMD is available, a new `ahoy` global is created with the individual exports.
+ * - ESM: the module 'ahoy.js' contains a single `default` export that is an object with the individual exports. No
+ *   named exports are available.
+ *
+ * Since it is up to the bundler to pick which style gets used, this file attempts to model all supported situations:
+ *
+ * - To support CJS, types and functions are exported "normally" through ES2015 `export` declarations.
+ * - `export as namespace ahoy` supports the global case.
+ * - For the ESM case, we create a whole new `ahoy` namespace with copies of the exported functions. This namespace is
+ *   the default export.
+ */
+
+export type EventProperties = Record<string, unknown>;
+
+export interface Config {
+    urlPrefix: string;
+    visitsUrl: string;
+    eventsUrl: string;
+
+    page: string | null;
+    platform: string;
+
+    /** Use navigator.sendBeacon to send events. */
+    useBeacon: boolean;
+    /** @deprecated same as useBeacon */
+    trackNow?: boolean;
+
+    /** Call ahoy.start() upon the document's DOMContentLoaded event. */
+    startOnReady: boolean;
+    /** Send a visit to visitsUrl upon ahoy.start(). */
+    trackVisits: boolean;
+
+    /** Use cookies to store visit and visitor IDs. */
+    cookies: boolean;
+    /** Domain of the generated cookies. */
+    cookieDomain: string | null;
+    /** @deprecated same as cookieDomain */
+    domain?: string;
+
+    headers: Record<string, string>;
+    withCredentials: boolean;
+    visitParams: Record<string, unknown>;
+
+    /** Expiry of the visit cookie in minutes. */
+    visitDuration: number;
+    /** Expiry of the visitor cookie in minutes. */
+    visitorDuration: number;
+}
+
+/**
+ * Modify Ahoy configuration. Must be called before ahoy.start() (or before DOMContentLoaded if startOnReady is set to
+ * true).
+ */
+export function configure(options: Partial<Config>): void;
+
+/** Initialize Ahoy.js if it has not yet been. */
+export function start(): void;
+
+/** Call callback when Ahoy.js has been initialized. */
+export function ready(callback: () => void): void;
+
+export function getVisitToken(): string;
+export function getVisitId(): string;
+export function getVisitorToken(): string;
+export function getVisitorId(): string;
+
+/** Force a new visit. */
+export function reset(): boolean;
+
+/**
+ * Enable or disable debug logging.
+ *
+ * @param [enabled=true]
+ */
+export function debug(enabled?: boolean): boolean;
+
+/** Send a single Ahoy tracking event. */
+export function track(name: string, properties?: EventProperties): boolean;
+
+/** Track all views and clicks. */
+export function trackAll(): void;
+
+/** Track form control changes. */
+export function trackChanges(): void;
+
+/** Track link and button clicks. */
+export function trackClicks(): void;
+
+/** Track form submits. */
+export function trackSubmits(): void;
+
+/** Send a view event for the current page. */
+export function trackView(additionalProperties?: EventProperties): void;
+
+export as namespace ahoy;
+
+declare namespace ahoy {
+    /**
+     * Modify Ahoy configuration. Must be called before ahoy.start() (or before DOMContentLoaded if startOnReady is set
+     * to true).
+     */
+    function configure(options: Partial<Config>): void;
+
+    /** Initialize Ahoy.js if it has not yet been. */
+    function start(): void;
+
+    /** Call callback when Ahoy.js has been initialized. */
+    function ready(callback: () => void): void;
+
+    function getVisitToken(): string;
+    function getVisitId(): string;
+    function getVisitorToken(): string;
+    function getVisitorId(): string;
+
+    /** Force a new visit. */
+    function reset(): boolean;
+
+    /**
+     * Enable or disable debug logging.
+     *
+     * @param [enabled=true]
+     */
+    function debug(enabled?: boolean): boolean;
+
+    /** Send a single Ahoy tracking event. */
+    function track(name: string, properties?: EventProperties): boolean;
+
+    /** Track all views and clicks. */
+    function trackAll(): void;
+
+    /** Track form control changes. */
+    function trackChanges(): void;
+
+    /** Track link and button clicks. */
+    function trackClicks(): void;
+
+    /** Track form submits. */
+    function trackSubmits(): void;
+
+    /** Send a view event for the current page. */
+    function trackView(additionalProperties?: EventProperties): void;
+}
+
+export default ahoy;

--- a/types/ahoy.js/test/ahoy.js-tests.cjs.ts
+++ b/types/ahoy.js/test/ahoy.js-tests.cjs.ts
@@ -1,0 +1,18 @@
+import ahoy = require('ahoy.js');
+import { trackAll } from 'ahoy.js';
+
+// $ExpectType void
+ahoy.start();
+
+ahoy.configure({});
+
+ahoy.configure({
+    cookies: false,
+});
+
+ahoy.configure({
+    cookies: 1, // $ExpectError
+});
+
+// $ExpectType void
+trackAll();

--- a/types/ahoy.js/test/ahoy.js-tests.esm.ts
+++ b/types/ahoy.js/test/ahoy.js-tests.esm.ts
@@ -1,0 +1,17 @@
+import ahoy from 'ahoy.js';
+
+// $ExpectType void
+ahoy.start();
+
+ahoy.configure({});
+
+ahoy.configure({
+    cookies: false,
+});
+
+ahoy.configure({
+    cookies: 1, // $ExpectError
+});
+
+// $ExpectType void
+ahoy.trackAll();

--- a/types/ahoy.js/tsconfig.json
+++ b/types/ahoy.js/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "test/ahoy.js-tests.cjs.ts",
+        "test/ahoy.js-tests.esm.ts"
+    ]
+}

--- a/types/ahoy.js/tslint.json
+++ b/types/ahoy.js/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Hi all, this PR adds typings for ahoy.js, located at https://github.com/ankane/ahoy.js and published to npm under the same name. While this library is a fairly standard CommonJS library, there's a twist: its [package.json](https://github.com/ankane/ahoy.js/blob/bf9c9dc7ffece0227a245913a232c2cc38871c93/package.json#L6-L7) has these lines:
```json
  "main": "dist/ahoy.js",
  "module": "dist/ahoy.esm.js",
```

Those two files seem to have different export styles:

```js
// dist/ahoy.js

(function (global, factory) {
  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
  typeof define === 'function' && define.amd ? define(factory) :
  (global = global || self, global.ahoy = factory());
}(this, (function () { 'use strict';

  var ahoy = window.ahoy || window.Ahoy || {};
  ahoy.start = function() {};

  return ahoy;
})));
```

```js
// dist/ahoy.esm.js

var ahoy = window.ahoy || window.Ahoy || {};
ahoy.start = function() {};

export default ahoy;
```

This PR prioritizes the first style (UMD) and allows declarations such as `import { start } from 'ahoy.js'`, but does not allow `import ahoy from 'ahoy.js'` as per the second style. Do y'all have any guidance what I can do here?

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.