### PR TITLE
make-fetch-happen: introduce new definitions

### DIFF
--- a/types/make-fetch-happen/index.d.ts
+++ b/types/make-fetch-happen/index.d.ts
@@ -127,13 +127,13 @@ declare namespace fetch {
         integrity?: string | Integrity;
     }
 
-    type CachingFetchOpts = NodeFetchOpts & TlsOpts & MakeFetchHappenOpts;
+    type FetchOptions = NodeFetchOpts & TlsOpts & MakeFetchHappenOpts;
 
     interface FetchInterface {
         prototype: FetchInterface;
-        (uriOrRequest: string | Request, opts?: CachingFetchOpts): Promise<Response>;
-        (opts: CachingFetchOpts): Promise<Response>;
-        defaults(uri: string, opts?: CachingFetchOpts): FetchInterface;
-        defaults(opts?: CachingFetchOpts): FetchInterface;
+        (uriOrRequest: string | Request, opts?: FetchOptions): Promise<Response>;
+        (opts: FetchOptions): Promise<Response>;
+        defaults(uri: string, opts?: FetchOptions): FetchInterface;
+        defaults(opts?: FetchOptions): FetchInterface;
     }
 }

--- a/types/make-fetch-happen/index.d.ts
+++ b/types/make-fetch-happen/index.d.ts
@@ -18,13 +18,16 @@ export = fetch;
 // `make-fetch-happen`'s use of the `module.exports` pattern.
 declare const fetch: fetch.FetchInterface;
 declare namespace fetch {
-    type NodeFetchOpts = Pick<RequestInit, 'method' | 'body' | 'redirect' | 'follow' | 'timeout' | 'compress' | 'size'>;
+    type NodeFetchOptions = Pick<
+        RequestInit,
+        'method' | 'body' | 'redirect' | 'follow' | 'timeout' | 'compress' | 'size'
+    >;
 
-    type TlsOpts = Pick<SecureContextOptions, 'ca' | 'cert' | 'key'> & {
+    type TlsOptions = Pick<SecureContextOptions, 'ca' | 'cert' | 'key'> & {
         strictSSL?: CommonConnectionOptions['rejectUnauthorized'];
     };
 
-    interface MakeFetchHappenOpts {
+    interface MakeFetchHappenOptions {
         /**
          * Either a `String` or a `Cache`. If the former, it will be assumed to
          * be a `Path` to be used as the cache root for
@@ -127,7 +130,7 @@ declare namespace fetch {
         integrity?: string | Integrity;
     }
 
-    type FetchOptions = NodeFetchOpts & TlsOpts & MakeFetchHappenOpts;
+    type FetchOptions = NodeFetchOptions & TlsOptions & MakeFetchHappenOptions;
 
     interface FetchInterface {
         prototype: FetchInterface;

--- a/types/make-fetch-happen/index.d.ts
+++ b/types/make-fetch-happen/index.d.ts
@@ -1,0 +1,139 @@
+// Type definitions for make-fetch-happen 8.0
+// Project: https://github.com/npm/make-fetch-happen#readme
+// Definitions by: Jesse Rosenberger <https://github.com/abernix>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference types="node" />
+import { ClientRequestArgs, AgentOptions } from 'http';
+import { CommonConnectionOptions, SecureContextOptions } from 'tls';
+import { URL } from 'url';
+
+import { RequestInit, Response } from 'node-fetch';
+import { Integrity } from 'ssri';
+import { TimeoutsOptions } from 'retry';
+
+export = fetch;
+
+// The `const` and the `namespace` by the same name will be merged into the
+// default export using `esModuleInterop`, which is necessitated by
+// `make-fetch-happen`'s use of the `module.exports` pattern.
+declare const fetch: fetch.FetchInterface;
+declare namespace fetch {
+    type NodeFetchOpts = Pick<RequestInit, 'method' | 'body' | 'redirect' | 'follow' | 'timeout' | 'compress' | 'size'>;
+
+    type TlsOpts = Pick<SecureContextOptions, 'ca' | 'cert' | 'key'> & {
+        strictSSL?: CommonConnectionOptions['rejectUnauthorized'];
+    };
+
+    interface MakeFetchHappenOpts {
+        /**
+         * Either a `String` or a `Cache`. If the former, it will be assumed to
+         * be a `Path` to be used as the cache root for
+         * [`cacache`](https://npm.im/cacache).
+         *
+         * If an object is provided, it will be assumed to be a compliant
+         * [`Cache`
+         * instance](https://developer.mozilla.org/en-US/docs/Web/API/Cache).
+         * Only `Cache.match()`, `Cache.put()`, and `Cache.delete()` are
+         * required. Options objects will not be passed in to `match()` or
+         * `delete()`.
+         *
+         * By implementing this API, you can customize the storage backend for
+         * make-fetch-happen itself -- for example, you could implement a cache
+         * that uses `redis` for caching, or simply keeps everything in memory.
+         * Most of the caching logic exists entirely on the make-fetch-happen
+         * side, so the only thing you need to worry about is reading, writing,
+         * and deleting, as well as making sure `fetch.Response` objects are
+         * what gets returned.
+         *
+         * Ref: https://github.com/npm/make-fetch-happen/#--optscachemanager
+         */
+        cacheManager?: string | Cache;
+
+        cache?: RequestCache;
+        proxy?: string | URL;
+
+        /**
+         * If present, should be a comma-separated string or an array of domain
+         * extensions that a proxy should _not_ be used for.
+         *
+         * This option may also be provided through `process.env.NO_PROXY`.
+         */
+        noProxy?: string | string[];
+
+        /**
+         * Passed directly to `http` and `https` request calls. Determines the
+         * local address to bind to.
+         */
+        localAddress?: ClientRequestArgs['localAddress'];
+
+        /**
+         * Maximum number of active concurrent sockets to use for the underlying
+         * Http/Https/Proxy agents. This setting applies once per spawned agent.
+         */
+        maxSockets?: AgentOptions['maxSockets'];
+
+        /**
+         * An object that can be used to tune request retry settings. Retries
+         * will only be attempted on the following conditions:
+         *
+         * - Request method is NOT `POST`; **AND**
+         * - Request status is one of: `408`, `420`, `429`, or any status in the
+         *   500-range.; **OR**
+         * - Request errored with `ECONNRESET`, `ECONNREFUSED`, `EADDRINUSE`,
+         *   `ETIMEDOUT`, or the `fetch` error `request-timeout`.
+         *
+         * The following are worth noting as explicitly not retried:
+         *
+         * - `getaddrinfo ENOTFOUND` and will be assumed to be either an
+         *   unreachable domain or the user will be assumed offline. If a
+         *   response is cached, it will be returned immediately.
+         * - `ECONNRESET` currently has no support for restarting. It will
+         *   eventually be supported but requires a bit more juggling due to
+         *   streaming.
+         *
+         * If `opts.retry` is `false`, it is equivalent to `{retries: 0}`
+         *
+         * If `opts.retry` is a number, it is equivalent to `{retries: num}`
+         *
+         * The following retry options are available if you want more control
+         * over it:
+         *
+         * - `retries`
+         * - `factor`
+         * - `minTimeout`
+         * - `maxTimeout`
+         * - `randomize`
+         *
+         * For details on what each of these do, refer to the
+         * [`retry`](https://npm.im/retry) documentation.
+         */
+
+        retry?: boolean | number | TimeoutsOptions;
+
+        /**
+         * A function called whenever a retry is attempted.
+         */
+        onRetry?: () => void;
+
+        /**
+         * Matches the response body against the given [Subresource
+         * Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)
+         * metadata. If verification fails, the request will fail with an
+         * `EINTEGRITY` error.
+         *
+         * `integrity` may either be a string or an
+         * [`ssri`](https://npm.im/ssri) `Integrity`-like.
+         */
+        integrity?: string | Integrity;
+    }
+
+    type CachingFetchOpts = NodeFetchOpts & TlsOpts & MakeFetchHappenOpts;
+
+    interface FetchInterface {
+        prototype: FetchInterface;
+        (uriOrRequest: string | Request, opts?: CachingFetchOpts): Promise<Response>;
+        (opts: CachingFetchOpts): Promise<Response>;
+        defaults(uri: string, opts?: CachingFetchOpts): FetchInterface;
+        defaults(opts?: CachingFetchOpts): FetchInterface;
+    }
+}

--- a/types/make-fetch-happen/index.d.ts
+++ b/types/make-fetch-happen/index.d.ts
@@ -5,7 +5,7 @@
 /// <reference types="node" />
 import { ClientRequestArgs, AgentOptions } from 'http';
 import { CommonConnectionOptions, SecureContextOptions } from 'tls';
-import { URL } from 'url';
+import { URL as NodeURL } from 'url';
 
 import { RequestInit, Response } from 'node-fetch';
 import { Integrity } from 'ssri';
@@ -50,7 +50,7 @@ declare namespace fetch {
         cacheManager?: string | Cache;
 
         cache?: RequestCache;
-        proxy?: string | URL;
+        proxy?: string | NodeURL | URL;
 
         /**
          * If present, should be a comma-separated string or an array of domain

--- a/types/make-fetch-happen/index.d.ts
+++ b/types/make-fetch-happen/index.d.ts
@@ -135,5 +135,6 @@ declare namespace fetch {
         (opts: FetchOptions): Promise<Response>;
         defaults(uri: string, opts?: FetchOptions): FetchInterface;
         defaults(opts?: FetchOptions): FetchInterface;
+        delete(uri: string, opts?: FetchOptions): ReturnType<Cache['delete']>;
     }
 }

--- a/types/make-fetch-happen/make-fetch-happen-tests.ts
+++ b/types/make-fetch-happen/make-fetch-happen-tests.ts
@@ -66,3 +66,9 @@ fetcher('http://url', { proxy: new NodeURL('http://secure-proxy') });
 // Test the imported `tls` type `rejectUnauthorized` remapped to `strictSSL`.
 // $ExpectType Promise<Response>
 fetcher('https://url', { strictSSL: true });
+
+// Test the `Cache` return type of the `delete` method.
+// $ExpectType Promise<boolean>
+fetcher.delete('http://ok');
+// $ExpectType Promise<boolean>
+fetcher.delete('http://ok', { cacheManager: cache });

--- a/types/make-fetch-happen/make-fetch-happen-tests.ts
+++ b/types/make-fetch-happen/make-fetch-happen-tests.ts
@@ -1,4 +1,5 @@
 import fetcher from 'make-fetch-happen';
+import { Integrity } from 'ssri';
 import { URL as NodeURL } from 'url';
 
 // Needs arguments when invoked
@@ -35,6 +36,11 @@ fetcher.defaults()('http://url');
 
 // $ExpectType Promise<Response>
 fetcher.defaults().defaults()('http://url');
+
+// Test the SSRI types from `ssri`
+const integrity = new Integrity();
+// $ExpectType Promise<Response>
+fetcher('https://url', { integrity });
 
 // Test both the DOM URL and the Node.js `url` module.
 // $ExpectType Promise<Response>

--- a/types/make-fetch-happen/make-fetch-happen-tests.ts
+++ b/types/make-fetch-happen/make-fetch-happen-tests.ts
@@ -1,0 +1,36 @@
+import fetcher from 'make-fetch-happen';
+
+// Needs arguments when invoked
+// $ExpectError
+fetcher();
+
+// Works with no defaults applied.
+// $ExpectType FetchInterface
+fetcher.defaults();
+
+// When used recursively, still needs arguments when invoked.
+// $ExpectError
+fetcher.defaults()();
+
+// $ExpectType FetchInterface
+fetcher.defaults();
+
+// Returns a Response when fetched.
+// $ExpectType Promise<Response>
+fetcher('http://url');
+
+// $ExpectType Promise<Response>
+fetcher.defaults('http://default-uri')({
+    cert: 'MY_PEM',
+});
+
+// $ExpectType Promise<Response>
+fetcher('http://default-uri', {
+    cert: 'MY_PEM',
+});
+
+// $ExpectType Promise<Response>
+fetcher.defaults()('http://url');
+
+// $ExpectType Promise<Response>
+fetcher.defaults().defaults()('http://url');

--- a/types/make-fetch-happen/make-fetch-happen-tests.ts
+++ b/types/make-fetch-happen/make-fetch-happen-tests.ts
@@ -1,4 +1,5 @@
 import fetcher from 'make-fetch-happen';
+import { URL as NodeURL } from 'url';
 
 // Needs arguments when invoked
 // $ExpectError
@@ -34,3 +35,9 @@ fetcher.defaults()('http://url');
 
 // $ExpectType Promise<Response>
 fetcher.defaults().defaults()('http://url');
+
+// Test both the DOM URL and the Node.js `url` module.
+// $ExpectType Promise<Response>
+fetcher('http://url', { proxy: new URL('http://secure-proxy') });
+// $ExpectType Promise<Response>
+fetcher('http://url', { proxy: new NodeURL('http://secure-proxy') });

--- a/types/make-fetch-happen/make-fetch-happen-tests.ts
+++ b/types/make-fetch-happen/make-fetch-happen-tests.ts
@@ -37,13 +37,32 @@ fetcher.defaults()('http://url');
 // $ExpectType Promise<Response>
 fetcher.defaults().defaults()('http://url');
 
+// $ExpectError
+fetcher('https://secure', { cache: "invalid-option" });
+
+const cache = new Cache();
+// $ExpectType Promise<Response>
+fetcher('https://secure', { cacheManager: cache });
+
+// Test using a `Request` to the `fetcher` instead of URL.
+// $ExpectType Promise<Response>
+fetcher(new Request('http://localhost'), { ca: 'MY_CA_PEM' });
+
 // Test the SSRI types from `ssri`
 const integrity = new Integrity();
 // $ExpectType Promise<Response>
 fetcher('https://url', { integrity });
+
+// Test the `retry` types.
+// $ExpectType Promise<Response>
+fetcher('http://url', { retry: { retries: 1, maxTimeout: 1 }});
 
 // Test both the DOM URL and the Node.js `url` module.
 // $ExpectType Promise<Response>
 fetcher('http://url', { proxy: new URL('http://secure-proxy') });
 // $ExpectType Promise<Response>
 fetcher('http://url', { proxy: new NodeURL('http://secure-proxy') });
+
+// Test the imported `tls` type `rejectUnauthorized` remapped to `strictSSL`.
+// $ExpectType Promise<Response>
+fetcher('https://url', { strictSSL: true });

--- a/types/make-fetch-happen/make-fetch-happen-tests.ts
+++ b/types/make-fetch-happen/make-fetch-happen-tests.ts
@@ -1,4 +1,4 @@
-import fetcher from 'make-fetch-happen';
+import fetcher = require('make-fetch-happen');
 import { Integrity } from 'ssri';
 import { URL as NodeURL } from 'url';
 
@@ -14,8 +14,9 @@ fetcher.defaults();
 // $ExpectError
 fetcher.defaults()();
 
+// Recursively, should do the same!
 // $ExpectType FetchInterface
-fetcher.defaults();
+fetcher.defaults().defaults();
 
 // Returns a Response when fetched.
 // $ExpectType Promise<Response>

--- a/types/make-fetch-happen/tsconfig.json
+++ b/types/make-fetch-happen/tsconfig.json
@@ -5,7 +5,6 @@
             "es6",
             "dom"
         ],
-        "esModuleInterop": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/make-fetch-happen/tsconfig.json
+++ b/types/make-fetch-happen/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "esModuleInterop": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "make-fetch-happen-tests.ts"
+    ]
+}

--- a/types/make-fetch-happen/tslint.json
+++ b/types/make-fetch-happen/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Inspired by @trevor-scheer's https://github.com/npm/make-fetch-happen/pull/31.

Although @trevor-scheer tried to land these types in the (non-TypeScript) `make-fetch-happen` library itself, the attempt to do so did not receive traction and still awaits attention.  Instead, I'm opening this submission to `DefinitelyTyped` directly for this package, largely inspired by the above-referenced PR, with a couple changes to account for the package submission guidelines of DefinitelyTyped (e.g., `esModuleInterop` ☯️, tests 🥳 ) along with supporting the truly recursive nature of the case where using `.defaults()` is used to factory-function a new `fetch` instance with newly specified defaults.

(Worth noting that I haven't added `Trevor Scheer` as a [definition owner](https://github.com/DefinitelyTyped/DefinitelyTyped#definition-owners), even though he is the original author of the package.  If he'd like to be included, he's more than welcome to add himself!)

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.