### PR TITLE
[ember-data] fix for defaultValue return type when using a custom transform

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -119,10 +119,10 @@ export namespace DS {
     ): string;
     const VERSION: string;
 
-    interface AttrOptions<T = any> {
-      defaultValue?: T extends Transform ? (() => ReturnType<T['deserialize']>) : T | (() => T);
-      allowNull?: boolean; // TODO: restrict to boolean transform (TS 2.8)
-  }
+    interface AttrOptions<T extends Transform | string | number | boolean | Date = any> {
+        defaultValue?: T extends Transform ? (() => ReturnType<T['deserialize']>) : string | number | boolean | (() => T);
+        allowNull?: boolean; // TODO: restrict to boolean transform (TS 2.8)
+    }
 
     /**
      * `DS.attr` defines an attribute on a [DS.Model](/api/data/classes/DS.Model.html).

--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -120,9 +120,9 @@ export namespace DS {
     const VERSION: string;
 
     interface AttrOptions<T = any> {
-        defaultValue?: T | (() => T);
-        allowNull?: boolean; // TODO: restrict to boolean transform (TS 2.8)
-    }
+      defaultValue?: T extends Transform ? (() => ReturnType<T['deserialize']>) : T | (() => T);
+      allowNull?: boolean; // TODO: restrict to boolean transform (TS 2.8)
+  }
 
     /**
      * `DS.attr` defines an attribute on a [DS.Model](/api/data/classes/DS.Model.html).

--- a/types/ember-data/test/model.ts
+++ b/types/ember-data/test/model.ts
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import DS, { ChangedAttributes } from 'ember-data';
 import { assertType } from './lib/assert';
 import RSVP from 'rsvp';
+import { Point } from './transform';
 
 const Person = DS.Model.extend({
     firstName: DS.attr(),
@@ -12,6 +13,8 @@ const Person = DS.Model.extend({
     fullName: Ember.computed('firstName', 'lastName', function () {
         return `${this.get('firstName')} ${this.get('lastName')}`;
     }),
+
+    point: DS.attr('point', { defaultValue: () => Point.create({ x: 1, y: 2 })}),
 });
 
 const User = DS.Model.extend({

--- a/types/ember-data/test/transform.ts
+++ b/types/ember-data/test/transform.ts
@@ -1,16 +1,22 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-class Point extends Ember.Object {
+export class Point extends Ember.Object {
     x: number;
     y: number;
 }
 
-const PointTransform = DS.Transform.extend({
+class PointTransform extends DS.Transform {
     serialize(value: Point): number[] {
         return [value.get('x'), value.get('y')];
-    },
+    }
     deserialize(value: [number, number]): Point {
         return Point.create({ x: value[0], y: value[1] });
-    },
-});
+    }
+}
+
+declare module 'ember-data/types/registries/transform' {
+  export default interface TransformRegistry {
+    point: PointTransform;
+  }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.emberjs.com/ember-data/3.23/functions/@ember-data%2Fmodel/attr
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

As mentioned in [ember-cli-typescript](https://github.com/typed-ember/ember-cli-typescript/issues/1387)

There's a type bug with setting a default value when using a custom transform, it enforces that the return type is the same as the value in the `TransformRegistery`, which is fine for `string`, `number` etc. as the transforms are just set to the corresponding primitive. But not for custom ones, where the actual value needs to be whatever the return type of the `deserialize` method on the custom Transform class.

[This assertion](https://github.com/emberjs/data/blob/cafc3db253d1661015a7335a51c2dd0bd8b7dd86/packages/model/addon/-private/attr.js#L20) in ember-data also shows that ember will error if `defaultValue` is set to anything other than a string, number, boolean or function so have added a type check for that.