### PR TITLE
ember: Fix tests for TS 4.2 template literals

### DIFF
--- a/types/ember/test/private/computed-tests.ts
+++ b/types/ember/test/private/computed-tests.ts
@@ -14,7 +14,8 @@ class Example1 extends Ember.Object.extend({
         return [this.fullName];
     }) as Ember.ComputedProperty<string[]>,
     fullName: Ember.computed('firstName', 'lastName', function () {
-        return `${this.firstName} ${this.lastName}`;
+        // tslint:disable-next-line:no-unnecessary-type-assertion
+        return `${this.firstName} ${this.lastName}` as string;
     }),
 }) {}
 
@@ -35,7 +36,8 @@ class Example2 extends Ember.Object.extend({
         return [this.fullName + ''];
     }),
     fullName: Ember.computed('firstName', 'lastName', function () {
-        return `${this.firstName} ${this.lastName}`;
+        // tslint:disable-next-line:no-unnecessary-type-assertion
+        return `${this.firstName} ${this.lastName}` as string;
     }),
 }) {
     firstName = '';

--- a/types/ember/test/utils.ts
+++ b/types/ember/test/utils.ts
@@ -106,7 +106,8 @@ function testTryInvoke() {
             return x + parseInt(y, 10);
         }
         apples(n: number) {
-            return `${n} apples`;
+            // tslint:disable-next-line:no-unnecessary-type-assertion
+            return `${n} apples` as string;
         }
     }
     // zero-argument function


### PR DESCRIPTION
In Typescript 4.2, template literals no longer have type `string`; instead they have a template literal type.
However, that breaks ember tests, which have to work with Typescript 3.7 and above. In the interest of backward compatibility, I added a cast instead, since the template literal type isn't interesting for the tests anyway.
