### PR TITLE
[react-router-dom] re-export types from react-router

### DIFF
--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -15,7 +15,9 @@ import * as H from 'history';
 
 export {
     generatePath,
+    PromptProps,
     Prompt,
+    MemoryRouterProps,
     MemoryRouter,
     RedirectProps,
     Redirect,
@@ -23,7 +25,9 @@ export {
     RouteComponentProps,
     RouteProps,
     Route,
+    RouterProps,
     Router,
+    StaticRouterProps,
     StaticRouter,
     SwitchProps,
     Switch,


### PR DESCRIPTION
`react-router-dom` [re-exports everything](https://github.com/ReactTraining/react-router/issues/4648#issuecomment-284479720) from `react-router`; the types file should do the same. I.e. component prop interfaces — such as `MemoryRouterProps` — weren't being re-exported from `@types/react-router`.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-router/index.d.ts
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
