### PR TITLE
Fix user define promisify definition for line-reader package

### DIFF
--- a/types/line-reader/index.d.ts
+++ b/types/line-reader/index.d.ts
@@ -15,7 +15,7 @@ interface LineReader {
     eachLine(): Function; // For Promise.promisify;
     open(): Function;
     eachLine(file: string | NodeJS.ReadableStream, cb: (line: string, last?: boolean, cb?: Function) => void): LineReader;
-    eachLine(file: string | NodeJS.ReadableStream, options: LineReaderOptions, cb: (line: string, last?: boolean, cb?: Function) => void): LineReader;
+    eachLine(file: string | NodeJS.ReadableStream, options: LineReaderOptions, cb: (line: string, last?: boolean, cb?: Function) => void, errCb?: (err: Error) => void): LineReader;
     open(file: string | NodeJS.ReadableStream, cb: (err: Error, reader: LineReader) => void): void;
     open(file: string | NodeJS.ReadableStream, options: LineReaderOptions, cb: (err: Error, reader: LineReader) => void): void;
     hasNextLine(): boolean;

--- a/types/line-reader/line-reader-tests.ts
+++ b/types/line-reader/line-reader-tests.ts
@@ -2,6 +2,31 @@
 
 import lineReader = require('line-reader');
 
+const eachLine = (
+    filename: string | NodeJS.ReadableStream,
+    options: LineReaderOptions,
+    iteratee: (line: string, last?: boolean, cb?: Function) => void,
+): Promise<void> =>
+    new Promise((resolve, reject) => {
+        lineReader.eachLine(filename, options, iteratee, (err: Error) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve();
+            }
+        });
+    });
+
+eachLine('line-reader-tests.ts', {}, function(line) {
+    console.log(line);
+})
+    .then(function() {
+        console.log('done');
+    })
+    .catch(function(err: Error) {
+        console.error(err);
+    });
+
 lineReader.open('line-reader-tests.ts', function(err: Error, reader: LineReader) {
     if (err) throw err;
     if (reader.hasNextLine()) {


### PR DESCRIPTION
Please fill in this template.

- [x] For line-reader package there wasn't any definition for custom promisify function added definition.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/nickewing/line-reader#promises>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

