### PR TITLE
Engine.io handlePreFlightRequest arguments don't match function.

### DIFF
--- a/types/engine.io/engine.io-tests.ts
+++ b/types/engine.io/engine.io-tests.ts
@@ -33,8 +33,7 @@ attachOptions = {
 };
 attachOptions.handlePreflightRequest = true;
 attachOptions.handlePreflightRequest = false;
-attachOptions.handlePreflightRequest = (server, req, res) => {
-    console.log(server.clientsCount);
+attachOptions.handlePreflightRequest = (req, res) => {
     console.log(req.httpVersion);
     console.log(res.finished);
 };

--- a/types/engine.io/index.d.ts
+++ b/types/engine.io/index.d.ts
@@ -104,7 +104,7 @@ declare namespace engine {
         /**
          * whether to let engine.io handle the OPTIONS requests. You can also pass a custom function to handle the requests (true)
          */
-        handlePreflightRequest?: boolean|((server: Server, req: http.IncomingMessage, res: http.ServerResponse) => void);
+        handlePreflightRequest?: boolean|((req: http.IncomingMessage, res: http.ServerResponse) => void);
     }
     interface ServerAttachOptions extends ServerOptions, AttachOptions {}
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ x [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/socketio/engine.io/blob/3.5.0/lib/server.js#L468
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The original @types/engine.io has:
```        /**
         * whether to let engine.io handle the OPTIONS requests. You can also pass a custom function to handle the requests (true)
         */
        handlePreflightRequest?: boolean|((server: Server, req: http.IncomingMessage, res: http.ServerResponse) => void);
```

But in engine.io, this is executed with handlePreflightRequest.call(server, req, res), so server is `this` not an argument.

```
      if ('OPTIONS' === req.method && 'function' === typeof options.handlePreflightRequest) {
        options.handlePreflightRequest.call(server, req, res);
```
