### PR TITLE
update(omelette): Added on('completion') types

### DIFF
--- a/types/omelette/index.d.ts
+++ b/types/omelette/index.d.ts
@@ -22,6 +22,7 @@ declare namespace omelette {
         next(fn: () => void): void;
 
         on(action: string, callback: Callback): void;
+        on(action: 'complete', callback: CallbackOnComplete): void;
 
         onAsync(actions: string, callback: CallbackAsync): void;
 
@@ -47,6 +48,7 @@ declare namespace omelette {
     }
 
     type Callback = (obj: CallbackValue) => void;
+    type CallbackOnComplete = (fragment: string, obj: CallbackValue) => void;
 
     type CallbackAsync = (obj: CallbackAsyncValue) => Promise<void>;
 

--- a/types/omelette/omelette-tests.ts
+++ b/types/omelette/omelette-tests.ts
@@ -49,6 +49,8 @@ completion.on("repo", ({ before, reply }) => {
   reply([`http://github.com/${before}/helloworld`, `http://github.com/${before}/blabla`]);
 });
 
+completion.on('complete', (fragment, { reply }) => reply(["hello", "world"]));
+
 // Initialize the omelette.
 completion.init();
 


### PR DESCRIPTION
This PR adds a type definition for omelette's `on('completion')` functionality. See URL linked below. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [URL](https://github.com/f/omelette#global-event)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - I'm not sure whether the on completion functionality is a new release or not in the JS library... 

