### PR TITLE
Add prosemirror-changeset type definitions

### DIFF
--- a/types/prosemirror-changeset/index.d.ts
+++ b/types/prosemirror-changeset/index.d.ts
@@ -1,0 +1,88 @@
+// Type definitions for prosemirror-changeset 2.1
+// Project: https://github.com/prosemirror/prosemirror-changeset#readme
+// Definitions by: Pierre-Marc Airoldi <https://github.com/pmairoldi>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.6
+
+import { StepMap } from 'prosemirror-transform';
+import { Node, Schema } from 'prosemirror-model';
+
+export class Span {
+    constructor(lenght: number, data: any);
+
+    get lenght(): number;
+    get data(): any;
+
+    cut(length: number): Span;
+
+    static slice(spans: Span[], from: number, to: number): Span[];
+
+    static join(a: Span[], b: Span[], combine: (a: any, b: any) => any): Span[];
+
+    static len(spans: Span[]): number;
+}
+
+export class Change {
+    constructor(fromA: number, toA: number, fromB: number, toB: number, deleted: Span[], inserted: Span[]);
+
+    get fromA(): number;
+    get toA(): number;
+    get fromB(): number;
+    get toB(): number;
+    get deleted(): Span[];
+    get inserted(): Span[];
+
+    get lenA(): number;
+    get lenB(): number;
+
+    slice(startA: number, endA: number, startB: number, endB: number): Change;
+
+    // : ([Change], [Change], (any, any) → any) → [Change]
+    // This merges two changesets (the end document of x should be the
+    // start document of y) into a single one spanning the start of x to
+    // the end of y.
+    static merge(x: Change[], y: Change[], combine: (a: any, b: any) => any): Change[];
+}
+
+export class ChangeSet<S extends Schema = any> {
+    constructor(config: any, changes: Change[]);
+
+    get changes(): Change[];
+
+    // :: (Node, [StepMap], union<[any], any>) → ChangeSet
+    // Computes a new changeset by adding the given step maps and
+    // metadata (either as an array, per-map, or as a single value to be
+    // associated with all maps) to the current set. Will not mutate the
+    // old set.
+    //
+    // Note that due to simplification that happens after each add,
+    // incrementally adding steps might create a different final set
+    // than adding all those changes at once, since different document
+    // tokens might be matched during simplification depending on the
+    // boundaries of the current changed ranges.
+    addSteps(newDoc: Node<S>, maps: StepMap[], data?: any): ChangeSet<S>;
+
+    // :: Node
+    // The starting document of the change set.
+    get startDoc(): Node<S>;
+
+    // :: (f: (range: Change) → any) → ChangeSet
+    // Map the span's data values in the given set through a function
+    // and construct a new set with the resulting data.
+    map(f: (range: Change) => any): ChangeSet<S>;
+
+    // :: (ChangeSet, ?[StepMap]) → ?{from: number, to: number}
+    // Compare two changesets and return the range in which they are
+    // changed, if any. If the document changed between the maps, pass
+    // the maps for the steps that changed it as second argument, and
+    // make sure the method is called on the old set and passed the new
+    // set. The returned positions will be in new document coordinates.
+    changedRange(b: ChangeSet<S>, maps?: StepMap[]): { from: number; to: number } | undefined;
+
+    // :: (Node, ?(a: any, b: any) → any) → ChangeSet
+    // Create a changeset with the given base object and configuration.
+    // The `combine` function is used to compare and combine metadata—it
+    // should return null when metadata isn't compatible, and a combined
+    // version for a merged range when it is.
+    static create<S extends Schema = any>(doc: Node<S>, combine?: (a: any, b: any) => any): ChangeSet<S>;
+}

