### PR TITLE
linkifyjs: Fix tests for TS 4.2 template literals

### DIFF
--- a/types/linkifyjs/linkifyjs-tests.ts
+++ b/types/linkifyjs/linkifyjs-tests.ts
@@ -30,7 +30,8 @@ options = { attributes: href => ({}) }; // $ExpectType { attributes: (href: stri
 
 options = { className: null }; // $ExpectError
 options = { className: 'new-link--url' }; // $ExpectType { className: string; }
-options = { className: (href, type) => `new-link-${type}` }; // $ExpectType { className: (href: string, type: LinkEntityType) => string; }
+// tslint:disable-next-line:no-unnecessary-type-assertion
+options = { className: (href, type) => (`new-link-${type}` as string) }; // $ExpectType { className: (href: string, type: LinkEntityType) => string; }
 options = { className: { sunshine: v => v } }; // $ExpectError
 options = { className: { email: () => 'new-link--email' } }; // $ExpectType { className: { email: () => string; }; }
 


### PR DESCRIPTION
In Typescript 4.2, template literals no longer have type string;
instead they have a template literal type.
However, that breaks tests, which have to work with older versions
of Typescript. In the interest of backward compatibility, I added a cast
instead, since the template literal type isn't interesting for the tests
anyway.