### PR TITLE
Patch createAuthorizeURL for spotify-web-api-node package

### DIFF
--- a/types/spotify-web-api-node/index.d.ts
+++ b/types/spotify-web-api-node/index.d.ts
@@ -457,9 +457,10 @@ declare class SpotifyWebApi {
      * @param scopes The scopes corresponding to the permissions the application needs.
      * @param state A parameter that you can use to maintain a value between the request and the callback to redirect_uri.It is useful to prevent CSRF exploits.
      * @param showDialog A parameter that you can use to force the user to approve the app on each login rather than being automatically redirected.
+     * @param responseType A parameter that you can use to specify the code response based on the authentication type - can be set to 'code' or 'token'.
      * @returns The URL where the user can give application permissions.
      */
-    createAuthorizeURL(scopes: ReadonlyArray<string>, state: string, showDialog?: boolean): string;
+    createAuthorizeURL(scopes: ReadonlyArray<string>, state: string, showDialog?: boolean, responseType?: 'code' | 'token'): string;
 
     /**
      * Retrieve the tracks that are saved to the authenticated users Your Music library.

--- a/types/spotify-web-api-node/spotify-web-api-node-tests.ts
+++ b/types/spotify-web-api-node/spotify-web-api-node-tests.ts
@@ -13,7 +13,7 @@ spotifyApi.createAuthorizeURL(
   "state",
   true,
   "token"
-)
+);
 
 // Create the authorization URL with code response type
 spotifyApi.createAuthorizeURL(
@@ -21,20 +21,20 @@ spotifyApi.createAuthorizeURL(
   "state",
   true,
   "code"
-)
+);
 
 // Create the authorization URL with default response type
 spotifyApi.createAuthorizeURL(
   ["user-read-private"],
   "state",
   true
-)
+);
 
 // Create the authorization URL with default response type and showDialog option
 spotifyApi.createAuthorizeURL(
   ["user-read-private"],
   "state"
-)
+);
 
 // Get multiple albums
 spotifyApi.getAlbums(['5U4W9E5WsYb2jUQWePT8Xm', '3KyVcddATClQKIdtaap4bV'])

--- a/types/spotify-web-api-node/spotify-web-api-node-tests.ts
+++ b/types/spotify-web-api-node/spotify-web-api-node-tests.ts
@@ -7,6 +7,35 @@ import SpotifyWebApi = require('spotify-web-api-node');
 
 const spotifyApi = new SpotifyWebApi();
 
+// Create the authorization URL with token response type
+spotifyApi.createAuthorizeURL(
+  ["user-read-private"],
+  "state",
+  true,
+  "token"
+)
+
+// Create the authorization URL with code response type
+spotifyApi.createAuthorizeURL(
+  ["user-read-private"],
+  "state",
+  true,
+  "code"
+)
+
+// Create the authorization URL with default response type
+spotifyApi.createAuthorizeURL(
+  ["user-read-private"],
+  "state",
+  true
+)
+
+// Create the authorization URL with default response type and showDialog option
+spotifyApi.createAuthorizeURL(
+  ["user-read-private"],
+  "state"
+)
+
 // Get multiple albums
 spotifyApi.getAlbums(['5U4W9E5WsYb2jUQWePT8Xm', '3KyVcddATClQKIdtaap4bV'])
   .then((data) => {


### PR DESCRIPTION
Patch `createAuthorizeURL` for `spotify-web-api-node` package

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/thelinmichael/spotify-web-api-node/blob/master/src/server-methods.js#L16
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~