--- a/types/prosemirror-changeset/index.d.ts
+++ b/types/prosemirror-changeset/index.d.ts
@@ -37,7 +37,7 @@ export class Change {
 
     slice(startA: number, endA: number, startB: number, endB: number): Change;
 
-    // : ([Change], [Change], (any, any) → any) → [Change]
+    // :: ([Change], [Change], (any, any) → any) → [Change]
     // This merges two changesets (the end document of x should be the
     // start document of y) into a single one spanning the start of x to
     // the end of y.
@@ -86,3 +86,12 @@ export class ChangeSet<S extends Schema = any> {
     // version for a merged range when it is.
     static create<S extends Schema = any>(doc: Node<S>, combine?: (a: any, b: any) => any): ChangeSet<S>;
 }
+
+// :: ([Change], Node) → [Change]
+// Simplifies a set of changes for presentation. This makes the
+// assumption that having both insertions and deletions within a word
+// is confusing, and, when such changes occur without a word boundary
+// between them, they should be expanded to cover the entire set of
+// words (in the new document) they touch. An exception is made for
+// single-character replacements.
+export function simplifyChanges(changes: Change[], doc: Node): Change[];

--- a/types/prosemirror-changeset/prosemirror-changeset-tests.ts
+++ b/types/prosemirror-changeset/prosemirror-changeset-tests.ts
@@ -1,0 +1,91 @@
+import { ChangeSet, Span, Change } from 'prosemirror-changeset';
+import { Node, Schema } from 'prosemirror-model';
+import { StepMap } from 'prosemirror-transform';
+
+const span = new Span(0, { test: 'test' });
+
+// $ExpectType number
+span.lenght;
+// $ExpectType any
+span.data;
+// $ExpectType Span
+span.cut(2);
+
+// $ExpectType Span[]
+Span.slice([new Span(0, { test: 'test' })], 1, 2);
+
+// $ExpectType Span[]
+Span.join([new Span(0, { test: 'test' })], [new Span(0, { test: 'test' })], (a, b) => ({ ...a, ...b }));
+
+// $ExpectType number
+Span.len([new Span(0, { test: 'test' })]);
+
+const change = new Change(0, 0, 1, 1, [new Span(0, { test: 'test' })], [new Span(0, { test: 'test' })]);
+
+// $ExpectType number
+change.fromA;
+
+// $ExpectType number
+change.toA;
+
+// $ExpectType number
+change.fromB;
+
+// $ExpectType number
+change.toB;
+
+// $ExpectType Span[]
+change.deleted;
+
+// $ExpectType Span[]
+change.inserted;
+
+// $ExpectType number
+change.lenA;
+
+// $ExpectType number
+change.lenB;
+
+// $ExpectType Change
+change.slice(0, 0, 1, 1);
+
+// $ExpectType Change[]
+Change.merge(
+    [new Change(0, 0, 1, 1, [new Span(0, { test: 'test' })], [new Span(0, { test: 'test' })])],
+    [new Change(0, 0, 1, 1, [new Span(0, { test: 'test' })], [new Span(0, { test: 'test' })])],
+    (a, b) => ({ ...a, ...b }),
+);
+
+const changeset = new ChangeSet<any>({}, [
+    new Change(0, 0, 1, 1, [new Span(0, { test: 'test' })], [new Span(0, { test: 'test' })]),
+]);
+
+// $ExpectType Change[]
+changeset.changes;
+
+// $ExpectType ChangeSet<any>
+changeset.addSteps(new Node(), [new StepMap([0, 1, 1])]);
+// $ExpectType ChangeSet<any>
+changeset.addSteps(new Node(), [new StepMap([0, 1, 1])], { test: 'test' });
+
+// $ExpectType ProsemirrorNode<any>
+changeset.startDoc;
+
+// $ExpectType ChangeSet<any>
+changeset.map(range => ({ test: 'test' }));
+
+// $ExpectType { from: number; to: number; } | undefined
+changeset.changedRange(
+    new ChangeSet({}, [new Change(0, 0, 1, 1, [new Span(0, { test: 'test' })], [new Span(0, { test: 'test' })])]),
+);
+
+// $ExpectType { from: number; to: number; } | undefined
+changeset.changedRange(
+    new ChangeSet({}, [new Change(0, 0, 1, 1, [new Span(0, { test: 'test' })], [new Span(0, { test: 'test' })])]),
+    [new StepMap([0, 1, 1])],
+);
+
+// $ExpectType ChangeSet<any>
+ChangeSet.create(new Node());
+// $ExpectType ChangeSet<any>
+ChangeSet.create(new Node(), (a, b) => ({ ...a, ...b }));

--- a/types/prosemirror-changeset/prosemirror-changeset-tests.ts
+++ b/types/prosemirror-changeset/prosemirror-changeset-tests.ts
@@ -1,5 +1,5 @@
-import { ChangeSet, Span, Change } from 'prosemirror-changeset';
-import { Node, Schema } from 'prosemirror-model';
+import { Change, ChangeSet, simplifyChanges, Span } from 'prosemirror-changeset';
+import { Node } from 'prosemirror-model';
 import { StepMap } from 'prosemirror-transform';
 
 const span = new Span(0, { test: 'test' });
@@ -89,3 +89,6 @@ changeset.changedRange(
 ChangeSet.create(new Node());
 // $ExpectType ChangeSet<any>
 ChangeSet.create(new Node(), (a, b) => ({ ...a, ...b }));
+
+// $ExpectType Change[]
+simplifyChanges([new Change(0, 0, 1, 1, [new Span(0, { test: 'test' })], [new Span(0, { test: 'test' })])], new Node());

--- a/types/prosemirror-changeset/tsconfig.json
+++ b/types/prosemirror-changeset/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "prosemirror-changeset-tests.ts"
+    ]
+}

--- a/types/prosemirror-changeset/tslint.json
+++ b/types/prosemirror-changeset/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [X] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
