### PR TITLE
fix(evernote): Change return types of tag and notebook counts to a Dictonary instead of a Map

### DIFF
--- a/types/evernote/evernote-tests.ts
+++ b/types/evernote/evernote-tests.ts
@@ -7,3 +7,6 @@ const filter = new Evernote.NoteStore.NoteFilter({
 });
 const userStore = client.getUserStore();
 userStore.getUser();
+
+const noteStore = client.getNoteStore();
+noteStore.findNoteCounts(filter, false).then(n => Object.keys(n.notebookCounts || {}));

--- a/types/evernote/index.d.ts
+++ b/types/evernote/index.d.ts
@@ -8,7 +8,7 @@
 
 import { oauth1tokenCallback, OAuth } from 'oauth';
 
-export {}
+export {};
 type Dictionary<TKey extends number | string, TValue> = {
     [key in TKey]: TValue
 };

--- a/types/evernote/index.d.ts
+++ b/types/evernote/index.d.ts
@@ -8,6 +8,10 @@
 
 import { oauth1tokenCallback, OAuth } from 'oauth';
 
+type Dictionary<TKey extends number | string, TValue> = {
+    [key in TKey]: TValue
+};
+
 /* NoteStore: Data types and Constants */
 export namespace NoteStore {
     class CreateOrUpdateNotebookSharesResult {
@@ -100,8 +104,8 @@ export namespace NoteStore {
         });
     }
     class NoteCollectionCounts {
-        notebookCounts?: Map<Types.Guid, number>;
-        tagCounts?: Map<Types.Guid, number>;
+        notebookCounts?: Dictionary<Types.Guid, number>;
+        tagCounts?: Dictionary<Types.Guid, number>;
         trashCount?: number;
         constructor(args?: {
             notebookCounts?: Map<Types.Guid, number>;

--- a/types/evernote/index.d.ts
+++ b/types/evernote/index.d.ts
@@ -8,6 +8,7 @@
 
 import { oauth1tokenCallback, OAuth } from 'oauth';
 
+export {}
 type Dictionary<TKey extends number | string, TValue> = {
     [key in TKey]: TValue
 };

--- a/types/evernote/index.d.ts
+++ b/types/evernote/index.d.ts
@@ -109,8 +109,8 @@ export namespace NoteStore {
         tagCounts?: Dictionary<Types.Guid, number>;
         trashCount?: number;
         constructor(args?: {
-            notebookCounts?: Map<Types.Guid, number>;
-            tagCounts?: Map<Types.Guid, number>;
+            notebookCounts?: Dictionary<Types.Guid, number>;
+            tagCounts?: Dictionary<Types.Guid, number>;
             trashCount?: number;
         });
     }

--- a/types/evernote/index.d.ts
+++ b/types/evernote/index.d.ts
@@ -4,7 +4,6 @@
 //                 Felipe Castillo <https://github.com/fcastilloec>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 //              https://dev.evernote.com/doc/reference/
-// TypeScript Version: 2.3
 
 import { oauth1tokenCallback, OAuth } from 'oauth';
 

--- a/types/evernote/index.d.ts
+++ b/types/evernote/index.d.ts
@@ -8,11 +8,6 @@
 
 import { oauth1tokenCallback, OAuth } from 'oauth';
 
-export {};
-type Dictionary<TKey extends number | string, TValue> = {
-    [key in TKey]: TValue
-};
-
 /* NoteStore: Data types and Constants */
 export namespace NoteStore {
     class CreateOrUpdateNotebookSharesResult {
@@ -105,12 +100,12 @@ export namespace NoteStore {
         });
     }
     class NoteCollectionCounts {
-        notebookCounts?: Dictionary<Types.Guid, number>;
-        tagCounts?: Dictionary<Types.Guid, number>;
+        notebookCounts?: Record<Types.Guid, number>;
+        tagCounts?: Record<Types.Guid, number>;
         trashCount?: number;
         constructor(args?: {
-            notebookCounts?: Dictionary<Types.Guid, number>;
-            tagCounts?: Dictionary<Types.Guid, number>;
+            notebookCounts?: Record<Types.Guid, number>;
+            tagCounts?: Record<Types.Guid, number>;
             trashCount?: number;
         });
     }

--- a/types/evernote/tsconfig.json
+++ b/types/evernote/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
The library is actually returning an object with key value pairs for the tag and notebook keys and the count of entries.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/evernote/evernote-sdk-js/blob/master/src/thrift/thrift.js> -> You can see Thrift.Map.define actually returns {} and not a Map object
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. -> no new version

