### PR TITLE
[argparse]: Expose ArgumentTypeError exception

### DIFF
--- a/types/argparse/argparse-tests.ts
+++ b/types/argparse/argparse-tests.ts
@@ -12,6 +12,7 @@ import {
     SUPPRESS,
     REMAINDER,
     ArgumentError,
+    ArgumentTypeError,
 } from 'argparse';
 let args: any;
 
@@ -152,11 +153,23 @@ console.log('-----------');
 args = nargsExample.parse_args('--bar b c f --foo a'.split(' '));
 console.dir(args);
 
+function positiveInt(s: string): number {
+    const i = parseInt(s, 10);
+    if (i <= 0) {
+        throw new ArgumentTypeError('must be positive');
+    }
+    return i;
+}
+
 const parent_parser = new ArgumentParser({ add_help: false });
 // note add_help:false to prevent duplication of the -h option
 parent_parser.add_argument(
     '--parent',
     { type: 'int', help: 'parent' }
+);
+parent_parser.add_argument(
+    '--blah',
+    { type: positiveInt, help: 'blah' }
 );
 
 const foo_parser = new ArgumentParser({

--- a/types/argparse/index.d.ts
+++ b/types/argparse/index.d.ts
@@ -90,6 +90,11 @@ export class ArgumentError extends Error {
     str(): string;
 }
 
+// An error from trying to convert a command line string to a type.
+export class ArgumentTypeError extends Error {
+    constructor(message: string);
+}
+
 // Passed to the Action constructor.  Subclasses are just expected to relay this to
 // the super() constructor, so using an "opaque type" pattern is probably fine.
 // Someone may want to fill this out in the future.


### PR DESCRIPTION
It's for when there's an error parsing the value of an argument.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [declaration](https://github.com/nodeca/argparse/blob/70fc26eb5a9a829d6ddcceb6b4c87802218227fd/argparse.js#L1165), [use](https://github.com/nodeca/argparse/blob/70fc26eb5a9a829d6ddcceb6b4c87802218227fd/argparse.js#L3540).
- [N/A] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.