### PR TITLE
meteor: Fix tests for TS 4.2 template literals

### DIFF
--- a/types/meteor/test/meteor-tests-module-only.ts
+++ b/types/meteor/test/meteor-tests-module-only.ts
@@ -11,7 +11,8 @@ const request = new Request('https://github.com', { headers });
 const reply: Promise<Response> = fetch(request);
 
 function foo(x: number) {
-    return `${x}`;
+    // tslint:disable-next-line:no-unnecessary-type-assertion
+    return `${x}` as string;
 }
 
 // $ExpectType Promise<string>


### PR DESCRIPTION
In Typescript 4.2, template literals no longer have type string;
instead they have a template literal type.
However, that breaks tests, which have to work with older versions
of Typescript. In the interest of backward compatibility, I added a cast
instead, since the template literal type isn't interesting for the tests
anyway.