### PR TITLE
jasmine: Fix tests for TS 4.2 template literals

### DIFF
--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -1586,7 +1586,8 @@ describe("Custom async matcher: 'toBeEight'", () => {
 describe('better typed spys', () => {
     describe('a typed spy', () => {
         const spy = jasmine.createSpy('spy', (num: number, str: string) => {
-            return `${num} and ${str}`;
+            // tslint:disable-next-line:no-unnecessary-type-assertion
+            return `${num} and ${str}` as string;
         });
         it('has a typed returnValue', () => {
             // $ExpectType (val: string) => Spy<(num: number, str: string) => string>

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -1585,9 +1585,8 @@ describe("Custom async matcher: 'toBeEight'", () => {
 
 describe('better typed spys', () => {
     describe('a typed spy', () => {
-        const spy = jasmine.createSpy('spy', (num: number, str: string) => {
-            // tslint:disable-next-line:no-unnecessary-type-assertion
-            return `${num} and ${str}` as string;
+        const spy = jasmine.createSpy('spy', (num: number, str: string): string => {
+            return `${num} and ${str}`;
         });
         it('has a typed returnValue', () => {
             // $ExpectType (val: string) => Spy<(num: number, str: string) => string>


### PR DESCRIPTION
In Typescript 4.2, template literals no longer have type string;
instead they have a template literal type.
However, that breaks tests, which have to work with older versions
of Typescript. In the interest of backward compatibility, I added a cast
instead, since the template literal type isn't interesting for the tests
anyway.
