### PR TITLE
[@types/i18n-js] Allow the translate function to return something other than a string

### DIFF
--- a/types/i18n-js/i18n-js-tests.ts
+++ b/types/i18n-js/i18n-js-tests.ts
@@ -87,7 +87,10 @@ I18n.t("point", { count: point_in_number, formatted_number: I18n.toNumber(point_
 I18n.translations = {};
 I18n.translations["en"] = {
     message: "Some special message for you",
+    genericNames: ["John", "Adam", "Sara"],
 };
 I18n.translations["pt-BR"] = {
     message: "Uma mensagem especial para você",
 };
+
+I18n.t<string[]>("genericNames");

--- a/types/i18n-js/i18n-js-tests.ts
+++ b/types/i18n-js/i18n-js-tests.ts
@@ -93,4 +93,4 @@ I18n.translations["pt-BR"] = {
     message: "Uma mensagem especial para você",
 };
 
-I18n.t<string[]>("genericNames");
+const name = I18n.t("genericNames")[1];

--- a/types/i18n-js/index.d.ts
+++ b/types/i18n-js/index.d.ts
@@ -47,7 +47,11 @@ declare namespace I18n {
         defaultValue?: string;
     }
     function translate(scope: Scope, options?: TranslateOptions): string;
+    // tslint:disable-next-line no-unnecessary-generics
+    function translate<T>(scope: Scope, options?: TranslateOptions): T;
     function t(scope: Scope, options?: TranslateOptions): string;
+    // tslint:disable-next-line no-unnecessary-generics
+    function t<T>(scope: Scope, options?: TranslateOptions): T;
 
     function localize(scope: "currency" | "number" | "percentage", value: number, options?: InterpolateOptions): string;
     function localize(scope: Scope, value: string | number | Date, options?: InterpolateOptions): string;

--- a/types/i18n-js/index.d.ts
+++ b/types/i18n-js/index.d.ts
@@ -46,12 +46,8 @@ declare namespace I18n {
         defaults?: Array<{ message: string } | { scope: Scope }>;
         defaultValue?: string;
     }
-    function translate(scope: Scope, options?: TranslateOptions): string;
-    // tslint:disable-next-line no-unnecessary-generics
-    function translate<T>(scope: Scope, options?: TranslateOptions): T;
-    function t(scope: Scope, options?: TranslateOptions): string;
-    // tslint:disable-next-line no-unnecessary-generics
-    function t<T>(scope: Scope, options?: TranslateOptions): T;
+    function translate(scope: Scope, options?: TranslateOptions): any;
+    function t(scope: Scope, options?: TranslateOptions): any;
 
     function localize(scope: "currency" | "number" | "percentage", value: number, options?: InterpolateOptions): string;
     function localize(scope: Scope, value: string | number | Date, options?: InterpolateOptions): string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes). **See note below**
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/fnando/i18n-js/blob/6aec93574bb6721f600d930ebe6500f09dd39f23/app/assets/javascripts/i18n.js#L572>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **It does not**

I do realize that this uses a generic type against the common mistakes guidelines. However, this is the only way I have found to adjust this without breaking existing code. 95% of the time (and I'm sure 100% in some applications), t will return a string. However, it does not have to. By specifying an array of strings in the translation file, you will get an array back. The definition needs to accommodate this usage. I did try adding a second definition that returns any but because they take the same parameters, TypeScript still prefers the string variant even when type assertion is used. This is the only way that worked for me to allow this usage without breaking existing code. Please let me know if there is another way, I am new to TS.
