### PR TITLE
Bootstrap 5 + Popperjs 2

### DIFF
--- a/types/bootstrap/bootstrap-tests.ts
+++ b/types/bootstrap/bootstrap-tests.ts
@@ -76,7 +76,7 @@ element.addEventListener(Collapse.Events.hidden, event => {
  */
 
 // $ExpectType Dropdown
-const dropdown = new Dropdown(element, { flip: false });
+const dropdown = new Dropdown(element, { flip: true });
 
 // $ExpectType Dropdown
 const instanceDropdown = Dropdown.getInstance(element);

--- a/types/bootstrap/bootstrap-tests.ts
+++ b/types/bootstrap/bootstrap-tests.ts
@@ -76,7 +76,7 @@ element.addEventListener(Collapse.Events.hidden, event => {
  */
 
 // $ExpectType Dropdown
-const dropdown = new Dropdown(element, { offset: 10 });
+const dropdown = new Dropdown(element, { flip: false });
 
 // $ExpectType Dropdown
 const instanceDropdown = Dropdown.getInstance(element);

--- a/types/bootstrap/js/dist/dropdown.d.ts
+++ b/types/bootstrap/js/dist/dropdown.d.ts
@@ -1,4 +1,4 @@
-import * as Popper from 'popper.js';
+import * as Popper from '@popperjs/core';
 
 declare class Dropdown {
     constructor(element: Element, options?: Partial<Dropdown.Options>);
@@ -62,25 +62,10 @@ declare namespace Dropdown {
 
     interface Options {
         /**
-         * Offset of the dropdown relative to its target.
-         *
-         * When a function is used to determine the offset, it is called with an
-         * object containing the offset data as its first argument. The function
-         * must return an object with the same structure. The triggering element
-         * DOM node is passed as the second argument.
-         *
-         * For more information refer to Popper.js's offset docs.
-         *
-         * @see {@link https://popper.js.org/docs/v1/#modifiers..offset.offset}
-         * @default 0
-         */
-        offset: number;
-
-        /**
          * Allow Dropdown to flip in case of an overlapping on the reference
          * element. For more information refer to Popper.js's flip docs.
          *
-         * @see {@link https://popper.js.org/docs/v1/#modifiers..flip.enabled}
+         * @see {@link https://popper.js.org/docs/v2/modifiers/flip}
          * @default true
          */
         flip: boolean;
@@ -91,7 +76,7 @@ declare namespace Dropdown {
          * (JavaScript only). For more information refer to Popper.js's
          * preventOverflow docs.
          *
-         * @see {@link https://popper.js.org/docs/v1/#modifiers..preventOverflow.boundariesElement}
+         * @see {@link https://popper.js.org/docs/v2/modifiers/prevent-overflow/#boundary}
          * @default "scrollParent"
          */
         boundary: Popper.Boundary | Element;
@@ -101,7 +86,7 @@ declare namespace Dropdown {
          * 'toggle', 'parent', or an HTMLElement reference. For more information
          * refer to Popper.js's referenceObject docs.
          *
-         * @see {@link https://popper.js.org/docs/v1/#referenceObject}
+         * @see {@link https://popper.js.org/docs/v2/constructors/#createpopper}
          * @default "toggle"
          */
         reference: 'toggle' | 'parent' | Element;
@@ -118,10 +103,10 @@ declare namespace Dropdown {
          * To change Bootstrap's default Popper.js config, see Popper.js's
          * configuration
          *
-         * @see {@link https://popper.js.org/docs/v1/#Popper.Defaults}
+         * @see {@link https://popper.js.org/docs/v2}
          * @default null
          */
-        popperConfig: Popper.PopperOptions | null;
+        popperConfig: Popper.Options | null;
     }
 }
 

--- a/types/bootstrap/js/dist/popover.d.ts
+++ b/types/bootstrap/js/dist/popover.d.ts
@@ -213,7 +213,7 @@ declare namespace Popover {
          * @see {@link https://popper.js.org/docs/v2/modifiers/flip/#fallbackplacements}
          * @default 'flip'
          */
-        fallbackPlacement: Popper.Behavior | Popper.Position[];
+        fallbackPlacement: string | string[];
 
         /**
          * Overflow constraint boundary of the popover. Accepts the values of

--- a/types/bootstrap/js/dist/popover.d.ts
+++ b/types/bootstrap/js/dist/popover.d.ts
@@ -1,4 +1,4 @@
-import * as Popper from 'popper.js';
+import * as Popper from '@popperjs/core';
 
 declare class Popover {
     constructor(element: Element, options?: Partial<Popover.Options>);
@@ -202,7 +202,7 @@ declare namespace Popover {
         /**
          * Offset of the popover relative to its target.
          *
-         * @see {@link https://popper.js.org/docs/v1/#modifiers..offset.offset}
+         * @see {@link https://popper.js.org/docs/v2/modifiers/offset}
          * @default 0
          */
         offset: number | string;
@@ -210,7 +210,7 @@ declare namespace Popover {
         /**
          * Allow to specify which position Popper will use on fallback.
          *
-         * @see {@link https://popper.js.org/docs/v1/#modifiers..flip.behavior}
+         * @see {@link https://popper.js.org/docs/v2/modifiers/flip/#fallbackplacements}
          * @default 'flip'
          */
         fallbackPlacement: Popper.Behavior | Popper.Position[];
@@ -220,7 +220,7 @@ declare namespace Popover {
          * 'viewport', 'window', 'scrollParent', or an HTMLElement reference
          * (JavaScript only).
          *
-         * @see {@link https://popper.js.org/docs/v1/#modifiers..preventOverflow.boundariesElement}
+         * @see {@link https://popper.js.org/docs/v2/modifiers/flip/#boundary}
          * @default 'scrollParent'
          */
         boundary: 'viewport' | 'window' | 'scrollParent' | Element;
@@ -251,10 +251,10 @@ declare namespace Popover {
         /**
          * To change Bootstrap's default Popper.js config
          *
-         * @see {@link https://popper.js.org/docs/v1/#Popper.Defaults}
+         * @see {@link https://popper.js.org/docs/v2}
          * @default null
          */
-        popperConfig: Popper.PopperOptions | null;
+        popperConfig: Popper.Options | null;
     }
 }
 

--- a/types/bootstrap/js/dist/tooltip.d.ts
+++ b/types/bootstrap/js/dist/tooltip.d.ts
@@ -226,7 +226,7 @@ declare namespace Tooltip {
          * @see {@link https://popper.js.org/docs/v2/modifiers/flip/#fallbackplacements}
          * @default 'flip'
          */
-        fallbackPlacement: Popper.Behavior | Popper.Position[];
+        fallbackPlacement: string | string[];
 
         /**
          * Overflow constraint boundary of the popover. Accepts the values of

--- a/types/bootstrap/js/dist/tooltip.d.ts
+++ b/types/bootstrap/js/dist/tooltip.d.ts
@@ -1,4 +1,4 @@
-import * as Popper from 'popper.js';
+import * as Popper from '@popperjs/core';
 
 declare class Tooltip {
     constructor(element: Element, options?: Partial<Tooltip.Options>);
@@ -215,7 +215,7 @@ declare namespace Tooltip {
          * must return an object with the same structure. The triggering element
          * DOM node is passed as the second argument.
          *
-         * @see {@link https://popper.js.org/docs/v1/#modifiers..offset.offset}
+         * @see {@link https://popper.js.org/docs/v2/modifiers/offset}
          * @default 0
          */
         offset: number | string | (() => void);
@@ -223,7 +223,7 @@ declare namespace Tooltip {
         /**
          * Allow to specify which position Popper will use on fallback.
          *
-         * @see {@link https://popper.js.org/docs/v1/#modifiers..flip.behavior}
+         * @see {@link https://popper.js.org/docs/v2/modifiers/flip/#fallbackplacements}
          * @default 'flip'
          */
         fallbackPlacement: Popper.Behavior | Popper.Position[];
@@ -264,10 +264,10 @@ declare namespace Tooltip {
         /**
          * To change Bootstrap's default Popper.js config
          *
-         * @see {@link https://popper.js.org/docs/v1/#Popper.Defaults}
+         * @see {@link https://popper.js.org/docs/v2}
          * @default null
          */
-        popperConfig: Popper.PopperOptions | null;
+        popperConfig: Popper.Options | null;
     }
 }
 

--- a/types/bootstrap/package.json
+++ b/types/bootstrap/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "popper.js": "^1.14.1"
+        "popper.js": "^1.14.1",
+        "@popperjs/core": "^2.6.0"
     }
 }

--- a/types/bootstrap/package.json
+++ b/types/bootstrap/package.json
@@ -1,7 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "popper.js": "^1.14.1",
         "@popperjs/core": "^2.6.0"
     }
 }


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
- <https://getbootstrap.com/docs/5.0/components/dropdowns/#options>
- <https://popper.js.org/docs/v2/constructors/#options>
