### PR TITLE
[@feathersjs/authentication-client] Add timeout param to FeathersAuthClientConfig

### DIFF
--- a/types/feathersjs__authentication-client/feathersjs__authentication-client-tests.ts
+++ b/types/feathersjs__authentication-client/feathersjs__authentication-client-tests.ts
@@ -1,8 +1,9 @@
 import feathers from '@feathersjs/feathers';
-import feathersAuthClient from '@feathersjs/authentication-client';
+import feathersAuthClient, { defaults } from '@feathersjs/authentication-client';
 
 const app = feathers();
-app.configure(feathersAuthClient());
+// check that the default options are valid when configuring the client
+app.configure(feathersAuthClient(defaults));
 app.authenticate({strategy : 'abcdef'}).then(() => {});
 app.logout().then(() => {});
 

--- a/types/feathersjs__authentication-client/index.d.ts
+++ b/types/feathersjs__authentication-client/index.d.ts
@@ -17,6 +17,7 @@ export interface FeathersAuthClientConfig {
     path?: string;
     entity?: string;
     service?: string;
+    timeout?: number;
 }
 
 export interface FeathersAuthCredentials {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/feathersjs/feathers/blob/%40feathersjs/authentication-client%401.0.3/packages/authentication-client/lib/index.js

---

As best as I can tell, `@feathersjs/authentication-client` has always supported the `timeout` parameter. This is evidenced by the fact that it is included in the default params (in above link).
