### PR TITLE
[@types/node] Make AssertionError extend Error, not just implement its interface

### DIFF
--- a/types/node/assert.d.ts
+++ b/types/node/assert.d.ts
@@ -2,9 +2,7 @@ declare module 'assert' {
     /** An alias of `assert.ok()`. */
     function assert(value: any, message?: string | Error): asserts value;
     namespace assert {
-        class AssertionError implements Error {
-            name: string;
-            message: string;
+        class AssertionError extends Error {
             actual: any;
             expected: any;
             operator: string;

--- a/types/node/test/assert.ts
+++ b/types/node/test/assert.ts
@@ -1,6 +1,10 @@
 import * as assert from 'assert';
 
 {
+    const { stack } = new assert.AssertionError({});
+}
+
+{
     const { message } = new assert.AssertionError({
         actual: 1,
         expected: 2,

--- a/types/node/test/assert.ts
+++ b/types/node/test/assert.ts
@@ -8,7 +8,7 @@ import * as assert from 'assert';
     const { message } = new assert.AssertionError({
         actual: 1,
         expected: 2,
-        operator: 'strictEqual'
+        operator: 'strictEqual',
     });
 
     try {
@@ -40,32 +40,50 @@ import * as assert from 'assert';
 
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 
-assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, "DEEP WENT DERP");
+assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, 'DEEP WENT DERP');
 
-assert.deepStrictEqual({ a: 1 }, { a: 1 }, "uses === comparator");
+assert.deepStrictEqual({ a: 1 }, { a: 1 }, 'uses === comparator');
 
-assert.doesNotThrow(() => {
-    const b = false;
-    if (b) { throw new Error("a hammer at your face"); }
-}, () => 1, "What the...*crunch*");
+assert.doesNotThrow(
+    () => {
+        const b = false;
+        if (b) {
+            throw new Error('a hammer at your face');
+        }
+    },
+    () => 1,
+    'What the...*crunch*',
+);
 
-assert.equal(3, "3", "uses == comparator");
+assert.equal(3, '3', 'uses == comparator');
 
 assert.ifError(0);
 
-assert.notDeepStrictEqual({ x: { y: "3" } }, { x: { y: 3 } }, "uses !== comparator");
+assert.notDeepStrictEqual({ x: { y: '3' } }, { x: { y: 3 } }, 'uses !== comparator');
 
-assert.notEqual(1, 2, "uses != comparator");
+assert.notEqual(1, 2, 'uses != comparator');
 
-assert.notStrictEqual(2, "2", "uses === comparator");
+assert.notStrictEqual(2, '2', 'uses === comparator');
 
 assert.ok(true);
 assert.ok(1);
 
-assert.strictEqual(1, 1, "uses === comparator");
+assert.strictEqual(1, 1, 'uses === comparator');
 
-assert.throws(() => { throw new Error("a hammer at your face"); }, Error, "DODGED IT");
-assert.throws(() => { throw new Error("a hammer at your face"); }, (err: Error) => true, "DODGED IT");
+assert.throws(
+    () => {
+        throw new Error('a hammer at your face');
+    },
+    Error,
+    'DODGED IT',
+);
+assert.throws(
+    () => {
+        throw new Error('a hammer at your face');
+    },
+    (err: Error) => true,
+    'DODGED IT',
+);
 
 assert.rejects(async () => 1);
 assert.rejects(Promise.resolve(1));


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/v15.5.0/lib/internal/assert/assertion_error.js#L316
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
