### PR TITLE
[asciichart] Allow plot to accept two dimensional array

### DIFF
--- a/types/asciichart/asciichart-tests.ts
+++ b/types/asciichart/asciichart-tests.ts
@@ -29,6 +29,7 @@ asciichart.plot([1, 2, 3], { max: 15 });
 asciichart.plot([1, 2, 3], { symbols: ['┼', '┤', '╶', '╴', '─', '╰', '╭', '╮', '╯', '│'] });
 asciichart.plot([1, 2, 3], { format: x => x.toFixed(1) });
 asciichart.plot([1, 2, 3], { format: (x, i) => (i === 2 ? '  * ' : x.toFixed(2)) });
+asciichart.plot([[1, 2, 3], [4, 5, 6]]);
 
 asciichart.plot([1, 2, 3], {
     offset: 4,

--- a/types/asciichart/index.d.ts
+++ b/types/asciichart/index.d.ts
@@ -42,4 +42,4 @@ export interface PlotConfig {
     format?: (x: number, i: number) => string;
 }
 
-export function plot(series: ReadonlyArray<number>, cfg?: PlotConfig): string;
+export function plot(series: ReadonlyArray<number | number[]>, cfg?: PlotConfig): string;


### PR DESCRIPTION
`asciichart.plot` accepts a two dimensional array to plot more than one chart on the same graph. This updates the types to allow for that.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/kroitor/asciichart#multiple-series>>