### PR TITLE
[types/factory_girl] Make `factory` can be used named import / Add override definitions for `seq` and `sequence`

### DIFF
--- a/types/factory-girl/factory-girl-tests.ts
+++ b/types/factory-girl/factory-girl-tests.ts
@@ -1,4 +1,5 @@
 import * as factory from "factory-girl";
+// tslint:disable-next-line:no-duplicate-imports
 import { factory as namedImportedFactory } from "factory-girl";
 
 interface User {

--- a/types/factory-girl/factory-girl-tests.ts
+++ b/types/factory-girl/factory-girl-tests.ts
@@ -1,4 +1,5 @@
 import * as factory from "factory-girl";
+import { factory as namedImportedFactory } from "factory-girl";
 
 interface User {
     username?: string;
@@ -124,3 +125,6 @@ factory
 
 // Testing cleanUp
 factory.cleanUp();
+
+// Testing namedImportedFactory
+namedImportedFactory.seq();

--- a/types/factory-girl/factory-girl-tests.ts
+++ b/types/factory-girl/factory-girl-tests.ts
@@ -29,6 +29,24 @@ const scoreSequence = factory.sequence<number>(
 );
 const scoreSeq = factory.seq<number>('User.score', score => score + 1);
 
+// Testing sequence with no params
+// $ExpectType Generator<number>
+factory.seq();
+// $ExpectType Generator<number>
+factory.sequence();
+
+// Testing sequence with id
+// $ExpectType Generator<number>
+factory.seq('User.score');
+// $ExpectType Generator<number>
+factory.sequence('User.score');
+
+// Testing sequence with callback
+// $ExpectType Generator<string>
+factory.seq(value => `${value}`);
+// $ExpectType Generator<string>
+factory.sequence(value => `${value}`);
+
 // Testing sequence resetting
 factory.resetSeq();
 factory.resetSequence();

--- a/types/factory-girl/factory-girl-tests.ts
+++ b/types/factory-girl/factory-girl-tests.ts
@@ -43,9 +43,9 @@ factory.sequence('User.score');
 
 // Testing sequence with callback
 // $ExpectType Generator<string>
-factory.seq(value => `${value}`);
+factory.seq(value => value.toString());
 // $ExpectType Generator<string>
-factory.sequence(value => `${value}`);
+factory.sequence(value => value.toString());
 
 // Testing sequence resetting
 factory.resetSeq();

--- a/types/factory-girl/index.d.ts
+++ b/types/factory-girl/index.d.ts
@@ -19,6 +19,8 @@ declare namespace factory {
     }>;
 
     interface Static {
+        factory: Static;
+
         /**
          * Associate the factory to other model
          */

--- a/types/factory-girl/index.d.ts
+++ b/types/factory-girl/index.d.ts
@@ -86,8 +86,13 @@ declare namespace factory {
         /**
          * Generate values sequentially inside a factory
          */
+        seq(name?: string): Generator<number>;
         seq<T>(name: string, fn: (sequence: number) => T): Generator<T>;
+        seq<T>(fn: (sequence: number) => T): Generator<T>;
+
+        sequence(name?: string): Generator<number>;
         sequence<T>(name: string, fn: (sequence: number) => T): Generator<T>;
+        sequence<T>(fn: (sequence: number) => T): Generator<T>;
 
         /**
          * Register an adapter, either as default or tied to a specific model

--- a/types/factory-girl/tslint.json
+++ b/types/factory-girl/tslint.json
@@ -1,6 +1,1 @@
-{
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "no-duplicate-imports": false
-    }
-}
+{ "extends": "dtslint/dt.json" }

--- a/types/factory-girl/tslint.json
+++ b/types/factory-girl/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-duplicate-imports": false
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Named export https://github.com/simonexmachina/factory-girl/blob/2b71a77af25a5dab18e6849a389955e6d4a2ce72/src/index.js#L13
  - Function signature of `seq/sequence` https://github.com/simonexmachina/factory-girl/blob/2b71a77af25a5dab18e6849a389955e6d4a2ce72/src/generators/
