### PR TITLE
Added ignoreBox property to resemble outputSettings

### DIFF
--- a/types/resemblejs/index.d.ts
+++ b/types/resemblejs/index.d.ts
@@ -30,7 +30,7 @@ declare namespace Resemble {
           left: number,
           top: number,
           right: number,
-          button: number
+          bottom: number
      };
   }
 

--- a/types/resemblejs/index.d.ts
+++ b/types/resemblejs/index.d.ts
@@ -18,14 +18,20 @@ declare namespace Resemble {
   function outputSettings(settings: OutputSettings): typeof Resemble;
 
   interface OutputSettings {
-    errorColor: {
+    errorColor?: {
       red: number;
       green: number;
       blue: number;
     };
-    errorType: string;
-    transparency: number;
-    largeImageThreshold: number;
+    errorType?: string;
+    transparency?: number;
+    largeImageThreshold?: number;
+    ignoredBox?: {
+          left: number,
+          top: number,
+          right: number,
+          button: number
+     };
   }
 
   interface ResembleAnalysis {


### PR DESCRIPTION
Added ignoredBox property. 
Example usage:
const box = {
    left: 100,
    top: 200,
    right: 200,
    bottom: 600
};
resemble.outputSettings({ ignoredBox: box });

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
