### PR TITLE
update(markdown-it-emoji): v2 changes

### DIFF
--- a/types/markdown-it-emoji/bare.d.ts
+++ b/types/markdown-it-emoji/bare.d.ts
@@ -1,0 +1,6 @@
+import emoji = require('./index');
+
+declare namespace bare {}
+
+declare const bare: typeof emoji;
+export = bare;

--- a/types/markdown-it-emoji/index.d.ts
+++ b/types/markdown-it-emoji/index.d.ts
@@ -1,11 +1,13 @@
-// Type definitions for markdown-it-emoji 1.4
+// Type definitions for markdown-it-emoji 2.0
 // Project: https://github.com/markdown-it/markdown-it-emoji
 // Definitions by: Christopher Quadflieg <https://github.com/Shinigami92>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import { PluginSimple, PluginWithOptions } from 'markdown-it/lib';
 
-import { PluginSimple, PluginWithOptions } from 'markdown-it';
+export as namespace markdownitEmoji;
 
-declare namespace MarkdownItEmoji {
+declare namespace markdownitEmoji {
     interface Options {
         defs?: Record<string, string>;
         enabled?: string[];
@@ -13,6 +15,5 @@ declare namespace MarkdownItEmoji {
     }
 }
 
-declare const emoji: PluginSimple | PluginWithOptions<MarkdownItEmoji.Options>;
-
-export = emoji;
+declare const markdownitEmoji: PluginSimple | PluginWithOptions<markdownitEmoji.Options>;
+export = markdownitEmoji;

--- a/types/markdown-it-emoji/light.d.ts
+++ b/types/markdown-it-emoji/light.d.ts
@@ -1,0 +1,6 @@
+import emoji = require('./index');
+
+declare namespace light {}
+
+declare const light: typeof emoji;
+export = light;

--- a/types/markdown-it-emoji/test/markdown-it-emoji-cjs.ts
+++ b/types/markdown-it-emoji/test/markdown-it-emoji-cjs.ts
@@ -1,5 +1,7 @@
 import MarkdownIt = require('markdown-it');
 import emoji = require('markdown-it-emoji');
+import bare = require('markdown-it-emoji/bare');
+import light = require('markdown-it-emoji/light');
 
 {
     const md = MarkdownIt();
@@ -26,6 +28,12 @@ import emoji = require('markdown-it-emoji');
     const md = MarkdownIt();
 
     md.use(emoji, {
+        enabled: ['smile', 'grin'],
+    });
+    md.use(bare, {
+        enabled: ['smile', 'grin'],
+    });
+    md.use(light, {
         enabled: ['smile', 'grin'],
     });
 }

--- a/types/markdown-it-emoji/test/markdown-it-emoji-global.ts
+++ b/types/markdown-it-emoji/test/markdown-it-emoji-global.ts
@@ -1,0 +1,23 @@
+/// <reference lib="dom" />
+/// <reference types="markdown-it-emoji" />
+
+{
+    const md = markdownit();
+
+    md.use(markdownitEmoji);
+}
+
+{
+    const md = markdownit();
+
+    md.use(markdownitEmoji, {
+        defs: {
+            one: '!!!one!!!',
+            fifty: '!!50!!',
+        },
+        shortcuts: {
+            fifty: [':50', '|50'],
+            one: ':uno',
+        },
+    });
+}

--- a/types/markdown-it-emoji/tsconfig.json
+++ b/types/markdown-it-emoji/tsconfig.json
@@ -18,6 +18,7 @@
     },
     "files": [
         "index.d.ts",
-        "markdown-it-emoji-tests.ts"
+        "test/markdown-it-emoji-cjs.ts",
+        "test/markdown-it-emoji-global.ts"
     ]
 }

--- a/types/markdown-it/index.d.ts
+++ b/types/markdown-it/index.d.ts
@@ -8,4 +8,6 @@
 
 import MarkdownIt = require('./lib');
 
+export as namespace markdownit;
+
 export = MarkdownIt;


### PR DESCRIPTION
- bump markdown-it-emojis to v2
- correct markdown-it-emoji to UMD with 'markdownitEmoji' export
- correct markdown-it to UMD with 'markdowntit' export
- introduce support for markdown-it-emoji default, bare and light modes
- align types naming to package naming conventions
- maintainer added

https://github.com/markdown-it/markdown-it-emoji/compare/1.4.0...2.0.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.