### PR TITLE
Update return type for 'all' function in 'franc' package and use type alias

### DIFF
--- a/types/franc/franc-tests.ts
+++ b/types/franc/franc-tests.ts
@@ -7,8 +7,8 @@ const testOptions = {
     blacklist: [],
 };
 
-detect(testText);
-detect(testText, testOptions);
+detect(testText); // $ExpectType string
+detect(testText, testOptions); // $ExpectType string
 
-detect.all(testText);
-detect.all(testText, testOptions)[0];
+detect.all(testText); // $ExpectType [string, number][]
+detect.all(testText, testOptions)[0]; // $ExpectType [string, number]

--- a/types/franc/index.d.ts
+++ b/types/franc/index.d.ts
@@ -13,13 +13,13 @@ interface Options {
     minLength?: number;
     whitelist?: ISO6393[];
     blacklist?: ISO6393[];
-    only?: string[];
+    only?: ISO6393[];
 }
 
 declare function detect(text: string, options?: Options): ISO6393;
 
 declare namespace detect {
-    function all(text: string, options?: Options): [ISO6393, number];
+    function all(text: string, options?: Options): Array<[ISO6393, Confidence]>;
 }
 
 export = detect;

--- a/types/franc/index.d.ts
+++ b/types/franc/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for franc 4.0
+// Type definitions for franc 5.0
 // Project: https://github.com/wooorm/franc/
 // Definitions by: William LeGate <https://github.com/wlegate>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wooorm/franc/blob/c3f5afaceac3f1a4ef7891d0e058110d7308dddb/packages/franc/index.js#L75
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
Whilst there is no breaking change in the 'franc' package between version `4` and `5`, this PR introduces a breaking change in the type system. I've proceeded by updating the version to `5`, matching the original package.
