### PR TITLE
[@types/plotly.js]: Add missing automargin prop to data

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1281,6 +1281,7 @@ export interface PlotData {
     ids: string[];
     level: string;
     cliponaxis: boolean;
+    automargin: boolean;
 }
 
 /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

## Details

`automargin`, in addition to it's use in [layout](https://plotly.com/javascript/setting-graph-size/#automatically-adjust-margins), is also accepted in `data` params, example:

```javascript
var data = [{
  type: "pie",
  values: [2, 3, 4, 4],
  labels: ["Wages", "Operating expenses", "Cost of sales", "Insurance"],
  textinfo: "label+percent",
  textposition: "outside",
  automargin: true
}]

var layout = {
  height: 400,
  width: 400,
  margin: {"t": 0, "b": 0, "l": 0, "r": 0},
  showlegend: false
  }

Plotly.newPlot('myDiv', data, layout)
```

Source: https://plotly.com/javascript/pie-charts/#automatically-adjust-margins

Instances where it's used:  https://github.com/plotly/plotly.js/blob/c09fe29bb5d4bc9c2ae568e9df9d7579dca74af5/src/traces/pie/plot.js#L259


Original error:

```
ERROR in src/App.tsx
./src/App.tsx
[tsl] ERROR in src/App.tsx(283,17)
      TS2769: No overload matches this call.
  Overload 1 of 2, '(props: PlotParams | Readonly<PlotParams>): Plot', gave the following error.
    Type '{ type: "pie"; values: number[]; labels: string[]; textinfo: "label+percent"; textposition: "outside"; automargin: true; }' is not assignable to type 'Data'.
      Object literal may only specify known properties, and 'automargin' does not exist in type 'Partial<PlotData>'.
  Overload 2 of 2, '(props: PlotParams, context: any): Plot', gave the following error.
    Type '{ type: "pie"; values: number[]; labels: string[]; textinfo: "label+percent"; textposition: "outside"; automargin: true; }' is not assignable to type 'Data'.
      Object literal may only specify known properties, and 'automargin' does not exist in type 'Partial<PlotData>'.
```

*Without* `data.automargin: true`:
![image](https://user-images.githubusercontent.com/26336/103460862-66bccf80-4cdf-11eb-85a4-bb48d1791f24.png)


With `data.automargin: true` + `@ts-ignore`:
![image](https://user-images.githubusercontent.com/26336/103460870-74725500-4cdf-11eb-9558-9dfbc52bb0c2.png)

