### PR TITLE
Update types for swagger-jsdoc 6.0

### DIFF
--- a/types/swagger-jsdoc/index.d.ts
+++ b/types/swagger-jsdoc/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for swagger-jsdoc 3.0
+// Type definitions for swagger-jsdoc 6.0
 // Project: https://github.com/surnet/swagger-jsdoc
 // Definitions by: Daniel Grove <https://github.com/drGrove>
 //                 Neil Bryson Cargamento <https://github.com/neilbryson>
+//                 Preyansh Mitharwal <https://github.com/preyansh07>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -12,15 +13,14 @@
 
     const app = express();
 
-    const options: swaggerJSDoc.Options = {
-        swaggerDefinition: {
+    const options: swaggerJSDoc.Oas3Options = {
+        definition: {
+          openapi: '3.0.0',
           info: {
             title: 'Hello World',
-            version: '1.0.0',
-            description: 'A sample API'
-          },
-          host: 'localhost:3000',
-          basePath: '/'
+            description: 'A sample API',
+            version: '1.0.0'
+          }
         },
         apis: [
           './example/routes*.js',
@@ -44,30 +44,285 @@
 declare function swaggerJSDoc(options?: swaggerJSDoc.Options): object;
 
 declare namespace swaggerJSDoc {
-    interface ApiInformation {
-        description?: string;
-        title: string;
-        version: string;
+    /**
+     * Open API Specification (OAS) version 3.0 options
+     */
+    interface Oas3Options {
+        apis?: ReadonlyArray<string>;
+        definition?: Oas3Definition;
+        swaggerDefinition?: Oas3Definition;
+        [key: string]: any;
     }
 
-    interface ServerInformation {
+    /**
+     * For describing Open API Specification (OAS) version 3.0
+     */
+    interface Oas3Definition {
+        openapi: string;
+        info: Information;
+        servers?: ReadonlyArray<Server>;
+        paths?: Paths;
+        components?: Components;
+        security?: ReadonlyArray<SecurityRequirement>;
+        tags?: ReadonlyArray<Tag>;
+        externalDocs?: ExternalDocumentation;
+        [key: string]: any;
+    }
+
+    interface Information {
+        title: string;
+        description?: string;
+        termsOfService?: string;
+        contact?: Contact;
+        license?: License;
+        version: string;
+        [key: string]: any;
+    }
+
+    interface Contact {
+        name?: string;
+        url?: string;
+        email?: string;
+        [key: string]: any;
+    }
+
+    interface License {
+        name: string;
+        url?: string;
+        [key: string]: any;
+    }
+
+    interface Server {
+        url: string;
+        description?: string;
+        variables?: { [key: string]: ServerVariable };
+        [key: string]: any;
+    }
+
+    interface ServerVariable {
+        enum?: ReadonlyArray<string>;
+        default: string;
+        description?: string;
+        [key: string]: any;
+    }
+
+    interface Paths {
+        [key: string]: PathItem;
+    }
+
+    interface PathItem {
+        $ref?: string;
+        summary?: string;
+        description?: string;
+        get?: Operation;
+        put?: Operation;
+        post?: Operation;
+        delete?: Operation;
+        options?: Operation;
+        head?: Operation;
+        patch?: Operation;
+        trace?: Operation;
+        servers?: ReadonlyArray<Server>;
+        parameters?: Parameter | Reference;
+        [key: string]: any;
+    }
+
+    interface Operation {
+        tags?: string[];
+        summary?: string;
+        description?: string;
+        externalDocs?: ExternalDocumentation;
+        operationId?: string;
+        parameters?: ReadonlyArray<Parameter | Reference>;
+        requestBody?: RequestBody | Reference;
+        responses?: Responses;
+        callbacks?: { [key: string]: Callback | Reference };
+        deprecated?: boolean;
+        security?: ReadonlyArray<SecurityRequirement>;
+        servers?: ReadonlyArray<Server>;
+        [key: string]: any;
+    }
+
+    interface Parameter {
+        name: string;
+        in: string;
+        description?: string;
+        required?: boolean;
+        deprecated?: boolean;
+        allowEmptyValue?: boolean;
+        style?: string;
+        explode?: boolean;
+        allowReserved?: boolean;
+        schema?: Schema | Reference;
+        example?: any;
+        examples?: { [key: string]: Example | Reference };
+        [key: string]: any;
+    }
+
+    interface Schema {
+        type?: string;
+        format?: string;
+        [key: string]: any;
+    }
+
+    interface Reference {
+        $ref: string;
+    }
+
+    interface Example {
+        summary?: string;
+        description?: string;
+        value?: any;
+        externalValue?: string;
+        [key: string]: any;
+    }
+
+    interface RequestBody {
+        description?: string;
+        content: { [key: string]: MediaType };
+        required?: boolean;
+        [key: string]: any;
+    }
+
+    interface Responses {
+        default?: Response | Reference;
+        [key: string]: any;
+    }
+
+    interface Response {
+        description: string;
+        headers?: { [key: string]: Header | Reference };
+        content?: { [key: string]: MediaType };
+        links?: { [key: string]: Link | Reference };
+        [key: string]: any;
+    }
+
+    interface Header {
+        description?: string;
+        required?: boolean;
+        deprecated?: boolean;
+        allowEmptyValue?: boolean;
+        style?: string;
+        explode?: boolean;
+        allowReserved?: boolean;
+        schema?: Schema | Reference;
+        example?: any;
+        examples?: { [key: string]: Example | Reference };
+        [key: string]: any;
+    }
+
+    interface MediaType {
+        schema?: Schema | Reference;
+        example?: any;
+        examples?: { [key: string]: Example | Reference };
+        encoding?: { [key: string]: Encoding };
+        [key: string]: any;
+    }
+
+    interface Encoding {
+        contentType?: string;
+        headers?: { [key: string]: Header | Reference };
+        style?: string;
+        explode?: boolean;
+        allowReserved?: boolean;
+        [key: string]: any;
+    }
+
+    interface Link {
+        operationRef?: string;
+        operationId?: string;
+        parameters?: { [key: string]: any };
+        requestBody?: { [key: string]: any };
+        description?: string;
+        server?: Server;
+        [key: string]: any;
+    }
+
+    interface Callback {
+        [key: string]: PathItem;
+    }
+
+    interface SecurityRequirement {
+        [key: string]: ReadonlyArray<string>;
+    }
+
+    interface Components {
+        schemas?: { [key: string]: Schema | Reference };
+        responses?: { [key: string]: Response | Reference };
+        parameters?: { [key: string]: Parameter | Reference };
+        examples?: { [key: string]: Example | Reference };
+        requestBodies?: { [key: string]: RequestBody | Reference };
+        headers?: { [key: string]: Header | Reference };
+        securitySchemes?: { [key: string]: SecurityScheme | Reference };
+        links?: { [key: string]: Link | Reference };
+        callbacks?: { [key: string]: Callback | Reference };
+        [key: string]: any;
+    }
+
+    interface SecurityScheme {
+        type: string;
+        description?: string;
+        name?: string;
+        in?: string;
+        scheme?: string;
+        bearerFormat?: string;
+        flows?: OAuthFlows;
+        openIdConnectUrl?: string;
+        [key: string]: any;
+    }
+
+    interface OAuthFlows {
+        implicit?: OAuthFlow;
+        password?: OAuthFlow;
+        clientCredentials?: OAuthFlow;
+        authorizationCode?: OAuthFlow;
+        [key: string]: any;
+    }
+
+    interface OAuthFlow {
+        authorizationUrl?: string;
+        tokenUrl?: string;
+        refreshUrl?: string;
+        scopes: { [key: string]: string };
+        [key: string]: any;
+    }
+
+    interface Tag {
+        name: string;
+        description?: string;
+        externalDocs?: ExternalDocumentation;
+        [key: string]: any;
+    }
+
+    interface ExternalDocumentation {
+        description?: string;
         url: string;
         [key: string]: any;
     }
 
-    interface SwaggerDefinition {
-        basePath?: string;
-        host?: string;
-        info: ApiInformation;
-        openapi?: string;
-        servers?: ReadonlyArray<ServerInformation>;
-        [key: string]: any;
-    }
-
+    /**
+     * Open API Specification (OAS) version 2.0 options (fka Swagger specification)
+     */
     interface Options {
         apis?: ReadonlyArray<string>;
         definition?: SwaggerDefinition;
         swaggerDefinition?: SwaggerDefinition;
+        [key: string]: any;
+    }
+
+    /**
+     * For describing Open API Specification (OAS) version 2.0 (fka Swagger specification)
+     */
+    interface SwaggerDefinition {
+        swagger?: string;
+        info: Information;
+        host?: string;
+        basePath?: string;
+        schemes?: ReadonlyArray<string>;
+        consumes?: ReadonlyArray<string>;
+        produces?: ReadonlyArray<string>;
+        tags?: ReadonlyArray<Tag>;
+        externalDocs?: ExternalDocumentation;
         [key: string]: any;
     }
 }

--- a/types/swagger-jsdoc/index.d.ts
+++ b/types/swagger-jsdoc/index.d.ts
@@ -13,7 +13,7 @@
 
     const app = express();
 
-    const options: swaggerJSDoc.Oas3Options = {
+    const options: swaggerJSDoc.OAS3Options = {
         definition: {
           openapi: '3.0.0',
           info: {
@@ -47,17 +47,17 @@ declare namespace swaggerJSDoc {
     /**
      * Open API Specification (OAS) version 3.0 options
      */
-    interface Oas3Options {
+    interface OAS3Options {
         apis?: ReadonlyArray<string>;
-        definition?: Oas3Definition;
-        swaggerDefinition?: Oas3Definition;
+        definition?: OAS3Definition;
+        swaggerDefinition?: OAS3Definition;
         [key: string]: any;
     }
 
     /**
      * For describing Open API Specification (OAS) version 3.0
      */
-    interface Oas3Definition {
+    interface OAS3Definition {
         openapi: string;
         info: Information;
         servers?: ReadonlyArray<Server>;

--- a/types/swagger-jsdoc/swagger-jsdoc-tests.ts
+++ b/types/swagger-jsdoc/swagger-jsdoc-tests.ts
@@ -3,22 +3,51 @@ import * as swaggerJSDoc from 'swagger-jsdoc';
 
 const app = express();
 
-const options: swaggerJSDoc.Options = {
-    swaggerDefinition: {
+const options: swaggerJSDoc.Oas3Options = {
+    definition: {
+        openapi: '3.0.0',
         info: {
-            title: 'A test api',
+            title: 'Sample REST API',
+            description: 'API description',
             version: '1.0.0',
         },
-        host: 'localhost:3000',
-        basePath: '/',
-        openapi: '3.0.0',
-        servers: [{ url: '/api/v1' }, { url: '/api/v2' }],
+        servers: [
+            { url: '/api/v1', description: 'API version 1 URL' },
+            { url: '/api/v2', description: 'API version 2 URL' },
+        ],
+        components: {
+            schemas: {
+                User: {
+                    type: 'object',
+                    properties: {
+                        id: {
+                            type: 'integer',
+                            format: 'int64',
+                        },
+                        username: {
+                            type: 'string',
+                        },
+                    },
+                },
+            },
+        },
+        tags: [
+            {
+                name: 'my tag',
+                description: 'tag description',
+            },
+        ],
+        externalDocs: {
+            url: 'https://example.com',
+            description: 'API external documentation',
+        },
     },
     apis: ['./example/routes*.js', './example/parameters.yaml'],
 };
 
 const swaggerSpec = swaggerJSDoc(options);
 
+// prettier-ignore
 app.get('/api-docs.json', function(req, res) {
     res.send(swaggerSpec);
 });

--- a/types/swagger-jsdoc/swagger-jsdoc-tests.ts
+++ b/types/swagger-jsdoc/swagger-jsdoc-tests.ts
@@ -3,7 +3,7 @@ import * as swaggerJSDoc from 'swagger-jsdoc';
 
 const app = express();
 
-const options: swaggerJSDoc.Oas3Options = {
+const options: swaggerJSDoc.OAS3Options = {
     definition: {
         openapi: '3.0.0',
         info: {


### PR DESCRIPTION
* Update swagger-jsdoc types to version 6.0
* Add Oas3Options and Oas3Definition interfaces for [swagger-jsdoc options](https://github.com/Surnet/swagger-jsdoc/blob/7aaa3e00b75c6deffcce09126beee391716549d2/examples/app/app.js#L38) and [OAS 3.0 object](https://swagger.io/specification/#openapi-object) respectively
* Add types for OAS 3.0 schema objects

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [swagger-spec](https://github.com/Surnet/swagger-jsdoc/blob/master/examples/app/swagger-spec.json), [swagger-jsdoc getting started](https://github.com/Surnet/swagger-jsdoc/blob/master/docs/GETTING-STARTED.md#getting-started), [Open API Specification v3](https://swagger.io/specification/#openapi-object)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
