### PR TITLE
ramda: R.has() shall be usable as a type guard

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -699,7 +699,7 @@ export function gte(a: number): (b: number) => boolean;
  * Returns whether or not an object has an own property with the specified name.
  */
 export function has(__: Placeholder, obj: unknown): (s: string) => boolean;
-export function has<P extends string>(__: Placeholder): (obj: unknown, s: P) => obj is ObjectHavingSome<P>;
+export function has(__: Placeholder): <P extends string>(obj: unknown, s: P) => obj is ObjectHavingSome<P>;
 export function has<P extends string>(s: P, obj: unknown): obj is ObjectHavingSome<P>;
 export function has<P extends string>(s: P): (obj: unknown) => obj is ObjectHavingSome<P>;
 

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -50,6 +50,7 @@ import {
     Lens,
     Merge,
     MergeAll,
+    ObjectHavingSome,
     ObjPred,
     Ord,
     Path,
@@ -697,10 +698,10 @@ export function gte(a: number): (b: number) => boolean;
 /**
  * Returns whether or not an object has an own property with the specified name.
  */
-export function has<T>(__: Placeholder, obj: T): (s: string) => boolean;
-export function has<T>(__: Placeholder): (obj: T, s: string) => boolean;
-export function has<T>(s: string, obj: T): boolean;
-export function has(s: string): <T>(obj: T) => boolean;
+export function has(__: Placeholder, obj: unknown): (s: string) => boolean;
+export function has<P extends string>(__: Placeholder): (obj: unknown, s: P) => obj is ObjectHavingSome<P>;
+export function has<P extends string>(s: P, obj: unknown): obj is ObjectHavingSome<P>;
+export function has<P extends string>(s: P): (obj: unknown) => obj is ObjectHavingSome<P>;
 
 /**
  * Returns whether or not an object or its prototype chain has a property with the specified name

--- a/types/ramda/test/has-tests.ts
+++ b/types/ramda/test/has-tests.ts
@@ -1,13 +1,13 @@
 import * as R from 'ramda';
 
 () => {
-  const hasName = R.has('name');
-  const a1: boolean = hasName({ name: 'alice' }); // => true
-  const a2: boolean = hasName({ name: 'bob' }); // => true
-  const a3: boolean = hasName({}); // => false
+    const hasName = R.has('name');
+    const a1: boolean = hasName({ name: 'alice' }); // => true
+    const a2: boolean = hasName({ name: 'bob' }); // => true
+    const a3: boolean = hasName({}); // => false
 };
 
 () => {
-  R.has(R.__, { x: 0, y: 0 })('x'); // true;
-  R.has(R.__)({ x: 0, y: 0 }, 'x'); // true;
+    R.has(R.__, { x: 0, y: 0 })('x'); // true;
+    R.has(R.__)({ x: 0, y: 0 }, 'x'); // true;
 };

--- a/types/ramda/test/has-tests.ts
+++ b/types/ramda/test/has-tests.ts
@@ -11,3 +11,41 @@ import * as R from 'ramda';
     R.has(R.__, { x: 0, y: 0 })('x'); // true;
     R.has(R.__)({ x: 0, y: 0 }, 'x'); // true;
 };
+
+// R.has() can be used as a type guard
+() => {
+    const foo: unknown = {};
+
+    () => {
+        if (R.has('name', foo)) console.log(foo.name);
+        if (R.has('name')(foo)) console.log(foo.name);
+        if (R.has(R.__)(foo, 'name')) console.log(foo.name);
+    };
+
+    () => {
+        const key = 'name';
+
+        if (R.has(key as 'name' | 'weight', foo)) {
+            // $ExpectType { name: unknown; } | { weight: unknown; }
+            const bar = foo;
+        }
+
+        if (R.has(key as string, foo)) {
+            // $ExpectType { [x: string]: unknown; }
+            const bar = foo;
+        }
+    };
+};
+
+// The key argument needs to be compatible to string
+() => {
+    R.has(4, {}); // $ExpectError
+    R.has(4); // $ExpectError
+    R.has(R.__, {})(4); // $ExpectError
+    R.has(R.__)({}, 4); // $ExpectError
+
+    R.has(null, {}); // $ExpectError
+    R.has(null); // $ExpectError
+    R.has(R.__, {})(null); // $ExpectError
+    R.has(R.__)({}, null); // $ExpectError
+};

--- a/types/ramda/tools.d.ts
+++ b/types/ramda/tools.d.ts
@@ -311,6 +311,21 @@ export type ObjPred<T = unknown> = (value: any, key: unknown extends T ? string 
  */
 export type Ord = number | string | boolean | Date;
 
+/**
+ * An object with at least one of its properties beeing of type `Key`.
+ *
+ * @example
+ * ```
+ * // $ExpectType { foo: unknown } | { bar: unknown }
+ * type Foo = ObjectHavingSome<"foo" | "bar">
+ * ```
+ */
+// Implementation taken from
+// https://github.com/piotrwitek/utility-types/blob/df2502ef504c4ba8bd9de81a45baef112b7921d0/src/mapped-types.ts#L351-L362
+export type ObjectHavingSome<Key extends string> = A.Clean<{
+    [K in Key]: { [P in K]: unknown }
+}[Key]>;
+
 // ---------------------------------------------------------------------------------------
 // P
 


### PR DESCRIPTION
#### Template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://ramdajs.com/docs/#has

#### About this PR

This PR changes the signature of [`R.has()`](https://ramdajs.com/docs/#has) so that it can be used as a type guard. An example:

```ts
const data: unknown = { ... }

if (R.has("name", foo)) {
  console.log(data.name) // name can now be accessed
}
```

In the changes of `types/ramda/test/has-tests.ts` you see other examples.

#### Possible follow ups

There might be some improvements which I'll point to in further comments / questions in the code directly. In case you like this feature I can extend it to `R.hasIn()` as well. (For `R.hasPath()` I am not sure whether my TypeScript skills are sufficient. Thus I would like to try this in a new PR).