### PR TITLE
fix(googlemaps): accept mixed LatLng | WeightedLocation array in HeatmapLayer.setData

### DIFF
--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -418,6 +418,12 @@ heatmap.setData([
     { weight: 2, location: new google.maps.LatLng({ lat: 37.782745, lng: -122.444586 }) },
 ]);
 
+// setData Should Accept (LatLng | WeightedLocation)[]
+heatmap.setData([
+    new google.maps.LatLng(37.782551, -122.445368),
+    { weight: 2, location: new google.maps.LatLng({ lat: 37.782745, lng: -122.444586 }) },
+]);
+
 // setOptions should required data and accepted any HeatmapLayerOptions
 heatmap.setOptions({
     data: [

--- a/types/googlemaps/reference/visualization.d.ts
+++ b/types/googlemaps/reference/visualization.d.ts
@@ -3,13 +3,13 @@ declare namespace google.maps.visualization {
         constructor(opts?: HeatmapLayerOptions);
         getData(): MVCArray<LatLng | WeightedLocation>;
         getMap(): Map;
-        setData(data: MVCArray<LatLng | WeightedLocation> | LatLng[] | WeightedLocation[]): void;
+        setData(data: MVCArray<LatLng | WeightedLocation> | Array<LatLng | WeightedLocation>): void;
         setMap(map: Map | null): void;
         setOptions(options: HeatmapLayerOptions): void;
     }
 
     interface HeatmapLayerOptions {
-        data: any;
+        data: MVCArray<LatLng | WeightedLocation> | Array<LatLng | WeightedLocation>;
         dissipating?: boolean;
         gradient?: string[];
         map?: Map;


### PR DESCRIPTION
According to the Google Maps API docs, `HeatmapLayer.setData` accepts either a mixed `MVCArray<LatLng | WeightedLocation>` or a native mixed array of `LatLng` and `WeightedLocation`, however the current typings only allow a mixed `MVCArray` or a `LatLng[]` or `WeightedLocation[]`.

These changes align the type to the one in the docs. I've also replaced the `any` in `HeatmapLayerOptions.data` with the correct type.

More information: https://developers.google.com/maps/documentation/javascript/reference/visualization#HeatmapLayer.setData

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/maps/documentation/javascript/reference/visualization#HeatmapLayer.setData