### PR TITLE
[react-router] Fix regression in generatePath with non-literal strings

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -139,7 +139,7 @@ export type ExtractRouteOptionalParam<T extends string> = T extends `${infer Par
     : { [k in T]: string | number | boolean };
 
 export type ExtractRouteParams<T extends string> = string extends T
-    ? Record<string, string | number>
+    ? { [k in string]?: string | number | boolean }
     : T extends `${infer _Start}:${infer Param}/${infer Rest}`
     ? ExtractRouteOptionalParam<Param> & ExtractRouteParams<Rest>
     : T extends `${infer _Start}:${infer Param}`

--- a/types/react-router/test/generatePath.ts
+++ b/types/react-router/test/generatePath.ts
@@ -1,9 +1,12 @@
 import { generatePath } from 'react-router';
 
+declare const unknownPath: string;
+
 // inncorect usage, type errors
 generatePath('/posts/:postId', {}); // $ExpectError
 generatePath('/posts/:postId/comments/:commentId', { postId: '1' }); // $ExpectError
 generatePath('/posts/:postId', { userId: '1', postId: '1' }); // $ExpectError
+generatePath(unknownPath, { nullParam: null }); // $ExpectError
 
 // correct
 generatePath('/posts/:postId', { postId: '1' });
@@ -14,3 +17,4 @@ generatePath('/posts/:postId?', {});
 generatePath('/posts/:postId?', { postId: '1' });
 generatePath('/posts/:postId/comments/:commentId?', { postId: '1' });
 generatePath('/posts/:postId/comments/:commentId?', { postId: '1', commentId: '1' });
+generatePath(unknownPath, { stringParam: '', numParam: 3, boolParam: true, undefinedParam: undefined });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Prior to the changes to generatePath in #50295, it accepted boolean and undefined parameters in addition to strings and numbers:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/2a43fe2f451a26f47c1360fb4d90d77a5b9046ee/types/react-router/index.d.ts#L137-L140

#50427 fixes this for literal strings with `?` specifiers, but not for plain strings with unknown content.