### PR TITLE
[@types/dexie-batch]: Support Dexie 3.x

### DIFF
--- a/types/dexie-batch/package.json
+++ b/types/dexie-batch/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "peerDependencies": {
+  "dependencies": {
     "dexie": ">1.3.6"
   }
 }

--- a/types/dexie-batch/package.json
+++ b/types/dexie-batch/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "dependencies": {
-    "dexie": "^2.0.0"
+  "peerDependencies": {
+    "dexie": ">1.3.6"
   }
 }

--- a/types/dexie-batch/package.json
+++ b/types/dexie-batch/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "dexie": ">1.3.6"
+    "dexie": ">=2.0.0"
   }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/raphinesse/dexie-batch/blob/v0.4.2/package.json#L50

## Description

The "dexie-batch" package supports all Dexie versions greather than v1.3.6 (https://github.com/raphinesse/dexie-batch/blob/v0.4.2/package.json#L50) but the types for it limit it to 2.x versions. When using Dexie v3, the typings break (https://github.com/raphinesse/dexie-batch/issues/3), so I propose to widen the allowed versions of dexie.