### PR TITLE
[react-router] Allow numeric and optional router params for generatePath

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -135,11 +135,11 @@ export function matchPath<Params extends { [K in keyof Params]?: string }>(
 ): match<Params> | null;
 
 export type ExtractRouteParams<T extends string> = string extends T
-    ? Record<string, string>
+    ? Record<string, string | number>
     : T extends `${infer _Start}:${infer Param}/${infer Rest}`
-    ? { [k in Param | keyof ExtractRouteParams<Rest>]: string }
+    ? { [k in Param | keyof ExtractRouteParams<Rest>]: string | number }
     : T extends `${infer _Start}:${infer Param}`
-    ? { [k in Param]: string }
+    ? { [k in Param]: string | number }
     : {};
 
 export function generatePath<S extends string>(path: S, params?: ExtractRouteParams<S>): string;

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -135,8 +135,8 @@ export function matchPath<Params extends { [K in keyof Params]?: string }>(
 ): match<Params> | null;
 
 export type ExtractRouteOptionalParam<T extends string> = T extends `${infer Param}?`
-    ? { [k in Param]?: string | number }
-    : { [k in T]: string | number };
+    ? { [k in Param]?: string | number | boolean }
+    : { [k in T]: string | number | boolean };
 
 export type ExtractRouteParams<T extends string> = string extends T
     ? Record<string, string | number>

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -136,8 +136,12 @@ export function matchPath<Params extends { [K in keyof Params]?: string }>(
 
 export type ExtractRouteParams<T extends string> = string extends T
     ? Record<string, string | number>
+    : T extends `${infer _Start}:${infer Param}?/${infer Rest}`
+    ? { [k in Param]?: string | number } & ExtractRouteParams<Rest>
     : T extends `${infer _Start}:${infer Param}/${infer Rest}`
-    ? { [k in Param | keyof ExtractRouteParams<Rest>]: string | number }
+    ? { [k in Param]: string | number } & ExtractRouteParams<Rest>
+    : T extends `${infer _Start}:${infer Param}?`
+    ? { [k in Param]?: string | number }
     : T extends `${infer _Start}:${infer Param}`
     ? { [k in Param]: string | number }
     : {};

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -134,16 +134,16 @@ export function matchPath<Params extends { [K in keyof Params]?: string }>(
     parent?: match<Params> | null,
 ): match<Params> | null;
 
+export type ExtractRouteOptionalParam<T extends string> = T extends `${infer Param}?`
+    ? { [k in Param]?: string | number }
+    : { [k in T]: string | number };
+
 export type ExtractRouteParams<T extends string> = string extends T
     ? Record<string, string | number>
-    : T extends `${infer _Start}:${infer Param}?/${infer Rest}`
-    ? { [k in Param]?: string | number } & ExtractRouteParams<Rest>
     : T extends `${infer _Start}:${infer Param}/${infer Rest}`
-    ? { [k in Param]: string | number } & ExtractRouteParams<Rest>
-    : T extends `${infer _Start}:${infer Param}?`
-    ? { [k in Param]?: string | number }
+    ? ExtractRouteOptionalParam<Param> & ExtractRouteParams<Rest>
     : T extends `${infer _Start}:${infer Param}`
-    ? { [k in Param]: string | number }
+    ? ExtractRouteOptionalParam<Param>
     : {};
 
 export function generatePath<S extends string>(path: S, params?: ExtractRouteParams<S>): string;

--- a/types/react-router/test/generatePath.ts
+++ b/types/react-router/test/generatePath.ts
@@ -8,3 +8,6 @@ generatePath('/posts/:postId', { userId: '1', postId: '1' }); // $ExpectError
 // correct
 generatePath('/posts/:postId', { postId: '1' });
 generatePath('/posts/:postId');
+generatePath('/posts/:postId?', {});
+generatePath('/posts/:postId/comments/:commentId?', { postId: '1' });
+generatePath('/posts/:postId?/comments/:commentId', { commentId: '1' });

--- a/types/react-router/test/generatePath.ts
+++ b/types/react-router/test/generatePath.ts
@@ -7,7 +7,9 @@ generatePath('/posts/:postId', { userId: '1', postId: '1' }); // $ExpectError
 
 // correct
 generatePath('/posts/:postId', { postId: '1' });
+generatePath('/posts/:postId', { postId: 1 });
 generatePath('/posts/:postId');
 generatePath('/posts/:postId?', {});
+generatePath('/posts/:postId?', { postId: '1' });
 generatePath('/posts/:postId/comments/:commentId?', { postId: '1' });
-generatePath('/posts/:postId?/comments/:commentId', { commentId: '1' });
+generatePath('/posts/:postId/comments/:commentId?', { postId: '1', commentId: '1' });

--- a/types/react-router/test/generatePath.ts
+++ b/types/react-router/test/generatePath.ts
@@ -8,6 +8,7 @@ generatePath('/posts/:postId', { userId: '1', postId: '1' }); // $ExpectError
 // correct
 generatePath('/posts/:postId', { postId: '1' });
 generatePath('/posts/:postId', { postId: 1 });
+generatePath('/posts/:postId', { postId: true });
 generatePath('/posts/:postId');
 generatePath('/posts/:postId?', {});
 generatePath('/posts/:postId?', { postId: '1' });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stackoverflow.com/a/35604855/3328079
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Note: This fixes two things.

Firstly this reverts a regression that used to support any type of primitive data. Previous type definition:

```ts
export function generatePath(
    pattern: string,
    params?: { [paramName: string]: string | number | boolean | undefined },
): string;
```

Secondly this now understands the difference between required and optional path params. This isn't documented properly, although is linked in the stackoverflow answer. Essentially it allows a `?` suffixed param to be optional (as used by [path-to-regexp](https://www.npmjs.com/package/path-to-regexp)), instead of the previous "everything is optional" or the current "everything is required".

Tests are added to check that the optional params are recognised correctly, and that params are allowed to be numbers or booleans in addition to strings.
