### PR TITLE
karma-coverage: Fix tests for TS 4.2 template literals

### DIFF
--- a/types/karma-coverage/karma-coverage-tests.ts
+++ b/types/karma-coverage/karma-coverage-tests.ts
@@ -24,7 +24,8 @@ module.exports = function(config: karma.Config) {
       dir: 'coverage/',
       // $ExpectType (browser: string) => string
       subdir: (browser) => {
-          return `cool-${browser}-directory`;
+          // tslint:disable-next-line:no-unnecessary-type-assertion
+          return `cool-${browser}-directory` as string;
       },
       // $ExpectType string
       file: 'index.html',


### PR DESCRIPTION
In Typescript 4.2, template literals no longer have type string;
instead they have a template literal type.
However, that breaks tests, which have to work with older versions
of Typescript. In the interest of backward compatibility, I added a cast
instead, since the template literal type isn't interesting for the tests
anyway.