### PR TITLE
Include config and output value in `json-diff`

### DIFF
--- a/types/json-diff/index.d.ts
+++ b/types/json-diff/index.d.ts
@@ -3,5 +3,9 @@
 // Definitions by: Tommy Wong <https://github.com/wchtommy20013/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export function diff(obj1: any, obj2: any): any;
-export function diffString(obj1: any, obj2: any): any;
+export interface JsonDiffConfig {
+    color?: boolean;
+}
+
+export function diff(obj1: unknown, obj2: unknown): any;
+export function diffString(obj1: unknown, obj2: unknown, config?: JsonDiffConfig): string;

--- a/types/json-diff/index.d.ts
+++ b/types/json-diff/index.d.ts
@@ -3,9 +3,9 @@
 // Definitions by: Tommy Wong <https://github.com/wchtommy20013/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export interface JsonDiffConfig {
+export interface ColorizeOptions {
     color?: boolean;
 }
 
 export function diff(obj1: unknown, obj2: unknown): any;
-export function diffString(obj1: unknown, obj2: unknown, config?: JsonDiffConfig): string;
+export function diffString(obj1: unknown, obj2: unknown, colorizeOptions?: ColorizeOptions): string;

--- a/types/json-diff/json-diff-tests.ts
+++ b/types/json-diff/json-diff-tests.ts
@@ -1,4 +1,6 @@
-import { diff, diffString } from "json-diff";
+import { diff, diffString } from 'json-diff';
 
-diff({}, { Hello : "World"});
-diffString({}, { Hello : "World"});
+diff({}, { Hello: 'World' });
+diffString({}, { Hello: 'World' });
+diffString({}, { Hello: 'World' }, {});
+diffString({}, { Hello: 'World' }, { color: true });


### PR DESCRIPTION
`json-diff`'s `diffString` helper takes an optional config and returns a string. Note some additional formatting changes were applied by prettier.

See usage in library test suite: https://github.com/andreyvit/json-diff/blob/master/test/diff_test.coffee#L173-L174

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
