### PR TITLE
@hapi/yar: Allow calling flash() without arguments and add missing commit() function

### DIFF
--- a/types/hapi__yar/hapi__yar-tests.ts
+++ b/types/hapi__yar/hapi__yar-tests.ts
@@ -20,12 +20,14 @@ async function boot() {
     server.route({
         path: '/test',
         method: 'get',
-        handler(request: Request) {
+        async handler(request: Request, h) {
             const example = request.yar.get('example');
 
             request.yar.flash('info', 'Hello world.');
             const all_flashes = request.yar.flash();
             const info_flashes = request.yar.flash('info');
+
+            await request.yar.commit(h);
 
             return {
                 id: request.yar.id,

--- a/types/hapi__yar/hapi__yar-tests.ts
+++ b/types/hapi__yar/hapi__yar-tests.ts
@@ -1,5 +1,5 @@
-import { Server, Request } from 'hapi';
-import * as yar from 'yar';
+import { Server, Request } from '@hapi/hapi';
+import * as yar from '@hapi/yar';
 
 async function boot() {
     const server = new Server();

--- a/types/hapi__yar/hapi__yar-tests.ts
+++ b/types/hapi__yar/hapi__yar-tests.ts
@@ -22,9 +22,16 @@ async function boot() {
         method: 'get',
         handler(request: Request) {
             const example = request.yar.get('example');
+
+            request.yar.flash('info', 'Hello world.');
+            const all_flashes = request.yar.flash();
+            const info_flashes = request.yar.flash('info');
+
             return {
                 id: request.yar.id,
                 key: example.key,
+                all_flashes,
+                info_flashes
             };
         },
     });

--- a/types/hapi__yar/index.d.ts
+++ b/types/hapi__yar/index.d.ts
@@ -149,7 +149,7 @@ declare namespace yar {
          * 'isOverride' used to indicate that the message provided should replace
          * any existing value instead of being appended to it (defaults to false).
          */
-        flash(type: string, message?: any, isOverride?: boolean): any[];
+        flash(type?: string, message?: any, isOverride?: boolean): any[];
 
         /**
          * if set to 'true', enables lazy mode.

--- a/types/hapi__yar/index.d.ts
+++ b/types/hapi__yar/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @hapi/yar 9.2
+// Type definitions for @hapi/yar 10.1
 // Project: https://github.com/hapijs/yar#readme
 // Definitions by: Simon Schick <https://github.com/SimonSchick>
 //                 Silas Rech <https://github.com/lenovouser>
@@ -6,13 +6,7 @@
 // TypeScript Version: 2.8
 // From https://github.com/hapijs/yar/blob/master/API.md
 
-import {
-    Server,
-    ServerOptionsCache,
-    Request,
-    Plugin,
-    CachePolicyOptions,
-} from '@hapi/hapi';
+import { Server, ServerOptionsCache, Request, Plugin, CachePolicyOptions, ResponseToolkit } from '@hapi/hapi';
 import { PolicyOptions, Id } from '@hapi/catbox';
 declare namespace yar {
     interface YarOptions {
@@ -159,6 +153,14 @@ declare namespace yar {
          * it has to store the session state on every responses regardless of any changes being made.
          */
         lazy(enabled: boolean): void;
+
+        /**
+         * used to manually prepare the session state and commit it into the response when the response is taken
+         * over in an onPreResponse handler. Normally, the yar onPreRespinse handler performs the commit, but if
+         * an application extension handler takes over, yar doesn't get a chance to commit the state before the
+         * response goes out. The method requires the hapi h toolkit argument available in the extension handler.
+         */
+        commit(h: ResponseToolkit): Promise<void>;
     }
 
     interface ServerYar {


### PR DESCRIPTION
This PR updates the definitions for @hapi/yar. In particular:

* Allow calling flash() without arguments  
  `flash()` can be called without any arguments to get the flashes for all types. This can be seen in the [documentation](https://hapi.dev/module/yar/api/?v=10.1.1#methods) and the existing docstring.
* Add missing commit() function  
  This function was added in [v10.1.0](https://github.com/hapijs/yar/compare/v10.0.0...v10.1.0). The other releases since v9.2 didn't implement any interface changes so, the definitions are now up-to-date for v10.1.1.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).  

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://hapi.dev/module/yar/api/?v=10.1.1#methods>, <https://github.com/hapijs/yar/compare/v10.0.0...v10.1.0>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.