### PR TITLE
auth0: add SignUpUserData for database connections

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -663,3 +663,5 @@ const oauthAuthenticator = new auth0.OAuthAuthenticator({
 
 oauthAuthenticator.refreshToken({ refresh_token:'{YOUR_REFRESH_TOKEN}' }).then(() => console.log('refreshed'));
 oauthAuthenticator.refreshToken({ refresh_token:'{YOUR_REFRESH_TOKEN}' }, err => console.log('refreshed'));
+
+authentication.database.signUp({email: 'email', password: 'password'})

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -9,6 +9,7 @@
 //                 Meng Bernie Sung <https://github.com/MengRS>
 //                 Léo Haddad Carneiro <https://github.com/Scoup>
 //                 Isabela Morais <https://github.com/isabela-morais>
+//                 Raimondo Butera <https://github.com/rbutera>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -68,6 +69,10 @@ export interface UserData<A = AppMetadata, U=UserMetadata> {
 
 export interface CreateUserData extends UserData {
   connection: string;
+}
+
+export interface SignUpUserData extends UserData {
+  connection?: string;
 }
 
 export interface UpdateUserData extends UserData {
@@ -1330,8 +1335,8 @@ export class DatabaseAuthenticator<A=AppMetadata, U=UserMetadata> {
   signIn(data: SignInOptions): Promise<SignInToken>;
   signIn(data: SignInOptions, cb: (err: Error, data: SignInToken) => void): void;
 
-  signUp(data: CreateUserData): Promise<User<A, U>>;
-  signIn(data: CreateUserData, cb: (err: Error, data: User) => void): void;
+  signUp(data: SignUpUserData): Promise<User<A, U>>;
+  signIn(data: SignUpUserData, cb: (err: Error, data: User) => void): void;
 
 }
 


### PR DESCRIPTION
As per [Auth0 documentation](https://auth0.github.io/node-auth0/module-auth.DatabaseAuthenticator.html#signUp), connection is optional when creating a user, and can default to 'Username-Password-Authentication'

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://auth0.github.io/node-auth0/module-auth.DatabaseAuthenticator.html#signUp

