### PR TITLE
@types/react-native-push-notification change actions type to string[] instead of string

### DIFF
--- a/types/react-native-push-notification/index.d.ts
+++ b/types/react-native-push-notification/index.d.ts
@@ -65,7 +65,7 @@ export class PushNotificationObject {
 
     messageId?: string;
 
-    actions?: string;
+    actions?: string[];
     invokeApp?: boolean;
 
     /* iOS only properties */

--- a/types/react-native-push-notification/react-native-push-notification-tests.ts
+++ b/types/react-native-push-notification/react-native-push-notification-tests.ts
@@ -14,8 +14,8 @@ PushNotification.configure({
 });
 
 PushNotification.unregister();
-PushNotification.localNotification({ message: '' });
-PushNotification.localNotificationSchedule({ date: new Date(), message: '' });
+PushNotification.localNotification({ message: '', actions: ["Yes", "No"] });
+PushNotification.localNotificationSchedule({ date: new Date(), message: '', actions: ["Yes", "No"] });
 PushNotification.requestPermissions();
 PushNotification.subscribeToTopic("topic");
 PushNotification.presentLocalNotification({ message: '' });


### PR DESCRIPTION
actions type should be string[] not string
see https://github.com/zo0r/react-native-push-notification#local-notifications

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zo0r/react-native-push-notification#local-notifications
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


