### PR TITLE
[@types/carbon-components-react] Add missing args types on translateWithId prop for TableBatchActions and TableHeader

### DIFF
--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -281,7 +281,18 @@ const t4 = (
                 <TableHeader {...data.getHeaderProps({ header, randomAttr: 'asdf' })}>{header.header}</TableHeader>
             ));
             data.headers.map(header => (
-                <TableHeader {...data.getHeaderProps<ExtraStuff>({ header, extra1: 'test' })}>
+                <TableHeader
+                    {...data.getHeaderProps<ExtraStuff>({ header, extra1: 'test' })}
+                    translateWithId={(mId, args) => {
+                        if (args) {
+                            console.log(args.header);
+                            console.log(args.isSortHeader);
+                            console.log(args.sortDirection);
+                            console.log(args.sortStates);
+                        }
+                        return "string";
+                    }}
+                >
                     {header.header}
                 </TableHeader>
             ));
@@ -294,7 +305,10 @@ const t4 = (
             ));
             let rowProps = data.getRowProps({ row: rowData1, extra1: 'qwerty', ...rowData1 });
             let batchActions = (
-                <TableBatchActions {...data.getBatchActionProps({ spellCheck: true, randomAttr: 'Asdf' })}>
+                <TableBatchActions
+                    {...data.getBatchActionProps({ spellCheck: true, randomAttr: 'Asdf' })}
+                    translateWithId={(mId, args) => `${args ? args.totalSelected : 0}`}
+                >
                     Content
                 </TableBatchActions>
             );

--- a/types/carbon-components-react/lib/components/DataTable/TableBatchActions.d.ts
+++ b/types/carbon-components-react/lib/components/DataTable/TableBatchActions.d.ts
@@ -1,12 +1,21 @@
-import * as React from "react";
-import { InternationalProps, ReactDivAttr } from "../../../typings/shared";
+import * as React from 'react';
+import { InternationalProps, ReactDivAttr } from '../../../typings/shared';
 
-export type TableBatchActionsTranslationKey = "carbon.table.batch.cancel" | "carbon.table.batch.items.selected" | "carbon.table.batch.item.selected";
+export type TableBatchActionsTranslationKey =
+    | 'carbon.table.batch.cancel'
+    | 'carbon.table.batch.items.selected'
+    | 'carbon.table.batch.item.selected';
 
-export interface TableBatchActionsProps extends ReactDivAttr, InternationalProps<TableBatchActionsTranslationKey> {
-    onCancel(event: React.MouseEvent<HTMLButtonElement>): void,
-    shouldShowBatchActions?: boolean,
-    totalSelected: number,
+export interface TableBatchActionsTranslationArgs {
+    totalSelected?: number;
+}
+
+export interface TableBatchActionsProps
+    extends ReactDivAttr,
+        InternationalProps<TableBatchActionsTranslationKey, TableBatchActionsTranslationArgs> {
+    onCancel(event: React.MouseEvent<HTMLButtonElement>): void;
+    shouldShowBatchActions?: boolean;
+    totalSelected: number;
 }
 
 interface TableBatchActionsFC extends React.FC<TableBatchActionsProps> {

--- a/types/carbon-components-react/lib/components/DataTable/TableHeader.d.ts
+++ b/types/carbon-components-react/lib/components/DataTable/TableHeader.d.ts
@@ -1,13 +1,20 @@
 import * as React from "react";
 import { InternationalProps, ReactButtonAttr, ForwardRefReturn } from "../../../typings/shared";
-import { DataTableSortState } from "./state/sorting";
+import { DataTableSortState, DataTableSortStates } from "./state/sorting";
 
 export type TableHeaderTranslationKey = "carbon.table.header.icon.description";
+
+export interface TableHeaderTranslationArgs {
+    header: React.ReactNode,
+    isSortHeader: boolean | undefined,
+    sortDirection: DataTableSortState | undefined,
+    sortStates: DataTableSortStates,
+}
 
 export interface TableHeaderProps extends
     ReactButtonAttr<HTMLElement>,
     React.ThHTMLAttributes<HTMLElement>,
-    InternationalProps<TableHeaderTranslationKey>
+    InternationalProps<TableHeaderTranslationKey, TableHeaderTranslationArgs>
 {
     isSortable?: boolean,
     isSortHeader?: boolean,

--- a/types/carbon-components-react/typings/shared.d.ts
+++ b/types/carbon-components-react/typings/shared.d.ts
@@ -31,8 +31,8 @@ export interface DownshiftTypedProps<ItemType> {
     itemToString?(item: ItemType): string;
 }
 
-export interface InternationalProps<MID = string> {
-    translateWithId?(messageId: MID): string;
+export interface InternationalProps<MID = string, ARGS = Record<string, unknown>> {
+    translateWithId?(messageId: MID, args?: ARGS): string;
 }
 
 export interface MenuOffsetData {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/carbon-design-system/carbon/blob/v10.25.0/packages/react/src/components/DataTable/TableBatchActions.js#L52-L54
  - https://github.com/carbon-design-system/carbon/blob/v10.25.0/packages/react/src/components/DataTable/TableHeader.js#L99-L116
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
